### PR TITLE
Several fixes to the build

### DIFF
--- a/src/ILToNative.TypeSystem/src/project.json
+++ b/src/ILToNative.TypeSystem/src/project.json
@@ -14,7 +14,7 @@
     "System.Threading": "4.0.0",
     "System.Text.Encoding.Extensions": "4.0.0",
     "System.Reflection.Extensions": "4.0.0",
-    "System.Reflection.Metadata": "1.0.22",
+    "System.Reflection.Metadata": "1.0.22"
   },
   "frameworks": {
     "dotnet": {}

--- a/src/ILToNative/desktop/desktop.csproj
+++ b/src/ILToNative/desktop/desktop.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -56,7 +56,13 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ILToNative/src/project.json
+++ b/src/ILToNative/src/project.json
@@ -20,6 +20,8 @@
     "System.Reflection.Metadata": "1.0.22"
   },
   "frameworks": {
-    "dotnet": {}
+    "dotnet": {
+      "imports": "portable-net452"
+    }
   }
 }

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -6,10 +6,10 @@
     <add key="repositoryPath" value="..\packages" />
   </config>
   <packageSources>
-    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
-    <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
-    <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
-    <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v2" />
+    <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/api/v2" />
+    <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/api/v2" />
+    <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v2" />
+    <add key="nuget.org2" value="https://www.nuget.org/api/v2/" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
- ILToNative was missing an imports statement
- Nuget.config's nuget.org source was updated to avoid redirects and
  also work around a bug in nuget where globally disabled nuget.org sources
  override locally enabled ones.
- Updated desktop.csproj to use the right targets (ResolveNuGetPackageAssets didn't run)
