### PR TITLE
Fix project GUID in the ProjectReference from ILToNative

### DIFF
--- a/src/ILToNative/src/ILToNative.csproj
+++ b/src/ILToNative/src/ILToNative.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ILToNative.TypeSystem\src\ILToNative.TypeSystem.csproj">
-      <Project>{dd5b6baa-d41a-4a6e-9e7d-83060f394b10}</Project>
+      <Project>{1a9df196-43a9-44bb-b2c6-d62aa56b0e49}</Project>
       <Name>ILToNative.TypeSystem</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Managed to get the GUID wrong. Build.cmd doesn't care about it, but
Visual Studio project system does.
