### PR TITLE
Updates to Dotnet-compile-native.bat

### DIFF
--- a/src/scripts/dotnet-compile-native.bat
+++ b/src/scripts/dotnet-compile-native.bat
@@ -4,11 +4,11 @@ setlocal EnableDelayedExpansion
 REM
 REM Script to compile a MSIL assembly to native code. 
 REM 
-REM Supported code-generators: CPPCODEGEN
+REM Supported code-generators: CPPCODEGEN, ProtoJIT
 REM
 
-if "%VCINSTALLDIR%" == "" (
-	echo Please run the script from within VS native tools command prompt
+if "%VS140COMNTOOLS%" == "" (
+	echo Please install Microsoft Visual Studio 2015.
 	goto InvalidArgs
 )
 
@@ -21,9 +21,12 @@ set __AppDepSdk=
 set __ILToNative=%~dp0
 set __CompileMode=cpp
 set __LogFilePath=%__Temp%
+set __CodegenPath=
+set __ObjgenPath=
+set __LinkLibs=
 
 :Arg_Loop
-if "%1" == "" goto ArgsDone
+if "%1" == "" goto :ArgsDone
 if /i "%1" == "x64"    (set __BuildArch=x64&&shift&goto Arg_Loop)
 
 if /i "%1" == "debug"    (set __BuildType=Debug&shift&goto Arg_Loop)
@@ -31,46 +34,115 @@ if /i "%1" == "release"   (set __BuildType=Release&shift&goto Arg_Loop)
 
 if /i "%1" == "/in" (set __Infile=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "/out" (set __Outfile=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "/appdepsdk" (set __AppDepSdk="%2"&shift&shift&goto Arg_Loop)
-if /i "%1" == "/mode" (set __CompileMode="%2"&shift&shift&goto Arg_Loop)
-if /i "%1" == "/logpath" (set __LogFilePath="%2"&shift&shift&goto Arg_Loop)
+if /i "%1" == "/appdepsdk" (set __AppDepSdk=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "/mode" (set __CompileMode=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "/logpath" (set __LogFilePath=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "/codegenpath" (set __CodegenPath=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "/objgenpath" (set __ObjgenPath=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "/linklibs" (set __LinkLibs=%2&shift&shift&goto Arg_Loop)
 
 echo Invalid command line argument: %1
-goto InvalidArgs
+goto :InvalidArgs
 
 :ArgsDone
 
 REM Do we have valid arguments?
-if "%__Infile%" == "" goto InvalidArgs
-if "%__Outfile%" == "" goto InvalidArgs
-if "%__AppDepSdk%" == "" goto InvalidArgs
-if "%__CompileMode%" == "" goto InvalidArgs
+if "%__Infile%" == "" (
+	echo Please specify MSIL assembly to be compiled.
+	goto :InvalidArgs
+)	
+if "%__Outfile%" == "" (
+	echo Please specify the native executable to be generated.
+	goto :InvalidArgs
+)
+
+if "%__AppDepSdk%" == "" (
+	echo Please specify the path to the extracted Microsoft.DotNet.AppDep nuget package.
+	goto :InvalidArgs
+)
+
+if "%__CompileMode%" == "" (
+	echo Please specify a valid compilation mode.
+	goto :InvalidArgs
+)
 
 REM Set path contain Runtime.lib/PortableRuntime.lib and System.Private.Corelib.dll
-set __LibPath="%__ILToNative%\sdk"
+set __LibPath=%__ILToNative%\sdk
 
-REM Validate the code-generation mode
-if NOT "%__CompileMode%" == "cpp" goto InvalidArgs
+REM Initialize environment to invoke native tools
+call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
 
-REM *** CPPCodegeneration ***
 REM Extract the name of the MSIL file we are compiling
 set AssemblyFileName=
 set AssemblyExt=
-for /f %%i IN ("%__Infile%") DO (
+for /f %%i IN (%__Infile%) DO (
 	set AssemblyFileName=%%~ni
 	set AssemblyExt=%%~xi
 )
 
 set Assembly=%AssemblyFileName%%AssemblyExt%
-set CPPFileName="%temp%\%Assembly%.cpp"
-set ObjFileName="%temp%\%Assembly%.cpp.obj"
+
+REM Validate the code-generation mode
+if /i "%__CompileMode%" == "cpp" goto :ModeCPP
+if /i "%__CompileMode%" == "protojit" goto :ModeProtoJIT
+echo Please specify a valid compilation mode.
+goto :InvalidArgs
+
+:ModeProtoJIT
+REM *** ProtoJIT Codegen ***
+REM Generate the obj file for the MSIL assembly
+
+set ObjFileName=%__Infile%.obj
+call :DeleteFile %ObjFileName%
+set libBootstrapper=%__LibPath%\bootstrapper.lib
+set libRuntime=%__LibPath%\Runtime.lib
+
+if not exist "%__CodegenPath%\%__CompileMode%.dll" (
+	echo Unable to find %__CodegenPath%\%__CompileMode%.dll to compile application!
+	goto :InvalidArgs
+)
+
+if not exist "%__ObjgenPath%\objwriter.dll" (
+	echo Unable to find %__ObjgenPath%\objwriter.dll to generate generate binaries for application!
+	goto :InvalidArgs
+)
+
+setlocal
+REM Setup the path to include the location of the codegenerator and binary file generator
+REM so that they can be located by the OS loader.
+set path=%path%;%__CodegenPath%;%__ObjgenPath%
+echo Generating app obj file
+"%__ILToNative%\ILToNative.exe" %__Infile% -r "%__ILToNative%\sdk\System.Private.CoreLib.dll" -r %__AppDepSdk%\*.dll -out %ObjFileName% > %__LogFilePath%\ILToNative.App.log
+endlocal
+
+set EXITCode=%ERRORLEVEL%
+if %EXITCode% GEQ 1 (
+	echo Unable to generate App object file.
+	goto :FailedExit
+)
+
+REM We successfully generated the object file, so proceed to link phase
+goto :LinkObj
+
+:ModeCPP
+REM *** CPPCodegeneration ***
+set CPPFileName=%__Infile%.cpp
+set ObjFileName=%__Infile%.cpp.obj
+set libBootstrapper=%__LibPath%\bootstrappercpp.lib
+set libRuntime=%__LibPath%\PortableRuntime.lib
+
+REM Perform basic cleanup
+call :DeleteFile "%CPPFileName%"
+call :DeleteFile "%ObjFileName%"
+call :DeleteFile "%__Outfile%"
+
 
 REM Generate the CPP file for the MSIL assembly
 echo Generating source file
-"%__ILToNative%\ILToNative.exe" %__Infile% -r "%__ILToNative%\sdk\System.Private.CoreLib.dll" -r "%__AppDepSdk%\*.dll" -out "%CPPFileName%" -cpp > %__LogFilePath%\ILToNative.MSILToCpp.log
+"%__ILToNative%\ILToNative.exe" %__Infile% -r "%__ILToNative%\sdk\System.Private.CoreLib.dll" -r %__AppDepSdk%\*.dll -out "%CPPFileName%" -cpp > %__LogFilePath%\ILToNative.MSILToCpp.log
 if ERRORLEVEL 1 (
 	echo Unable to generate CPP file.
-	goto :eof
+	goto :FailedExit
 )
 
 set DefinesDebug=/ZI /nologo /W3 /WX- /sdl /Od /D CPPCODEGEN /D WIN32 /D _DEBUG /D _CONSOLE /D _LIB /D _UNICODE /D UNICODE /Gm /EHsc /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline
@@ -94,22 +166,30 @@ echo Compiling application source files
 "%VCINSTALLDIR%\bin\x86_amd64\CL.exe" /c /I %__AppDepSdk%\CPPSdk\Windows_NT /I %__AppDepSdk%\CPPSdk\ %CPPDefines% /Fo"%ObjFileName%" /Gd /TP /wd4477 /errorReport:prompt %CPPFileName% > %__LogFilePath%\ILToNative.App.log
 if ERRORLEVEL 1 (
 	echo Unable to compile app source file.
-	goto :eof
+	goto :FailedExit
 )
 
+:LinkObj
 echo Generating native executable
-"%VCINSTALLDIR%\bin\x86_amd64\link.exe" /ERRORREPORT:PROMPT /OUT:"%__Outfile%" /NOLOGO kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib %__LibPath%\PortableRuntime.lib %__LibPath%\bootstrappercpp.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /Debug /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT %LinkOpts% /MACHINE:%__BuildArch% "%ObjFileName%" > %__LogFilePath%\ILToNative.Link.log
+"%VCINSTALLDIR%\bin\x86_amd64\link.exe" /ERRORREPORT:PROMPT /OUT:"%__Outfile%" /NOLOGO kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib %libRuntime% %libBootstrapper% %__LinkLibs% /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /Debug /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT %LinkOpts% /MACHINE:%__BuildArch% "%ObjFileName%" > %__LogFilePath%\ILToNative.Link.log
 if ERRORLEVEL 1 (
 	echo Unable to link native executable.
-	goto :eof
+	goto :FailedExit
 )
 
 :BuildComplete
 echo Build successfully completed.
+exit /B 0
+
+:DeleteFile
+if exist %1 del %1
 goto :eof
 
 :InvalidArgs
-echo
-echo Usage: dotnet-compile-native <arch> <buildType> /in <path to MSIL assembly> /out <path to native executable> /appdepsdk <path to contents of Microsoft.DotNet.AppDep nuget package> [/mode cpp] [/logpath <path to drop logfiles in>]
-goto :eof
+echo Invalid command line
+echo.
+echo Usage: dotnet-compile-native arch buildType /in path-to-MSIL-assembly /out path-to-native executable /appdepsdk path to contents of Microsoft.DotNet.AppDep nuget package [/mode cpp|protojit /codegenpath path to contents of Microsoft.DotNet.ProtoJit package /objgenpath path to contents of Microsoft.DotNet.ObjWriter package] [/logpath path to drop logfiles in]
+
+:FailedExit
+exit /B 1
 


### PR DESCRIPTION
1) Enable dotnet-compile-native to run from a regular command prompt and setup the x86_x64 cross tools environment. 
2) Enable dotnet-compile-native.bat to generate code using a non-CPP codegenerator (e.g. ProtoJIT).
3) Switch test infrastructure to use dotnet-compile-native to compile the tests.

@schellap @jkotas PTAL

@brthor - FYI
