### PR TITLE
Fix Unix runtime so that it can be linked to again.

### DIFF
--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -72,7 +72,6 @@ else()
   include_directories(unix)
 
   list(APPEND COMMON_RUNTIME_SOURCES
-    ../gc/env/gcenv.unix.cpp    
     unix/PalRedhawkUnix.cpp
   )
 

--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -19,6 +19,7 @@
 
 #include <sal.h>
 #include <stdarg.h>
+#include "gcenv.structs.h"
 
 #ifndef PAL_REDHAWK_INCLUDED
 #define PAL_REDHAWK_INCLUDED
@@ -50,16 +51,6 @@ typedef void(__stdcall *PFLS_CALLBACK_FUNCTION) (void* lpFlsData);
 #define WINAPI              __stdcall
 #define WINBASEAPI          __declspec(dllimport)
 
-union LARGE_INTEGER
-{
-    struct
-    {
-        UInt32  LowPart;
-        Int32   HighPart;
-    } u;
-    Int64       QuadPart;
-};
-
 typedef struct _GUID {
     unsigned long  Data1;
     unsigned short Data2;
@@ -67,15 +58,6 @@ typedef struct _GUID {
     unsigned char  Data4[8];
 } GUID;
 
-struct CRITICAL_SECTION
-{
-    void *      DebugInfo;
-    Int32       LockCount;
-    Int32       RecursionCount;
-    HANDLE      OwningThread;
-    HANDLE      LockSemaphore;
-    UIntNative  SpinCount;
-};
 #endif //!GCENV_INCLUDED
 
 #define DECLARE_HANDLE(_name) typedef HANDLE _name
@@ -583,12 +565,6 @@ EventDataDescCreate(_Out_ EVENT_DATA_DESCRIPTOR * EventDataDescriptor, _In_opt_ 
 #endif // EVENT_PROVIDER_INCLUDED
 
 #ifndef GCENV_INCLUDED
-struct GCSystemInfo
-{
-    uint32_t dwNumberOfProcessors;
-    uint32_t dwPageSize;
-    uint32_t dwAllocationGranularity;
-};
 extern GCSystemInfo g_SystemInfo;
 
 #define REDHAWK_PALIMPORT EXTERN_C

--- a/src/Native/Runtime/gcenv.h
+++ b/src/Native/Runtime/gcenv.h
@@ -10,6 +10,7 @@
 #endif
 
 #include "sal.h"
+#include "gcenv.structs.h"
 #include "gcenv.base.h"
 
 #include "Crst.h"

--- a/src/Native/gc/env/gcenv.structs.h
+++ b/src/Native/gc/env/gcenv.structs.h
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+#ifndef __GCENV_STRUCTS_INCLUDED__
+#define __GCENV_STRUCTS_INCLUDED__
+//
+// Structs shared between the GC and the environment
+//
+
+struct GCSystemInfo
+{
+    uint32_t dwNumberOfProcessors;
+    uint32_t dwPageSize;
+    uint32_t dwAllocationGranularity;
+};
+
+// An 'abstract' definition of Windows MEMORYSTATUSEX.  In practice, the only difference is the missing struct size
+// field and one field that Windows documents to always be 0.  If additional information is available on other OSes,
+// this information should be surfaced through this structure as additional fields that the GC may optionally depend on.
+struct GCMemoryStatus
+{
+    uint32_t dwMemoryLoad;
+    uint64_t ullTotalPhys;
+    uint64_t ullAvailPhys;
+    uint64_t ullTotalPageFile;
+    uint64_t ullAvailPageFile;
+    uint64_t ullTotalVirtual;
+    uint64_t ullAvailVirtual;
+};
+
+typedef void * HANDLE;
+
+#ifndef _INC_WINDOWS
+
+typedef union _LARGE_INTEGER {
+    struct {
+#if BIGENDIAN
+        int32_t HighPart;
+        uint32_t LowPart;
+#else
+        uint32_t LowPart;
+        int32_t HighPart;
+#endif
+    } u;
+    int64_t QuadPart;
+} LARGE_INTEGER, *PLARGE_INTEGER;
+
+#ifdef WIN32
+
+#pragma pack(push, 8)
+
+typedef struct _RTL_CRITICAL_SECTION {
+    void* DebugInfo;
+
+    //
+    //  The following three fields control entering and exiting the critical
+    //  section for the resource
+    //
+
+    int32_t LockCount;
+    int32_t RecursionCount;
+    HANDLE OwningThread;        // from the thread's ClientId->UniqueThread
+    HANDLE LockSemaphore;
+    uintptr_t SpinCount;        // force size on 64-bit systems when packed
+} CRITICAL_SECTION, RTL_CRITICAL_SECTION, *PRTL_CRITICAL_SECTION;
+
+#pragma pack(pop)
+
+#else
+
+typedef struct _RTL_CRITICAL_SECTION {
+    pthread_mutex_t mutex;
+} CRITICAL_SECTION, RTL_CRITICAL_SECTION, *PRTL_CRITICAL_SECTION;
+
+#endif
+
+#endif // _INC_WINDOWS
+
+#endif // __GCENV_STRUCTS_INCLUDED__

--- a/src/Native/gc/sample/gcenv.h
+++ b/src/Native/gc/sample/gcenv.h
@@ -17,6 +17,7 @@
 #endif
 
 #include "sal.h"
+#include "gcenv.structs.h"
 #include "gcenv.base.h"
 #include "gcenv.object.h"
 #include "gcenv.sync.h"


### PR DESCRIPTION
This change fixes issues introduced recently when functions like
ClrVirtualAlloc etc. were added to the gcrhenv.cpp so that the
gcenv.windows.cpp is only used for the sample GC app and not shared
with the runtime.
For Unix though, the gcenv.unix.cpp remained being compiled as part of
the runtime and resulted in multiply defined symbols while linking.
There were also some function signature changes that were not projected
tothe PalRedhawkUnix.cpp. Finally, after removing the gcenv.unix.cpp,
several functions have to be copied from it to the PalRedhawkUnix.cpp.
Finally, I have modified the PalVirtualAlloc to always reserve memory 
aligned to 64k like Windows do.