### PR TITLE
Make build.cmd more like the build.cmd in CoreCLR repo

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,53 +1,143 @@
 @echo off
-setlocal
+setlocal EnableDelayedExpansion
 
+:: Set the default arguments for build
+set __BuildArch=x64
+set __BuildType=Debug
+set __BuildOS=Windows_NT
+
+:: Default to highest Visual Studio version available
+set __VSVersion=vs2015
+
+:: Default to highest Visual Studio version available
+if defined VS120COMNTOOLS set __VSVersion=vs2013
+if defined VS140COMNTOOLS set __VSVersion=vs2015
+
+:: Set the various build properties here so that CMake and MSBuild can pick them up
+set "__ProjectDir=%~dp0"
+:: remove trailing slash
+if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
+set "__SourceDir=%__ProjectDir%\src"
+set "__PackagesDir=%__ProjectDir%\packages"
+set "__RootBinDir=%__ProjectDir%\bin"
+set "__LogsDir=%__RootBinDir%\Logs"
+set __MSBCleanBuildArgs=
+set __SkipTestBuild=
+
+:Arg_Loop
+if "%1" == "" goto ArgsDone
+if /i "%1" == "/?" goto Usage
+
+if /i "%1" == "debug"    (set __BuildType=Debug&shift&goto Arg_Loop)
+if /i "%1" == "release"   (set __BuildType=Release&shift&goto Arg_Loop)
+
+if /i "%1" == "clean"   (set __CleanBuild=1&shift&goto Arg_Loop)
+
+if /i "%1" == "skiptestbuild" (set __SkipTestBuild=1&shift&goto Arg_Loop)
+
+echo Invalid command line argument: %1
+goto Usage
+
+:ArgsDone
+
+echo Commencing CoreRT Repo build
+echo.
+
+:: Set the remaining variables based upon the determined build configuration
+set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
+
+:: Configure environment if we are doing a clean build.
+if not defined __CleanBuild goto MakeDirs
+echo Doing a clean build
+echo.
+
+:: MSBuild projects would need a rebuild
+set __MSBCleanBuildArgs=/t:rebuild
+
+:: Cleanup the previous output for the selected configuration
+if exist "%__BinDir%" rd /s /q "%__BinDir%"
+if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"
+
+if exist "%__LogsDir%" del /f /q "%__LogsDir%\*_%__BuildOS%__%__BuildArch%__%__BuildType%.*"
+
+:MakeDirs
+if not exist "%__BinDir%" md "%__BinDir%"
+if not exist "%__LogsDir%" md "%__LogsDir%"
+
+:CheckPrereqs
+:: Check prerequisites
+echo Checking pre-requisites...
+echo.
+rem ******************************************
+rem PUT NATIVE BUILD PRE-REQUISITES CHECK HERE
+rem ******************************************
+
+:CheckVS
+
+set __VSProductVersion=
+if /i "%__VSVersion%" == "vs2013" set __VSProductVersion=120
+if /i "%__VSVersion%" == "vs2015" set __VSProductVersion=140
+
+
+:: Check presence of VS
+if defined VS%__VSProductVersion%COMNTOOLS goto CheckVSExistence
+echo Visual Studio 2013+ (Community is free) is a pre-requisite to build this repository.
+echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites
+exit /b 1
+
+:CheckVSExistence
+:: Does VS 2013 or VS 2015 really exist?
+if exist "!VS%__VSProductVersion%COMNTOOLS!\..\IDE\devenv.exe" goto CheckMSBuild
+echo Visual Studio 2013+ (Community is free) is a pre-requisite to build this repository.
+echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites
+exit /b 1
+
+:CheckMSBuild
 :: Note: We've disabled node reuse because it causes file locking issues.
 ::       The issue is that we extend the build with our own targets which
 ::       means that that rebuilding cannot successfully delete the task
 ::       assembly. 
+if /i "%__VSVersion%" =="vs2015" goto MSBuild14
+set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
+if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
+if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+goto :CheckMSBuild14
+:MSBuild14
+set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+:CheckMSBuild14
+if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
+if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md for build instructions. && exit /b 1
 
-if not defined VisualStudioVersion (
-    if defined VS140COMNTOOLS (
-        call "%VS140COMNTOOLS%\VsDevCmd.bat"
-        goto :EnvSet
-    )
+:: All set to commence the build
 
-    if defined VS120COMNTOOLS (
-        call "%VS120COMNTOOLS%\VsDevCmd.bat"
-        goto :EnvSet
-    )
+setlocal
+rem *********************
+rem PUT NATIVE BUILD HERE
+rem *********************
 
-    echo Error: build.cmd requires Visual Studio 2013 or 2015.  
-    echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
-    exit /b 1
-)
+:ManagedBuild
+REM endlocal to rid us of environment changes from vcvarsall.bat
+endlocal
 
-:EnvSet
+REM setlocal to prepare for vsdevcmd.bat
+setlocal
 
