### PR TITLE
Enable range check code in MDArray accessors

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -61,6 +61,13 @@ namespace Internal.TypeSystem
             }
         }
 
+        static public MethodDesc GetDefaultConstructor(this TypeDesc type)
+        {
+            // TODO: Do we want check for specialname/rtspecialname? Maybe add another overload on GetMethod?
+            var sig = new MethodSignature(0, 0, type.Context.GetWellKnownType(WellKnownType.Void), Array.Empty<TypeDesc>());
+            return type.GetMethod(".ctor", sig);
+        }
+
         static private MethodDesc FindMethodOnExactTypeWithMatchingTypicalMethod(this TypeDesc type, MethodDesc method)
         {
             // Assert that either type is instantiated and its type definition is the type that defines the typical

--- a/src/ILCompiler.Compiler/src/IL/HelperExtensions.cs
+++ b/src/ILCompiler.Compiler/src/IL/HelperExtensions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using ILCompiler;
+using Internal.TypeSystem;
+
+namespace Internal.IL
+{
+    static class HelperExtensions
+    {
+        public static MetadataType GetHelperType(this TypeSystemContext context, string name)
+        {
+            MetadataType helperType = ((CompilerTypeSystemContext)context).SystemModule.GetType("Internal.Runtime.CompilerHelpers", name, false);
+            if (helperType == null)
+            {
+                // TODO: throw the exception that means 'Core Library doesn't have a required thing in it'
+                throw new NotImplementedException();
+            }
+
+            return helperType;
+        }
+
+        public static MethodDesc GetHelperEntryPoint(this TypeSystemContext context, string typeName, string methodName)
+        {
+            MetadataType helperType = context.GetHelperType(typeName);
+            MethodDesc helperMethod = helperType.GetMethod(methodName, null);
+            if (helperMethod == null)
+            {
+                // TODO: throw the exception that means 'Core Library doesn't have a required thing in it'
+                throw new NotImplementedException();
+            }
+
+            return helperMethod;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Compiler\RvaFieldData.cs" />
     <Compile Include="Compiler\IntrinsicMethods.cs" />
     <Compile Include="CppCodeGen\CppWriter.cs" />
+    <Compile Include="IL\HelperExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\System\Collections\Generic\ArrayBuilder.cs">

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ArrayMethodILHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ArrayMethodILHelpers.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    /// <summary>
+    /// These methods are targeted by the ArrayMethodILEmitter in the compiler.
+    /// </summary>
+    static class ArrayMethodILHelpers
+    {
+        static void ThrowIndexOutOfRangeException()
+        {
+            throw new IndexOutOfRangeException();
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -84,6 +84,7 @@
   <ItemGroup>
     <Compile Include="Internal\Diagnostics\ExceptionExtensions.cs" />
     <Compile Include="Internal\Diagnostics\StackTraceHelper.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\ArrayMethodILHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\FixupRuntimeTypeHandle.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\FunctionPointerOps.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\GenericMethodDescriptor.cs" />


### PR DESCRIPTION
The code was already there, but ILEmitter didn't support labels at the
time it was written.

We now emit IL to check the bounds of multidimensional arrays in
Get/Set/Address methods and throw an IndexOutOfRangeException if an out
of bounds access was made.

Fixes half of what's in scope for issue #89.