### PR TITLE
Add support for pinned locals

### DIFF
--- a/src/Common/src/TypeSystem/Common/LocalVariableDefinition.cs
+++ b/src/Common/src/TypeSystem/Common/LocalVariableDefinition.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Internal.TypeSystem
+{
+    public struct LocalVariableDefinition
+    {
+        /// <summary>
+        /// Gets a value indicating whether the stored target should be pinned in the runtime
+        /// heap and shouldn't be moved by the actions of the garbage collector.
+        /// </summary>
+        public readonly bool IsPinned;
+
+        /// <summary>
+        /// Gets the type of the local variable.
+        /// </summary>
+        public readonly TypeDesc Type;
+
+        public LocalVariableDefinition(TypeDesc type, bool isPinned)
+        {
+            IsPinned = isPinned;
+            Type = type;
+        }
+
+        public override string ToString()
+        {
+            return IsPinned ? "pinned " + Type.ToString() : Type.ToString();
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/EcmaMethodIL.cs
+++ b/src/Common/src/TypeSystem/IL/EcmaMethodIL.cs
@@ -19,7 +19,7 @@ namespace Internal.IL
 
         // Cached values
         byte[] _ilBytes;
-        TypeDesc[] _locals;
+        LocalVariableDefinition[] _locals;
         ILExceptionRegion[] _ilExceptionRegions;
 
         static public EcmaMethodIL Create(EcmaMethod method)
@@ -73,7 +73,7 @@ namespace Internal.IL
             return _methodBody.MaxStack;
         }
 
-        public override TypeDesc[] GetLocals()
+        public override LocalVariableDefinition[] GetLocals()
         {
             if (_locals != null)
                 return _locals;
@@ -81,11 +81,11 @@ namespace Internal.IL
             var metadataReader = _module.MetadataReader;
             var localSignature = _methodBody.LocalSignature;
             if (localSignature.IsNil)
-                return TypeDesc.EmptyTypes;
+                return Array.Empty<LocalVariableDefinition>();
             BlobReader signatureReader = metadataReader.GetBlobReader(metadataReader.GetStandaloneSignature(localSignature).Signature);
 
             EcmaSignatureParser parser = new EcmaSignatureParser(_module, signatureReader);
-            TypeDesc[] locals = parser.ParseLocalsSignature();
+            LocalVariableDefinition[] locals = parser.ParseLocalsSignature();
             return (_locals = locals);
         }
 

--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -32,7 +32,7 @@ namespace Internal.IL
 
             if (method.Name == "UncheckedCast" && method.OwningType.Name == "System.Runtime.CompilerServices.RuntimeHelpers")
             {
-                return new ILStubMethodIL(new byte[] { (byte)ILOpcode.ldarg_0, (byte)ILOpcode.ret }, Array.Empty<TypeDesc>(), null);
+                return new ILStubMethodIL(new byte[] { (byte)ILOpcode.ldarg_0, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
             }
 
             return null;

--- a/src/Common/src/TypeSystem/IL/InstantiatedMethodIL.cs
+++ b/src/Common/src/TypeSystem/IL/InstantiatedMethodIL.cs
@@ -41,26 +41,26 @@ namespace Internal.IL
             return _methodIL.GetInitLocals();
         }
 
-        public override TypeDesc[] GetLocals()
+        public override LocalVariableDefinition[] GetLocals()
         {
-            TypeDesc[] locals = _methodIL.GetLocals();
-            TypeDesc[] clone = null;
+            LocalVariableDefinition[] locals = _methodIL.GetLocals();
+            LocalVariableDefinition[] clone = null;
 
             for (int i = 0; i < locals.Length; i++)
             {
-                TypeDesc uninst = locals[i];
+                TypeDesc uninst = locals[i].Type;
                 TypeDesc inst  = uninst.InstantiateSignature(_typeInstantiation, _methodInstantiation);
                 if (uninst != inst)
                 {
                     if (clone == null)
                     {
-                        clone = new TypeDesc[locals.Length];
+                        clone = new LocalVariableDefinition[locals.Length];
                         for (int j = 0; j < clone.Length; j++)
                         {
                             clone[j] = locals[j];
                         }
                     }
-                    clone[i] = inst;
+                    clone[i] = new LocalVariableDefinition(inst, locals[i].IsPinned);
                 }
             }
 

--- a/src/Common/src/TypeSystem/IL/MethodIL.cs
+++ b/src/Common/src/TypeSystem/IL/MethodIL.cs
@@ -91,7 +91,7 @@ namespace Internal.IL
         public abstract byte[] GetILBytes();
         public abstract int GetMaxStack();
         public abstract bool GetInitLocals();
-        public abstract TypeDesc[] GetLocals();
+        public abstract LocalVariableDefinition[] GetLocals();
         public abstract Object GetObject(int token);
         public abstract ILExceptionRegion[] GetExceptionRegions();
     }

--- a/src/Common/src/TypeSystem/IL/MethodILDebugView.cs
+++ b/src/Common/src/TypeSystem/IL/MethodILDebugView.cs
@@ -31,7 +31,7 @@ namespace Internal.IL
                 sb.Append(_methodIL.GetMaxStack());
                 sb.AppendLine();
 
-                TypeDesc[] locals = _methodIL.GetLocals();
+                LocalVariableDefinition[] locals = _methodIL.GetLocals();
                 if (locals != null && locals.Length > 0)
                 {
                     sb.Append(".locals ");
@@ -47,8 +47,10 @@ namespace Internal.IL
                             sb.AppendLine(",");
                             sb.Append(' ', 4);
                         }
-                        sb.Append(locals[i].ToString());
+                        sb.Append(locals[i].Type.ToString());
                         sb.Append(" ");
+                        if (locals[i].IsPinned)
+                            sb.Append("pinned ");
                         sb.Append("V_");
                         sb.Append(i);
                     }

--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -126,10 +126,10 @@ namespace Internal.IL.Stubs
     class ILStubMethodIL : MethodIL
     {
         byte[] _ilBytes;
-        TypeDesc[] _locals;
+        LocalVariableDefinition[] _locals;
         Object[] _tokens;
 
-        public ILStubMethodIL(byte[] ilBytes, TypeDesc[] locals, Object[] tokens)
+        public ILStubMethodIL(byte[] ilBytes, LocalVariableDefinition[] locals, Object[] tokens)
         {
             _ilBytes = ilBytes;
             _locals = locals;
@@ -152,7 +152,7 @@ namespace Internal.IL.Stubs
         {
             return true;
         }
-        public override TypeDesc[] GetLocals()
+        public override LocalVariableDefinition[] GetLocals()
         {
             return _locals;
         }
@@ -165,7 +165,7 @@ namespace Internal.IL.Stubs
     public class ILEmitter
     {
         ArrayBuilder<ILCodeStream> _codeStreams;
-        ArrayBuilder<TypeDesc> _locals;
+        ArrayBuilder<LocalVariableDefinition> _locals;
         ArrayBuilder<Object> _tokens;
 
         public ILEmitter()
@@ -210,10 +210,10 @@ namespace Internal.IL.Stubs
             return NewToken(value, 0x11000000);
         }
 
-        public int NewLocal(TypeDesc localType)
+        public int NewLocal(TypeDesc localType, bool isPinned = false)
         {
             int index = _locals.Count;
-            _locals.Add(localType);
+            _locals.Add(new LocalVariableDefinition(localType, isPinned));
             return index;
         }
 

--- a/src/ILToNative.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILToNative.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -43,7 +43,7 @@ namespace Internal.IL
 
         MethodIL _methodIL;
         byte[] _ilBytes;
-        TypeDesc[] _locals;
+        LocalVariableDefinition[] _locals;
 
         struct SequencePoint
         {
@@ -376,7 +376,7 @@ namespace Internal.IL
             }
             else
             {
-               return _locals[index];
+               return _locals[index].Type;
             }
         }
 
@@ -446,12 +446,12 @@ namespace Internal.IL
             bool initLocals = _methodIL.GetInitLocals();
             for (int i = 0; i < _locals.Length; i++)
             {
-                Append(_writer.GetCppSignatureTypeName(_locals[i]));
+                Append(_writer.GetCppSignatureTypeName(_locals[i].Type));
                 Append(" ");
                 Append(GetVarName(i, false));
                 if (initLocals)
                 {
-                    TypeDesc localType = _locals[i];
+                    TypeDesc localType = _locals[i].Type;
                     if (localType.IsValueType && !localType.IsPrimitive && !localType.IsEnum)
                     {
                         Finish();

--- a/src/ILToNative.TypeSystem/src/ILToNative.TypeSystem.csproj
+++ b/src/ILToNative.TypeSystem/src/ILToNative.TypeSystem.csproj
@@ -98,6 +98,9 @@
     <Compile Include="$(CommonPath)\TypeSystem\NoMetadata\NoMetadataType.cs">
       <Link>NoMetadata\NoMetadataType.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\LocalVariableDefinition.cs">
+      <Link>LocalVariableDefinition.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -226,7 +226,7 @@ namespace Internal.JitInterface
             // }
         }
 
-        void Get_CORINFO_SIG_INFO(TypeDesc[] locals, out CORINFO_SIG_INFO sig)
+        void Get_CORINFO_SIG_INFO(LocalVariableDefinition[] locals, out CORINFO_SIG_INFO sig)
         {
             sig.callConv = CorInfoCallConv.CORINFO_CALLCONV_DEFAULT;
             sig._retType = (byte)CorInfoType.CORINFO_TYPE_VOID;
@@ -1248,11 +1248,12 @@ namespace Internal.JitInterface
             }
             else
             {
-                TypeDesc type = ((TypeDesc[])sigObj)[index];
-
-                // TODO: Pinning
+                LocalVariableDefinition[] locals = (LocalVariableDefinition[])sigObj;
+                TypeDesc type = locals[index].Type;
+                
                 CorInfoType corInfoType = asCorInfoType(type, out vcTypeRet);
-                return (CorInfoTypeWithMod)corInfoType;
+
+                return (CorInfoTypeWithMod)corInfoType | (locals[index].IsPinned ? CorInfoTypeWithMod.CORINFO_TYPE_MOD_PINNED : 0);
             }
         }
 


### PR DESCRIPTION
With this change, local variables can no longer be represented as
an array of TypeDefs, so adding a new structure that will hold
the TypeDef and additional metadata.

Most of the changes are just the ripple effect.

We are now reporting pinned locals to RyuJIT.
