### PR TITLE
Enable command line args for RyuJit bootstrapper

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -420,14 +420,21 @@ namespace ILCompiler
         {
             var stringType = TypeSystemContext.GetWellKnownType(WellKnownType.String);
 
+            // TODO: We are rooting String[] so the bootstrap code can find the EEType for making the command-line args
+            // string array.  Once we generate the startup code in managed code, we should remove this
+            var arrayOfStringType = stringType.MakeArrayType();
+
             if (_dependencyGraph != null)
             {
                 _dependencyGraph.AddRoot(_nodeFactory.ConstructedTypeSymbol(stringType), "String type is always generated");
+                _dependencyGraph.AddRoot(_nodeFactory.ConstructedTypeSymbol(arrayOfStringType), "String[] type is always generated");
             }
             else
             {
                 AddType(stringType);
                 MarkAsConstructed(stringType);
+                AddType(arrayOfStringType);
+                MarkAsConstructed(arrayOfStringType);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -48,10 +48,6 @@ namespace ILCompiler.CppCodeGen
             // TODO: For now, ensure that all types/methods referenced by unmanaged helpers are present
             var stringType = _compilation.TypeSystemContext.GetWellKnownType(WellKnownType.String);
             AddInstanceFields(stringType);
-
-            var stringArrayType = stringType.MakeArrayType();
-            _compilation.AddType(stringArrayType);
-            _compilation.MarkAsConstructed(stringArrayType);
         }
 
         public string GetCppSignatureTypeName(TypeDesc type)


### PR DESCRIPTION
Create managed objects for String[] args and each string command line
argument and pass them in through the call to __managed__Main.

Add System.String[] as a rooted type (until we generate start-up code in
managed and don't need the lib export).