### PR TITLE
Fixes for Runtime.Base compilation with RyuJIT

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis
             get
             {
                 StringBuilder nameBuilder = new StringBuilder();
-                nameBuilder.Append("__GCStaticEEType_");
+                nameBuilder.Append(NodeFactory.NameMangler.CompilationUnitPrefix + "__GCStaticEEType_");
                 int totalSize = 0;
                 foreach (int run in _runLengths)
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -248,7 +248,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else if (kind == SpecialMethodKind.RuntimeImport)
             {
-                return ExternSymbol(((EcmaMethod)method).GetRuntimeImportEntryPointName());
+                return ExternSymbol(((EcmaMethod)method).GetAttributeStringValue("System.Runtime", "RuntimeImportAttribute"));
             }
 
             return _methodCode.GetOrAdd(method);
@@ -311,11 +311,34 @@ namespace ILCompiler.DependencyAnalysis
             return _stringIndirectionNodes.GetOrAdd(data);
         }
 
-        public ArrayOfEmbeddedDataNode GCStaticsRegion = new ArrayOfEmbeddedDataNode("__GCStaticRegionStart", "__GCStaticRegionEnd", null);
-        public ArrayOfEmbeddedDataNode ThreadStaticsRegion = new ArrayOfEmbeddedDataNode("__ThreadStaticRegionStart", "__ThreadStaticRegionEnd", null);
-        public ArrayOfEmbeddedDataNode StringTable = new ArrayOfEmbeddedDataNode("__str_fixup", "__str_fixup_end", null);
+        /// <summary>
+        /// Returns alternative symbol name that object writer should produce for given symbols
+        /// in addition to the regular one.
+        /// </summary>
+        public string GetSymbolAlternateName(ISymbolNode node)
+        {
+            string value;
+            if (!NodeAliases.TryGetValue(node, out value))
+                return null;
+            return value;
+        }
+
+        public ArrayOfEmbeddedDataNode GCStaticsRegion = new ArrayOfEmbeddedDataNode(
+            NameMangler.CompilationUnitPrefix + "__GCStaticRegionStart", 
+            NameMangler.CompilationUnitPrefix + "__GCStaticRegionEnd", 
+            null);
+        public ArrayOfEmbeddedDataNode ThreadStaticsRegion = new ArrayOfEmbeddedDataNode(
+            NameMangler.CompilationUnitPrefix + "__ThreadStaticRegionStart",
+            NameMangler.CompilationUnitPrefix + "__ThreadStaticRegionEnd", 
+            null);
+        public ArrayOfEmbeddedDataNode StringTable = new ArrayOfEmbeddedDataNode(
+            NameMangler.CompilationUnitPrefix + "__str_fixup",
+            NameMangler.CompilationUnitPrefix + "__str_fixup_end", 
+            null);
 
         public Dictionary<TypeDesc, List<MethodDesc>> VirtualSlots = new Dictionary<TypeDesc, List<MethodDesc>>();
+
+        public Dictionary<ISymbolNode, string> NodeAliases = new Dictionary<ISymbolNode, string>();
 
         public static NameMangler NameMangler;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
