### PR TITLE
Add dotnet-compile-native.bat

### DIFF
--- a/src/.nuget/Linux/Microsoft.DotNet.ILToNative.nuspec
+++ b/src/.nuget/Linux/Microsoft.DotNet.ILToNative.nuspec
@@ -15,7 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
         <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
-        <dependency id="Microsoft.NETCore.Console" version="1.0.0" />
     </dependencies>
   </metadata>
   <files>
@@ -24,6 +23,9 @@
     <file src="../ILToNative.DependencyAnalysisFramework.dll" target="ILToNative.DependencyAnalysisFramework.dll" />
     <file src="../ILToNative.TypeSystem.dll" target="ILToNative.TypeSystem.dll" />
     <file src="../lib/libRuntime.a" target="sdk/libRuntime.a" />
+    <file src="../lib/libPortableRuntime.a" target="sdk/libPortableRuntime.a" />
+    <file src="../lib/libbootstrapper.a" target="sdk/libbootstrapper.a" />
+    <file src="../lib/libbootstrappercpp.a" target="sdk/libbootstrappercpp.a" />
     <file src="../System.Private.Corelib.dll" target="sdk/System.Private.Corelib.dll" />
     <file src="../ToolRuntime/*.dll" />
     <file src="../ToolRuntime/*.so" />

--- a/src/.nuget/Microsoft.Dotnet.ILToNative.Development.nuspec
+++ b/src/.nuget/Microsoft.Dotnet.ILToNative.Development.nuspec
@@ -15,7 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
         <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
-        <dependency id="Microsoft.NETCore.Console" version="1.0.0" />
     </dependencies>
   </metadata>
   <files>
@@ -29,10 +28,13 @@
     <file src="..\ILToNative.TypeSystem.pdb" target="pdb\ILToNative.TypeSystem.pdb" />
     <file src="..\lib\Runtime.lib" target="sdk\Runtime.lib" />
     <file src="..\lib\PortableRuntime.lib" target="sdk\PortableRuntime.lib" />
+    <file src="..\lib\bootstrapper.lib" target="sdk\bootstrapper.lib" />
+    <file src="..\lib\bootstrappercpp.lib" target="sdk\bootstrappercpp.lib" />
     <file src="..\System.Private.Corelib.dll" target="sdk\System.Private.Corelib.dll" />
     <file src="..\System.Private.Corelib.pdb" target="pdb\System.Private.Corelib.pdb" />
     <file src="..\toolruntime\*.dll" />
     <file src="..\toolruntime\coreconsole.exe" target="ILToNative.exe" />
     <file src="..\..\..\..\packages\Microsoft.DiaSymReader\1.0.6\lib\portable-net45+win8\Microsoft.DiaSymReader.dll" />
+    <file src="..\..\..\..\src\scripts\dotnet-compile-native.bat" />
   </files>
 </package>

--- a/src/.nuget/Microsoft.Dotnet.ILToNative.nuspec
+++ b/src/.nuget/Microsoft.Dotnet.ILToNative.nuspec
@@ -15,7 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
         <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
-        <dependency id="Microsoft.NETCore.Console" version="1.0.0" />
     </dependencies>
   </metadata>
   <files>
@@ -24,9 +23,13 @@
     <file src="..\ILToNative.DependencyAnalysisFramework.dll" target="ILToNative.DependencyAnalysisFramework.dll" />
     <file src="..\ILToNative.TypeSystem.dll" target="ILToNative.TypeSystem.dll" />
     <file src="..\lib\Runtime.lib" target="sdk\Runtime.lib" />
+    <file src="..\lib\PortableRuntime.lib" target="sdk\PortableRuntime.lib" />
+    <file src="..\lib\bootstrapper.lib" target="sdk\bootstrapper.lib" />
+    <file src="..\lib\bootstrappercpp.lib" target="sdk\bootstrappercpp.lib" />
     <file src="..\System.Private.Corelib.dll" target="sdk\System.Private.Corelib.dll" />
     <file src="..\toolruntime\*.dll" />
     <file src="..\toolruntime\coreconsole.exe" target="ILToNative.exe" />
     <file src="..\..\..\..\packages\Microsoft.DiaSymReader\1.0.6\lib\portable-net45+win8\Microsoft.DiaSymReader.dll" />
+    <file src="..\..\..\..\src\scripts\dotnet-compile-native.bat" />
   </files>
 </package>

--- a/src/.nuget/OSX/Microsoft.DotNet.ILToNative.nuspec
+++ b/src/.nuget/OSX/Microsoft.DotNet.ILToNative.nuspec
@@ -15,7 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
         <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
-        <dependency id="Microsoft.NETCore.Console" version="1.0.0" />
     </dependencies>
   </metadata>
   <files>
@@ -24,6 +23,9 @@
     <file src="../ILToNative.DependencyAnalysisFramework.dll" target="ILToNative.DependencyAnalysisFramework.dll" />
     <file src="../ILToNative.TypeSystem.dll" target="ILToNative.TypeSystem.dll" />
     <file src="../lib/libRuntime.a" target="sdk/libRuntime.a" />
