### PR TITLE
Fixed argument processing for -?

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -267,7 +267,7 @@ for i in "$@"
     do
         lowerI="$(echo $i | awk '{print tolower($0)}')"
         case $lowerI in
-        -?|-h|--help)
+        -h|--help)
             usage
             exit 1
             ;;


### PR DESCRIPTION
In bash, the ? will actually be treated as any character. So it needs escaping. But since this is not Unix style to use ?, I wonder if we should not just remove it.