@@ -38,9 +38,9 @@ namespace ILCompiler.DependencyAnalysis
             get
             {
                 if (_id.HasValue)
-                    return "__str_table_entry_" + _id.Value.ToString(CultureInfo.InvariantCulture);
+                    return NodeFactory.NameMangler.CompilationUnitPrefix + "__str_table_entry_" + _id.Value.ToString(CultureInfo.InvariantCulture);
                 else
-                    return "__str_table_entry_" + _data;
+                    return NodeFactory.NameMangler.CompilationUnitPrefix + "__str_table_entry_" + _data;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
@@ -31,9 +31,9 @@ namespace ILCompiler.DependencyAnalysis
             get
             {
                 if (base.Offset != 1)
-                    return "__str" + base.Offset.ToString(CultureInfo.InvariantCulture);
+                    return NodeFactory.NameMangler.CompilationUnitPrefix + "__str" + base.Offset.ToString(CultureInfo.InvariantCulture);
                 else
-                    return "__str" + _data;
+                    return NodeFactory.NameMangler.CompilationUnitPrefix + "__str" + _data;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/MethodExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MethodExtensions.cs
@@ -19,7 +19,7 @@ namespace ILCompiler
 
     internal static class MethodExtensions
     {
-        public static string GetRuntimeImportEntryPointName(this EcmaMethod This)
+        public static string GetAttributeStringValue(this EcmaMethod This, string nameSpace, string name)
         {
             var metadataReader = This.MetadataReader;
             foreach (var attributeHandle in metadataReader.GetMethodDefinition(This.Handle).GetCustomAttributes())
@@ -38,8 +38,8 @@ namespace ILCompiler
                     continue;
                 }
 
-                if (metadataReader.StringComparer.Equals(namespaceHandle, "System.Runtime")
-                    && metadataReader.StringComparer.Equals(nameHandle, "RuntimeImportAttribute"))
+                if (metadataReader.StringComparer.Equals(namespaceHandle, nameSpace)
+                    && metadataReader.StringComparer.Equals(nameHandle, name))
                 {
                     var constructor = This.Module.GetMethod(attributeCtor);
 

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -335,5 +335,32 @@ namespace ILCompiler
 
             return mangledName;
         }
+
+        private string _compilationUnixPrefix;
+
+        /// <summary>
+        /// Prefix to prepend to compilation unit global symbols to make them disambiguated between different .obj files.
+        /// </summary>
+        public string CompilationUnitPrefix
+        {
+            get
+            {
+                if (_compilationUnixPrefix == null)
+                {
+                    string systemModuleName = ((EcmaModule)_compilation.TypeSystemContext.SystemModule).GetName().Name;
+
+                    // TODO: just something to get Runtime.Base compiled
+                    if (systemModuleName != "System.Private.CoreLib")
+                    {
+                        _compilationUnixPrefix = systemModuleName.Replace(".", "_");
+                    }
+                    else
+                    {
+                        _compilationUnixPrefix = "";
+                    }
+                }
+                return _compilationUnixPrefix;
+            }
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -264,7 +264,7 @@ namespace ILCompiler.CppCodeGen
                         EcmaMethod ecmaMethod = method as EcmaMethod;
 
                         string importName = kind == SpecialMethodKind.PInvoke ?
-                            method.GetPInvokeMethodMetadata().Name : ecmaMethod.GetRuntimeImportEntryPointName();
+                            method.GetPInvokeMethodMetadata().Name : ecmaMethod.GetAttributeStringValue("System.Runtime", "RuntimeImport");
 
                         if (importName == null)
                             importName = method.Name;

--- a/src/JitInterface/src/CorInfoHelpFunc.cs
+++ b/src/JitInterface/src/CorInfoHelpFunc.cs
@@ -10,8 +10,6 @@ namespace Internal.JitInterface
     // CorInfoHelpFunc defines the set of helpers (accessed via the ICorDynamicInfo::getHelperFtn())
     // These helpers can be called by native code which executes in the runtime.
     // Compilers can emit calls to these helpers.
-    //
-    // The signatures of the helpers are below (see RuntimeHelperArgumentCheck)
 
     public enum CorInfoHelpFunc
     {
@@ -239,9 +237,6 @@ namespace Internal.JitInterface
 
         // These helpers are required for MDIL backward compatibility only. They are not used by current JITed code.
         CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE_OBSOLETE, // Convert from a TypeHandle (native structure pointer) to RuntimeTypeHandle at run-time
-#if RYUJIT_CTPBUILD
-        CORINFO_HELP_METHODDESC_TO_RUNTIMEMETHODHANDLE_MAYBENULL_OBSOLETE, // Convert from a MethodDesc (native structure pointer) to RuntimeMethodHandle at run-time
-#endif
         CORINFO_HELP_METHODDESC_TO_RUNTIMEMETHODHANDLE_OBSOLETE, // Convert from a MethodDesc (native structure pointer) to RuntimeMethodHandle at run-time
         CORINFO_HELP_FIELDDESC_TO_RUNTIMEFIELDHANDLE_OBSOLETE, // Convert from a FieldDesc (native structure pointer) to RuntimeFieldHandle at run-time
 
@@ -261,47 +256,6 @@ namespace Internal.JitInterface
         CORINFO_HELP_READYTORUN_STATIC_BASE,
         CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR,
         CORINFO_HELP_READYTORUN_DELEGATE_CTOR,
-
-#if REDHAWK
-        // these helpers are arbitrary since we don't have any relation to the actual CLR corinfo.h.
-        CORINFO_HELP_PINVOKE,               // transition to preemptive mode for a pinvoke, frame in EAX
-        CORINFO_HELP_PINVOKE_2,             // transition to preemptive mode for a pinvoke, frame in ESI / R10
-        CORINFO_HELP_PINVOKE_RETURN,        // return to cooperative mode from a pinvoke
-        CORINFO_HELP_REVERSE_PINVOKE,       // transition to cooperative mode for a callback from native
-        CORINFO_HELP_REVERSE_PINVOKE_RETURN,// return to preemptive mode to return to native from managed
-        CORINFO_HELP_REGISTER_MODULE,       // module load notification
-        CORINFO_HELP_CREATECOMMANDLINE,     // get the command line from the system and return it for Main
-        CORINFO_HELP_VSD_INITIAL_TARGET,    // all VSD indirection cells initially point to this function
-        CORINFO_HELP_NEW_FINALIZABLE,       // allocate finalizable object
-        CORINFO_HELP_SHUTDOWN,              // called when Main returns from a managed executable
-        CORINFO_HELP_CHECKARRAYSTORE,       // checks that an array element assignment is of the right type
-        CORINFO_HELP_CHECK_VECTOR_ELEM_ADDR,// does a precise type check on the array element type
-        CORINFO_HELP_FLT2INT_OVF,           // checked float->int conversion
-        CORINFO_HELP_FLT2LNG,               // float->long conversion
-        CORINFO_HELP_FLT2LNG_OVF,           // checked float->long conversion
-        CORINFO_HELP_FLTREM_REV,            // Bartok helper for float remainder - uses reversed param order from CLR helper
-        CORINFO_HELP_DBLREM_REV,            // Bartok helper for double remainder - uses reversed param order from CLR helper
-        CORINFO_HELP_HIJACKFORGCSTRESS,     // this helper hijacks the caller for GC stress
-        CORINFO_HELP_INIT_GCSTRESS,         // this helper initializes the runtime for GC stress
-        CORINFO_HELP_SUPPRESS_GCSTRESS,     // disables gc stress
-        CORINFO_HELP_UNSUPPRESS_GCSTRESS,   // re-enables gc stress
-        CORINFO_HELP_THROW_INTRA,           // Throw an exception object to a hander within the method
-        CORINFO_HELP_THROW_INTER,           // Throw an exception object to a hander within the caller
-        CORINFO_HELP_THROW_ARITHMETIC,      // Throw the classlib-defined arithmetic exception
-        CORINFO_HELP_THROW_DIVIDE_BY_ZERO,  // Throw the classlib-defined divide by zero exception
-        CORINFO_HELP_THROW_INDEX,           // Throw the classlib-defined index out of range exception
-        CORINFO_HELP_THROW_OVERFLOW,        // Throw the classlib-defined overflow exception
-        CORINFO_HELP_EHJUMP_SCALAR,         // Helper to jump to a handler in a different method for EH dispatch.
-        CORINFO_HELP_EHJUMP_OBJECT,         // Helper to jump to a handler in a different method for EH dispatch.
-        CORINFO_HELP_EHJUMP_BYREF,          // Helper to jump to a handler in a different method for EH dispatch.
-        CORINFO_HELP_EHJUMP_SCALAR_GCSTRESS,// Helper to jump to a handler in a different method for EH dispatch.
-        CORINFO_HELP_EHJUMP_OBJECT_GCSTRESS,// Helper to jump to a handler in a different method for EH dispatch.
-        CORINFO_HELP_EHJUMP_BYREF_GCSTRESS, // Helper to jump to a handler in a different method for EH dispatch.
-
-        // Bartok emits code with destination in ECX rather than EDX and only ever uses EDX as the reference
-        // register. It also only ever specifies the checked version.
-        CORINFO_HELP_CHECKED_ASSIGN_REF_EDX, // EDX hold GC ptr, want do a 'mov [ECX], EDX' and inform GC
-#endif // REDHAWK
 
         CORINFO_HELP_EE_PRESTUB,            // Not real JIT helper. Used in native images.
 

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -499,9 +499,6 @@ namespace Internal.JitInterface
         // This is due to how we implement the NoStringInterningAttribute
         // (by reusing the fixup table).
         INLINE_SAME_THIS = 0x00000004, // You can inline only if the callee is on the same this reference as caller
-#if MDIL
-    INLINE_NOT_FOR_MDIL     = 0x00000008, // You cannot inline this method for MDIL
-#endif
     }
 
     // If you add more values here, keep it in sync with TailCallTypeMap in ..\vm\ClrEtwAll.man
@@ -811,9 +808,6 @@ namespace Internal.JitInterface
     public struct CORINFO_HELPER_ARG
     {
         public IntPtr argHandle;
-#if  MDIL
-    public uint token;
-#endif
         public CorInfoAccessAllowedHelperArgType argType;
     }
 
@@ -1200,10 +1194,6 @@ namespace Internal.JitInterface
 
         VLT_COUNT,
         VLT_INVALID,
-#if MDIL
-        VLT_MDIL_SYMBOLIC = 0x20
-#endif
-
     };
 
     public struct VarLoc

--- a/src/System.Private.CoreLib/src/AllowedDependencies.csv
+++ b/src/System.Private.CoreLib/src/AllowedDependencies.csv
@@ -119,6 +119,5 @@ T:System.IO.LongPathHelper,G:Interop,Regular MCG interop dependancy
 T:System.IO.PathHelper,T:System.IO.LongPathHelper,Used to get long path from short path
 ,,
 T:System.Runtime.InteropServices.InteropExtensions,T:System.Runtime.RuntimeImports,Needed to provide the marshal class details about types
-T:System.Runtime.InteropServices.InteropExtensions,T:Midori.Runtime.Magic,Needed to provide runtime magic for interop
 T:Internal.Numerics.BigIntegerFormatProvider,T:System.Globalization.FormatProvider,Currently implemented inside System.Private.CoreLib so needs access to the basic globalization
 T:Internal.Numerics.BigIntegerFormatProvider,T:System.Globalization.NumberFormatInfo,Currently implemented inside System.Private.CoreLib so needs access to the basic globalization


### PR DESCRIPTION
Make Runtime.Base compiled to native code and linked into the final .exe. It makes a lot of the stubbed out Rh* methods disappear. It is also start of the multiple .obj plan.