### PR TITLE
Generate Nuget Packages for ILToNative

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -35,7 +35,10 @@
     <!-- Output directories -->
     <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
     <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
+    <ProductBinDir Condition="'$(ProductBinDir)'==''">$(BinDir)Product/</ProductBinDir>
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests/</TestWorkingDir>
+
+    <!-- Folder where restored Nuget packages will go -->
     <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(BinDir)packages/</PackagesOutDir>
 
     <!-- Input Directories -->
@@ -43,10 +46,33 @@
     <ToolsDir Condition="'$(ToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)/lib/</ToolsDir>
   </PropertyGroup>
 
+  <!-- Set up the default output and intermediate paths -->
+  <PropertyGroup>
+    <OSPlatformConfig>$(__BuildOS).$(__BuildArch).$(__BuildType)</OSPlatformConfig>
+
+    <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(ProductBinDir)</BaseOutputPath>
+    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)\</OutputPath>
+
+    <!-- Folder where we will drop the Nuget package for the toolchain -->
+    <ProductPackageDir Condition="'$(ProductPackageDir)'==''">$(OutputPath).nuget/</ProductPackageDir>
+    
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
+    <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)\</IntermediateOutputRootPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)\</IntermediateOutputPath>
+
+    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)\$(MSBuildProjectName)\</TestPath>
+
+    <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
+  </PropertyGroup>
+
   <!-- list of nuget package sources passed to nuget.exe -->
   <ItemGroup>
     <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools" />
     <NuGetSourceList Include="https:%2F%2Fwww.nuget.org/api/v2" />
+    <NuSpecSrcs Include="$(SourceDir).nuget\Microsoft.DotNet.ILToNative.nuspec" />
+    <NuSpecSrcs Include="$(SourceDir).nuget\Microsoft.DotNet.ILToNative.Development.nuspec" />
+    <NuSpecs Include="$(ProductPackageDir)Microsoft.DotNet.ILToNative.nuspec" />
+    <NuSpecs Include="$(ProductPackageDir)Microsoft.DotNet.ILToNative.Development.nuspec" />
   </ItemGroup>
 
   <!-- Common nuget properties -->
@@ -199,22 +225,6 @@
   <PropertyGroup>
     <CommonPath>$(SourceDir)Common\src</CommonPath>
     <CommonTestPath>$(SourceDir)Common\tests</CommonTestPath>
-  </PropertyGroup>
-
-  <!-- Set up the default output and intermediate paths -->
-  <PropertyGroup>
-    <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>
-
-    <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)\$(MSBuildProjectName)\</OutputPath>
-
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
-    <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)\</IntermediateOutputRootPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)\</IntermediateOutputPath>
-
-    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)\$(MSBuildProjectName)\</TestPath>
-
-    <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
   </PropertyGroup>
 
   <!-- Set up common target properties that we use to conditionally include sources -->

--- a/src/.nuget/Microsoft.Dotnet.ILToNative.Development.nuspec
+++ b/src/.nuget/Microsoft.Dotnet.ILToNative.Development.nuspec
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.ILToNative.Development</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET ILToNative Toolchain - Development Version</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides the toolchain to compile managed code to native.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+    <dependencies>
+        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
+        <dependency id="Microsoft.NETCore.Console" version="1.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\ILToNative.dll" target="ILToNative.dll" />
+    <file src="..\ILToNative.pdb" target="pdb\ILToNative.pdb" />
+    <file src="..\ILToNative.Compiler.dll" target="ILToNative.Compiler.dll" />
+    <file src="..\ILToNative.Compiler.pdb" target="pdb\ILToNative.Compiler.pdb" />
+    <file src="..\ILToNative.DependencyAnalysisFramework.dll" target="ILToNative.DependencyAnalysisFramework.dll" />
+    <file src="..\ILToNative.DependencyAnalysisFramework.pdb" target="pdb\ILToNative.DependencyAnalysisFramework.pdb" />
+    <file src="..\ILToNative.TypeSystem.dll" target="ILToNative.TypeSystem.dll" />
+    <file src="..\ILToNative.TypeSystem.pdb" target="pdb\ILToNative.TypeSystem.pdb" />
+    <file src="..\lib\Runtime.lib" target="sdk\Runtime.lib" />
+    <file src="..\System.Private.Corelib.dll" target="sdk\System.Private.Corelib.dll" />
+    <file src="..\System.Private.Corelib.pdb" target="pdb\System.Private.Corelib.pdb" />
+    <file src="..\toolruntime\*.dll" />
+    <file src="..\toolruntime\coreconsole.exe" target="ILToNative.exe" />
+    <file src="..\..\..\..\packages\Microsoft.DiaSymReader\1.0.6\lib\portable-net45+win8\Microsoft.DiaSymReader.dll" />
+  </files>
+</package>

