### PR TITLE
Fix MDArray generated Get and Address methods

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -146,8 +146,8 @@ namespace Internal.IL.Stubs
             codeStream.Emit(ILOpcode.pop);
 
             MethodDesc throwHelper = _method.Context.GetHelperEntryPoint("ArrayMethodILHelpers", "ThrowIndexOutOfRangeException");
-            codeStream.Emit(ILOpcode.call, _emitter.NewToken(throwHelper));
-            codeStream.Emit(ILOpcode.ret);
+            codeStream.EmitCallThrowHelper(_emitter, throwHelper);
+
 #if false
             if (typeMismatchExceptionLabel != null)
             {


### PR DESCRIPTION
We need to push something on the stack for these after ThrowHelper
returns (even though it really doesn't return).