### PR TITLE
Make Runtime.Base compile with ilc

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -92,7 +92,7 @@ namespace ILCompiler.DependencyAnalysis
                         // We need to trigger the cctor before returning the base
                         encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.TypeCctorContextSymbol((MetadataType)Helper.Target));
                         encoder.EmitLEAQ(encoder.TargetRegister.Arg1, factory.TypeNonGCStaticsSymbol((MetadataType)Helper.Target));
-                        encoder.EmitJMP(factory.WellKnownEntrypoint(WellKnownEntrypoint.EnsureClassConstructorRunAndReturnNonGCStaticBase));
+                        encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnNonGCStaticBase));
                     }
                     break;
 
@@ -117,7 +117,7 @@ namespace ILCompiler.DependencyAnalysis
                         AddrMode loadFromRdx = new AddrMode(encoder.TargetRegister.Arg1, null, 0, 0, AddrModeSize.Int64);
                         encoder.EmitMOV(encoder.TargetRegister.Arg1, ref loadFromRdx);
                         encoder.EmitMOV(encoder.TargetRegister.Arg1, ref loadFromRdx);
-                        encoder.EmitJMP(factory.WellKnownEntrypoint(WellKnownEntrypoint.EnsureClassConstructorRunAndReturnGCStaticBase));
+                        encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnGCStaticBase));
                     }
                     break;
 

--- a/src/ILCompiler.Compiler/src/Compiler/MethodExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MethodExtensions.cs
@@ -72,18 +72,11 @@ namespace ILCompiler
                 return SpecialMethodKind.PInvoke;
             }
 
-            if (method is EcmaMethod)
+            if (method.HasCustomAttribute("System.Runtime", "RuntimeImportAttribute"))
             {
-                if (method.HasCustomAttribute("System.Runtime", "RuntimeImportAttribute"))
-                {
-                    return SpecialMethodKind.RuntimeImport;
-                }
-                else if (method.HasCustomAttribute("System.Runtime.InteropServices", "NativeCallableAttribute"))
-                {
-                    // TODO: add reverse pinvoke callout
-                    throw new NotImplementedException();
-                }
+                return SpecialMethodKind.RuntimeImport;
             }
+
             return SpecialMethodKind.Unknown;
         }
     }

--- a/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -87,7 +87,13 @@ namespace System.Runtime
 
     public unsafe static class EH
     {
-        internal static UIntPtr c_maxSP = new UIntPtr(unchecked((void*)(ulong)-1L));
+        internal static UIntPtr MaxSP
+        {
+            get
+            {
+                return new UIntPtr(unchecked((void*)(ulong)-1L));
+            }
+        }
 
         private enum RhEHClauseKind
         {
@@ -122,8 +128,8 @@ namespace System.Runtime
                         (codeOffset < _tryEndOffset));
             }
         }
-        [StructLayout(LayoutKind.Explicit, Size = AsmOffsets.SIZEOF__EHEnum)]
 
+        [StructLayout(LayoutKind.Explicit, Size = AsmOffsets.SIZEOF__EHEnum)]
         private struct EHEnum
         {
             [FieldOffset(0)]
@@ -199,7 +205,7 @@ namespace System.Runtime
         }
 
 #if ARM
-        const int c_IPAdjustForHardwareFault = 2;
+        private const int c_IPAdjustForHardwareFault = 2;
 #else
         private const int c_IPAdjustForHardwareFault = 1;
 #endif
@@ -420,6 +426,7 @@ namespace System.Runtime
             BinderIntrinsics.TailCall_RhpThrowEx(e);
         }
 
+#if !CORERT
         private static OutOfMemoryException s_theOOMException = new OutOfMemoryException();
 
         // Rtm exports GetRuntimeException for the few cases where we have a helper that throws an exception
@@ -451,6 +458,7 @@ namespace System.Runtime
                     return null;
             }
         }