--- a/src/.nuget/Microsoft.Dotnet.ILToNative.nuspec
+++ b/src/.nuget/Microsoft.Dotnet.ILToNative.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.ILToNative</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET ILToNative Toolchain</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides the toolchain to compile managed code to native.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+    <dependencies>
+        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
+        <dependency id="Microsoft.NETCore.Console" version="1.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\ILToNative.dll" target="ILToNative.dll" />
+    <file src="..\ILToNative.Compiler.dll" target="ILToNative.Compiler.dll" />
+    <file src="..\ILToNative.DependencyAnalysisFramework.dll" target="ILToNative.DependencyAnalysisFramework.dll" />
+    <file src="..\ILToNative.TypeSystem.dll" target="ILToNative.TypeSystem.dll" />
+    <file src="..\lib\Runtime.lib" target="sdk\Runtime.lib" />
+    <file src="..\System.Private.Corelib.dll" target="sdk\System.Private.Corelib.dll" />
+    <file src="..\toolruntime\*.dll" />
+    <file src="..\toolruntime\coreconsole.exe" target="ILToNative.exe" />
+    <file src="..\..\..\..\packages\Microsoft.DiaSymReader\1.0.6\lib\portable-net45+win8\Microsoft.DiaSymReader.dll" />
+  </files>
+</package>

--- a/src/ILToNative/src/ILToNative.csproj
+++ b/src/ILToNative/src/ILToNative.csproj
@@ -18,7 +18,6 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +25,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -16,6 +16,27 @@
   <Import Project="$(ToolsDir)packages.targets" Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'" />
   <Import Project="$(ToolsDir)UpdateBuildValues.targets" Condition="Exists('$(ToolsDir)UpdateBuildValues.targets')" />
 
+  <!-- Have a task to copy ILToNative.exe to ILToNative.dll for inclusion into the NoDep nuget package -->
+  <ItemGroup>
+        <SourceName Include="$(OutputPath)ILToNative.exe"/>
+        <TargetName Include="$(OutputPath)ILToNative.dll"/>
+  </ItemGroup>
+
+  <Target Name="RenameILToNative" AfterTargets="Build">
+    <Copy SourceFiles="@(SourceName)" DestinationFiles="@(TargetName)" />
+  </Target>
+
+  <!-- 
+      Generate Microsoft.Dotnet.CoreRT nuget package and associated development package 
+      TODO: For now, we will generate Nuget packages only for Windows.
+  -->
+
+  <Target Name="BuildNuGetPackages" Condition="'$(BuildNugetPackage)' != 'false' and '$(OSGroup)' == 'Windows_NT'" AfterTargets="RenameILToNative">
+    <MakeDir Directories="$(ProductPackageDir)" Condition="!Exists('$(ProductPackageDir)')" />
+    <Copy SourceFiles="@(NuSpecSrcs)" DestinationFolder="$(ProductPackageDir)" />
+    <Exec Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(ProductPackageDir)&quot;" />
+  </Target>
+
   <PropertyGroup Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'">
     <TraversalBuildDependsOn>
       $(TraversalBuildDependsOn);


### PR DESCRIPTION
This change does the following only for Windows:

1) Generate Microsoft.Dotnet.ILToNative and Microsoft.Dotnet.ILToNative.Development nuget packages. The latter contains PDBs.

2) Get ILToNative.exe to be dropped to the bin folder. Also added a task to create ILToNative.dll from ILToNative.exe so that CoreConsole can launch the driver.

3) Unify all product drops to be dropped under bin\product\ - currently they were getting dropped to random locations (native components would go in the intended location but managed would not).

4) Package Runtime.lib and System.Private.CoreLib.dll within the Nuget packages.

@jkotas @schellap Can you please take a look?
