### PR TITLE
Make ThreadSafeFlags public

### DIFF
--- a/src/TypeSystem/src/Common/ThreadSafeFlags.cs
+++ b/src/TypeSystem/src/Common/ThreadSafeFlags.cs
@@ -6,7 +6,7 @@ using Interlocked = System.Threading.Interlocked;
 
 namespace Internal.TypeSystem
 {
-    struct ThreadSafeFlags
+    public struct ThreadSafeFlags
     {
         private volatile int _value;
 


### PR DESCRIPTION
These are consumed from the ECMA type system implementation and need to
be public.
