### PR TITLE
Build System.Private.CoreLib.Native as .a

### DIFF
--- a/src/Native/System.Private.CoreLib.Native/CMakeLists.txt
+++ b/src/Native/System.Private.CoreLib.Native/CMakeLists.txt
@@ -5,7 +5,7 @@ set(NATIVE_SOURCES
 )
 
 add_library(System.Private.CoreLib.Native
-    SHARED
+    STATIC
     ${NATIVE_SOURCES}
 )
 


### PR DESCRIPTION
System.Private.CoreLib.Native has to be built as .a to allow linking everything into single binary.
