### PR TITLE
Add the default globalization implementation for Linux

### DIFF
--- a/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
+++ b/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
@@ -998,6 +998,7 @@ internal partial class Interop
     // declare the specialized callback context type, deriving from the CallbackContext type that MCG expects the class library to implement.  
     internal partial class mincore_private
     {
+#pragma warning disable 649
         internal class LParamCallbackContext : CallbackContext
         {
             // Put any user data to pass to the callback here.  The user code being called back will get the instance of this class that was passed to the API originally.

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
+
   <PropertyGroup>
     <ProjectGuid>{BE95C560-B508-4588-8907-F9FC5BC1A0CF}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-<!-- 
-	temporary workaround to exclude all references including mscorlib.dll 
+<!--
+	temporary workaround to exclude all references including mscorlib.dll
     <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)</_TargetFrameworkDirectories>
     <_FullFrameworkReferenceAssemblyPaths>$(_TargetFrameworkDirectories)</_FullFrameworkReferenceAssemblyPaths>
-    Condition="'$(IsProjectNLibrary)' != 'true'  
+    Condition="'$(IsProjectNLibrary)' != 'true'
 -->
-    <IsCoreAssembly>true</IsCoreAssembly> 
+    <IsCoreAssembly>true</IsCoreAssembly>
     <!--
       Need to avoid target platform being empty because that would drag in an mscorlib design-time
       facade into the references and break us.
@@ -29,17 +29,17 @@
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
     <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
-	
-<!--    
+
+<!--
     <ExcludeDefaultReferences>true</ExcludeDefaultReferences>
 
     <ExcludeVersioningImport>true</ExcludeVersioningImport>
     <TargetingDefaultPlatform>true</TargetingDefaultPlatform>
     <ExcludeFrameworkTargetingImport>true</ExcludeFrameworkTargetingImport>
-    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>  
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
 -->
   </PropertyGroup>
-  
+
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -70,7 +70,7 @@
       <Link>Resources\Common</Link>
     </Compile>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="Internal\Diagnostics\ExceptionExtensions.cs" />
     <Compile Include="Internal\Diagnostics\StackTraceHelper.cs" />
@@ -223,14 +223,10 @@
     <Compile Include="System\GC.cs" />
     <Compile Include="System\Globalization\Calendar.cs" />
     <Compile Include="System\Globalization\CalendarData.cs" />
-    <Compile Include="System\Globalization\CalendarData.Win32.cs" />
     <Compile Include="System\Globalization\CharUnicodeInfo.cs" />
     <Compile Include="System\Globalization\CompareInfo.cs" />
-    <Compile Include="System\Globalization\CompareInfo.Win32.cs" />
     <Compile Include="System\Globalization\CultureData.cs" />
-    <Compile Include="System\Globalization\CultureData.Win32.cs" />
     <Compile Include="System\Globalization\CultureInfo.cs" />
-    <Compile Include="System\Globalization\CultureInfo.Win32.cs" />
     <Compile Include="System\Globalization\FormatProvider.DateTimeFormat.cs" />
     <Compile Include="System\Globalization\DateTimeFormatInfo.cs" />
     <Compile Include="System\Globalization\DateTimeFormatInfoScanner.cs" />
@@ -250,7 +246,6 @@
     <Compile Include="System\Globalization\NumberFormatInfo.cs" />
     <Compile Include="System\Globalization\NumberStyles.cs" />
     <Compile Include="System\Globalization\TextInfo.cs" />
-    <Compile Include="System\Globalization\TextInfo.Win32.cs" />
     <Compile Include="System\Globalization\TimeSpanStyles.cs" />
     <Compile Include="System\Globalization\UnicodeCategory.cs" />
     <Compile Include="System\Guid.cs" />
@@ -471,6 +466,24 @@
     <Compile Include="System\WeakReference.cs" />
     <Compile Include="System\WeakReferenceOfT.cs" />
   </ItemGroup>
+
+  <!-- Windows is default build -->
+  <ItemGroup Condition="'$(OSGroup)' != 'Linux'">
+      <Compile Include="System\Globalization\CultureInfo.Win32.cs" />
+      <Compile Include="System\Globalization\CompareInfo.Win32.cs" />
+      <Compile Include="System\Globalization\CultureData.Win32.cs" />
+      <Compile Include="System\Globalization\TextInfo.Win32.cs" />
+      <Compile Include="System\Globalization\CalendarData.Win32.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(OSGroup)' == 'Linux'">
+      <Compile Include="System\Globalization\CultureInfo.Dummy.cs" />
+      <Compile Include="System\Globalization\CompareInfo.Dummy.cs" />
+      <Compile Include="System\Globalization\CultureData.Dummy.cs" />
+      <Compile Include="System\Globalization\TextInfo.Dummy.cs" />
+      <Compile Include="System\Globalization\CalendarData.Dummy.cs" />
+</ItemGroup>
+
   <ItemGroup>
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.cs" />
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.Events.cs" />
@@ -500,7 +513,7 @@
         <LogicalName>Resources.$(AssemblyName).rd.xml</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
   <PropertyGroup>

--- a/src/System.Private.CoreLib/src/System/Globalization/CalendarData.Dummy.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CalendarData.Dummy.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Diagnostics.Contracts;
+using System.Collections.Generic;
+
+namespace System.Globalization
+{
+    internal partial class CalendarData
+    {
+        private bool LoadCalendarDataFromSystem(String localeName, CalendarId calendarId)
+        {
+            return true;
+        }
+
+        internal static CalendarData GetCalendarData(CalendarId calendarId)
+        {
+            return CultureInfo.InvariantCulture.m_cultureData.GetCalendar(calendarId);
+        }
+
+        internal static int GetCalendars(String localeName, bool useUserOverride, CalendarId[] calendars)
+        {
+            return 1;
+        }
+
+        private static bool SystemSupportsTaiwaneseCalendar()
+        {
+            return false;
+        }
+
+        internal static int GetTwoDigitYearMax(CalendarId calendarId)
+        {
+            return 2029;
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Dummy.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Dummy.cs
@@ -1,0 +1,393 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Contracts;
+
+namespace System.Globalization
+{
+    public partial class CompareInfo
+    {
+        internal unsafe CompareInfo(CultureInfo culture)
+        {
+            _name = culture.m_name;
+            _sortName = culture.SortName;
+        }
+
+        internal unsafe static int IndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
+        {
+            fixed (char *pSource = source) fixed (char *pValue = value)
+            {
+                char *pSrc = &pSource[startIndex];
+                int index = FindStringOrdinal(pSrc, count, pValue, value.Length, FindStringOptions.Start, ignoreCase);
+                if (index >= 0)
+                {
+                    return index + startIndex;
+                }
+                return -1;
+            }
+        }
+
+        internal unsafe static int LastIndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
+        {
+            fixed (char *pSource = source) fixed (char *pValue = value)
+            {
+                char *pSrc = &pSource[startIndex - count + 1];
+                int index = FindStringOrdinal(pSrc, count, pValue, value.Length, FindStringOptions.End, ignoreCase);
+                if (index >= 0)
+                {
+                    return index + startIndex - (count - 1);
+                }
+                return -1;
+            }
+        }
+
+        private unsafe bool StartsWith(string source, string prefix, CompareOptions options)
+        {
+            fixed (char *pSource = source) fixed (char *pValue = prefix)
+            {
+                return FindStringOrdinal(pSource, source.Length, pValue, prefix.Length, FindStringOptions.StartsWith,
+                                         (options & CompareOptions.IgnoreCase) != 0) >= 0;
+            }
+        }
+
+        private unsafe bool EndsWith(string source, string suffix, CompareOptions options)
+        {
+            fixed (char *pSource = source) fixed (char *pValue = suffix)
+            {
+                return FindStringOrdinal(pSource, source.Length, pValue, suffix.Length, FindStringOptions.EndsWith,
+                                         (options & CompareOptions.IgnoreCase) != 0) >= 0;
+            }
+        }
+
+        private unsafe int IndexOfCore(string source, string value, int startIndex, int count, CompareOptions options)
+        {
+            return IndexOfOrdinal(source, value, startIndex, count, (options & (CompareOptions.IgnoreCase | CompareOptions.OrdinalIgnoreCase)) != 0);
+        }
+
+        private unsafe int LastIndexOfCore(string source, string value, int startIndex, int count, CompareOptions options)
+        {
+            return LastIndexOfOrdinal(source, value, startIndex, count, (options & (CompareOptions.IgnoreCase | CompareOptions.OrdinalIgnoreCase)) != 0);
+        }
+
+        private unsafe int GetHashCodeOfStringCore(string source, CompareOptions options)
+        {
+            bool ignoreCase = (options & (CompareOptions.IgnoreCase | CompareOptions.OrdinalIgnoreCase)) != 0;
+
+            if (ignoreCase)
+            {
+                return source.ToUpper().GetHashCode();
+            }
+
+            return source.GetHashCode();
+        }
+
+        private unsafe int CompareString(string string1, int offset1, int length1, string string2, int offset2, int length2, CompareOptions options)
+        {
+            fixed (char *pStr1 = string1) fixed (char *pStr2 = string2)
+            {
+                char *pString1 = &pStr1[offset1];
+                char *pString2 = &pStr2[offset2];
+
+                return CompareString(pString1, length1, pString2, length2, options);
+            }
+        }
+
+        private static unsafe int CompareStringOrdinalIgnoreCase(char* string1, int count1, char* string2, int count2)
+        {
+            return CompareString(string1, count1, string2, count2, 0);
+        }
+
+        private static unsafe int CompareString(char *pString1, int length1, char *pString2, int length2, CompareOptions options)
+        {
+            bool ignoreCase = (options & (CompareOptions.IgnoreCase | CompareOptions.OrdinalIgnoreCase)) != 0;
+            int index = 0;
+
+            if (ignoreCase)
+            {
+                while ( index < length1 &&
+                        index < length2 &&
+                        ToUpper(pString1[index]) == ToUpper(pString2[index]))
+                {
+                    index++;
+                }
+            }
+            else
+            {
+                while ( index < length1 &&
+                        index < length2 &&
+                        pString1[index] == pString2[index])
+                {
+                    index++;
+                }
+            }
+
+            if (index >= length1)
+            {
+                if (index >= length2)
+                {
+                    return 0;
+                }
+                return -1;
+            }
+
+            if (index >= length2)
+            {
+                return 1;
+            }
+
+            return ignoreCase ? ToUpper(pString1[index]) - ToUpper(pString2[index]) : pString1[index] - pString2[index];
+        }
+
+
+        private unsafe static int FindStringOrdinal(char *source, int sourceCount, char *value,int valueCount, FindStringOptions option, bool ignoreCase)
+        {
+            int ctrSource = 0;  // index value into source
+            int ctrValue = 0;   // index value into value
+            char sourceChar;    // Character for case lookup in source
+            char valueChar;     // Character for case lookup in value
+            int lastSourceStart;
+
+            Contract.Assert(source != null);
+            Contract.Assert(value != null);
+            Contract.Assert(sourceCount>= 0);
+            Contract.Assert(valueCount >= 0);
+
+            if(valueCount == 0)
+            {
+                switch (option)
+                {
+                    case FindStringOptions.StartsWith:
+                    case FindStringOptions.Start:
+                        return(0);
+
+                    case FindStringOptions.EndsWith:
+                    case FindStringOptions.End:
+                        return(sourceCount);
+
+                    default:
+                        return -1;
+                }
+            }
+
+            if(sourceCount < valueCount)
+            {
+                return -1;
+            }
+
+            switch (option)
+            {
+                case FindStringOptions.StartsWith:
+                {
+                    if (ignoreCase)
+                    {
+                        for (ctrValue = 0; ctrValue < valueCount; ctrValue++)
+                        {
+                            sourceChar = ToUpper(source[ctrValue]);
+                            valueChar  = ToUpper(value[ctrValue]);
+
+                            if (sourceChar != valueChar)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (ctrValue = 0; ctrValue < valueCount; ctrValue++)
+                        {
+                                sourceChar = source[ctrValue];
+                                valueChar  = value[ctrValue];
+
+                                if (sourceChar != valueChar)
+                                {
+                                    break;
+                                }
+                        }
+                    }
+
+                    if (ctrValue == valueCount)
+                    {
+                        return 0;
+                    }
+                }
+                break;
+
+                case FindStringOptions.Start:
+                {
+                    lastSourceStart = sourceCount - valueCount;
+                    if (ignoreCase)
+                    {
+                        char firstValueChar = ToUpper(value[0]);
+                        for (ctrSource = 0; ctrSource <= lastSourceStart; ctrSource++)
+                        {
+                            sourceChar = ToUpper(source[ctrSource]);
+                            if (sourceChar != firstValueChar)
+                            {
+                                continue;
+                            }
+
+                            for (ctrValue = 1; ctrValue < valueCount; ctrValue++)
+                            {
+                                sourceChar = ToUpper(source[ctrSource + ctrValue]);
+                                valueChar  = ToUpper(value[ctrValue]);
+
+                                if (sourceChar != valueChar)
+                                {
+                                    break;
+                                }
+                            }
+
+                            if (ctrValue == valueCount)
+                            {
+                                return ctrSource;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        char firstValueChar = value[0];
+                        for (ctrSource = 0; ctrSource <= lastSourceStart; ctrSource++)
+                        {
+                            sourceChar = source[ctrSource];
+                            if (sourceChar != firstValueChar)
+                            {
+                                continue;
+                            }
+
+                            for (ctrValue = 1; ctrValue < valueCount; ctrValue++)
+                            {
+                                sourceChar = source[ctrSource + ctrValue];
+                                valueChar  = value[ctrValue];
+
+                                if (sourceChar != valueChar)
+                                {
+                                    break;
+                                }
+                            }
+
+                            if (ctrValue == valueCount)
+                            {
+                                return ctrSource;
+                            }
+                        }
+                    }
+                }
+                break;
+
+                case FindStringOptions.EndsWith:
+                {
+                    lastSourceStart = sourceCount - valueCount;
+                    if (ignoreCase)
+                    {
+                        for (ctrSource = lastSourceStart, ctrValue = 0; ctrValue < valueCount; ctrSource++,ctrValue++)
+                        {
+                            sourceChar = ToUpper(source[ctrSource]);
+                            valueChar  = ToUpper(value[ctrValue]);
+
+                            if (sourceChar != valueChar)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (ctrSource = lastSourceStart, ctrValue = 0; ctrValue < valueCount; ctrSource++,ctrValue++)
+                        {
+                            sourceChar = source[ctrSource];
+                            valueChar  = value[ctrValue];
+
+                            if (sourceChar != valueChar)
+                            {
+                                break;
+                            }
+                        }
+                    }
+
+                    if (ctrValue == valueCount)
+                    {
+                        return sourceCount - valueCount;
+                    }
+                }
+                break;
+
+                case FindStringOptions.End:
+                {
+                    lastSourceStart = sourceCount - valueCount;
+                    if (ignoreCase)
+                    {
+                        char firstValueChar = ToUpper(value[0]);
+                        for (ctrSource = lastSourceStart; ctrSource >= 0; ctrSource--)
+                        {
+                            sourceChar = ToUpper(source[ctrSource]);
+                            if(sourceChar != firstValueChar)
+                            {
+                                continue;
+                            }
+                            for (ctrValue = 1; ctrValue < valueCount; ctrValue++)
+                            {
+                                sourceChar = ToUpper(source[ctrSource + ctrValue]);
+                                valueChar  = ToUpper(value[ctrValue]);
+
+                                if (sourceChar != valueChar)
+                                {
+                                    break;
+                                }
+                            }
+
+                            if (ctrValue == valueCount)
+                            {
+                                return ctrSource;
+                            }
+                        }
+                    } else {
+                        char firstValueChar = value[0];
+                        for (ctrSource = lastSourceStart; ctrSource >= 0; ctrSource--)
+                        {
+                            sourceChar = source[ctrSource];
+                            if(sourceChar != firstValueChar)
+                            {
+                                continue;
+                            }
+
+                            for (ctrValue = 1; ctrValue < valueCount; ctrValue++)
+                            {
+                                sourceChar = source[ctrSource + ctrValue];
+                                valueChar  = value[ctrValue];
+
+                                if (sourceChar != valueChar)
+                                {
+                                    break;
+                                }
+                            }
+
+                            if (ctrValue == valueCount)
+                            {
+                                return ctrSource;
+                            }
+                        }
+                    }
+                }
+                break;
+
+                default:
+                    return -1;
+            }
+
+            return -1;
+        }
+
+        private static char ToUpper(char c)
+        {
+            return ('a' <= c && c <= 'z') ? (char)(c - 0x20) : c;
+        }
+
+        private enum FindStringOptions
+        {
+            Start,
+            StartsWith,
+            End,
+            EndsWith,
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureData.Dummy.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureData.Dummy.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
+using System.Text;
+using Internal.Runtime.Augments;
+
+namespace System.Globalization
+{
+
+    internal partial class CultureData
+    {
+        private unsafe bool InitCultureData()
+        {
+            if (_sSpecificCulture == null)
+            {
+                _sSpecificCulture = "";
+            }
+            return true;
+        }
+
+        [System.Security.SecurityCritical]
+        private string GetLocaleInfo(LocaleStringData type)
+        {
+            return "";
+        }
+
+        [System.Security.SecurityCritical]
+        private string GetLocaleInfo(string localeName, LocaleStringData type)
+        {
+            return "";
+        }
+
+        private int GetLocaleInfo(LocaleNumberData type)
+        {
+            return 0;
+        }
+
+        private int[] GetLocaleInfo(LocaleGroupingData type)
+        {
+            return new int [] { 0 };
+        }
+
+        private static CultureInfo GetUserDefaultCulture()
+        {
+            return CultureInfo.InvariantCulture;
+        }
+
+        private static string GetLanguageDisplayName(string cultureName)
+        {
+            return "Invariant";
+        }
+
+        private static string GetRegionDisplayName(string isoCountryCode)
+        {
+            return "Invariant";
+        }
+
+        private static CultureData GetCultureDataFromRegionName(String regionName)
+        {
+            return CultureInfo.InvariantCulture.m_cultureData;
+        }
+
+        private string GetTimeFormatString()
+        {
+            return "h:mm tt";
+        }
+
+        private String[] GetShortTimeFormats()
+        {
+            return new string [] { "h:mm tt" };
+        }
+
+        private String[] GetTimeFormats()
+        {
+            return new string [] { "h:mm:ss tt", "h:mm tt" };
+        }
+
+        private static bool IsCustomCultureId(int cultureId)
+        {
+            return false;
+        }
+
+        private int GetFirstDayOfWeek()
+        {
+            return 0;
+        }
+
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Dummy.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Dummy.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Internal.Runtime.Augments;
+
+namespace System.Globalization
+{
+    public partial class CultureInfo : IFormatProvider
+    {
+        /// <summary>
+        /// Gets the default user culture from WinRT, if available.
+        /// </summary>
+        /// <remarks>
+        /// This method may return null, if there is no default user culture or if WinRT isn't available.
+        /// </remarks>
+        private static CultureInfo GetUserDefaultCultureCacheOverride()
+        {
+            return CultureInfo.InvariantCulture;
+        }
+
+        private static CultureInfo GetUserDefaultCulture()
+        {
+            return CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -69,13 +69,13 @@ namespace System.Globalization
 
         // Names are confusing.  Here are 3 names we have:
         //
-        //  new CultureInfo()   m_name        m_nonSortName   m_sortName
+        //  new CultureInfo()   m_name         _nonSortName    _sortName
         //      en-US           en-US           en-US           en-US
         //      de-de_phoneb    de-DE_phoneb    de-DE           de-DE_phoneb
         //      fj-fj (custom)  fj-FJ           fj-FJ           en-US (if specified sort is en-US)
-        //      en              en              
+        //      en              en
         //
-        // Note that in Silverlight we ask the OS for the text and sort behavior, so the 
+        // Note that in Silverlight we ask the OS for the text and sort behavior, so the
         // textinfo and compareinfo names are the same as the name
 
         // Note that the name used to be serialized for Everett; it is now serialized
@@ -164,6 +164,12 @@ namespace System.Globalization
                     SR.ArgumentNull_String);
             }
 
+#if CORERT
+            // CORERT-TODO CultureInfo
+            m_cultureData = s_InvariantCultureInfo.m_cultureData;
+            m_name = _sortName = _nonSortName = name;
+            m_isInherited = false;
+#else
             // Get our data providing record
             this.m_cultureData = CultureData.GetCultureData(name, useUserOverride);
 
@@ -173,6 +179,7 @@ namespace System.Globalization
 
             this.m_name = this.m_cultureData.CultureName;
             this.m_isInherited = (this.GetType() != typeof(System.Globalization.CultureInfo));
+#endif // CORERT
         }
 
 
@@ -212,7 +219,7 @@ namespace System.Globalization
 
         internal static bool VerifyCultureName(String cultureName, bool throwException)
         {
-            // This function is used by ResourceManager.GetResourceFileName(). 
+            // This function is used by ResourceManager.GetResourceFileName().
             // ResourceManager searches for resource using CultureInfo.Name,
             // so we should check against CultureInfo.Name.
 
@@ -271,7 +278,7 @@ namespace System.Globalization
             {
 #if CORERT
                 // CORERT-TODO CultureInfo
-                return null;
+                return CultureInfo.InvariantCulture;
 #else
                 CultureInfo ci = GetUserDefaultCultureCacheOverride();
                 if (ci != null)
@@ -290,7 +297,7 @@ namespace System.Globalization
                     return ci;
                 }
 
-                // if s_userDefaultCulture == null means CultureInfo statics didn't get initialized yet. this can happen if there early static 
+                // if s_userDefaultCulture == null means CultureInfo statics didn't get initialized yet. this can happen if there early static
                 // method get executed which eventually hit the cultureInfo code while CultureInfo statics didn’t get chance to initialize
                 if (s_userDefaultCulture == null)
                 {
@@ -324,6 +331,10 @@ namespace System.Globalization
         {
             get
             {
+#if CORERT
+                // CORERT-TODO CultureInfo
+                return CultureInfo.InvariantCulture;
+#else
                 CultureInfo ci = GetUserDefaultCultureCacheOverride();
                 if (ci != null)
                 {
@@ -341,7 +352,7 @@ namespace System.Globalization
                     return ci;
                 }
 
-                // if s_userDefaultCulture == null means CultureInfo statics didn't get initialized yet. this can happen if there early static 
+                // if s_userDefaultCulture == null means CultureInfo statics didn't get initialized yet. this can happen if there early static
                 // method get executed which eventually hit the cultureInfo code while CultureInfo statics didn’t get chance to initialize
                 if (s_userDefaultCulture == null)
                 {
@@ -350,6 +361,7 @@ namespace System.Globalization
 
                 Contract.Assert(s_userDefaultCulture != null);
                 return s_userDefaultCulture;
+#endif // CORERT
             }
 
             set
@@ -378,7 +390,7 @@ namespace System.Globalization
             [System.Security.SecuritySafeCritical]  // auto-generated
             set
             {
-                // If you add pre-conditions to this method, check to see if you also need to 
+                // If you add pre-conditions to this method, check to see if you also need to
                 // add them to Thread.CurrentCulture.set.
 
                 s_DefaultThreadCurrentCulture = value;
@@ -394,7 +406,7 @@ namespace System.Globalization
                 //If they're trying to use a Culture with a name that we can't use in resource lookup,
                 //don't even let them set it on the thread.
 
-                // If you add more pre-conditions to this method, check to see if you also need to 
+                // If you add more pre-conditions to this method, check to see if you also need to
                 // add them to Thread.CurrentUICulture.set.
 
                 if (value != null)

--- a/src/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -160,12 +160,18 @@ namespace System.Globalization
                     // be thrown out of a .cctor stack that will need this.
                     NumberFormatInfo nfi = new NumberFormatInfo();
                     nfi.m_isInvariant = true;
+#if CORERT
+                    // CORERT-TODO CultureInfo
+                    nfi.isReadOnly = true;
+                    s_invariantInfo = nfi;
+#else
                     s_invariantInfo = ReadOnly(nfi);
+#endif // CORERT
+
                 }
                 return s_invariantInfo;
             }
         }
-
 
         public static NumberFormatInfo GetInstance(IFormatProvider formatProvider)
         {

--- a/src/System.Private.CoreLib/src/System/Globalization/TextInfo.Dummy.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/TextInfo.Dummy.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Contracts;
+
+namespace System.Globalization
+{
+    public partial class TextInfo
+    {
+        internal unsafe TextInfo(CultureData cultureData)
+        {
+            _cultureData = cultureData;
+            _cultureName = _cultureData.CultureName;
+            _textInfoName = _cultureData.STEXTINFO;
+        }
+
+        private unsafe string ChangeCase(string s, bool toUpper)
+        {
+            if (s.Length == 0)
+            {
+                return s;
+            }
+
+            char[] buffer = new char[s.Length];
+
+            if (toUpper)
+            {
+                for (int i=0; i<s.Length; i++)
+                {
+                    buffer[i] = ('a' <= s[i] && s[i] <= 'z') ? (char)(s[i] - 0x20) : s[i];
+                }
+            }
+            else
+            {
+                for (int i=0; i<s.Length; i++)
+                {
+                    buffer[i] = ('A' <= s[i] && s[i] <= 'Z') ? (char)(s[i] | 0x20) : s[i];
+                }
+            }
+
+            return new string(buffer, 0, buffer.Length);
+        }
+
+        private unsafe char ChangeCase(char c, bool toUpper)
+        {
+            if (toUpper)
+            {
+                return ('a' <= c && c <= 'z') ? (char)(c - 0x20) : c;
+            }
+
+            return ('A' <= c && c <= 'Z') ? (char)(c | 0x20) : c;
+        }
+    }
+}


### PR DESCRIPTION
The change here is just adding some default implmentation to be used for
Linux so we can avoid calling any path end up calling Win32 API.

The change also will make it easier in the future to determine what
functionality needed for Linux to implement the real PAL layer.

Note that, the changes here cover most of the globalization implemntation but
we may need to do more as needed if we run into any other problem when getting
the demo ready
