### PR TITLE
Reduce compiler crashes

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1351,8 +1351,7 @@ namespace Internal.JitInterface
 
         int FilterException(IntPtr _this, _EXCEPTION_POINTERS* pExceptionPointers)
         {
-            Debug.Assert(false);
-            throw new NotImplementedException();
+            return 0; // EXCEPTION_CONTINUE_SEARCH
         }
 
         void HandleException(IntPtr _this, _EXCEPTION_POINTERS* pExceptionPointers)


### PR DESCRIPTION
There were two heavy hitters on the CoreCLR test suite:
- Uses of RuntimeFieldHandle outside of the limited area we support were crashing the compiler. Moving the detection to the catchall block so that we do whatever we do for other unsupported features.
- FilterException is getting called by JIT when one of the locals in a method refers to a type we couldn't load and JitInterface is throwing an exception.
