### PR TITLE
Binplace JIT/ObjWriter next to ILC in Development Package

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -11,7 +11,7 @@
   <!-- Build Tools Versions -->
   <PropertyGroup>
     <BuildToolsVersion>1.0.25-prerelease-00104</BuildToolsVersion>
-    <DnxVersion>1.0.0-beta7</DnxVersion>
+    <DnxVersion>1.0.0-beta8</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>
     <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>
@@ -158,6 +158,7 @@
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-coreclr/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxtestdata/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet/" />
     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
   </ItemGroup>
 

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00104" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
-  <package id="dnx-mono" version="1.0.0-beta7" />
+  <package id="dnx-mono" version="1.0.0-beta8" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />
   <package id="Microsoft.Build.Mono.Debug" version="14.1.0.0-prerelease" />
 </packages>

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00104" />
-  <package id="dnx-coreclr-win-x86" version="1.0.0-beta7" />
+  <package id="dnx-coreclr-win-x86" version="1.0.0-beta8" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -32,6 +32,8 @@
       <file src="../ToolRuntime/*.dll" />
       <file src="../ToolRuntime/*.so" />
       <file src="../ToolRuntime/corerun" target="corerun" />
+      <file src="../../../../packages/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit/1.0.0-prerelease/runtimes/ubuntu.14.04-x64/native/libryujit.so" target="ryujit.so" />
+      <file src="../../../../packages/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter/1.0.2-prerelease/runtimes/ubuntu.14.04-x64/native/libobjwriter.so" target="objwriter.so" />
       <file src="../../../../packages/Microsoft.DiaSymReader/1.0.6/lib/portable-net45+win8/Microsoft.DiaSymReader.dll" />
   </files>
 </package>

--- a/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -36,6 +36,8 @@
     <file src="..\toolruntime\*.dll" />
     <file src="..\toolruntime\corerun.exe" target="corerun.exe" />
     <file src="..\..\..\..\packages\Microsoft.DiaSymReader\1.0.6\lib\portable-net45+win8\Microsoft.DiaSymReader.dll" />
+    <file src="..\..\..\..\packages\toolchain.win7-x64.Microsoft.DotNet.RyuJit\1.0.0-prerelease\runtimes\win7-x64\native\ryujit.dll" />
+    <file src="..\..\..\..\packages\toolchain.win7-x64.Microsoft.DotNet.ObjectWriter\1.0.2-prerelease\runtimes\win7-x64\native\objwriter.dll" />
     <file src="..\..\..\..\src\scripts\dotnet-compile-native.bat" />
   </files>
 </package>

--- a/src/AotPackageReference/project.json
+++ b/src/AotPackageReference/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NetCore.Platforms": "1.0.1-beta-23213",
+    "Microsoft.NETCore.Platforms": "1.0.1-beta-23213",
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "System.Diagnostics.Tracing": "4.0.20",

--- a/src/AotPackageReference/project.lock.json
+++ b/src/AotPackageReference/project.lock.json
@@ -1,9 +1,9 @@
 {
   "locked": false,
-  "version": 1,
+  "version": 2,
   "targets": {
     ".NETCore,Version=v5.0": {
-      "Microsoft.NetCore.Platforms/1.0.1-beta-23213": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23213": {
         "type": "package"
       },
       "System.Collections/4.0.10": {
@@ -24,9 +24,6 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
         "compile": {
           "ref/netcore50/System.Diagnostics.Contracts.dll": {}
         },
@@ -76,7 +73,7 @@
           "ref/netcore50/System.Globalization.dll": {}
         },
         "runtime": {
-          "lib/win8/_._": {}
+          "lib/wpa81/_._": {}
         }
       },
       "System.IO/4.0.10": {
@@ -302,7 +299,7 @@
       }
     },
     ".NETCore,Version=v5.0/win8-aot": {
-      "Microsoft.NetCore.Platforms/1.0.1-beta-23213": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23213": {
         "type": "package"
       },
       "System.Collections/4.0.10": {
@@ -323,9 +320,6 @@
       },
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
         "compile": {
           "ref/netcore50/System.Diagnostics.Contracts.dll": {}
         },
