### PR TITLE
Use fixed version of System.Console nuget package

### DIFF
--- a/src/ILToNative.DependencyAnalysisFramework/tests/project.json
+++ b/src/ILToNative.DependencyAnalysisFramework/tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "System.Collections": "4.0.10",
     "System.Collections.Immutable": "1.1.37",
-    "System.Console": "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-23419",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Diagnostics.Tracing": "4.0.20",
     "System.Linq": "4.0.0",

--- a/src/ILToNative.TypeSystem/tests/project.json
+++ b/src/ILToNative.TypeSystem/tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "System.Collections": "4.0.10",
     "System.Collections.Concurrent": "4.0.10",
-    "System.Console": "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-23419",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Diagnostics.Tracing": "4.0.20",
     "System.Linq": "4.0.0",

--- a/src/ILToNative/desktop/project.json
+++ b/src/ILToNative/desktop/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.10",
     "System.Text.Encoding.Extensions": "4.0.10",
     "System.Reflection.Extensions": "4.0.0",
-    "System.Console": "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-23419",
     "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.0.22",

--- a/src/ILToNative/repro/project.json
+++ b/src/ILToNative/repro/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.0",
     "System.Text.Encoding.Extensions": "4.0.0",
     "System.Reflection.Extensions": "4.0.0",
-    "System.Console": "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-23419",
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/ILToNative/src/project.json
+++ b/src/ILToNative/src/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.10",
     "System.Text.Encoding.Extensions": "4.0.10",
     "System.Reflection.Extensions": "4.0.0",
-    "System.Console": "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-23419",
     "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.0.22"


### PR DESCRIPTION
The floating version of System.Console nuget package makes us vulnerable to garbage getting published on Nuget. Switch to using fixed version instead.
