### PR TITLE
Add script to run native format generator

### DIFF
--- a/src/Common/src/Internal/Metadata/NativeFormat/Script/CsMdBinaryRWCommonGen.py
+++ b/src/Common/src/Internal/Metadata/NativeFormat/Script/CsMdBinaryRWCommonGen.py
@@ -174,7 +174,7 @@ else
     #------------------------------------------------------------------------------------------------------
     def CsEmitSource(self):
         # Source MdBinaryReaderGen.cs
-        with open(r'System\Reflection\Metadata\MdBinaryReaderGen.cs', 'w') as output :
+        with open(r'MdBinaryReaderGen.cs', 'w') as output :
             ns = NamespaceDef('Internal.Metadata.NativeFormat')
             ns.members.add(self.CreateMdBinaryReaderClass())
 
@@ -193,7 +193,7 @@ else
             ns.CsDefine(iprint)
 
         # Source MdBinaryWriterGen.cs
-        with open(r'..\..\..\PnToolChain\Metadata\NativeFormatWriter\MdBinaryWriterGen.cs', 'w') as output :
+        with open(r'..\..\..\..\..\ILCompiler.MetadataWriter\src\Internal\Metadata\NativeFormat\Writer\MdBinaryWriterGen.cs', 'w') as output :
             ns = NamespaceDef('Internal.Metadata.NativeFormat.Writer')
             ns.members.add(self.CreateMdBinaryWriterClass())
 

--- a/src/Common/src/Internal/Metadata/NativeFormat/Script/CsPublicGen2.py
+++ b/src/Common/src/Internal/Metadata/NativeFormat/Script/CsPublicGen2.py
@@ -314,7 +314,7 @@ def CsEmitSource():
             sig = [hnd, [(Ty.MetadataReader, 'reader')]]))
 
     # Source NativeFormatReaderCommonGen.cs
-    with open(r'System\Reflection\Metadata\NativeFormatReaderCommonGen.cs', 'w') as output :
+    with open(r'NativeFormatReaderCommonGen.cs', 'w') as output :
         iprint = IPrint(output)
         CsEmitFileHeader(iprint)
         iprint('using System;')

--- a/src/Common/src/Internal/Metadata/NativeFormat/Script/CsReaderGen2.py
+++ b/src/Common/src/Internal/Metadata/NativeFormat/Script/CsReaderGen2.py
@@ -538,7 +538,7 @@ def CsEmitSource():
     Ty.MetadataReader.members += CreateReaderMembers(Ty.MetadataReader, records, handles)
 
     # Source NativeFormatReaderGen.cs
-    with open(r'System\Reflection\Metadata\NativeFormatReaderGen.cs', 'w') as output :
+    with open(r'NativeFormatReaderGen.cs', 'w') as output :
         iprint = IPrint(output)
         CsEmitFileHeader(iprint)
         iprint('#pragma warning disable 649')

--- a/src/Common/src/Internal/Metadata/NativeFormat/Script/CsWriterGen2.py
+++ b/src/Common/src/Internal/Metadata/NativeFormat/Script/CsWriterGen2.py
@@ -389,7 +389,7 @@ finally
             # ns.members.add(CreateHandleEnumerable(reader, hnd))
 
         # Source NativeFormatReaderGen.cs
-        with open(r'..\..\..\PnToolChain\Metadata\NativeFormatWriter\NativeFormatWriterGen.cs', 'w') as output :
+        with open(r'..\..\..\..\..\ILCompiler.MetadataWriter\src\Internal\Metadata\NativeFormat\Writer\NativeFormatWriterGen.cs', 'w') as output :
             iprint = IPrint(output)
             CsEmitFileHeader(iprint)
             iprint('#pragma warning disable 649')

--- a/src/Common/src/Internal/Metadata/NativeFormat/UpdateNativeFormatSources.cmd
+++ b/src/Common/src/Internal/Metadata/NativeFormat/UpdateNativeFormatSources.cmd
@@ -1,0 +1,30 @@
+@echo off
+
+if "%PYTHON%"=="" (
+  echo PYTHON environment variable not set. Point this to a Python interpreter EXE (e.g. ipy.exe for IronPython^)
+  exit /b 1
+)
+
+set __py=%PYTHON% -W "ignore::DeprecationWarning::"
+
+echo Generating public APIs.
+%__py% Script\CsPublicGen2.py
+if ERRORLEVEL 1 goto Fail
+
+echo Generating native format reader sources.
+%__py% Script\CsReaderGen2.py
+if ERRORLEVEL 1 goto Fail
+
+echo Generating native format writer sources.
+%__py% Script\CsWriterGen2.py
+if ERRORLEVEL 1 goto Fail
+
+echo Generating binary format reader and writer sources.
+%__py% Script\CsMdBinaryRWCommonGen.py
+if ERRORLEVEL 1 goto Fail
+
+goto :EOF
+
+:Fail
+echo ERROR: Failed running script
+exit /b 1

--- a/src/Common/src/Internal/Metadata/NativeFormat/UpdateNativeFormatSources.cmd
+++ b/src/Common/src/Internal/Metadata/NativeFormat/UpdateNativeFormatSources.cmd
@@ -1,5 +1,7 @@
 @echo off
 
+setlocal
+
 if "%PYTHON%"=="" (
   echo PYTHON environment variable not set. Point this to a Python interpreter EXE (e.g. ipy.exe for IronPython^)
   exit /b 1


### PR DESCRIPTION
Use this script to update the metadata reader and writer sources when
the metadata schema (SchemaDef2.py) changes.