### PR TITLE
Switch to dotnet tools and add unix testing

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -27,7 +27,7 @@ This will result in the following:
 
 * Ensure that you have done a repo build per the instructions above.
 * Install the contents of `<repo_root>/bin/product/<OS>.<Arch>.<BuildType>/.nuget/toolchain.<nupkg-rid>.Microsoft.DotNet.ILCompiler.Development*.nupkg` to a folder, say, **c:\newilc** using NuGet
-  * Example: `<repo_root>/packages/NuGet.exe install -Source <repo_root>/bin/Product/<OS>.<Arch>.<BuildType>/.nuget/ toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development -Version 1.0.0-prerelease -prerelease -OutputDirectory c:\newilc`
+  * Example: `<repo_root>/packages/NuGet.exe install -Source <repo_root>/bin/Product/<OS>.<Arch>.<BuildType>/.nuget/ toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development -Version 1.0.2-prerelease-00001 -prerelease -OutputDirectory c:\newilc`
   * On OSX/Ubuntu, use `mono` to run `NuGet.exe`.
 * Create a new folder and switch into it. 
 * Issue the command, `dotnet init`, on the command/shell prompt. This will add a template source file and corresponding project.json. If you get an error, please ensure the [pre-requisites](prerequisites-for-building.md) are installed. 

--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
@@ -12,7 +12,7 @@ _Note_:
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r c:\corert\bin\tests\package\toolchain.win7-x64.Microsoft.DotNet.AppDep.1.0.1-prerelease\*.dll -out c:\corert\src\ILCompiler\reproNative\repro.obj`
+`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r c:\corert\bin\tests\package\toolchain.win7-x64.Microsoft.DotNet.AppDep.1.0.2-prerelease-00002\*.dll -out c:\corert\src\ILCompiler\reproNative\repro.obj`
 
   - Copy ryujit.dll from `c:\corert\bin\tests\package\toolchain.win7-x64.Microsoft.DotNet.RyuJit\1.0.*\runtimes\win7-x64\native\ryujit.dll` to `c:\corert\src\ILCompiler\desktop\bin\Debug`
   - Copy objwriter.dll from `c:\corert\bin\tests\package\toolchain.win7-x64.Microsoft.DotNet.ObjectWriter\1.0.*\runtimes\win7-x64\native\objwriter.dll` to `c:\corert\src\ILCompiler\desktop\bin\Debug`
@@ -37,7 +37,7 @@ _Note_:
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r c:\corert\bin\tests\package\toolchain.win7-x64.Microsoft.DotNet.AppDep.1.0.1-prerelease\*.dll -out C:\corert\src\ILCompiler\reproNative\repro.cpp -cpp`
+`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r c:\corert\bin\tests\package\toolchain.win7-x64.Microsoft.DotNet.AppDep.1.0.2-prerelease-00002\*.dll -out C:\corert\src\ILCompiler\reproNative\repro.cpp -cpp`
 
     - `-nolinenumbers` command line option can be used to suppress generation of line number mappings in C++ files - useful for debugging
 

--- a/Documentation/nuget-dependencies-for-the-toolchain.md
+++ b/Documentation/nuget-dependencies-for-the-toolchain.md
@@ -5,23 +5,23 @@
 
 The following packages redirect to platform specific packages further below:
 
-Microsoft.DotNet.AppDep 1.0.0-prerelease
+Microsoft.DotNet.AppDep 1.0.2-prerelease-00002
 
-Microsoft.DotNet.ObjectWriter 1.0.2-prerelease
+Microsoft.DotNet.ObjectWriter 1.0.3-prerelease-00001
 
-Microsoft.DotNet.RyuJit 1.0.0-prerelease
+Microsoft.DotNet.RyuJit 1.0.1-prerelease-00002
 
 ## Linux
-toolchain.ubuntu.14.04-x64.Microsoft.DotNet.AppDep 1.0.0-prerelease
+toolchain.ubuntu.14.04-x64.Microsoft.DotNet.AppDep 1.0.2-prerelease-00002
 
-toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter 1.0.2-prerelease
+toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter 1.0.3-prerelease-00001
 
-toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit 1.0.0-prerelease
+toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit 1.0.1-prerelease-00002
 
 ## Windows
 
-toolchain.win7-x64.Microsoft.DotNet.AppDep 1.0.0-prerelease
+toolchain.win7-x64.Microsoft.DotNet.AppDep 1.0.2-prerelease-00002
 
-toolchain.win7-x64.Microsoft.DotNet.ObjectWriter 1.0.2-prerelease
+toolchain.win7-x64.Microsoft.DotNet.ObjectWriter 1.0.3-prerelease-00001
 
-toolchain.win7-x64.Microsoft.DotNet.RyuJit 1.0.0-prerelease
+toolchain.win7-x64.Microsoft.DotNet.RyuJit 1.0.1-prerelease-00002

--- a/build.cmd
+++ b/build.cmd
@@ -142,6 +142,20 @@ setlocal
 rem Explicitly set Platform causes conflicts in managed project files. Clear it to allow building from VS x64 Native Tools Command Prompt
 set Platform=
 
