### PR TITLE
Enable XUnit style testResults only for windows

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -60,8 +60,10 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
                 }
             }
 
-            // This call performs test run checks for the CI.
-            Utilities.addXUnitDotNETResults(newJob, '**/testResults.xml')
+            if (os == 'Windows_NT') {
+                // This call performs test run checks for the CI.
+                Utilities.addXUnitDotNETResults(newJob, '**/testResults.xml')
+            }
 
             // This call performs remaining common job setup on the newly created job.
             // This is used most commonly for simple inner loop testing.


### PR DESCRIPTION
The CI system would pick this up on the next PR. Enable XUnit test checking only for Windows.
