### PR TITLE
Add Runtime.Base.dll to the build

### DIFF
--- a/src/Native/Runtime/Full/CMakeLists.txt
+++ b/src/Native/Runtime/Full/CMakeLists.txt
@@ -12,9 +12,25 @@ add_definitions(-DUSE_PORTABLE_HELPERS)
 
 add_library(Runtime STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM})
 
+# Get the current list of definitions
+get_compile_definitions(DEFINITIONS)
+
+set(ASM_OFFSETS_CSPP ${RUNTIME_DIR}/../../Runtime.Base/src/AsmOffsets.cspp)
+
+add_custom_command(
+    # The AsmOffsets.cs is consumed later by the managed build
+    TARGET Runtime
+    COMMAND ${CMAKE_CXX_COMPILER} ${DEFINITIONS} -E "${ASM_OFFSETS_CSPP}" >"${CMAKE_CURRENT_BINARY_DIR}/AsmOffsets.cs"
+    DEPENDS "${RUNTIME_DIR}/AsmOffsets.cpp" "${RUNTIME_DIR}/AsmOffsets.h"
+)
+
 if (WIN32)
-    # Get the current list of definitions
-    get_compile_definitions(DEFINITIONS)
+    add_custom_command(
+        # The AsmOffsets.inc will be built in the pre-build phase of the Runtime build
+        TARGET Runtime PRE_BUILD
+        COMMAND ${CMAKE_CXX_COMPILER} ${DEFINITIONS} -EP "${RUNTIME_DIR}/AsmOffsets.cpp" >"${CMAKE_CURRENT_BINARY_DIR}/AsmOffsets.inc"
+        DEPENDS "${RUNTIME_DIR}/AsmOffsets.cpp" "${RUNTIME_DIR}/AsmOffsets.h"
+    )
 
     # Extract the definitions for the ASM code. Since there is a bug in the cmake that prevents us from
     # using the generator expressions, we split the definitions into lists based on the configuration.
@@ -36,12 +52,6 @@ if (WIN32)
         string(TOUPPER ${CONFIG} CONFIG)
         set_property(SOURCE ${RUNTIME_SOURCES_ARCH_ASM} PROPERTY COMPILE_DEFINITIONS_${CONFIG} ${ASM_DEFINITIONS_${CONFIG}})
     endforeach()
-
-    add_custom_command(
-        # The AsmOffsets.inc will be built in the pre-build phase of the Runtime build
-        TARGET Runtime PRE_BUILD
-        COMMAND ${CMAKE_CXX_COMPILER} ${DEFINITIONS} /EP "${RUNTIME_DIR}/AsmOffsets.cpp" >"${CMAKE_CURRENT_BINARY_DIR}/AsmOffsets.inc"
-    )
 endif()
 
 # Install the static Runtime library

--- a/src/Runtime.Base/src/AsmOffsets.cspp
+++ b/src/Runtime.Base/src/AsmOffsets.cspp
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#define PLAT_ASM_OFFSET(offset, cls, member) internal const int OFFSETOF__##cls##__##member = 0x##offset;
+#define PLAT_ASM_SIZEOF(offset, cls) internal const int SIZEOF__##cls = 0x##offset;
+#define PLAT_ASM_CONST(constant, expr) internal const int expr = 0x##constant;
+
+static class AsmOffsets
+{
+#include "../../Native/Runtime/AsmOffsets.h"
+}

--- a/src/Runtime.Base/src/RhBaseName.cs
+++ b/src/Runtime.Base/src/RhBaseName.cs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+internal class Redhawk { public const string BaseName = "*"; }

