### PR TITLE
Fixes for Release build of ReproNativeCpp

### DIFF
--- a/src/Native/Runtime/eetype.cpp
+++ b/src/Native/Runtime/eetype.cpp
@@ -18,6 +18,8 @@
 #include "PalRedhawk.h"
 #endif
 
+#include "CommonMacros.inl"
+
 #pragma warning(disable:4127) // C4127: conditional expression is constant
 
 // Validate an EEType extracted from an object.
@@ -146,4 +148,31 @@ bool EEType::Validate(bool assertOnFail /* default: true */)
 #undef REPORT_FAILURE
 
     return true;
+}
+
+//-----------------------------------------------------------------------------------------------------------
+EEType::Kinds EEType::get_Kind()
+{
+	return (Kinds)(m_usFlags & (UInt16)EETypeKindMask);
+}
+
+//-----------------------------------------------------------------------------------------------------------
+EEType * EEType::get_CanonicalEEType()
+{
+	// cloned EETypes must always refer to types in other modules
+	ASSERT(IsCloned());
+	ASSERT(IsRelatedTypeViaIAT());
+
+	return *PTR_PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_ppCanonicalTypeViaIAT));
+}
+
+//-----------------------------------------------------------------------------------------------------------
+EEType * EEType::get_RelatedParameterType()
+{
+	ASSERT(IsParameterizedType());
+
+	if (IsRelatedTypeViaIAT())
+		return *PTR_PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_ppRelatedParameterTypeViaIAT));
+	else
+		return PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_pRelatedParameterType));
 }

--- a/src/Native/Runtime/eetype.inl
+++ b/src/Native/Runtime/eetype.inl
@@ -92,12 +92,6 @@ inline void EEType::set_SealedVirtualSlot(PTR_Code pValue, UInt16 slotNumber)
 #endif // !BINDER && !DACCESS_COMPILE
 
 //-----------------------------------------------------------------------------------------------------------
-inline EEType::Kinds EEType::get_Kind()
-{
-    return (Kinds)(m_usFlags & (UInt16)EETypeKindMask);
-}
-
-//-----------------------------------------------------------------------------------------------------------
 inline EEType * EEType::get_BaseType()
 {
 #ifdef DACCESS_COMPILE
@@ -194,27 +188,6 @@ inline EEInterfaceInfoMap EEType::GetInterfaceMap()
 
     return EEInterfaceInfoMap(reinterpret_cast<EEInterfaceInfo *>((UInt8*)this + cbInterfaceMapOffset),
                               GetNumInterfaces());
-}
-
-//-----------------------------------------------------------------------------------------------------------
-inline EEType * EEType::get_CanonicalEEType()
-{
-    // cloned EETypes must always refer to types in other modules
-    ASSERT(IsCloned());
-    ASSERT(IsRelatedTypeViaIAT());
-
-    return *PTR_PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_ppCanonicalTypeViaIAT));
-}
-
-//-----------------------------------------------------------------------------------------------------------
-inline EEType * EEType::get_RelatedParameterType()
-{
-    ASSERT(IsParameterizedType());
-
-    if (IsRelatedTypeViaIAT())
-        return *PTR_PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_ppRelatedParameterTypeViaIAT));
-    else
-        return PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_pRelatedParameterType));
 }
 
 #ifdef DACCESS_COMPILE


### PR DESCRIPTION
@smosier  PTAL

Certain inlined functions remain inaccessible across modules in the Release build of ReproNativeCpp project. It does not happen on Debug builds of the project, likely because the function does not get inlined.
