### PR TITLE
Fix a few small issues

### DIFF
--- a/src/Native/Runtime/GCMemoryHelpers.inl
+++ b/src/Native/Runtime/GCMemoryHelpers.inl
@@ -7,14 +7,21 @@
 // Unmanaged GC memory helpers
 //
 
+#ifndef DACCESS_COMPILE
 #ifdef WRITE_BARRIER_CHECK
 extern uint8_t* g_GCShadow;
 extern uint8_t* g_GCShadowEnd;
-extern "C" uint8_t* g_lowest_address;
-extern "C" uint8_t* g_highest_address;
+typedef DPTR(uint8_t)   PTR_uint8_t;
+extern "C" {
+    GPTR_DECL(uint8_t, g_lowest_address);
+    GPTR_DECL(uint8_t, g_highest_address);
+}
 #endif
 
-extern "C" uint32_t* g_card_table;
+typedef DPTR(uint32_t)   PTR_uint32_t;
+extern "C" {
+    GPTR_DECL(uint32_t, g_card_table);
+}
 static const UInt32 INVALIDGCVALUE = 0xcccccccd;
 
 FORCEINLINE void InlinedBulkWriteBarrier(void* pMemStart, UInt32 cbMemSize)
@@ -105,3 +112,4 @@ FORCEINLINE void InlinedBulkWriteBarrier(void* pMemStart, UInt32 cbMemSize)
     }
     while (clumpCount != 0);
 }
+#endif // DACCESS_COMPILE

--- a/src/Native/Runtime/amd64/AsmMacros.inc
+++ b/src/Native/Runtime/amd64/AsmMacros.inc
@@ -208,6 +208,11 @@ Name label proc
 PUBLIC Name
         endm
 
+LABELED_RETURN_ADDRESS macro Name
+
+Name label proc
+PUBLIC Name
+        endm
 
 _tls_array     equ 58h     ;; offsetof(TEB, ThreadLocalStoragePointer)
 

--- a/src/Native/Runtime/amd64/CallDescrWorker.asm
+++ b/src/Native/Runtime/amd64/CallDescrWorker.asm
@@ -57,8 +57,8 @@ StackCopyLoop:                          ; copy the arguments to stack top-down t
         movdqa  xmm3, [rax + 30h]       ;
 DoCall:
         call    qword ptr [rbx + OFFSETOF__CallDescrData__pTarget]     ; call target function
-ALTERNATE_ENTRY ReturnFromCallDescrThunk ; Symbol used to identify thunk call to managed function so the special 
-                                         ; case unwinder can unwind through this function
+LABELED_RETURN_ADDRESS ReturnFromCallDescrThunk ; Symbol used to identify thunk call to managed function so the special 
+                                                ; case unwinder can unwind through this function
 
         ; Save FP return value
 

--- a/src/Native/Runtime/amd64/ManagedCalloutThunk.asm
+++ b/src/Native/Runtime/amd64/ManagedCalloutThunk.asm
@@ -46,7 +46,7 @@ NESTED_ENTRY ManagedCallout2, _TEXT
         ;; Call the target method. Arguments are already in the correct registers. The
         ;; ReturnFromManagedCallout2 label must immediately follow the call instruction.
         call    r8
-ALTERNATE_ENTRY ReturnFromManagedCallout2
+LABELED_RETURN_ADDRESS ReturnFromManagedCallout2
 
         ;; Pop the rbp frame and return.
         mov     rsp, rbp

--- a/src/Native/Runtime/amd64/UniversalTransition.asm
+++ b/src/Native/Runtime/amd64/UniversalTransition.asm
@@ -84,7 +84,7 @@ NESTED_ENTRY RhpUniversalTransition, _TEXT
         mov  rdx, r11
         lea  rcx, [rsp + OFFSETOF_SCRATCH_SPACE] 
         call rax
-ALTERNATE_ENTRY ReturnFromUniversalTransition
+LABELED_RETURN_ADDRESS ReturnFromUniversalTransition
 
         ; restore fp argument registers
         movdqa          xmm0, [rsp + OFFSETOF_FP_ARG_SPILL      ]

