### PR TITLE
Fixed missing double quotes which causes an error in other cmd.exe interpreters

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -48,7 +48,7 @@ echo.
 
 :: Set the remaining variables based upon the determined build configuration
 set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
-set "__IntermediatesDir=%__RootBinDir%\obj\Native\%__BuildOS%.%__BuildArch%\
+set "__IntermediatesDir=%__RootBinDir%\obj\Native\%__BuildOS%.%__BuildArch%\"
 
 :: Generate path to be set for CMAKE_INSTALL_PREFIX to contain forward slash
 set "__CMakeBinDir=%__BinDir%"


### PR DESCRIPTION
Fixed a minor missing double quotes error in the build script.
