### PR TITLE
Define WIN64 when building System.Private.CoreLib.csproj

### DIFF
--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -62,8 +62,8 @@
 
   <PropertyGroup>
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
-    <!-- TODO: @tarekgh Define this for CoreRT builds only -->
-    <DefineConstants>CORERT</DefineConstants>
+    <!-- TODO: @tarekgh Define this for CoreRT / 64-bit builds only -->
+    <DefineConstants>CORERT;WIN64</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\System\SR.Core.cs">


### PR DESCRIPTION
@tarekgh This is one more define to reconcile
