### PR TITLE
[WIP] Generate multiple source files for CPPCodegen

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -39,6 +39,10 @@ namespace ILCompiler
         Dictionary<TypeDesc, RegisteredType> _registeredTypes = new Dictionary<TypeDesc, RegisteredType>();
         Dictionary<MethodDesc, RegisteredMethod> _registeredMethods = new Dictionary<MethodDesc, RegisteredMethod>();
         Dictionary<FieldDesc, RegisteredField> _registeredFields = new Dictionary<FieldDesc, RegisteredField>();
+        Dictionary<EcmaModule, TextWriter> _codegenWritersCpp = new Dictionary<EcmaModule, TextWriter>();
+        EcmaModule _moduleEntryPoint = null;
+        string _outPathCpp = null;
+
         List<MethodDesc> _methodsThatNeedsCompilation = null;
 
         NameMangler _nameMangler = null;
@@ -85,6 +89,30 @@ namespace ILCompiler
         {
             get;
             set;
+        }
+
+        public EcmaModule EntryPointModule
+        {
+            get
+            {
+                return _moduleEntryPoint;
+            }
+            set
+            {
+                _moduleEntryPoint = value;
+            }
+        }
+
+        public string CPPOutPath
+        {
+            get
+            {
+                return _outPathCpp;
+            }
+            set
+            {
+                _outPathCpp = value;
+            }
         }
 
         MethodDesc _mainMethod;
@@ -607,6 +635,102 @@ namespace ILCompiler
                 _rvaFieldDatas.Add(field, result = new RvaFieldData(this, field));
             }
             return result;
