### PR TITLE
Implement GetEnvironmentVariable and ExpandEnvironmentStrings on Windows

### DIFF
--- a/src/Common/src/Interop/Unix/libc/Interop.Environment.cs
+++ b/src/Common/src/Interop/Unix/libc/Interop.Environment.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal unsafe partial class libc
+    {
+
+    }
+}

--- a/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    private static class Libraries
+    {
+        internal const string Process = "api-ms-win-core-processenvironment-l1-1-0.dll";
+    }
+
+    internal static unsafe partial class mincore
+    {
+        // TODO: Once we have marshalling setup we probably want to revisit these PInvokes
+        [DllImport(Libraries.Process, EntryPoint = "GetEnvironmentVariableW")]
+        internal static unsafe extern int GetEnvironmentVariable(char* lpName, char* lpValue, int size);
+
+        [DllImport(Libraries.Process, EntryPoint = "ExpandEnvironmentStringsW")]
+        internal static unsafe extern int ExpandEnvironmentStrings(char* lpSrc, char* lpDst, int nSize);
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -219,7 +219,7 @@
     <Compile Include="System\Double.cs" />
     <Compile Include="System\Enum.cs" />
     <Compile Include="System\Environment.cs" />
-    <Compile Include="System\Environment.EnvironmentVariables.cs" />
+    <Compile Include="System\Environment.EnvironmentVariables.cs" />    
     <Compile Include="System\EventArgs.cs" />
     <Compile Include="System\EventHandler.cs" />
     <Compile Include="System\FormatException.cs" />
@@ -477,6 +477,11 @@
       <Compile Include="System\Globalization\CultureData.Win32.cs" />
       <Compile Include="System\Globalization\TextInfo.Win32.cs" />
       <Compile Include="System\Globalization\CalendarData.Win32.cs" />
+
+      <Compile Condition="'$(IsProjectNLibrary)' == 'true'" Include="System\Environment.EnvironmentVariables.UWP.cs" />
+      <!-- For CoreRT we have a different implementation -->
+      <Compile Condition="'$(IsProjectNLibrary)' != 'true'" Include="System\Environment.EnvironmentVariables.Win32.cs" />
+      <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Environment.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OSGroup)' == 'Linux'">
@@ -485,6 +490,9 @@
       <Compile Include="System\Globalization\CultureData.Dummy.cs" />
       <Compile Include="System\Globalization\TextInfo.Dummy.cs" />
       <Compile Include="System\Globalization\CalendarData.Dummy.cs" />
