### PR TITLE
Allow mismatch between .exe name and AssemblyName

### DIFF
--- a/src/ILToNative/src/Program.cs
+++ b/src/ILToNative/src/Program.cs
@@ -99,7 +99,7 @@ namespace ILToNative
             EcmaModule mainModule = null;
             foreach (var inputFile in _inputFilePaths)
             {
-                EcmaModule module = _compilerTypeSystemContext.GetModuleForSimpleName(inputFile.Key);
+                EcmaModule module = _compilerTypeSystemContext.GetModuleFromPath(inputFile.Value);
                 if (module.PEReader.PEHeaders.IsExe)
                 {
                     if (mainModule != null)


### PR DESCRIPTION
It is not unusual for .exe name to differ from Assembly (this situation occurs in some of the CoreCLR tests). This change suppresses throwing of "Assembly name does not match filename" exception for this case.