+:: Obtain dotnet CLI tools to perform restore packages/test runs
+:GetDotNetCli
+
+set "__DotNetCliPath=%__RootBinDir%\tools\cli"
+if not exist "%__DotNetCliPath%" (
+    for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& "%__SourceDir%\scripts\install-cli.ps1" -installdir "%__RootBinDir%\tools""') do (
+        echo "" > nul
+    )
+)
+if not exist "%__DotNetCliPath%" (
+    echo DotNet CLI could not be downloaded or installed.
+    exit /b 1
+)
+
 :: Set the environment for the managed build
 call "!VS%__VSProductVersion%COMNTOOLS!\VsDevCmd.bat"
 echo Commencing build of managed components for %__BuildOS%.%__BuildArch%.%__BuildType%

--- a/dir.props
+++ b/dir.props
@@ -11,9 +11,6 @@
   <!-- Build Tools Versions -->
   <PropertyGroup>
     <BuildToolsVersion>1.0.25-prerelease-00104</BuildToolsVersion>
-    <DnxVersion>1.0.0-beta8</DnxVersion>
-    <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
-    <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>
     <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
   </PropertyGroup>
@@ -169,9 +166,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DnxPackageDir Condition="'$(DnxPackageDir)'==''">$(PackagesDir)/$(DnxPackageName)/</DnxPackageDir>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'!='Unix'">$(DnxPackageDir)\bin\dnu.cmd</DnuToolPath>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'=='Unix'">$(DnxPackageDir)/bin/dnu</DnuToolPath>
+    <DnuToolPath Condition="'$(DnuToolPath)'==''">$(BinDir)/tools/cli/bin/dotnet</DnuToolPath>
 
     <DnuRestoreSource>@(DnuSourceList -> '--source %(Identity)', ' ')</DnuRestoreSource>
     <DnuRestoreDirs>@(DnuRestoreDir -> '%(Identity)', ' ')</DnuRestoreDirs>

--- a/dir.targets
+++ b/dir.targets
@@ -94,11 +94,7 @@
     <!-- Restore build tools -->
     <Exec Command="$(_RestoreBuildToolsCommand)" StandardOutputImportance="Low" />
 
-    <!-- Add DNU and Roslyn tool execute rights -->
-    <Exec Condition="'$(OsEnvironment)'=='Unix'"
-          Command="chmod a+x &quot;$(DnxPackageDir)/bin/dnu&quot;" />
-    <Exec Condition="'$(OsEnvironment)'=='Unix'"
-          Command="chmod a+x &quot;$(DnxPackageDir)/bin/dnx&quot;" />
+    <!-- Add Roslyn tool execute rights -->
     <Exec Condition="'$(OsEnvironment)'=='Unix'"
           Command="find '$(RoslynPackageDir)tools' -name &quot;*.exe&quot; -exec chmod &quot;+x&quot; '{}' ';'" />
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -59,10 +59,8 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
                 }
             }
 
-            if (os == 'Windows_NT') {
-                // This call performs test run checks for the CI.
-                Utilities.addXUnitDotNETResults(newJob, '**/testResults.xml')
-            }
+            // This call performs test run checks for the CI.
+            Utilities.addXUnitDotNETResults(newJob, '**/testResults.xml')
 
             // This call performs remaining common job setup on the newly created job.
             // This is used most commonly for simple inner loop testing.

--- a/src/.nuget/Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/Microsoft.DotNet.ILCompiler.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.ILCompiler</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.2-prerelease-00001</version>
     <title>Microsoft .NET Native Toolchain</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -14,6 +14,32 @@
     <releaseNotes>Initial release</releaseNotes>
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
+        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.3-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.RyuJit" version="1.0.1-prerelease-00002" />
+        <dependency id="System.AppContext" version="4.0.0" />
+        <dependency id="System.Collections" version="4.0.10" />
+        <dependency id="System.Collections.Concurrent" version="4.0.10" />
+        <dependency id="System.Collections.Immutable" version="1.1.37" />
+        <dependency id="System.Console" version="4.0.0-beta-23419" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
+        <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
+        <dependency id="System.IO" version="4.0.10" />
+        <dependency id="System.IO.FileSystem" version="4.0.0" />
+        <dependency id="System.Linq" version="4.0.0" />
+        <dependency id="System.Reflection" version="4.0.10" />
+        <dependency id="System.Reflection.Extensions" version="4.0.0" />
+        <dependency id="System.Reflection.Metadata" version="1.0.22" />
+        <dependency id="System.Reflection.Primitives" version="4.0.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.0" />
+        <dependency id="System.Runtime" version="4.0.20" />
+        <dependency id="System.Runtime.Extensions" version="4.0.10" />
+        <dependency id="System.Runtime.InteropServices" version="4.0.20" />
+        <dependency id="System.Text.Encoding" version="4.0.10" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.10" />
+        <dependency id="System.Threading" version="4.0.10" />
+        <dependency id="System.Threading.Tasks" version="4.0.10" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00104" />
-  <package id="dnx-coreclr-win-x86" version="1.0.0-beta8" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/.nuget/runtime.json
+++ b/src/.nuget/runtime.json
@@ -2,17 +2,17 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.DotNet.ILCompiler": {
-        "toolchain.win7-x64.Microsoft.DotNet.ILCompiler": "1.0.0-prerelease"
-      }
-    },
-    "ubuntu.14.04-x64": {
-      "Microsoft.DotNet.ILCompiler": {
-        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler": "1.0.0-prerelease"
+        "toolchain.win7-x64.Microsoft.DotNet.ILCompiler": "1.0.2-prerelease-00001"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.DotNet.ILCompiler": {
-        "toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler": "1.0.0-prerelease"
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler": "1.0.2-prerelease-00001"
+      }
+    },
+    "ubuntu.14.04-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler": "1.0.2-prerelease-00001"
       }
     }
   }

