### PR TITLE
Move HelperExtensions to Common

### DIFF
--- a/src/Common/src/TypeSystem/IL/HelperExtensions.cs
+++ b/src/Common/src/TypeSystem/IL/HelperExtensions.cs
@@ -12,7 +12,7 @@ namespace Internal.IL
     {
         public static MetadataType GetHelperType(this TypeSystemContext context, string name)
         {
-            MetadataType helperType = ((CompilerTypeSystemContext)context).SystemModule.GetType("Internal.Runtime.CompilerHelpers", name, false);
+            MetadataType helperType = context.SystemModule.GetType("Internal.Runtime.CompilerHelpers", name, false);
             if (helperType == null)
             {
                 // TODO: throw the exception that means 'Core Library doesn't have a required thing in it'

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -81,7 +81,6 @@
     <Compile Include="Compiler\RvaFieldData.cs" />
     <Compile Include="Compiler\IntrinsicMethods.cs" />
     <Compile Include="CppCodeGen\CppWriter.cs" />
-    <Compile Include="IL\HelperExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\System\Collections\Generic\ArrayBuilder.cs">
@@ -91,6 +90,9 @@
   <ItemGroup>
     <Compile Include="..\..\Common\src\TypeSystem\IL\EcmaMethodIL.cs">
       <Link>IL\EcmaMethodIL.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\HelperExtensions.cs">
+      <Link>IL\HelperExtensions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILOpcode.cs">
       <Link>IL\ILOpcode.cs</Link>


### PR DESCRIPTION
These no longer rely on CompilerTypeSystemContext and therefore can live
in the Common directory.