### PR TITLE
Proposed fix for solving some of the issue involving generic type in method signatures

### DIFF
--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -165,8 +165,7 @@ namespace Internal.TypeSystem
             {
                 if (meth.Name == name)
                 {
-                    Instantiation noInstantiation = new Instantiation();
-                    MethodDesc result = meth.InstantiateSignature(Instantiation, noInstantiation);
+                    MethodDesc result = meth.InstantiateSignature(Instantiation, new Instantiation());
                     if (result.Signature.Equals(signature.InstantiateSignature(Instantiation, new Instantiation())))
                     {
                         return result;

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -161,10 +161,19 @@ namespace Internal.TypeSystem
         // TODO: Substitutions, generics, modopts, ...
         public override MethodDesc GetMethod(string name, MethodSignature signature)
         {
-            MethodDesc typicalMethodDef = _typeDef.GetMethod(name, signature);
-            if (typicalMethodDef == null)
-                return null;
-            return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);
+            foreach (var meth in _typeDef.GetMethods())
+            {
+                if (meth.Name == name)
+                {
+                    Instantiation noInstantiation = new Instantiation();
+                    MethodDesc result = meth.InstantiateSignature(Instantiation, noInstantiation);
+                    if (result.Signature.Equals(signature.InstantiateSignature(Instantiation, new Instantiation())))
+                    {
+                        return result;
+                    }
+                }
+            }
+            return null;
         }
 
         public override MethodDesc GetStaticConstructor()

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -59,6 +59,26 @@ namespace Internal.TypeSystem
         /// Returns true if the type has given custom attribute.
         /// </summary>
         public abstract bool HasCustomAttribute(string attributeNamespace, string attributeName);
+
+        /// <summary>
+        /// Adapt current to the <paramref name="typeInstantiation"/> context. For example, if you have C <T> and a
+        /// context [int], it will yield C <int>.
+        /// </summary>
+        /// <param name="typeInstantiation">Context</param>
+        /// <param name="methodInstantiation">Not used for types.</param>
+        /// <returns></returns>
+        public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            // Type is either not generic, or no valid context is provided.
+            if (!HasInstantiation || typeInstantiation.IsNull)
+            {
+                return this;
+            }
+            else
+            {
+                return new InstantiatedType(this, typeInstantiation);
+            }
+        }
     }
 
     public struct ClassLayoutMetadata

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -123,7 +123,7 @@ namespace Internal.TypeSystem
                 {
                     if (parameters == null)
                     {
-                        // Copy the all _parameters array to parameters.
+                        // Copy all entries of_parameters to parameters.
                         parameters = new TypeDesc[_parameters.Length];
                         Array.Copy(_parameters, 0, parameters, 0, _parameters.Length);
                     }

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -104,6 +104,34 @@ namespace Internal.TypeSystem
 
             return true;
         }
+
+        /// <summary>
+        /// Adapt current signature to the instantation contexts.
+        /// </summary>
+        /// <param name="typeInstantiation">Context used for adapting the signature if it involves generic type parameter.</param>
+        /// <param name="methodInstantiation">Context used for adapting the signature if it involves generic method type parameter.</param>
+        /// <returns></returns>
+        public MethodSignature InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            // Instantiate parameters first. If instantiation has no effects, avoid the allocation of a new array.
+            TypeDesc[] parameters = null;
+            for (int i = 0; i < _parameters.Length; i++)
+            {
+                TypeDesc oldType = _parameters[i];
+                TypeDesc newType = oldType.InstantiateSignature(typeInstantiation, methodInstantiation);
+                if (newType != oldType)
+                {
+                    if (parameters == null)
+                    {
+                        // Copy the all _parameters array to parameters.
+                        parameters = new TypeDesc[_parameters.Length];
+                        Array.Copy(_parameters, 0, parameters, 0, _parameters.Length);
+                    }
+                    parameters[i] = newType;
+                }
+            }
+            return new MethodSignature(_flags, _genericParameterCount, _returnType.InstantiateSignature(typeInstantiation, methodInstantiation), parameters??_parameters);
+        }
     }
 
     public struct MethodSignatureBuilder

