### PR TITLE
Fix build break

### DIFF
--- a/src/TypeSystem/src/Common/VirtualFunctionResolution.cs
+++ b/src/TypeSystem/src/Common/VirtualFunctionResolution.cs
@@ -44,7 +44,7 @@ namespace Internal.TypeSystem
             public void RemoveFromGroup(MethodDesc method)
             {
                 if (method == DefiningMethod)
-                    throw new InvalidProgramException();
+                    throw new BadImageFormatException();
 
                 Members.Remove(method);
             }

--- a/src/TypeSystem/src/TypeSystem.csproj
+++ b/src/TypeSystem/src/TypeSystem.csproj
@@ -54,7 +54,9 @@
     <Compile Include="Common\WellKnownType.cs" />
     <Compile Include="Common\FieldDesc.cs" />
     <Compile Include="Common\MethodDesc.cs" />
+    <Compile Include="Common\VirtualFunctionResolution.cs" />
     <Compile Include="Common\TypeDesc.cs" />
+    <Compile Include="Common\TypeDesc.MethodImpls.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
Since we only build standalone TypeSystem from build.cmd, it's pretty
easy to get this out of sync.

InvalidProgramException is not in the portable subset. We build the type system as a portable library. We will need to replace these with custom exceptions soon anyway.
