### PR TITLE
ObjectWriter

### DIFF
--- a/src/ILToNative.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILToNative.Compiler/src/Compiler/Compilation.cs
@@ -26,6 +26,7 @@ namespace ILToNative
         public bool NoLineNumbers;
         public string DgmlLog;
         public bool FullLog;
+        public bool EmitAsm;
     }
 
     public partial class Compilation
@@ -70,6 +71,12 @@ namespace ILToNative
         }
 
         public TextWriter Log
+        {
+            get;
+            set;
+        }
+
+        public string OutputPath
         {
             get;
             set;
@@ -288,7 +295,14 @@ namespace ILToNative
 
                 _dependencyGraph.ComputeDependencyRoutine += ComputeDependencyNodeDependencies;
                 var nodes = _dependencyGraph.MarkedNodeList;
-                AsmWriter.EmitAsm(Out, nodes, rootNode, _nodeFactory);
+                if (_options.EmitAsm)
+                {
+                    AsmWriter.EmitAsm(Out, nodes, rootNode, _nodeFactory);
+                }
+                else
+                {
+                    ObjectWriter.EmitObject(OutputPath, nodes, rootNode, _nodeFactory);
+                }
 
                 if (_options.DgmlLog != null)
                 {

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/AsmWriter.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/AsmWriter.cs
@@ -75,8 +75,8 @@ namespace ILToNative.DependencyAnalysis
                     // TODO: Remove if and when entry point is directly emitted.
                     if (node == mainMethodNode)
                     {
-                        output.WriteLine(".global __managed__Main");
-                        output.WriteLine("__managed__Main:");
+                        output.WriteLine(".global {0}", ObjectWriter.MainEntryNodeName);
+                        output.WriteLine("{0}:", ObjectWriter.MainEntryNodeName);
                     }
                 }
             }

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using ILToNative.DependencyAnalysisFramework;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace ILToNative.DependencyAnalysis
+{
+    /// <summary>
+    /// Object writer using https://github.com/dotnet/llilc
+    /// </summary>
+    class ObjectWriter : IDisposable
+    {
+        public const string MainEntryNodeName = "__managed__Main";
+        const string NativeObjectWriterFileName = "objwriter";
+        [DllImport(NativeObjectWriterFileName)]
+        static extern IntPtr InitObjWriter(string objectFilePath);
+
+        [DllImport(NativeObjectWriterFileName)]
+        static extern void FinishObjWriter(IntPtr objWriter);
+
+        [DllImport(NativeObjectWriterFileName)]
+        static extern void SwitchSection(IntPtr objWriter, string sectionName);
+        public void SwitchSection(string sectionName)
+        {
+            SwitchSection(_nativeObjectWriter, sectionName);
+        }
+
+        [DllImport(NativeObjectWriterFileName)]
+        static extern void EmitAlignment(IntPtr objWriter, int byteAlignment);
+        public void EmitAlignment(int byteAlignment)
+        {
+            EmitAlignment(_nativeObjectWriter, byteAlignment);
+        }
+
+        [DllImport(NativeObjectWriterFileName)]
+        static extern void EmitBlob(IntPtr objWriter, byte[] blob, int blobSize);
+        public void EmitBlob(byte[] blob, int blobSize)
+        {
+            EmitBlob(_nativeObjectWriter, blob, blobSize);
+        }
+
+        [DllImport(NativeObjectWriterFileName)]
+        static extern void EmitIntValue(IntPtr objWriter, ulong value, int size);
+        public void EmitIntValue(ulong value, int size)
+        {
+            EmitIntValue(_nativeObjectWriter, value, size);
+        }
+
+        [DllImport(NativeObjectWriterFileName)]
+        static extern void EmitSymbolDef(IntPtr objWriter, string symbolName);
+        public void EmitSymbolDef(string symbolName)
+        {
+            EmitSymbolDef(_nativeObjectWriter, symbolName);
+        }
+
+        [DllImport(NativeObjectWriterFileName)]
+        static extern void EmitSymbolRef(IntPtr objWriter, string symbolName, int Size, bool isPCRelative, int delta = 0);
+        public void EmitSymbolRef(string symbolName, int size, bool isPCRelative, int delta = 0)
+        {
+            EmitSymbolRef(_nativeObjectWriter, symbolName, size, isPCRelative, delta);
+        }
+
+        // This is one to multiple mapping -- we might have multiple symbols at the give offset.
+        // We preserved the original order of ISymbolNode[].
+        Dictionary<int, List<ISymbolNode>> _offsetToDefSymbol = new Dictionary<int, List<ISymbolNode>>();
+        public void BuildSymbolDefinitionMap(ISymbolNode[] definedSymbols)
+        {
+            _offsetToDefSymbol.Clear();
+            foreach (ISymbolNode n in definedSymbols)
+            {
+                if (!_offsetToDefSymbol.ContainsKey(n.Offset)) {
+                    _offsetToDefSymbol[n.Offset] = new List<ISymbolNode>();
+                }
+                _offsetToDefSymbol[n.Offset].Add(n);
+            }
+        }
+
+        public void EmitSymbolDefinition(int currentOffset)
+        {
+            List<ISymbolNode> nodes;
+            if (_offsetToDefSymbol.TryGetValue(currentOffset, out nodes)) {
+                foreach (var node in nodes)
+                {
+                    EmitSymbolDef(node.MangledName);
+                }
+            }
+        }
+
+        IntPtr _nativeObjectWriter = IntPtr.Zero;
+
+        public ObjectWriter(string outputPath)
+        {
+            _nativeObjectWriter = InitObjWriter(outputPath);
+            if (_nativeObjectWriter == IntPtr.Zero)
+            {
+                throw new IOException("Fail to initialize Native Object Writer");
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        public virtual void Dispose(bool bDisposing)
+        {
+            if (_nativeObjectWriter != null)
+            {
+                // Finalize object emission.
+                FinishObjWriter(_nativeObjectWriter);
+                _nativeObjectWriter = IntPtr.Zero;
+            }
+
+            if (bDisposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        ~ObjectWriter()
+        {
+            Dispose(false);
+        }
+
+        public static void EmitObject(string OutputPath, IEnumerable<DependencyNode> nodes, ISymbolNode mainMethodNode, NodeFactory factory)
+        {
+            using (ObjectWriter objectWriter = new ObjectWriter(OutputPath))
+            {
+                string currentSection = "";
+
+                foreach (DependencyNode depNode in nodes)
+                {
+                    ObjectNode node = depNode as ObjectNode;
+                    if (node == null)
+                        continue;
+
+                    if (node.ShouldSkipEmittingObjectNode(factory))
+                        continue;
+
+                    ObjectNode.ObjectData nodeContents = node.GetData(factory);
+
+                    if (currentSection != node.Section)
+                    {
+                        currentSection = node.Section;
+                        objectWriter.SwitchSection(currentSection);
+                    }
+
+                    objectWriter.EmitAlignment(nodeContents.Alignment);
+
+                    Relocation[] relocs = nodeContents.Relocs;
+                    int nextRelocOffset = -1;
+                    int nextRelocIndex = -1;
+                    if (relocs != null && relocs.Length > 0)
+                    {
+                        nextRelocOffset = relocs[0].Offset;
+                        nextRelocIndex = 0;
+                    }
+
+                    if (mainMethodNode == node)
+                    {
+                        objectWriter.EmitSymbolDef(MainEntryNodeName);
+                    }
+
+                    // Build symbol definition map.
+                    objectWriter.BuildSymbolDefinitionMap(nodeContents.DefinedSymbols);
+
+                    for (int i = 0; i < nodeContents.Data.Length; i++)
+                    {
+                        // Emit symbol definitions if necessary
+                        objectWriter.EmitSymbolDefinition(i);
+
+                        if (i == nextRelocOffset)
+                        {
+                            Relocation reloc = relocs[nextRelocIndex];
+
+                            ISymbolNode target = reloc.Target;
+                            string targetName = target.MangledName;
+                            int size = 0;
+                            bool isPCRelative = false;
+                            switch (reloc.RelocType)
+                            {
+                                // REVIEW: I believe the JIT is emitting 0x3 instead of 0xA
+                                // for x64, because emitter from x86 is ported for RyuJIT.
+                                // I will consult with Bruce and if he agrees, I will delete
+                                // this "case" duplicated by IMAGE_REL_BASED_DIR64.
+                                case (RelocType)0x03: // IMAGE_REL_BASED_HIGHLOW
+                                case RelocType.IMAGE_REL_BASED_DIR64:
+                                    size = 8;
+                                    break;
+                                case RelocType.IMAGE_REL_BASED_REL32:
+                                    size = 4;
+                                    isPCRelative = true;
+                                    break;
+                                default:
+                                    throw new NotImplementedException();
+                            }
+                            // Emit symbol reference
+                            objectWriter.EmitSymbolRef(targetName, size, isPCRelative);
+
+                            // Update nextRelocIndex/Offset
+                            if (++nextRelocIndex < relocs.Length)
+                            {
+                                nextRelocOffset = relocs[nextRelocIndex].Offset;
+                            }
+                            i += size - 1;
+                            continue;
+                        }
+
+                        objectWriter.EmitIntValue(nodeContents.Data[i], 1);
+                    }
+
+                    // It is possible to have a symbol just after all of the data.
+                    objectWriter.EmitSymbolDefinition(nodeContents.Data.Length);
+                }
+
+            }
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
+++ b/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ObjectAndOffsetSymbolNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectDataBuilder.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ObjectWriter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Relocation.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\TargetRegisterMap.cs" />

--- a/src/ILToNative/reproNative/reproNative.vcxproj
+++ b/src/ILToNative/reproNative/reproNative.vcxproj
@@ -59,7 +59,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\obj\Native\Windows_NT.x64\Runtime\Full\Debug\Runtime.lib</AdditionalDependencies>
+      <AdditionalDependencies>repro.obj;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\obj\Native\Windows_NT.x64\Runtime\Full\Debug\Runtime.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -80,7 +80,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\obj\Native\Windows_NT.x64\Runtime\Full\Release\Runtime.lib</AdditionalDependencies>
+      <AdditionalDependencies>repro.obj;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\obj\Native\Windows_NT.x64\Runtime\Full\Release\Runtime.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -96,9 +96,9 @@
     <ClCompile Include="..\..\Native\Bootstrap\platform.windows.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <CustomBuild Include="repro.s">
-      <Command>"C:\Program Files\LLVM\bin\clang.exe" -c %(FullPath) -o $(IntermediateOutputPath)repro.obj</Command>
-      <Outputs>$(IntermediateOutputPath)repro.obj</Outputs>
+    <CustomBuild Include="repro.s" Condition="Exists('repro.s')" >
+      <Command>"C:\Program Files\LLVM\bin\clang.exe" -c %(FullPath) -o repro.obj</Command>
+      <Outputs>repro.obj</Outputs>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/ILToNative/src/Program.cs
+++ b/src/ILToNative/src/Program.cs
@@ -88,6 +88,10 @@ namespace ILToNative
                     _options.NoLineNumbers = true;
                     break;
 
+                case "asm":
+                    _options.EmitAsm = true;
+                    break;
+
                 default:
                     throw new CommandLineException("Unrecognized option: " + parser.GetCurrentOption());
                 }
@@ -121,7 +125,12 @@ namespace ILToNative
 
             Compilation compilation = new Compilation(_compilerTypeSystemContext, _options);
             compilation.Log = Console.Out;
-            compilation.Out = new StreamWriter(File.Create(_outputPath));
+            compilation.OutputPath = _outputPath;
+            if (_options.EmitAsm || _options.IsCppCodeGen)
+            {
+                // Don't set Out when using object writer which is handled by LLVM.
+                compilation.Out = new StreamWriter(File.Create(_outputPath));
+            }
 
             compilation.CompileSingleFile(entryPointMethod);
         }


### PR DESCRIPTION
Object writer support for CoreRT

The source and prebuilt binary (objwriter.dll) is checked in since this relies on LLVM build.
AsmWriter is still there but it's active with "-asm" flag to ILToNative.
The default output of ILToNative is now object file (for native case)

The APIs surfaced are the following. Mostly there work with platform independent type like string/int, etc.  In the most case they will be translated into the right form of relocation as of now regardless of platforms.
But definitely this is not the all cases, and I will add and modify things per project needs.

InitObjWriter
FinishObjWriter
SwitchSection
EmitAlignment
EmitBlob
EmitIntValue
EmitSymbolDef
EmitSymbolRef

Confirm HelloWorld runs same as before correctly with this change.
Also verified that other than alignment byte sequence, the disassemble and fixups are all identical.

I will update one note as well once it's in.
