### PR TITLE
Introduce size check on env var

### DIFF
--- a/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
@@ -13,6 +13,15 @@ extern "C" int32_t GetEnvironmentVariable(const char* variable, char** result)
    {
        return 0;
    }
-   
-   return (int32_t)strlen(*result);
+
+   size_t resultSize = strlen(*result);
+
+   // Return -1 if the size overflows an integer so that we can throw on managed side
+   if ((size_t)(int32_t)resultSize != resultSize)
+   {
+       *result = NULL;
+       return -1;
+   }
+
+   return (int32_t)resultSize;
 }

--- a/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.EnvironmentVariables.Unix.cs
@@ -68,7 +68,13 @@ namespace System
                 IntPtr result;
                 int size = Interop.Sys.GetEnvironmentVariable(pVar, out result);
 
-                if (size > 0)
+                // The size can be -1 if the environment variable's size overflows an integer
+                if (size == -1)
+                {
+                    throw new OverflowException();
+                }
+
+                if (result != IntPtr.Zero)
                 {
                     return Encoding.UTF8.GetString((byte*)result, size);
                 }


### PR DESCRIPTION
When the value of the reported environment variable is larger than the size of a byte[] in a managed size we are going to return -1 as the size from native code and throw an exception from managed code.

Fixes #166 