+        }
+
+        // Returns the TextWriter to be used for generating code for the specified type.
+        public TextWriter GetOutWriterForType(TypeDesc type)
+        {
+            TextWriter swRetVal = null;
+            TypeDesc typeToWorkWith = GetActualTypeFromTypeDesc(type);
+
+            // Get the Module in which the type is defined
+            EcmaModule moduleType = ((EcmaType)typeToWorkWith).Module;
+
+            // And get the writer for the module
+            swRetVal = GetOutWriterForModule(moduleType);
+
+            return swRetVal;
+        }
+
+        private TypeDesc GetActualTypeFromTypeDesc(TypeDesc type)
+        {
+            if (type is EcmaType)
+            {
+                // Ecma types represent the actual type we need to work with.
+                return type;
+            }
+            else if (type is ArrayType)
+            {
+                // ElementType represents the actual type of the array
+                return GetActualTypeFromTypeDesc(((ArrayType)type).ElementType);
+            }
+            else if ((type is ByRefType) || (type is PointerType))
+            {
+                // We are dealing with a non-ArrayType parameterized type
+                return GetActualTypeFromTypeDesc(((ParameterizedType)type).ParameterType);
+            }
+            else
+            {
+                // This is the case of generic instanatiation, so we will
+                // extract the actual type from typeDefinition.
+                return GetActualTypeFromTypeDesc(type.GetTypeDefinition());
+            }
+        }
+
+        // Returns the TextWriter, corresponding to the specified module, from the Dictionary maintained
+        // by the Compilation instance. If the Module is not found in the Dictionary, it implies we are seeing
+        // it for the first time and thus, a new Textwriter would be created for it and the pair (of Module/TextWriter)
+        // will be inserted into the Dictionary.
+        public TextWriter GetOutWriterForModule(EcmaModule moduleType)
+        {
+            TextWriter swRetVal = null;
+
+            // Check if we have the writer for the module already
+            if (!_codegenWritersCpp.TryGetValue(moduleType, out swRetVal))
+            {
+                // Create a stream writer for the module that will write to a <modulename>.cpp file
+                // in CPPOutPath
+                string outpathCpp = Path.Combine(CPPOutPath, moduleType.GetName().Name + ".cpp");
+                swRetVal = new StreamWriter(File.Create(outpathCpp));
+
+                // Update the dictionary with the mapping details
+                _codegenWritersCpp.Add(moduleType, swRetVal);
+
+                // Insert include statements in the source file 
+                swRetVal.WriteLine("#include \"common.h\"");
+                swRetVal.WriteLine("#include \"appdependency.h\"");
+                swRetVal.WriteLine();
+            }
+            
+            return swRetVal;
+        }
+
+        // Returns the TextWriter for a specified method, based upon its owning type.
+        public TextWriter GetOutWriterForMethod(MethodDesc method)
+        {
+            TypeDesc typeContainingMethod = method.OwningType;
+            TextWriter swMethod = GetOutWriterForType(typeContainingMethod);
+
+            return swMethod;
+        }
+
+        public Dictionary<EcmaModule, TextWriter> CppCodegenWriters
+        {
+            get
+            {
+                return _codegenWritersCpp;
+            }
+        }
+
+        public void DisposeCppOutWriters()
+        {
+            if (_codegenWritersCpp != null)
+            {
+                foreach(KeyValuePair<EcmaModule, TextWriter> outWriter in _codegenWritersCpp)
+                {
+                    outWriter.Value.Dispose();
+                }
+            }
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -395,7 +395,9 @@ namespace ILCompiler.CppCodeGen
         // Base classes and valuetypes has to be emitted before they are used.
         HashSet<RegisteredType> _emittedTypes;
 
-        void OutputTypes(bool full)
+        // Writes the type details (minimal or detailed) to the specified writer (which points to a source file
+        // corresponding to an EcmaModule).
+        void OutputTypes(bool full, TextWriter outWriter)
         {
             if (full)
             {
@@ -417,35 +419,35 @@ namespace ILCompiler.CppCodeGen
                 if (_emittedTypes != null && _emittedTypes.Contains(t))
                     continue;
 
-                OutputType(t, full);
+                OutputType(t, full, outWriter);
             }
             if (full)
                 _emittedTypes = null;
 
             if (full)
             {
-                Out.WriteLine();
-                Out.WriteLine("struct {");
-                Out.Write(_statics.ToString());
-                Out.WriteLine("} __statics;");
+                outWriter.WriteLine();
+                outWriter.WriteLine("static struct {");
+                outWriter.Write(_statics.ToString());
+                outWriter.WriteLine("} __statics;");
 
                 // TODO: Register GC statics with GC
-                Out.WriteLine();
-                Out.WriteLine("struct {");
-                Out.Write(_gcStatics.ToString());
-                Out.WriteLine("} __gcStatics;");
+                outWriter.WriteLine();
+                outWriter.WriteLine("static struct {");
+                outWriter.Write(_gcStatics.ToString());
+                outWriter.WriteLine("} __gcStatics;");
 
-                Out.WriteLine();
+                outWriter.WriteLine();
                 // @TODO_SDM: do for real - note: the 'extra' series are just testing the init syntax for 0-length arrays, they should be removed
                 // TODO: preinitialized 0-length arrays are not supported in CLang
-                Out.WriteLine("#ifdef _MSC_VER");
-                Out.WriteLine("StaticGcDesc __gcStaticsDescs = { 1, { { sizeof(__gcStatics), 0 }, { 123, 456 }, { 789, 101112 } } };");
-                Out.WriteLine("#else");
-                Out.WriteLine("StaticGcDesc __gcStaticsDescs;");
-                Out.WriteLine("#endif");
+                outWriter.WriteLine("#ifdef _MSC_VER");
+                outWriter.WriteLine("static StaticGcDesc __gcStaticsDescs = { 1, { { sizeof(__gcStatics), 0 }, { 123, 456 }, { 789, 101112 } } };");
+                outWriter.WriteLine("#else");
+                outWriter.WriteLine("static StaticGcDesc __gcStaticsDescs;");
+                outWriter.WriteLine("#endif");
 
-                Out.WriteLine();
-                Out.WriteLine("SimpleModuleHeader __module = { &__gcStatics, &__gcStaticsDescs };");
+                outWriter.WriteLine();
+                outWriter.WriteLine("static SimpleModuleHeader __module = { &__gcStatics, &__gcStaticsDescs };");
 
 
                 _statics = null;
@@ -455,7 +457,7 @@ namespace ILCompiler.CppCodeGen
             }
         }
 
-        void OutputType(RegisteredType t, bool full)
+        void OutputType(RegisteredType t, bool full, TextWriter outWriterOverride = null)
         {
             if (_emittedTypes != null)
             {
@@ -467,7 +469,7 @@ namespace ILCompiler.CppCodeGen
                         var baseRegistration = _compilation.GetRegisteredType(baseType);
                         if (!_emittedTypes.Contains(baseRegistration))
                         {
-                            OutputType(baseRegistration, full);
+                            OutputType(baseRegistration, full, outWriterOverride);
                         }
                     }
                 }
@@ -483,12 +485,19 @@ namespace ILCompiler.CppCodeGen
                         var fieldTypeRegistration = _compilation.GetRegisteredType(fieldType);
                         if (!_emittedTypes.Contains(fieldTypeRegistration))
                         {
-                            OutputType(fieldTypeRegistration, full);
+                            OutputType(fieldTypeRegistration, full, outWriterOverride);
                         }
                     }
                 }
 
                 _emittedTypes.Add(t);
