### PR TITLE
Create two build flavors of the runtime

### DIFF
--- a/src/.nuget/Microsoft.Dotnet.ILToNative.Development.nuspec
+++ b/src/.nuget/Microsoft.Dotnet.ILToNative.Development.nuspec
@@ -28,6 +28,7 @@
     <file src="..\ILToNative.TypeSystem.dll" target="ILToNative.TypeSystem.dll" />
     <file src="..\ILToNative.TypeSystem.pdb" target="pdb\ILToNative.TypeSystem.pdb" />
     <file src="..\lib\Runtime.lib" target="sdk\Runtime.lib" />
+    <file src="..\lib\PortableRuntime.lib" target="sdk\PortableRuntime.lib" />
     <file src="..\System.Private.Corelib.dll" target="sdk\System.Private.Corelib.dll" />
     <file src="..\System.Private.Corelib.pdb" target="pdb\System.Private.Corelib.pdb" />
     <file src="..\toolruntime\*.dll" />

--- a/src/ILToNative/reproNative/reproNative.sln
+++ b/src/ILToNative/reproNative/reproNative.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "reproNative", "reproNative.vcxproj", "{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Runtime", "..\..\..\bin\obj\Windows_NT.x64.Debug\Runtime\Runtime.vcxproj", "{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Runtime", "..\..\..\bin\obj\Windows_NT.x64.Debug\Runtime\Full\Runtime.vcxproj", "{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/ILToNative/reproNative/reproNativeCpp.sln
+++ b/src/ILToNative/reproNative/reproNativeCpp.sln
@@ -8,7 +8,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "reproNativeCpp", "reproNati
 		{82CD69C7-FA29-45D3-A87C-2FCA61CE7613} = {82CD69C7-FA29-45D3-A87C-2FCA61CE7613}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Runtime", "..\..\..\bin\obj\Windows_NT.x64.Debug\Runtime\Runtime.vcxproj", "{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Runtime", "..\..\..\bin\obj\Windows_NT.x64.Debug\Runtime\Portable\PortableRuntime.vcxproj", "{82CD69C7-FA29-45D3-A87C-2FCA61CE7613}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/ILToNative/reproNative/reproNativeCpp.vcxproj
+++ b/src/ILToNative/reproNative/reproNativeCpp.vcxproj
@@ -62,7 +62,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\Product\Windows_NT.x64.Debug\lib\Runtime.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\Product\Windows_NT.x64.Debug\lib\PortableRuntime.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -83,7 +83,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\Product\Windows_NT.x64.Release\lib\Runtime.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);..\..\..\bin\Product\Windows_NT.x64.Release\lib\PortableRuntime.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -99,6 +99,17 @@ elseif(WIN32)
     endif()
 endif()
 
+# Set the passed in RetSources variable to the list of sources with added current source directory
+# to form absolute paths. 
+# The parameters after the RetSources are the input files. 
+function(convert_to_absolute_path RetSources)
+    set(Sources ${ARGN})
+    foreach(Source IN LISTS Sources)
+        list(APPEND AbsolutePathSources ${CMAKE_CURRENT_SOURCE_DIR}/${Source})
+    endforeach()            
+    set(${RetSources} ${AbsolutePathSources} PARENT_SCOPE)
+endfunction(convert_to_absolute_path)
+
 if(WIN32)
     add_definitions(-DWIN32)
     add_compile_options($<$<CONFIG:Debug>:-DDEBUG>)

--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -1,11 +1,4 @@
-project(Runtime)
-
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-include_directories(../gc)
-include_directories(../gc/env)
-
-set(SOURCES
+set(COMMON_RUNTIME_SOURCES
     allocheap.cpp
     AsmOffsets.cpp
 #    AsmOffsetsVerify.cpp
@@ -52,20 +45,19 @@ set(SOURCES
     ../gc/handletablecore.cpp
     ../gc/handletablescan.cpp
     ../gc/objecthandle.cpp
-    ../gc/env/common.cpp    
 )
 
 if(WIN32)
-  list(APPEND SOURCES
+  list(APPEND COMMON_RUNTIME_SOURCES
     DebugEventSource.cpp
-    ../gc/env/gcenv.windows.cpp    
+    ../gc/env/gcenv.windows.cpp
     PalRedhawkCommon.cpp
     PalRedhawkMinWin.cpp
   )
 else()
   include_directories(unix)
-  list(APPEND SOURCES
-    ../gc/env/gcenv.unix.cpp    
+  list(APPEND COMMON_RUNTIME_SOURCES
+    ../gc/env/gcenv.unix.cpp
   )
 endif()
 
@@ -140,7 +132,7 @@ else()
   add_compile_options(-Wno-self-assign)
 endif()
 
-add_library(Runtime STATIC ${SOURCES})
+convert_to_absolute_path(COMMON_RUNTIME_SOURCES ${COMMON_RUNTIME_SOURCES})
 
-# Install the static Runtime library
-install (TARGETS Runtime DESTINATION lib)
+add_subdirectory(Full)
+add_subdirectory(Portable)

--- a/src/Native/Runtime/Full/CMakeLists.txt
+++ b/src/Native/Runtime/Full/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(Runtime)
+
+# Full version of the runtime is required by the JIT CodeGen.
+# The low-level helpers can be implemented in assembly code.
+
+include_directories(..)
+include_directories(../../gc)
+include_directories(../../gc/env)
+
+add_library(Runtime STATIC ${COMMON_RUNTIME_SOURCES} ${SOURCES})
+
+# Install the static Runtime library
+install (TARGETS Runtime DESTINATION lib)

--- a/src/Native/Runtime/Portable/CMakeLists.txt
+++ b/src/Native/Runtime/Portable/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(PortableRuntime)
+
+# Portable version of the runtime is designed to be used with CppCodeGen only.
+# It should be written in pure C/C++, with no assembly code.
+
+include_directories(..)
+include_directories(../../gc)
+include_directories(../../gc/env)
+
+add_library(PortableRuntime STATIC ${COMMON_RUNTIME_SOURCES} ${SOURCES})
+
+# Install the static Runtime library
+install (TARGETS PortableRuntime DESTINATION lib)


### PR DESCRIPTION
- Full - required by the JITCodeGen. The low-level helpers can be implemented in assembly code.
- Portable - mean to be used with CppCodeGen only. Pure C/C++. No assembly code.