--- a/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.Development</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.2-prerelease-00001</version>
     <title>Microsoft .NET Native Toolchain - Development Version</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -29,7 +29,7 @@
       <file src="../lib/libSystem.Private.CoreLib.Native.a" target="libSystem.Private.CoreLib.Native.a" />
       <file src="../System.Private.Corelib.dll" target="System.Private.Corelib.dll" />
       <file src="../ToolRuntime/*.dll" />
-      <file src="../ToolRuntime/*.so" />
+      <file src="../ToolRuntime/*.dylib" />
       <file src="../ToolRuntime/corerun" target="corerun" />
       <file src="../../../../packages/Microsoft.DiaSymReader/1.0.6/lib/portable-net45+win8/Microsoft.DiaSymReader.dll" />
   </files>

--- a/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.osx.10.10-x64.Microsoft.DotNet.ILCompiler</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.2-prerelease-00001</version>
     <title>Microsoft .NET Native Toolchain</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -15,6 +15,8 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
         <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.3-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.RyuJit" version="1.0.1-prerelease-00002" />
         <dependency id="System.AppContext" version="4.0.0" />
         <dependency id="System.Collections" version="4.0.10" />
         <dependency id="System.Collections.Concurrent" version="4.0.10" />

--- a/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.Development</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.2-prerelease-00001</version>
     <title>Microsoft .NET Native Toolchain - Development Version</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -31,8 +31,8 @@
       <file src="../ToolRuntime/*.dll" />
       <file src="../ToolRuntime/*.so" />
       <file src="../ToolRuntime/corerun" target="corerun" />
-      <file src="../../../../packages/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit/1.0.0-prerelease/runtimes/ubuntu.14.04-x64/native/libryujit.so" target="ryujit.so" />
-      <file src="../../../../packages/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter/1.0.2-prerelease/runtimes/ubuntu.14.04-x64/native/libobjwriter.so" target="objwriter.so" />
+      <file src="../../../../packages/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit/1.0.1-prerelease-00002/runtimes/ubuntu.14.04-x64/native/libryujit.so" target="ryujit.so" />
+      <file src="../../../../packages/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter/1.0.3-prerelease-00001/runtimes/ubuntu.14.04-x64/native/libobjwriter.so" target="objwriter.so" />
       <file src="../../../../packages/Microsoft.DiaSymReader/1.0.6/lib/portable-net45+win8/Microsoft.DiaSymReader.dll" />
   </files>
 </package>

--- a/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ILCompiler</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.2-prerelease-00001</version>
     <title>Microsoft .NET Native Toolchain</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -15,6 +15,8 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
         <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.3-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.RyuJit" version="1.0.1-prerelease-00002" />
         <dependency id="System.AppContext" version="4.0.0" />
         <dependency id="System.Collections" version="4.0.10" />
         <dependency id="System.Collections.Concurrent" version="4.0.10" />

--- a/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.win7-x64.Microsoft.DotNet.ILCompiler.Development</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.2-prerelease-00001</version>
     <title>Microsoft .NET Native Toolchain - Development Version</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -35,8 +35,8 @@
     <file src="..\toolruntime\*.dll" />
     <file src="..\toolruntime\corerun.exe" target="corerun.exe" />
     <file src="..\..\..\..\packages\Microsoft.DiaSymReader\1.0.6\lib\portable-net45+win8\Microsoft.DiaSymReader.dll" />
-    <file src="..\..\..\..\packages\toolchain.win7-x64.Microsoft.DotNet.RyuJit\1.0.0-prerelease\runtimes\win7-x64\native\ryujit.dll" />
-    <file src="..\..\..\..\packages\toolchain.win7-x64.Microsoft.DotNet.ObjectWriter\1.0.2-prerelease\runtimes\win7-x64\native\objwriter.dll" />
+    <file src="..\..\..\..\packages\toolchain.win7-x64.Microsoft.DotNet.RyuJit\1.0.1-prerelease-00002\runtimes\win7-x64\native\ryujit.dll" />
+    <file src="..\..\..\..\packages\toolchain.win7-x64.Microsoft.DotNet.ObjectWriter\1.0.3-prerelease-00001\runtimes\win7-x64\native\objwriter.dll" />
     <file src="..\..\..\..\src\scripts\dotnet-compile-native.bat" />
   </files>
 </package>

--- a/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.ILCompiler.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.win7-x64.Microsoft.DotNet.ILCompiler</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.2-prerelease-00001</version>
     <title>Microsoft .NET Native Toolchain</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -15,6 +15,8 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
     <dependencies>
         <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.3-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.RyuJit" version="1.0.1-prerelease-00002" />
         <dependency id="System.AppContext" version="4.0.0" />
         <dependency id="System.Collections" version="4.0.10" />
         <dependency id="System.Collections.Concurrent" version="4.0.10" />

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -26,6 +26,7 @@ namespace ILCompiler
         public bool NoLineNumbers;
         public string DgmlLog;
         public bool FullLog;
+        public bool Verbose;
     }
 
     public partial class Compilation

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -845,7 +845,7 @@ namespace ILCompiler.CppCodeGen
                 Out.WriteLine("__reverse_pinvoke_return(&frame);");
                 Out.WriteLine("__shutdown_runtime();");
 
-                if (voidReturn) Out.WriteLine(voidReturn ? "return 0;" : "return ret;");
+                Out.WriteLine(voidReturn ? "return 0;" : "return ret;");
                 Out.WriteLine("}");
             }
 

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -77,6 +77,10 @@ namespace ILCompiler
                         _options.FullLog = true;
                         break;
 
