### PR TITLE
Use dependency graph to drive compilation and prep for object file emission

### DIFF
--- a/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
@@ -29,6 +29,21 @@ namespace System.Collections.Generic
             _items[_count++] = item;
         }
 
+        public void Append(T[] newItems)
+        {
+            if (_items == null || (_count + newItems.Length) >= _items.Length)
+            {
+                int newCount = 2 * _count + 1;
+                while ((_count + newItems.Length) >= newCount)
+                {
+                    newCount = 2 * newCount + 1;
+                }
+                Array.Resize(ref _items, newCount);
+            }
+            Array.Copy(newItems, 0, _items, _count, newItems.Length);
+            _count += newItems.Length;
+        }
+
         public int Count
         {
             get

--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -42,6 +42,15 @@ namespace Internal.TypeSystem
             }
         }
 
+        public int MinimumFunctionAlignment
+        {
+            get
+            {
+                // We use a minimum alignment of 4 irrespective of the platform.
+                return 4;
+            }
+        }
+
         public TargetDetails(TargetArchitecture architecture)
         {
             Architecture = architecture;

--- a/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
@@ -469,5 +469,31 @@ namespace Internal.TypeSystem
                 currentType = currentType.BaseType;
             }
         }
+
+        // Enumerate all possible virtual slots of a type
+        public static IEnumerable<MethodDesc> EnumAllVirtualSlots(MetadataType type)
+        {
+            HashSet<MethodDesc> alreadyEnumerated = new HashSet<MethodDesc>();
+            if (!type.IsInterface)
+            {
+                do
+                {
+                    foreach (MethodDesc m in type.GetMethods())
+                    {
+                        if (m.IsVirtual)
+                        {
+                            MethodDesc possibleVirtual = FindSlotDefiningMethodForVirtualMethod(m);
+                            if (!alreadyEnumerated.Contains(possibleVirtual))
+                            {
+                                alreadyEnumerated.Add(possibleVirtual);
+                                yield return possibleVirtual;
+                            }
+                        }
+                    }
+
+                    type = type.BaseType;
+                } while (type != null);
+            }
+        }
     }
 }

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public class ArrayOfEmbeddedDataNode : ObjectNode
+    {
+        HashSet<EmbeddedObjectNode> _nestedNodes = new HashSet<EmbeddedObjectNode>();
+        List<EmbeddedObjectNode> _nestedNodesList = new List<EmbeddedObjectNode>();
+        ObjectAndOffsetSymbolNode _startSymbol;
+        ObjectAndOffsetSymbolNode _endSymbol;
+        IComparer<EmbeddedObjectNode> _sorter;
+
+        public ArrayOfEmbeddedDataNode(string startSymbolMangledName, string endSymbolMangledName, IComparer<EmbeddedObjectNode> nodeSorter)
+        {
+            _startSymbol = new ObjectAndOffsetSymbolNode(this, 0, startSymbolMangledName);
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, endSymbolMangledName);
+            _sorter = nodeSorter;
+        }
+
+        public void AddEmbeddedObject(EmbeddedObjectNode symbol)
+        {
+            if (_nestedNodes.Add(symbol))
+            {
+                _nestedNodesList.Add(symbol);
+            }
+        }
+
+        public override string GetName()
+        {
+            return "Region " + ((ISymbolNode)_startSymbol).MangledName;
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "data";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory);
+            builder.Alignment = factory.Target.PointerSize;
+
+            if (_sorter != null)
+                _nestedNodesList.Sort(_sorter);
+
+            builder.DefinedSymbols.Add(_startSymbol);
+            foreach (EmbeddedObjectNode node in _nestedNodesList)
+            {
+                if (!relocsOnly)
+                    node.Offset = builder.CountBytes;
+
+                node.EncodeData(ref builder, factory, relocsOnly);
+                if (node is ISymbolNode)
+                {
+                    builder.DefinedSymbols.Add((ISymbolNode)node);
+                }
+            }
+            _endSymbol.SetSymbolOffset(builder.CountBytes);
+            builder.DefinedSymbols.Add(_endSymbol);
+
+            ObjectData objData = builder.ToObjectData();
+            return objData;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/AsmWriter.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/AsmWriter.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using ILToNative.DependencyAnalysisFramework;
+using System.Diagnostics;
+
+namespace ILToNative.DependencyAnalysis
+{
+    /// <summary>
+    /// Temporary assembly writer for use until direct obj writer is implemented.
+    /// </summary>
+    static class AsmWriter
+    {
+        private static int FindNextRelocOffset(int currentRelocIndex, Relocation[] relocs, byte[] bytes)
+        {
+            if ((relocs != null) && (currentRelocIndex < relocs.Length))
+            {
+                int nextRelocOffset = relocs[currentRelocIndex].Offset;
+                if (relocs[currentRelocIndex].RelocType == RelocType.IMAGE_REL_BASED_REL32)
+                {
+                    if (relocs[currentRelocIndex].InstructionLength == 1)
+                    {
+                        nextRelocOffset--;
+                        Debug.Assert((bytes[nextRelocOffset] == 0xE9) || // jmp
+                                     (bytes[nextRelocOffset] == 0xE8));  // call
+                    }
+                    else if (relocs[currentRelocIndex].InstructionLength == 3)
+                    {
+                        // TODO make this more structured, and flexible to handle other instructions
+                        nextRelocOffset -= 3;
+                        Debug.Assert((bytes[nextRelocOffset] == 0x48) || (bytes[nextRelocOffset] == 0x44)); // REX
+                        Debug.Assert(bytes[nextRelocOffset + 1] == 0x8D); // lea opcode
+                        byte regTargetByte = bytes[nextRelocOffset + 2];
+                        Debug.Assert((regTargetByte & 0x07) == 5);
+                        Debug.Assert((regTargetByte & 0xC0) == 0);
+                    }
+                    else
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+
+                return nextRelocOffset;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        private static void EmitSymbolDefinition(TextWriter output, int currentOffset, ISymbolNode[] definedSymbols, ref int lineLength)
+        {
+            foreach (ISymbolNode node in definedSymbols)
+            {
+                if (node.Offset == currentOffset)
+                {
+                    if (lineLength > 0)
+                    {
+                        output.WriteLine();
+                        lineLength = 0;
+                    }
+
+                    output.Write(".global ");
+                    output.WriteLine(node.MangledName);
+
+                    output.Write(node.MangledName);
+                    output.WriteLine(":");
+                }
+            }
+        }
+
+        public static void EmitAsm(TextWriter Out, IEnumerable<DependencyNode> nodes, NodeFactory factory)
+        {
+            string currentSection = "";
+
+            foreach (DependencyNode depNode in nodes)
+            {
+                ObjectNode node = depNode as ObjectNode;
+                if (node == null)
+                    continue;
+
+                if (node.ShouldSkipEmittingObjectNode(factory))
+                    continue;
+
+                ObjectNode.ObjectData nodeContents = node.GetData(factory);
+
+                if (currentSection != node.Section)
+                {
+                    Out.WriteLine("." + node.Section);
+                    currentSection = node.Section;
+                }
+
+                Out.WriteLine(".align " + nodeContents.Alignment);
+
+                int lineLength = 0;
+                int currentRelocIndex = 0;
+                Relocation[] relocs = nodeContents.Relocs;
+                int nextRelocOffset = FindNextRelocOffset(currentRelocIndex, relocs, nodeContents.Data);
+
+                for (int i = 0; i < nodeContents.Data.Length; i++)
+                {
+                    // Emit symbol definitions if necessary
+                    EmitSymbolDefinition(Out, i, nodeContents.DefinedSymbols, ref lineLength);
+
+                    if (i == nextRelocOffset)
+                    {
+                        if (lineLength > 0)
+                        {
+                            Out.WriteLine();
+                            lineLength = 0;
+                        }
+
+                        Relocation reloc = relocs[currentRelocIndex];
+
+                        ISymbolNode target = reloc.Target;
+                        string targetName = target.MangledName;
+
+                        switch (reloc.RelocType)
+                        {
+                            // REVIEW: I believe the JIT is emitting 0x3 instead of 0xA
+                            // for x64, because emitter from x86 is ported for RyuJIT.
+                            // I will consult with Bruce and if he agrees, I will delete
+                            // this "case" duplicated by IMAGE_REL_BASED_DIR64.
+                            case (RelocType)0x03: // IMAGE_REL_BASED_HIGHLOW
+                            case RelocType.IMAGE_REL_BASED_DIR64:
+                                Out.Write(".quad ");
+                                Out.WriteLine(targetName);
+                                i += 7;
+                                break;
+                            case RelocType.IMAGE_REL_BASED_REL32:
+                                if (reloc.InstructionLength == 1)
+                                {
+                                    switch (nodeContents.Data[i])
+                                    {
+                                        case 0xE8: // call
+                                            Out.Write("call ");
+                                            break;
+                                        case 0xE9: // jmp
+                                            Out.Write("jmp ");
+                                            break;
+                                        default:
+                                            throw new NotImplementedException();
+                                    }
+                                    Out.WriteLine(targetName);
+                                }
+                                else if (reloc.InstructionLength == 3)
+                                {
+                                    int registerHighBit = nodeContents.Data[i] == 0x48 ? 0 : 8;
+                                    int registerOtherBits = (nodeContents.Data[i + 2] & 0x38) >> 3;
+                                    X64.Register reg = (X64.Register)(registerHighBit | registerOtherBits);
+
+                                    Out.Write("leaq ");
+                                    Out.Write(targetName);
+                                    Out.Write("(%rip), %");
+                                    Out.WriteLine(reg.ToString().ToLowerInvariant());
+                                    i += 2;
+                                }
+
+                                i += 4;
+                                break;
+                            default:
+                                throw new NotImplementedException();
+                        }
+
+                        currentRelocIndex++;
+                        nextRelocOffset = FindNextRelocOffset(currentRelocIndex, relocs, nodeContents.Data);
+                        continue;
+                    }
+
+                    if (lineLength == 0)
+                    {
+                        Out.Write(".byte ");
+                    }
+                    else
+                    {
+                        Out.Write(",");
+                    }
+
+                    Out.Write(nodeContents.Data[i]);
+
+                    if (lineLength++ > 15)
+                    {
+                        Out.WriteLine();
+                        lineLength = 0;
+                    }
+                }
+
+                // It is possible to have a symbol just after all of the data.
+                EmitSymbolDefinition(Out, nodeContents.Data.Length, nodeContents.DefinedSymbols, ref lineLength);
+
+                if (lineLength > 0)
+                    Out.WriteLine();
+                Out.WriteLine();
+                Out.Flush();
+            }
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ILToNative.DependencyAnalysisFramework;
+using System.Diagnostics;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public abstract class AssemblyStubNode : ObjectNode, ISymbolNode
+    {
+        public AssemblyStubNode()
+        {
+        }
+
+        public ISymbolNode Symbol
+        {
+            get
+            {
+                return this;
+            }
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "text";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public abstract string MangledName
+        {
+            get;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            switch (factory.Target.Architecture)
+            {
+                case TargetArchitecture.X64:
+                    X64.X64Emitter x64Emitter = new X64.X64Emitter(factory);
+                    EmitCode(factory, ref x64Emitter, relocsOnly);
+                    x64Emitter.Builder.Alignment = factory.Target.MinimumFunctionAlignment;
+                    x64Emitter.Builder.DefinedSymbols.Add(this);
+                    return x64Emitter.Builder.ToObjectData();
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        protected abstract void EmitCode(NodeFactory factory, ref X64.X64Emitter instructionEncoder, bool relocsOnly);
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1,0 +1,190 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ILToNative.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    class EETypeNode : ObjectNode, ISymbolNode
+    {
+        TypeDesc _type;
+        bool _constructed;
+
+        public EETypeNode(TypeDesc type, bool constructed)
+        {
+            _type = type;
+            _constructed = constructed;
+        }
+
+        public override string GetName()
+        {
+            if (_constructed)
+            {
+                return ((ISymbolNode)this).MangledName + " constructed";
+            }
+            else
+            {
+                return ((ISymbolNode)this).MangledName;
+            }
+        }
+
+        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
+        {
+            if (!_constructed)
+            {
+                // If there is a constructed version of this node in the graph, emit that instead
+                if (((DependencyNode)factory.ConstructedTypeSymbol(_type)).Marked)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public TypeDesc Type
+        {
+            get { return _type; }
+        }
+
+        public bool Constructed
+        {
+            get { return _constructed; }
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "data";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return "__EEType_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory);
+            objData.Alignment = 16;
+            objData.DefinedSymbols.Add(this);
+            if (_type.IsArray && ((ArrayType)_type).Rank == 1)
+            {
+                objData.EmitShort((short)_type.GetElementSize()); // m_ComponentSize
+                objData.EmitShort(0x4);                           // m_flags: IsArray(0x4)
+            }
+            else
+            {
+                objData.EmitShort(0); // m_ComponentSize
+                objData.EmitShort(0); // m_flags: 0
+            }
+            objData.EmitInt(24);
+            if (Type.BaseType != null)
+            {
+                if (_constructed)
+                {
+                    objData.EmitPointerReloc(factory.ConstructedTypeSymbol(Type.BaseType));
+                }
+                else
+                {
+                    objData.EmitPointerReloc(factory.NecessaryTypeSymbol(Type.BaseType));
+                }
+            }
+            else
+            {
+                objData.EmitZeroPointer();
+            }
+
+            if (_constructed)
+            {
+                OutputVirtualSlots(ref objData, _type, _type, factory);
+            }
+
+            return objData.ToObjectData();
+        }
+
+        public override bool HasConditionalStaticDependencies
+        {
+            get
+            {
+                // non constructed types don't have vtables
+                if (!_constructed)
+                    return false;
+
+                // Since the vtable is dependency driven, generate conditional static dependencies for
+                // all possible vtable entries
+                foreach (MethodDesc method in _type.GetMethods())
+                {
+                    if (method.IsVirtual)
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
+        {
+            if (_type is MetadataType)
+            {
+                foreach (MethodDesc decl in VirtualFunctionResolution.EnumAllVirtualSlots((MetadataType)_type))
+                {
+                    MethodDesc impl = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(decl, (MetadataType)_type);
+                    if (impl.OwningType == _type)
+                    {
+                        yield return new DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry(factory.MethodEntrypoint(impl), factory.VirtualMethodUse(decl), "Virtual method");
+                    }
+                }
+            }
+        }
+
+        private void OutputVirtualSlots(ref ObjectDataBuilder objData, TypeDesc implType, TypeDesc declType, NodeFactory context)
+        {
+            var baseType = declType.BaseType;
+            if (baseType != null)
+                OutputVirtualSlots(ref objData, implType, baseType, context);
+
+            List<MethodDesc> virtualSlots;
+            context.VirtualSlots.TryGetValue(declType, out virtualSlots);
+
+            if (virtualSlots != null)
+            {
+                for (int i = 0; i < virtualSlots.Count; i++)
+                {
+                    MethodDesc declMethod = virtualSlots[i];
+
+                    MethodDesc implMethod = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(declMethod, implType.GetClosestDefType());
+
+                    objData.EmitPointerReloc(context.MethodEntrypoint(implMethod));
+                }
+            }
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ILToNative.DependencyAnalysisFramework;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public abstract class EmbeddedObjectNode : DependencyNodeCore<NodeFactory>
+    {
+        public int Offset
+        {
+            get;
+            set;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        {
+            return null;
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasDynamicDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasConditionalStaticDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+        public abstract void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly);
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using ILToNative.DependencyAnalysisFramework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a symbol that is defined externally and statically linked to the output obj file.
+    /// </summary>
+    public class ExternSymbolNode : DependencyNodeCore<NodeFactory>, ISymbolNode
+    {
+        string _name;
+
+        public ExternSymbolNode(string name)
+        {
+            _name = name;
+        }
+
+        public override string GetName()
+        {
+            return "ExternSymbol " + _name;
+        }
+
+        public int Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public string MangledName
+        {
+            get
+            {
+                return _name;
+            }
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasDynamicDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasConditionalStaticDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        {
+            return null;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysis
+{
+    class GCStaticEETypeNode : ObjectNode, ISymbolNode
+    {
+        int[] _runLengths; // First is offset to first gc field, second is length of gc static run, third is length of non-gc data, etc
+        int _targetPointerSize;
+
+        public GCStaticEETypeNode(bool[] gcDesc, NodeFactory factory)
+        {
+            List<int> runLengths = new List<int>();
+            bool encodingGCPointers = false;
+            int currentPointerCount = 0;
+            foreach (bool pointerIsGC in gcDesc)
+            {
+                if (encodingGCPointers == pointerIsGC)
+                {
+                    currentPointerCount++;
+                }
+                else
+                {
+                    runLengths.Add(currentPointerCount * factory.Target.PointerSize);
+                    encodingGCPointers = pointerIsGC;
+                }
+            }
+            runLengths.Add(currentPointerCount);
+            _runLengths = runLengths.ToArray();
+            _targetPointerSize = factory.Target.PointerSize;
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "data";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                StringBuilder nameBuilder = new StringBuilder();
+                nameBuilder.Append("__GCStaticEEType_");
+                int totalSize = 0;
+                foreach (int run in _runLengths)
+                {
+                    nameBuilder.Append(run.ToString(CultureInfo.InvariantCulture));
+                    nameBuilder.Append("_");
+                    totalSize += run;
+                }
+                nameBuilder.Append(totalSize.ToString(CultureInfo.InvariantCulture));
+                nameBuilder.Append("_");
+
+                return nameBuilder.ToString();
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                if (NumSeries > 0)
+                {
+                    return _targetPointerSize * ((NumSeries * 2) + 1);
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        private int NumSeries
+        {
+            get
+            {
+                return (_runLengths.Length - 1) / 2;
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            ObjectDataBuilder dataBuilder = new ObjectDataBuilder(factory);
+            dataBuilder.Alignment = 16;
+            dataBuilder.DefinedSymbols.Add(this);
+
+            bool hasPointers = NumSeries > 0;
+            if (hasPointers)
+            {
+                for (int i = ((_runLengths.Length / 2) * 2) - 1; i >= 0; i--)
+                {
+                    if (_targetPointerSize == 4)
+                    {
+                        dataBuilder.EmitInt(_runLengths[i]);
+                    }
+                    else
+                    {
+                        dataBuilder.EmitLong(_runLengths[i]);
+                    }
+                }
+                if (_targetPointerSize == 4)
+                {
+                    dataBuilder.EmitInt(NumSeries);
+                }
+                else
+                {
+                    dataBuilder.EmitLong(NumSeries);
+                }
+            }
+
+            int totalSize = 0;
+            foreach (int run in _runLengths)
+            {
+                totalSize += run;
+            }
+
+            dataBuilder.EmitShort(0); // ComponentSize is always 0
+
+            if (hasPointers)
+                dataBuilder.EmitShort(0x20); // TypeFlags.HasPointers
+            else
+                dataBuilder.EmitShort(0x00);
+
+            totalSize = Math.Max(totalSize, _targetPointerSize * 3); // minimum GC eetype size is 3 pointers
+            dataBuilder.EmitInt(totalSize);
+
+            return dataBuilder.ToObjectData();
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Internal.TypeSystem;
+using ILToNative.DependencyAnalysisFramework;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public class GCStaticsNode : EmbeddedObjectNode, ISymbolNode
+    {
+        MetadataType _type;
+
+        public GCStaticsNode(MetadataType type, NodeFactory factory)
+        {
+            _type = type;
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        protected override void OnMarked(NodeFactory factory)
+        {
+            factory.GCStaticsRegion.AddEmbeddedObject(this);
+        } 
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return "__GCStaticBase_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
+            }
+        }
+
+        public ISymbolNode GetGCStaticEETypeNode(NodeFactory context)
+        {
+            // TODO Replace with better gcDesc computation algorithm when we add gc handling to the type system
+            bool[] gcDesc = new bool[_type.GCStaticFieldSize / context.Target.PointerSize + 1];
+            return context.GCStaticEEType(gcDesc);
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+
+            return new DependencyListEntry[] { new DependencyListEntry(context.GCStaticsRegion, "GCStatics Region"),
+                                               new DependencyListEntry(GetGCStaticEETypeNode(context), "GCStatic EEType")};
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return Offset;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
+        {
+            builder.RequirePointerAlignment();
+            builder.EmitPointerReloc(GetGCStaticEETypeNode(factory));
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public interface ISymbolNode
+    {
+        int Offset
+        {
+            get;
+        }
+
+        string MangledName
+        {
+            get;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    class MethodCodeNode : ObjectNode, ISymbolNode
+    {
+        MethodDesc _method;
+        ObjectData _methodCode;
+
+        public MethodCodeNode(MethodDesc method)
+        {
+            _method = method;
+        }
+
+        public void SetCode(ObjectData data)
+        {
+            Debug.Assert(_methodCode == null);
+            _methodCode = data;
+        }
+
+        public MethodDesc Method
+        {
+            get
+            {
+                return _method;
+            }
+        }
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "text";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return _methodCode != null;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return NodeFactory.NameMangler.GetMangledMethodName(_method);
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            return _methodCode;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -1,0 +1,250 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using ILToNative.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public class NodeFactory
+    {
+        TargetDetails _target;
+
+        public NodeFactory(TargetDetails target)
+        {
+            _target = target;
+            CreateNodeCaches();
+        }
+
+        public TargetDetails Target
+        {
+            get
+            {
+                return _target;
+            }
+        }
+
+        struct NodeCache<TKey, TValue>
+        {
+            Func<TKey, TValue> _creator;
+            Dictionary<TKey, TValue> _cache;
+
+            public NodeCache(Func<TKey, TValue> creator, IEqualityComparer<TKey> comparer)
+            {
+                _creator = creator;
+                _cache = new Dictionary<TKey, TValue>(comparer);
+            }
+
+            public NodeCache(Func<TKey, TValue> creator)
+            {
+                _creator = creator;
+                _cache = new Dictionary<TKey, TValue>();
+            }
+
+            public TValue GetOrAdd(TKey key)
+            {
+                TValue result;
+                if (!_cache.TryGetValue(key, out result))
+                {
+                    result = _creator(key);
+                    _cache.Add(key, result);
+                }
+                return result;
+            }
+        }
+
+        private void CreateNodeCaches()
+        {
+            _typeSymbols = new NodeCache<TypeDesc, EETypeNode>((TypeDesc type) =>
+            {
+                return new EETypeNode(type, false);
+            });
+
+            _constructedTypeSymbols = new NodeCache<TypeDesc, EETypeNode>((TypeDesc type) =>
+            {
+                return new EETypeNode(type, true);
+            });
+
+
+            _nonGCStatics = new NodeCache<MetadataType, NonGCStaticsNode>((MetadataType type) =>
+            {
+                return new NonGCStaticsNode(type);
+            });
+
+            _GCStatics = new NodeCache<MetadataType, GCStaticsNode>((MetadataType type) =>
+            {
+                return new GCStaticsNode(type, this);
+            });
+
+            _GCStaticEETypes = new NodeCache<bool[], GCStaticEETypeNode>((bool[] gcdesc) =>
+            {
+                return new GCStaticEETypeNode(gcdesc, this);
+            }, new BoolArrayEqualityComparer());
+
+            _externSymbols = new NodeCache<string, ExternSymbolNode>((string name) =>
+            {
+                return new ExternSymbolNode(name);
+            });
+
+            _internalSymbols = new NodeCache<Tuple<ObjectNode, int, string>, ObjectAndOffsetSymbolNode>(
+                (Tuple<ObjectNode, int, string> key) =>
+                {
+                    return new ObjectAndOffsetSymbolNode(key.Item1, key.Item2, key.Item3);
+                });
+
+            _methodCode = new NodeCache<MethodDesc, MethodCodeNode>((MethodDesc method) =>
+            {
+                return new MethodCodeNode(method);
+            });
+
+            _virtMethods = new NodeCache<MethodDesc, VirtualMethodUseNode>((MethodDesc method) =>
+            {
+                return new VirtualMethodUseNode(method);
+            });
+
+            _readyToRunHelpers = new NodeCache<ReadyToRunHelper, ReadyToRunHelperNode>((ReadyToRunHelper helper) =>
+            {
+                return new ReadyToRunHelperNode(helper);
+            });
+
+            _stringDataNodes = new NodeCache<string, StringDataNode>((string data) =>
+            {
+                return new StringDataNode(data);
+            });
+
+            _stringIndirectionNodes = new NodeCache<string, StringIndirectionNode>((string data) =>
+            {
+                return new StringIndirectionNode(data);
+            });
+        }
+
+        private NodeCache<TypeDesc, EETypeNode> _typeSymbols;
+
+        public ISymbolNode NecessaryTypeSymbol(TypeDesc type)
+        {
+            return _typeSymbols.GetOrAdd(type);
+        }
+
+        private NodeCache<TypeDesc, EETypeNode> _constructedTypeSymbols;
+
+        public ISymbolNode ConstructedTypeSymbol(TypeDesc type)
+        {
+            return _constructedTypeSymbols.GetOrAdd(type);
+        }
+
+        private NodeCache<MetadataType, NonGCStaticsNode> _nonGCStatics;
+
+        public ISymbolNode TypeNonGCStaticsSymbol(MetadataType type)
+        {
+            return _nonGCStatics.GetOrAdd(type);
+        }
+
+        private NodeCache<MetadataType, GCStaticsNode> _GCStatics;
+
+        public GCStaticsNode TypeGCStaticsSymbol(MetadataType type)
+        {
+            return _GCStatics.GetOrAdd(type);
+        }
+
+        class BoolArrayEqualityComparer : IEqualityComparer<bool[]>
+        {
+            bool IEqualityComparer<bool[]>.Equals(bool[] x, bool[] y)
+            {
+                if (x.Length != y.Length)
+                    return false;
+                
+                for (int i = 0; i < x.Length; i++)
+                {
+                    if (x[i] != y[i])
+                        return false;
+                }
+
+                return true;
+            }
+
+            int IEqualityComparer<bool[]>.GetHashCode(bool[] obj)
+            {
+                // TODO get better combining function for bools
+                int hash = 0x5d83481;
+                foreach (bool b in obj)
+                {
+                    int bAsInt = b ? 1 : 0;
+                    hash = (hash << 4) ^ hash ^ bAsInt;
+                }
+
+                return hash;
+            }
+        }
+
+        private NodeCache<bool[], GCStaticEETypeNode> _GCStaticEETypes;
+
+        public ISymbolNode GCStaticEEType(bool[] gcdesc)
+        {
+            return _GCStaticEETypes.GetOrAdd(gcdesc);
+        }
+
+        private NodeCache<string, ExternSymbolNode> _externSymbols;
+
+        public ISymbolNode ExternSymbol(string name)
+        {
+            return _externSymbols.GetOrAdd(name);
+        }
+
+        private NodeCache<Tuple<ObjectNode, int, string>, ObjectAndOffsetSymbolNode> _internalSymbols;
+
+        public ISymbolNode ObjectAndOffset(ObjectNode obj, int offset, string name)
+        {
+            return _internalSymbols.GetOrAdd(new Tuple<ObjectNode, int, string>(obj, offset, name));
+        }
+
+        private NodeCache<MethodDesc, MethodCodeNode> _methodCode;
+
+        public ISymbolNode MethodEntrypoint(MethodDesc method)
+        {
+            return _methodCode.GetOrAdd(method);
+        }
+
+        private NodeCache<MethodDesc, VirtualMethodUseNode> _virtMethods;
+
+        public DependencyNode VirtualMethodUse(MethodDesc decl)
+        {
+            return _virtMethods.GetOrAdd(decl);
+        }
+
+        private NodeCache<ReadyToRunHelper, ReadyToRunHelperNode> _readyToRunHelpers;
+
+        public ReadyToRunHelperNode ReadyToRunHelper(ReadyToRunHelper helper)
+        {
+            return _readyToRunHelpers.GetOrAdd(helper);
+        }
+
+        private NodeCache<string, StringDataNode> _stringDataNodes;
+
+        public StringDataNode StringData(string data)
+        {
+            return _stringDataNodes.GetOrAdd(data);
+        }
+
+        private NodeCache<string, StringIndirectionNode> _stringIndirectionNodes;
+
+        public StringIndirectionNode StringIndirection(string data)
+        {
+            return _stringIndirectionNodes.GetOrAdd(data);
+        }
+
+        public ArrayOfEmbeddedDataNode GCStaticsRegion = new ArrayOfEmbeddedDataNode("__GCStaticRegionStart", "__GCStaticRegionEnd", null);
+        public ArrayOfEmbeddedDataNode StringTable = new ArrayOfEmbeddedDataNode("__str_fixup", "__str_fixup_end", null);
+
+        public Dictionary<TypeDesc, List<MethodDesc>> VirtualSlots = new Dictionary<TypeDesc, List<MethodDesc>>();
+
+        public static NameMangler NameMangler;
+
+        public void AttachToDependencyGraph(DependencyAnalysisFramework.DependencyAnalyzerBase<NodeFactory> graph)
+        {
+            graph.AddRoot(GCStaticsRegion, "GC StaticsRegion is always generated");
+            graph.AddRoot(StringTable, "StringTable is always generated");
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    class NonGCStaticsNode : ObjectNode, ISymbolNode
+    {
+        MetadataType _type;
+
+        public NonGCStaticsNode(MetadataType type)
+        {
+            _type = type;
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "data";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return "__NonGCStaticBase_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            ObjectData data = new ObjectData(new byte[_type.NonGCStaticFieldSize],
+                                             Array.Empty<Relocation>(),
+                                             _type.NonGCStaticFieldAlignment,
+                                             new ISymbolNode[] { this });
+            return data;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using ILToNative.DependencyAnalysisFramework;
+
+namespace ILToNative.DependencyAnalysis
+{
+    class ObjectAndOffsetSymbolNode : DependencyNodeCore<NodeFactory>, ISymbolNode
+    {
+        private ObjectNode _object;
+        private int _offset;
+        private string _name;
+
+        public ObjectAndOffsetSymbolNode(ObjectNode obj, int offset, string name)
+        {
+            _object = obj;
+            _offset = offset;
+            _name = name;
+        }
+
+        public override string GetName()
+        {
+            return "Symbol " + _name + " at offset " + _offset.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public override bool HasConditionalStaticDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasDynamicDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return _name;
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return _offset;
+            }
+        }
+
+        public void SetSymbolOffset(int offset)
+        {
+            _offset = offset;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return new DependencyListEntry[] { new DependencyListEntry(_object, "ObjectAndOffsetDependency") };
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        {
+            return null;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ObjectNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ObjectNode.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using ILToNative.DependencyAnalysisFramework;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public abstract class ObjectNode : DependencyNodeCore<NodeFactory>
+    {
+        public class ObjectData
+        {
+            public ObjectData(byte[] data, Relocation[] relocs, int alignment, ISymbolNode[] definedSymbols)
+            {
+                Data = data;
+                Relocs = relocs;
+                Alignment = alignment;
+                DefinedSymbols = definedSymbols;
+            }
+
+            public readonly Relocation[] Relocs;
+            public readonly byte[] Data;
+            public readonly int Alignment;
+            public readonly ISymbolNode[] DefinedSymbols;
+        }
+
+        public abstract ObjectData GetData(NodeFactory factory, bool relocsOnly = false);
+
+        public abstract string Section
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Override this function to have a node which should be skipped when emitting
+        /// to the object file. (For instance, if there are two nodes describing the same
+        /// data structure, one of those nodes should return true here.)
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <returns></returns>
+        public virtual bool ShouldSkipEmittingObjectNode(NodeFactory factory)
+        {
+            return false;
+        }
+
+        public override bool HasConditionalStaticDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasDynamicDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            DependencyList dependencies = ComputeNonRelocationBasedDependencies(context);
+            Relocation[] relocs = GetData(context, true).Relocs;
+
+            if (relocs != null)
+            {
+                if (dependencies == null)
+                    dependencies = new DependencyList();
+
+                foreach (Relocation reloc in relocs)
+                {
+                    dependencies.Add(reloc.Target, "reloc");
+                }
+            }
+
+            if (dependencies == null)
+                return Array.Empty<DependencyListEntry>();
+            else
+                return dependencies;
+        }
+
+        protected virtual DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        {
+            return null;
+        }
+
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ILToNative.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public partial class ReadyToRunHelperNode : AssemblyStubNode
+    {
+        ReadyToRunHelper _helper;
+
+        public ReadyToRunHelperNode(ReadyToRunHelper helper)
+        {
+            _helper = helper;
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public ReadyToRunHelper Helper
+        {
+            get
+            {
+                return _helper;
+            }
+        }
+
+        public override string MangledName
+        {
+            get
+            {
+                return _helper.MangledName;
+            }
+        }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        {
+            if (Helper.Id == ReadyToRunHelperId.VirtualCall)
+            {
+                DependencyList dependencyList = new DependencyList();
+                dependencyList.Add(context.VirtualMethodUse((MethodDesc)Helper.Target), "ReadyToRun Virtual Method Call");
+                return dependencyList;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public enum RelocType
+    {
+        IMAGE_REL_BASED_DIR64 = 0x0A,
+        IMAGE_REL_BASED_REL32 = 0x10,
+    }
+    public struct Relocation
+    {
+        public RelocType RelocType;
+        public int Offset;
+        public ISymbolNode Target;
+        public short Delta; // Currently unused
+        public byte InstructionLength; // Temporary. Used to make emission as an assembly file straightforward. Remove when asmwriter removed.
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public class StringDataNode : ObjectNode, ISymbolNode
+    {
+        public string _data;
+        private int? _id;
+
+        public StringDataNode(string data)
+        {
+            _data = data;
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "data";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                if (_id.HasValue)
+                    return "__str_table_entry_" + _id.Value.ToString(CultureInfo.InvariantCulture);
+                else
+                    return "__str_table_entry_" + _data;
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public void SetId(int id)
+        {
+            _id = id;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            Encoding encoding = UTF8Encoding.UTF8;
+
+            ObjectDataBuilder objDataBuilder = new ObjectDataBuilder(factory);
+            AsmStringWriter stringWriter = new AsmStringWriter((byte b) =>objDataBuilder.EmitByte(b));
+            stringWriter.WriteString(_data);
+            objDataBuilder.DefinedSymbols.Add(this);
+
+            return objDataBuilder.ToObjectData();
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using ILToNative.DependencyAnalysisFramework;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public class StringIndirectionNode : EmbeddedObjectNode, ISymbolNode
+    {
+        public string _data;
+
+        public StringIndirectionNode(string data)
+        {
+            base.Offset = 1; // 1 is not a valid offset, so when the wrapper object emitter sets offsets, it will become more reasonable
+            _data = data;
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                if (base.Offset != 1)
+                    return "__str" + base.Offset.ToString(CultureInfo.InvariantCulture);
+                else
+                    return "__str" + _data;
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return base.Offset;
+            }
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            dataBuilder.RequirePointerAlignment();
+
+            StringDataNode stringDataNode = factory.StringData(_data);
+            if (!relocsOnly)
+                stringDataNode.SetId(base.Offset);
+
+            dataBuilder.EmitPointerReloc(stringDataNode);
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return new DependencyListEntry[] { new DependencyListEntry(context.StringData(_data), "string contents") };
+        }
+
+        protected override void OnMarked(NodeFactory context)
+        {
+            context.StringTable.AddEmbeddedObject(this);
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/AddrMode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/AddrMode.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ILToNative.DependencyAnalysis.X64
+{
+    public enum AddrModeSize
+    {
+        Int8 = 1,
+        Int16 = 2,
+        Int32 = 4,
+        Int64 = 8,
+        Int128 = 16
+    }
+
+    public struct AddrMode
+    {
+        public AddrMode(Register baseRegister, Register? indexRegister, int offset, byte scale, AddrModeSize size)
+        {
+            _baseReg = baseRegister;
+            _indexReg = indexRegister;
+            _offset = offset;
+            _scale = scale;
+            _size = size;
+        }
+
+        Register _baseReg;
+        Register? _indexReg;
+        int _offset;
+        byte _scale;
+        AddrModeSize _size;
+
+        public Register BaseReg
+        {
+            get { return _baseReg; }
+        }
+        public int Offset
+        {
+            get { return _offset; }
+        }
+
+        public Register? IndexReg
+        {
+            get { return _indexReg; }
+        }
+
+        public byte Scale
+        {
+            get { return _scale; }
+        }
+
+        public AddrModeSize Size
+        {
+            get { return _size; }
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/Register.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/Register.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ILToNative.DependencyAnalysis.X64
+{
+    public enum Register
+    {
+        RAX = 0,
+        RCX = 1,
+        RDX = 2,
+        RBX = 3,
+        RSP = 4,
+        RBP = 5,
+        RSI = 6,
+        RDI = 7,
+        R8 = 8,
+        R9 = 9,
+        R10 = 10,
+        R11 = 11,
+        R12 = 12,
+        R13 = 13,
+        R14 = 14,
+        R15 = 15,
+
+        None = 16,
+        RegDirect = 24,
+
+        NoIndex = 128,
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace ILToNative.DependencyAnalysis.X64
+{
+    public struct X64Emitter
+    {
+        public X64Emitter(NodeFactory factory)
+        {
+            Builder = new ObjectDataBuilder(factory);
+        }
+
+        public ObjectDataBuilder Builder;
+
+        // Assembly stub creation api. TBD, actually make this general purpose
+        public void EmitMOV(Register regDst, ref AddrMode memory)
+        {
+            EmitIndirInstructionSize(0x8a, regDst, ref memory);
+        }
+
+        public void EmitLEAQ(Register reg, ISymbolNode symbol)
+        {
+            AddrMode rexAddrMode = new AddrMode(Register.RAX, null, 0, 0, AddrModeSize.Int64);
+            EmitRexPrefix(reg, ref rexAddrMode);
+            Builder.EmitByte(0x8D);
+            int regNumLowBits = ((int)reg) & 0x07;
+            int regNumLowBitsShifted = regNumLowBits << 3;
+            byte modRM = (byte)(regNumLowBitsShifted | 0x05);
+            Builder.EmitByte(modRM);
+            EmitRel32RelocFor3ByteOpcode(symbol);
+        }
+
+        public void EmitJMP(ISymbolNode symbol)
+        {
+            Builder.EmitByte(0xE9);
+            EmitRel32RelocFor1ByteOpcode(symbol);
+        }
+
+        public void EmitJmpToAddrMode(ref AddrMode addrMode)
+        {
+            EmitIndirInstruction(0xFF, 0x4, ref addrMode);
+        }
+
+        public void EmitRET()
+        {
+            Builder.EmitByte(0xC3);
+        }
+
+        private bool InSignedByteRange(int i)
+        {
+            return i == (int)(sbyte)i;
+        }
+
+        private void EmitImmediate(int immediate, int size)
+        {
+            switch (size)
+            {
+                case 0:
+                    break;
+                case 1:
+                    Builder.EmitByte((byte)immediate);
+                    break;
+                case 2:
+                    Builder.EmitShort((short)immediate);
+                    break;
+                case 4:
+                    Builder.EmitInt(immediate);
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        private void EmitModRM(byte subOpcode, ref AddrMode addrMode)
+        {
+            byte modRM = (byte)((subOpcode & 0x07) << 3);
+            if (addrMode.BaseReg > Register.None)
+            {
+                Debug.Assert(addrMode.BaseReg >= Register.RegDirect);
+
+                Register reg = (Register)(addrMode.BaseReg - Register.RegDirect);
+                Builder.EmitByte((byte)(0xC0 | modRM | ((int)reg & 0x07)));
+            }
+            else
+            {
+                byte lowOrderBitsOfBaseReg = (byte)((int)addrMode.BaseReg & 0x07);
+                modRM |= lowOrderBitsOfBaseReg;
+                int offsetSize = 0;
+
+                if (addrMode.Offset == 0 && (lowOrderBitsOfBaseReg != (byte)Register.RBP))
+                {
+                    offsetSize = 0;
+                }
+                else if (InSignedByteRange(addrMode.Offset))
+                {
+                    offsetSize = 1;
+                    modRM |= 0x40;
+                }
+                else
+                {
+                    offsetSize = 4;
+                    modRM |= 0x80;
+                }
+
+                bool emitSibByte = false;
+                Register sibByteBaseRegister = addrMode.BaseReg;
+
+                if (addrMode.BaseReg == Register.None)
+                {
+                    //# ifdef TARGET_X64          
+                    // x64 requires SIB to avoid RIP relative address
+                    emitSibByte = true;
+                    //#else
+                    //                    emitSibByte = (addrMode.m_indexReg != MDIL_REG_NO_INDEX);
+                    //#endif
+
+                    modRM &= 0x38;    // set Mod bits to 00 and clear out base reg
+                    offsetSize = 4;   // this forces 32-bit displacement
+
+                    if (emitSibByte)
+                    {
+                        // EBP in SIB byte means no base
+                        // ModRM base register forced to ESP in SIB code below
+                        sibByteBaseRegister = Register.RBP;
+                    }
+                    else
+                    {
+                        // EBP in ModRM means no base
+                        modRM |= (byte)(Register.RBP);
+                    }
+                }
+                else if (lowOrderBitsOfBaseReg == (byte)Register.RSP || addrMode.IndexReg.HasValue)
+                {
+                    emitSibByte = true;
+                }
+
+                if (!emitSibByte)
+                {
+                    Builder.EmitByte(modRM);
+                }
+                else
+                {
+                    // MDIL_REG_ESP as the base is the marker that there is a SIB byte
+                    modRM = (byte)((modRM & 0xF8) | (int)Register.RSP);
+                    Builder.EmitByte(modRM);
+
+                    int indexRegAsInt = (int)(addrMode.IndexReg.HasValue ? addrMode.IndexReg.Value : Register.RSP);
+
+                    Builder.EmitByte((byte)((addrMode.Scale << 6) + ((indexRegAsInt & 0x07) << 3) + ((int)sibByteBaseRegister & 0x07)));
+                }
+                EmitImmediate(addrMode.Offset, offsetSize);
+            }
+        }
+
+        private void EmitExtendedOpcode(int opcode)
+        {
+            if ((opcode >> 16) != 0)
+            {
+                if ((opcode >> 24) != 0)
+                {
+                    Builder.EmitByte((byte)(opcode >> 24));
+                }
+                Builder.EmitByte((byte)(opcode >> 16));
+            }
+            Builder.EmitByte((byte)(opcode >> 8));
+        }
+
+        private void EmitRexPrefix(Register reg, ref AddrMode addrMode)
+        {
+            byte rexPrefix = 0;
+
+            // Check the situations where a REX prefix is needed
+
+            // Are we accessing a byte register that wasn't byte accessible in x86?
+            if (addrMode.Size == AddrModeSize.Int8 && reg >= Register.RSP)
+            {
+                rexPrefix |= 0x40;
+            }
+
+            // Is this a 64 bit instruction?
+            if (addrMode.Size == AddrModeSize.Int64)
+            {
+                rexPrefix |= 0x48;
+            }
+
+            // Is the destination register one of the new ones?
+            if (reg >= Register.R8)
+            {
+                rexPrefix |= 0x44;
+            }
+
+            // Is the index register one of the new ones?
+            if (addrMode.IndexReg.HasValue && addrMode.IndexReg.Value >= Register.R8 && addrMode.IndexReg.Value <= Register.R15)
+            {
+                rexPrefix |= 0x42;
+            }
+
+            // Is the base register one of the new ones?
+            if (addrMode.BaseReg >= Register.R8 && addrMode.BaseReg <= Register.R15
+               || addrMode.BaseReg >= (int)Register.R8 + Register.RegDirect && addrMode.BaseReg <= (int)Register.R15 + Register.RegDirect)
+            {
+                rexPrefix |= 0x41;
+            }
+
+            // If we have anything so far, emit it.
+            if (rexPrefix != 0)
+            {
+                Builder.EmitByte(rexPrefix);
+            }
+        }
+
+        private void EmitIndirInstruction(int opcode, byte subOpcode, ref AddrMode addrMode)
+        {
+            EmitRexPrefix(Register.RAX, ref addrMode);
+            if ((opcode >> 8) != 0)
+            {
+                EmitExtendedOpcode(opcode);
+            }
+            Builder.EmitByte((byte)opcode);
+            EmitModRM(subOpcode, ref addrMode);
+        }
+
+        void EmitIndirInstruction(int opcode, Register dstReg, ref AddrMode addrMode)
+        {
+            EmitRexPrefix(dstReg, ref addrMode);
+            if ((opcode >> 8) != 0)
+            {
+                EmitExtendedOpcode(opcode);
+            }
+            Builder.EmitByte((byte)opcode);
+            EmitModRM((byte)((int)dstReg & 0x07), ref addrMode);
+        }
+
+        private void EmitIndirInstructionSize(int opcode, Register dstReg, ref AddrMode addrMode)
+        {
+            //# ifndef TARGET_X64
+            // assert that ESP, EBP, ESI, EDI are not accessed as bytes in 32-bit mode
+            //            Debug.Assert(!(addrMode.Size == AddrModeSize.Int8 && dstReg > Register.RBX));
+            //#endif
+            Debug.Assert(addrMode.Size != 0);
+            if (addrMode.Size == AddrModeSize.Int16)
+                Builder.EmitByte(0x66);
+            EmitIndirInstruction(opcode + ((((int)addrMode.Size) > 1) ? 1 : 0), dstReg, ref addrMode);
+        }
+
+        private void EmitRel32RelocFor1ByteOpcode(ISymbolNode symbol)
+        {
+            Builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_REL32, 1);
+        }
+
+        private void EmitRel32RelocFor3ByteOpcode(ISymbolNode symbol)
+        {
+            Builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_REL32, 3);
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using ILToNative.DependencyAnalysis.X64;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    /// <summary>
+    /// X64 specific portions of ReadyToRunHelperNode
+    /// </summary>
+    public partial class ReadyToRunHelperNode
+    {
+        protected override void EmitCode(NodeFactory factory, ref X64Emitter encoder, bool relocsOnly)
+        {
+            switch (Helper.Id)
+            {
+                case ReadyToRunHelperId.NewHelper:
+                    encoder.EmitLEAQ(Register.RCX, factory.ConstructedTypeSymbol((TypeDesc)Helper.Target));
+                    encoder.EmitJMP(factory.ExternSymbol("__allocate_object"));
+                    break;
+
+                case ReadyToRunHelperId.VirtualCall:
+                    if (relocsOnly)
+                        break;
+
+                    AddrMode loadFromRcx = new AddrMode(Register.RCX, null, 0, 0, AddrModeSize.Int64);
+                    encoder.EmitMOV(Register.RAX, ref loadFromRcx);
+
+                    // TODO: More efficient lookup of the slot
+                    {
+                        MethodDesc method = (MethodDesc)Helper.Target;
+                        TypeDesc owningType = method.OwningType;
+
+                        int baseSlots = 0;
+                        var baseType = owningType.BaseType;
+
+                        while (baseType != null)
+                        {
+                            List<MethodDesc> baseVirtualSlots;
+                            factory.VirtualSlots.TryGetValue(baseType, out baseVirtualSlots);
+
+                            if (baseVirtualSlots != null)
+                                baseSlots += baseVirtualSlots.Count;
+                            baseType = baseType.BaseType;
+                        }
+
+                        List<MethodDesc> virtualSlots = factory.VirtualSlots[owningType];
+                        int methodSlot = -1;
+                        for (int slot = 0; slot < virtualSlots.Count; slot++)
+                        {
+                            if (virtualSlots[slot] == method)
+                            {
+                                methodSlot = slot;
+                                break;
+                            }
+                        }
+
+                        Debug.Assert(methodSlot != -1);
+                        AddrMode jmpAddrMode = new AddrMode(Register.RAX, null, 16 + (baseSlots + methodSlot) * factory.Target.PointerSize, 0, AddrModeSize.Int64);
+                        encoder.EmitJmpToAddrMode(ref jmpAddrMode);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.IsInstanceOf:
+                    encoder.EmitLEAQ(Register.RDX, factory.NecessaryTypeSymbol((TypeDesc)Helper.Target));
+                    encoder.EmitJMP(factory.ExternSymbol("__isinst_class"));
+                    break;
+
+                case ReadyToRunHelperId.CastClass:
+                    encoder.EmitLEAQ(Register.RDX, factory.NecessaryTypeSymbol((TypeDesc)Helper.Target));
+                    encoder.EmitJMP(factory.ExternSymbol("__castclass_class"));
+                    break;
+
+                case ReadyToRunHelperId.NewArr1:
+                    encoder.EmitLEAQ(Register.RDX, factory.NecessaryTypeSymbol((TypeDesc)Helper.Target));
+                    encoder.EmitJMP(factory.ExternSymbol("__allocate_array"));
+                    break;
+
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    encoder.EmitLEAQ(Register.RAX, factory.TypeNonGCStaticsSymbol((MetadataType)Helper.Target));
+                    encoder.EmitRET();
+                    break;
+
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    encoder.EmitLEAQ(Register.RAX, factory.TypeGCStaticsSymbol((MetadataType)Helper.Target));
+                    AddrMode loadFromRax = new AddrMode(Register.RAX, null, 0, 0, AddrModeSize.Int64);
+                    encoder.EmitMOV(Register.RAX, ref loadFromRax);
+                    encoder.EmitMOV(Register.RAX, ref loadFromRax);
+                    encoder.EmitRET();
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ILToNative.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis
+{
+    // This node represents the concept of a virtual method being used.
+    // It has no direct depedencies, but may be referred to by conditional static 
+    // dependencies, or static dependencies from elsewhere.
+    //
+    // It is used to keep track of uses of virtual methods to ensure that the
+    // vtables are properly constructed
+    class VirtualMethodUseNode : DependencyNodeCore<NodeFactory>
+    {
+        MethodDesc _decl;
+
+        public VirtualMethodUseNode(MethodDesc decl)
+        {
+            _decl = decl;
+        }
+
+        public override string GetName()
+        {
+            return "VirtualMethodUse" + _decl.ToString();
+        }
+
+        protected override void OnMarked(NodeFactory factory)
+        {
+            // For each virtual method use in the graph, ensure that our side
+            // table of live virtual method slots is kept up to date.
+
+            MethodDesc virtualMethod = (MethodDesc)this._decl;
+            TypeDesc typeOfVirtual = virtualMethod.OwningType;
+
+            List<MethodDesc> virtualSlots;
+            if (!factory.VirtualSlots.TryGetValue(typeOfVirtual, out virtualSlots))
+            {
+                virtualSlots = new List<MethodDesc>();
+                factory.VirtualSlots.Add(typeOfVirtual, virtualSlots);
+            }
+            if (!virtualSlots.Contains(virtualMethod))
+            {
+                virtualSlots.Add(virtualMethod);
+            }
+        }
+
+        public override bool HasConditionalStaticDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasDynamicDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        {
+            return null;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/ReadyToRunHelper.cs
+++ b/src/ILToNative.Compiler/src/Compiler/ReadyToRunHelper.cs
@@ -22,7 +22,7 @@ namespace ILToNative
         GetGCStaticBase,
     }
 
-    class ReadyToRunHelper
+    public class ReadyToRunHelper : IEquatable<ReadyToRunHelper>
     {
         Compilation _compilation;
 
@@ -60,7 +60,25 @@ namespace ILToNative
                     default:
                         throw new NotImplementedException();
                 }
-            }            
+            }
+        }
+
+        public bool Equals(ReadyToRunHelper other)
+        {
+            return (Id == other.Id) && ReferenceEquals(Target, other.Target);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode() ^ Target.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is ReadyToRunHelper))
+                return false;
+
+            return Equals((ReadyToRunHelper)obj);
         }
     }
 }

--- a/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
+++ b/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
@@ -19,6 +19,10 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\ILToNative.DependencyAnalysisFramework\src\ILToNative.DependencyAnalysisFramework.csproj">
+      <Project>{dac23e9f-f826-4577-ae7a-0849ff83280c}</Project>
+      <Name>ILToNative.DependencyAnalysisFramework</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\ILToNative.TypeSystem\src\ILToNative.TypeSystem.csproj">
       <Project>{1a9df196-43a9-44bb-b2c6-d62aa56b0e49}</Project>
       <Name>ILToNative.TypeSystem</Name>
@@ -29,6 +33,30 @@
     <Compile Include="Compiler\AsmWriter.cs" />
     <Compile Include="Compiler\Compilation.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\EmbeddedObjectNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\StringDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\StringIndirectionNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_X64\AddrMode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\AsmWriter.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\AssemblyStubNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\EETypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ExternSymbolNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GCStaticEETypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GCStaticsNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ISymbolNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\MethodCodeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NodeFactory.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NonGCStaticsNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ObjectAndOffsetSymbolNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ObjectDataBuilder.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ObjectNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRunHelperNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Relocation.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\VirtualMethodUseNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_X64\Register.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64Emitter.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\JitHelper.cs" />
     <Compile Include="Compiler\MemoryHelper.cs" />
     <Compile Include="Compiler\MethodCode.cs" />

--- a/src/ILToNative.DependencyAnalysisFramework/src/ComputedStaticDependencyNode.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/ComputedStaticDependencyNode.cs
@@ -14,7 +14,6 @@ namespace ILToNative.DependencyAnalysisFramework
     {
         private IEnumerable<DependencyListEntry> _dependencies;
         private IEnumerable<CombinedDependencyListEntry> _conditionalDependencies;
-        private static CombinedDependencyListEntry[] s_emptyDynamicList = new CombinedDependencyListEntry[0];
 
         public void SetStaticDependencies(IEnumerable<DependencyListEntry> dependencies,
                                           IEnumerable<CombinedDependencyListEntry> conditionalDependencies)
@@ -71,7 +70,7 @@ namespace ILToNative.DependencyAnalysisFramework
 
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<DependencyContextType>> markedNodes, int firstNode, DependencyContextType context)
         {
-            return s_emptyDynamicList;
+            return Array.Empty<CombinedDependencyListEntry>();
         }
     }
 }

--- a/src/ILToNative.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
@@ -135,9 +135,13 @@ namespace ILToNative.DependencyAnalysisFramework
         // Internal details
         void GetStaticDependenciesImpl(DependencyNodeCore<DependencyContextType> node)
         {
-            foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in node.GetStaticDependencies(_dependencyContext))
+            IEnumerable<DependencyNodeCore<DependencyContextType>.DependencyListEntry> staticDependencies = node.GetStaticDependencies(_dependencyContext);
+            if (staticDependencies != null)
             {
-                AddToMarkStack(dependency.Node, dependency.Reason, node, null);
+                foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in staticDependencies)
+                {
+                    AddToMarkStack(dependency.Node, dependency.Reason, node, null);
+                }
             }
 
             if (node.HasConditionalStaticDependencies)
@@ -222,9 +226,6 @@ namespace ILToNative.DependencyAnalysisFramework
 
                         _conditional_dependency_store.Remove(currentNode);
                     }
-
-                    if (NewMarkedNode != null)
-                        NewMarkedNode(currentNode);
                 }
 
                 // Find new dependencies introduced by dynamic depedencies
@@ -270,6 +271,11 @@ namespace ILToNative.DependencyAnalysisFramework
             {
                 _markStack.Push(node);
                 _markedNodes.Add(node);
+
+                node.CallOnMarked(_dependencyContext);
+
+                if (NewMarkedNode != null)
+                    NewMarkedNode(node);
 
                 return true;
             }

--- a/src/ILToNative.DependencyAnalysisFramework/src/DependencyAnalyzerBase.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DependencyAnalyzerBase.cs
@@ -30,6 +30,14 @@ namespace ILToNative.DependencyAnalysisFramework
         public abstract void AddRoot(DependencyNodeCore<DependencyContextType> rootNode, string reason);
 
         /// <summary>
+        /// Add a root node
+        /// </summary>
+        public void AddRoot(object rootNode, string reason)
+        {
+            AddRoot((DependencyNodeCore<DependencyContextType>)rootNode, reason);
+        }
+
+        /// <summary>
         /// Return the marked node list. Do not modify this list, as it will cause unexpected behavior.
         /// </summary>
         public abstract ImmutableArray<DependencyNodeCore<DependencyContextType>> MarkedNodeList

--- a/src/ILToNative.DependencyAnalysisFramework/src/DependencyNode.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DependencyNode.cs
@@ -3,13 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace ILToNative.DependencyAnalysisFramework
 {
-    public class DependencyNode
+    public abstract class DependencyNode
     {
         private object _mark;
 
@@ -19,8 +20,11 @@ namespace ILToNative.DependencyAnalysisFramework
 
         internal void SetMark(object mark)
         {
+            Debug.Assert(mark != null);
+            Debug.Assert(_mark == null);
             _mark = mark;
         }
+
         internal object GetMark()
         {
             return _mark;
@@ -32,6 +36,14 @@ namespace ILToNative.DependencyAnalysisFramework
             {
                 return _mark != null;
             }
+        }
+
+        // Force all non-abstract nodes to provide a name
+        public abstract string GetName();
+
+        public sealed override string ToString()
+        {
+            return GetName();
         }
     }
 }

--- a/src/ILToNative.DependencyAnalysisFramework/src/DependencyNodeCore.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/src/DependencyNodeCore.cs
@@ -20,8 +20,29 @@ namespace ILToNative.DependencyAnalysisFramework
                 Reason = reason;
             }
 
+            public DependencyListEntry(object node,
+                                       string reason)
+            {
+                Node = (DependencyNodeCore<DependencyContextType>)node;
+                Reason = reason;
+            }
+
             public DependencyNodeCore<DependencyContextType> Node;
             public string Reason;
+        }
+
+        public class DependencyList : List<DependencyListEntry>
+        {
+            public void Add(DependencyNodeCore<DependencyContextType> node,
+                                       string reason)
+            {
+                this.Add(new DependencyListEntry(node, reason));
+            }
+
+            public void Add(object node, string reason)
+            {
+                this.Add(new DependencyListEntry((DependencyNodeCore<DependencyContextType>)node, reason));
+            }
         }
 
         public struct CombinedDependencyListEntry
@@ -32,6 +53,15 @@ namespace ILToNative.DependencyAnalysisFramework
             {
                 Node = node;
                 OtherReasonNode = otherReasonNode;
+                Reason = reason;
+            }
+
+            public CombinedDependencyListEntry(object node,
+                                               object otherReasonNode,
+                                               string reason)
+            {
+                Node = (DependencyNodeCore<DependencyContextType>)node;
+                OtherReasonNode = (DependencyNodeCore<DependencyContextType>)otherReasonNode;
                 Reason = reason;
             }
 
@@ -66,5 +96,20 @@ namespace ILToNative.DependencyAnalysisFramework
         public abstract IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(DependencyContextType context);
 
         public abstract IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<DependencyContextType>> markedNodes, int firstNode, DependencyContextType context);
+
+        internal void CallOnMarked(DependencyContextType context)
+        {
+            OnMarked(context);
+        }
+
+        /// <summary>
+        /// Overrides of this method allow a node to perform actions when said node becomes
+        /// marked.
+        /// </summary>
+        /// <param name="context"></param>
+        protected virtual void OnMarked(DependencyContextType context)
+        {
+            // Do nothing by default
+        }
     }
 }

--- a/src/ILToNative.DependencyAnalysisFramework/src/project.json
+++ b/src/ILToNative.DependencyAnalysisFramework/src/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0",
+    "System.Runtime": "4.0.20",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Reflection.Primitives": "4.0.0",
     "System.Diagnostics.Debug": "4.0.0",

--- a/src/ILToNative.DependencyAnalysisFramework/tests/TestGraph.cs
+++ b/src/ILToNative.DependencyAnalysisFramework/tests/TestGraph.cs
@@ -30,7 +30,7 @@ namespace ILToNative.DependencyAnalysisFramework.Tests
                 }
             }
 
-            public override string ToString()
+            public override string GetName()
             {
                 return _data;
             }

--- a/src/ILToNative/ILToNative.sln
+++ b/src/ILToNative/ILToNative.sln
@@ -1,13 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23023.0
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative", "src\ILToNative.csproj", "{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "repro", "repro\repro.csproj", "{FBA029C3-B184-4457-AEEC-38D0C2523067}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.TypeSystem", "..\ILToNative.TypeSystem\src\ILToNative.TypeSystem.csproj", "{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.DependencyAnalysisFramework", "..\ILToNative.DependencyAnalysisFramework\src\ILToNative.DependencyAnalysisFramework.csproj", "{DAC23E9F-F826-4577-AE7A-0849FF83280C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILToNative.Compiler", "..\ILToNative.Compiler\src\ILToNative.Compiler.csproj", "{13BB3788-C3EB-4046-8105-A95F8AE49404}"
@@ -32,6 +33,10 @@ Global
 		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|x64.Build.0 = Debug|Any CPU
 		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|x64.ActiveCfg = Release|Any CPU
 		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|x64.Build.0 = Release|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|x64.Build.0 = Debug|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|x64.ActiveCfg = Release|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|x64.Build.0 = Release|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Debug|x64.Build.0 = Debug|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Release|x64.ActiveCfg = Release|Any CPU
@@ -40,10 +45,6 @@ Global
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|x64.Build.0 = Debug|x64
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.ActiveCfg = Release|x64
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.Build.0 = Release|x64
-		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|x64.Build.0 = Debug|Any CPU
-		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|x64.ActiveCfg = Release|Any CPU
-		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ILToNative/src/Program.cs
+++ b/src/ILToNative/src/Program.cs
@@ -37,6 +37,8 @@ namespace ILToNative
             Console.WriteLine();
             Console.WriteLine("-help        Display this usage message (Short form: -?)");
             Console.WriteLine("-out         Specify output file name");
+            Console.WriteLine("-dgmllog     Dump dgml log of dependency graph to specified file");
+            Console.WriteLine("-fulllog     Generate full dependency log graph");
             Console.WriteLine("-reference   Reference metadata from the specified assembly (Short form: -r)");
         }
 
@@ -62,6 +64,14 @@ namespace ILToNative
                 case "o":
                 case "out":
                     _outputPath = parser.GetStringValue();
+                    break;
+
+                case "dgmllog":
+                    _options.DgmlLog = parser.GetStringValue();
+                    break;
+                   
+                case "fulllog":
+                    _options.FullLog = true;
                     break;
 
                 case "r":


### PR DESCRIPTION
- Abstraction for symbols
- Abstraction for individual contents of the object file
- Abstraction for generation of assembly stubs
- Nodes for EETypes, non-gc statics, ready to run helpers, method code
- Abstraction for careful expansion of virtual methods
- New asmwriter based on object nodes from dependency graph
- Refactor code generator based compilation to use new graph. (Old logic is still in place for the Cpp code generator, and for ease of merging in changes as they occur. Once this change is merged, I'll work to get rid of the old asm emission path, and work with Jan to change over Cpp emission)
- Dependency graph can be logged to a dgml file and viewed in visual studio.
- New assembly emitter helper library for use by stubs
- Make ReadyToRunHelper class hash table friendly, and use in node table for lookup.
- Add node naming function GetName to force all non-abstract nodes to implement it
- Add concept of ObjectNodes which aren't actually emitted in the end. Use to only emit 1 eetype even if both constructed and non-constructed ones are in the graph.
- Target specific items are (mostly) in a target specific directory

DependencyAnalysisFramework changes
- Make the OnMarked override take a context parameter
- Simplify ISymbolNode
