### PR TITLE
Update instructions to use CLI to test dev ilc bits

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -28,7 +28,9 @@ This will result in the following:
 *Note: On Windows, please ensure you have VS 2015 installed to get the native toolset and work within a VS 2015 x64 Native Tools command prompt.*
 
 * Ensure that you have done a repo build per the instructions above.
-* Extract the contents of `<repo_root>/bin/product/<OS>_<Arch>_<BuildType>/.nuget/toolchain.<OS>-<Arch>-<BuildType>.Microsoft.DotNet.ILCompiler.Development*.nupkg` to a folder, say, **c:\extractedilc**
+* Install the contents of `<repo_root>/bin/product/<OS>.<Arch>.<BuildType>/.nuget/toolchain.<nupkg-rid>.Microsoft.DotNet.ILCompiler.Development*.nupkg` to a folder, say, **c:\newilc** using NuGet
+  * Example: `<repo_root>/packages/NuGet.exe install -Source <repo_root>/bin/Product/<OS>.<Arch>.<BuildType>/.nuget/ toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development -Version 1.0.0-prerelease -prerelease -OutputDirectory c:\newilc`
+  * On OSX/Ubuntu, use `mono` to run `NuGet.exe`.
 * Create a new folder and switch into it. 
 * Issue the command, `dotnet init`, on the command/shell prompt. This will add a template source file and corresponding project.json. If you get an error, please ensure the [pre-requisites](prerequisites-for-building.md) are installed. 
 
@@ -38,7 +40,7 @@ This will result in the following:
 This approach uses the same code-generator (RyuJIT), as [CoreCLR](https://github.com/dotnet/coreclr), for compiling the application. From the shell/command prompt, issue the following commands, from the folder containing your source file and project.json, to generate the native executable
 
     dotnet restore
-    dotnet compile --native --ilcpath c:\extractedilc
+    dotnet compile --native --ilcpath c:\newilc
 
 Native executable will be dropped in `./bin/[configuration]/[framework]/native/` folder and will have the same name as the folder in which your source file is present.
 
@@ -51,4 +53,4 @@ This approach uses platform specific C++ compiler and linker for compiling/linki
 From the shell/command prompt, issue the following commands to generate the native executable:
 
     dotnet restore
-    dotnet compile --native --cpp --ilcpath c:\extractedilc
+    dotnet compile --native --cpp --ilcpath c:\newilc

--- a/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -14,7 +14,6 @@
     <releaseNotes>Initial release</releaseNotes>
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
-        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
     </dependencies>
   </metadata>
   <files>

--- a/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -14,7 +14,6 @@
     <releaseNotes>Initial release</releaseNotes>
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
-        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
     </dependencies>
   </metadata>
   <files>

--- a/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -14,7 +14,6 @@
     <releaseNotes>Initial release</releaseNotes>
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
-        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
@gkhanna79, removing the DiaSymReader dependency as we are including anyway in the dev packages. Also updated the instructions to use NuGet which preserves file permissions. This is necessary to invoke corerun by the cli from where the nupkg is installed.