### PR TITLE
Simplify intrinsics handling in the compiler

### DIFF
--- a/src/ILToNative.Compiler/src/Compiler/MethodExtensions.cs
+++ b/src/ILToNative.Compiler/src/Compiler/MethodExtensions.cs
@@ -14,17 +14,11 @@ namespace ILToNative
     {
         Unknown,
         PInvoke,
-        RuntimeImport,
-        Intrinsic
+        RuntimeImport
     };
 
     static class MethodExtensions
     {
-        public static bool IsRuntimeImport(this EcmaMethod This)
-        {
-            return This.HasCustomAttribute("System.Runtime", "RuntimeImportAttribute");
-        }
-
         public static string GetRuntimeImportEntryPointName(this EcmaMethod This)
         {
             var metadataReader = This.MetadataReader;
@@ -82,10 +76,6 @@ namespace ILToNative
                 else if (method.HasCustomAttribute("System.Runtime", "RuntimeImportAttribute"))
                 {
                     return SpecialMethodKind.RuntimeImport;
-                }
-                else if (method.HasCustomAttribute("System.Runtime.CompilerServices", "IntrinsicAttribute"))
-                {
-                    return SpecialMethodKind.Intrinsic;
                 }
                 else if (method.HasCustomAttribute("System.Runtime.InteropServices", "NativeCallableAttribute"))
                 {

--- a/src/ILToNative.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILToNative.Compiler/src/CppCodeGen/CppWriter.cs
@@ -258,8 +258,7 @@ namespace ILToNative.CppCodeGen
         {
             Unknown,
             PInvoke,
-            RuntimeImport,
-            Intrinsic
+            RuntimeImport
         };
 
         SpecialMethodKind DetectSpecialMethodKind(MethodDesc method)
@@ -274,11 +273,6 @@ namespace ILToNative.CppCodeGen
                 {
                     _compilation.Log.WriteLine("RuntimeImport: " + method.ToString());
                     return SpecialMethodKind.RuntimeImport;
-                }
-                else if (method.HasCustomAttribute("System.Runtime.CompilerServices", "IntrinsicAttribute"))
-                {
-                    _compilation.Log.WriteLine("Intrinsic: " + method.ToString());
-                    return SpecialMethodKind.Intrinsic;
                 }
                 else if (method.HasCustomAttribute("System.Runtime.InteropServices", "NativeCallableAttribute"))
                 {
@@ -297,7 +291,6 @@ namespace ILToNative.CppCodeGen
             {
                 case SpecialMethodKind.PInvoke:
                 case SpecialMethodKind.RuntimeImport:
-                case SpecialMethodKind.Intrinsic:
                     {
                         EcmaMethod ecmaMethod = (EcmaMethod)method;
 
@@ -341,7 +334,7 @@ namespace ILToNative.CppCodeGen
 
             SpecialMethodKind kind = DetectSpecialMethodKind(method);
 
-            if (kind != SpecialMethodKind.Unknown && kind != SpecialMethodKind.Intrinsic)
+            if (kind != SpecialMethodKind.Unknown)
             {
                 string specialMethodCode = CompileSpecialMethod(method, kind);
                 _compilation.GetRegisteredMethod(method).MethodCode = specialMethodCode;
@@ -350,11 +343,7 @@ namespace ILToNative.CppCodeGen
 
             var methodIL = _compilation.GetMethodIL(method);
             if (methodIL == null)
-            {
-                string specialMethodCode = CompileSpecialMethod(method, kind);
-                _compilation.GetRegisteredMethod(method).MethodCode = specialMethodCode;
                 return;
-            }
 
             string methodCode;
             try

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -550,63 +550,103 @@ namespace System.Runtime
         internal extern static unsafe void RhpEtwExceptionThrown(char* exceptionTypeName, char* exceptionMessage, IntPtr faultingIP, long hresult);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "_copysign")]
         internal static extern double _copysign(double x, double y);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "floor")]
         internal static extern double floor(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "fmod")]
         internal static extern double fmod(double x, double y);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "pow")]
         internal static extern double pow(double x, double y);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "sqrt")]
         internal static extern double sqrt(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "ceil")]
         internal static extern double ceil(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "cos")]
         internal static extern double cos(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "sin")]
         internal static extern double sin(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "tan")]
         internal static extern double tan(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "cosh")]
         internal static extern double cosh(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "sinh")]
         internal static extern double sinh(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "tanh")]
         internal static extern double tanh(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "acos")]
         internal static extern double acos(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "asin")]
         internal static extern double asin(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "atan")]
         internal static extern double atan(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "atan2")]
         internal static extern double atan2(double x, double y);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "log")]
         internal static extern double log(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "log10")]
         internal static extern double log10(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "exp")]
         internal static extern double exp(double x);
 
         [Intrinsic]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "modf")]
         internal static unsafe extern double modf(double x, double* intptr);
 
         // ExactSpelling = 'true' to force MCG to resolve it to default


### PR DESCRIPTION
- Delete code that tried to guess where the non-inlined code for intrinsic may come from (compiled from IL vs. RuntimeImport).
- Mark all intrinsics that may turn into runtime import with explicit RuntimeImport attribute.