--- a/src/Native/Runtime/arm/CallDescrWorker.asm
+++ b/src/Native/Runtime/arm/CallDescrWorker.asm
@@ -59,7 +59,7 @@ LNoFloatingPoint
         ;; Note that remoting expect target in r4.
         ldr     r4, [r5,#OFFSETOF__CallDescrData__pTarget]
         blx     r4
-        ALTERNATE_ENTRY ReturnFromCallDescrThunk
+    LABELED_RETURN_ADDRESS ReturnFromCallDescrThunk
 
         ldr     r3, [r5,#OFFSETOF__CallDescrData__fpReturnSize]
 

--- a/src/Native/Runtime/arm/ManagedCalloutThunk.asm
+++ b/src/Native/Runtime/arm/ManagedCalloutThunk.asm
@@ -44,7 +44,7 @@
         ;; Call the target method. Arguments are already in the correct registers. The
         ;; ReturnFromManagedCallout2 label must immediately follow the blx instruction.
         blx     r2
-    ALTERNATE_ENTRY ReturnFromManagedCallout2
+    LABELED_RETURN_ADDRESS ReturnFromManagedCallout2
 
         ;; Pop the frame and return.
         EPILOG_STACK_RESTORE r7

--- a/src/Native/Runtime/arm/UniversalTransition.asm
+++ b/src/Native/Runtime/arm/UniversalTransition.asm
@@ -115,7 +115,7 @@
         ALIGN 4
         add         r0, sp, #(RETURN_BLOCK_STACK_OFFSET) ; First parameter to target function is a pointer to the return block
         blx         r12
-        ALTERNATE_ENTRY ReturnFromUniversalTransition
+    LABELED_RETURN_ADDRESS ReturnFromUniversalTransition
 
         ;; Move the result (the target address) to r12 so it doesn't get overridden when we restore the
         ;; argument registers. Additionally make sure the thumb2 bit is set.

--- a/src/Native/Runtime/gcenv.h
+++ b/src/Native/Runtime/gcenv.h
@@ -40,6 +40,14 @@
     #define FireEtwPinPlugAtGCTime(PlugStart, PlugEnd, GapBeforeSize, ClrInstanceID) 0
     #define FireEtwGCTriggered(Reason, ClrInstanceID) 0
 
+    #ifndef _INC_WINDOWS
+        typedef uint64_t ULONGLONG;
+        typedef uint32_t ULONG;
+        typedef int64_t LONGLONG;
+        typedef uint8_t BYTE;
+        typedef uint16_t UINT16;
+    #endif // _INC_WINDOWS
+
     #include "etwevents.h"
     #include "eventtrace.h"
 #endif
@@ -152,7 +160,7 @@ public:
     bool    IsGCStressMix()                 const { return false; }
 
     int     GetGCtraceStart()               const { return 0; }
-    int     GetGCtraceEnd  ()               const { return 0; }//1000000000; }
+    int     GetGCtraceEnd  ()               const { return 1000000000; }
     int     GetGCtraceFac  ()               const { return 0; }
     int     GetGCprnLvl    ()               const { return 0; }
     bool    IsGCBreakOnOOMEnabled()         const { return false; }

--- a/src/Native/Runtime/i386/AsmMacros.inc
+++ b/src/Native/Runtime/i386/AsmMacros.inc
@@ -26,6 +26,14 @@ decoratedName label proc
 PUBLIC decoratedName
         endm
 
+LABELED_RETURN_ADDRESS macro Name
+
+decoratedName TEXTEQU @CatStr( _, Name ) )
+
+decoratedName label proc
+PUBLIC decoratedName
+        endm
+
 __tls_array     equ 2Ch     ;; offsetof(TEB, ThreadLocalStoragePointer)
 
 ;;

--- a/src/Native/Runtime/i386/CallDescrWorker.asm
+++ b/src/Native/Runtime/i386/CallDescrWorker.asm
@@ -49,7 +49,7 @@ donestack:
         mov     ecx, dword ptr [eax + 4]
         mov     eax,[ebx + OFFSETOF__CallDescrData__pTarget]
         call    eax
-ALTERNATE_ENTRY ReturnFromCallDescrThunk ; Symbol used to identify thunk call to managed function so the special case unwinder can unwind through this function
+LABELED_RETURN_ADDRESS ReturnFromCallDescrThunk ; Symbol used to identify thunk call to managed function so the special case unwinder can unwind through this function
 
         ; Save FP return value if necessary
         mov     ecx, [ebx + OFFSETOF__CallDescrData__fpReturnSize]

--- a/src/Native/Runtime/i386/ManagedCalloutThunk.asm
+++ b/src/Native/Runtime/i386/ManagedCalloutThunk.asm
@@ -50,7 +50,7 @@ FASTCALL_FUNC ManagedCallout2, 16
         ;; we can just go. The _ReturnFromManagedCallout2 label must immediately follow the call instruction.
         mov     eax, [ebp + 08h]
         call    eax
-ALTERNATE_ENTRY ReturnFromManagedCallout2
+LABELED_RETURN_ADDRESS ReturnFromManagedCallout2
 
         ;; Pop the ebp frame and return.
         mov     esp, ebp

--- a/src/Native/Runtime/i386/UniversalTransition.asm
+++ b/src/Native/Runtime/i386/UniversalTransition.asm
@@ -73,7 +73,7 @@ ALTERNATE_ENTRY RhpUniversalTransition@0
         mov  edx, [ebp-8]    ; Get first argument
         lea  ecx, [ebp-14h]  ; Get pointer to argument information
         call eax
-ALTERNATE_ENTRY ReturnFromUniversalTransition
+LABELED_RETURN_ADDRESS ReturnFromUniversalTransition
 
         POP_COOP_PINVOKE_FRAME
         pop edx

--- a/src/Native/Runtime/module.h
+++ b/src/Native/Runtime/module.h
@@ -16,18 +16,8 @@ struct GenericInstanceDesc;
 typedef SPTR(struct GenericInstanceDesc) PTR_GenericInstanceDesc;
 struct SimpleModuleHeader;
 
-class Module
-//#ifndef DACCESS_COMPILE
-    // TODO: JIT support in DAC
-    : public ICodeManager
-//#endif
+class Module : public ICodeManager
 {
-#ifdef DACCESS_COMPILE
-    // The DAC does not support registration of dynamic code managers yet, but we need a space for the vtable used at runtime.
-    // TODO: JIT support in DAC
-    TADDR m_vptr;
-#endif
-
     friend class AsmOffsets;
     friend struct DefaultSListTraits<Module>;
     friend class RuntimeInstance;

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -3113,6 +3113,7 @@ in_range_for_segment(uint8_t* add, heap_segment* seg)
 struct bk
 {
     uint8_t* add;
+    size_t val;
 };
 
 class sorted_table
@@ -3133,7 +3134,7 @@ public:
     void    delete_sorted_table();
     void    delete_old_slots();
     void    enqueue_old_slot(bk* sl);
-    BOOL    insure_space_for_insert();
+    BOOL    ensure_space_for_insert();
 };
 
 sorted_table*
@@ -3199,7 +3200,7 @@ sorted_table::lookup (uint8_t*& add)
             if ((ti > 0) && (buck[ti-1].add <= add))
             {
                 add = buck[ti-1].add;
-                return 0;
+                return buck[ti - 1].val;
             }
             high = mid - 1;
         }
