### PR TITLE
Fix incorrect handling of MethodSpecificiations for MethodImpl overrides

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -424,7 +424,7 @@ namespace Internal.TypeSystem.Ecma
 
                 bool foundRecord = false;
 
-                switch (methodImpl.MethodDeclaration.Kind)
+                switch (methodDeclHandleKind)
                 {
                     case HandleKind.MethodDefinition:
                         if (stringComparer.Equals(metadataReader.GetMethodDefinition((MethodDefinitionHandle)methodDeclCheckHandle).Name, declName))
@@ -470,8 +470,9 @@ namespace Internal.TypeSystem.Ecma
                 EntityHandle methodDeclCheckHandle = methodImpl.MethodDeclaration;
                 HandleKind methodDeclHandleKind = methodDeclCheckHandle.Kind;
 
-                // We want to check that the method name matches before actually getting the MethodDesc. For MethodSpecifications
-                // we need to dereference that handle to the underlying member reference to look at name matching.
+                // We want to check that the type is not an interface matches before actually getting the MethodDesc. 
+                // For MethodSpecifications we need to dereference that handle to the underlying member reference to 
+                // look at the owning type.
                 if (methodDeclHandleKind == HandleKind.MethodSpecification)
                 {
                     methodDeclCheckHandle = metadataReader.GetMethodSpecification((MethodSpecificationHandle)methodDeclCheckHandle).Method;

--- a/src/ILToNative.TypeSystem/TypeSystem.sln
+++ b/src/ILToNative.TypeSystem/TypeSystem.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23023.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TypeSystem.Tests", "tests\TypeSystem.Tests.csproj", "{8874CEEC-5594-511B-A44C-5CA9EC1CEB11}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.TypeSystem", "src\ILToNative.TypeSystem.csproj", "{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreTestAssembly", "tests\CoreTestAssembly\CoreTestAssembly.csproj", "{5813B7DC-6588-4553-B04D-387EC9630AC8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8874CEEC-5594-511B-A44C-5CA9EC1CEB11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8874CEEC-5594-511B-A44C-5CA9EC1CEB11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8874CEEC-5594-511B-A44C-5CA9EC1CEB11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8874CEEC-5594-511B-A44C-5CA9EC1CEB11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5813B7DC-6588-4553-B04D-387EC9630AC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5813B7DC-6588-4553-B04D-387EC9630AC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5813B7DC-6588-4553-B04D-387EC9630AC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5813B7DC-6588-4553-B04D-387EC9630AC8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/ILToNative.TypeSystem/tests/CoreTestAssembly/CoreTestAssembly.csproj
+++ b/src/ILToNative.TypeSystem/tests/CoreTestAssembly/CoreTestAssembly.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -6,10 +6,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AssemblyName>CoreTestAssembly</AssemblyName>
-
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsCoreAssembly>true</IsCoreAssembly>
-
     <!--
       Need to avoid target platform being empty because that would drag in an mscorlib design-time
       facade into the references and break us.
@@ -20,20 +18,18 @@
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
     <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
-
+    <ProjectGuid>{5813B7DC-6588-4553-B04D-387EC9630AC8}</ProjectGuid>
   </PropertyGroup>
-
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Platform.cs" />
     <Compile Include="InstanceFieldLayout.cs" />
     <Compile Include="StaticFieldLayout.cs" />
+    <Compile Include="VirtualFunctionOverride.cs" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/ILToNative.TypeSystem/tests/CoreTestAssembly/VirtualFunctionOverride.cs
+++ b/src/ILToNative.TypeSystem/tests/CoreTestAssembly/VirtualFunctionOverride.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace VirtualFunctionOverride
+{
+    interface IIFaceWithGenericMethod
+    {
+        void GenMethod<T>();
+    }
+
+    class HasMethodInterfaceOverrideOfGenericMethod : IIFaceWithGenericMethod
+    {
+        void IIFaceWithGenericMethod.GenMethod<T>() { }
+    }
+}

--- a/src/ILToNative.TypeSystem/tests/TypeSystem.Tests.csproj
+++ b/src/ILToNative.TypeSystem/tests/TypeSystem.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -9,7 +9,6 @@
     <AssemblyName>TypeSystem.Tests</AssemblyName>
     <RootNamespace>TypeSystem.Tests</RootNamespace>
   </PropertyGroup>
-
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -20,7 +19,6 @@
       <Project>{dd5b6baa-d41a-4a6e-9e7d-83060f394b10}</Project>
       <Name>ILToNative.TypeSystem</Name>
     </ProjectReference>
-
     <!-- Make sure the test data gets built -->
     <ProjectReference Include="CoreTestAssembly\CoreTestAssembly.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
@@ -30,11 +28,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="VirtualFunctionOverrideTests.cs" />
     <Compile Include="InstanceFieldLayoutTests.cs" />
     <Compile Include="StaticFieldLayoutTests.cs" />
     <Compile Include="TestTypeSystemContext.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/ILToNative.TypeSystem/tests/VirtualFunctionOverrideTests.cs
+++ b/src/ILToNative.TypeSystem/tests/VirtualFunctionOverrideTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Internal.TypeSystem.Ecma;
+using Internal.TypeSystem;
+
+using Xunit;
+
+
+namespace TypeSystemTests
+{
+    public class VirtualFunctionOverrideTests
+    {
+        TestTypeSystemContext _context;
+        EcmaModule _testModule;
+
+        public VirtualFunctionOverrideTests()
+        {
+            _context = new TestTypeSystemContext(TargetArchitecture.X64);
+            var systemModule = _context.CreateModuleForSimpleName("CoreTestAssembly");
+            _context.SetSystemModule(systemModule);
+
+            _testModule = systemModule;
+        }
+
+        [Fact]
+        public void TestGenericMethodInterfaceMethodImplOverride()
+        {
+            //
+            // Ensure MethodImpl based overriding works for MethodSpecs
+            //
+
+            MetadataType interfaceType = _testModule.GetType("VirtualFunctionOverride", "IIFaceWithGenericMethod");
+            MethodDesc interfaceMethod = null;
+
+            foreach(MethodDesc m in interfaceType.GetMethods())
+            {
+                if (m.Name == "GenMethod")
+                {
+                    interfaceMethod = m;
+                    break;
+                }
+            }
+            Assert.NotNull(interfaceMethod);
+
+            MetadataType objectType = _testModule.GetType("VirtualFunctionOverride", "HasMethodInterfaceOverrideOfGenericMethod");
+            MethodDesc expectedVirtualMethod = null;
+            foreach (MethodDesc m in objectType.GetMethods())
+            {
+                if (m.Name.Contains("GenMethod"))
+                {
+                    expectedVirtualMethod = m;
+                    break;
+                }
+            }
+            Assert.NotNull(expectedVirtualMethod);
+
+            Assert.Equal(expectedVirtualMethod, VirtualFunctionResolution.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, objectType));
+        }
+    }
+}


### PR DESCRIPTION
In earlier code review comments, a minor fix was missed.
- Fix incorrect handling of MethodSpecifications for MethodImpl overrides
- Update comment to be more correct
- Add sln file for type system to ease test development
- Add test for generic method impl case
