### PR TITLE
Improve usability of ILEmitter

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -15,7 +15,7 @@ namespace Internal.IL.Stubs
         private TypeDesc _elementType;
         private int _rank;
 
-        private int _helperFieldToken;
+        private ILToken _helperFieldToken;
 
         public ArrayMethodILEmitter(ArrayMethod method)
         {

--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -64,10 +64,10 @@ namespace Internal.IL.Stubs
             EmitByte((byte)opcode);
         }
 
-        public void Emit(ILOpcode opcode, int token)
+        public void Emit(ILOpcode opcode, ILToken token)
         {
             Emit(opcode);
-            EmitUInt32(token);
+            EmitUInt32((int)token);
         }
 
         public void EmitLdc(int value)
@@ -101,8 +101,10 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public void EmitLdLoc(int index)
+        public void EmitLdLoc(ILLocalVariable variable)
         {
+            int index = (int)variable;
+
             if (index < 4)
             {
                 Emit((ILOpcode)(ILOpcode.ldloc_0 + index));
@@ -119,8 +121,10 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public void EmitLdLoca(int index)
+        public void EmitLdLoca(ILLocalVariable variable)
         {
+            int index = (int)variable;
+
             if (index < 0x100)
             {
                 Emit(ILOpcode.ldloca_s);
@@ -133,8 +137,10 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public void EmitStLoc(int index)
+        public void EmitStLoc(ILLocalVariable variable)
         {
+            int index = (int)variable;
+
             if (index < 4)
             {
                 Emit((ILOpcode)(ILOpcode.stloc_0 + index));
@@ -189,6 +195,17 @@ namespace Internal.IL.Stubs
             }
         }
     }
+
+    /// <summary>
+    /// Represent a token. Use one of the overloads of <see cref="ILEmitter.NewToken"/>
+    /// to create a new token.
+    /// </summary>
+    public enum ILToken { }
+
+    /// <summary>
+    /// Represents a local variable. Use <see cref="ILEmitter.NewLocal"/> to create a new local variable.
+    /// </summary>
+    public enum ILLocalVariable { }
 
     internal class ILStubMethodIL : MethodIL
     {
@@ -281,42 +298,42 @@ namespace Internal.IL.Stubs
             return stream;
         }
 
-        private int NewToken(Object value, int tokenType)
+        private ILToken NewToken(Object value, int tokenType)
         {
             _tokens.Add(value);
-            return _tokens.Count | tokenType;
+            return (ILToken)(_tokens.Count | tokenType);
         }
 
-        public int NewToken(TypeDesc value)
+        public ILToken NewToken(TypeDesc value)
         {
             return NewToken(value, 0x01000000);
         }
 
-        public int NewToken(MethodDesc value)
+        public ILToken NewToken(MethodDesc value)
         {
             return NewToken(value, 0x0a000000);
         }
 
-        public int NewToken(FieldDesc value)
+        public ILToken NewToken(FieldDesc value)
         {
             return NewToken(value, 0x0a000000);
         }
 
-        public int NewToken(string value)
+        public ILToken NewToken(string value)
         {
             return NewToken(value, 0x70000000);
         }
 
-        public int NewToken(MethodSignature value)
+        public ILToken NewToken(MethodSignature value)
         {
             return NewToken(value, 0x11000000);
         }
 
-        public int NewLocal(TypeDesc localType, bool isPinned = false)
+        public ILLocalVariable NewLocal(TypeDesc localType, bool isPinned = false)
         {
             int index = _locals.Count;
             _locals.Add(new LocalVariableDefinition(localType, isPinned));
-            return index;
+            return (ILLocalVariable)index;
         }
 
         public ILCodeLabel NewCodeLabel()

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeMarshallingILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeMarshallingILEmitter.cs
@@ -130,8 +130,8 @@ namespace Internal.IL.Stubs
             if (!IsSimpleType(arrayType.ParameterType) && !IsBlittableStruct(arrayType.ParameterType))
                 throw new NotSupportedException();
 
-            int vPinnedFirstElement = _emitter.NewLocal(arrayType.ParameterType.MakeByRefType(), true);
-            int vArray = _emitter.NewLocal(arrayType);
+            ILLocalVariable vPinnedFirstElement = _emitter.NewLocal(arrayType.ParameterType.MakeByRefType(), true);
+            ILLocalVariable vArray = _emitter.NewLocal(arrayType);
             ILCodeLabel lNullArray = _emitter.NewCodeLabel();
 
             // Check for null array, or 0 element array.
@@ -166,7 +166,7 @@ namespace Internal.IL.Stubs
             if (!IsSimpleType(byRefType.ParameterType) && !IsBlittableStruct(byRefType.ParameterType))
                 throw new NotSupportedException();
 
-            int vPinnedByRef = _emitter.NewLocal(byRefType, true);
+            ILLocalVariable vPinnedByRef = _emitter.NewLocal(byRefType, true);
             _marshallingCodeStream.EmitStLoc(vPinnedByRef);
             _marshallingCodeStream.EmitLdLoc(vPinnedByRef);
             _marshallingCodeStream.Emit(ILOpcode.conv_i);
@@ -204,7 +204,7 @@ namespace Internal.IL.Stubs
                 // Unicode marshalling. Pin the string and push a pointer to the first character on the stack.
                 //
 
-                int vPinnedString = _emitter.NewLocal(stringType, true);
+                ILLocalVariable vPinnedString = _emitter.NewLocal(stringType, true);
                 ILCodeLabel lNullString = _emitter.NewCodeLabel();
 
                 _marshallingCodeStream.EmitStLoc(vPinnedString);
@@ -240,7 +240,7 @@ namespace Internal.IL.Stubs
                 ILCodeLabel lDone = _emitter.NewCodeLabel();
 
                 // Check for the simple case: string is null
-                int vStringToMarshal = _emitter.NewLocal(stringType);
+                ILLocalVariable vStringToMarshal = _emitter.NewLocal(stringType);
                 _marshallingCodeStream.EmitStLoc(vStringToMarshal);
                 _marshallingCodeStream.EmitLdLoc(vStringToMarshal);
                 _marshallingCodeStream.Emit(ILOpcode.brfalse, lNullString);
@@ -253,12 +253,12 @@ namespace Internal.IL.Stubs
                 _marshallingCodeStream.EmitLdc(1);
                 _marshallingCodeStream.Emit(ILOpcode.add);
                 _marshallingCodeStream.Emit(ILOpcode.newarr, _emitter.NewToken(byteType));
-                int vByteArray = _emitter.NewLocal(byteArrayType);
+                ILLocalVariable vByteArray = _emitter.NewLocal(byteArrayType);
                 _marshallingCodeStream.EmitStLoc(vByteArray);
 
                 // for (int i = 0; i < byteArray.Length - 1; i++)
                 //     byteArray[i] = (byte)stringToMarshal[i];
-                int vIterator = _emitter.NewLocal(context.GetWellKnownType(WellKnownType.Int32));
+                ILLocalVariable vIterator = _emitter.NewLocal(context.GetWellKnownType(WellKnownType.Int32));
                 _marshallingCodeStream.Emit(ILOpcode.ldc_i4_0);
                 _marshallingCodeStream.EmitStLoc(vIterator);
                 _marshallingCodeStream.Emit(ILOpcode.br, lStart);
@@ -287,7 +287,7 @@ namespace Internal.IL.Stubs
                 // Pin first element and load the byref on the stack.
                 _marshallingCodeStream.EmitLdc(0);
                 _marshallingCodeStream.Emit(ILOpcode.ldelema, _emitter.NewToken(byteType));
-                int vPinnedFirstElement = _emitter.NewLocal(byteArrayType.MakeByRefType(), true);
+                ILLocalVariable vPinnedFirstElement = _emitter.NewLocal(byteArrayType.MakeByRefType(), true);
                 _marshallingCodeStream.EmitStLoc(vPinnedFirstElement);
                 _marshallingCodeStream.EmitLdLoc(vPinnedFirstElement);
                 _marshallingCodeStream.Emit(ILOpcode.conv_i);
@@ -354,7 +354,7 @@ namespace Internal.IL.Stubs
 
                 nativeParameterTypes[i] = nativeType;
 
-                int vMarshalledTypeTemp = _emitter.NewLocal(nativeType);
+                ILLocalVariable vMarshalledTypeTemp = _emitter.NewLocal(nativeType);
                 _marshallingCodeStream.EmitStLoc(vMarshalledTypeTemp);
 
                 callsiteSetupCodeStream.EmitLdLoc(vMarshalledTypeTemp);


### PR DESCRIPTION
Introduce ILLocalVariable and ILToken types and use them in lieu of int.
This makes the "where do I get the int from" question self-documenting.

It also avoids bugs where, uh... "a friend of mine" uses ldloc instead
of ldarg to load an argument because they didn't check what IntelliSense
autocompleted.

I used an enum instead of a struct with a single integer field because
it's easier to deal with.