### PR TITLE
Fix issue 149 - Ignore unused typedef warnings on OSX

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -66,7 +66,12 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     add_compile_options(-Wno-null-conversion)
     add_compile_options(-Wno-invalid-offsetof)
     add_compile_options(-Wno-null-arithmetic)
-    add_compile_options(-Wno-unused-local-typedef)
+
+    if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        # Apple Clang 7+ is strict about unused typedefs warnings by default.
+        # To keep things consistent, flag the warning to be ignored.
+        add_compile_options(-Wno-unused-local-typedef)
+    endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
     # The -fms-extensions enable the stuff like __if_exists, __declspec(uuid()), etc.
     add_compile_options(-fms-extensions )


### PR DESCRIPTION
@janvorli PTAL
