### PR TITLE
Half-implementation of RyuJIT generated ROData blocks

### DIFF
--- a/src/ILToNative.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILToNative.Compiler/src/Compiler/Compilation.cs
@@ -346,6 +346,16 @@ namespace ILToNative
                         };
                     }
 
+                    // TODO: ROData
+                    if (methodCode.Relocs != null && methodCode.Relocs.Any(r => r.Target is BlockRelativeTarget))
+                    {
+                        Log.WriteLine("Reloc to ROData block (" + method + ")");
+                        methodCode = new MethodCode
+                        {
+                            Code = new byte[] { 0xCC }
+                        };
+                    }
+
                     ObjectDataBuilder objData = new ObjectDataBuilder();
                     objData.Alignment = _nodeFactory.Target.MinimumFunctionAlignment;
                     objData.EmitBytes(methodCode.Code);

--- a/src/ILToNative.Compiler/src/Compiler/MethodCode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/MethodCode.cs
@@ -18,6 +18,12 @@ namespace ILToNative
         public Relocation[] Relocs;
     }
 
+    class BlockRelativeTarget
+    {
+        public sbyte Block;
+        public int Offset;
+    }
+
     struct Relocation
     {
         public ushort RelocType;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1808,7 +1808,23 @@ namespace Internal.JitInterface
             Debug.Assert(locationBlock >= 0);
             reloc.Block = (sbyte)locationBlock;
 
-            reloc.Target = HandleToObject((IntPtr)target);
+            int targetOffset;
+            int targetBlock = findKnownBlock(target, out targetOffset);
+            if (targetBlock < 0)
+            {
+                // Reloc points to something outside of the generated blocks
+                reloc.Target = HandleToObject((IntPtr)target);
+            }
+            else
+            {
+                // Target is relative to one of the blocks
+                reloc.Target = new BlockRelativeTarget
+                {
+                    Block = (sbyte)targetBlock,
+                    Offset = targetOffset
+                };
+            }
+
             reloc.Delta = addlDelta;
 
             if (_relocs == null)


### PR DESCRIPTION
Instead of trying to call HandleToObject on something that is not a
handle and throwing an ArgumentOverflowException, capture the ROData
information.

We're still dropping the generated method body on the floor in
Compilation.cs, but the difference is that we no longer throw a managed
exception from something that is called by RyuJIT (which we expect to be
problematic on CoreCLR).

This way we don't need to blacklist 11 methods from getting compiled for
Linux Hello World.