@@ -375,7 +369,7 @@
           "ref/netcore50/System.Globalization.dll": {}
         },
         "runtime": {
-          "lib/win8/_._": {}
+          "lib/wpa81/_._": {}
         }
       },
       "System.IO/4.0.10": {
@@ -602,13 +596,13 @@
     }
   },
   "libraries": {
-    "Microsoft.NetCore.Platforms/1.0.1-beta-23213": {
+    "Microsoft.NETCore.Platforms/1.0.1-beta-23213": {
       "type": "package",
       "sha512": "C7vDZPS/4Gn5+4Pei3oOL62r4FH/rOlozCNpfe/T58ClkHuSau/XoiWqq/BBmS6LOlF0qMcNHnCogjhvrN5O5Q==",
       "files": [
-        "Microsoft.NetCore.Platforms.1.0.1-beta-23213.nupkg",
-        "Microsoft.NetCore.Platforms.1.0.1-beta-23213.nupkg.sha512",
-        "Microsoft.NetCore.Platforms.nuspec",
+        "Microsoft.NETCore.Platforms.1.0.1-beta-23213.nupkg",
+        "Microsoft.NETCore.Platforms.1.0.1-beta-23213.nupkg.sha512",
+        "Microsoft.NETCore.Platforms.nuspec",
         "runtime.json"
       ]
     },
@@ -1319,7 +1313,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "Microsoft.NetCore.Platforms >= 1.0.1-beta-23213",
+      "Microsoft.NETCore.Platforms >= 1.0.1-beta-23213",
       "System.Runtime >= 4.0.20",
       "System.Runtime.Extensions >= 4.0.10",
       "System.Diagnostics.Tracing >= 4.0.20",

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -18,7 +18,9 @@
     "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.0.22",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23409"
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23409",
+    "Microsoft.DotNet.RyuJit": "1.0.0-prerelease",
+    "Microsoft.DotNet.ObjectWriter": "1.0.2-prerelease",
   },
   "frameworks": {
     "dotnet": {

--- a/tests/restore.cmd
+++ b/tests/restore.cmd
@@ -54,16 +54,6 @@ echo.
 echo Installing CoreRT external dependencies
 %__NuGetExeDir%\NuGet.exe install -Source %__NuGetFeedUrl% -OutputDir %__NuPkgInstallDir% -Version %CoreRT_AppDepSdkVer% %CoreRT_AppDepSdkPkg% -prerelease %__NuGetOptions%
 
-REM ** Install RyuJit
-echo.
-echo Installing RyuJit from NuGet
-%__NuGetExeDir%\NuGet.exe install -Source %__NuGetFeedUrl% -OutputDir %__NuPkgInstallDir% -Version %CoreRT_RyuJitVer% %CoreRT_RyuJitPkg% -prerelease %__NuGetOptions%
-
-REM ** Install ObjectWriter
-echo.
-echo Installing ObjectWriter from NuGet
-%__NuGetExeDir%\NuGet.exe install -Source %__NuGetFeedUrl% -OutputDir %__NuPkgInstallDir% -Version %CoreRT_ObjWriterVer% %CoreRT_ObjWriterPkg% -prerelease %__NuGetOptions%
-
 REM ** Install the built toolchain from product dir
 echo.
 echo Installing ILCompiler from %__BuiltNuPkgPath% into %__NuPkgInstallDir%
@@ -78,11 +68,13 @@ echo ^<packages^>^<package id="%CoreRT_ToolchainPkg%" version="%CoreRT_Toolchain
 %__NuGetExeDir%\NuGet.exe install "%__NuPkgUnpackDir%\packages.config" -Source "%__NuPkgUnpackDir%" -OutputDir "%__NuPkgInstallDir%" -prerelease %__NuGetOptions%
 rmdir /s /q %__NuPkgUnpackDir%
 
+set __ToolchainDir=%__NuPkgInstallDir%\%CoreRT_ToolchainPkg%.%CoreRT_ToolchainVer%
+
 endlocal & (
+  set CoreRT_ToolchainDir=%__ToolchainDir%
+  set    CoreRT_RyuJitDir=%__ToolchainDir%
+  set CoreRT_ObjWriterDir=%__ToolchainDir%
   set CoreRT_AppDepSdkDir=%__NuPkgInstallDir%\%CoreRT_AppDepSdkPkg%.%CoreRT_AppDepSdkVer%
-  set CoreRT_RyuJitDir=%__NuPkgInstallDir%\%CoreRT_RyuJitPkg%.%CoreRT_RyuJitVer%\runtimes\win7-%CoreRT_BuildArch%\native
-  set CoreRT_ObjWriterDir=%__NuPkgInstallDir%\%CoreRT_ObjWriterPkg%.%CoreRT_ObjWriterVer%\runtimes\win7-%CoreRT_BuildArch%\native
-  set CoreRT_ToolchainDir=%__NuPkgInstallDir%\%CoreRT_ToolchainPkg%.%CoreRT_ToolchainVer%
 )
 
 exit /b 100


### PR DESCRIPTION
These changes are required for correct DLL loading by the CLI. See PR in conjunction with https://github.com/dotnet/cli/pull/303. @gkhanna79, PTAL.