### PR TITLE
Rename Nuget packages

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -112,12 +112,11 @@
     <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools" />
     <NuGetSourceList Include="https:%2F%2Fwww.nuget.org/api/v2" />
     
-    <NuSpecSrcs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(SourceDir).nuget\Microsoft.DotNet.ILToNative.nuspec" />
-    <NuSpecSrcs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(SourceDir).nuget\Microsoft.DotNet.ILToNative.Development.nuspec" />
-    <NuSpecSrcs Condition="'$(OSGroup)' != 'Windows_NT'" Include="$(SourceDir).nuget\$(OSGroup)\Microsoft.DotNet.ILToNative.nuspec" />
+    <NuSpecSrcs Include="$(SourceDir).nuget\toolchain.$(BinDirOSGroup)-$(BinDirPlatform).Microsoft.DotNet.ILToNative.nuspec" />
+    <NuSpecSrcs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(SourceDir).nuget\toolchain.$(BinDirOSGroup)-$(BinDirPlatform).Microsoft.DotNet.ILToNative.Development.nuspec" />
 
-    <NuSpecs Include="$(ProductPackageDir)Microsoft.DotNet.ILToNative.nuspec" />
-    <NuSpecs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(ProductPackageDir)Microsoft.DotNet.ILToNative.Development.nuspec" />
+    <NuSpecs Include="$(ProductPackageDir)toolchain.$(BinDirOSGroup)-$(BinDirPlatform).Microsoft.DotNet.ILToNative.nuspec" />
+    <NuSpecs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(ProductPackageDir)toolchain.$(BinDirOSGroup)-$(BinDirPlatform).Microsoft.DotNet.ILToNative.Development.nuspec" />
   </ItemGroup>
 
   <!-- Common nuget properties -->

--- a/src/.nuget/toolchain.Linux-x64.Microsoft.DotNet.ILToNative.nuspec
+++ b/src/.nuget/toolchain.Linux-x64.Microsoft.DotNet.ILToNative.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft.DotNet.ILToNative</id>
+    <id>toolchain.Linux-x64.Microsoft.DotNet.ILToNative</id>
     <version>1.0.0-prerelease</version>
     <title>Microsoft .NET ILToNative Toolchain</title>
     <authors>Microsoft</authors>
@@ -28,7 +28,7 @@
     <file src="../lib/libbootstrappercpp.a" target="sdk/libbootstrappercpp.a" />
     <file src="../System.Private.Corelib.dll" target="sdk/System.Private.Corelib.dll" />
     <file src="../ToolRuntime/*.dll" />
-    <file src="../ToolRuntime/*.dylib" />
+    <file src="../ToolRuntime/*.so" />
     <file src="../ToolRuntime/coreconsole" target="ILToNative" />
     <file src="../../../../packages/Microsoft.DiaSymReader/1.0.6/lib/portable-net45+win8/Microsoft.DiaSymReader.dll" />
   </files>

--- a/src/.nuget/toolchain.OSX-x64.Microsoft.Dotnet.ILToNative.nuspec
+++ b/src/.nuget/toolchain.OSX-x64.Microsoft.Dotnet.ILToNative.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft.DotNet.ILToNative</id>
+    <id>toolchain.OSX-x64.Microsoft.DotNet.ILToNative</id>
     <version>1.0.0-prerelease</version>
     <title>Microsoft .NET ILToNative Toolchain</title>
     <authors>Microsoft</authors>
@@ -28,7 +28,7 @@
     <file src="../lib/libbootstrappercpp.a" target="sdk/libbootstrappercpp.a" />
     <file src="../System.Private.Corelib.dll" target="sdk/System.Private.Corelib.dll" />
     <file src="../ToolRuntime/*.dll" />
-    <file src="../ToolRuntime/*.so" />
+    <file src="../ToolRuntime/*.dylib" />
     <file src="../ToolRuntime/coreconsole" target="ILToNative" />
     <file src="../../../../packages/Microsoft.DiaSymReader/1.0.6/lib/portable-net45+win8/Microsoft.DiaSymReader.dll" />
   </files>

--- a/src/.nuget/toolchain.Windows_NT-x64.Microsoft.Dotnet.ILToNative.Development.nuspec
+++ b/src/.nuget/toolchain.Windows_NT-x64.Microsoft.Dotnet.ILToNative.Development.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft.DotNet.ILToNative</id>
+    <id>toolchain.Windows_NT-x64.Microsoft.DotNet.ILToNative.Development</id>
     <version>1.0.0-prerelease</version>
-    <title>Microsoft .NET ILToNative Toolchain</title>
+    <title>Microsoft .NET ILToNative Toolchain - Development Version</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
@@ -19,14 +19,19 @@
   </metadata>
   <files>
     <file src="..\ILToNative.dll" target="ILToNative.dll" />
+    <file src="..\ILToNative.pdb" target="pdb\ILToNative.pdb" />
     <file src="..\ILToNative.Compiler.dll" target="ILToNative.Compiler.dll" />