--- a/src/Runtime.Base/src/Runtime.Base.csproj
+++ b/src/Runtime.Base/src/Runtime.Base.csproj
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <ProjectGuid>{BE95C560-B508-4588-8907-F9FC5BC1A0CF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Runtime.Base</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ExcludeDefaultReferences>true</ExcludeDefaultReferences>
+    <IsCoreAssembly>true</IsCoreAssembly>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+      Need to avoid target platform being empty because that would drag in an mscorlib design-time
+      facade into the references and break us.
+    -->
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetPlatformIdentifier>Portable</TargetPlatformIdentifier>
+    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
+    <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- The properties use amd64 as their platform string, we want to keep in sync with those, so set Platform appropriately,
+         though still use the 'x64' output path -->
+    <Platform Condition=" '$(Platform)' == 'x64' ">amd64</Platform>
+  </PropertyGroup>
+
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|amd64' ">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|amd64' ">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|arm' ">
+    <PlatformTarget>arm</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|arm' ">
+    <PlatformTarget>arm</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineConstants>FEATURE_CLR_EH;FEATURE_SHARED_GENERICS;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DefineConstants>FEATURE_GC_STRESS;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Platform)' == 'amd64'">
+    <DefineConstants>AMD64;BIT64;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'x86'">
+    <DefineConstants>X86;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'arm'">
+    <DefineConstants>ARM;FEATURE_64BIT_ALIGNMENT;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'arm64'">
+    <DefineConstants>ARM64;BIT64;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
+    <DefineConstants>CORERT;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="System\Nullable.cs" />
+    <Compile Include="System\Object.cs" />
+    <Compile Include="System\Runtime\CachedInterfaceDispatch.cs" />
+    <Compile Include="System\Runtime\CompilerServices\StackOnlyAttribute.cs" />
+    <Compile Include="System\Runtime\DispatchResolve.cs" />
+    <Compile Include="System\Runtime\GCStress.cs" />
+    <Compile Include="System\Runtime\BinderIntrinsics.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Array.cs" />
+    <Compile Include="System\Attribute.cs" />
+    <Compile Include="System\AttributeTargets.cs" />
+    <Compile Include="System\AttributeUsageAttribute.cs" />
+    <Compile Include="System\Delegate.cs" />
+    <Compile Include="System\Exception.cs" />
+    <Compile Include="System\FlagsAttribute.cs" />
+    <Compile Include="System\GC.cs" />
+    <Compile Include="System\multicastdelegate.cs" />
+    <Compile Include="System\ParamArrayAttribute.cs" />
+    <Compile Include="System\primitives.cs" />
+    <Compile Include="System\RuntimeHandles.cs" />
+    <Compile Include="System\RuntimeTypeHandle.cs" />
+    <Compile Include="System\String.cs" />
+    <Compile Include="System\Void.cs" />
+    <Compile Include="System\Diagnostics\ConditionalAttribute.cs" />
+    <Compile Include="System\Diagnostics\Debug.cs" />
+    <Compile Include="System\Runtime\__Finalizer.cs" />
+    <Compile Include="System\Runtime\CalliIntrinsics.cs" />
+    <Compile Include="System\Runtime\EEType.cs" />
+    <Compile Include="System\Runtime\EETypePtr.cs" />
+    <Compile Include="System\Runtime\ExceptionHandling.cs" />
+    <Compile Include="System\Runtime\ExceptionIDs.cs" />
+    <Compile Include="System\Runtime\InternalCalls.cs" />
+    <Compile Include="System\Runtime\RuntimeExportAttribute.cs" />
+    <Compile Include="System\Runtime\Runtimeexports.cs" />
+    <Compile Include="System\Runtime\RuntimeImportAttribute.cs" />
+    <Compile Include="System\Runtime\StackFrameIterator.cs" />
+    <Compile Include="System\Runtime\TypeCast.cs" />
+    <Compile Include="System\Runtime\CompilerServices\FixedBufferAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\IntrinsicAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\ICastable.cs" />
+    <Compile Include="System\Runtime\CompilerServices\IsVolatile.cs" />
+    <Compile Include="System\Runtime\CompilerServices\ManuallyManagedAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\MethodImplAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\RuntimeHelpers.cs" />
+    <Compile Include="System\Runtime\CompilerServices\UnsafeValueTypeAttribute.cs" />
+    <Compile Include="System\Runtime\InteropServices\CallingConvention.cs" />
+    <Compile Include="System\Runtime\InteropServices\CharSet.cs" />
+    <Compile Include="System\Runtime\InteropServices\DllImportAttribute.cs" />
+    <Compile Include="System\Runtime\InteropServices\FieldOffsetAttribute.cs" />
+    <Compile Include="System\Runtime\interopservices\GCHandle.cs" />
+    <Compile Include="System\Runtime\InteropServices\LayoutKind.cs" />
+    <Compile Include="System\Runtime\InteropServices\NativeCallableAttribute.cs" />
+    <Compile Include="System\Runtime\InteropServices\OutAttribute.cs" />
+    <Compile Include="System\Runtime\InteropServices\StructLayoutAttribute.cs" />
+    <Compile Include="RhBaseName.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(BaseIntermediateOutputPath)\Native\$(BinDirOSGroup).$(BinDirPlatform)\Runtime\Full\AsmOffsets.cs" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
+  <PropertyGroup>
+    <!-- Exclude AssemblyInfoPartialFile -->
+    <AssemblyInfoPartialFile></AssemblyInfoPartialFile>
+  </PropertyGroup>
+
+</Project>

