### PR TITLE
Switch reproNative to use MRT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,6 +271,4 @@ cross/rootfs/*
 # Temporary files from ad hoc testing projects
 src/ILToNative/reproNative/repro.cpp
 src/ILToNative/reproNative/repro.s
-src/ILToNative/reproNative/reproNative.sln
-src/ILToNative/reproNative/reproNativeCpp.sln
 

--- a/src/ILToNative/reproNative/common.h
+++ b/src/ILToNative/reproNative/common.h
@@ -135,10 +135,6 @@ struct RawEEType
     uint32_t    m_uHashCode;
 };
 
-#if !USE_MRT
-#define EEType MethodTable
-#endif
-
 struct ReversePInvokeFrame
 {
     void*   m_savedPInvokeTransitionFrame;

--- a/src/ILToNative/reproNative/main.cpp
+++ b/src/ILToNative/reproNative/main.cpp
@@ -3,64 +3,30 @@
 
 #include "common.h"
 
-#define USE_MRT 0
-
 #include "gcenv.h"
 
-#if !USE_MRT
 #include "gc.h"
 #include "objecthandle.h"
-#include "gcdesc.h"
-#else
+
+#pragma warning(disable:4297)
+
 extern "C" Object * RhNewObject(MethodTable * pMT);
 extern "C" Object * RhNewArray(MethodTable * pMT, int32_t elements);
 extern "C" void RhpReversePInvoke2(ReversePInvokeFrame* pRevFrame);
 extern "C" void RhpReversePInvokeReturn(ReversePInvokeFrame* pRevFrame);
 extern "C" int32_t RhpEnableConservativeStackReporting();
 extern "C" void RhpRegisterSimpleModule(SimpleModuleHeader* pModule);
-#endif // USE_MRT
+
+#define DLL_PROCESS_ATTACH      1
+extern "C" BOOL WINAPI RtuDllMain(HANDLE hPalInstance, DWORD dwReason, void* pvReserved);
 
 #include "platform.h"
 
 int __initialize_runtime()
 {
-#if USE_MRT
+    RtuDllMain(NULL, DLL_PROCESS_ATTACH, NULL);
+
     RhpEnableConservativeStackReporting();
-#else
-    //
-    // Initialize system info
-    //
-    InitializeSystemInfo();
-
-    // 
-    // Initialize free object methodtable. The GC uses a special array-like methodtable as placeholder
-    // for collected free space.
-    //
-    static MethodTable freeObjectMT;
-    freeObjectMT.InitializeFreeObject();
-    g_pFreeObjectMethodTable = &freeObjectMT;
-
-    //
-    // Initialize handle table
-    //
-    if (!Ref_Initialize())
-        return -1;
-
-    //
-    // Initialize GC heap
-    //
-    GCHeap *pGCHeap = GCHeap::CreateGCHeap();
-    if (!pGCHeap)
-        return -1;
-
-    if (FAILED(pGCHeap->Initialize()))
-        return -1;
-
-    //
-    // Initialize current thread
-    //
-    ThreadStore::AttachCurrentThread(false);
-#endif
 
     return 0;
 }
@@ -71,44 +37,24 @@ void __shutdown_runtime()
 
 void __reverse_pinvoke(ReversePInvokeFrame* pRevFrame)
 {
-#if USE_MRT
     RhpReversePInvoke2(pRevFrame);
-#endif // USE_MRT
 }
 
 void __reverse_pinvoke_return(ReversePInvokeFrame* pRevFrame)
 {
-#if USE_MRT
     RhpReversePInvokeReturn(pRevFrame);
-#endif // USE_MRT
 }
-
-extern "C" void* __GCStaticRegionStart;
-extern "C" void* __GCStaticRegionEnd;
 
 void __register_module(SimpleModuleHeader* pModule)
 {
-#if USE_MRT
     RhpRegisterSimpleModule(pModule);
-#endif // USE_MRT
-
-#ifndef CPPCODEGEN
-    // Initialize GC statics in the module
-    // TODO: emit a ModuleHeader and use it here
-
-    for (void** currentBlock = &__GCStaticRegionStart; currentBlock < &__GCStaticRegionEnd; currentBlock++)
-    {
-        Object* gcBlock = __allocate_object((MethodTable*)*currentBlock);
-        *currentBlock = CreateGlobalHandle(ObjectToOBJECTREF(gcBlock));
-    }
-#endif
 }
 
 namespace mscorlib { namespace System { 
 
     class Object {
     public:
-        EEType * get_EEType() { return *(EEType **)this; }
+        MethodTable * get_EEType() { return *(MethodTable **)this; }
     };
 
     class Array : public Object {
@@ -143,105 +89,23 @@ using namespace mscorlib;
 //
 extern "C" Object * __allocate_object(MethodTable * pMT)
 {
-#if !USE_MRT
-    alloc_context * acontext = GetThread()->GetAllocContext();
-    Object * pObject;
-
-    size_t size = pMT->GetBaseSize();
-
-    BYTE* result = acontext->alloc_ptr;
-    BYTE* advance = result + size;
-    if (advance <= acontext->alloc_limit)
-    {
-        acontext->alloc_ptr = advance;
-        pObject = (Object *)result;
-    }
-    else
-    {
-        pObject = GCHeap::GetGCHeap()->Alloc(acontext, size, 0);
-        if (pObject == NULL)
-            return NULL; // TODO: Throw OOM
-    }
-
-    pObject->SetMethodTable(pMT);
-
-    return pObject;
-#else
     return RhNewObject(pMT);
-#endif
 }
 
 extern "C" void __EEType_mscorlib_System_String();
 
 Object * __allocate_string(int32_t len)
 {
-#if !USE_MRT
-    alloc_context * acontext = GetThread()->GetAllocContext();
-    Object * pObject;
-
-    // TODO: Overflow checks
-    size_t size = 2 * sizeof(intptr_t) + sizeof(int32_t) + 2 * len;
-    // Align up
-    size = (size + (sizeof(intptr_t) - 1)) & ~(sizeof(intptr_t) - 1);
-
-    BYTE* result = acontext->alloc_ptr;
-    BYTE* advance = result + size;
-    if (advance <= acontext->alloc_limit)
-    {
-        acontext->alloc_ptr = advance;
-        pObject = (Object *)result;
-    }
-    else
-    {
-        pObject = GCHeap::GetGCHeap()->Alloc(acontext, size, 0);
-        if (pObject == NULL)
-            return NULL; // TODO: Throw OOM
-    }
 #ifdef CPPCODEGEN
-    pObject->SetMethodTable(System::String::__getMethodTable());
-#else
-    pObject->SetMethodTable((MethodTable*)__EEType_mscorlib_System_String);
-#endif
-	*(int32_t *)(((intptr_t *)pObject) + 1) = len;
-	return pObject;
-#else
     return RhNewArray(System::String::__getMethodTable(), len);
+#else
+    return RhNewArray((MethodTable*)__EEType_mscorlib_System_String, len);
 #endif
 }
 
 extern "C" Object * __allocate_array(size_t elements, MethodTable * pMT)
 {
-#if !USE_MRT
-    alloc_context * acontext = GetThread()->GetAllocContext();
-    Object * pObject;
-
-    // TODO: Overflow checks
-    size_t size = 3 * sizeof(intptr_t) + (elements * pMT->RawGetComponentSize());
-    // Align up
-    size = (size + (sizeof(intptr_t) - 1)) & ~(sizeof(intptr_t) - 1);
-
-    BYTE* result = acontext->alloc_ptr;
-    BYTE* advance = result + size;
-    if (advance <= acontext->alloc_limit)
-    {
-        acontext->alloc_ptr = advance;
-        pObject = (Object *)result;
-    }
-    else
-    {
-        pObject = GCHeap::GetGCHeap()->Alloc(acontext, size, 0);
-        if (pObject == NULL)
-            return NULL; // TODO: Throw OOM
-    }
-
-    pObject->SetMethodTable(pMT);
-
-    *(int32_t *)(((intptr_t *)pObject)+1) = (int32_t)elements;
-
-    return pObject;
-#else
     return RhNewArray(pMT, (int32_t)elements); // TODO: type mismatch
-#endif 
 }
 
 #if defined(_WIN64)
@@ -387,230 +251,86 @@ Object * __get_commandline_args(int argc, char * argv[])
 }
 #endif
 
-// FCalls
-
-#ifdef _MSC_VER
-#pragma warning(disable:4297)
-#endif
-
-FORCEINLINE bool CheckArraySlice(System::Array * pArray, int32_t index, int32_t length)
-{
-    int32_t arrayLength = pArray->GetArrayLength();
-
-    return (0 <= index) && (index <= arrayLength) &&
-        (0 <= length) && (length <= arrayLength) &&
-        (length <= arrayLength - index);
-}
-
-extern "C" uint8_t RhpArrayCopy(System::Array* pSourceArray, int32_t sourceIndex, System::Array* pDestinationArray, int32_t destinationIndex, int32_t length)
-{
-    if (pSourceArray == NULL || pDestinationArray == NULL)
-        return false;
-
-    EEType* pArrayType = pSourceArray->get_EEType();
-    EEType* pDestinationArrayType = pDestinationArray->get_EEType();
-
-    if (pArrayType != pDestinationArrayType)
-    {
-        // TODO: Type safety check
-        return false;
-#if false
-        if (!pArrayType->IsEquivalentTo(pDestinationArrayType))
-            return false;
-#endif
-    }
-
-    if (!pArrayType->HasComponentSize())
-        return false; // an array
-
-    size_t componentSize = pArrayType->RawGetComponentSize();
-
-    if (!CheckArraySlice(pSourceArray, sourceIndex, length))
-        return false;
-
-    if (!CheckArraySlice(pDestinationArray, destinationIndex, length))
-        return false;
-
-    if (length == 0)
-        return true;
-
-    uint8_t * pSourceData = (uint8_t *)pSourceArray->GetArrayData() + sourceIndex * componentSize;
-    uint8_t * pDestinationData = (uint8_t *)pDestinationArray->GetArrayData() + destinationIndex * componentSize;
-    size_t size = length * componentSize;
-
-    // TODO: Write barrier
-#if false
-    if (pArrayType->HasReferenceFields())
-    {
-        if (pDestinationData <= pSourceData || pSourceData + size <= pDestinationData)
-            ForwardGCSafeCopy(pDestinationData, pSourceData, size);
-        else
-            BackwardGCSafeCopy(pDestinationData, pSourceData, size);
-
-        RhpBulkWriteBarrier(pDestinationData, (UInt32)size);
-    }
-    else
-#endif
-    {
-        memmove(pDestinationData, pSourceData, size);
-    }
-
-    return true;
-}
-
-void GCSafeFillMemory(void * mem, size_t size, size_t pv)
-{
-    uint8_t * memBytes = (uint8_t *)mem;
-    uint8_t * endBytes = &memBytes[size];
-
-    // handle unaligned bytes at the beginning 
-    while (!IS_ALIGNED(memBytes, sizeof(void *)) && (memBytes < endBytes))
-        *memBytes++ = (uint8_t)pv;
-
-    // now write pointer sized pieces 
-    size_t nPtrs = (endBytes - memBytes) / sizeof(void *);
-    UIntNative* memPtr = (UIntNative*)memBytes;
-    for (size_t i = 0; i < nPtrs; i++)
-        *memPtr++ = pv;
-
-    // handle remaining bytes at the end 
-    memBytes = (uint8_t*)memPtr;
-    while (memBytes < endBytes)
-        *memBytes++ = (uint8_t)pv;
-}
-
-extern "C" uint8_t RhpArrayClear(System::Array *pArray, int32_t index, int32_t length)
-{
-    if (pArray == NULL)
-        return false;
-
-    EEType* pArrayType = pArray->get_EEType();
-
-    size_t componentSize = pArrayType->RawGetComponentSize();
-    if (componentSize == 0) // Not an array
-        return false;
-
-    if (!CheckArraySlice(pArray, index, length))
-        return false;
-
-    if (length == 0)
-        return true;
-
-    GCSafeFillMemory((uint8_t *)pArray->GetArrayData() + index * componentSize, length * componentSize, 0);
-
-    return true;
-}
-
-extern "C" uint8_t RhTypeCast_AreTypesEquivalent(System::EETypePtr pType1, System::EETypePtr pType2)
-{
-    if (pType1.m_value == pType2.m_value)
-    {
-        return 1;
-    }
-
-    throw 42;
-}
-
-extern "C" System::String* RhNewArray(System::EETypePtr, int32_t len)
-{
-    return (System::String*)__allocate_string(len);
-}
-
-extern "C" intptr_t RhFindMethodStartAddress(intptr_t)
+extern "C" Object* RhMemberwiseClone(Object*)
 {
     throw 42;
 }
 
-extern "C" intptr_t RhGetModuleFromPointer(intptr_t)
+extern "C" uint8_t RhGetCorElementType(MethodTable*)
 {
     throw 42;
 }
 
-extern "C" System::Object* RhMemberwiseClone(System::Object*)
+extern "C" MethodTable* RhGetRelatedParameterType(MethodTable*)
 {
     throw 42;
 }
 
-extern "C" int32_t RhGetModuleFileName(intptr_t, uint16_t**)
+extern "C" uint16_t RhGetComponentSize(MethodTable*)
 {
     throw 42;
 }
 
-extern "C" void RhSuppressFinalize(System::Object*)
-{
-}
-
-extern "C" uint8_t RhGetCorElementType(System::EETypePtr)
+extern "C" uint8_t RhHasReferenceFields(MethodTable*)
 {
     throw 42;
 }
 
-extern "C" System::EETypePtr RhGetRelatedParameterType(System::EETypePtr)
+extern "C" uint8_t RhIsValueType(MethodTable*)
 {
     throw 42;
 }
 
-extern "C" uint16_t RhGetComponentSize(System::EETypePtr)
+extern "C" intptr_t RhHandleAllocDependent(Object*, Object*)
 {
     throw 42;
 }
 
-extern "C" uint8_t RhHasReferenceFields(System::EETypePtr)
+extern "C" void RhpUniversalTransition()
 {
     throw 42;
 }
-
-extern "C" uint8_t RhIsValueType(System::EETypePtr)
+extern "C" void RhpAssignRefEDX()
 {
     throw 42;
 }
-
-extern "C" uint8_t RhIsArray(System::EETypePtr)
+extern "C" void RhpCheckedAssignRefEDX()
 {
     throw 42;
 }
-
-extern "C" intptr_t RhHandleAlloc(System::Object *pObject, int type)
-{
-    return (intptr_t)HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, (OBJECTREF)pObject);
-}
-
-extern "C" void RhHandleFree(OBJECTHANDLE handle)
-{
-    DestroyTypedHandle(handle);
-}
-
-extern "C" intptr_t RhHandleAllocDependent(System::Object*, System::Object*)
+extern "C" void RhpCheckedLockCmpXchgAVLocation()
 {
     throw 42;
 }
-
-extern "C" System::Object* RhHandleGetDependent(intptr_t)
+extern "C" void RhpCheckedXchgAVLocation()
 {
     throw 42;
 }
-
-extern "C" System::Object* RhHandleGet(OBJECTHANDLE handle)
-{
-    return (System::Object*)ObjectFromHandle(handle);
-}
-
-extern "C" intptr_t RhSetErrorInfoBuffer(intptr_t)
+extern "C" void RhpCopyMultibyteDestAVLocation()
 {
     throw 42;
 }
-
-extern "C" uint32_t RhGetLoadedModules(System::Object*)
+extern "C" void RhpCopyMultibyteSrcAVLocation()
 {
     throw 42;
 }
-
-extern "C" uint8_t RhGetExceptionsForCurrentThread(System::Object*, int *)
+extern "C" void RhpCopyMultibyteNoGCRefsDestAVLocation()
 {
     throw 42;
 }
-
-extern "C" intptr_t RhGetModuleFromEEType(System::EETypePtr)
+extern "C" void RhpCopyMultibyteNoGCRefsSrcAVLocation()
+{
+    throw 42;
+}
+extern "C" void RhpFailFastForPInvokeExceptionPreemp()
+{
+    throw 42;
+}
+extern "C" void RhpFailFastForPInvokeExceptionCoop()
+{
+    throw 42;
+}
+extern "C" void RhpThrowHwEx()
 {
     throw 42;
 }
@@ -622,7 +342,7 @@ extern "C" int repro_Program__Main();
 
 extern "C" void __str_fixup();
 extern "C" void __str_fixup_end();
-int __reloc_string_fixup()
+int __strings_fixup()
 {
     for (unsigned** ptr = (unsigned**)__str_fixup;
          ptr < (unsigned**)__str_fixup_end; ptr++)
@@ -642,10 +362,22 @@ int __reloc_string_fixup()
             if (strLen <= 0) return -1;
         }
 
-        OBJECTHANDLE handle;
         *((OBJECTHANDLE*)ptr) = __load_static_string_literal(bytes, utf8Len, strLen);
         // TODO: This "handle" will leak, deallocate with __unload
     }
+    return 0;
+}
+
+extern "C" void* __GCStaticRegionStart;
+extern "C" void* __GCStaticRegionEnd;
+int __statics_fixup()
+{
+    for (void** currentBlock = &__GCStaticRegionStart; currentBlock < &__GCStaticRegionEnd; currentBlock++)
+    {
+        Object* gcBlock = __allocate_object((MethodTable*)*currentBlock);
+        *currentBlock = CreateGlobalHandle(ObjectToOBJECTREF(gcBlock));
+    }
+
     return 0;
 }
 
@@ -654,7 +386,8 @@ int main(int argc, char * argv[]) {
     __register_module(&__module);
     ReversePInvokeFrame frame; __reverse_pinvoke(&frame);
 	
-    if (__reloc_string_fixup() != 0) return -1;
+    if (__strings_fixup() != 0) return -1;
+    if (__statics_fixup() != 0) return -1;
 
     repro_Program__Main();
 

--- a/src/ILToNative/reproNative/reproNative.sln
+++ b/src/ILToNative/reproNative/reproNative.sln
@@ -1,0 +1,38 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "reproNative", "reproNative.vcxproj", "{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Runtime", "..\..\..\bin\obj\Windows_NT.x64.Debug\Runtime\Runtime.vcxproj", "{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		MinSizeRel|x64 = MinSizeRel|x64
+		Release|x64 = Release|x64
+		RelWithDebInfo|x64 = RelWithDebInfo|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.Debug|x64.ActiveCfg = Debug|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.Debug|x64.Build.0 = Debug|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.MinSizeRel|x64.ActiveCfg = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.MinSizeRel|x64.Build.0 = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.Release|x64.ActiveCfg = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.Release|x64.Build.0 = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.RelWithDebInfo|x64.ActiveCfg = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.RelWithDebInfo|x64.Build.0 = Release|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.Debug|x64.ActiveCfg = Debug|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.Debug|x64.Build.0 = Debug|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.MinSizeRel|x64.ActiveCfg = MinSizeRel|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.MinSizeRel|x64.Build.0 = MinSizeRel|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.Release|x64.ActiveCfg = Release|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.Release|x64.Build.0 = Release|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.RelWithDebInfo|x64.ActiveCfg = RelWithDebInfo|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.RelWithDebInfo|x64.Build.0 = RelWithDebInfo|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/ILToNative/reproNative/reproNative.vcxproj
+++ b/src/ILToNative/reproNative/reproNative.vcxproj
@@ -59,6 +59,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\Product\Windows_NT.x64.Debug\lib\Runtime.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -79,6 +80,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\Product\Windows_NT.x64.Release\lib\Runtime.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -86,19 +88,6 @@
     <ClInclude Include="platform.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\Native\gc\gccommon.cpp" />
-    <ClCompile Include="..\..\Native\gc\gceesvr.cpp" />
-    <ClCompile Include="..\..\Native\gc\gceewks.cpp" />
-    <ClCompile Include="..\..\Native\gc\gcscan.cpp" />
-    <ClCompile Include="..\..\Native\gc\gcsvr.cpp" />
-    <ClCompile Include="..\..\Native\gc\gcwks.cpp" />
-    <ClCompile Include="..\..\Native\gc\handletable.cpp" />
-    <ClCompile Include="..\..\Native\gc\handletablecache.cpp" />
-    <ClCompile Include="..\..\Native\gc\handletablecore.cpp" />
-    <ClCompile Include="..\..\Native\gc\handletablescan.cpp" />
-    <ClCompile Include="..\..\Native\gc\objecthandle.cpp" />
-    <ClCompile Include="..\..\Native\gc\env\gcenv.windows.cpp" />
-    <ClCompile Include="..\..\Native\gc\sample\gcenv.cpp" />
     <ClCompile Include="common.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>

--- a/src/ILToNative/reproNative/reproNativeCpp.sln
+++ b/src/ILToNative/reproNative/reproNativeCpp.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "reproNativeCpp", "reproNativeCpp.vcxproj", "{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613} = {82CD69C7-FA29-45D3-A87C-2FCA61CE7613}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Runtime", "..\..\..\bin\obj\Windows_NT.x64.Debug\Runtime\Runtime.vcxproj", "{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		MinSizeRel|x64 = MinSizeRel|x64
+		Release|x64 = Release|x64
+		RelWithDebInfo|x64 = RelWithDebInfo|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.Debug|x64.ActiveCfg = Debug|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.Debug|x64.Build.0 = Debug|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.MinSizeRel|x64.ActiveCfg = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.MinSizeRel|x64.Build.0 = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.Release|x64.ActiveCfg = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.Release|x64.Build.0 = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.RelWithDebInfo|x64.ActiveCfg = Release|x64
+		{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}.RelWithDebInfo|x64.Build.0 = Release|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.Debug|x64.ActiveCfg = Debug|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.Debug|x64.Build.0 = Debug|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.MinSizeRel|x64.ActiveCfg = MinSizeRel|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.MinSizeRel|x64.Build.0 = MinSizeRel|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.Release|x64.ActiveCfg = Release|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.Release|x64.Build.0 = Release|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.RelWithDebInfo|x64.ActiveCfg = RelWithDebInfo|x64
+		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}.RelWithDebInfo|x64.Build.0 = RelWithDebInfo|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/ILToNative/reproNative/reproNativeCpp.vcxproj
+++ b/src/ILToNative/reproNative/reproNativeCpp.vcxproj
@@ -62,6 +62,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\Product\Windows_NT.x64.Debug\lib\Runtime.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -82,25 +83,13 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\Product\Windows_NT.x64.Release\lib\Runtime.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="common.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\Native\gc\gccommon.cpp" />
-    <ClCompile Include="..\..\Native\gc\gceesvr.cpp" />
-    <ClCompile Include="..\..\Native\gc\gceewks.cpp" />
-    <ClCompile Include="..\..\Native\gc\gcscan.cpp" />
-    <ClCompile Include="..\..\Native\gc\gcsvr.cpp" />
-    <ClCompile Include="..\..\Native\gc\gcwks.cpp" />
-    <ClCompile Include="..\..\Native\gc\handletable.cpp" />
-    <ClCompile Include="..\..\Native\gc\handletablecache.cpp" />
-    <ClCompile Include="..\..\Native\gc\handletablecore.cpp" />
-    <ClCompile Include="..\..\Native\gc\handletablescan.cpp" />
-    <ClCompile Include="..\..\Native\gc\objecthandle.cpp" />
-    <ClCompile Include="..\..\Native\gc\env\gcenv.windows.cpp" />
-    <ClCompile Include="..\..\Native\gc\sample\gcenv.cpp" />
     <ClCompile Include="common.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>


### PR DESCRIPTION
Deleted a lot of stubbed out implementations that got replaced with proper implementations in MRT.

After this change, the repo needs to be built from the command-line first using build.cmd before the reproNative solutions can be used.
