### PR TITLE
Select ABI for the helpers based on the target OS

### DIFF
--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -6,6 +6,9 @@ using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem
 {
+    /// <summary>
+    /// Specifies the target CPU architecture.
+    /// </summary>
     public enum TargetArchitecture
     {
         Unknown,
@@ -14,13 +17,43 @@ namespace Internal.TypeSystem
         X86,
     }
 
+    /// <summary>
+    /// Specifies the target ABI.
+    /// </summary>
+    public enum TargetOS
+    {
+        Unknown,
+        Windows,
+        Linux,
+        OSX,
+        FreeBSD,
+    }
+
+    /// <summary>
+    /// Represents various details about the compilation target that affect
+    /// layout, padding, allocations, or ABI.
+    /// </summary>
     public class TargetDetails
     {
+        /// <summary>
+        /// Gets the target CPU architecture.
+        /// </summary>
         public TargetArchitecture Architecture
         {
             get; private set;
         }
 
+        /// <summary>
+        /// Gets the target ABI.
+        /// </summary>
+        public TargetOS OperatingSystem
+        {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Gets the size of a pointer for the target of the compilation.
+        /// </summary>
         public int PointerSize
         {
             get
@@ -38,6 +71,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets the default field packing size.
+        /// </summary>
         public int DefaultPackingSize
         {
             get
@@ -47,6 +83,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets the minimum required method alignment.
+        /// </summary>
         public int MinimumFunctionAlignment
         {
             get
@@ -56,11 +95,15 @@ namespace Internal.TypeSystem
             }
         }
 
-        public TargetDetails(TargetArchitecture architecture)
+        public TargetDetails(TargetArchitecture architecture, TargetOS targetOS)
         {
             Architecture = architecture;
+            OperatingSystem = targetOS;
         }
 
+        /// <summary>
+        /// Retrieves the size of a well known type.
+        /// </summary>
         public int GetWellKnownTypeSize(MetadataType type)
         {
             switch (type.Category)
@@ -97,6 +140,9 @@ namespace Internal.TypeSystem
             throw new InvalidOperationException();
         }
 
+        /// <summary>
+        /// Retrieves the alignment required by a well known type.
+        /// </summary>
         public int GetWellKnownTypeAlignment(MetadataType type)
         {
             // Size == Alignment for all platforms.

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -13,7 +13,7 @@ namespace Internal.TypeSystem
     {
         public TypeSystemContext()
         {
-            Target = new TargetDetails(TargetArchitecture.Unknown);
+            Target = new TargetDetails(TargetArchitecture.Unknown, TargetOS.Unknown);
         }
 
         public TypeSystemContext(TargetDetails target)

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/TargetRegisterMap.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/TargetRegisterMap.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Internal.TypeSystem;
+
+namespace ILToNative.DependencyAnalysis.X64
+{
+    /// <summary>
+    /// Maps logical registers to physical registers on a specified OS.
+    /// </summary>
+    public struct TargetRegisterMap
+    {
+        public readonly Register Arg0;
+        public readonly Register Arg1;
+        public readonly Register Arg2;
+        public readonly Register Arg3;
+        public readonly Register Result;
+
+        public TargetRegisterMap(TargetOS os)
+        {
+            switch (os)
+            {
+                case TargetOS.Windows:
+                    Arg0 = Register.RCX;
+                    Arg1 = Register.RDX;
+                    Arg2 = Register.R8;
+                    Arg3 = Register.R9;
+                    Result = Register.RAX;
+                    break;
+
+                case TargetOS.Linux:
+                case TargetOS.OSX:
+                case TargetOS.FreeBSD:
+                    Arg0 = Register.RDI;
+                    Arg1 = Register.RSI;
+                    Arg2 = Register.RDX;
+                    Arg3 = Register.RCX;
+                    Result = Register.RAX;
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -11,9 +11,11 @@ namespace ILToNative.DependencyAnalysis.X64
         public X64Emitter(NodeFactory factory)
         {
             Builder = new ObjectDataBuilder(factory);
+            TargetRegister = new TargetRegisterMap(factory.Target.OperatingSystem);
         }
 
         public ObjectDataBuilder Builder;
+        public TargetRegisterMap TargetRegister;
 
         // Assembly stub creation api. TBD, actually make this general purpose
         public void EmitMOV(Register regDst, ref AddrMode memory)

--- a/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
+++ b/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ObjectNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Relocation.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_X64\TargetRegisterMap.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64JumpStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ThreadStaticsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\VirtualMethodUseNode.cs" />

--- a/src/ILToNative.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILToNative.TypeSystem/tests/TestTypeSystemContext.cs
@@ -58,7 +58,7 @@ namespace TypeSystemTests
         MetadataFieldLayout _metadataFieldLayout = new TestMetadataFieldLayout();
 
         public TestTypeSystemContext(TargetArchitecture arch)
-            : base(new TargetDetails(arch))
+            : base(new TargetDetails(arch, TargetOS.Unknown))
         {
         }
 

--- a/src/ILToNative/src/ILToNative.csproj
+++ b/src/ILToNative/src/ILToNative.csproj
@@ -13,21 +13,11 @@
     <CLSCompliant>false</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ExcludeResourcesImport>true</ExcludeResourcesImport>
+    <DefineConstants>$(DefineConstants);FXCORE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />

--- a/src/ILToNative/src/Program.cs
+++ b/src/ILToNative/src/Program.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
 
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -141,7 +142,21 @@ namespace ILToNative
             if (_outputPath == null)
                 throw new CommandLineException("Output filename must be specified (/out <file>)");
 
-            _compilerTypeSystemContext = new CompilerTypeSystemContext(new TargetDetails(TargetArchitecture.X64));
+            TargetOS targetOS;
+#if FXCORE
+            // We could offer this as a command line option, but then we also need to
+            // load a different RyuJIT, so this is a future nice to have...
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                targetOS = TargetOS.Windows;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                targetOS = TargetOS.Linux;
+            else
+                throw new NotImplementedException();
+#else
+            targetOS = TargetOS.Windows;
+#endif
+
+            _compilerTypeSystemContext = new CompilerTypeSystemContext(new TargetDetails(TargetArchitecture.X64, targetOS));
             _compilerTypeSystemContext.InputFilePaths = _inputFilePaths;
             _compilerTypeSystemContext.ReferenceFilePaths = _referenceFilePaths;
 

--- a/src/ILToNative/src/project.json
+++ b/src/ILToNative/src/project.json
@@ -17,7 +17,8 @@
     "System.Console": "4.0.0-beta-23419",
     "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
-    "System.Reflection.Metadata": "1.0.22"
+    "System.Reflection.Metadata": "1.0.22",
+	"System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23409"
   },
   "frameworks": {
     "dotnet": {


### PR DESCRIPTION
- Set target OS based on the currently running OS
- Introduce an abstraction to address differences between Windows and
  System V register ABIs

I wasn't sure where to put the TargetOS thing. It doesn't seem like a
type system thing, so I put it on the NodeFactory instead of
TargetDetails. We can move it around based on how it works out.
