### PR TITLE
Add ModuleDesc as the base type of EcmaModule

### DIFF
--- a/src/Common/src/TypeSystem/Common/ModuleDesc.cs
+++ b/src/Common/src/TypeSystem/Common/ModuleDesc.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Internal.TypeSystem
+{
+    public abstract partial class ModuleDesc
+    {
+        /// <summary>
+        /// Gets the type system context the module belongs to.
+        /// </summary>
+        public TypeSystemContext Context
+        {
+            get;
+            private set;
+        }
+
+        public ModuleDesc(TypeSystemContext context)
+        {
+            Context = context;
+        }
+
+        /// <summary>
+        /// Gets a type in this module with the specified name.
+        /// </summary>
+        public abstract MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true);
+    }
+}

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -40,10 +40,21 @@ namespace Internal.TypeSystem
             get; private set;
         }
 
+        public ModuleDesc SystemModule
+        {
+            get;
+            private set;
+        }
+
+        protected void InitializeSystemModule(ModuleDesc systemModule)
+        {
+            Debug.Assert(SystemModule == null);
+            SystemModule = systemModule;
+        }
+
         public abstract MetadataType GetWellKnownType(WellKnownType wellKnownType);
 
-        // TODO: Optional interface instead? Return ModuleDesc instead?
-        public virtual Object ResolveAssembly(AssemblyName name)
+        public virtual ModuleDesc ResolveAssembly(AssemblyName name)
         {
             return null;
         }

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -12,10 +12,8 @@ using Internal.TypeSystem;
 
 namespace Internal.TypeSystem.Ecma
 {
-    public sealed class EcmaModule
+    public sealed class EcmaModule : ModuleDesc
     {
-        TypeSystemContext _context;
-
         PEReader _peReader;
         MetadataReader _metadataReader;
 
@@ -163,9 +161,8 @@ namespace Internal.TypeSystem.Ecma
         LockFreeReaderHashtable<EntityHandle, IEntityHandleObject> _resolvedTokens;
 
         public EcmaModule(TypeSystemContext context, PEReader peReader)
+            : base(context)
         {
-            _context = context;
-
             _peReader = peReader;
 
             var stringDecoderProvider = context as IMetadataStringDecoderProvider;
@@ -179,18 +176,9 @@ namespace Internal.TypeSystem.Ecma
         }
 
         public EcmaModule(TypeSystemContext context, MetadataReader metadataReader)
+            : base(context)
         {
-            _context = context;
-
             _metadataReader = metadataReader;
-        }
-
-        public TypeSystemContext Context
-        {
-            get
-            {
-                return _context;
-            }
         }
 
         public PEReader PEReader
@@ -217,7 +205,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
+        public override MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
         {
             var stringComparer = _metadataReader.StringComparer;
 
@@ -313,7 +301,7 @@ namespace Internal.TypeSystem.Ecma
             EcmaSignatureParser parser = new EcmaSignatureParser(this, signatureReader);
 
             TypeDesc[] instantiation = parser.ParseMethodSpecSignature();
-            return _context.GetInstantiatedMethod(methodDef, new Instantiation(instantiation));
+            return Context.GetInstantiatedMethod(methodDef, new Instantiation(instantiation));
         }
 
         Object ResolveTypeSpecification(TypeSpecificationHandle handle)
@@ -406,7 +394,7 @@ namespace Internal.TypeSystem.Ecma
 
             // TODO: ContentType, Culture - depends on newer version of the System.Reflection contract
 
-            return _context.ResolveAssembly(an);
+            return Context.ResolveAssembly(an);
         }
 
         Object ResolveExportedType(ExportedTypeHandle handle)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -53,8 +53,6 @@ namespace ILCompiler
 
         MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
 
-        EcmaModule _systemModule;
-
         MetadataFieldLayoutAlgorithm _metadataFieldLayoutAlgorithm = new CompilerMetadataFieldLayoutAlgorithm();
         MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
         ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
@@ -87,17 +85,9 @@ namespace ILCompiler
             set;
         }
 
-        public EcmaModule SystemModule
-        {
-            get
-            {
-                return _systemModule;
-            }
-        }
-
         public void SetSystemModule(EcmaModule systemModule)
         {
-            _systemModule = systemModule;
+            InitializeSystemModule(systemModule);
 
             // Sanity check the name table
             Debug.Assert(s_wellKnownTypeNames[(int)WellKnownType.MulticastDelegate - 1] == "MulticastDelegate");
@@ -105,7 +95,7 @@ namespace ILCompiler
             // Initialize all well known types - it will save us from checking the name for each loaded type
             for (int typeIndex = 0; typeIndex < _wellKnownTypes.Length; typeIndex++)
             {
-                MetadataType type = _systemModule.GetType("System", s_wellKnownTypeNames[typeIndex]);
+                MetadataType type = systemModule.GetType("System", s_wellKnownTypeNames[typeIndex]);
                 type.SetWellKnownType((WellKnownType)(typeIndex + 1));
                 _wellKnownTypes[typeIndex] = type;
             }
@@ -116,7 +106,7 @@ namespace ILCompiler
             return _wellKnownTypes[(int)wellKnownType - 1];
         }
 
-        public override object ResolveAssembly(System.Reflection.AssemblyName name)
+        public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name)
         {
             return GetModuleForSimpleName(name.Name);
         }
@@ -190,7 +180,7 @@ namespace ILCompiler
         {
             if (_arrayOfTRuntimeInterfacesAlgorithm == null)
             {
-                _arrayOfTRuntimeInterfacesAlgorithm = new ArrayOfTRuntimeInterfacesAlgorithm(_systemModule.GetType("System", "Array`1"));
+                _arrayOfTRuntimeInterfacesAlgorithm = new ArrayOfTRuntimeInterfacesAlgorithm(SystemModule.GetType("System", "Array`1"));
             }
             return _arrayOfTRuntimeInterfacesAlgorithm;
         }

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -23,6 +23,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\AlignmentHelper.cs">
       <Link>Utilities\AlignmentHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ModuleDesc.cs">
+      <Link>ModuleDesc.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
       <Link>Utilities\LockFreeReaderHashtable.cs</Link>
     </Compile>

--- a/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
@@ -101,7 +101,7 @@ namespace TypeSystemTests
             return module;
         }
 
-        public override object ResolveAssembly(System.Reflection.AssemblyName name)
+        public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name)
         {
             return GetModuleForSimpleName(name.Name);
         }


### PR DESCRIPTION
I didn't move much functionality over to ModuleDesc mostly to find out
what are the exact things we will need on a ModuleDesc.

Notably, I didn't put GetName() on it to keep the door open to introduce
AssemblyDesc/EcmaAssembly (deriving from ModuleDesc).