### PR TITLE
Add more stubs for managed runtime calls

### DIFF
--- a/src/ILToNative/reproNative/main.cpp
+++ b/src/ILToNative/reproNative/main.cpp
@@ -324,6 +324,16 @@ extern "C" intptr_t RhHandleAllocDependent(Object* pPrimary, Object* pSecondary)
     return (intptr_t)CreateDependentHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pPrimary, pSecondary);
 }
 
+extern "C" void RhGetNonArrayBaseType()
+{
+    throw 42;
+}
+
+extern "C" void RhGetEETypeClassification()
+{
+    throw 42;
+}
+
 extern "C" void RhpUniversalTransition()
 {
     throw 42;


### PR DESCRIPTION
We are compiling more of Hello World, so we need more stubs.

The way we deal with unimplemented functionality in the compiler is that
we abort compilation of the method and emit a method body that has INT 3
in it. More functionality in the compiler means more stuff is getting
compiled, and more of the runtime needs to be present to successfully
link.