+#endif
 
         private enum HwExceptionCode : uint
         {
@@ -654,7 +662,7 @@ namespace System.Runtime
             // First pass
             //
             // ------------------------------------------------
-            UIntPtr handlingFrameSP = c_maxSP;
+            UIntPtr handlingFrameSP = MaxSP;
             byte* pCatchHandler = null;
             uint catchingTryRegionIdx = MaxTryRegionIdx;
 
@@ -763,7 +771,7 @@ namespace System.Runtime
         [System.Diagnostics.Conditional("DEBUG")]
         private static void DebugVerifyHandlingFrame(UIntPtr handlingFrameSP)
         {
-            Debug.Assert(handlingFrameSP != c_maxSP, "Handling frame must have an SP value");
+            Debug.Assert(handlingFrameSP != MaxSP, "Handling frame must have an SP value");
             Debug.Assert(((UIntPtr*)handlingFrameSP) > &handlingFrameSP,
                 "Handling frame must have a valid stack frame pointer");
         }

--- a/src/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -845,34 +845,41 @@ namespace System.Runtime
         static private unsafe bool ArePrimitveTypesEquivalentSize(EEType* pType1, EEType* pType2)
         {
             CorElementType sourceCorType = pType1->CorElementType;
-            int sourcePrimitiveTypeEquivalenceSize = s_CorElementTypeIntegralSizeCompareArray[(int)sourceCorType];
+            int sourcePrimitiveTypeEquivalenceSize = GetIntegralTypeMatchSize(sourceCorType);
 
             // Quick check to see if the first type is even primitive.
             if (sourcePrimitiveTypeEquivalenceSize == 0)
                 return false;
+
             CorElementType targetCorType = pType2->CorElementType;
-            int targetPrimitiveTypeEquivalenceSize = s_CorElementTypeIntegralSizeCompareArray[(int)targetCorType];
+            int targetPrimitiveTypeEquivalenceSize = GetIntegralTypeMatchSize(targetCorType);
 
             return sourcePrimitiveTypeEquivalenceSize == targetPrimitiveTypeEquivalenceSize;
         }
 
-        private unsafe static int[] ComputeCorElementTypeIntegralSizeMatchArray()
+        private unsafe static int GetIntegralTypeMatchSize(CorElementType corType)
         {
-            int[] result = new int[(int)CorElementType.ELEMENT_TYPE_MAX];
-            result[(int)CorElementType.ELEMENT_TYPE_I1] = 1;
-            result[(int)CorElementType.ELEMENT_TYPE_U1] = 1;
-            result[(int)CorElementType.ELEMENT_TYPE_I2] = 2;
-            result[(int)CorElementType.ELEMENT_TYPE_U2] = 2;
-            result[(int)CorElementType.ELEMENT_TYPE_I4] = 4;
-            result[(int)CorElementType.ELEMENT_TYPE_U4] = 4;
-            result[(int)CorElementType.ELEMENT_TYPE_I8] = 8;
-            result[(int)CorElementType.ELEMENT_TYPE_U8] = 8;
-            result[(int)CorElementType.ELEMENT_TYPE_I] = sizeof(IntPtr);
-            result[(int)CorElementType.ELEMENT_TYPE_U] = sizeof(IntPtr);
-            return result;
+            switch (corType)
+            {
+                case CorElementType.ELEMENT_TYPE_I1:
+                case CorElementType.ELEMENT_TYPE_U1:
+                    return 1;
+                case CorElementType.ELEMENT_TYPE_I2:
+                case CorElementType.ELEMENT_TYPE_U2:
+                    return 2;
+                case CorElementType.ELEMENT_TYPE_I4:
+                case CorElementType.ELEMENT_TYPE_U4:
+                    return 4;
+                case CorElementType.ELEMENT_TYPE_I8:
+                case CorElementType.ELEMENT_TYPE_U8:
+                    return 8;
+                case CorElementType.ELEMENT_TYPE_I:
+                case CorElementType.ELEMENT_TYPE_U:
+                    return sizeof(IntPtr);
+                default:
+                    return 0;
+            }
         }
-
-        private static int[] s_CorElementTypeIntegralSizeCompareArray = ComputeCorElementTypeIntegralSizeMatchArray();
 
         // copied from CorHdr.h
         internal enum CorElementType : byte

--- a/src/Runtime.Base/src/System/Runtime/__Finalizer.cs
+++ b/src/Runtime.Base/src/System/Runtime/__Finalizer.cs
@@ -14,7 +14,7 @@ namespace System.Runtime
     // We choose this name to avoid clashing with any future public class with the name Finalizer. 
     public static class __Finalizer
     {
-        private static bool s_fHaveNewClasslibs = false;
+        private static bool s_fHaveNewClasslibs /* = false */;
 
         [NativeCallable(EntryPoint = "ProcessFinalizers", CallingConvention = CallingConvention.Cdecl)]
         public static void ProcessFinalizers()

--- a/src/Runtime.Base/src/System/RuntimeHandles.cs
+++ b/src/Runtime.Base/src/System/RuntimeHandles.cs
@@ -7,12 +7,11 @@
 
 namespace System
 {
-    // This type will be used only for static fields.  It will simply be the address of the static field in 
-    // the loaded PE image.
-    internal unsafe struct RuntimeFieldHandle
+    internal struct RuntimeFieldHandle
     {
-#pragma warning disable 649 // Field 'blah' is never assigned to, and will always have its default value
-        internal byte* m_pbStaticFieldData;
-#pragma warning restore
+    }
+
+    internal struct RuntimeMethodHandle
+    {
     }
 }


### PR DESCRIPTION
- Add -systemmodule command line option that allows specification of the system module
- Root RuntimeExport methods for compilation
- Change the static constructor helpers to be looked up lazily in ReadyToRunHelperNode
- Fix up a few places in Runtime.Base that used to need static constructors