+            }
+
+            // Get the StreamWriter for the type, unless it was overridden by the caller.
+            TextWriter swType = outWriterOverride;
+            if (swType == null)
+            {
+                swType = _compilation.GetOutWriterForType(t.Type);
             }
 
             string mangledName = GetCppTypeName(t.Type);
@@ -501,7 +510,7 @@ namespace ILCompiler.CppCodeGen
                 if (sep < 0)
                     break;
 
-                Out.Write("namespace " + mangledName.Substring(current, sep - current) + " { ");
+                swType.Write("namespace " + mangledName.Substring(current, sep - current) + " { ");
                 current = sep + 2;
 
                 nesting++;
@@ -509,19 +518,19 @@ namespace ILCompiler.CppCodeGen
 
             if (full)
             {
-                Out.Write("class " + mangledName.Substring(current));
+                swType.Write("class " + mangledName.Substring(current));
                 if (!t.Type.IsValueType)
                 {
                     var baseType = t.Type.BaseType;
                     if (baseType != null)
                     {
-                        Out.Write(" : public " + GetCppTypeName(baseType));
+                        swType.Write(" : public " + GetCppTypeName(baseType));
                     }
                 }
-                Out.WriteLine(" { public:");
+                swType.WriteLine(" { public:");
                 if (t.IncludedInCompilation)
                 {
-                    Out.WriteLine("static MethodTable * __getMethodTable();");
+                    swType.WriteLine("static MethodTable * __getMethodTable();");
                 }
                 if (t.VirtualSlots != null)
                 {
@@ -538,12 +547,12 @@ namespace ILCompiler.CppCodeGen
                     for (int slot = 0; slot < t.VirtualSlots.Count; slot++)
                     {
                         MethodDesc virtualMethod = t.VirtualSlots[slot];
-                        Out.WriteLine(GetCodeForVirtualMethod(virtualMethod, baseSlots + slot));
+                        swType.WriteLine(GetCodeForVirtualMethod(virtualMethod, baseSlots + slot));
                     }
                 }
                 if (t.Type.IsDelegate)
                 {
-                    Out.WriteLine(GetCodeForDelegate(t.Type));
+                    swType.WriteLine(GetCodeForDelegate(t.Type));
                 }
                 foreach (var field in t.Type.GetFields())
                 {
@@ -568,7 +577,7 @@ namespace ILCompiler.CppCodeGen
                     }
                     else
                     {
-                        Out.WriteLine(GetCppSignatureTypeName(field.FieldType) + " " + GetCppFieldName(field) + ";");
+                        swType.WriteLine(GetCppSignatureTypeName(field.FieldType) + " " + GetCppFieldName(field) + ";");
                     }
                 }
                 if (t.Type.GetMethod(".cctor", null) != null)
@@ -581,27 +590,28 @@ namespace ILCompiler.CppCodeGen
                     foreach (var m in t.Methods)
                     {
                         if (m.IncludedInCompilation)
-                            OutputMethod(m);
+                            OutputMethod(m, swType);
                     }
                 }
-                Out.Write("};");
+                swType.Write("};");
             }
             else
             {
-                Out.Write("class " + mangledName.Substring(current) + ";");
+                swType.Write("class " + mangledName.Substring(current) + ";");
             }
 
             while (nesting > 0)
             {
-                Out.Write(" };");
+                swType.Write(" };");
                 nesting--;
             }
-            Out.WriteLine();
+            swType.WriteLine();
         }
 
-        void OutputMethod(RegisteredMethod m)
+        void OutputMethod(RegisteredMethod m, TextWriter outWriterMethod)
         {
-            Out.WriteLine(GetCppMethodDeclaration(m.Method, false));
+            // Write the method declaration to the specified writer
+            outWriterMethod.WriteLine(GetCppMethodDeclaration(m.Method, false));
         }
 
         void AppendSlotTypeDef(StringBuilder sb, MethodDesc method)
