### PR TITLE
Improve unimplemented MemberRef bucketing

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -362,9 +362,16 @@ namespace Internal.TypeSystem.Ecma
                     throw new MissingMemberException("Method not found " + parent.ToString() + "." + name);
                 }
             }
+            else if (parent is MethodDesc)
+            {
+                throw new NotSupportedException("Vararg methods not supported in .NET Core.");
+            }
+            else if (parent is ModuleDesc)
+            {
+                throw new NotImplementedException("MemberRef to a global function or variable.");
+            }
 
-            // TODO: Not implemented
-            throw new NotImplementedException();
+            throw new BadImageFormatException();
         }
 
         private Object ResolveTypeReference(TypeReferenceHandle handle)


### PR DESCRIPTION
The only two unimplemented options are MethodDesc and ModuleDesc.