### PR TITLE
Hello World fix for Memmove

### DIFF
--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -271,6 +271,8 @@ namespace System
             }
 #endif
 
+            // TODO-CORERT: re-enable this once we can handle the relocs for JIT code for large switch blocks
+#if !CORERT
             //
             // This is portable version of memcpy. It mirrors what the hand optimized assembly versions of memcpy typically do.
             //
@@ -404,6 +406,7 @@ namespace System
                 _Memmove(dest, src, len);
                 return;
             }
+#endif
 
             if (((int)dest & 3) != 0)
             {


### PR DESCRIPTION
We can't handle the JIT-generated relocs for large switch blocks.
