### PR TITLE
Use BIT64 define for 64-bit specific code

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/FunctionPointerOps.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/FunctionPointerOps.cs
@@ -118,7 +118,7 @@ namespace Internal.Runtime.CompilerServices
         public static unsafe bool IsGenericMethodPointer(IntPtr functionPointer)
         {
             // Check the low bit to find out what kind of function pointer we have here.
-#if WIN64
+#if BIT64
             if ((functionPointer.ToInt64() & c_genericFunctionPointerOffset) == c_genericFunctionPointerOffset)
 #else
             if ((functionPointer.ToInt32() & c_genericFunctionPointerOffset) == c_genericFunctionPointerOffset)

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -65,7 +65,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
-    <DefineConstants>CORERT;WIN64</DefineConstants>
+    <DefineConstants>CORERT;BIT64</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -171,11 +171,11 @@ namespace System
         // C# may optimize away the pinned local, producing incorrect results.
         static internal unsafe byte* GetAddrOfPinnedArrayFromEETypeField(IntPtr* ppEEType)
         {
-#if WIN32
-            return (byte*)ppEEType + sizeof(EETypePtr) + sizeof(int);
-#else
+#if BIT64
             // on 64-bit there is an extra 4 byte padding before the array data starts
             return (byte*)ppEEType + sizeof(EETypePtr) + (2 * sizeof(int));
+#else
+            return (byte*)ppEEType + sizeof(EETypePtr) + sizeof(int);
 #endif
         }
 

--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -222,11 +222,11 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException("sourceBytesToCopy");
             }
-#if WIN64
+#if BIT64
             Memmove((byte*)destination, (byte*)source, checked((ulong)sourceBytesToCopy));
 #else
             Memmove((byte*)destination, (byte*)source, checked((uint)sourceBytesToCopy));
-#endif // WIN64
+#endif // BIT64
         }
 
         // The attributes on this method are chosen for best JIT performance. 
@@ -240,16 +240,16 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException("sourceBytesToCopy");
             }
-#if WIN64
+#if BIT64
             Memmove((byte*)destination, (byte*)source, sourceBytesToCopy);
 #else
             Memmove((byte*)destination, (byte*)source, checked((uint)sourceBytesToCopy));
-#endif // WIN64
+#endif // BIT64
         }
 
         // This method has different signature for x64 and other platforms and is done for performance reasons.
         [System.Security.SecurityCritical]
-#if WIN64
+#if BIT64
         internal unsafe static void Memmove(byte* dest, byte* src, ulong len)
 #else
         internal unsafe static void Memmove(byte* dest, byte* src, uint len)
