### PR TITLE
Call cctor when accessing type's static base

### DIFF
--- a/src/ILToNative.Compiler/src/Compiler/AsmWriter.cs
+++ b/src/ILToNative.Compiler/src/Compiler/AsmWriter.cs
@@ -288,18 +288,6 @@ namespace ILToNative
                         Out.WriteLine("ret");
                         break;
 
-                    case ReadyToRunHelperId.CCtorTrigger:
-                        Out.Write("leaq __NonGCStaticBase_");
-                        Out.Write(NameMangler.GetMangledTypeName((TypeDesc)helper.Target));
-                        Out.WriteLine(" - 16(%rip), %rax");
-
-                        Out.WriteLine("jmp *(%rax)");
-
-                        // TODO: actually call into the managed helper that does a better job at this
-                        //       and won't call the same constructor twice...
-
-                        break;
-
                     default:
                         throw new NotImplementedException();
                 }

--- a/src/ILToNative.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILToNative.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -50,7 +50,8 @@ namespace ILToNative
         };
 
         static readonly string[][] s_wellKnownEntrypointNames = new string[][] {
-            new string[] { "System.Runtime.CompilerServices", "CctorHelper", "CheckStaticClassConstruction" }
+            new string[] { "System.Runtime.CompilerServices", "CctorHelper", "CheckStaticClassConstructionReturnGCStaticBase" },
+            new string[] { "System.Runtime.CompilerServices", "CctorHelper", "CheckStaticClassConstructionReturnNonGCStaticBase" }
         };
 
         MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
@@ -228,6 +229,7 @@ namespace ILToNative
     public enum WellKnownEntrypoint
     {
         Unknown,
-        EnsureClassConstructorRun,
+        EnsureClassConstructorRunAndReturnGCStaticBase,
+        EnsureClassConstructorRunAndReturnNonGCStaticBase,
     }
 }

--- a/src/ILToNative.Compiler/src/Compiler/ReadyToRunHelper.cs
+++ b/src/ILToNative.Compiler/src/Compiler/ReadyToRunHelper.cs
@@ -20,7 +20,6 @@ namespace ILToNative
         CastClass,
         GetNonGCStaticBase,
         GetGCStaticBase,
-        CCtorTrigger,
         DelegateCtor,
     }
 
@@ -59,8 +58,6 @@ namespace ILToNative
                         return "__GetNonGCStaticBase_" + _compilation.NameMangler.GetMangledTypeName((TypeDesc)this.Target);
                     case ReadyToRunHelperId.GetGCStaticBase:
                         return "__GetGCStaticBase_" + _compilation.NameMangler.GetMangledTypeName((TypeDesc)this.Target);
-                    case ReadyToRunHelperId.CCtorTrigger:
-                        return "__CCtorTrigger_" + _compilation.NameMangler.GetMangledTypeName((TypeDesc)this.Target);
                     case ReadyToRunHelperId.DelegateCtor:
                         return "__DelegateCtor_" + _compilation.NameMangler.GetMangledMethodName(((DelegateInfo)this.Target).Target);
                     default:

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -852,7 +852,7 @@ namespace Internal.JitInterface
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_STATIC_BASE:
                     {
                         var type = HandleToObject(pResolvedToken.hClass);
-                        pLookup.addr = (void*)ObjectToHandle(_compilation.GetReadyToRunHelper(ReadyToRunHelperId.CCtorTrigger, type));
+                        pLookup.addr = (void*)ObjectToHandle(_compilation.GetReadyToRunHelper(ReadyToRunHelperId.GetNonGCStaticBase, type));
                     }
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_DELEGATE_CTOR:

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
@@ -99,7 +99,27 @@ namespace System.Runtime.CompilerServices
                 // before we could. Loop at try again.
             }
         }
-        
+
+        private static object CheckStaticClassConstructionReturnGCStaticBase(ref StaticClassConstructionContext context, object gcStaticBase)
+        {
+            // CORERT-TODO: Early out if initializer was set to anything. The runner doesn't handle recursion and assumes it's access from
+            //              a different thread and deadlocks itself. CoreRT will cause recursion for things like trying to get a static
+            //              base from the CCtor (which means that pretty much all cctors will deadlock).
+            if (context.initialized == 0)
+                CheckStaticClassConstruction(ref context);
+            return gcStaticBase;
+        }
+
+        private static IntPtr CheckStaticClassConstructionReturnNonGCStaticBase(ref StaticClassConstructionContext context, IntPtr nonGcStaticBase)
+        {
+            // CORERT-TODO: Early out if initializer was set to anything. The runner doesn't handle recursion and assumes it's access from
+            //              a different thread and deadlocks itself. CoreRT will cause recursion for things like trying to get a static
+            //              base from the CCtor (which means that pretty much all cctors will deadlock).
+            if (context.initialized == 0)
+                CheckStaticClassConstruction(ref context);
+            return nonGcStaticBase;
+        }
+
         // Intrinsic to call the cctor given a pointer to the code (this method's body is ignored and replaced
         // with a calli during compilation). The transform doesn't handle non-generic versions yet (i.e.
         // functions that are void).


### PR DESCRIPTION
JIT expects that accessing the static base will trigger the cctor if
necessary and does not insert explicit triggers.