+      <!-- For CoreRT we have a different implementation -->
+      <Compile Include="System\Environment.EnvironmentVariables.Unix.cs" />
+      <Compile Include="..\..\Common\src\Interop\Unix\libc\Interop.Environment.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.UWP.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.UWP.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/*============================================================
+**
+**
+** Purpose: Provides some basic access to some environment 
+** functionality.
+**
+**
+============================================================*/
+
+using System.Text;
+using System.Collections;
+
+namespace System
+{
+    public static partial class Environment
+    {
+        public unsafe static String ExpandEnvironmentVariables(String name)
+        {
+            if (name == null)
+                throw new ArgumentNullException("name");
+
+            // Environment variable accessors are not approved modern API.
+            // Behave as if no variables are defined in this case.
+            return name;
+        }
+
+        public unsafe static String GetEnvironmentVariable(String variable)
+        {
+            if (variable == null)
+                throw new ArgumentNullException("variable");
+
+            // Environment variable accessors are not approved modern API.
+            // Behave as if the variable was not found in this case.
+            return null;
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.Unix.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/*============================================================
+**
+**
+** Purpose: Provides some basic access to some environment 
+** functionality.
+**
+**
+============================================================*/
+
+using System.Text;
+using System.Collections;
+
+namespace System
+{
+    public static partial class Environment
+    {
+        public unsafe static String ExpandEnvironmentVariables(String name)
+        {
+            if (name == null)
+                throw new ArgumentNullException("name");
+
+            //TODO: Unix implementations
+            return name;
+        }
+
+        public unsafe static String GetEnvironmentVariable(String variable)
+        {
+            if (variable == null)
+                throw new ArgumentNullException("variable");
+
+            //TODO: Unix implementations
+            return null;
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.Win32.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/*============================================================
+**
+**
+** Purpose: Provides some basic access to some environment 
+** functionality.
+**
+**
+============================================================*/
+
+using System.Text;
+using System.Collections;
+
+namespace System
+{
+    public static partial class Environment
+    {
+        public unsafe static String ExpandEnvironmentVariables(String name)
+        {
+            if (name == null)
+                throw new ArgumentNullException("name");
+
+            if (name.Length == 0)
+            {
+                return name;
+            }
+
+            int currentSize = 128;
+            char* blob = stackalloc char[currentSize]; // A somewhat reasonable default size
+            int requiredSize;
+            fixed (char* pName = name)
+            {
+                requiredSize = Interop.mincore.ExpandEnvironmentStrings(pName, blob, currentSize);
+            }
+
+            if (requiredSize == 0)
+            {
+                // TODO: This used to throw an exception:
+                // Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                throw new ArgumentException();
+            }
+
+            if (requiredSize <= currentSize)
+            {
+                return new string(blob);
+            }
+
+            // Fallback to using heap allocated buffers.
+            char[] newBlob = null;
+            while (requiredSize > currentSize)
+            {
+                currentSize = requiredSize;
+                newBlob = new char[currentSize];
+
+                fixed (char* pName = name, pBlob = newBlob)
+                {
+                    requiredSize = Interop.mincore.ExpandEnvironmentStrings(pName, pBlob, currentSize);
+                }
+
+                if (requiredSize == 0)
+                {
+                    // TODO: This used to throw an exception:
+                    // Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                    throw new ArgumentException();
+                }
+            }
+
+            return new string(newBlob);
+        }
+
+        public unsafe static String GetEnvironmentVariable(String variable)
+        {
+            if (variable == null)
+                throw new ArgumentNullException("variable");
+
+            // The convention of the API is as follows:
+            // You call the API with a buffer of a given size. 
+            // If the size of the buffer is insufficient to hold the value, 
+            //   the API will return the required size for the buffer. 
+            // In that case we resize the buffer and try again.
+
+            int currentSize = 128;
+            char* blob = stackalloc char[currentSize];   // A somewhat reasonable default size
+
+            int requiredSize;
+            fixed (char* pText = variable)
+            {
+                requiredSize = Interop.mincore.GetEnvironmentVariable(pText, blob, currentSize);
+            }
+
+            if (requiredSize == 0)
+            {
+                return null;
+            }
+
+            if (requiredSize <= currentSize)
+            {
+                return new string(blob);
+            }
+
+            // Fallback to using heap allocated buffers.
+            char[] newblob = null;
+            while (requiredSize > currentSize)
+            {
+                currentSize = requiredSize;
+                // need to retry since the environment variable might be changed 
+                newblob = new char[currentSize];
+                fixed (char* pText = variable, pBlob = newblob)
+                {
+                    requiredSize = Interop.mincore.GetEnvironmentVariable(pText, pBlob, currentSize);
+                }
+
+                if (requiredSize == 0)
+                {
+                    return null;
+                }
+            }
+            // We should never end up with a null blob
+            Diagnostics.Debug.Assert(newblob != null);
+
+            return new string(newblob);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.cs
@@ -15,29 +15,10 @@ using System.Collections;
 
 namespace System
 {
+
     public static partial class Environment
     {
         private const int MaxEnvVariableValueLength = 32767;  // maximum length for environment variable name and value
-
-        public static String ExpandEnvironmentVariables(String name)
-        {
-            if (name == null)
-                throw new ArgumentNullException("name");
-
-            // Environment variable accessors are not approved modern API.
-            // Behave as if no variables are defined in this case.
-            return name;
-        }
-
-        public static String GetEnvironmentVariable(String variable)
-        {
-            if (variable == null)
-                throw new ArgumentNullException("variable");
-
-            // Environment variable accessors are not approved modern API.
-            // Behave as if the variable was not found in this case.
-            return null;
-        }
 
         public static IDictionary GetEnvironmentVariables()
         {


### PR DESCRIPTION
The change refactors the Environment.EnvironmentVariables into 3 parts:
- Environment.EnvironmentVariables.UWP.cs
  -> This contains the implementations that we want to carry over for UWP apps
- Environment.EnvironmentVariables.Win32.cs
  -> This contains the implementation we want to have for CoreRT on Windows
- Environment.EnvironmentVariables.Unix.cs
  -> This contains the implementation we want to have for CoreRT on Unix

I have also introduced 2 Interop files (Win32 and Unix) that will contain the
corresponding PInvokes.

Partially fixes #6 
