### PR TITLE
InstantiatedType.GetMethod workaround

### DIFF
--- a/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
@@ -166,7 +166,25 @@ namespace Internal.TypeSystem
             string name = targetMethod.Name;
             MethodSignature sig = targetMethod.Signature;
 
-            MethodDesc implMethod = currentType.GetMethod(name, sig);
+            // TODO: InstantiatedType.GetMethod can't handle this for a situation like
+            // an instantiation of Foo<T>.M(T) because sig is instantiated, but it compares
+            // it to the uninstantiated version
+            //MethodDesc implMethod = currentType.GetMethod(name, sig);
+            MethodDesc implMethod = null;
+            foreach (MethodDesc candidate in currentType.GetMethods())
+            {
+                if (candidate.Name == name)
+                {
+                    if (candidate.Signature.Equals(sig))
+                    {
+                        if (implMethod != null)
+                        {
+                            throw new NotImplementedException("NYI: differentiating between overloads on instantiations when the instantiated signatures match.");
+                        }
+                        implMethod = candidate;
+                    }
+                }
+            }
 
             // Only find virtual methods
             if ((implMethod != null) && !implMethod.IsVirtual)


### PR DESCRIPTION
Workaround for InstantiatedType.GetMethod not being able to handle a signature that's been instantiated.