-:: Log build command line
-set _buildproj=%~dp0build.proj
-set _buildlog=%~dp0msbuild.log
-set _buildprefix=echo
-set _buildpostfix=^> "%_buildlog%"
-call :build %*
+rem Explicitly set Platform causes conflicts in managed project files. Clear it to allow building from VS x64 Native Tools Command Prompt
+set Platform=
 
-:: Build
-set _buildprefix=
-set _buildpostfix=
-call :build %*
-
-goto :AfterBuild
-
-:build
-%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%_buildlog%";Append %* %_buildpostfix%
-set BUILDERRORLEVEL=%ERRORLEVEL%
-goto :eof
-
-:AfterBuild
-
+:: Set the environment for the managed build
+call "!VS%__VSProductVersion%COMNTOOLS!\VsDevCmd.bat"
+echo Commencing build of ILToNative for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
-:: Pull the build summary from the log file
-findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%_buildlog%"
-echo Build Exit Code = %BUILDERRORLEVEL%
+set "__ILToNativeBuildLog=%__LogsDir%\ILToNative_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
+%_msbuildexe% "%__ProjectDir%\build.proj" %__MSBCleanBuildArgs% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__ILToNativeBuildLog%"
+IF NOT ERRORLEVEL 1 (
+  findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%__ILToNativeBuildLog%"
+  goto AfterILToNativeBuild
+)
+echo ILToNative build failed. Refer !__ILToNativeBuildLog! for details.
+exit /b 1
 
-exit /b %BUILDERRORLEVEL%
+
+:AfterILToNativeBuild
+

--- a/build.proj
+++ b/build.proj
@@ -34,7 +34,7 @@
 
   <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
   <Target Name="Clean">
-    <RemoveDir Directories="$(BinDir)" />
+    <RemoveDir Directories="$(ObjDir)" />
   </Target>
 
 </Project>

--- a/src/ILToNative/repro/repro.csproj
+++ b/src/ILToNative/repro/repro.csproj
@@ -12,6 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <CLSCompliant>false</CLSCompliant>
+    <ExcludeResourcesImport>true</ExcludeResourcesImport>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/ILToNative/src/ILToNative.csproj
+++ b/src/ILToNative/src/ILToNative.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <CLSCompliant>false</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ExcludeResourcesImport>true</ExcludeResourcesImport>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/ILToNative/src/project.json
+++ b/src/ILToNative/src/project.json
@@ -3,16 +3,16 @@
     "System.Runtime": "4.0.20",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.IO": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.IO": "4.0.10",
     "System.IO.FileSystem": "4.0.0",
-    "System.Collections": "4.0.0",
-    "System.Text.Encoding": "4.0.0",
-    "System.Runtime.InteropServices": "4.0.10",
+    "System.Collections": "4.0.10",
+    "System.Text.Encoding": "4.0.10",
+    "System.Runtime.InteropServices": "4.0.20",
     "System.Reflection": "4.0.0",
     "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.0",
-    "System.Text.Encoding.Extensions": "4.0.0",
+    "System.Threading": "4.0.10",
+    "System.Text.Encoding.Extensions": "4.0.10",
     "System.Reflection.Extensions": "4.0.0",
     "System.Console": "4.0.0-beta-*",
     "System.AppContext": "4.0.0",
@@ -20,6 +20,6 @@
     "System.Reflection.Metadata": "1.0.22"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dotnet": {}
   }
 }

--- a/src/TypeSystem.Ecma/src/TypeSystem.Ecma.csproj
+++ b/src/TypeSystem.Ecma/src/TypeSystem.Ecma.csproj
@@ -12,6 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <CLSCompliant>false</CLSCompliant>
+    <ExcludeResourcesImport>true</ExcludeResourcesImport>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/TypeSystem.Ecma/src/project.json
+++ b/src/TypeSystem.Ecma/src/project.json
@@ -17,6 +17,6 @@
     "System.Reflection.Metadata": "1.0.22"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dotnet": {}
   }
 }

--- a/src/TypeSystem/src/TypeSystem.csproj
+++ b/src/TypeSystem/src/TypeSystem.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <CLSCompliant>false</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ExcludeResourcesImport>true</ExcludeResourcesImport>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/TypeSystem/src/project.json
+++ b/src/TypeSystem/src/project.json
@@ -16,6 +16,6 @@
     "System.Reflection.Extensions": "4.0.0"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dotnet": {}
   }
 }


### PR DESCRIPTION
- The CoreFX build.cmd we used as the baseline doesn't need to handle
  native build and it can afford to just pass it's command line arguments
  to msbuild verbatim. We won't have that luxury in CoreRT since we have
  native bits on Windows too.
- Fix up project.json files to remove the annoying downgrade warning
  messages in Visual Studio.
- Change framework in project.json to dotnet, since the other one is
  apparently ASP.NET specific.
- Disable the framework resource handling that makes our projects include
  a phantom Common\src\System\SR.cs file.

I'm not fixing everything with this. We are still using a bunch of
*.target files designed to build the framework to build a compiler,
after all. I don't want to remove that support, because eventually we
will also be building pieces of the framework here, but clearly we need
a way to distinguish between "this is a compiler assembly" and "this is
a framework assembly" at some point.
