### PR TITLE
Emit frame info

### DIFF
--- a/src/ILToNative.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILToNative.Compiler/src/Compiler/Compilation.cs
@@ -428,6 +428,8 @@ namespace ILToNative
                     throw new NotImplementedException();
 
                 methodCodeNodeNeedingCode.SetCode(objData.ToObjectData());
+
+                methodCodeNodeNeedingCode.SetFrameInfos(methodCode.FrameInfos);
             }
         }
 

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -7,7 +7,7 @@ using Internal.TypeSystem;
 
 namespace ILToNative.DependencyAnalysis
 {
-    class MethodCodeNode : ObjectNode, ISymbolNode
+    class MethodCodeNode : ObjectNodeWithFrameInfo, ISymbolNode
     {
         MethodDesc _method;
         ObjectData _methodCode;

--- a/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeWithFrameInfo.cs
+++ b/src/ILToNative.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeWithFrameInfo.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace ILToNative.DependencyAnalysis
+{
+    public abstract class ObjectNodeWithFrameInfo : ObjectNode
+    {
+        FrameInfo[] _frameInfos;
+
+        public void SetFrameInfos(FrameInfo[] frameInfos)
+        {
+            Debug.Assert(_frameInfos == null);
+            _frameInfos = frameInfos;
+        }
+
+        public FrameInfo[] GetFrameInfos()
+        {
+            return _frameInfos;
+        }
+    }
+}

--- a/src/ILToNative.Compiler/src/Compiler/MethodCode.cs
+++ b/src/ILToNative.Compiler/src/Compiler/MethodCode.cs
@@ -18,6 +18,8 @@ namespace ILToNative
         public byte[] ROData;
 
         public Relocation[] Relocs;
+
+        public FrameInfo[] FrameInfos;
     }
 
     class BlockRelativeTarget
@@ -33,5 +35,12 @@ namespace ILToNative
         public int Offset;
         public Object Target;
         public int Delta;
+    }
+
+    public class FrameInfo
+    {
+        public int StartOffset;
+        public int EndOffset;
+        public byte[] BlobData;
     }
 }

--- a/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
+++ b/src/ILToNative.Compiler/src/ILToNative.Compiler.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ObjectAndOffsetSymbolNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectDataBuilder.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ObjectNodeWithFrameInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectWriter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Relocation.cs" />

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -73,7 +73,7 @@ set PROTOJIT_VERSION=1.0.0-prerelease
 echo.
 echo Installing ObjectWriter from NuGet.
 set OBJWRITER_PACKAGE=Microsoft.DotNet.ObjectWriter
-set OBJWRITER_VERSION=1.0.0-prerelease
+set OBJWRITER_VERSION=1.0.1-prerelease
 %NUGET_PATH%\NuGet.exe install -Source %NUGET_FEED_URL% -OutputDir %NUPKG_INSTALL_DIR% -Version %OBJWRITER_VERSION% %OBJWRITER_PACKAGE% -prerelease
 
 echo.


### PR DESCRIPTION
This supports for emitting frame info for Windows.
Basically pdata/xdata is constructed like C++ to allow call stack dumps.
EH table itself is not populated yet since EH model is not determined.
The native object writer part is under review -- https://github.com/dotnet/llilc/pull/933

Tested debugger now shows call stacks on the managed code that we emit in Windows.
