### PR TITLE
Add CachingMetadataStringDecoder

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/CachingMetadataStringDecoder.cs
+++ b/src/Common/src/TypeSystem/Ecma/CachingMetadataStringDecoder.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
+using Debug = System.Diagnostics.Debug;
+
+using Internal.NativeFormat;
+
+namespace Internal.TypeSystem.Ecma
+{
+    /// <summary>
+    /// MetadataReader string decoder that caches and reuses strings rather than allocating
+    /// on each call to MetadataReader.GetString(handle).
+    /// Safe to use from multiple threads and lock free.
+    /// </summary>
+    public sealed class CachingMetadataStringDecoder : MetadataStringDecoder
+    {
+        private struct Entry
+        {
+            // hash code of the entry
+            public int HashCode;
+
+            // full text of the item
+            public string Text;
+        }
+
+        // TODO: Tune the bucket size
+        private const int BucketSize = 4;
+
+        // The table of cached entries. The size of the table has to be power of 2.
+        private Entry[] _table;
+
+        // The next candidate in the bucket range for eviction
+        private int _evictionHint;
+
+        public CachingMetadataStringDecoder(int size)
+            : base(System.Text.Encoding.UTF8)
+        {
+            // Verify that the size is power of 2
+            Debug.Assert((size & (size - 1)) == 0);
+
+            _table = new Entry[size];
+        }
+
+        private string Find(int hashCode, string s)
+        {
+            var arr = _table;
+            int mask = _table.Length - 1;
+
+            int idx = hashCode & mask;
+
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            for (int i = 1; i < BucketSize + 1; i++)
+            {
+                string e = arr[idx].Text;
+                int hash = arr[idx].HashCode;
+
+                if (e == null)
+                {
+                    // once we see unfilled entry, the rest of the bucket will be empty
+                    break;
+                }
+
+                if (hash == hashCode && s == e)
+                {
+                    return e;
+                }
+
+                idx = (idx + i) & mask;
+            }
+            return null;
+        }
+
+        private unsafe string FindASCII(int hashCode, byte* bytes, int byteCount)
+        {
+            var arr = _table;
+            int mask = _table.Length - 1;
+
+            int idx = hashCode & mask;
+
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            for (int i = 1; i < BucketSize + 1; i++)
+            {
+                string e = arr[idx].Text;
+                int hash = arr[idx].HashCode;
+
+                if (e == null)
+                {
+                    // once we see unfilled entry, the rest of the bucket will be empty
+                    break;
+                }
+
+                if (hash == hashCode && TextEqualsASCII(e, bytes, byteCount))
+                {
+                    return e;
+                }
+
+                idx = (idx + i) & mask;
+            }
+            return null;
+        }
+
+        private static unsafe bool TextEqualsASCII(string text, byte* ascii, int length)
+        {
+#if DEBUG
+            for (var i = 0; i < length; i++)
+            {
+                Debug.Assert((ascii[i] & 0x80) == 0, "The byte* input to this method must be valid ASCII.");
+            }
+#endif
+
+            if (length != text.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < length; i++)
+            {
+                if (ascii[i] != text[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private string Add(int hashCode, string s)
+        {
+            var arr = _table;
+            int mask = _table.Length - 1;
+
+            int idx = hashCode & mask;
+
+            // try finding an empty spot in the bucket
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            int curIdx = idx;
+            for (int i = 1; i < BucketSize + 1; i++)
+            {
+                if (arr[curIdx].Text == null)
+                {
+                    idx = curIdx;
+                    goto foundIdx;
+                }
+
+                curIdx = (curIdx + i) & BucketSize;
+            }
+
+            // or pick a victim within the bucket range
+            // and replace with new entry
+            var i1 = _evictionHint++ & (BucketSize - 1);
+            idx = (idx + ((i1 * i1 + i1) / 2)) & mask;
+
+        foundIdx:
+            arr[idx].HashCode = hashCode;
+            arr[idx].Text = s;
+
+            return s;
+        }
+
+        public string Lookup(string s)
+        {
+            int hashCode = TypeHashingAlgorithms.ComputeNameHashCode(s);
+
+            string existing = Find(hashCode, s);
+            if (existing != null)
+                return existing;
+
+            return Add(hashCode, s);
+        }
+
+        public unsafe override string GetString(byte* bytes, int byteCount)
+        {
+            bool isAscii;
+            int hashCode = TypeHashingAlgorithms.ComputeASCIINameHashCode(bytes, byteCount, out isAscii);
+
+            if (isAscii)
+            {
+                string existing = FindASCII(hashCode, bytes, byteCount);
+                if (existing != null)
+                    return existing;
+                return Add(hashCode, Encoding.GetString(bytes, byteCount));
+            }
+            else
+            {
+                return Lookup(Encoding.GetString(bytes, byteCount));
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -16,7 +16,7 @@ using Internal.IL;
 
 namespace ILCompiler
 {
-    public class CompilerTypeSystemContext : TypeSystemContext
+    public class CompilerTypeSystemContext : TypeSystemContext, IMetadataStringDecoderProvider
     {
         static readonly string[] s_wellKnownTypeNames = new string[] {
             "Void",
@@ -65,6 +65,8 @@ namespace ILCompiler
         MetadataFieldLayoutAlgorithm _metadataFieldLayoutAlgorithm = new CompilerMetadataFieldLayoutAlgorithm();
         MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
         ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
+
+        MetadataStringDecoder _metadataStringDecoder;
 
         Dictionary<string, EcmaModule> _modules = new Dictionary<string, EcmaModule>(StringComparer.OrdinalIgnoreCase);
 
@@ -203,6 +205,13 @@ namespace ILCompiler
         public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type)
         {
             return _metadataRuntimeInterfacesAlgorithm;
+        }
+
+        MetadataStringDecoder IMetadataStringDecoderProvider.GetMetadataStringDecoder()
+        {
+            if (_metadataStringDecoder == null)
+                _metadataStringDecoder = new CachingMetadataStringDecoder(0x10000); // TODO: Tune the size
+            return _metadataStringDecoder;
         }
 
         //

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -92,6 +92,9 @@
     <Compile Include="$(CommonPath)\TypeSystem\Ecma\IMetadataStringDecoderProvider.cs">
       <Link>Ecma\IMetadataStringDecoderProvider.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\TypeSystem\Ecma\CachingMetadataStringDecoder.cs">
+      <Link>Ecma\CachingMetadataStringDecoder.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\MethodDesc.Interop.cs">
       <Link>MethodDesc.Interop.cs</Link>
     </Compile>

--- a/src/ILCompiler.TypeSystem/src/project.json
+++ b/src/ILCompiler.TypeSystem/src/project.json
@@ -6,7 +6,7 @@
     "System.Diagnostics.Debug": "4.0.0",
     "System.IO": "4.0.10",
     "System.Collections": "4.0.0",
-    "System.Text.Encoding": "4.0.0",
+    "System.Text.Encoding": "4.0.10",
     "System.Runtime.InteropServices": "4.0.0",
     "System.Reflection": "4.0.0",
     "System.Runtime.Extensions": "4.0.0",


### PR DESCRIPTION
CachingMetadataStringDecoder caches and reuses strings rather than allocating on each call to MetadataReader.GetString(handle)
