### PR TITLE
Remove String::get_Chars workaround

### DIFF
--- a/src/ILToNative/reproNative/main.cpp
+++ b/src/ILToNative/reproNative/main.cpp
@@ -422,32 +422,4 @@ int main(int argc, char * argv[]) {
     return 0;
 }
 
-extern "C" void System_Private_CoreLib_System_Runtime_RuntimeImports__RhNewArrayAsString()
-{
-    throw 42;
-}
-extern "C" void System_Console_Interop_mincore__GetConsoleOutputCP()
-{
-    throw 42;
-}
-extern "C" void System_Console_Interop_mincore__GetStdHandle()
-{
-    throw 42;
-}
-extern "C" void System_Console_Interop_mincore__WriteFile()
-{
-    throw 42;
-}
-extern "C" void System_Private_CoreLib_System_Runtime_RuntimeImports__memmove()
-{
-    throw 42;
-}
-extern "C" void System_Private_CoreLib_Interop_mincore__PInvoke_CompareStringOrdinal()
-{
-    throw 42;
-}
-extern "C" void System_Console_Interop_mincore__GetFileType()
-{
-    throw 42;
-}
 #endif


### PR DESCRIPTION
CoreLib now has a workaround applied that lets us compile this method
just fine and this is giving errors about duplicate symbols.
