### PR TITLE
Fix runtime assert default behavior

### DIFF
--- a/src/Native/Runtime/RhConfig.cpp
+++ b/src/Native/Runtime/RhConfig.cpp
@@ -27,7 +27,7 @@
 
 #include <string.h>
 
-UInt32 RhConfig::ReadConfigValue(_In_z_ const WCHAR *wszName)
+UInt32 RhConfig::ReadConfigValue(_In_z_ const WCHAR *wszName, UInt32 uiDefaultValue)
 {
     WCHAR wszBuffer[CONFIG_VAL_MAXLEN + 1]; // 8 hex digits plus a nul terminator.
     const UInt32 cchBuffer = sizeof(wszBuffer) / sizeof(wszBuffer[0]);
@@ -43,7 +43,7 @@ UInt32 RhConfig::ReadConfigValue(_In_z_ const WCHAR *wszName)
         cchResult = GetIniVariable(wszName, wszBuffer, cchBuffer);
 
     if ((cchResult == 0) || (cchResult >= cchBuffer))
-        return 0;
+        return uiDefaultValue; // not found, return default
 
     UInt32 uiResult = 0;
 
@@ -59,7 +59,7 @@ UInt32 RhConfig::ReadConfigValue(_In_z_ const WCHAR *wszName)
         else if ((ch >= L'A') && (ch <= L'F'))
             uiResult += (ch - L'A') + 10;
         else
-            return 0;
+            return uiDefaultValue; // parse error, return default
     }
 
     return uiResult;

--- a/src/Native/Runtime/RhConfig.h
+++ b/src/Native/Runtime/RhConfig.h
@@ -56,12 +56,12 @@ private:
 
 public:
 
-#define DEFINE_VALUE_ACCESSOR(_name)                    \
+#define DEFINE_VALUE_ACCESSOR(_name, defaultVal)        \
     UInt32 Get##_name()                                 \
     {                                                   \
         if (m_uiConfigValuesRead & (1 << RCV_##_name))  \
             return m_uiConfigValues[RCV_##_name];       \
-        UInt32 uiValue = ReadConfigValue(L"RH_" L ## #_name); \
+        UInt32 uiValue = ReadConfigValue(L"RH_" L ## #_name, defaultVal); \
         m_uiConfigValues[RCV_##_name] = uiValue;        \
         m_uiConfigValuesRead |= 1 << RCV_##_name;       \
         return uiValue;                                 \
@@ -69,26 +69,35 @@ public:
 
 
 #ifdef _DEBUG
-#define DEBUG_CONFIG_VALUE(_name) DEFINE_VALUE_ACCESSOR(_name)
+#define DEBUG_CONFIG_VALUE(_name) DEFINE_VALUE_ACCESSOR(_name, 0)
+#define DEBUG_CONFIG_VALUE_WITH_DEFAULT(_name, defaultVal) DEFINE_VALUE_ACCESSOR(_name, defaultVal)
 #else
 #define DEBUG_CONFIG_VALUE(_name) 
+#define DEBUG_CONFIG_VALUE_WITH_DEFAULT(_name, defaultVal) 
 #endif
-#define RETAIL_CONFIG_VALUE(_name) DEFINE_VALUE_ACCESSOR(_name)
+#define RETAIL_CONFIG_VALUE(_name) DEFINE_VALUE_ACCESSOR(_name, 0)
+#define RETAIL_CONFIG_VALUE_WITH_DEFAULT(_name, defaultVal) DEFINE_VALUE_ACCESSOR(_name, defaultVal)
 #include "RhConfigValues.h"
 #undef DEBUG_CONFIG_VALUE
 #undef RETAIL_CONFIG_VALUE
+#undef DEBUG_CONFIG_VALUE_WITH_DEFAULT
+#undef RETAIL_CONFIG_VALUE_WITH_DEFAULT
 
 private:
 
-    UInt32 ReadConfigValue(_In_z_ const WCHAR *wszName);
+    UInt32 ReadConfigValue(_In_z_ const WCHAR *wszName, UInt32 uiDefault);
 
     enum RhConfigValue
     {
 #define DEBUG_CONFIG_VALUE(_name) RCV_##_name,
 #define RETAIL_CONFIG_VALUE(_name) RCV_##_name,
+#define DEBUG_CONFIG_VALUE_WITH_DEFAULT(_name, defaultVal) RCV_##_name,
+#define RETAIL_CONFIG_VALUE_WITH_DEFAULT(_name, defaultVal) RCV_##_name,
 #include "RhConfigValues.h"
 #undef DEBUG_CONFIG_VALUE
 #undef RETAIL_CONFIG_VALUE
+#undef DEBUG_CONFIG_VALUE_WITH_DEFAULT
+#undef RETAIL_CONFIG_VALUE_WITH_DEFAULT
         RCV_Count
     };
     

--- a/src/Native/Runtime/RhConfigValues.h
+++ b/src/Native/Runtime/RhConfigValues.h
@@ -12,7 +12,9 @@
 // very few configuration values are exposed in this manner.
 //
 
-DEBUG_CONFIG_VALUE(BreakOnAssert)
+// By default, print assert to console and break in the debugger, if attached.  Set to 0 for a pop-up dialog on assert.
+DEBUG_CONFIG_VALUE_WITH_DEFAULT(BreakOnAssert, 1) 
+
 RETAIL_CONFIG_VALUE(HeapVerify)
 RETAIL_CONFIG_VALUE(StressLogLevel)
 RETAIL_CONFIG_VALUE(TotalStressLogSize)


### PR DESCRIPTION
Change the default to be console-oriented.  This is better for
unattended test passes because it now prints to the console instead
of popping up a dialog box.  You can get back to the old behavior
by setting RH_BreakOnAssert=0 in the environment or config file.