+                    case "verbose":
+                        _options.Verbose = true;
+                        break;
+
                     case "r":
                     case "reference":
                         parser.AppendExpandedPaths(_referenceFilePaths, false);
@@ -129,7 +133,7 @@ namespace ILCompiler
             }
 
             Compilation compilation = new Compilation(_compilerTypeSystemContext, _options);
-            compilation.Log = Console.Out;
+            compilation.Log = _options.Verbose ? Console.Out : TextWriter.Null;
             compilation.OutputPath = _outputPath;
             if (_options.IsCppCodeGen)
             {

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -19,8 +19,8 @@
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.0.22",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23409",
-    "Microsoft.DotNet.RyuJit": "1.0.0-prerelease",
-    "Microsoft.DotNet.ObjectWriter": "1.0.2-prerelease",
+    "Microsoft.DotNet.RyuJit": "1.0.1-prerelease-00002",
+    "Microsoft.DotNet.ObjectWriter": "1.0.3-prerelease-00001",
   },
   "frameworks": {
     "dotnet": {

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -376,13 +376,6 @@ extern "C" void RhRethrow()
     throw "RhRethrow";
 }
 
-#ifdef CPPCODEGEN
-extern "C" void RhpBulkWriteBarrier()
-{
-    throw 42;
-}
-#endif
-
 #ifndef CPPCODEGEN
 SimpleModuleHeader __module = { NULL, NULL /* &__gcStatics, &__gcStaticsDescs */ };
 

--- a/src/scripts/install-cli.ps1
+++ b/src/scripts/install-cli.ps1
@@ -1,0 +1,98 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+param (
+    [string] $InstallDir = $null,
+    [string] $TargetPlatform = "x64"
+)
+
+# The below code is from dotnet/cli install.ps1
+
+$ErrorActionPreference="Stop"
+$ProgressPreference="SilentlyContinue"
+
+$Feed="https://dotnetcli.blob.core.windows.net/dotnet"
+$Channel="dev"
+$DotNetFileName="dotnet-win-" + $TargetPlatform + ".latest.zip"
+$DotNetUrl="$Feed/$Channel/Binaries/Latest"
+
+function say($str)
+{
+    Write-Host "dotnet_install: $str"
+}
+
+if (!$InstallDir) {
+    $InstallDir = "$env:LocalAppData\Microsoft\dotnet"
+}
+
+say "Preparing to install .NET Tools to $InstallDir"
+
+# Check if we need to bother
+$LocalFile = "$InstallDir\cli\.version"
+if (Test-Path $LocalFile)
+{
+    $LocalData = @(cat $LocalFile)
+    $LocalHash = $LocalData[0].Trim()
+    $LocalVersion = $LocalData[1].Trim()
+    if ($LocalVersion -and $LocalHash)
+    {
+        $RemoteResponse = Invoke-WebRequest -UseBasicParsing "$Feed/$Channel/dnvm/latest.win.version"
+        $RemoteData = @([Text.Encoding]::UTF8.GetString($RemoteResponse.Content).Split());
+        $RemoteHash = $RemoteData[0].Trim()
+        $RemoteVersion = $RemoteData[1].Trim()
+
+        if (!$RemoteVersion -or !$RemoteHash) {
+            throw "Invalid response from feed"
+        }
+
+        say "Latest version: $RemoteVersion"
+        say "Local Version: $LocalVersion"
+
+        if($LocalHash -eq $RemoteHash)
+        {
+            say "You already have the latest version"
+            exit 0
+        }
+    }
+}
+
+# Set up the install location
+if (!(Test-Path $InstallDir)) {
+    mkdir $InstallDir | Out-Null
+}
+
+# De-powershell the path before passing to .NET APIs
+$InstallDir = Convert-Path $InstallDir
+
+say "Downloading $DotNetFileName from $DotNetUrl"
+$resp = Invoke-WebRequest -UseBasicParsing "$DotNetUrl/$DotNetFileName" -OutFile "$InstallDir\$DotNetFileName"
+
+say "Extracting zip"
+
+# Create the destination
+if (Test-Path "$InstallDir\cli_new") {
+    del -rec -for "$InstallDir\cli_new"
+}
+mkdir "$InstallDir\cli_new" | Out-Null
+
+Add-Type -Assembly System.IO.Compression.FileSystem | Out-Null
+[System.IO.Compression.ZipFile]::ExtractToDirectory("$InstallDir\$DotNetFileName", "$InstallDir\cli_new")
+
+# Replace the old installation (if any)
+if (Test-Path "$InstallDir\cli") {
+    del -rec -for "$InstallDir\cli"
+}
+mv "$InstallDir\cli_new" "$InstallDir\cli"
+
+# Clean the zip
+if (Test-Path "$InstallDir\$DotNetFileName") {
+    del -for "$InstallDir\$DotNetFileName"
+}
+
+say "The .NET Tools have been installed to $InstallDir\cli!"
+
+# New layout
+say "Add '$InstallDir\cli\bin' to your PATH to use dotnet"
+

--- a/tests/restore.cmd
+++ b/tests/restore.cmd
@@ -7,13 +7,9 @@ if not defined CoreRT_BuildArch ((call :Fail "Set CoreRT_BuildArch to x86/x64/ar
 if not defined CoreRT_BuildType ((call :Fail "Set CoreRT_BuildType to Debug or Release") & exit /b -1)
 
 set CoreRT_ToolchainPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.ILCompiler.Development
-set CoreRT_ToolchainVer=1.0.0-prerelease
+set CoreRT_ToolchainVer=1.0.2-prerelease-00001
 set CoreRT_AppDepSdkPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.AppDep
-set CoreRT_AppDepSdkVer=1.0.1-prerelease
-set CoreRT_RyuJitPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.RyuJit
-set CoreRT_RyuJitVer=1.0.0-prerelease
-set CoreRT_ObjWriterPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.ObjectWriter
-set CoreRT_ObjWriterVer=1.0.2-prerelease
+set CoreRT_AppDepSdkVer=1.0.2-prerelease-00002
 
 setlocal EnableExtensions
 set __ScriptDir=%~dp0
@@ -30,11 +26,6 @@ if /i "%1" == "/nugetopt"      (set __NuGetOptions=%2&shift&shift&goto Arg_Loop)
 echo Invalid command line argument: %1
 goto Usage
 :ArgsDone
-
-:SetTempFolder
-set __TempFolder=%TMP%\unpack-%RANDOM%-%RANDOM%
-if exist "%__TempFolder%" goto :SetTempFolder
-set __NuPkgUnpackDir=%__TempFolder%
 
 if not exist %__NuGetExeDir%\NuGet.exe ((call :Fail "No NuGet.exe found at %__NuGetExeDir%. Specify /nugetexedir option") & exit /b -1)
 if "%__NuPkgInstallDir%"=="" ((call :Fail "Specify /installdir option") & exit /b -1)
@@ -55,18 +46,12 @@ echo Installing CoreRT external dependencies
 %__NuGetExeDir%\NuGet.exe install -Source %__NuGetFeedUrl% -OutputDir %__NuPkgInstallDir% -Version %CoreRT_AppDepSdkVer% %CoreRT_AppDepSdkPkg% -prerelease %__NuGetOptions%
 
 REM ** Install the built toolchain from product dir
+set __BuiltNuPkgPath=%__BuiltNuPkgDir%\%CoreRT_ToolchainPkg%.%CoreRT_ToolchainVer%.nupkg
 echo.
 echo Installing ILCompiler from %__BuiltNuPkgPath% into %__NuPkgInstallDir%
-
-set __BuiltNuPkgPath=%__BuiltNuPkgDir%\%CoreRT_ToolchainPkg%.%CoreRT_ToolchainVer%.nupkg
 if not exist "%__BuiltNuPkgPath%" ((call :Fail "Did not find a built %__BuiltNuPkgPath%. Did you run build.cmd?") & exit /b -1)
 
-mkdir %__NuPkgUnpackDir%
-if not exist %__NuPkgUnpackDir% ((call :Fail "Could not make install dir") & exit /b -1)
-copy /y %__BuiltNuPkgPath% %__NuPkgUnpackDir% > nul
-echo ^<packages^>^<package id="%CoreRT_ToolchainPkg%" version="%CoreRT_ToolchainVer%"/^>^</packages^> > %__NuPkgUnpackDir%\packages.config
-%__NuGetExeDir%\NuGet.exe install "%__NuPkgUnpackDir%\packages.config" -Source "%__NuPkgUnpackDir%" -OutputDir "%__NuPkgInstallDir%" -prerelease %__NuGetOptions%
-rmdir /s /q %__NuPkgUnpackDir%
+%__NuGetExeDir%\NuGet.exe install %CoreRT_ToolchainPkg% -Version %CoreRT_ToolchainVer% -Source "%__BuiltNuPkgDir%" -OutputDir "%__NuPkgInstallDir%" -prerelease %__NuGetOptions%
 
 set __ToolchainDir=%__NuPkgInstallDir%\%CoreRT_ToolchainPkg%.%CoreRT_ToolchainVer%
 

--- a/tests/restore.sh
+++ b/tests/restore.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Usage: $0 [dbg^|rel] [x86^|amd64^|arm] [-?]"
+    exit -8
+}
+
+
+source $(cd "$(dirname "$0")"; pwd -P)/testenv.sh "$@"
+
+if [ -z ${CoreRT_BuildOS} ]; then
+    export CoreRT_BuildOS=Linux
+fi
+
+if [ -z ${CoreRT_BuildArch} ]; then
+    echo "Set CoreRT_BuildArch to x86/x64/arm/arm64"
+    exit -1
+fi
+
+if [ -z ${CoreRT_BuildType} ]; then
+    echo "Set CoreRT_BuildType to Debug or Release"
+    exit -1
+fi
+
+__build_os_lowcase=$(echo "${CoreRT_BuildOS}" | tr '[:upper:]' '[:lower:]')
+if [ ${__build_os_lowcase} != "osx" ]; then
+    __BuildRid=ubuntu.14.04
+else
+    __BuildRid=osx.10.10
+fi
+export CoreRT_ToolchainPkg=toolchain.${__BuildRid}-${CoreRT_BuildArch}.Microsoft.DotNet.ILCompiler.Development
+export CoreRT_ToolchainVer=1.0.2-prerelease-00001
+export CoreRT_AppDepSdkPkg=toolchain.${__BuildRid}-${CoreRT_BuildArch}.Microsoft.DotNet.AppDep
+export CoreRT_AppDepSdkVer=1.0.2-prerelease-00002
+
+__ScriptDir=$(cd "$(dirname "$0")"; pwd -P)
+__BuildStr=${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}
+
+while test $# -gt 0
+    do
+        lowerI="$(echo $1 | awk '{print tolower($0)}')"
+        case $lowerI in
+        -h|-help)
+            usage
+            exit 1
+            ;;
+        -nugetexedir)
+            shift
+            __NuGetExeDir=$1
+            ;;
+        -nupkgdir)
+            shift
+            __BuiltNuPkgDir=$1
+            ;;
+        -installdir)
+            shift
+            __NuPkgInstallDir=$1
+            ;;
+        -nugetopt)
+            shift
+            __NuGetOptions=$1
+            ;;
+        *)
+            ;;
+        esac
+    shift
+done
+
+if [ ! -f ${__NuGetExeDir}/NuGet.exe ] ; then
+    echo "No NuGet.exe found at ${__NuGetExeDir}.  Specify -nugetexedir option"
+    exit -1
+fi
+
+if [ -z ${__NuPkgInstallDir} ] ; then
+    echo "Specify -installdir option"
+    exit -1
+fi
+
+if [ ! -d ${__BuiltNuPkgDir} ] ; then
+    echo "Specify -nupkgdir to point to the build toolchain path"
+    echo ${__BuiltNuPkgDir}
+    exit -1
+fi
+
+echo "Cleaning up ${__NuPkgInstallDir}"
+rm -rf ${__NuPkgInstallDir}
+mkdir -p ${__NuPkgInstallDir}
+if [ ! -d ${__NuPkgInstallDir} ]; then
+    echo "Could not make install dir"
+    exit -1
+fi
+
+__NuGetFeedUrl="https://www.myget.org/F/dotnet/auth/3e4f1dbe-f43a-45a8-b029-3ad4d25605ac/api/v2"
+
+echo Installing CoreRT external dependencies
+mono ${__NuGetExeDir}/NuGet.exe install -Source ${__NuGetFeedUrl} -OutputDir ${__NuPkgInstallDir} -Version ${CoreRT_AppDepSdkVer} ${CoreRT_AppDepSdkPkg} -prerelease ${__NuGetOptions} -nocache
+
+__BuiltNuPkgPath=${__BuiltNuPkgDir}/${CoreRT_ToolchainPkg}.${CoreRT_ToolchainVer}.nupkg
+echo Installing ILCompiler from ${__BuiltNuPkgPath} into ${__NuPkgInstallDir}
+
+if [ ! -f ${__BuiltNuPkgPath} ]; then
+    echo "Did not find a build ${__BuiltNuPkgPath}.  Did you run build.sh?"
+    exit -1
+fi
+
+mono ${__NuGetExeDir}/NuGet.exe install -Source "${__BuiltNuPkgDir}" -OutputDir "${__NuPkgInstallDir}" ${CoreRT_ToolchainPkg} -Version ${CoreRT_ToolchainVer} -prerelease ${__NuGetOptions}
+chmod +x ${__NuPkgInstallDir}/${CoreRT_ToolchainPkg}.${CoreRT_ToolchainVer}/corerun
+
+export CoreRT_AppDepSdkDir=${__NuPkgInstallDir}/${CoreRT_AppDepSdkPkg}.${CoreRT_AppDepSdkVer}
+export CoreRT_ToolchainDir=${__NuPkgInstallDir}/${CoreRT_ToolchainPkg}.${CoreRT_ToolchainVer}
+export CoreRT_RyuJitDir=${CoreRT_ToolchainDir}
+export CoreRT_ObjWriterDir=${CoreRT_ToolchainDir}

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Usage: $0 [OS] [arch] [flavor] [-extrepo] [-buildextrepo] [-mode] [-runtest]"
+    echo "    -mode         : Compilation mode. Specify cpp/ryujit. Default: ryujit"
+    echo "    -runtest      : Should just compile or run compiled bianry? Specify: true/false. Default: true."
+    echo "    -extrepo      : Path to external repo, currently supports: GitHub: dotnet/coreclr. Specify full path. If unspecified, runs corert tests"
+    echo "    -buildextrepo : Should build at root level of external repo? Specify: true/false. Default: true"
+    echo "    -nocache      : When restoring toolchain packages, obtain them from the feed not the cache."
+    exit 1
+}
+
+runtest()
+{
+    echo "Running test $1 $2"
+    __SourceFolder=$1
+    __SourceFileName=$2
+    __SourceFile=${__SourceFolder}/${__SourceFileName}
+    ${__SourceFile}.sh $1 $2 ${CoreRT_BuildType}
+    return $?
+}
+
+restore()
+{
+    ${CoreRT_CliBinDir}/dotnet restore $1
+}
+
+compiletest()
+{
+    echo "Compiling dir $1 with dotnet compile $2"
+    rm -rf $1/bin $1/obj
+    ${CoreRT_CliBinDir}/dotnet compile --native -c ${CoreRT_BuildType} --ilcpath ${CoreRT_ToolchainDir} $1 $2
+}
+
+run_test_dir()
+{
+    local __test_dir=$1
+    local __restore=$2
+    local __mode=$3
+    local __dir_path=`dirname ${__test_dir}`
+    local __filename=`basename ${__dir_path}`
+    if [ ${__restore} == 1 ]; then
+      restore ${__dir_path}
+    fi
+    local __compile_args=""
+    if [ "${__mode}" = "Cpp" ]; then
+      __compile_args="--cpp"
+    fi
+    compiletest ${__dir_path} ${__compile_args}
+    runtest ${__dir_path} ${__filename}
+    local __exitcode=$?
+    if [ ${__exitcode} == 0 ]; then
+        local __pass_var=__${__mode}PassedTests
+        eval ${__pass_var}=$((${__pass_var} + 1))
+        echo "<test name=\"${__dir_path}\" type=\"${__filename}:${__mode}\" method=\"Main\" result=\"Pass\" />" >> ${__TestBinDir}/testResults.tmp
+    else
+        echo "<test name=\"${__dir_path}\" type=\"${__filename}:${__mode}\" method=\"Main\" result=\"Fail\" />" >> ${__TestBinDir}/testResults.tmp
+        echo "<failure exception-type=\"Exit code: ${__exitcode}\">" >> ${__TestBinDir}/testResults.tmp
+        echo     "<message>See ${__dir_path} /bin or /obj for logs </message>" >> ${__TestBinDir}/testResults.tmp
+        echo "</failure>" >> ${__TestBinDir}/testResults.tmp
+        echo "</test>" >> ${__TestBinDir}/testResults.tmp
+    fi
+    local __total_var=__${__mode}TotalTests
+    eval ${__total_var}=$((${__total_var} + 1))
+    return $?
+}
+
+CoreRT_TestRoot=$(cd "$(dirname "$0")"; pwd -P)
+CoreRT_CliBinDir=${CoreRT_TestRoot}/../bin/tools/cli/bin
+CoreRT_BuildArch=x64
+CoreRT_BuildType=Debug
+CoreRT_TestRun=true
+CoreRT_TestCompileMode=ryujit
+CoreRT_TestExtRepo=
+CoreRT_BuildExtRepo=
+
+# Use uname to determine what the OS is.
+OSName=$(uname -s)
+case $OSName in
+    Linux)
+        CoreRT_BuildOS=Linux
+        ;;
+
+    Darwin)
+        CoreRT_BuildOS=OSX
+        ;;
+
+    FreeBSD)
+        CoreRT_BuildOS=FreeBSD
+        ;;
+
+    *)
+        echo "Unsupported OS $OSName detected, configuring as if for Linux"
+        CoreRT_BuildOS=Linux
+        ;;
+esac
+
+for i in "$@"
+    do
+        lowerI="$(echo $i | awk '{print tolower($0)}')"
+        case $lowerI in
+        -?|-h|--help)
+            usage
+            exit 1
+            ;;
+        x86)
+            CoreRT_BuildArch=x86
+            ;;
+        x64)
+            CoreRT_BuildArch=x64
+            ;;
+        arm)
+            CoreRT_BuildArch=arm
+            ;;
+        arm64)
+            CoreRT_BuildArch=arm64
+            ;;
+        debug)
+            CoreRT_BuildType=Debug
+            ;;
+        release)
+            CoreRT_BuildType=Release
+            ;;
+        -extrepo)
+            shift
+            CoreRT_TestExtRepo=$i
+            ;;
+        -mode)
+            shift
+            CoreRT_TestCompileMode=$i
+            ;;
+        -runtest)
+            shift
+            CoreRT_TestRun=$i
+            ;;
+        -nocache)
+            CoreRT_NuGetOptions=-nocache
+            ;;
+        *)
+            ;;
+    esac
+done
+
+__BuildStr=${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}
+__TestBinDir=${CoreRT_TestRoot}/../bin/tests
+__LogDir=${CoreRT_TestRoot}/../bin/Logs/${__BuildStr}/tests
+__NuPkgInstallDir=${__TestBinDir}/package
+__BuiltNuPkgDir=${CoreRT_TestRoot}/../bin/Product/${__BuildStr}/.nuget
+__PackageRestoreCmd=$CoreRT_TestRoot/restore.sh
+source ${__PackageRestoreCmd} -nugetexedir ${CoreRT_TestRoot}/../packages -installdir ${__NuPkgInstallDir} -nupkgdir ${__BuiltNuPkgDir} -nugetopt ${CoreRT_NuGetOptions}
+
+if [ ! -d ${CoreRT_AppDepSdkDir} ]; then
+    echo "AppDep SDK not installed at ${CoreRT_AppDepSdkDir}"
+    exit -1
+fi
+
+if [ ! -d ${CoreRT_ToolchainDir} ]; then
+    echo "Toolchain not found in ${CoreRT_ToolchainDir}"
+    exit -1
+fi
+
+__CppTotalTests=0
+__CppPassedTests=0
+__JitTotalTests=0
+__JitPassedTests=0
+
+echo > ${__TestBinDir}/testResults.tmp
+
+__BuildOsLowcase=$(echo "${CoreRT_BuildOS}" | tr '[:upper:]' '[:lower:]')
+
+for json in $(find src -iname 'project.json')
+do
+    __restore=1
+    # Disable RyuJIT for OSX.
+    if [ ${__BuildOsLowcase} != "osx" ]; then
+        run_test_dir ${json} ${__restore} "Jit"
+        __restore=0
+    fi
+    run_test_dir ${json} ${__restore} "Cpp"
+done
+
+__TotalTests=$((${__JitTotalTests} + ${__CppTotalTests}))
+__PassedTests=$((${__JitPassedTests} + ${__CppPassedTests}))
+__FailedTests=$((${__TotalTests} - ${__PassedTests}))
+
+echo "<?xml version=\"1.0\" encoding=\"utf-8\"?^>" > ${__TestBinDir}/testResults.xml
+echo "<assemblies>"  >> ${__TestBinDir}/testResults.xml
+echo "<assembly name=\"ILCompiler\" total=\"${__TotalTests}\" passed=\"${__PassedTests}\" failed=\"${__FailedTests}\" skipped=\"0\">"  >> ${__TestBinDir}/testResults.xml
+echo "<collection total=\"${__TotalTests}\" passed=\"${__PassedTests}\" failed=\"${__FailedTests}\" skipped=\"0\">"  >> ${__TestBinDir}/testResults.xml
+cat "${__TestBinDir}/testResults.tmp" >> ${__TestBinDir}/testResults.xml
+echo "</collection>"  >> ${__TestBinDir}/testResults.xml
+echo "</assembly>"  >> ${__TestBinDir}/testResults.xml
+echo "</assemblies>"  >> ${__TestBinDir}/testResults.xml
+
+
+echo "JIT - TOTAL: ${__JitTotalTests} PASSED: ${__JitPassedTests}"
+echo "CPP - TOTAL: ${__CppTotalTests} PASSED: ${__CppPassedTests}"
+
+# Disable RyuJIT for OSX.
+if [ ${__BuildOsLowcase} != "osx" ]; then
+    if [ ${__JitTotalTests} == 0 ]; then
+        exit 1
+    fi
+fi
+
+if [ ${__CppTotalTests} == 0 ]; then
+    exit 1
+fi
+if [ ${__JitTotalTests} -gt ${__JitPassedTests} ]; then
+    exit 1
+fi
+if [ ${__CppTotalTests} -gt ${__CppPassedTests} ]; then
+    exit 1
+fi
+
+exit 0
+
+

