### PR TITLE
Add support for Call intrinsic

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -24,6 +24,17 @@ namespace Internal.IL
         {
             if (method is EcmaMethod)
             {
+                // TODO: Workaround: we should special case methods with Intrinsic attribute, but since
+                //       CoreLib source is still not in the repo, we have to work with what we have, which is
+                //       an MCG attribute on the type itself...
+                if (((EcmaType)method.OwningType).HasCustomAttribute("System.Runtime.InteropServices.McgIntrinsicsAttribute"))
+                {
+                    if (method.Name == "Call")
+                    {
+                        return CalliIntrinsic.EmitIL(method);
+                    }
+                }
+
                 return EcmaMethodIL.Create((EcmaMethod)method);
             }
             else

--- a/src/Common/src/TypeSystem/IL/InstantiatedMethodIL.cs
+++ b/src/Common/src/TypeSystem/IL/InstantiatedMethodIL.cs
@@ -75,16 +75,26 @@ namespace Internal.IL
             {
                 o = ((MethodDesc)o).InstantiateSignature(_typeInstantiation, _methodInstantiation);
             }
-            else
-            if (o is TypeDesc)
+            else if (o is TypeDesc)
             {
                 o = ((TypeDesc)o).InstantiateSignature(_typeInstantiation, _methodInstantiation);
             }
-            else
-            if (o is FieldDesc)
+            else if (o is FieldDesc)
             {
                 o = ((FieldDesc)o).InstantiateSignature(_typeInstantiation, _methodInstantiation);
             }
+            else if (o is MethodSignature)
+            {
+                MethodSignature template = (MethodSignature)o;
+                MethodSignatureBuilder builder = new MethodSignatureBuilder(template);
+
+                builder.ReturnType = template.ReturnType.InstantiateSignature(_typeInstantiation, _methodInstantiation);
+                for (int i = 0; i < template.Length; i++)
+                    builder[i] = template[i].InstantiateSignature(_typeInstantiation, _methodInstantiation);
+
+                o = builder.ToSignature();
+            }
+
 
             return o;
         }

--- a/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Internal.TypeSystem;
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Provides method bodies for Calli intrinsics. The intrinsics work around the inability to express
+    /// calli instruction in C#. The intrinsic method has a shape of
+    /// "T Call&lt;T&gt;(IntPtr address, X arg0,... Y argN)", for which a body will be provided by
+    /// this generator that loads the arguments and performs a calli to the address specified as the first argument.
+    /// </summary>
+    public static class CalliIntrinsic
+    {
+        public static MethodIL EmitIL(MethodDesc target)
+        {
+            Debug.Assert(target.Name == "Call");
+            Debug.Assert(target.Signature.Length > 0
+                && target.Signature[0] == target.Context.GetWellKnownType(WellKnownType.IntPtr));
+
+            ILEmitter emitter = new ILEmitter();
+            var codeStream = emitter.NewCodeStream();
+
+            // Load all the arguments except the first one (IntPtr address)
+            for (int i = 1; i < target.Signature.Length; i++)
+            {
+                codeStream.EmitLdArg(i);
+            }
+
+            // now load IntPtr address
+            codeStream.EmitLdArg(0);
+
+            // Create a signature for the calli by copying the signature of the containing method
+            // while skipping the first argument
+            MethodSignature template = target.Signature;
+            TypeDesc returnType = template.ReturnType;
+            TypeDesc[] parameters = new TypeDesc[template.Length - 1];
+            for (int i = 1; i < template.Length; i++)
+            {
+                parameters[i - 1] = template[i];
+            }
+
+            var signature = new MethodSignature(template.Flags, 0, returnType, parameters);
+
+            codeStream.Emit(ILOpcode.calli, emitter.NewToken(signature));
+            codeStream.Emit(ILOpcode.ret);
+
+            return emitter.Link();
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -205,6 +205,11 @@ namespace Internal.IL.Stubs
             return NewToken(value, 0x70000000);
         }
 
+        public int NewToken(MethodSignature value)
+        {
+            return NewToken(value, 0x11000000);
+        }
+
         public int NewLocal(TypeDesc localType)
         {
             int index = _locals.Count;

--- a/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
+++ b/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
@@ -97,6 +97,9 @@
     <Compile Include="$(CommonPath)\TypeSystem\IL\Stubs\ArrayMethodILEmitter.cs">
       <Link>IL\Stubs\ArrayMethodILEmitter.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\TypeSystem\IL\Stubs\CalliIntrinsic.cs">
+      <Link>IL\Stubs\CalliIntrinsic.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\TypeSystem\IL\Stubs\DelegateThunks.cs">
       <Link>IL\Stubs\DelegateThunks.cs</Link>
     </Compile>


### PR DESCRIPTION
The concept of Call intrinsic is used in the .NET Native compiler when
C# code needs to perform an indirect call to an address. Since calli is
not exposed in the language, the C# code calls a special method that
will be transformed by the compiler to perform a calli.

The method has shape T Call<T>(IntPtr address, X arg0,... Z argN). The
generated method body loads arguments arg0...argN and performs a calli
to the address given in the first argument.