--- a/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
@@ -259,7 +259,9 @@ namespace Internal.TypeSystem
         private static bool VerifyMethodsHaveTheSameVirtualSlot(MethodDesc methodToVerify, MethodDesc slotDefiningMethod)
         {
             MethodDesc slotDefiningMethodOfMethodToVerify = FindSlotDefiningMethodForVirtualMethod(methodToVerify);
-            return slotDefiningMethodOfMethodToVerify == slotDefiningMethod;
+                // With generic types, methods get instantiated and thus one cannot use reference equality.
+            return slotDefiningMethodOfMethodToVerify.GetTypicalMethodDefinition() ==
+                   slotDefiningMethod.GetTypicalMethodDefinition();
         }
 
         private static void FindBaseUnificationGroup(MetadataType currentType, UnificationGroup unificationGroup)

--- a/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
@@ -166,25 +166,7 @@ namespace Internal.TypeSystem
             string name = targetMethod.Name;
             MethodSignature sig = targetMethod.Signature;
 
-            // TODO: InstantiatedType.GetMethod can't handle this for a situation like
-            // an instantiation of Foo<T>.M(T) because sig is instantiated, but it compares
-            // it to the uninstantiated version
-            //MethodDesc implMethod = currentType.GetMethod(name, sig);
-            MethodDesc implMethod = null;
-            foreach (MethodDesc candidate in currentType.GetMethods())
-            {
-                if (candidate.Name == name)
-                {
-                    if (candidate.Signature.Equals(sig))
-                    {
-                        if (implMethod != null)
-                        {
-                            throw new NotImplementedException("NYI: differentiating between overloads on instantiations when the instantiated signatures match.");
-                        }
-                        implMethod = candidate;
-                    }
-                }
-            }
+            MethodDesc implMethod = currentType.GetMethod(name, sig);
 
             // Only find virtual methods
             if ((implMethod != null) && !implMethod.IsVirtual)

--- a/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
@@ -259,9 +259,7 @@ namespace Internal.TypeSystem
         private static bool VerifyMethodsHaveTheSameVirtualSlot(MethodDesc methodToVerify, MethodDesc slotDefiningMethod)
         {
             MethodDesc slotDefiningMethodOfMethodToVerify = FindSlotDefiningMethodForVirtualMethod(methodToVerify);
-                // With generic types, methods get instantiated and thus one cannot use reference equality.
-            return slotDefiningMethodOfMethodToVerify.GetTypicalMethodDefinition() ==
-                   slotDefiningMethod.GetTypicalMethodDefinition();
+            return slotDefiningMethodOfMethodToVerify == slotDefiningMethod;
         }
 
         private static void FindBaseUnificationGroup(MetadataType currentType, UnificationGroup unificationGroup)

--- a/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualFunctionResolution.cs
@@ -241,7 +241,7 @@ namespace Internal.TypeSystem
         private static bool VerifyMethodsHaveTheSameVirtualSlot(MethodDesc methodToVerify, MethodDesc slotDefiningMethod)
         {
             MethodDesc slotDefiningMethodOfMethodToVerify = FindSlotDefiningMethodForVirtualMethod(methodToVerify);
-            return slotDefiningMethodOfMethodToVerify == slotDefiningMethod;
+            return slotDefiningMethodOfMethodToVerify.GetTypicalMethodDefinition() == slotDefiningMethod.GetTypicalMethodDefinition();
         }
 
         private static void FindBaseUnificationGroup(MetadataType currentType, UnificationGroup unificationGroup)


### PR DESCRIPTION
Yesterday I hit some NullReference exceptions and found that signatures were not properly updated. I took this as a good way to explore the code and made some fixes that seems to let the simple Hello World compile (modulo some exceptions for non-implemented calls on interfaces). I now realize that there was already the issue #190 to solve this.

Here is my take at solving this: I've  changed the way GetMethod is implemented on InstantiatedType and added the ability to instantiate a method's signature. I've also implemented the instantiation of an InstantiatedType. Finally to VerifyMethodsHaveTheSameVirtualSlot I'm using the TypeDefinition as methods will be different objects upon instantiation.

I don't know if the way I made it work is ok. Let me know if this is useful and if you have any recommendation for future contributions.