### PR TITLE
Update build instructions and package restore for AppDep 1.0.1

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
@@ -12,7 +12,7 @@ _Note_:
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r <repo_root>\bin\tests\package\toolchain.<OS>-<Arch>.Microsoft.DotNet.App.1.0.0-prerelease\*.dll -out c:\corert\src\ILCompiler\reproNative\repro.obj`
+`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r <repo_root>\bin\tests\package\toolchain.<OS>-<Arch>.Microsoft.DotNet.AppDep.1.0.1-prerelease\*.dll -out c:\corert\src\ILCompiler\reproNative\repro.obj`
 
   - Copy ryujit.dll from `<repo_root>\bin\tests\package\toolchain.<OS>-<Arch>.Microsoft.DotNet.RyuJIT.*` to `c:\corert\src\ILCompiler\desktop\bin\Debug`
   - Copy objectwriter.dll from `<repo_root>\bin\tests\package\toolchain.<OS>-<Arch>.Microsoft.DotNet.ObjectWriter.*` to `c:\corert\src\ILCompiler\desktop\bin\Debug`
@@ -37,7 +37,7 @@ _Note_:
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r <repo_root>\bin\tests\package\toolchain.<OS>-<Arch>.Microsoft.DotNet.App.1.0.0-prerelease\*.dlll -out C:\corert\src\ILCompiler\reproNative\repro.cpp -cpp`
+`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r <repo_root>\bin\tests\package\toolchain.<OS>-<Arch>.Microsoft.DotNet.AppDep.1.0.1-prerelease\*.dll -out C:\corert\src\ILCompiler\reproNative\repro.cpp -cpp`
 
     - `-nolinenumbers` command line option can be used to suppress generation of line number mappings in C++ files - useful for debugging
 

--- a/tests/restore.cmd
+++ b/tests/restore.cmd
@@ -9,7 +9,7 @@ if not defined CoreRT_BuildType ((call :Fail "Set CoreRT_BuildType to Debug or R
 set CoreRT_ToolchainPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.ILCompiler.Development
 set CoreRT_ToolchainVer=1.0.0-prerelease
 set CoreRT_AppDepSdkPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.AppDep
-set CoreRT_AppDepSdkVer=1.0.0-prerelease
+set CoreRT_AppDepSdkVer=1.0.1-prerelease
 set CoreRT_RyuJitPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.RyuJit
 set CoreRT_RyuJitVer=1.0.0-prerelease
 set CoreRT_ObjWriterPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.ObjectWriter


### PR DESCRIPTION
Move to AppDep 1.0.1 which has mscorlib.dll so we can run CoreCLR tests