@@ -257,7 +257,7 @@ namespace System
         {
             // P/Invoke into the native version when the buffers are overlapping and the copy needs to be performed backwards
             // This check can produce false positives for lengths greater than Int32.MaxInt. It is fine because we want to use PInvoke path for the large lengths anyway.
-#if WIN64
+#if BIT64
             if ((ulong)dest - (ulong)src < len)
             {
                 _Memmove(dest, src, len);
@@ -308,7 +308,7 @@ namespace System
                     *(dest + 6) = *(src + 6);
                     return;
                 case 8:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
 #else
                     *(int*)dest = *(int*)src;
@@ -316,7 +316,7 @@ namespace System
 #endif
                     return;
                 case 9:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
 #else
                     *(int*)dest = *(int*)src;
@@ -325,7 +325,7 @@ namespace System
                     *(dest + 8) = *(src + 8);
                     return;
                 case 10:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
 #else
                     *(int*)dest = *(int*)src;
@@ -334,7 +334,7 @@ namespace System
                     *(short*)(dest + 8) = *(short*)(src + 8);
                     return;
                 case 11:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
 #else
                     *(int*)dest = *(int*)src;
@@ -344,7 +344,7 @@ namespace System
                     *(dest + 10) = *(src + 10);
                     return;
                 case 12:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
 #else
                     *(int*)dest = *(int*)src;
@@ -353,7 +353,7 @@ namespace System
                     *(int*)(dest + 8) = *(int*)(src + 8);
                     return;
                 case 13:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
 #else
                     *(int*)dest = *(int*)src;
@@ -363,7 +363,7 @@ namespace System
                     *(dest + 12) = *(src + 12);
                     return;
                 case 14:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
 #else
                     *(int*)dest = *(int*)src;
@@ -373,7 +373,7 @@ namespace System
                     *(short*)(dest + 12) = *(short*)(src + 12);
                     return;
                 case 15:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
 #else
                     *(int*)dest = *(int*)src;
@@ -384,7 +384,7 @@ namespace System
                     *(dest + 14) = *(src + 14);
                     return;
                 case 16:
-#if WIN64
+#if BIT64
                     *(long*)dest = *(long*)src;
                     *(long*)(dest + 8) = *(long*)(src + 8);
 #else
@@ -426,7 +426,7 @@ namespace System
             Aligned:;
             }
 
-#if WIN64
+#if BIT64
             if (((int)dest & 4) != 0)
             {
                 *(int*)dest = *(int*)src;
@@ -436,14 +436,14 @@ namespace System
             }
 #endif
 
-#if WIN64
+#if BIT64
             ulong count = len / 16;
 #else
             uint count = len / 16;
 #endif
             while (count > 0)
             {
-#if WIN64
+#if BIT64
                 ((long*)dest)[0] = ((long*)src)[0];
                 ((long*)dest)[1] = ((long*)src)[1];
 #else
@@ -459,7 +459,7 @@ namespace System
 
             if ((len & 8) != 0)
             {
-#if WIN64
+#if BIT64
                 ((long*)dest)[0] = ((long*)src)[0];
 #else
                 ((int*)dest)[0] = ((int*)src)[0];
@@ -488,7 +488,7 @@ namespace System
         // with P/Invoke prolog/epilog.
         [System.Security.SecurityCritical]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-#if WIN64 || AMD64
+#if BIT64
         private unsafe static void _Memmove(byte* dest, byte* src, ulong len)
 #else
         private unsafe static void _Memmove(byte* dest, byte* src, uint len)

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -145,7 +145,7 @@ namespace System
 
         // Support for AddMemoryPressure and RemoveMemoryPressure below.
         private const uint PressureCount = 4;
-#if WIN64
+#if BIT64
         private const uint MinGCMemoryPressureBudget = 4 * 1024 * 1024;
 #else
         private const uint MinGCMemoryPressureBudget = 3 * 1024 * 1024;
@@ -226,7 +226,7 @@ namespace System
                         SR.ArgumentOutOfRange_NeedPosNum);
             }
 
-#if !WIN64
+#if !BIT64
             if (bytesAllocated > Int32.MaxValue)
             {
                 throw new ArgumentOutOfRangeException("bytesAllocated",
@@ -296,7 +296,7 @@ namespace System
                         SR.ArgumentOutOfRange_NeedPosNum);
             }
 
-#if !WIN64
+#if !BIT64
             if (bytesAllocated > Int32.MaxValue)
             {
                 throw new ArgumentOutOfRangeException("bytesAllocated",

--- a/src/System.Private.CoreLib/src/System/Intptr.cs
+++ b/src/System.Private.CoreLib/src/System/Intptr.cs
@@ -31,10 +31,10 @@ namespace System
         [NonVersionable]
         public unsafe IntPtr(int value)
         {
-#if WIN32
-            _value = (void *)value;
-#else
+#if BIT64
             _value = (void*)(long)value;
+#else
+            _value = (void*)value;
 #endif
         }
 
@@ -42,10 +42,10 @@ namespace System
         [NonVersionable]
         public unsafe IntPtr(long value)
         {
-#if WIN32
-            _value = (void *)checked((int)value);
-#else
+#if BIT64
             _value = (void*)value;
+#else
+            _value = (void*)checked((int)value);
 #endif
         }
 
@@ -70,11 +70,11 @@ namespace System
         [NonVersionable]
         public unsafe int ToInt32()
         {
-#if WIN32
-            return (int)_value;
-#else
+#if BIT64
             long l = (long)_value;
             return checked((int)l);
+#else
+            return (int)_value;
 #endif
         }
 
@@ -82,10 +82,10 @@ namespace System
         [NonVersionable]
         public unsafe long ToInt64()
         {
-#if WIN32
-            return (long)(int)_value;
-#else
+#if BIT64
             return (long)_value;
+#else
+            return (long)(int)_value;
 #endif
         }
 
@@ -124,11 +124,11 @@ namespace System
         [NonVersionable]
         public unsafe static explicit operator int (IntPtr value)
         {
-#if WIN32
-            return (int)value._value;
-#else
+#if BIT64
             long l = (long)value._value;
             return checked((int)l);
+#else
+            return (int)value._value;
 #endif
         }
 
@@ -136,10 +136,10 @@ namespace System
         [NonVersionable]
         public unsafe static explicit operator long (IntPtr value)
         {
-#if WIN32
-            return (long)(int)value._value;
-#else
+#if BIT64
             return (long)value._value;
+#else
+            return (long)(int)value._value;
 #endif
         }
 
@@ -172,10 +172,10 @@ namespace System
         [NonVersionable]
         public unsafe static IntPtr operator +(IntPtr pointer, int offset)
         {
-#if WIN32
-            return new IntPtr((int)pointer._value + offset);
-#else
+#if BIT64
             return new IntPtr((long)pointer._value + offset);
+#else
+            return new IntPtr((int)pointer._value + offset);
 #endif
         }
 
@@ -189,10 +189,10 @@ namespace System
         [NonVersionable]
         public unsafe static IntPtr operator -(IntPtr pointer, int offset)
         {
-#if WIN32
-            return new IntPtr((int)pointer._value - offset);
-#else
+#if BIT64
             return new IntPtr((long)pointer._value - offset);
+#else
+            return new IntPtr((int)pointer._value - offset);
 #endif
         }
 
@@ -202,29 +202,29 @@ namespace System
             [NonVersionable]
             get
             {
-#if WIN32
-                return 4;
-#else
+#if BIT64
                 return 8;
+#else
+                return 4;
 #endif
             }
         }
 
         public unsafe override String ToString()
         {
-#if WIN32
-            return ((int)_value).ToString(FormatProvider.InvariantCulture);
-#else
+#if BIT64
             return ((long)_value).ToString(FormatProvider.InvariantCulture);
+#else
+            return ((int)_value).ToString(FormatProvider.InvariantCulture);
 #endif
         }
 
         public unsafe String ToString(String format)
         {
-#if WIN32
-            return ((int)_value).ToString(format, FormatProvider.InvariantCulture);
-#else
+#if BIT64
             return ((long)_value).ToString(format, FormatProvider.InvariantCulture);
+#else
+            return ((int)_value).ToString(format, FormatProvider.InvariantCulture);
 #endif
         }
 

--- a/src/System.Private.CoreLib/src/System/PrimitivesRuntimeContracts.cs
+++ b/src/System.Private.CoreLib/src/System/PrimitivesRuntimeContracts.cs
@@ -322,10 +322,10 @@ namespace System
 
         public unsafe IntPtr(long value)
         {
-#if WIN32
-            m_value = (void*)checked((int)value);
-#else
+#if BIT64
             m_value = (void*)value;
+#else
+            m_value = (void*)checked((int)value);
 #endif
         }
 
@@ -350,10 +350,10 @@ namespace System
 
         public unsafe static explicit operator long (IntPtr value)
         {
-#if WIN32
-            return (long)(int)value.m_value;
-#else
+#if BIT64
             return (long)value.m_value;
+#else
+            return (long)(int)value.m_value;
 #endif
         }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
@@ -91,10 +91,10 @@ namespace System.Runtime.InteropServices
             // Free the handle if it hasn't already been freed.
             if (handle != default(IntPtr) && Interlocked.CompareExchange(ref _handle, default(IntPtr), handle) == handle)
             {
-#if WIN32
-                RuntimeImports.RhHandleFree((IntPtr)(((int)handle) & ~1));
-#else
+#if BIT64
                 RuntimeImports.RhHandleFree((IntPtr)(((long)handle) & ~1L));
+#else
+                RuntimeImports.RhHandleFree((IntPtr)(((int)handle) & ~1));
 #endif
             }
             else
@@ -250,28 +250,28 @@ namespace System.Runtime.InteropServices
 
         internal IntPtr GetHandleValue()
         {
-#if WIN32
-            return new IntPtr(((int)_handle) & ~1);
-#else
+#if BIT64
             return new IntPtr(((long)_handle) & ~1L);
+#else
+            return new IntPtr(((int)_handle) & ~1);
 #endif
         }
 
         internal bool IsPinned()
         {
-#if WIN32
-            return (((int)_handle) & 1) != 0;
-#else
+#if BIT64
             return (((long)_handle) & 1) != 0;
+#else
+            return (((int)_handle) & 1) != 0;
 #endif
         }
 
         internal void SetIsPinned()
         {
-#if WIN32
-            _handle = new IntPtr(((int)_handle) | 1);
-#else
+#if BIT64
             _handle = new IntPtr(((long)_handle) | 1L);
+#else
+            _handle = new IntPtr(((int)_handle) | 1);
 #endif
         }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -613,7 +613,7 @@ namespace System.Runtime
         [DllImport(RuntimeImports.RuntimeLibrary, ExactSpelling = true)]
         internal static unsafe extern void _ecvt_s(byte* buffer, int sizeInBytes, double value, int count, int* dec, int* sign);
 
-#if WIN64
+#if BIT64
         [DllImport(RuntimeImports.RuntimeLibrary, ExactSpelling = true)]
         internal static unsafe extern void memmove(byte* dmem, byte* smem, ulong size);
 #else
@@ -749,7 +749,7 @@ namespace System.Runtime
             private ushort _widenMask;
 
 
-#if WIN64
+#if BIT64
             const byte log2PointerSize = 3;
 #else
             private const byte log2PointerSize = 2;

--- a/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -648,7 +648,7 @@ namespace System.Text
                     byteCount++;
                 }
 
-#if WIN64
+#if BIT64
                 // check for overflow
                 if (byteCount < 0)
                 {
@@ -684,7 +684,7 @@ namespace System.Text
                     break;
                 }
 
-#if WIN64
+#if BIT64
                 // make sure that we won't get a silent overflow inside the fast loop
                 // (Fall out to slow loop if we have this many characters)
                 availableChars &= 0x0FFFFFFF;
@@ -823,7 +823,7 @@ namespace System.Text
                 ch = 0;
             }
 
