### PR TITLE
Enable range check code in MDArray accessors

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -127,6 +127,7 @@ namespace Internal.TypeSystem
                 case WellKnownType.Array:
                 case WellKnownType.MulticastDelegate:
                 case WellKnownType.Exception:
+                case WellKnownType.IndexOutOfRangeException:
                     flags = TypeFlags.Class;
                     break;
 

--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -61,6 +61,13 @@ namespace Internal.TypeSystem
             }
         }
 
+        static public MethodDesc GetDefaultConstructor(this TypeDesc type)
+        {
+            // TODO: Do we want check for specialname/rtspecialname? Maybe add another overload on GetMethod?
+            var sig = new MethodSignature(0, 0, type.Context.GetWellKnownType(WellKnownType.Void), Array.Empty<TypeDesc>());
+            return type.GetMethod(".ctor", sig);
+        }
+
         static private MethodDesc FindMethodOnExactTypeWithMatchingTypicalMethod(this TypeDesc type, MethodDesc method)
         {
             // Assert that either type is instantiated and its type definition is the type that defines the typical

--- a/src/Common/src/TypeSystem/Common/WellKnownType.cs
+++ b/src/Common/src/TypeSystem/Common/WellKnownType.cs
@@ -40,5 +40,6 @@ namespace Internal.TypeSystem
         RuntimeFieldHandle,
 
         Exception,
+        IndexOutOfRangeException,
     }
 }

--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -72,6 +72,8 @@ namespace Internal.IL.Stubs
 
             int pointerSize = _method.Context.Target.PointerSize;
 
+            var rangeExceptionLabel1 = NewCodeLabel();
+
             // TODO: type check
 
             for (int i = 0; i < _rank; i++)
@@ -85,13 +87,10 @@ namespace Internal.IL.Stubs
 
                 codeStream.EmitLdArg(i + 1);
 
-#if false
-                // TODO: generate IL to check bounds
                 // Compare with length
                 codeStream.Emit(ILOpcode.dup);
                 codeStream.EmitLdLoc(lengthLocalNum);
                 codeStream.Emit(ILOpcode.bge_un, rangeExceptionLabel1);
-#endif
 
                 // Add to the running total if we have one already
                 if (i > 0)
@@ -136,16 +135,19 @@ namespace Internal.IL.Stubs
 
             codeStream.Emit(ILOpcode.ret);
 
-#if false
             codeStream.EmitLdc(0);
             codeStream.EmitLabel(rangeExceptionLabel1); // Assumes that there is one "int" pushed on the stack
             codeStream.Emit(ILOpcode.pop);
 
-            var tokIndexOutOfRangeCtorExcep = GetToken(GetException(kIndexOutOfRangeException).GetDefaultConstructor());
+            TypeDesc indexOutOfRangeException = _method.Context.GetWellKnownType(WellKnownType.IndexOutOfRangeException);
+            int tokIndexOutOfRangeCtorExcep = NewToken(indexOutOfRangeException.GetDefaultConstructor());
+#if false
             codeStream.EmitLabel(rangeExceptionLabel);
-            codeStream.Emit(ILOpcode.newobj, tokIndexOutOfRangeCtorExcep, 0);
+#endif
+            codeStream.Emit(ILOpcode.newobj, tokIndexOutOfRangeCtorExcep);
             codeStream.Emit(ILOpcode.throw_);
 
+#if false
             if (typeMismatchExceptionLabel != null)
             {
                 var tokTypeMismatchExcepCtor = GetToken(GetException(kArrayTypeMismatchException).GetDefaultConstructor());

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -49,6 +49,7 @@ namespace ILCompiler
             "RuntimeFieldHandle",
 
             "Exception",
+            "IndexOutOfRangeException",
         };
 
         MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];


### PR DESCRIPTION
The code was already there, but ILEmitter didn't support labels at the
time it was written.

We now emit IL to check the bounds of multidimensional arrays in
Get/Set/Address methods and throw an IndexOutOfRangeException if an out
of bounds access was made.

Fixes half of what's in scope for issue #89.