### PR TITLE
Formalize nupkg names

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -69,6 +69,17 @@
     <BinDirPlatform Condition="'$(BinDirPlatform)'=='AnyCPU' or '$(BinDirPlatform)'=='amd64'">x64</BinDirPlatform> 
   </PropertyGroup>
 
+  <!-- Initialize the NuPkg name specific RuntimeStr -->
+  <PropertyGroup>
+    <NuPkgRuntimeOS Condition="'$(NuPkgRuntimeOS)'==''">$(OSGroup)</NuPkgRuntimeOS>
+    <NuPkgRuntimeOS Condition="'$(NuPkgRuntimeOS)'=='Windows_NT'">win7</NuPkgRuntimeOS> 
+    <NuPkgRuntimeOS Condition="'$(NuPkgRuntimeOS)'=='Linux'">ubuntu.14.04</NuPkgRuntimeOS> 
+    <NuPkgRuntimeOS Condition="'$(NuPkgRuntimeOS)'=='OSX'">osx.10.10</NuPkgRuntimeOS> 
+
+    <NuPkgRuntimePlatform Condition="'$(NuPkgRuntimePlatform)'==''">$(Platform)</NuPkgRuntimePlatform>
+    <NuPkgRuntimePlatform Condition="'$(NuPkgRuntimePlatform)'=='AnyCPU' or '$(NuPkgRuntimePlatform)'=='amd64'">x64</NuPkgRuntimePlatform> 
+  </PropertyGroup>
+
   <!-- Common repo directories -->
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
@@ -113,11 +124,16 @@
     <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools" />
     <NuGetSourceList Include="https:%2F%2Fwww.nuget.org/api/v2" />
     
-    <NuSpecSrcs Include="$(SourceDir).nuget\toolchain.$(BinDirOSGroup)-$(BinDirPlatform).Microsoft.DotNet.ILCompiler.nuspec" />
-    <NuSpecSrcs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(SourceDir).nuget\toolchain.$(BinDirOSGroup)-$(BinDirPlatform).Microsoft.DotNet.ILCompiler.Development.nuspec" />
+    <!-- Platform agnostic parent NuSpec -->
+    <NuSpecSrcs Include="$(SourceDir).nuget\Microsoft.DotNet.ILCompiler.nuspec" />
+    <NuPkgRuntimeJson Include="$(SourceDir).nuget\runtime.json" />
 
-    <NuSpecs Include="$(ProductPackageDir)toolchain.$(BinDirOSGroup)-$(BinDirPlatform).Microsoft.DotNet.ILCompiler.nuspec" />
-    <NuSpecs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(ProductPackageDir)toolchain.$(BinDirOSGroup)-$(BinDirPlatform).Microsoft.DotNet.ILCompiler.Development.nuspec" />
+    <NuSpecSrcs Include="$(SourceDir).nuget\toolchain.$(NuPkgRuntimeOS)-$(NuPkgRuntimePlatform).Microsoft.DotNet.ILCompiler.nuspec" />
+    <NuSpecSrcs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(SourceDir).nuget\toolchain.$(NuPkgRuntimeOS)-$(NuPkgRuntimePlatform).Microsoft.DotNet.ILCompiler.Development.nuspec" />
+
+    <NuSpecs Include="$(ProductPackageDir)Microsoft.DotNet.ILCompiler.nuspec" />
+    <NuSpecs Include="$(ProductPackageDir)toolchain.$(NuPkgRuntimeOS)-$(NuPkgRuntimePlatform).Microsoft.DotNet.ILCompiler.nuspec" />
+    <NuSpecs Condition="'$(OSGroup)' == 'Windows_NT'" Include="$(ProductPackageDir)toolchain.$(NuPkgRuntimeOS)-$(NuPkgRuntimePlatform).Microsoft.DotNet.ILCompiler.Development.nuspec" />
   </ItemGroup>
 
   <!-- Common nuget properties -->

--- a/src/.nuget/Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/Microsoft.DotNet.ILCompiler.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.ILCompiler</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET Native Toolchain</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides the toolchain to compile managed code to native.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+    <dependencies>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="runtime.json" />
+  </files>
+</package>
+

--- a/src/.nuget/runtime.json
+++ b/src/.nuget/runtime.json
@@ -1,0 +1,20 @@
+{
+  "runtimes": {
+    "win7-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "toolchain.win7-x64.Microsoft.DotNet.ILCompiler": "1.0.0-prerelease"
+      }
+    },
+    "ubuntu.14.04-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler": "1.0.0-prerelease"
+      }
+    },
+    "osx.10.10-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler": "1.0.0-prerelease"
+      }
+    }
+  }
+}
+

--- a/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>toolchain.Linux-x64.Microsoft.DotNet.ILCompiler</id>
+    <id>toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler</id>
     <version>1.0.0-prerelease</version>
     <title>Microsoft .NET Native Toolchain</title>
     <authors>Microsoft</authors>
