### PR TITLE
Workaround for delegate marshaling

### DIFF
--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -99,10 +99,13 @@ namespace System
         // @todo: Not an api but some NativeThreadPool code still depends on it.
         internal IntPtr GetNativeFunctionPointer()
         {
+            // CORERT-TODO: PInvoke delegate marshalling
+#if !CORERT
             if (GetThunk(ReversePinvokeThunk) != m_functionPointer)
             {
                 throw new InvalidOperationException("GetNativeFunctionPointer may only be used on a reverse pinvoke delegate");
             }
+#endif
 
             return m_extraFunctionPointerOrData;
         }


### PR DESCRIPTION
This workaround is sufficient to make delegate marshaling needed by libuv work
