### PR TITLE
Remove internal uint CompareExchange overload

### DIFF
--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -15,7 +15,6 @@ using System.Runtime;
 using System.Globalization;
 using System.Collections;
 using System.Text;
-//    using System.Configuration.Assemblies;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
 using System.Runtime.CompilerServices;
@@ -29,24 +28,6 @@ namespace System
     [EagerOrderedStaticConstructor(EagerStaticConstructorOrder.SystemEnvironment)]
     public static partial class Environment
     {
-        //// Assume the following constants include the terminating '\0' - use <, not <=
-        //const int MaxEnvVariableValueLength = 32767;  // maximum length for environment variable name and value
-        //// System environment variables are stored in the registry, and have 
-        //// a size restriction that is separate from both normal environment 
-        //// variables and registry value name lengths, according to MSDN.
-        //// MSDN doesn't detail whether the name is limited to 1024, or whether
-        //// that includes the contents of the environment variable.
-        //const int MaxSystemEnvVariableLength = 1024;
-        //const int MaxUserEnvVariableLength = 255;
-
-        //// Desktop dropped support for Win2k3 in version 4.5, but Silverlight 5 supports Win2k3.
-
-
-        //private const  int    MaxMachineNameLength = 256;
-
-
-        //private static volatile OperatingSystem m_os;  // Cached OperatingSystem value
-
         /*==================================TickCount===================================
         **Action: Gets the number of ticks since the system was started.
         **Returns: The number of ticks since the system was started.

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -114,9 +114,9 @@ namespace System.Globalization
         private static volatile CultureInfo s_DefaultThreadCurrentCulture;
 
         [ThreadStatic]
-        private static volatile CultureInfo s_currentThreadCulture;
+        private static CultureInfo s_currentThreadCulture;
         [ThreadStatic]
-        private static volatile CultureInfo s_currentThreadUICulture;
+        private static CultureInfo s_currentThreadUICulture;
 
         private static readonly Lock s_lock = new Lock();
         private static volatile LowLevelDictionary<string, CultureInfo> s_NameCachedCultures;

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -49,15 +49,15 @@ namespace System.Runtime.CompilerServices
             return RuntimeImports.RhMemberwiseClone(obj);
         }
 
-        private const uint HASHCODE_BITS = 26;
-        private const uint MASK_HASHCODE = (1 << (int)HASHCODE_BITS) - 1;
+        private const int HASHCODE_BITS = 26;
+        private const int MASK_HASHCODE = (1 << (int)HASHCODE_BITS) - 1;
 
         [ThreadStatic]
-        private static uint t_hashSeed;
+        private static int t_hashSeed;
 
-        private static uint GetNewHashCode()
+        private static int GetNewHashCode()
         {
-            uint multiplier = (uint)Environment.CurrentManagedThreadId * 4 + 5;
+            int multiplier = Environment.CurrentManagedThreadId * 4 + 5;
             // Every thread has its own generator for hash codes so that we won't get into a situation
             // where two threads consistently give out the same hash codes.
             // Choice of multiplier guarantees period of 2**32 - see Knuth Vol 2 p16 (3.2.1.2 Theorem A).
@@ -72,28 +72,28 @@ namespace System.Runtime.CompilerServices
 
             fixed (IntPtr* pEEType = &o.m_pEEType)
             {
-                uint* pSyncBlockIndex = (uint*)((byte*)pEEType - 4); // skipping exactly 4 bytes for the SyncTableEntry (exactly 4 bytes not a pointer size).
-                uint hash = *pSyncBlockIndex & MASK_HASHCODE;
+                int* pSyncBlockIndex = (int*)((byte*)pEEType - 4); // skipping exactly 4 bytes for the SyncTableEntry (exactly 4 bytes not a pointer size).
+                int hash = *pSyncBlockIndex & MASK_HASHCODE;
 
                 if (hash == 0)
                     return MakeHashCode(o, pSyncBlockIndex);
                 else
-                    return (int)hash;
+                    return hash;
             }
         }
 
-        private static unsafe int MakeHashCode(Object o, uint* pSyncBlockIndex)
+        private static unsafe int MakeHashCode(Object o, int* pSyncBlockIndex)
         {
-            uint hash = GetNewHashCode() & MASK_HASHCODE;
+            int hash = GetNewHashCode() & MASK_HASHCODE;
 
             if (hash == 0)
                 hash = 1;
 
             while (true)
             {
-                uint oldIndex = Volatile.Read(ref *pSyncBlockIndex);
+                int oldIndex = Volatile.Read(ref *pSyncBlockIndex);
 
-                uint currentHash = oldIndex & MASK_HASHCODE;
+                int currentHash = oldIndex & MASK_HASHCODE;
                 if (currentHash != 0)
                 {
                     // Someone else set the hash code.
@@ -101,7 +101,7 @@ namespace System.Runtime.CompilerServices
                     break;
                 }
 
-                uint newIndex = oldIndex | hash;
+                int newIndex = oldIndex | hash;
 
                 if (Interlocked.CompareExchange(ref *pSyncBlockIndex, newIndex, oldIndex) == oldIndex)
                     break;

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
@@ -120,16 +120,16 @@ namespace System.Runtime.InteropServices
     {
         protected IntPtr handle;        // PUBLICLY DOCUMENTED handle field
 
-        private uint _state;            // Combined ref count and closed/disposed flags (so we can atomically modify them).
+        private int _state;            // Combined ref count and closed/disposed flags (so we can atomically modify them).
         private bool _ownsHandle;       // Whether we can release this handle.
 
         // Bitmasks for the _state field above.
-        private enum StateBits : uint
+        private static class StateBits
         {
-            Closed = 0x00000001,
-            Disposed = 0x00000002,
-            RefCount = 0xfffffffc,
-            RefCountOne = 4,            // Amount to increment state field to yield a ref count increment of 1
+            public const int Closed = 0x00000001;
+            public const int Disposed = 0x00000002;
+            public const int RefCount = unchecked((int)0xfffffffc);
+            public const int RefCountOne = 4;       // Amount to increment state field to yield a ref count increment of 1
         };
 
         // Creates a SafeHandle class.  Users must then set the Handle property.
@@ -138,7 +138,7 @@ namespace System.Runtime.InteropServices
         protected SafeHandle(IntPtr invalidHandleValue, bool ownsHandle)
         {
             handle = invalidHandleValue;
-            _state = (uint)StateBits.RefCountOne; // Ref count 1 and not closed or disposed.
+            _state = StateBits.RefCountOne; // Ref count 1 and not closed or disposed.
             _ownsHandle = ownsHandle;
 
             if (!ownsHandle)
@@ -225,7 +225,7 @@ namespace System.Runtime.InteropServices
 
         public bool IsClosed
         {
-            get { return (_state & (uint)StateBits.Closed) == (uint)StateBits.Closed; }
+            get { return (_state & StateBits.Closed) == StateBits.Closed; }
         }
 
         public abstract bool IsInvalid
@@ -251,15 +251,15 @@ namespace System.Runtime.InteropServices
 
         public void SetHandleAsInvalid()
         {
-            uint oldState, newState;
+            int oldState, newState;
             do
             {
                 oldState = _state;
 
-                if ((oldState & (uint)StateBits.Closed) != 0)
+                if ((oldState & StateBits.Closed) != 0)
                     return;
 
-                newState = oldState | (uint)StateBits.Closed;
+                newState = oldState | StateBits.Closed;
             } while (Interlocked.CompareExchange(ref _state, newState, oldState) != oldState);
         }
 
@@ -343,7 +343,7 @@ namespace System.Runtime.InteropServices
 
             // Might have to perform the following steps multiple times due to
             // interference from other AddRef's and Release's.
-            uint oldState, newState;
+            int oldState, newState;
             do
             {
                 // First step is to read the current handle state. We use this as a
@@ -352,7 +352,7 @@ namespace System.Runtime.InteropServices
                 oldState = _state;
 
                 // Check for closed state.
-                if ((oldState & (uint)StateBits.Closed) != 0)
+                if ((oldState & StateBits.Closed) != 0)
                 {
                     throw new ObjectDisposedException("SafeHandle");
                 }
@@ -362,7 +362,7 @@ namespace System.Runtime.InteropServices
                 // Continue doing this until the update succeeds (because nobody
                 // modifies the state field between the read and write operations) or
                 // the state moves to closed.
-                newState = oldState + (uint)StateBits.RefCountOne;
+                newState = oldState + StateBits.RefCountOne;
             } while (Interlocked.CompareExchange(ref _state, newState, oldState) != oldState);
             // If we got here we managed to update the ref count while the state
             // remained non closed. So we're done.
@@ -377,7 +377,7 @@ namespace System.Runtime.InteropServices
 
             // Might have to perform the following steps multiple times due to
             // interference from other AddRef's and Release's.
-            uint oldState, newState;
+            int oldState, newState;
             do
             {
                 // First step is to read the current handle state. We use this cached
@@ -391,14 +391,14 @@ namespace System.Runtime.InteropServices
                 // state and, in the case of successful state update, leave the disposed
                 // bit set. Silently do nothing if Dispose has already been called
                 // (because we advertise that as a semantic of Dispose).
-                if (fDispose && ((oldState & (uint)StateBits.Disposed) != 0))
+                if (fDispose && ((oldState & StateBits.Disposed) != 0))
                     return;
 
                 // We should never see a ref count of zero (that would imply we have
                 // unbalanced AddRef and Releases). (We might see a closed state before
                 // hitting zero though -- that can happen if SetHandleAsInvalid is
                 // used).
-                if ((oldState & (uint)StateBits.RefCount) == 0)
+                if ((oldState & StateBits.RefCount) == 0)
                 {
                     throw new ObjectDisposedException("SafeHandle");
                 }
@@ -406,7 +406,7 @@ namespace System.Runtime.InteropServices
                 // If we're proposing a decrement to zero and the handle is not closed
                 // and we own the handle then we need to release the handle upon a
                 // successful state update.
-                fPerformRelease = ((oldState & ((uint)StateBits.RefCount | (uint)StateBits.Closed)) == (uint)StateBits.RefCountOne);
+                fPerformRelease = ((oldState & (StateBits.RefCount | StateBits.Closed)) == StateBits.RefCountOne);
                 fPerformRelease &= _ownsHandle;
 
                 // If so we need to check whether the handle is currently invalid by
@@ -421,9 +421,9 @@ namespace System.Runtime.InteropServices
                 // substracting StateBits.RefCountOne from the state then OR in the bits for
                 // Dispose (if that's the reason for the Release) and closed (if the
                 // initial ref count was 1).
-                newState = (oldState - (uint)StateBits.RefCountOne) |
-                    ((oldState & (uint)StateBits.RefCount) == (uint)StateBits.RefCountOne ? (uint)StateBits.Closed : 0) |
-                    (fDispose ? (uint)StateBits.Disposed : 0);
+                newState = (oldState - StateBits.RefCountOne) |
+                    ((oldState & StateBits.RefCount) == StateBits.RefCountOne ? StateBits.Closed : 0) |
+                    (fDispose ? StateBits.Disposed : 0);
             } while (Interlocked.CompareExchange(ref _state, newState, oldState) != oldState);
 
             // If we get here we successfully decremented the ref count. Additonally we

--- a/src/System.Private.CoreLib/src/System/Threading/Interlocked.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Interlocked.cs
@@ -26,22 +26,6 @@ namespace System.Threading
         }
 
         [Intrinsic]
-        internal static uint CompareExchange(ref uint location1, uint value, uint comparand)
-        {
-#if CORERT
-            // CORERT-TODO: Implement interlocked intrinsics
-            var oldValue = location1;
-            if (oldValue == comparand)
-                location1 = value;
-            return oldValue;
-#else
-            // This is actually an intrinsic and not a recursive function call.
-            // We have it here so that you can do "ldftn" on the method or reflection invoke it.
-            return CompareExchange(ref location1, value, comparand);
-#endif
-        }
-
-        [Intrinsic]
         public static long CompareExchange(ref long location1, long value, long comparand)
         {
 #if CORERT


### PR DESCRIPTION
This internal overload was used on a few places that can be easily converted to use the public CompareExchange. Removing it helps with #85.

I have also included some minor cleanup that I had laying around.