+    <file src="../lib/libPortableRuntime.a" target="sdk/libPortableRuntime.a" />
+    <file src="../lib/libbootstrapper.a" target="sdk/libbootstrapper.a" />
+    <file src="../lib/libbootstrappercpp.a" target="sdk/libbootstrappercpp.a" />
     <file src="../System.Private.Corelib.dll" target="sdk/System.Private.Corelib.dll" />
     <file src="../ToolRuntime/*.dll" />
     <file src="../ToolRuntime/*.dylib" />

--- a/src/Native/Bootstrap/CMakeLists.txt
+++ b/src/Native/Bootstrap/CMakeLists.txt
@@ -1,18 +1,6 @@
-project(reproNative)
-
 include_directories(../gc)
 include_directories(../gc/env)
 include_directories(../gc/sample)
-
-set(SOURCES
-    main.cpp
-    common.cpp
-)
-
-if(WIN32)
-    list(APPEND SOURCES
-        platform.windows.cpp)
-endif()
 
 if(CLR_CMAKE_PLATFORM_UNIX)
 add_compile_options(-Wno-format)
@@ -37,7 +25,5 @@ else()
   clr_unknown_arch()
 endif()
 
-add_library(reproNative STATIC ${SOURCES})
-
-# Install the static reproNative library
-install (TARGETS reproNative DESTINATION lib)
+add_subdirectory(base)
+add_subdirectory(cpp)

--- a/src/Native/Bootstrap/base/CMakeLists.txt
+++ b/src/Native/Bootstrap/base/CMakeLists.txt
@@ -1,0 +1,16 @@
+project(bootstrapper)
+
+set(SOURCES
+    ../main.cpp
+    ../common.cpp
+)
+
+if(WIN32)
+    list(APPEND SOURCES
+        ../platform.windows.cpp)
+endif()
+
+add_library(bootstrapper STATIC ${SOURCES})
+
+# Install the static bootstrapper library
+install (TARGETS bootstrapper DESTINATION lib)

--- a/src/Native/Bootstrap/cpp/CMakeLists.txt
+++ b/src/Native/Bootstrap/cpp/CMakeLists.txt
@@ -1,0 +1,18 @@
+project(bootstrappercpp)
+
+add_definitions(-DCPPCODEGEN)
+
+set(SOURCES
+    ../main.cpp
+    ../common.cpp
+)
+
+if(WIN32)
+    list(APPEND SOURCES
+        ../platform.windows.cpp)
+endif()
+
+add_library(bootstrappercpp STATIC ${SOURCES})
+
+# Install the static bootstrappercpp library
+install (TARGETS bootstrappercpp DESTINATION lib)