--- a/src/Runtime.Base/src/System/Runtime/EEType.cs
+++ b/src/Runtime.Base/src/System/Runtime/EEType.cs
@@ -695,10 +695,10 @@ namespace System.Runtime
             {
                 if ((unchecked((uint)_interfaceType._pInterfaceEEType) & 1u) != 0)
                 {
-#if WIN32
-                    EEType** ppInterfaceEETypeViaIAT = (EEType**)(((uint)_interfaceType._ppInterfaceEETypeViaIAT) & ~1u);
-#else
+#if BIT64
                     EEType** ppInterfaceEETypeViaIAT = (EEType**)(((ulong)_interfaceType._ppInterfaceEETypeViaIAT) & ~1ul);
+#else
+                    EEType** ppInterfaceEETypeViaIAT = (EEType**)(((uint)_interfaceType._ppInterfaceEETypeViaIAT) & ~1u);
 #endif
                     return *ppInterfaceEETypeViaIAT;
                 }

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -9,16 +9,10 @@
     <AssemblyName>System.Private.CoreLib</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ExcludeDefaultReferences>true</ExcludeDefaultReferences>
+    <IsCoreAssembly>true</IsCoreAssembly>
   </PropertyGroup>
 
   <PropertyGroup>
-<!--
-	temporary workaround to exclude all references including mscorlib.dll
-    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)</_TargetFrameworkDirectories>
-    <_FullFrameworkReferenceAssemblyPaths>$(_TargetFrameworkDirectories)</_FullFrameworkReferenceAssemblyPaths>
-    Condition="'$(IsProjectNLibrary)' != 'true'
--->
-    <IsCoreAssembly>true</IsCoreAssembly>
     <!--
       Need to avoid target platform being empty because that would drag in an mscorlib design-time
       facade into the references and break us.
@@ -29,15 +23,12 @@
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
     <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
+  </PropertyGroup>
 
-<!--
-    <ExcludeDefaultReferences>true</ExcludeDefaultReferences>
-
-    <ExcludeVersioningImport>true</ExcludeVersioningImport>
-    <TargetingDefaultPlatform>true</TargetingDefaultPlatform>
-    <ExcludeFrameworkTargetingImport>true</ExcludeFrameworkTargetingImport>
-    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
--->
+  <PropertyGroup>
+    <!-- The properties use amd64 as their platform string, we want to keep in sync with those, so set Platform appropriately,
+         though still use the 'x64' output path -->
+    <Platform Condition=" '$(Platform)' == 'x64' ">amd64</Platform>
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the options -->
@@ -65,7 +56,23 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
-    <DefineConstants>CORERT;BIT64</DefineConstants>
+    <!-- TODO: For now, drop DEBUG define comming from central location - asserts compiled 
+         into DEBUG builds use interfaces that we are not able to handle yet -->
+    <!-- <DefineConstants>CORERT;$(DefineConstants)</DefineConstants> -->
+    <DefineConstants>CORERT</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Platform)' == 'amd64'">
+    <DefineConstants>AMD64;BIT64;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'x86'">
+    <DefineConstants>X86;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'arm'">
+    <DefineConstants>ARM;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'arm64'">
+    <DefineConstants>ARM64;BIT64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Most of the .csproj file plumbing is copied from System.Private.CoreLib.dll
- Runtime.Base.dll build depends on AsmOffsets.h run through C++ preprocessor produced during CMake step of the build
