### PR TITLE
Improve name mangling

### DIFF
--- a/src/ILToNative/reproNative/reproNativeCpp.vcxproj
+++ b/src/ILToNative/reproNative/reproNativeCpp.vcxproj
@@ -53,7 +53,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CPPCODEGEN;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <PrecompiledHeaderFile>common.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\Native\gc;..\..\Native\gc\env</AdditionalIncludeDirectories>
@@ -71,7 +71,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CPPCODEGEN;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <PrecompiledHeaderFile>common.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\gc;..\..\Native\gc\env</AdditionalIncludeDirectories>

--- a/src/ILToNative/reproNative/stubs.cpp
+++ b/src/ILToNative/reproNative/stubs.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using namespace mscorlib;
+
 //
 // BoundsChecking
 //

--- a/src/ILToNative/src/Compiler/AsmWriter.cs
+++ b/src/ILToNative/src/Compiler/AsmWriter.cs
@@ -16,12 +16,13 @@ namespace ILToNative
 
             foreach (var t in _registeredTypes.Values)
             {
-                RegisteredMethod m = t.Methods;
-                while (m != null)
+                if (t.Methods != null)
                 {
-                    if (m.MethodCode != null)
-                        OutputMethodCode(m);
-                    m = m.Next;
+                    foreach (var m in t.Methods)
+                    {
+                        if (m.MethodCode != null)
+                            OutputMethodCode(m);
+                    }
                 }
             }
 

--- a/src/ILToNative/src/Compiler/Compilation.cs
+++ b/src/ILToNative/src/Compiler/Compilation.cs
@@ -290,20 +290,23 @@ namespace ILToNative
                 return;
             reg.IncludedInCompilation = true;
 
+            RegisteredType regType = GetRegisteredType(method.OwningType);
+            if (regType.Methods == null)
+                regType.Methods = new List<RegisteredMethod>();
+            regType.Methods.Add(reg);
+
             if (_methodsThatNeedsCompilation == null)
                 _methodsThatNeedsCompilation = new List<MethodDesc>();
             _methodsThatNeedsCompilation.Add(method);
 
-            NameMangler.GetMangledMethodName(method);
-
             if (_options.IsCppCodeGen)
             {
                 // Precreate name to ensure that all types referenced by signatures are present
-                NameMangler.GetMangledTypeName(method.OwningType);
+                GetRegisteredType(method.OwningType);
                 var signature = method.Signature;
-                NameMangler.GetMangledTypeName(signature.ReturnType);
+                GetRegisteredType(signature.ReturnType);
                 for (int i = 0; i < signature.Length; i++)
-                    NameMangler.GetMangledTypeName(signature[i]);
+                    GetRegisteredType(signature[i]);
             }
         }
 
@@ -352,8 +355,8 @@ namespace ILToNative
             if (_options.IsCppCodeGen)
             {
                 // Precreate name to ensure that all types referenced by signatures are present
-                NameMangler.GetMangledTypeName(field.OwningType);
-                NameMangler.GetMangledTypeName(field.FieldType);
+                GetRegisteredType(field.OwningType);
+                GetRegisteredType(field.FieldType);
             }
         }
 

--- a/src/ILToNative/src/Compiler/RegisteredMethod.cs
+++ b/src/ILToNative/src/Compiler/RegisteredMethod.cs
@@ -13,10 +13,6 @@ namespace ILToNative
 
         public bool IncludedInCompilation;
 
-        public string MangledName;
-
         public Object MethodCode;
-
-        public RegisteredMethod Next;
     }
 }

--- a/src/ILToNative/src/Compiler/RegisteredType.cs
+++ b/src/ILToNative/src/Compiler/RegisteredType.cs
@@ -15,12 +15,9 @@ namespace ILToNative
         public bool IncludedInCompilation;
         public bool Constructed;
 
-        public int UniqueMethod;
-
-        public string MangledName;
         public string MangledSignatureName; // CppCodeGen specific
 
-        public RegisteredMethod Methods;
+        public List<RegisteredMethod> Methods;
 
         public List<MethodDesc> VirtualSlots;
     }

--- a/src/ILToNative/src/CppCodeGen/CppWriter.cs
+++ b/src/ILToNative/src/CppCodeGen/CppWriter.cs
@@ -613,12 +613,13 @@ namespace ILToNative.CppCodeGen
                     _statics.AppendLine("bool __cctor_" + GetCppTypeName(t.Type).Replace("::", "__") + ";");
                 }
 
-                RegisteredMethod m = t.Methods;
-                while (m != null)
+                if (t.Methods != null)
                 {
-                    if (m.IncludedInCompilation)
-                        OutputMethod(m);
-                    m = m.Next;
+                    foreach (var m in t.Methods)
+                    {
+                        if (m.IncludedInCompilation)
+                            OutputMethod(m);
+                    }
                 }
                 Out.Write("};");
             }
@@ -860,12 +861,14 @@ namespace ILToNative.CppCodeGen
                 {
                     Out.WriteLine(GetCodeForType(t.Type));
                 }
-                RegisteredMethod m = t.Methods;
-                while (m != null)
+
+                if (t.Methods != null)
                 {
-                    if (m.MethodCode != null)
-                        Out.WriteLine(m.MethodCode);
-                    m = m.Next;
+                    foreach (var m in t.Methods)
+                    {
+                        if (m.MethodCode != null)
+                            Out.WriteLine(m.MethodCode);
+                    }
                 }
             }
 

--- a/src/ILToNative/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILToNative/src/CppCodeGen/ILToCppImporter.cs
@@ -824,7 +824,7 @@ namespace Internal.IL
                 if (delegateInvoke)
                 {
                     _stack[_stackTop - (methodSignature.Length + 1)].Value.Name =
-                        "((System::Delegate *)" +
+                        "((" + _writer.GetCppSignatureTypeName(GetWellKnownType(WellKnownType.MulticastDelegate)) + ")" +
                             _stack[_stackTop - (methodSignature.Length + 1)].Value.Name + ")->m_firstParameter";
                 }
             }

--- a/src/TypeSystem/src/Common/InstantiatedMethod.cs
+++ b/src/TypeSystem/src/Common/InstantiatedMethod.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Text;
 
 namespace Internal.TypeSystem
 {
@@ -91,8 +92,12 @@ namespace Internal.TypeSystem
 
         public override string ToString()
         {
-            // TODO: Append instantiation
-            return _methodDef.ToString();
+            var sb = new StringBuilder(_methodDef.ToString());
+            sb.Append('<');
+            for (int i = 0; i < _instantiation.Length; i++)
+                sb.Append(_instantiation[i].ToString());
+            sb.Append('>');
+            return sb.ToString();
         }
     }
 }

--- a/src/TypeSystem/src/Common/InstantiatedType.cs
+++ b/src/TypeSystem/src/Common/InstantiatedType.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -202,6 +203,16 @@ namespace Internal.TypeSystem
         public override TypeDesc GetTypeDefinition()
         {
             return _typeDef;
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder(_typeDef.ToString());
+            sb.Append('<');
+            for (int i = 0; i < _instantiation.Length; i++)
+                sb.Append(_instantiation[i].ToString());
+            sb.Append('>');
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
- Prefix mangled type names by simple name of the containing module.
- Append instantiation to the mangled names of generic types and methods.
- Made names generated by the name mangler independent on the compilation order
- Made name mangler is thread safe by using immutable collections
- Avoid unnecessary copies while generating the mangled name
- Fix break in reproNative.vcxproj introduced by my recent commit

The one issue left is that the name mangling is not yet robust against collisions with built-in C++ identifiers or our internal identifiers.