--- a/tests/src/Simple/Add1/Add1.cmd
+++ b/tests/src/Simple/Add1/Add1.cmd
@@ -1,6 +1,6 @@
 @echo off
 setlocal
-%~dp0\%~n0.compiled.exe
+%~dp0\bin\%1\dnxcore50\native\%~n0.exe
 set ErrorCode=%ERRORLEVEL%
 IF "%ErrorCode%"=="100" (
     echo %~n0: pass

--- a/tests/src/Simple/Add1/Add1.sh
+++ b/tests/src/Simple/Add1/Add1.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+$1/bin/$3/dnxcore50/native/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/Add1/project.json
+++ b/tests/src/Simple/Add1/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "System.Console": "4.0.0-beta-*",
+        "System.Runtime": "4.0.21-beta-*"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/tests/src/Simple/AsgAdd1/AsgAdd1.cmd
+++ b/tests/src/Simple/AsgAdd1/AsgAdd1.cmd
@@ -1,6 +1,6 @@
 @echo off
 setlocal
-%~dp0\%~n0.compiled.exe
+%~dp0\bin\%1\dnxcore50\native\%~n0.exe
 set ErrorCode=%ERRORLEVEL%
 IF "%ErrorCode%"=="100" (
     echo %~n0: pass

--- a/tests/src/Simple/AsgAdd1/AsgAdd1.sh
+++ b/tests/src/Simple/AsgAdd1/AsgAdd1.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+$1/bin/$3/dnxcore50/native/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/AsgAdd1/project.json
+++ b/tests/src/Simple/AsgAdd1/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "System.Console": "4.0.0-beta-*",
+        "System.Runtime": "4.0.21-beta-*"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/tests/src/Simple/Hello/Hello.cmd
+++ b/tests/src/Simple/Hello/Hello.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 set ErrorCode=100
-for /f "usebackq delims=;" %%F in (`%~dp0\%~n0.compiled.exe`) do (
+for /f "usebackq delims=;" %%F in (`%~dp0\bin\%1\dnxcore50\native\%~n0.exe`) do (
     if "%%F"=="Hello world" set ErrorCode=0
 )
 IF "%ErrorCode%"=="0" (

--- a/tests/src/Simple/Hello/Hello.sh
+++ b/tests/src/Simple/Hello/Hello.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+dir=$1
+file=$2
+cmp=`$dir/bin/$3/dnxcore50/native/$file | tr '\r' ';'`
+if [[ $cmp = "Hello world;" ]]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/Hello/project.json
+++ b/tests/src/Simple/Hello/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "System.Console": "4.0.0-beta-*",
+        "System.Runtime": "4.0.21-beta-*"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/tests/testenv.sh
+++ b/tests/testenv.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+usage()
+{
+	echo "$0 [arch: x86/x64/arm/arm64] [flavor: debug/release]"
+	exit 1
+
+}
+
+for i in "$@"
+	do
+		lowerI="$(echo $i | awk '{print tolower($0)}')"
+		case $lowerI in
+		-?|-h|-help)
+			usage
+			exit 1
+			;;
+		x86)
+			export CoreRT_BuildArch=x86
+			;;
+		x64)
+			export CoreRT_BuildArch=x64
+			;;
+		arm)
+			export CoreRT_BuildArch=arm
+			;;
+		arm64)
+			export CoreRT_BuildArch=arm64
+			;;
+		dbg)
+			export CoreRT_BuildType=Debug
+			;;
+		debug)
+			export CoreRT_BuildType=Debug
+			;;
+		rel)
+			export CoreRT_BuildType=Release
+			;;
+		release)
+			export CoreRT_BuildType=Release
+			;;
+		*)
+			;;
+	esac
+done


### PR DESCRIPTION
Enables RyuJIT/CPP modes for Windows/Linux/OSX and switches restoration and testing to "latest" dotnet tools from dotnet/cli repo. Disabled OSX JIT tests as CLI doesn't support it yet.