@@ -45,11 +45,11 @@
     <file src="../ILCompiler.Compiler.dll" target="runtimes/any/lib/dotnet/ILCompiler.Compiler.dll" />
     <file src="../ILCompiler.DependencyAnalysisFramework.dll" target="runtimes/any/lib/dotnet/ILCompiler.DependencyAnalysisFramework.dll" />
     <file src="../ILCompiler.TypeSystem.dll" target="runtimes/any/lib/dotnet/ILCompiler.TypeSystem.dll" />
-    <file src="../lib/libRuntime.a" target="runtimes/Linux-x64/native/sdk/libRuntime.a" />
-    <file src="../lib/libPortableRuntime.a" target="runtimes/Linux-x64/native/sdk/libPortableRuntime.a" />
-    <file src="../lib/libbootstrapper.a" target="runtimes/Linux-x64/native/sdk/libbootstrapper.a" />
-    <file src="../lib/libbootstrappercpp.a" target="runtimes/Linux-x64/native/sdk/libbootstrappercpp.a" />
-    <file src="../lib/libSystem.Private.CoreLib.Native.a" target="runtimes/Linux-x64/native/sdk/libSystem.Private.CoreLib.Native.a" />
-    <file src="../System.Private.Corelib.dll" target="runtimes/Linux-x64/native/sdk/System.Private.Corelib.dll" />
+    <file src="../lib/libRuntime.a" target="runtimes/osx.10.10-x64/native/sdk/libRuntime.a" />
+    <file src="../lib/libPortableRuntime.a" target="runtimes/osx.10.10-x64/native/sdk/libPortableRuntime.a" />
+    <file src="../lib/libbootstrapper.a" target="runtimes/osx.10.10-x64/native/sdk/libbootstrapper.a" />
+    <file src="../lib/libbootstrappercpp.a" target="runtimes/osx.10.10-x64/native/sdk/libbootstrappercpp.a" />
+    <file src="../lib/libSystem.Private.CoreLib.Native.a" target="runtimes/osx.10.10-x64/native/sdk/libSystem.Private.CoreLib.Native.a" />
+    <file src="../System.Private.Corelib.dll" target="runtimes/osx.10.10-x64/native/sdk/System.Private.Corelib.dll" />
   </files>
 </package>

--- a/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>toolchain.Windows_NT-x64.Microsoft.DotNet.ILCompiler</id>
+    <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler</id>
     <version>1.0.0-prerelease</version>
     <title>Microsoft .NET Native Toolchain</title>
     <authors>Microsoft</authors>
@@ -41,14 +41,15 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\ilc.exe" target="runtimes\any\lib\dotnet\ilc.exe" />
-    <file src="..\ILCompiler.Compiler.dll" target="runtimes\any\lib\dotnet\ILCompiler.Compiler.dll" />
-    <file src="..\ILCompiler.DependencyAnalysisFramework.dll" target="runtimes\any\lib\dotnet\ILCompiler.DependencyAnalysisFramework.dll" />
-    <file src="..\ILCompiler.TypeSystem.dll" target="runtimes\any\lib\dotnet\ILCompiler.TypeSystem.dll" />
-    <file src="..\lib\Runtime.lib" target="runtimes\win7-x64\native\sdk\Runtime.lib" />
-    <file src="..\lib\PortableRuntime.lib" target="runtimes\win7-x64\native\sdk\PortableRuntime.lib" />
-    <file src="..\lib\bootstrapper.lib" target="runtimes\win7-x64\native\sdk\bootstrapper.lib" />
-    <file src="..\lib\bootstrappercpp.lib" target="runtimes\win7-x64\native\sdk\bootstrappercpp.lib" />
-    <file src="..\System.Private.Corelib.dll" target="runtimes\win7-x64\native\sdk\System.Private.Corelib.dll" />
+    <file src="../ilc.exe" target="runtimes/any/lib/dotnet/ilc.exe" />
+    <file src="../ILCompiler.Compiler.dll" target="runtimes/any/lib/dotnet/ILCompiler.Compiler.dll" />
+    <file src="../ILCompiler.DependencyAnalysisFramework.dll" target="runtimes/any/lib/dotnet/ILCompiler.DependencyAnalysisFramework.dll" />
+    <file src="../ILCompiler.TypeSystem.dll" target="runtimes/any/lib/dotnet/ILCompiler.TypeSystem.dll" />
+    <file src="../lib/libRuntime.a" target="runtimes/ubuntu.14.04-x64/native/sdk/libRuntime.a" />
+    <file src="../lib/libPortableRuntime.a" target="runtimes/ubuntu.14.04-x64/native/sdk/libPortableRuntime.a" />
+    <file src="../lib/libbootstrapper.a" target="runtimes/ubuntu.14.04-x64/native/sdk/libbootstrapper.a" />
+    <file src="../lib/libbootstrappercpp.a" target="runtimes/ubuntu.14.04-x64/native/sdk/libbootstrappercpp.a" />
+    <file src="../lib/libSystem.Private.CoreLib.Native.a" target="runtimes/ubuntu.14.04-x64/native/sdk/libSystem.Private.CoreLib.Native.a" />
+    <file src="../System.Private.Corelib.dll" target="runtimes/ubuntu.14.04-x64/native/sdk/System.Private.Corelib.dll" />
   </files>
 </package>