@@ -821,19 +831,19 @@ namespace ILCompiler.CppCodeGen
                     AddInstanceFields(t.Type);
             }
 
-            Out.WriteLine("#include \"common.h\"");
-            Out.WriteLine();
+            // Write common prototypes and include information
+            // for cross module references in a header
+            GenerateCrossModuleReferenceHeader();
 
-            OutputTypes(false);
-            Out.WriteLine();
-            OutputTypes(true);
-            Out.WriteLine();
-
+            // Generate the code for the sources files we have generated
             foreach (var t in _compilation.RegisteredTypes)
             {
+                // Get the writer for the type
+                TextWriter swOut = _compilation.GetOutWriterForType(t.Type);
+
                 if (t.IncludedInCompilation)
                 {
-                    Out.WriteLine(GetCodeForType(t.Type));
+                    swOut.WriteLine(GetCodeForType(t.Type));
                 }
 
                 if (t.Methods != null)
@@ -841,7 +851,9 @@ namespace ILCompiler.CppCodeGen
                     foreach (var m in t.Methods)
                     {
                         if (m.MethodCode != null)
-                            Out.WriteLine(m.MethodCode);
+                        {
+                            swOut.WriteLine(m.MethodCode);
+                        }
                     }
                 }
             }
@@ -880,7 +892,27 @@ namespace ILCompiler.CppCodeGen
                 Out.WriteLine("}");
             }
 
-            Out.Dispose();
+            // Dispose all generated Streamwriters from compilation
+            _compilation.DisposeCppOutWriters();
+        }
+
+        private void GenerateCrossModuleReferenceHeader()
+        {
+            // Form the path where the header will be generated.
+            string pathHeader = Path.Combine(_compilation.CPPOutPath, "appdependency.h");
+            TextWriter outHeader = new StreamWriter(File.Create(pathHeader));
+            outHeader.WriteLine("// This is a compile-time generated file and any changes made to it will be lost after the next compilation.");
+            outHeader.WriteLine();
+
+            // Write out the basic prototypes
+            OutputTypes(false, outHeader);
+            outHeader.WriteLine();
+            
+            // Now write the detailed type definitions alongwith information about statics, GC statics, etc
+            OutputTypes(true, outHeader);
+            outHeader.WriteLine();
+
+            outHeader.Dispose();
         }
     }
 }

--- a/src/ILCompiler/reproNative/reproNativeCpp.vcxproj
+++ b/src/ILCompiler/reproNative/reproNativeCpp.vcxproj
@@ -97,6 +97,12 @@
     <ClCompile Include="..\..\Native\Bootstrap\main.cpp" />
     <ClCompile Include="..\..\Native\Bootstrap\platform.windows.cpp" />
     <ClCompile Include="repro.cpp" />
+    <ClCompile Include="System.Console.cpp" />
+    <ClCompile Include="System.IO.cpp" />
+    <ClCompile Include="System.Private.CoreLib.cpp" />
+    <ClCompile Include="System.Private.Interop.cpp" />
+    <ClCompile Include="System.Private.Threading.cpp" />
+    <ClCompile Include="System.Resources.ResourceManager.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -124,8 +124,15 @@ namespace ILCompiler
             compilation.OutputPath = _outputPath;
             if (_options.IsCppCodeGen)
             {
+                // Set the entrypoint module
+                compilation.EntryPointModule = entryPointModule;
+
+                // Set the default output path for CPPCodgen
+                compilation.CPPOutPath = Path.GetDirectoryName(_outputPath);
+
                 // Don't set Out when using object writer which is handled by LLVM.
-                compilation.Out = new StreamWriter(File.Create(_outputPath));
+                // Set the writer corresponding to the entrypoint module.
+                compilation.Out = compilation.GetOutWriterForModule(entryPointModule); 
             }
 
             compilation.CompileSingleFile(entryPointMethod);


### PR DESCRIPTION
This PR will allow CPPCodegen mode to generate multiple source files, corresponding to the various assemblies involved in an app compilation, that contain source code for the types from the respective assemblies.

The -out parameter should now contain the path in which to generate the source files. 

@jkotas PTAL. 