### PR TITLE
[Mac] Fixes to support HelloWorld using CPPCodegen

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -264,7 +264,7 @@ namespace ILCompiler.CppCodeGen
                         EcmaMethod ecmaMethod = method as EcmaMethod;
 
                         string importName = kind == SpecialMethodKind.PInvoke ?
-                            method.GetPInvokeMethodMetadata().Name : ecmaMethod.GetAttributeStringValue("System.Runtime", "RuntimeImport");
+                            method.GetPInvokeMethodMetadata().Name : ecmaMethod.GetAttributeStringValue("System.Runtime", "RuntimeImportAttribute");
 
                         if (importName == null)
                             importName = method.Name;

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -164,6 +164,8 @@ namespace ILCompiler
                 targetOS = TargetOS.Windows;
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 targetOS = TargetOS.Linux;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                targetOS = TargetOS.OSX;
             else
                 throw new NotImplementedException();
 #else

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -478,7 +478,7 @@
   </ItemGroup>
 
   <!-- Windows is default build -->
-  <ItemGroup Condition="'$(OSGroup)' != 'Linux'">
+  <ItemGroup Condition="'$(OSGroup)' == 'Windows_NT'">
       <Compile Include="System\Globalization\CultureInfo.Win32.cs" />
       <Compile Include="System\Globalization\CompareInfo.Win32.cs" />
       <Compile Include="System\Globalization\CultureData.Win32.cs" />
@@ -491,7 +491,7 @@
       <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Environment.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(OSGroup)' == 'Linux'">
+  <ItemGroup Condition="'$(OSGroup)' != 'Windows_NT'">
       <Compile Include="System\Globalization\CultureInfo.Dummy.cs" />
       <Compile Include="System\Globalization\CompareInfo.Dummy.cs" />
       <Compile Include="System\Globalization\CultureData.Dummy.cs" />


### PR DESCRIPTION
These are the fixes required to compile HelloWorld using CPPCodegen on Mac. There are corresponding changes in the CLI repo as PR https://github.com/dotnet/cli/pull/292.

@jkotas @janvorli PTAL.