### PR TITLE
Use computed type size when reading field RVA data

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaField.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.cs
@@ -268,10 +268,9 @@ namespace Internal.TypeSystem.Ecma
             int addr = field.MetadataReader.GetFieldDefinition(field.Handle).GetRelativeVirtualAddress();
             var memBlock = field.Module.PEReader.GetSectionData(addr).GetContent();
 
-            var fieldType = (EcmaType)field.FieldType;
-            int size = fieldType.MetadataReader.GetTypeDefinition(fieldType.Handle).GetLayout().Size;
-            if (size == 0)
-                throw new NotImplementedException();
+            int size = field.FieldType.GetElementSize();
+            if (size > memBlock.Length)
+                throw new BadImageFormatException();
 
             byte[] result = new byte[size];
             memBlock.CopyTo(0, result, 0, result.Length);


### PR DESCRIPTION
It's not mandatory to set explicit layout for these and some of our IL
tests don't. This code was written before we knew how to do type layout.
We can now implement it the right way.