### PR TITLE
Delete TARGET_THUMB2

### DIFF
--- a/src/Native/Runtime/TargetPtrs.h
+++ b/src/Native/Runtime/TargetPtrs.h
@@ -12,7 +12,7 @@
 typedef UInt64 UIntTarget;
 #elif defined(TARGET_X86)
 typedef UInt32 UIntTarget;
-#elif defined(TARGET_THUMB2)
+#elif defined(TARGET_ARM)
 typedef UInt32 UIntTarget;
 #else
 #error unexpected target architecture
@@ -82,7 +82,7 @@ typedef TargetPtr<struct StaticGcDesc>          TgtPTR_StaticGcDesc;
 typedef UInt64 UIntTarget;
 #elif defined(TARGET_X86)
 typedef UInt32 UIntTarget;
-#elif defined(TARGET_THUMB2)
+#elif defined(TARGET_ARM)
 typedef UInt32 UIntTarget;
 #else
 #error unexpected target architecture
@@ -107,7 +107,7 @@ typedef SPTR(struct StaticGcDesc) PTR_StaticGcDesc;
 typedef UInt64 UIntTarget;
 #elif defined(TARGET_X86)
 typedef UInt32 UIntTarget;
-#elif defined(TARGET_THUMB2)
+#elif defined(TARGET_ARM)
 typedef UInt32 UIntTarget;
 #else
 #error unexpected target architecture

--- a/src/Native/Runtime/daccess.h
+++ b/src/Native/Runtime/daccess.h
@@ -543,7 +543,7 @@
 typedef UInt64 UIntTarget;
 #elif defined(TARGET_X86)
 typedef UInt32 UIntTarget;
-#elif defined(TARGET_THUMB2)
+#elif defined(TARGET_ARM)
 typedef UInt32 UIntTarget;
 #else
 #error unexpected target architecture

--- a/src/Native/Runtime/eetype.inl
+++ b/src/Native/Runtime/eetype.inl
@@ -562,7 +562,7 @@ inline void EEType::set_RelatedParameterType(EEType * pParameterType)
         // Do we need a alignment for value types?
         (pMT->IsValueTypeOrEnum() &&
             (pMT->GetClass()->GetAlignmentRequirement() != POINTER_SIZE)) ||
-#ifdef TARGET_THUMB2
+#ifdef TARGET_ARM
         // Do we need a rare flags field for a class or structure that requires 64-bit alignment on ARM?
         (pMT->GetClass()->GetAlignmentRequirement() > 4) ||
         (pMT->IsArray() && pElementMT->IsValueTypeOrEnum() && (pElementMT->GetClass()->GetAlignmentRequirement() > 4)) ||


### PR DESCRIPTION
A few places still used TARGET_THUMB2 instead of TARGET_ARM for no good reason.