@@ -3208,7 +3209,7 @@ sorted_table::lookup (uint8_t*& add)
             if (buck[ti+1].add > add)
             {
                 add = buck[ti].add;
-                return 0;
+                return buck[ti].val;
             }
             low = mid + 1;
         }
@@ -3218,7 +3219,7 @@ sorted_table::lookup (uint8_t*& add)
 }
 
 BOOL
-sorted_table::insure_space_for_insert()
+sorted_table::ensure_space_for_insert()
 {
     if (count == size)
     {
@@ -3242,8 +3243,6 @@ sorted_table::insure_space_for_insert()
 BOOL
 sorted_table::insert (uint8_t* add, size_t val)
 {
-    //val is ignored for non concurrent gc
-    val = val;
     //grow if no more room
     assert (count < size);
 
@@ -3267,6 +3266,7 @@ sorted_table::insert (uint8_t* add, size_t val)
                     buck [k] = buck [k-1];
                 }
                 buck[ti].add = add;
+                buck[ti].val = val;
                 count++;
                 return TRUE;
             }
@@ -3282,6 +3282,7 @@ sorted_table::insert (uint8_t* add, size_t val)
                     buck [k] = buck [k-1];
                 }
                 buck[ti+1].add = add;
+                buck[ti+1].val = val;
                 count++;
                 return TRUE;
             }
@@ -3290,7 +3291,6 @@ sorted_table::insert (uint8_t* add, size_t val)
     }
     assert (0);
     return TRUE;
-
 }
 
 void
@@ -3436,11 +3436,11 @@ void seg_mapping_table_remove_ro_segment (heap_segment* seg)
 
 heap_segment* ro_segment_lookup (uint8_t* o)
 {
-    uint8_t* ro_seg = 0;
-    gc_heap::seg_table->lookup (ro_seg);
+    uint8_t* ro_seg_start = o;
+    heap_segment* seg = (heap_segment*)gc_heap::seg_table->lookup (ro_seg_start);
 
-    if (ro_seg && in_range_for_segment (o, (heap_segment*)ro_seg))
-        return (heap_segment*)ro_seg;
+    if (ro_seg_start && in_range_for_segment (o, seg))
+        return seg;
     else
         return 0;
 }
