### PR TITLE
Disable managed build for non-Windows.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -181,7 +181,7 @@ __msbuildpath=$__packageroot/$__msbuildpackageid.$__msbuildpackageversion/lib/MS
 __ToolNugetRuntimeId=ubuntu.14.04-x64
 __TestNugetRuntimeId=ubuntu.14.04-x64
 __BuildArch=x64
-__buildmanaged=true
+__buildmanaged=false
 __buildnative=true
 
 # Workaround to enable nuget package restoration work successully on Mono


### PR DESCRIPTION
@mmitche would fix the managed build support in a day or so by installing Mono on CI machines. Until then, disable the managed build.

to perform the managed build on Linux or Mac, ensure Mono is installed and pass the "managed" argument to build.sh

@mmitche @janvorli PTAL.
