### PR TITLE
Enable compilation of AsmOffsetsVerify.cpp

### DIFF
--- a/src/Native/Runtime/AsmOffsetsVerify.cpp
+++ b/src/Native/Runtime/AsmOffsetsVerify.cpp
@@ -13,7 +13,7 @@
 #include "regdisplay.h"
 #include "StackFrameIterator.h"
 #include "thread.h"
-#include "targetptrs.h"
+#include "TargetPtrs.h"
 #include "rhbinder.h"
 #include "RWLock.h"
 #include "RuntimeInstance.h"

--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -48,7 +48,7 @@ set(COMMON_RUNTIME_SOURCES
 )
 
 set(FULL_RUNTIME_SOURCES
-    # AsmOffsetsVerify.cpp
+    AsmOffsetsVerify.cpp
 )
 
 set(PORTABLE_RUNTIME_SOURCES

--- a/src/Native/Runtime/CallDescr.h
+++ b/src/Native/Runtime/CallDescr.h
@@ -2,13 +2,14 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+
 struct CallDescrData
 {
-    BYTE* pSrc;
+    uint8_t* pSrc;
     int numStackSlots;
     int fpReturnSize;
-    BYTE* pArgumentRegisters;
-    BYTE* pFloatArgumentRegisters;
+    uint8_t* pArgumentRegisters;
+    uint8_t* pFloatArgumentRegisters;
     void* pTarget;
     void* pReturnBuffer;
 };


### PR DESCRIPTION
Fix issue #444 to ensure that pre-computed offsets match the C/C++ structures layout.