@@ -4549,7 +4549,7 @@ gc_heap::get_segment (size_t size, BOOL loh_p)
     if (!result)
     {
 #ifndef SEG_MAPPING_TABLE
-        if (!seg_table->insure_space_for_insert ())
+        if (!seg_table->ensure_space_for_insert ())
             return 0;
 #endif //SEG_MAPPING_TABLE
         void* mem = virtual_alloc (size);
@@ -7435,10 +7435,10 @@ BOOL gc_heap::insert_ro_segment (heap_segment* seg)
 {
     enter_spin_lock (&gc_heap::gc_lock);
 
-    if (!gc_heap::seg_table->insure_space_for_insert () ||
-        (!(should_commit_mark_array() && commit_mark_array_new_seg (__this, seg))))
+    if (!gc_heap::seg_table->ensure_space_for_insert ()
+        || (should_commit_mark_array() && !commit_mark_array_new_seg(__this, seg)))
     {
-        leave_spin_lock (&gc_heap::gc_lock);
+        leave_spin_lock(&gc_heap::gc_lock);
         return FALSE;
     }
 
@@ -7448,8 +7448,7 @@ BOOL gc_heap::insert_ro_segment (heap_segment* seg)
     heap_segment_next (seg) = oldhead;
     generation_start_segment (gen2) = seg;
 
-    ptrdiff_t sdelta = 0;
-    seg_table->insert ((uint8_t*)seg, sdelta);
+    seg_table->insert (heap_segment_mem(seg), (size_t)seg);
 
 #ifdef SEG_MAPPING_TABLE
     seg_mapping_table_add_ro_segment (seg);
@@ -10152,7 +10151,7 @@ gc_heap::init_gc_heap (int  h_number)
     gc_done_event_set = false;
 
 #ifndef SEG_MAPPING_TABLE
-    if (!gc_heap::seg_table->insure_space_for_insert ())
+    if (!gc_heap::seg_table->ensure_space_for_insert ())
     {
         return 0;
     }
@@ -10217,7 +10216,7 @@ gc_heap::init_gc_heap (int  h_number)
     ephemeral_heap_segment = seg;
 
 #ifndef SEG_MAPPING_TABLE
-    if (!gc_heap::seg_table->insure_space_for_insert ())
+    if (!gc_heap::seg_table->ensure_space_for_insert ())
     {
         return 0;
     }

--- a/src/Native/gc/handletable.cpp
+++ b/src/Native/gc/handletable.cpp
@@ -876,7 +876,7 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
  *
  */
 void HndEnumHandles(HHANDLETABLE hTable, const uint32_t *puType, uint32_t uTypeCount,
-                    HANDLESCANPROC pfnEnum, uintptr_t lParam1, uintptr_t lParam2, BOOL fAsync)
+                    HANDLESCANPROC pfnEnum, uintptr_t lParam1, uintptr_t lParam2, bool fAsync)
 {
     WRAPPER_NO_CONTRACT;
 

--- a/src/Native/gc/handletable.h
+++ b/src/Native/gc/handletable.h
@@ -113,7 +113,7 @@ typedef void (CALLBACK *HANDLESCANPROC)(PTR_UNCHECKED_OBJECTREF pref, uintptr_t 
  * NON-GC handle enumeration
  */
 void HndEnumHandles(HHANDLETABLE hTable, const uint32_t *puType, uint32_t uTypeCount,
-                    HANDLESCANPROC pfnEnum, uintptr_t lParam1, uintptr_t lParam2, BOOL fAsync);
+                    HANDLESCANPROC pfnEnum, uintptr_t lParam1, uintptr_t lParam2, bool fAsync);
 
 /*
  * GC-time handle scanning

--- a/src/Native/gc/objecthandle.cpp
+++ b/src/Native/gc/objecthandle.cpp
@@ -1218,7 +1218,7 @@ void Ref_TraceRefCountHandles(HANDLESCANPROC callback, uintptr_t lParam1, uintpt
                 {
                     HHANDLETABLE hTable = walk->pBuckets[i]->pTable[j];
                     if (hTable)
-                        HndEnumHandles(hTable, &handleType, 1, callback, lParam1, lParam2, FALSE);
+                        HndEnumHandles(hTable, &handleType, 1, callback, lParam1, lParam2, false);
                 }
             }
         }


### PR DESCRIPTION
GC code for RO segments had some bugs because it had never been
tested.  CoreCLR doesn't use RO segments.  The fix is to update
sorted_table to keep both the segment memory and the segment
descriptors separately as key/value pairs.  This isn't needed
for normal segments because they are the same, but with RO
segments the memory is in an executable file, while the descriptor
is dynamically allocated.  I also changed "insure" to "ensure".

Changed HndEnumHandles to use a bool parameter instead of BOOL.
This side-steps some differences in the definition of BOOL that
led to some compilation issues.

Port LABELED_RETURN_ADDRESS changes from PN tree.

Fixed a couple of DAC issues.