-#if WIN64
+#if BIT64
             // check for overflow
             if (byteCount < 0)
             {

--- a/src/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
@@ -484,7 +484,7 @@ namespace System.Text
                     if (!bigEndian &&
 #endif // BIGENDIAN
 
-#if WIN64           // 64 bit CPU needs to be long aligned for this to work.
+#if BIT64           // 64 bit CPU needs to be long aligned for this to work.
                           charLeftOver == 0 && (unchecked((long)chars) & 7) == 0)
 #else
                           charLeftOver == 0 && (unchecked((int)chars) & 3) == 0)
@@ -766,11 +766,11 @@ namespace System.Text
 #else
                     if (!bigEndian &&
 #endif // BIGENDIAN
-#if WIN64           // 64 bit CPU needs to be long aligned for this to work, 32 bit CPU needs to be 32 bit aligned
+#if BIT64           // 64 bit CPU needs to be long aligned for this to work, 32 bit CPU needs to be 32 bit aligned
                         (unchecked((long)chars) & 7) == 0 && (unchecked((long)bytes) & 7) == 0 &&
 #else
                         (unchecked((int)chars) & 3) == 0 && (unchecked((int)bytes) & 3) == 0 &&
-#endif // WIN64
+#endif // BIT64
                         charLeftOver == 0)
                     {
                         // Need -1 to check 2 at a time.  If we have an even #, longChars will go
@@ -852,11 +852,11 @@ namespace System.Text
                         !bigEndian &&
 #endif // BIGENDIAN
 
-#if WIN64
+#if BIT64
                         (unchecked((long)chars) & 7) != (unchecked((long)bytes) & 7) &&  // Only do this if chars & bytes are out of line, otherwise faster loop'll be faster next time
 #else
                         (unchecked((int)chars) & 3) != (unchecked((int)bytes) & 3) &&  // Only do this if chars & bytes are out of line, otherwise faster loop'll be faster next time
-#endif // WIN64
+#endif // BIT64
                         (unchecked((int)(bytes)) & 1) == 0)
                     {
                         // # to use
@@ -1185,11 +1185,11 @@ namespace System.Text
 #else // BIGENDIAN
                 if (!bigEndian &&
 #endif // BIGENDIAN
-#if WIN64 // win64 has to be long aligned
+#if BIT64 // win64 has to be long aligned
                     (unchecked((long)bytes) & 7) == 0 &&
 #else
                     (unchecked((int)bytes) & 3) == 0 &&
-#endif // WIN64
+#endif // BIT64
                     lastByte == -1 && lastChar == 0)
                 {
                     // Need new char* so we can check 4 at a time
@@ -1507,11 +1507,11 @@ namespace System.Text
 #else // BIGENDIAN
                 if (!bigEndian &&
 #endif // BIGENDIAN
-#if WIN64 // win64 has to be long aligned
+#if BIT64 // win64 has to be long aligned
                     (unchecked((long)chars) & 7) == 0 && (unchecked((long)bytes) & 7) == 0 &&
 #else
                     (unchecked((int)chars) & 3) == 0 && (unchecked((int)bytes) & 3) == 0 &&
-#endif // WIN64
+#endif // BIT64
                     lastByte == -1 && lastChar == 0)
                 {
                     // Need -1 to check 2 at a time.  If we have an even #, longChars will go

--- a/src/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -117,25 +117,25 @@ namespace System.Threading
 
         public static Int64 Read(ref Int64 location)
         {
-#if WIN32
-            return Interlocked.CompareExchange(ref location, 0, 0);
-#else
+#if BIT64
             fixed (Int64* p = &location)
             {
                 return (Int64)Read(ref *(IntPtr*)p);
             }
+#else
+            return Interlocked.CompareExchange(ref location, 0, 0);
 #endif
         }
 
         public static void Write(ref Int64 location, Int64 value)
         {
-#if WIN32
-            Interlocked.Exchange(ref location, value);
-#else
+#if BIT64
             fixed (Int64* p = &location)
             {
                 Write(ref *(IntPtr*)p, (IntPtr)value);
             }
+#else
+            Interlocked.Exchange(ref location, value);
 #endif
         }
         #endregion

--- a/src/System.Private.CoreLib/src/System/UIntptr.cs
+++ b/src/System.Private.CoreLib/src/System/UIntptr.cs
@@ -38,10 +38,10 @@ namespace System
         [NonVersionable]
         public unsafe UIntPtr(ulong value)
         {
-#if WIN32
-            _value = (void*)checked((uint)value);
-#else
+#if BIT64
             _value = (void*)value;
+#else
+            _value = (void*)checked((uint)value);
 #endif
         }
 
@@ -64,10 +64,10 @@ namespace System
         [NonVersionable]
         public unsafe uint ToUInt32()
         {
-#if WIN32
-            return (uint)_value;
-#else
+#if BIT64
             return checked((uint)_value);
+#else
+            return (uint)_value;
 #endif
         }
 
@@ -112,10 +112,10 @@ namespace System
         [NonVersionable]
         public unsafe static explicit operator uint (UIntPtr value)
         {
-#if WIN32
-            return (uint)value._value;
-#else
+#if BIT64
             return checked((uint)value._value);
+#else
+            return (uint)value._value;
 #endif
         }
 
@@ -146,20 +146,20 @@ namespace System
             [NonVersionable]
             get
             {
-#if WIN32
-                return 4;
-#else
+#if BIT64
                 return 8;
+#else
+                return 4;
 #endif
             }
         }
 
         public unsafe override String ToString()
         {
-#if WIN32
-            return ((uint)_value).ToString(FormatProvider.InvariantCulture);
-#else
+#if BIT64
             return ((ulong)_value).ToString(FormatProvider.InvariantCulture);
+#else
+            return ((uint)_value).ToString(FormatProvider.InvariantCulture);
 #endif
         }
 
@@ -188,10 +188,10 @@ namespace System
         [NonVersionable]
         public static UIntPtr operator +(UIntPtr pointer, int offset)
         {
-#if WIN32
-            return new UIntPtr(pointer.ToUInt32() + (uint)offset);
-#else
+#if BIT64
             return new UIntPtr(pointer.ToUInt64() + (ulong)offset);
+#else
+            return new UIntPtr(pointer.ToUInt32() + (uint)offset);
 #endif
         }
 
@@ -205,10 +205,10 @@ namespace System
         [NonVersionable]
         public static UIntPtr operator -(UIntPtr pointer, int offset)
         {
-#if WIN32
-            return new UIntPtr(pointer.ToUInt32() - (uint)offset);
-#else
+#if BIT64
             return new UIntPtr(pointer.ToUInt64() - (ulong)offset);
+#else
+            return new UIntPtr(pointer.ToUInt32() - (uint)offset);
 #endif
         }
     }


### PR DESCRIPTION
Using WIN32 and WIN64 for 32/64-bit specific code is confusing because of it has nothing to do with Windows. I have changed it to BIT64 in System.Private.CoreLib - it is the commonly used define for 64-bit specific code.
