### PR TITLE
Don't create InstantiatedMethodIL for null MethodIL

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -78,7 +78,10 @@ namespace Internal.IL
             else
             if (method is InstantiatedMethod)
             {
-                return new InstantiatedMethodIL(GetMethodIL(method.GetMethodDefinition()), new Instantiation(), method.Instantiation);
+                var methodDefinitionIL = GetMethodIL(method.GetMethodDefinition());
+                if (methodDefinitionIL == null)
+                    return null;
+                return new InstantiatedMethodIL(methodDefinitionIL, new Instantiation(), method.Instantiation);
             }
             else
             if (method is ILStubMethod)


### PR DESCRIPTION
A test found this. Abstract generic methods have null MethodIL.