### PR TITLE
Real fix for assert !IsStateSet(TSF_Detached)

### DIFF
--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -384,10 +384,6 @@ void Thread::Destroy()
 
     RedhawkGCInterface::ReleaseAllocContext(GetAllocContext());
 
-#if _DEBUG
-    memset(this, 0x06, sizeof(*this));
-#endif // _DEBUG
-
     // Thread::Destroy is called when the thread's "home" fiber dies.  We mark the thread as "detached" here
     // so that we can validate, in our DLL_THREAD_DETACH handler, that the thread was already destroyed at that
     // point.
@@ -942,8 +938,7 @@ bool Thread::IsDetached()
 
 void Thread::SetDetached()
 {
-    // https://github.com/dotnet/corert/issues/114
-    // ASSERT(!IsStateSet(TSF_Detached));
+    ASSERT(!IsStateSet(TSF_Detached));
     SetState(TSF_Detached);
 }
 


### PR DESCRIPTION
When I was making the Runtime build on Unix, I have fixed a memset in Thread::Destroy
that was intended to destroy the content of the object in debug builds, but instead
of filling sizeof(*this) bytes, it was filling sizeof(this). Clang issued a warning
at that spot.
But later on, when we have started to actually execute code, it turned out that the
object contents (well, at least its state flags) needs to be preserved since
the DllThreadDetach verifies that the thread was detached using that flag and
asserts since it fails.
@jkotas has commented out the assert as a temporary workaround. Now I am rectifying
it by actually removing the memset and re-enabling the assert.