### PR TITLE
Conditionalize workaround for struct calling convention bug

### DIFF
--- a/src/JitInterface/src/CorInfoBase.cs
+++ b/src/JitInterface/src/CorInfoBase.cs
@@ -257,7 +257,9 @@ namespace Internal.JitInterface
         [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
         delegate void _embedGenericHandle(IntPtr _this, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.Bool)]bool fEmbedParent, ref CORINFO_GENERICHANDLE_RESULT pResult);
         [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getLocationOfThisType(IntPtr _this, CORINFO_LOOKUP_KIND* result, CORINFO_METHOD_STRUCT_* context);
+        delegate void _getLocationOfThisType_Windows(IntPtr _this, CORINFO_LOOKUP_KIND* result, CORINFO_METHOD_STRUCT_* context);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
+        delegate CORINFO_LOOKUP_KIND _getLocationOfThisType(IntPtr _this, CORINFO_METHOD_STRUCT_* context);
         [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
         delegate void* _getPInvokeUnmanagedTarget(IntPtr _this, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection);
         [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
@@ -715,9 +717,18 @@ namespace Internal.JitInterface
             var d122 = new _embedGenericHandle(embedGenericHandle);
             vtable[122] = Marshal.GetFunctionPointerForDelegate(d122);
             keepalive[122] = d122;
-            var d123 = new _getLocationOfThisType(getLocationOfThisType);
-            vtable[123] = Marshal.GetFunctionPointerForDelegate(d123);
-            keepalive[123] = d123;
+            if (IsWindows())
+            {
+                var d123 = new _getLocationOfThisType_Windows(getLocationOfThisType_Windows);
+                vtable[123] = Marshal.GetFunctionPointerForDelegate(d123);
+                keepalive[123] = d123;
+            }
+            else
+            {
+                var d123 = new _getLocationOfThisType(getLocationOfThisType);
+                vtable[123] = Marshal.GetFunctionPointerForDelegate(d123);
+                keepalive[123] = d123;
+            }
             var d124 = new _getPInvokeUnmanagedTarget(getPInvokeUnmanagedTarget);
             vtable[124] = Marshal.GetFunctionPointerForDelegate(d124);
             keepalive[124] = d124;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1538,12 +1538,28 @@ namespace Internal.JitInterface
             }
         }
 
-        void getLocationOfThisType(IntPtr _this, CORINFO_LOOKUP_KIND* result, CORINFO_METHOD_STRUCT_* context)
+        // Workaround for struct return marshaling bug on Windows.
+        // Delete once https://github.com/dotnet/corert/issues/162 is fixed
+        bool IsWindows()
         {
-            result->needsRuntimeLookup = false;
-            result->runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_THISOBJ;
+            return Path.DirectorySeparatorChar == '\\';
+        }
+
+        void getLocationOfThisType_Windows(IntPtr _this, CORINFO_LOOKUP_KIND* result, CORINFO_METHOD_STRUCT_* context)
+        {
+            *result = getLocationOfThisType(_this, context);
+        }
+        // End of workaround
+
+        CORINFO_LOOKUP_KIND getLocationOfThisType(IntPtr _this, CORINFO_METHOD_STRUCT_* context)
+        {
+            CORINFO_LOOKUP_KIND result = new CORINFO_LOOKUP_KIND();
+            result.needsRuntimeLookup = false;
+            result.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_THISOBJ;
 
             // TODO: shared generics
+
+            return result;
         }
 
         void* getPInvokeUnmanagedTarget(IntPtr _this, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection)

--- a/src/JitInterface/src/ThunkGenerator/ThunkInput.txt
+++ b/src/JitInterface/src/ThunkGenerator/ThunkInput.txt
@@ -277,8 +277,7 @@ FUNCTIONS
     CORINFO_METHOD_HANDLE embedMethodHandle(CORINFO_METHOD_HANDLE   handle, void                  **ppIndirection);
     CORINFO_FIELD_HANDLE embedFieldHandle(CORINFO_FIELD_HANDLE    handle, void                  **ppIndirection);
     void embedGenericHandle(CORINFO_RESOLVED_TOKEN *        pResolvedToken, BOOL fEmbedParent, CORINFO_GENERICHANDLE_RESULT *  pResult);
-; WORKAROUND: CLR doesn't marshal the return struct right, so explicitly list the pointer to it as the first parameter
-    void getLocationOfThisType(CORINFO_LOOKUP_KIND * result, CORINFO_METHOD_HANDLE context);
+    CORINFO_LOOKUP_KIND getLocationOfThisType(CORINFO_METHOD_HANDLE context);
     void* getPInvokeUnmanagedTarget(CORINFO_METHOD_HANDLE   method, void                  **ppIndirection);
     void* getAddressOfPInvokeFixup(CORINFO_METHOD_HANDLE   method, void                  **ppIndirection);
     LPVOID GetCookieForPInvokeCalliSig(CORINFO_SIG_INFO* szMetaSig, void           ** ppIndirection);


### PR DESCRIPTION
The calling convention workaround on getLocationOfThisType breaks Unix. Apply it only when we are running on Windows.