--- a/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>toolchain.Windows_NT-x64.Microsoft.DotNet.ILCompiler.Development</id>
+    <id>toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development</id>
     <version>1.0.0-prerelease</version>
     <title>Microsoft .NET Native Toolchain - Development Version</title>
     <authors>Microsoft</authors>

--- a/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>toolchain.OSX-x64.Microsoft.DotNet.ILCompiler</id>
+    <id>toolchain.win7-x64.Microsoft.DotNet.ILCompiler</id>
     <version>1.0.0-prerelease</version>
     <title>Microsoft .NET Native Toolchain</title>
     <authors>Microsoft</authors>
@@ -41,15 +41,14 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="../ilc.exe" target="runtimes/any/lib/dotnet/ilc.exe" />
-    <file src="../ILCompiler.Compiler.dll" target="runtimes/any/lib/dotnet/ILCompiler.Compiler.dll" />
-    <file src="../ILCompiler.DependencyAnalysisFramework.dll" target="runtimes/any/lib/dotnet/ILCompiler.DependencyAnalysisFramework.dll" />
-    <file src="../ILCompiler.TypeSystem.dll" target="runtimes/any/lib/dotnet/ILCompiler.TypeSystem.dll" />
-    <file src="../lib/libRuntime.a" target="runtimes/OSX-x64/lib/dotnet/native/sdk/libRuntime.a" />
-    <file src="../lib/libPortableRuntime.a" target="runtimes/OSX-x64/native/sdk/libPortableRuntime.a" />
-    <file src="../lib/libbootstrapper.a" target="runtimes/OSX-x64/native/sdk/libbootstrapper.a" />
-    <file src="../lib/libbootstrappercpp.a" target="runtimes/OSX-x64/native/sdk/libbootstrappercpp.a" />
-    <file src="../lib/libSystem.Private.CoreLib.Native.a" target="runtimes/OSX-x64/native/sdk/libSystem.Private.CoreLib.Native.a" />
-    <file src="../System.Private.Corelib.dll" target="runtimes/OSX-x64/native/sdk/System.Private.Corelib.dll" />
+    <file src="..\ilc.exe" target="runtimes\any\lib\dotnet\ilc.exe" />
+    <file src="..\ILCompiler.Compiler.dll" target="runtimes\any\lib\dotnet\ILCompiler.Compiler.dll" />
+    <file src="..\ILCompiler.DependencyAnalysisFramework.dll" target="runtimes\any\lib\dotnet\ILCompiler.DependencyAnalysisFramework.dll" />
+    <file src="..\ILCompiler.TypeSystem.dll" target="runtimes\any\lib\dotnet\ILCompiler.TypeSystem.dll" />
+    <file src="..\lib\Runtime.lib" target="runtimes\win7-x64\native\sdk\Runtime.lib" />
+    <file src="..\lib\PortableRuntime.lib" target="runtimes\win7-x64\native\sdk\PortableRuntime.lib" />
+    <file src="..\lib\bootstrapper.lib" target="runtimes\win7-x64\native\sdk\bootstrapper.lib" />
+    <file src="..\lib\bootstrappercpp.lib" target="runtimes\win7-x64\native\sdk\bootstrappercpp.lib" />
+    <file src="..\System.Private.Corelib.dll" target="runtimes\win7-x64\native\sdk\System.Private.Corelib.dll" />
   </files>
 </package>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -32,6 +32,7 @@
 
   <Target Name="BuildNuGetPackages" Condition="'$(BuildNugetPackage)' != 'false'" AfterTargets="RenameILCompiler">
     <MakeDir Directories="$(ProductPackageDir)" Condition="!Exists('$(ProductPackageDir)')" />
+    <Copy SourceFiles="@(NuPkgRuntimeJson)" DestinationFolder="$(ProductPackageDir)" />
     <Copy SourceFiles="@(NuSpecSrcs)" DestinationFolder="$(ProductPackageDir)" />
     <Exec Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(ProductPackageDir)&quot;" />
   </Target>

--- a/tests/restore.cmd
+++ b/tests/restore.cmd
@@ -6,7 +6,7 @@ if not defined CoreRT_BuildOS set CoreRT_BuildOS=Windows_NT
 if not defined CoreRT_BuildArch ((call :Fail "Set CoreRT_BuildArch to x86/x64/arm") & exit /b -1)
 if not defined CoreRT_BuildType ((call :Fail "Set CoreRT_BuildType to Debug or Release") & exit /b -1)
 
-set CoreRT_ToolchainPkg=toolchain.%CoreRT_BuildOS%-%CoreRT_BuildArch%.Microsoft.DotNet.ILCompiler.Development
+set CoreRT_ToolchainPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.ILCompiler.Development
 set CoreRT_ToolchainVer=1.0.0-prerelease
 set CoreRT_AppDepSdkPkg=Microsoft.DotNet.AppDep
 set CoreRT_AppDepSdkVer=1.0.0-prerelease


### PR DESCRIPTION
@gkhanna79, PTAL. Redirection package to help @brthor just look at one version of our package. Note, that I've changed the name of the base redirection package to be "Microsoft.DotNet.ILCompiler". Also changed the OS specific names for each runtime.