+    <file src="..\ILToNative.Compiler.pdb" target="pdb\ILToNative.Compiler.pdb" />
     <file src="..\ILToNative.DependencyAnalysisFramework.dll" target="ILToNative.DependencyAnalysisFramework.dll" />
+    <file src="..\ILToNative.DependencyAnalysisFramework.pdb" target="pdb\ILToNative.DependencyAnalysisFramework.pdb" />
     <file src="..\ILToNative.TypeSystem.dll" target="ILToNative.TypeSystem.dll" />
+    <file src="..\ILToNative.TypeSystem.pdb" target="pdb\ILToNative.TypeSystem.pdb" />
     <file src="..\lib\Runtime.lib" target="sdk\Runtime.lib" />
     <file src="..\lib\PortableRuntime.lib" target="sdk\PortableRuntime.lib" />
     <file src="..\lib\bootstrapper.lib" target="sdk\bootstrapper.lib" />
     <file src="..\lib\bootstrappercpp.lib" target="sdk\bootstrappercpp.lib" />
     <file src="..\System.Private.Corelib.dll" target="sdk\System.Private.Corelib.dll" />
+    <file src="..\System.Private.Corelib.pdb" target="pdb\System.Private.Corelib.pdb" />
     <file src="..\toolruntime\*.dll" />
     <file src="..\toolruntime\coreconsole.exe" target="ILToNative.exe" />
     <file src="..\..\..\..\packages\Microsoft.DiaSymReader\1.0.6\lib\portable-net45+win8\Microsoft.DiaSymReader.dll" />

--- a/src/.nuget/toolchain.Windows_NT-x64.Microsoft.Dotnet.ILToNative.nuspec
+++ b/src/.nuget/toolchain.Windows_NT-x64.Microsoft.Dotnet.ILToNative.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft.DotNet.ILToNative.Development</id>
+    <id>toolchain.Windows_NT-x64.Microsoft.DotNet.ILToNative</id>
     <version>1.0.0-prerelease</version>
-    <title>Microsoft .NET ILToNative Toolchain - Development Version</title>
+    <title>Microsoft .NET ILToNative Toolchain</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
@@ -19,19 +19,14 @@
   </metadata>
   <files>
     <file src="..\ILToNative.dll" target="ILToNative.dll" />
-    <file src="..\ILToNative.pdb" target="pdb\ILToNative.pdb" />
     <file src="..\ILToNative.Compiler.dll" target="ILToNative.Compiler.dll" />
-    <file src="..\ILToNative.Compiler.pdb" target="pdb\ILToNative.Compiler.pdb" />
     <file src="..\ILToNative.DependencyAnalysisFramework.dll" target="ILToNative.DependencyAnalysisFramework.dll" />
-    <file src="..\ILToNative.DependencyAnalysisFramework.pdb" target="pdb\ILToNative.DependencyAnalysisFramework.pdb" />
     <file src="..\ILToNative.TypeSystem.dll" target="ILToNative.TypeSystem.dll" />
-    <file src="..\ILToNative.TypeSystem.pdb" target="pdb\ILToNative.TypeSystem.pdb" />
     <file src="..\lib\Runtime.lib" target="sdk\Runtime.lib" />
     <file src="..\lib\PortableRuntime.lib" target="sdk\PortableRuntime.lib" />
     <file src="..\lib\bootstrapper.lib" target="sdk\bootstrapper.lib" />
     <file src="..\lib\bootstrappercpp.lib" target="sdk\bootstrappercpp.lib" />
     <file src="..\System.Private.Corelib.dll" target="sdk\System.Private.Corelib.dll" />
-    <file src="..\System.Private.Corelib.pdb" target="pdb\System.Private.Corelib.pdb" />
     <file src="..\toolruntime\*.dll" />
     <file src="..\toolruntime\coreconsole.exe" target="ILToNative.exe" />
     <file src="..\..\..\..\packages\Microsoft.DiaSymReader\1.0.6\lib\portable-net45+win8\Microsoft.DiaSymReader.dll" />

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -28,7 +28,7 @@ set __BuildStr=%__BuildOS%.%__BuildArch%.%__BuildType%
 
 set SCRIPT_DIR=%~dp0
 set BIN_DIR=..\bin\tests
-set PACKAGE=Microsoft.DotNet.ILToNative
+set PACKAGE=toolchain.%__BuildOS%-%__BuildArch%.Microsoft.DotNet.ILToNative
 set VERSION=1.0.0-prerelease
 
 if /i "%__BuildType%"=="Debug" (


### PR DESCRIPTION
Renames the nuget packages to 
toolchain.<OS>-<Arch>.Microsoft.DotNet.ILToNative.\* form so that we can publish them for all OS/Arch combinations.

The scheme is similar to what is used for other implementation packages that get restored under <vbl_root>\packages.

@schellap @jkotas PTAL
