### PR TITLE
Some more Linux Hello World fixes

### DIFF
--- a/src/ILToNative.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILToNative.Compiler/src/Compiler/Compilation.cs
@@ -305,18 +305,13 @@ namespace ILToNative
         private HashSet<TypeAndMethod> _skipJitList = new HashSet<TypeAndMethod>
         {
             new TypeAndMethod("System.SR", "GetResourceString"),
-#if false
             new TypeAndMethod("System.Text.StringBuilder", "AppendFormatHelper"),
             new TypeAndMethod("System.Collections.Concurrent.ConcurrentUnifier`2", "GetOrAdd"),
-            new TypeAndMethod("System.Environment", "get_NewLine"), // causes segfault
             new TypeAndMethod("System.Globalization.NumberFormatInfo", "GetInstance"),
             new TypeAndMethod("System.Collections.Concurrent.ConcurrentUnifierW`2", "GetOrAdd"),
             new TypeAndMethod("System.Collections.Generic.LowLevelDictionary`2", "Find"),
             new TypeAndMethod("System.Collections.Generic.LowLevelDictionary`2", "GetBucket"),
-            new TypeAndMethod("System.Globalization.CalendarData", ".ctor"), // segfault
-            new TypeAndMethod("System.Globalization.CalendarData", "GetCalendars"), // segfault
             new TypeAndMethod("System.Collections.Generic.ArraySortHelper`1", "InternalBinarySearch"),
-#endif
         };
 
         private void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)

--- a/src/Native/Bootstrap/platform.linux.cpp
+++ b/src/Native/Bootstrap/platform.linux.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <cstdlib>
+#include <cstring>
+
+int UTF8ToWideCharLen(char* bytes, int len)
+{
+    return strlen(bytes);
+}
+
+int UTF8ToWideChar(char* bytes, int len, unsigned short* buffer, int bufLen)
+{
+    return mbtowc((wchar_t*)buffer, bytes, bufLen);
+}
+

--- a/src/Native/Runtime/amd64/WriteBarriers.s
+++ b/src/Native/Runtime/amd64/WriteBarriers.s
@@ -4,3 +4,14 @@
 //
 
 // TODO: Implement Unix write barriers
+
+.global RhpBulkWriteBarrier
+RhpBulkWriteBarrier:
+ret
+
+.global RhpAssignRef
+.global RhpCheckedAssignRef
+RhpAssignRef:
+RhpCheckedAssignRef:
+mov %rsi, (%rdi)
+ret


### PR DESCRIPTION
- Incomplete implementation of write barriers
- Sort-of implementation of platform.linux.cpp. I'm actually not sure if
  it works, but might for English.

We still need a fix for #162 to be able to actually use the same
implementation of JitInterface between desktop CLR and CoreCLR.

After that, Hello World on Linux can be compiled, linked, and partially
executed (it will crash on ROData access that we already have a pull
request for).
