### PR TITLE
Dependency Analysis Framework

### DIFF
--- a/src/ILToNative.DependencyAnalysisFramework/ILToNative.DependencyAnalysisFramework.sln
+++ b/src/ILToNative.DependencyAnalysisFramework/ILToNative.DependencyAnalysisFramework.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23023.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.DependencyAnalysisFramework.Tests", "tests\ILToNative.DependencyAnalysisFramework.Tests.csproj", "{90076B9B-918B-49DD-8ADE-E76426D60B4D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.DependencyAnalysisFramework", "src\ILToNative.DependencyAnalysisFramework.csproj", "{DAC23E9F-F826-4577-AE7A-0849FF83280C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{90076B9B-918B-49DD-8ADE-E76426D60B4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90076B9B-918B-49DD-8ADE-E76426D60B4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90076B9B-918B-49DD-8ADE-E76426D60B4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90076B9B-918B-49DD-8ADE-E76426D60B4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/ILToNative.DependencyAnalysisFramework/src/ComputedStaticDependencyNode.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/ComputedStaticDependencyNode.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public abstract class ComputedStaticDependencyNode<DependencyContextType> : DependencyNodeCore<DependencyContextType>
+    {
+        private IEnumerable<DependencyListEntry> _dependencies;
+        private IEnumerable<CombinedDependencyListEntry> _conditionalDependencies;
+        private static CombinedDependencyListEntry[] s_emptyDynamicList = new CombinedDependencyListEntry[0];
+
+        public void SetStaticDependencies(IEnumerable<DependencyListEntry> dependencies,
+                                          IEnumerable<CombinedDependencyListEntry> conditionalDependencies)
+        {
+            Debug.Assert(_dependencies == null);
+            Debug.Assert(_conditionalDependencies == null);
+            Debug.Assert(dependencies != null);
+
+            _dependencies = dependencies;
+            _conditionalDependencies = conditionalDependencies;
+        }
+
+        public override bool HasConditionalStaticDependencies
+        {
+            get
+            {
+                return _conditionalDependencies != null;
+            }
+        }
+
+        public override bool HasDynamicDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return _dependencies != null;
+            }
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(DependencyContextType context)
+        {
+            return _conditionalDependencies;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(DependencyContextType context)
+        {
+            return _dependencies;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<DependencyContextType>> markedNodes, int firstNode, DependencyContextType context)
+        {
+            return s_emptyDynamicList;
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
@@ -1,0 +1,280 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    /// <summary>
+    /// Implement a dependency analysis framework. This works much like a Garbage Collector's mark algorithm
+    /// in that it finds a set of nodes from an initial root set.
+    /// 
+    /// However, in contrast to a typical GC in addition to simple edges from a node, there may also
+    /// be conditional edges where a node has a dependency if some other specific node exists in the
+    /// graph, and dynamic edges in which a node has a dependency if some other node exists in the graph,
+    /// but what that other node might be is not known until it may exist in the graph.
+    /// 
+    /// This analyzer also attempts to maintain a serialized state of why nodes are in the graph
+    /// with strings describing the reason a given node was added to the graph. The degree of logging
+    /// is configurable via the MarkStrategy
+    /// 
+    /// </summary>
+    public sealed class DependencyAnalyzer<MarkStrategy, DependencyContextType> : DependencyAnalyzerBase<DependencyContextType> where MarkStrategy: struct, IDependencyAnalysisMarkStrategy<DependencyContextType>
+    {
+        private MarkStrategy _marker = new MarkStrategy();
+        private DependencyContextType _dependencyContext;
+        private IComparer<DependencyNodeCore<DependencyContextType>> _resultSorter = null;
+
+        private Stack<DependencyNodeCore<DependencyContextType>> _markStack = new Stack<DependencyNodeCore<DependencyContextType>>();
+        private List<DependencyNodeCore<DependencyContextType>> _markedNodes = new List<DependencyNodeCore<DependencyContextType>>();
+        private ImmutableArray<DependencyNodeCore<DependencyContextType>> _markedNodesFinal;
+        private List<DependencyNodeCore<DependencyContextType>> _rootNodes = new List<DependencyNodeCore<DependencyContextType>>();
+        private List<DependencyNodeCore<DependencyContextType>> _deferredStaticDependencies = new List<DependencyNodeCore<DependencyContextType>>();
+        private List<DependencyNodeCore<DependencyContextType>> _dynamicDependencyInterestingList = new List<DependencyNodeCore<DependencyContextType>>();
+        private List<DynamicDependencyNode> _markedNodesWithDynamicDependencies = new List<DynamicDependencyNode>();
+        private bool _newDynamicDependenciesMayHaveAppeared = false;
+
+        private Dictionary<DependencyNodeCore<DependencyContextType>, HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry>> _conditional_dependency_store = new Dictionary<DependencyNodeCore<DependencyContextType>, HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry>>();
+        private bool _markingCompleted = false;
+
+        private struct DynamicDependencyNode
+        {
+            private DependencyNodeCore<DependencyContextType> _node;
+            private int _next;
+
+            public DynamicDependencyNode(DependencyNodeCore<DependencyContextType> node)
+            {
+                _node = node;
+                _next = 0;
+            }
+
+            public void MarkNewDynamicDependencies(DependencyAnalyzer<MarkStrategy, DependencyContextType> analyzer)
+            {
+                foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in 
+                    _node.SearchDynamicDependencies(analyzer._dynamicDependencyInterestingList, _next, analyzer._dependencyContext))
+                {
+                    analyzer.AddToMarkStack(dependency.Node, dependency.Reason, _node, dependency.OtherReasonNode);
+                }
+                _next = analyzer._dynamicDependencyInterestingList.Count;
+            }
+        }
+
+        // Api surface
+        public DependencyAnalyzer(DependencyContextType dependencyContext, IComparer<DependencyNodeCore<DependencyContextType>> resultSorter)
+        {
+            _dependencyContext = dependencyContext;
+            _resultSorter = resultSorter;
+        }
+
+        /// <summary>
+        /// Add a root node
+        /// </summary>
+        public override sealed void AddRoot(DependencyNodeCore<DependencyContextType> rootNode, string reason)
+        {
+            if (AddToMarkStack(rootNode, reason, null, null))
+            {
+                _rootNodes.Add(rootNode);
+            }
+        }
+
+        public override sealed ImmutableArray<DependencyNodeCore<DependencyContextType>> MarkedNodeList
+        {
+            get
+            {
+                if (!_markingCompleted)
+                {
+                    _markingCompleted = true;
+                    ComputeMarkedNodes();
+                }
+
+                return _markedNodesFinal;
+            }
+        }
+
+        public override sealed event Action<DependencyNodeCore<DependencyContextType>> NewMarkedNode;
+
+        public override sealed event Action<List<DependencyNodeCore<DependencyContextType>>> ComputeDependencyRoutine;
+
+
+        private IEnumerable<DependencyNodeCore<DependencyContextType>> MarkedNodesEnumerable()
+        {
+            if (_markedNodesFinal != null)
+                return _markedNodesFinal;
+            else
+                return _markedNodes;
+        }
+
+        public override sealed void VisitLogNodes(IDependencyAnalyzerLogNodeVisitor logNodeVisitor)
+        {
+            foreach (DependencyNode node in MarkedNodesEnumerable())
+            {
+                logNodeVisitor.VisitNode(node);
+            }
+            _marker.VisitLogNodes(MarkedNodesEnumerable(), logNodeVisitor);
+        }
+
+        public override sealed void VisitLogEdges(IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor)
+        {
+            _marker.VisitLogEdges(MarkedNodesEnumerable(), logEdgeVisitor);
+        }
+
+
+        /// <summary>
+        /// Called by the algorithm to ensure that this set of nodes is processed such that static dependencies are computed.
+        /// </summary>
+        /// <param name="deferredStaticDependencies">List of nodes which must have static dependencies computed</param>
+        private void ComputeDependencies(List<DependencyNodeCore<DependencyContextType>> deferredStaticDependencies)
+        {
+            if (ComputeDependencyRoutine != null)
+                ComputeDependencyRoutine(deferredStaticDependencies);
+        }
+
+        // Internal details
+        void GetStaticDependenciesImpl(DependencyNodeCore<DependencyContextType> node)
+        {
+            foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in node.GetStaticDependencies(_dependencyContext))
+            {
+                AddToMarkStack(dependency.Node, dependency.Reason, node, null);
+            }
+
+            if (node.HasConditionalStaticDependencies)
+            {
+                foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in node.GetConditionalStaticDependencies(_dependencyContext))
+                {
+                    if (dependency.OtherReasonNode.Marked)
+                    {
+                        AddToMarkStack(dependency.Node, dependency.Reason, node, dependency.OtherReasonNode);
+                    }
+                    else
+                    {
+                        HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> storedDependencySet = null;
+                        if (!_conditional_dependency_store.TryGetValue(dependency.OtherReasonNode, out storedDependencySet))
+                        {
+                            storedDependencySet = new HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry>();
+                            _conditional_dependency_store.Add(dependency.OtherReasonNode, storedDependencySet);
+                        }
+                        // Swap out other reason node as we're storing that as the dictionary key
+                        DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry conditionalDependencyStoreEntry = new DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry();
+                        conditionalDependencyStoreEntry.Node = dependency.Node;
+                        conditionalDependencyStoreEntry.Reason = dependency.Reason;
+                        conditionalDependencyStoreEntry.OtherReasonNode = node;
+
+                        storedDependencySet.Add(conditionalDependencyStoreEntry);
+                    }
+                }
+            }
+        }
+
+        private void GetStaticDependencies(DependencyNodeCore<DependencyContextType> node)
+        {
+            if (node.StaticDependenciesAreComputed)
+            {
+                GetStaticDependenciesImpl(node);
+            }
+            else
+            {
+                _deferredStaticDependencies.Add(node);
+            }
+        }
+
+        private void ProcessMarkStack()
+        {
+            do
+            {
+                while (_markStack.Count > 0)
+                {
+                    // Pop the top node of the mark stack
+                    DependencyNodeCore<DependencyContextType> currentNode = _markStack.Pop();
+
+                    Debug.Assert(currentNode.Marked);
+
+                    // Only some marked objects are interesting for dynamic dependencies
+                    // store those in a seperate list to avoid excess scanning over non-interesting
+                    // nodes during dynamic dependency discovery
+                    if (currentNode.InterestingForDynamicDependencyAnalysis)
+                    {
+                        _dynamicDependencyInterestingList.Add(currentNode);
+                        _newDynamicDependenciesMayHaveAppeared = true;
+                    }
+
+                    // Add all static dependencies to the mark stack
+                    GetStaticDependencies(currentNode);
+
+                    // If there are dynamic dependencies, note for later
+                    if (currentNode.HasDynamicDependencies)
+                    {
+                        _newDynamicDependenciesMayHaveAppeared = true;
+                        _markedNodesWithDynamicDependencies.Add(new DynamicDependencyNode(currentNode));
+                    }
+
+                    // If this new node satisfies any stored conditional dependencies, 
+                    // add them to the mark stack
+                    HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> storedDependencySet = null;
+                    if (_conditional_dependency_store.TryGetValue(currentNode, out storedDependencySet))
+                    {
+                        foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry newlySatisfiedDependency in storedDependencySet)
+                        {
+                            AddToMarkStack(newlySatisfiedDependency.Node, newlySatisfiedDependency.Reason, newlySatisfiedDependency.OtherReasonNode, currentNode);
+                        }
+
+                        _conditional_dependency_store.Remove(currentNode);
+                    }
+
+                    if (NewMarkedNode != null)
+                        NewMarkedNode(currentNode);
+                }
+
+                // Find new dependencies introduced by dynamic depedencies
+                if (_newDynamicDependenciesMayHaveAppeared)
+                {
+                    _newDynamicDependenciesMayHaveAppeared = false;
+                    foreach (DynamicDependencyNode dynamicNode in _markedNodesWithDynamicDependencies)
+                    {
+                        dynamicNode.MarkNewDynamicDependencies(this);
+                    }
+                }
+            } while (_markStack.Count != 0);
+        }
+
+        void ComputeMarkedNodes()
+        {
+            do
+            {
+                // Run mark stack algorithm as much as possible
+                ProcessMarkStack();
+
+                // Compute all dependencies which were not ready during the ProcessMarkStack step
+                ComputeDependencies(_deferredStaticDependencies);
+                foreach (DependencyNodeCore<DependencyContextType> node in _deferredStaticDependencies)
+                {
+                    Debug.Assert(node.StaticDependenciesAreComputed);
+                    GetStaticDependenciesImpl(node);
+                }
+
+                _deferredStaticDependencies.Clear();
+            } while (_markStack.Count != 0);
+
+            if (_resultSorter != null)
+                _markedNodes.Sort(_resultSorter);
+
+            _markedNodesFinal = _markedNodes.ToImmutableArray();
+            _markedNodes = null;
+        }
+
+        private bool AddToMarkStack(DependencyNodeCore<DependencyContextType> node, string reason, DependencyNodeCore<DependencyContextType> reason1, DependencyNodeCore<DependencyContextType> reason2)
+        {
+            if (_marker.MarkNode(node, reason1, reason2, reason))
+            {
+                _markStack.Push(node);
+                _markedNodes.Add(node);
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/DependencyAnalyzerBase.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DependencyAnalyzerBase.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    /// <summary>
+    /// Api for dependency analyzer. The expected use pattern is that a set of nodes will be added to the
+    /// graph as roots. These nodes will internally implement the various dependency details
+    /// so that if MarkedNodeList is called, it can produce the complete graph. For the case
+    /// where nodes have deferred computation the ComputeDependencyRoutine even will be triggered
+    /// to fill in data.
+    /// 
+    /// The Log visitor logic can be called at any time, and should log the current set of marked 
+    /// nodes and edges in the analysis. (Notably, if its called before MarkedNodeList is evaluated
+    /// it will contain only roots, if its called during, the edges/nodes may be incomplete, and
+    /// if called after MarkedNodeList is computed it will be a complete graph.
+    /// 
+    /// </summary>
+    /// <typeparam name="DependencyContextType"></typeparam>
+    public abstract class DependencyAnalyzerBase<DependencyContextType>
+    {
+        /// <summary>
+        /// Add a root node
+        /// </summary>
+        public abstract void AddRoot(DependencyNodeCore<DependencyContextType> rootNode, string reason);
+
+        /// <summary>
+        /// Return the marked node list. Do not modify this list, as it will cause unexpected behavior.
+        /// </summary>
+        public abstract ImmutableArray<DependencyNodeCore<DependencyContextType>> MarkedNodeList
+        {
+            get;
+        }
+
+        /// <summary>
+        /// This event is triggered when a node is added to the graph.
+        /// </summary>
+        public abstract event Action<DependencyNodeCore<DependencyContextType>> NewMarkedNode;
+
+        /// <summary>
+        /// This event is triggered when the algorithm requires that dependencies of some set of
+        /// nodes be computed.
+        /// </summary>
+
+        public abstract event Action<List<DependencyNodeCore<DependencyContextType>>> ComputeDependencyRoutine;
+
+        /// <summary>
+        /// Used to walk all nodes that should be emitted to a log. Not intended for other purposes.
+        /// </summary>
+        /// <param name="logNodeVisitor"></param>
+        public abstract void VisitLogNodes(IDependencyAnalyzerLogNodeVisitor logNodeVisitor);
+
+        /// <summary>
+        /// Used to walk the logical edges in the graph as part of log building.
+        /// </summary>
+        /// <param name="logEdgeVisitor"></param>
+        public abstract void VisitLogEdges(IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor);
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/DependencyNode.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DependencyNode.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public class DependencyNode
+    {
+        private object _mark;
+
+        // Only DependencyNodeCore<T> is allowed to derive from this
+        internal DependencyNode()
+        { }
+
+        internal void SetMark(object mark)
+        {
+            _mark = mark;
+        }
+        internal object GetMark()
+        {
+            return _mark;
+        }
+
+        public bool Marked
+        {
+            get
+            {
+                return _mark != null;
+            }
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/DependencyNodeCore.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DependencyNodeCore.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public abstract class DependencyNodeCore<DependencyContextType> : DependencyNode
+    {
+        public struct DependencyListEntry
+        {
+            public DependencyListEntry(DependencyNodeCore<DependencyContextType> node,
+                                       string reason)
+            {
+                Node = node;
+                Reason = reason;
+            }
+
+            public DependencyNodeCore<DependencyContextType> Node;
+            public string Reason;
+        }
+
+        public struct CombinedDependencyListEntry
+        {
+            public CombinedDependencyListEntry(DependencyNodeCore<DependencyContextType> node,
+                                               DependencyNodeCore<DependencyContextType> otherReasonNode,
+                                               string reason)
+            {
+                Node = node;
+                OtherReasonNode = otherReasonNode;
+                Reason = reason;
+            }
+
+            // Used by HashSet, so must have good Equals/GetHashCode
+            public DependencyNodeCore<DependencyContextType> Node;
+            public DependencyNodeCore<DependencyContextType> OtherReasonNode;
+            public string Reason;
+        }
+
+        public abstract bool InterestingForDynamicDependencyAnalysis
+        {
+            get;
+        }
+
+        public abstract bool HasDynamicDependencies
+        {
+            get;
+        }
+
+        public abstract bool HasConditionalStaticDependencies
+        {
+            get;
+        }
+
+        public abstract bool StaticDependenciesAreComputed
+        {
+            get;
+        }
+
+        public abstract IEnumerable<DependencyListEntry> GetStaticDependencies(DependencyContextType context);
+
+        public abstract IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(DependencyContextType context);
+
+        public abstract IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<DependencyContextType>> markedNodes, int firstNode, DependencyContextType context);
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/DgmlWriter.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DgmlWriter.cs
@@ -1,0 +1,183 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.IO;
+using System.Diagnostics;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public class DgmlWriter : IDisposable, IDependencyAnalyzerLogEdgeVisitor, IDependencyAnalyzerLogNodeVisitor
+    {
+        XmlWriter _xmlWrite;
+        bool _done = false;
+        public DgmlWriter(XmlWriter xmlWrite)
+        {
+            _xmlWrite = xmlWrite;
+            _xmlWrite.WriteStartDocument();
+            _xmlWrite.WriteStartElement("DirectedGraph", "http://schemas.microsoft.com/vs/2009/dgml");
+        }
+
+        public void WriteNodesAndEdges(Action<Action<object>> nodeWriter, Action<Action<object, object, string>> edgeWriter)
+        {
+
+            _xmlWrite.WriteStartElement("Nodes");
+            {
+                nodeWriter(AddNode);
+            }
+            _xmlWrite.WriteEndElement();
+
+            _xmlWrite.WriteStartElement("Links");
+            {
+                edgeWriter(AddReason);
+            }
+            _xmlWrite.WriteEndElement();
+        }
+
+        public static void WriteDependencyGraphToStream<DependencyContextType>(Stream stream, DependencyAnalyzerBase<DependencyContextType> analysis)
+        {
+            XmlWriterSettings writerSettings = new XmlWriterSettings();
+            writerSettings.Indent = true;
+            writerSettings.IndentChars = " ";
+
+            using (XmlWriter xmlWriter = XmlWriter.Create(stream, writerSettings))
+            {
+                using (DgmlWriter dgmlWriter = new DgmlWriter(xmlWriter))
+                {
+                    dgmlWriter.WriteNodesAndEdges((Action<Object> writeNode) =>
+                    {
+                        analysis.VisitLogNodes(dgmlWriter);
+                    },
+                    (Action<object, object, string> writeEdge) =>
+                    {
+                        analysis.VisitLogEdges(dgmlWriter);
+                    }
+                    );
+                }
+            }
+        }
+
+        public void Close()
+        {
+            if (!_done)
+            {
+                _done = true;
+                _xmlWrite.WriteStartElement("Properties");
+                {
+                    _xmlWrite.WriteStartElement("Property");
+                    _xmlWrite.WriteAttributeString("Id", "Label");
+                    _xmlWrite.WriteAttributeString("Label", "Label");
+                    _xmlWrite.WriteAttributeString("DataType", "String");
+                    _xmlWrite.WriteEndElement();
+
+                    _xmlWrite.WriteStartElement("Property");
+                    _xmlWrite.WriteAttributeString("Id", "Reason");
+                    _xmlWrite.WriteAttributeString("Label", "Reason");
+                    _xmlWrite.WriteAttributeString("DataType", "String");
+                    _xmlWrite.WriteEndElement();
+                }
+                _xmlWrite.WriteEndElement();
+
+                _xmlWrite.WriteEndElement();
+                _xmlWrite.WriteEndDocument();
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            Close();
+        }
+
+        Dictionary<object, int> _nodeMappings = new Dictionary<object, int>();
+        int _nodeNextId = 0;
+
+        void AddNode(object node)
+        {
+            int nodeId = _nodeNextId++;
+            Debug.Assert(!_nodeMappings.ContainsKey(node));
+
+            _nodeMappings.Add(node, nodeId);
+
+            _xmlWrite.WriteStartElement("Node");
+            _xmlWrite.WriteAttributeString("Id", nodeId.ToString());
+            _xmlWrite.WriteAttributeString("Label", node.ToString());
+            _xmlWrite.WriteEndElement();
+        }
+
+        void AddReason(object nodeA, object nodeB, string reason)
+        {
+            _xmlWrite.WriteStartElement("Link");
+            _xmlWrite.WriteAttributeString("Source", _nodeMappings[nodeA].ToString());
+            _xmlWrite.WriteAttributeString("Target", _nodeMappings[nodeB].ToString());
+            _xmlWrite.WriteAttributeString("Reason", reason);
+            _xmlWrite.WriteEndElement();
+        }
+
+        void IDependencyAnalyzerLogEdgeVisitor.VisitEdge(DependencyNode nodeDepender, DependencyNode nodeDependedOn, string reason)
+        {
+            _xmlWrite.WriteStartElement("Link");
+            _xmlWrite.WriteAttributeString("Source", _nodeMappings[nodeDepender].ToString());
+            _xmlWrite.WriteAttributeString("Target", _nodeMappings[nodeDependedOn].ToString());
+            _xmlWrite.WriteAttributeString("Reason", reason);
+            _xmlWrite.WriteAttributeString("Stroke", "#FF0000");
+            _xmlWrite.WriteEndElement();
+        }
+
+        void IDependencyAnalyzerLogEdgeVisitor.VisitEdge(string root, DependencyNode dependedOn)
+        {
+            AddReason(root, dependedOn, null);
+        }
+
+        void IDependencyAnalyzerLogNodeVisitor.VisitCombinedNode(Tuple<DependencyNode, DependencyNode> node)
+        {
+            AddNode(node);
+        }
+
+        HashSet<Tuple<DependencyNode, DependencyNode>> _combinedNodesEdgeVisited = new HashSet<Tuple<DependencyNode, DependencyNode>>();
+
+        void IDependencyAnalyzerLogEdgeVisitor.VisitEdge(DependencyNode nodeDepender, DependencyNode nodeDependerOther, DependencyNode nodeDependedOn, string reason)
+        {
+            Tuple<DependencyNode, DependencyNode> combinedNode = new Tuple<DependencyNode, DependencyNode>(nodeDepender, nodeDependerOther);
+            if (!_combinedNodesEdgeVisited.Contains(combinedNode))
+            {
+                _combinedNodesEdgeVisited.Add(combinedNode);
+
+                _xmlWrite.WriteStartElement("Link");
+                _xmlWrite.WriteAttributeString("Source", _nodeMappings[nodeDepender].ToString());
+                _xmlWrite.WriteAttributeString("Target", _nodeMappings[combinedNode].ToString());
+                _xmlWrite.WriteAttributeString("Reason", "Primary");
+                _xmlWrite.WriteAttributeString("Stroke", "#00FF00");
+                _xmlWrite.WriteEndElement();
+
+                _xmlWrite.WriteStartElement("Link");
+                _xmlWrite.WriteAttributeString("Source", _nodeMappings[nodeDependerOther].ToString());
+                _xmlWrite.WriteAttributeString("Target", _nodeMappings[combinedNode].ToString());
+                _xmlWrite.WriteAttributeString("Reason", "Secondary");
+                _xmlWrite.WriteAttributeString("Stroke", "#00FF00");
+                _xmlWrite.WriteEndElement();
+            }
+
+            _xmlWrite.WriteStartElement("Link");
+            _xmlWrite.WriteAttributeString("Source", _nodeMappings[combinedNode].ToString());
+            _xmlWrite.WriteAttributeString("Target", _nodeMappings[nodeDependedOn].ToString());
+            _xmlWrite.WriteAttributeString("Reason", reason);
+            _xmlWrite.WriteAttributeString("Stroke", "#0000FF");
+            _xmlWrite.WriteEndElement();
+        }
+
+        void IDependencyAnalyzerLogNodeVisitor.VisitNode(DependencyNode node)
+        {
+            AddNode(node);
+        }
+
+        void IDependencyAnalyzerLogNodeVisitor.VisitRootNode(string rootName)
+        {
+            AddNode(rootName);
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/FirstMarkLogStrategy.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/FirstMarkLogStrategy.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.IO;
+using System.Diagnostics;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public struct FirstMarkLogStrategy<DependencyContextType> : IDependencyAnalysisMarkStrategy<DependencyContextType>
+    {
+        private class MarkData
+        {
+            public MarkData(string reason, DependencyNodeCore<DependencyContextType> reason1, DependencyNodeCore<DependencyContextType> reason2)
+            {
+                Reason = reason;
+                Reason1 = reason1;
+                Reason2 = reason2;
+            }
+
+            public string Reason
+            {
+                get;
+                private set;
+            }
+
+            public DependencyNodeCore<DependencyContextType> Reason1
+            {
+                get;
+                private set;
+            }
+
+            public DependencyNodeCore<DependencyContextType> Reason2
+            {
+                get;
+                private set;
+            }
+        }
+
+        private HashSet<string> _reasonStringOnlyNodes;
+
+        bool IDependencyAnalysisMarkStrategy<DependencyContextType>.MarkNode(
+            DependencyNodeCore<DependencyContextType> node, 
+            DependencyNodeCore<DependencyContextType> reasonNode, 
+            DependencyNodeCore<DependencyContextType> reasonNode2, 
+            string reason)
+        {
+            if (node.Marked)
+                return false;
+
+            if ((reasonNode == null) && (reasonNode2 == null))
+            {
+                Debug.Assert(reason != null);
+                if (_reasonStringOnlyNodes == null)
+                    _reasonStringOnlyNodes = new HashSet<string>();
+
+                _reasonStringOnlyNodes.Add(reason);
+            }
+
+            node.SetMark(new MarkData(reason, reasonNode, reasonNode2));
+            return true;
+        }
+
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor logNodeVisitor)
+        {
+            HashSet<Tuple<DependencyNode, DependencyNode>> combinedNodesReported = new HashSet<Tuple<DependencyNode, DependencyNode>>();
+
+            if (_reasonStringOnlyNodes != null)
+            {
+                foreach (string reasonOnly in _reasonStringOnlyNodes)
+                {
+                    logNodeVisitor.VisitRootNode(reasonOnly);
+                }
+            }
+
+            foreach (DependencyNodeCore<DependencyContextType> node in nodeList)
+            {
+                if (node.Marked)
+                {
+                    MarkData markData = (MarkData)node.GetMark();
+
+                    if (markData.Reason2 != null)
+                    {
+                        Tuple<DependencyNode, DependencyNode> combinedNode = new Tuple<DependencyNode, DependencyNode>(markData.Reason1, markData.Reason2);
+
+                        if (!combinedNodesReported.Contains(combinedNode))
+                        {
+                            logNodeVisitor.VisitCombinedNode(combinedNode);
+                        }
+                    }
+                }
+            }
+        }
+
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor)
+        {
+            foreach (DependencyNodeCore<DependencyContextType> node in nodeList)
+            {
+                if (node.Marked)
+                {
+                    MarkData markData = (MarkData)node.GetMark();
+
+                    if (markData.Reason2 != null)
+                    {
+                        Debug.Assert(markData.Reason1 != null);
+                        logEdgeVisitor.VisitEdge(markData.Reason1, markData.Reason2, node, markData.Reason);
+                    }
+                    else if (markData.Reason1 != null)
+                    {
+                        logEdgeVisitor.VisitEdge(markData.Reason1, node, markData.Reason);
+                    }
+                    else
+                    {
+                        Debug.Assert(markData.Reason != null);
+                        logEdgeVisitor.VisitEdge(markData.Reason, node);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/FullGraphLogStrategy.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/FullGraphLogStrategy.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Diagnostics;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public struct FullGraphLogStrategy<DependencyContextType> : IDependencyAnalysisMarkStrategy<DependencyContextType>
+    {
+        private sealed class MarkData : IEquatable<MarkData>
+        {
+            public MarkData(string reason, DependencyNodeCore<DependencyContextType> reason1, DependencyNodeCore<DependencyContextType> reason2)
+            {
+                Reason = reason;
+                Reason1 = reason1;
+                Reason2 = reason2;
+            }
+
+            public string Reason
+            {
+                get;
+                private set;
+            }
+
+            public DependencyNodeCore<DependencyContextType> Reason1
+            {
+                get;
+                private set;
+            }
+
+            public DependencyNodeCore<DependencyContextType> Reason2
+            {
+                get;
+                private set;
+            }
+
+            private static int CombineHashCodes(int h1, int h2)
+            {
+                return (((h1 << 5) + h1) ^ h2);
+            }
+
+            private static int CombineHashCodes(int h1, int h2, int h3)
+            {
+                return CombineHashCodes(CombineHashCodes(h1, h2), h3);
+            }
+
+            public override int GetHashCode()
+            {
+                int reasonHashCode = Reason != null ? Reason.GetHashCode() : 0;
+                int reason1HashCode = Reason1 != null ? Reason1.GetHashCode() : 0;
+                int reason2HashCode = Reason2 != null ? Reason2.GetHashCode() : 0;
+
+                return CombineHashCodes(reasonHashCode, reason1HashCode, reason2HashCode);
+            }
+
+            public override bool Equals(object obj)
+            {
+                MarkData other = obj as MarkData;
+                if (other == null)
+                    return false;
+
+                return Equals(other);
+            }
+
+            public bool Equals(MarkData other)
+            {
+                if (Reason1 != other.Reason1)
+                    return false;
+
+                if (Reason2 != other.Reason2)
+                    return false;
+
+                if (Reason == other.Reason)
+                    return true;
+
+                if (Reason != null)
+                {
+                    return Reason.Equals(other.Reason);
+                }
+                return false;
+            }
+        }
+
+        private sealed class MarkDataEqualityComparer : IEqualityComparer<MarkData>
+        {
+            public bool Equals(MarkData x, MarkData y)
+            {
+                return x.Equals(y);
+            }
+
+            public int GetHashCode(MarkData obj)
+            {
+                return obj.GetHashCode();
+            }
+
+            public static IEqualityComparer<MarkData> Default = new MarkDataEqualityComparer();
+        }
+
+        private HashSet<string> _reasonStringOnlyNodes;
+
+        bool IDependencyAnalysisMarkStrategy<DependencyContextType>.MarkNode(
+            DependencyNodeCore<DependencyContextType> node,
+            DependencyNodeCore<DependencyContextType> reasonNode,
+            DependencyNodeCore<DependencyContextType> reasonNode2,
+            string reason)
+        {
+            bool newlyMarked = !node.Marked;
+
+            HashSet<MarkData> associatedNodes;
+            if (newlyMarked)
+            {
+                associatedNodes = new HashSet<MarkData>(MarkDataEqualityComparer.Default);
+                node.SetMark(associatedNodes);
+            }
+            else
+            {
+                associatedNodes = (HashSet<MarkData>)node.GetMark();
+            }
+
+            if ((reasonNode == null) && (reasonNode2 == null))
+            {
+                Debug.Assert(reason != null);
+                if (_reasonStringOnlyNodes == null)
+                    _reasonStringOnlyNodes = new HashSet<string>();
+
+                _reasonStringOnlyNodes.Add(reason);
+            }
+
+            associatedNodes.Add(new MarkData(reason, reasonNode, reasonNode2));
+            return newlyMarked;
+        }
+        
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor logNodeVisitor)
+        {
+            HashSet<Tuple<DependencyNode, DependencyNode>> combinedNodesReported = new HashSet<Tuple<DependencyNode, DependencyNode>>();
+
+            if (_reasonStringOnlyNodes != null)
+            {
+                foreach (string reasonOnly in _reasonStringOnlyNodes)
+                {
+                    logNodeVisitor.VisitRootNode(reasonOnly);
+                }
+            }
+
+            foreach (DependencyNodeCore<DependencyContextType> node in nodeList)
+            {
+                if (node.Marked)
+                {
+                    HashSet<MarkData> nodeReasons = (HashSet<MarkData>)node.GetMark();
+                    foreach (MarkData markData in nodeReasons)
+                    {
+                        if (markData.Reason2 != null)
+                        {
+                            Tuple<DependencyNode, DependencyNode> combinedNode = new Tuple<DependencyNode, DependencyNode>(markData.Reason1, markData.Reason2);
+
+                            if (!combinedNodesReported.Contains(combinedNode))
+                            {
+                                logNodeVisitor.VisitCombinedNode(combinedNode);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor)
+        {
+            foreach (DependencyNodeCore<DependencyContextType> node in nodeList)
+            {
+                if (node.Marked)
+                {
+                    HashSet<MarkData> nodeReasons = (HashSet<MarkData>)node.GetMark();
+                    foreach (MarkData markData in nodeReasons)
+                    {
+                        if (markData.Reason2 != null)
+                        {
+                            Debug.Assert(markData.Reason1 != null);
+                            logEdgeVisitor.VisitEdge(markData.Reason1, markData.Reason2, node, markData.Reason);
+                        }
+                        else if (markData.Reason1 != null)
+                        {
+                            logEdgeVisitor.VisitEdge(markData.Reason1, node, markData.Reason);
+                        }
+                        else
+                        {
+                            Debug.Assert(markData.Reason != null);
+                            logEdgeVisitor.VisitEdge(markData.Reason, node);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/IDependencyAnalysisMarkStrategy.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/IDependencyAnalysisMarkStrategy.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public interface IDependencyAnalysisMarkStrategy<DependencyContextType>
+    {
+        /// <summary>
+        /// Use the provided node, reasonNode, reasonNode2, and reason to mark a node
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="reasonNode"></param>
+        /// <param name="reasonNode2"></param>
+        /// <param name="reason"></param>
+        /// <returns>true if the node is newly marked</returns>
+        bool MarkNode(DependencyNodeCore<DependencyContextType> node, DependencyNodeCore<DependencyContextType> reasonNode, DependencyNodeCore<DependencyContextType> reasonNode2, string reason);
+
+        void VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor logNodeVisitor);
+
+        void VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor);
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/IDependencyAnalyzerLogEdgeVisitor.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/IDependencyAnalyzerLogEdgeVisitor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public interface IDependencyAnalyzerLogEdgeVisitor
+    {
+        void VisitEdge(DependencyNode nodeDepender, DependencyNode nodeDependedOn, string reason);
+        void VisitEdge(string root, DependencyNode dependedOn);
+        void VisitEdge(DependencyNode nodeDepender, DependencyNode nodeDependerOther, DependencyNode nodeDependedOn, string reason);
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/IDependencyAnalyzerLogNodeVisitor.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/IDependencyAnalyzerLogNodeVisitor.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    public interface IDependencyAnalyzerLogNodeVisitor
+    {
+        void VisitCombinedNode(Tuple<DependencyNode, DependencyNode> node);
+        void VisitNode(DependencyNode node);
+        void VisitRootNode(string rootName);
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/ILToNative.DependencyAnalysisFramework.csproj
+++ b/src/ILToNative.DependencyAnalysisFramework/src/ILToNative.DependencyAnalysisFramework.csproj
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DAC23E9F-F826-4577-AE7A-0849FF83280C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ILToNative.DependencyAnalysisFramework</RootNamespace>
+    <AssemblyName>ILToNative.DependencyAnalysisFramework</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <ExcludeResourcesImport>true</ExcludeResourcesImport>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ComputedStaticDependencyNode.cs" />
+    <Compile Include="DependencyAnalyzer.cs" />
+    <Compile Include="DependencyAnalyzerBase.cs" />
+    <Compile Include="DependencyNode.cs" />
+    <Compile Include="DependencyNodeCore.cs" />
+    <Compile Include="DgmlWriter.cs" />
+    <Compile Include="FirstMarkLogStrategy.cs" />
+    <Compile Include="FullGraphLogStrategy.cs" />
+    <Compile Include="IDependencyAnalyzerLogEdgeVisitor.cs" />
+    <Compile Include="IDependencyAnalyzerLogNodeVisitor.cs" />
+    <Compile Include="IDependencyAnalysisMarkStrategy.cs" />
+    <Compile Include="NoLogStrategy.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/ILToNative.DependencyAnalysisFramework/src/NoLogStrategy.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/NoLogStrategy.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysisFramework
+{
+    /// <summary>
+    /// Very memory efficient, and potentially faster mark strategy that eschews keeping track of what caused what to exist
+    /// </summary>
+    /// <typeparam name="DependencyContextType"></typeparam>
+    public struct NoLogStrategy<DependencyContextType> : IDependencyAnalysisMarkStrategy<DependencyContextType>
+    {
+        private static object s_singleton = new object();
+
+        bool IDependencyAnalysisMarkStrategy<DependencyContextType>.MarkNode(
+            DependencyNodeCore<DependencyContextType> node,
+            DependencyNodeCore<DependencyContextType> reasonNode,
+            DependencyNodeCore<DependencyContextType> reasonNode2,
+            string reason)
+        {
+            if (node.Marked)
+                return false;
+
+            node.SetMark(s_singleton);
+            return true;
+        }
+
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor)
+        {
+            // This marker does not permit logging.
+            return;
+        }
+
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor logNodeVisitor)
+        {
+            // This marker does not permit logging.
+            return;
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/src/project.json
+++ b/src/ILToNative.DependencyAnalysisFramework/src/project.json
@@ -1,0 +1,22 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Reflection.Primitives": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.IO": "4.0.0",
+    "System.Collections.Immutable": "1.1.37",
+    "System.Collections": "4.0.0",
+    "System.Text.Encoding": "4.0.0",
+    "System.Runtime.InteropServices": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Runtime.Extensions": "4.0.0",
+    "System.Threading": "4.0.0",
+    "System.Text.Encoding.Extensions": "4.0.0",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Xml.ReaderWriter": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet": {}
+  }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/tests/DependencyAnalysisFrameworkTests.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/tests/DependencyAnalysisFrameworkTests.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using ILToNative.DependencyAnalysisFramework;
+
+using Xunit;
+
+namespace ILToNative.DependencyAnalysisFramework.Tests
+{
+    public class DependencyTests
+    {
+        public DependencyTests()
+        {
+        }
+
+        /// <summary>
+        /// Test on every graph type. Used to ensure that the behavior of the various markers is consistent
+        /// </summary>
+        /// <param name="testGraph"></param>
+        private void TestOnGraphTypes(Action<TestGraph, DependencyAnalyzerBase<TestGraph>> testGraph)
+        {
+            // Test using the full logging strategy
+            TestGraph testGraphFull = new TestGraph();
+            DependencyAnalyzerBase<TestGraph> analyzerFull = new DependencyAnalyzer<FullGraphLogStrategy<TestGraph>, TestGraph>(testGraphFull, null);
+            testGraphFull.AttachToDependencyAnalyzer(analyzerFull);
+            testGraph(testGraphFull, analyzerFull);
+
+            TestGraph testGraphFirstMark = new TestGraph();
+            DependencyAnalyzerBase<TestGraph> analyzerFirstMark = new DependencyAnalyzer<FirstMarkLogStrategy<TestGraph>, TestGraph>(testGraphFirstMark, null);
+            testGraphFirstMark.AttachToDependencyAnalyzer(analyzerFirstMark);
+            testGraph(testGraphFirstMark, analyzerFirstMark);
+
+            TestGraph testGraphNoLog = new TestGraph();
+            DependencyAnalyzerBase<TestGraph> analyzerNoLog = new DependencyAnalyzer<NoLogStrategy<TestGraph>, TestGraph>(testGraphNoLog, null);
+            testGraphNoLog.AttachToDependencyAnalyzer(analyzerNoLog);
+            testGraph(testGraphNoLog, analyzerNoLog);
+        }
+
+        [Fact]
+        public void TestADependsOnB()
+        {
+            TestOnGraphTypes((TestGraph testGraph, DependencyAnalyzerBase<TestGraph> analyzer) =>
+            {
+                testGraph.AddStaticRule("A", "B", "A depends on B");
+                testGraph.AddRoot("A", "A is root");
+                List<string> results = testGraph.AnalysisResults;
+
+                Assert.True(results.Contains("A"));
+                Assert.True(results.Contains("B"));
+            });
+        }
+
+        [Fact]
+        public void TestADependsOnBIfC_NoC()
+        {
+            TestOnGraphTypes((TestGraph testGraph, DependencyAnalyzerBase<TestGraph> analyzer) =>
+            {
+                testGraph.AddConditionalRule("A", "C", "B", "A depends on B if C");
+                testGraph.AddRoot("A", "A is root");
+                List<string> results = testGraph.AnalysisResults;
+
+                Assert.True(results.Contains("A"));
+                Assert.False(results.Contains("B"));
+                Assert.False(results.Contains("C"));
+                Assert.True(results.Count == 1);
+            });
+        }
+
+        [Fact]
+        public void TestADependsOnBIfC_HasC()
+        {
+            TestOnGraphTypes((TestGraph testGraph, DependencyAnalyzerBase<TestGraph> analyzer) =>
+            {
+                testGraph.AddConditionalRule("A", "C", "B", "A depends on B if C");
+                testGraph.AddRoot("A", "A is root");
+                testGraph.AddRoot("C", "C is root");
+                List<string> results = testGraph.AnalysisResults;
+
+                Assert.True(results.Contains("A"));
+                Assert.True(results.Contains("B"));
+                Assert.True(results.Contains("C"));
+                Assert.True(results.Count == 3);
+            });
+        }
+
+        [Fact]
+        public void TestSimpleDynamicRule()
+        {
+            TestOnGraphTypes((TestGraph testGraph, DependencyAnalyzerBase<TestGraph> analyzer) =>
+            {
+                testGraph.SetDynamicDependencyRule((string nodeA, string nodeB) =>
+                {
+                    if (nodeA.EndsWith("*") && nodeB.StartsWith("*"))
+                    {
+                        return new Tuple<string, string>(nodeA + nodeB, "DynamicRule");
+                    }
+                    return null;
+                });
+
+                testGraph.AddRoot("A*", "A* is root");
+                testGraph.AddRoot("B*", "B* is root");
+                testGraph.AddRoot("*C", "*C is root");
+                testGraph.AddRoot("*D", "*D is root");
+                testGraph.AddRoot("A*B", "A*B is root");
+                List<string> results = testGraph.AnalysisResults;
+
+                Assert.Contains("A*", results);
+                Assert.Contains("B*", results);
+                Assert.Contains("*C", results);
+                Assert.Contains("*D", results);
+                Assert.Contains("A*B", results);
+                Assert.Contains("A**C", results);
+                Assert.Contains("A**D", results);
+                Assert.Contains("B**C", results);
+                Assert.Contains("B**D", results);
+                Assert.True(results.Count == 9);
+            });
+        }
+
+        private void BuildGraphUsingAllTypesOfRules(TestGraph testGraph, DependencyAnalyzerBase<TestGraph> analyzer)
+        {
+            testGraph.SetDynamicDependencyRule((string nodeA, string nodeB) =>
+            {
+                if (nodeA.EndsWith("*") && nodeB.StartsWith("*"))
+                {
+                    return new Tuple<string, string>(nodeA + nodeB, "DynamicRule");
+                }
+                return null;
+            });
+
+            testGraph.AddConditionalRule("A**C", "B**D", "D", "A**C depends on D if B**D");
+            testGraph.AddStaticRule("D", "E", "D depends on E");
+
+            // Rules to ensure that there are some nodes that have multiple reasons to exist
+            testGraph.AddStaticRule("A*", "E", "A* depends on E");
+            testGraph.AddStaticRule("*C", "E", "*C depends on E");
+
+            testGraph.AddRoot("A*", "A* is root");
+            testGraph.AddRoot("B*", "B* is root");
+            testGraph.AddRoot("*C", "*C is root");
+            testGraph.AddRoot("*D", "*D is root");
+            testGraph.AddRoot("A*B", "A*B is root");
+
+            List<string> results = testGraph.AnalysisResults;
+            Assert.Contains("A*", results);
+            Assert.Contains("B*", results);
+            Assert.Contains("*C", results);
+            Assert.Contains("*D", results);
+            Assert.Contains("A*B", results);
+            Assert.Contains("A**C", results);
+            Assert.Contains("A**D", results);
+            Assert.Contains("B**C", results);
+            Assert.Contains("B**D", results);
+            Assert.Contains("D", results);
+            Assert.Contains("E", results);
+            Assert.True(results.Count == 11);
+        }
+
+        [Fact]
+        public void TestDGMLOutput()
+        {
+            Dictionary<string, string> dgmlOutputs = new Dictionary<string, string>();
+            TestOnGraphTypes((TestGraph testGraph, DependencyAnalyzerBase<TestGraph> analyzer) =>
+            {
+                BuildGraphUsingAllTypesOfRules(testGraph, analyzer);
+                MemoryStream dgmlOutput = new MemoryStream();
+                DgmlWriter.WriteDependencyGraphToStream(dgmlOutput, analyzer);
+                dgmlOutput.Seek(0, SeekOrigin.Begin);
+                TextReader tr = new StreamReader(dgmlOutput);
+                dgmlOutputs[analyzer.GetType().FullName] = tr.ReadToEnd();
+            });
+
+            foreach (var pair in dgmlOutputs)
+            {
+                int nodeCount = pair.Value.Split(new string[] { "<Node " }, StringSplitOptions.None).Length - 1;
+                int edgeCount = pair.Value.Split(new string[] { "<Link " }, StringSplitOptions.None).Length - 1;
+                if (pair.Key.Contains("FullGraph"))
+                {
+                    Assert.Equal(21, nodeCount);
+                    Assert.Equal(23, edgeCount);
+                }
+                else if (pair.Key.Contains("FirstMark"))
+                {
+                    // There are 2 edges in the all types of rules graph that are duplicates. Note that the edge count is 
+                    // 2 less than the full graph edge count
+                    Assert.Equal(21, nodeCount);
+                    Assert.Equal(21, edgeCount);
+                }
+                else
+                {
+                    Assert.Contains("NoLog", pair.Key);
+                    Assert.Equal(11, nodeCount);
+                    Assert.Equal(0, edgeCount);
+                }
+            }
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/tests/ILToNative.DependencyAnalysisFramework.Tests.csproj
+++ b/src/ILToNative.DependencyAnalysisFramework/tests/ILToNative.DependencyAnalysisFramework.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{90076B9B-918B-49DD-8ADE-E76426D60B4D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>ILToNative.DependencyAnalysisFramework.Tests</AssemblyName>
+    <RootNamespace>ILToNative.DependencyAnalysisFramework.Tests</RootNamespace>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\ILToNative.DependencyAnalysisFramework.csproj">
+      <Project>{DAC23E9F-F826-4577-AE7A-0849FF83280C}</Project>
+      <Name>ILToNative.DependencyAnalysisFramework</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DependencyAnalysisFrameworkTests.cs" />
+    <Compile Include="TestGraph.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/ILToNative.DependencyAnalysisFramework/tests/TestGraph.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/tests/TestGraph.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ILToNative.DependencyAnalysisFramework;
+
+namespace ILToNative.DependencyAnalysisFramework.Tests
+{
+    class TestGraph
+    {
+        public class TestNode : ComputedStaticDependencyNode<TestGraph>
+        {
+            private readonly string _data;
+            private readonly static CombinedDependencyListEntry[] s_emptyDynamicList = new CombinedDependencyListEntry[0];
+
+            public TestNode(string data)
+            {
+                _data = data;
+            } 
+
+            public string Data
+            {
+                get
+                {
+                    return _data;
+                }
+            }
+
+            public override string ToString()
+            {
+                return _data;
+            }
+
+            public override bool HasDynamicDependencies
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<TestGraph>> markedNodes, int firstNode, TestGraph context)
+            {
+                if (context._dynamicDependencyComputer == null)
+                    return s_emptyDynamicList;
+
+                IEnumerable<CombinedDependencyListEntry> returnValue = s_emptyDynamicList;
+                List<CombinedDependencyListEntry> returnValueWithData = null;
+                for (int i = firstNode; i < markedNodes.Count; i++)
+                {
+                    Tuple<string,string> nextResult = context._dynamicDependencyComputer(this.Data, ((TestNode)markedNodes[i]).Data);
+
+                    if (nextResult != null)
+                    {
+                        if (returnValueWithData == null)
+                        {
+                            returnValueWithData = new List<DependencyNodeCore<TestGraph>.CombinedDependencyListEntry>();
+                            returnValue = returnValueWithData;
+                        }
+
+                        returnValueWithData.Add(new CombinedDependencyListEntry(context.GetNode(nextResult.Item1), markedNodes[i], nextResult.Item2));
+                    }
+                }
+
+                return returnValue;
+            }
+        }
+
+        Dictionary<string, HashSet<Tuple<string, string>>> _staticNonConditionalRules = new Dictionary<string, HashSet<Tuple<string, string>>>();
+        Dictionary<string, HashSet<Tuple<string, Tuple<string, string>>>> _staticConditionalRules = new Dictionary<string, HashSet<Tuple<string, Tuple<string, string>>>>();
+
+        Func<string, string, Tuple<string,string>> _dynamicDependencyComputer;
+        Dictionary<string, TestNode> _nodes = new Dictionary<string, TestNode>();
+        DependencyAnalyzerBase<TestGraph> _analyzer;
+
+        public void AddStaticRule(string depender, string dependedOn, string reason)
+        {
+            HashSet<Tuple<string, string>> knownEdges = null;
+            if (!_staticNonConditionalRules.TryGetValue(depender, out knownEdges))
+            {
+                knownEdges = new HashSet<Tuple<string, string>>();
+                _staticNonConditionalRules[depender] = knownEdges;
+            }
+            knownEdges.Add(new Tuple<string,string>(dependedOn, reason));
+        }
+
+        public void AddConditionalRule(string depender, string otherdepender, string dependedOn, string reason)
+        {
+            HashSet<Tuple<string, Tuple<string, string>>> knownEdges = null;
+            if (!_staticConditionalRules.TryGetValue(depender, out knownEdges))
+            {
+                knownEdges = new HashSet<Tuple<string, Tuple<string, string>>>();
+                _staticConditionalRules[depender] = knownEdges;
+            }
+
+            knownEdges.Add(new Tuple<string, Tuple<string, string>>(dependedOn, new Tuple<string,string>(otherdepender, reason)));
+        }
+
+        public void SetDynamicDependencyRule(Func<string, string, Tuple<string, string>> dynamicDependencyComputer)
+        {
+            _dynamicDependencyComputer = dynamicDependencyComputer;
+        }
+
+        public void AddRoot(string nodeNode, string reason)
+        {
+            _analyzer.AddRoot(this.GetNode(nodeNode), reason);
+        }
+
+        public TestNode GetNode(string nodeName)
+        {
+            TestNode node;
+            if (!_nodes.TryGetValue(nodeName, out node))
+            {
+                node = new TestNode(nodeName);
+                _nodes.Add(nodeName, node);
+            }
+
+            return node;
+        }
+
+        public void AttachToDependencyAnalyzer(DependencyAnalyzerBase<TestGraph> analyzer)
+        {
+            analyzer.ComputeDependencyRoutine += Analyzer_ComputeDependencyRoutine;
+            _analyzer = analyzer;
+        }
+
+        private void Analyzer_ComputeDependencyRoutine(List<DependencyNodeCore<TestGraph>> obj)
+        {
+            foreach (TestNode node in obj)
+            {
+                List<TestNode.DependencyListEntry> staticList = new List<DependencyNodeCore<TestGraph>.DependencyListEntry>();
+                List<TestNode.CombinedDependencyListEntry> conditionalStaticList = new List<DependencyNodeCore<TestGraph>.CombinedDependencyListEntry>();
+
+                HashSet<Tuple<string, string>> nonConditionalRules;
+                if (_staticNonConditionalRules.TryGetValue(node.Data, out nonConditionalRules))
+                {
+                    foreach (Tuple<string, string> dependedOn in nonConditionalRules)
+                    {
+                        staticList.Add(new TestNode.DependencyListEntry(GetNode(dependedOn.Item1), dependedOn.Item2));
+                    }
+                }
+
+                HashSet<Tuple<string, Tuple<string, string>>> conditionalRules;
+                if (_staticConditionalRules.TryGetValue(node.Data, out conditionalRules))
+                {
+                    foreach (Tuple<string, Tuple<string, string>> dependedOn in conditionalRules)
+                    {
+                        conditionalStaticList.Add(new TestNode.CombinedDependencyListEntry(GetNode(dependedOn.Item1), GetNode(dependedOn.Item2.Item1), dependedOn.Item2.Item2));
+                    }
+                }
+
+                node.SetStaticDependencies(staticList, conditionalStaticList);
+            }
+        }
+
+        public List<string> AnalysisResults
+        {
+            get
+            {
+                List<string> liveNodes = new List<string>();
+                foreach (var node in _analyzer.MarkedNodeList)
+                {
+                    liveNodes.Add(((TestNode)node).Data);
+                }
+
+                return liveNodes;
+            }
+        }
+    }
+}

--- a/src/ILToNative.DependencyAnalysisFramework/tests/project.json
+++ b/src/ILToNative.DependencyAnalysisFramework/tests/project.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Collections.Immutable": "1.1.37",
+    "System.Console": "4.0.0-beta-*",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.Tracing": "4.0.20",
+    "System.Linq": "4.0.0",
+    "System.IO.FileSystem": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "xunit": "2.1.0-beta3-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*",
+  },
+  "frameworks": {
+    "dotnet": {}
+  }
+}

--- a/src/ILToNative/ILToNative.sln
+++ b/src/ILToNative/ILToNative.sln
@@ -1,13 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.23023.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative", "src\ILToNative.csproj", "{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "repro", "repro\repro.csproj", "{FBA029C3-B184-4457-AEEC-38D0C2523067}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.TypeSystem", "..\ILToNative.TypeSystem\src\ILToNative.TypeSystem.csproj", "{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.DependencyAnalysisFramework", "..\ILToNative.DependencyAnalysisFramework\src\ILToNative.DependencyAnalysisFramework.csproj", "{DAC23E9F-F826-4577-AE7A-0849FF83280C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.Compiler", "..\ILToNative.Compiler\src\ILToNative.Compiler.csproj", "{13BB3788-C3EB-4046-8105-A95F8AE49404}"
 EndProject
@@ -39,6 +40,10 @@ Global
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|x64.Build.0 = Debug|x64
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.ActiveCfg = Release|x64
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.Build.0 = Release|x64
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|x64.Build.0 = Debug|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|x64.ActiveCfg = Release|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Dependency analysis allows tracing what output components depend on other components from a root set instead of simply working with a list of already loaded things.

This patch adds a framework for performing this computation, but no rules that are specific to compiling ILToNative. That will be followon work.

Included in this change
- DependencyAnalyzerBase
  - Api surface for use of analyzer.
- DependencyAnalyzer
  - Object that should actually be constructed to perform analysis. Not intended for most use, so as to allow dynamic switching between various particular specializations.
  - Specialized over a mark strategy. (The mark strategy specialization allows log customization)
- DependencyNodeCore/DependencyNode
  - Base type of dependency node in depedency graph. Provides a set of facilities to describe dependents.
- IDependencyAnalysisMarkStrategy
  - Interface underlying mark logging customization.
  - Provided mark strategies
  - NoLogStrtegy, no support for logging.
    - Marks, but doesn't log anything. Most memory/performance efficient approach. Expected to be used in retail builds by default for best performance.
  - FirstMarkLogStrategy, the first edge to mark a node is logged
    - More memory efficient logging at mark points. In particular, only logs mark's that newly mark a node.
  - FullGraphLogStrategy
    - Used when the ability to generate a complete log of the graph is important. Fairly memory intensive due to the presence of a great many allocated hash tables
- DgmlWriter
  - Interfaces with DependencyAnalyzer and various mark strategies to generate a DGML graph of the dependencies. DGML graphs can be viewed in Visual Studio
- Tests
  - Basic unit test framework in place
  - All types of dependency are tested to minimal standards
  - DGML logging is tested.