--- a/src/scripts/dotnet-compile-native.bat
+++ b/src/scripts/dotnet-compile-native.bat
@@ -1,0 +1,115 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+REM
+REM Script to compile a MSIL assembly to native code. 
+REM 
+REM Supported code-generators: CPPCODEGEN
+REM
+
+if "%VCINSTALLDIR%" == "" (
+	echo Please run the script from within VS native tools command prompt
+	goto InvalidArgs
+)
+
+set __BuildArch=x64
+set __Infile=
+set __Outfile=
+set __LibPath=
+set __Temp=%temp%\
+set __AppDepSdk=
+set __ILToNative=%~dp0
+set __CompileMode=cpp
+set __LogFilePath=%__Temp%
+
+:Arg_Loop
+if "%1" == "" goto ArgsDone
+if /i "%1" == "x64"    (set __BuildArch=x64&&shift&goto Arg_Loop)
+
+if /i "%1" == "debug"    (set __BuildType=Debug&shift&goto Arg_Loop)
+if /i "%1" == "release"   (set __BuildType=Release&shift&goto Arg_Loop)
+
+if /i "%1" == "/in" (set __Infile=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "/out" (set __Outfile=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "/appdepsdk" (set __AppDepSdk="%2"&shift&shift&goto Arg_Loop)
+if /i "%1" == "/mode" (set __CompileMode="%2"&shift&shift&goto Arg_Loop)
+if /i "%1" == "/logpath" (set __LogFilePath="%2"&shift&shift&goto Arg_Loop)
+
+echo Invalid command line argument: %1
+goto InvalidArgs
+
+:ArgsDone
+
+REM Do we have valid arguments?
+if "%__Infile%" == "" goto InvalidArgs
+if "%__Outfile%" == "" goto InvalidArgs
+if "%__AppDepSdk%" == "" goto InvalidArgs
+if "%__CompileMode%" == "" goto InvalidArgs
+
+REM Set path contain Runtime.lib/PortableRuntime.lib and System.Private.Corelib.dll
+set __LibPath="%__ILToNative%\sdk"
+
+REM Validate the code-generation mode
+if NOT "%__CompileMode%" == "cpp" goto InvalidArgs
+
+REM *** CPPCodegeneration ***
+REM Extract the name of the MSIL file we are compiling
+set AssemblyFileName=
+set AssemblyExt=
+for /f %%i IN ("%__Infile%") DO (
+	set AssemblyFileName=%%~ni
+	set AssemblyExt=%%~xi
+)
+
+set Assembly=%AssemblyFileName%%AssemblyExt%
+set CPPFileName="%temp%\%Assembly%.cpp"
+set ObjFileName="%temp%\%Assembly%.cpp.obj"
+
+REM Generate the CPP file for the MSIL assembly
+echo Generating source file
+"%__ILToNative%\ILToNative.exe" %__Infile% -r "%__ILToNative%\sdk\System.Private.CoreLib.dll" -r "%__AppDepSdk%\*.dll" -out "%CPPFileName%" -cpp > %__LogFilePath%\ILToNative.MSILToCpp.log
+if ERRORLEVEL 1 (
+	echo Unable to generate CPP file.
+	goto :eof
+)
+
+set DefinesDebug=/ZI /nologo /W3 /WX- /sdl /Od /D CPPCODEGEN /D WIN32 /D _DEBUG /D _CONSOLE /D _LIB /D _UNICODE /D UNICODE /Gm /EHsc /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline
+
+set DefinesRelease=/Zi /nologo /W3 /WX- /sdl /O2 /Oi /GL /D CPPCODEGEN /D WIN32 /D NDEBUG /D _CONSOLE /D _LIB /D _UNICODE /D UNICODE /Gm- /EHsc /MD /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline
+
+set LinkDebug=
+set LinkRelease=/INCREMENTAL:NO /OPT:REF /OPT:ICF /LTCG:incremental
+
+
+set CPPDefines=%DefinesDebug%
+set LinkOpts=%LinkDebug%
+if "%__BuildType%" == "Release" (
+	set CPPDefines=%DefinesRelease%
+	set LinkOpts=%LinkRelease%
+)
+
+REM Now compile the CPP file to platform specific executable.
+
+echo Compiling application source files
+"%VCINSTALLDIR%\bin\x86_amd64\CL.exe" /c /I %__AppDepSdk%\CPPSdk\Windows_NT /I %__AppDepSdk%\CPPSdk\ %CPPDefines% /Fo"%ObjFileName%" /Gd /TP /wd4477 /errorReport:prompt %CPPFileName% > %__LogFilePath%\ILToNative.App.log
+if ERRORLEVEL 1 (
+	echo Unable to compile app source file.
+	goto :eof
+)
+
+echo Generating native executable
+"%VCINSTALLDIR%\bin\x86_amd64\link.exe" /ERRORREPORT:PROMPT /OUT:"%__Outfile%" /NOLOGO kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib %__LibPath%\PortableRuntime.lib %__LibPath%\bootstrappercpp.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /Debug /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT %LinkOpts% /MACHINE:%__BuildArch% "%ObjFileName%" > %__LogFilePath%\ILToNative.Link.log
+if ERRORLEVEL 1 (
+	echo Unable to link native executable.
+	goto :eof
+)
+
+:BuildComplete
+echo Build successfully completed.
+goto :eof
+
+:InvalidArgs
+echo
+echo Usage: dotnet-compile-native <arch> <buildType> /in <path to MSIL assembly> /out <path to native executable> /appdepsdk <path to contents of Microsoft.DotNet.AppDep nuget package> [/mode cpp] [/logpath <path to drop logfiles in>]
+goto :eof
+

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -183,7 +183,7 @@ goto :eof
     %TOOLCHAIN_DIR%\ILToNative.exe -in !SOURCE_FILE!.exe -r %CORERT_EXT_RUNTIME%\*.dll -out !SOURCE_FILE!.obj -r %TOOLCHAIN_DIR%\sdk\System.Private.Corelib.dll > !SOURCE_FILE!.il2n.log
     endlocal
 
-    link.exe  /ERRORREPORT:PROMPT !SOURCE_FILE!.obj /OUT:"!SOURCE_FILE!.compiled.exe" /NOLOGO kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"!SOURCE_FILE!.lib" /MACHINE:X64 ..\bin\Product\%__BuildStr%\lib\Runtime.lib ..\bin\Product\%__BuildStr%\lib\reproNative.lib %MSVCRT_LIB% > !SOURCE_FILE!.link.log
+    link.exe  /ERRORREPORT:PROMPT !SOURCE_FILE!.obj /OUT:"!SOURCE_FILE!.compiled.exe" /NOLOGO kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"!SOURCE_FILE!.lib" /MACHINE:X64 ..\bin\Product\%__BuildStr%\lib\Runtime.lib ..\bin\Product\%__BuildStr%\lib\bootstrapper.lib %MSVCRT_LIB% > !SOURCE_FILE!.link.log
 
     echo.
     echo Running test !SOURCE_FILENAME!


### PR DESCRIPTION
This change adds support for dotnet-compile-native.bat to compile MSIL assembly to native code. This will be used to participate in the overall "dotnet compile" experience.
Additionally:

1) Removed unrequired dependencies from Nuget packages
2) Generate Bootstrapper.lib and Bootstrappercpp.lib, include them in the nuget packages and update runtest.cmd to consume bootstrapper.lib.

@schellap @jkotas PTAL
