### PR TITLE
Add unit test for metadata reader and writer

### DIFF
--- a/src/ILCompiler.MetadataWriter/tests/readme.txt
+++ b/src/ILCompiler.MetadataWriter/tests/readme.txt
@@ -1,0 +1,3 @@
+Metadata reader and writer are tested together. There is no separate test for the writer.
+
+See ..\..\System.Private.Reflection.Metadata\tests.

--- a/src/System.Private.Reflection.Metadata/tests/RoundTripTests.cs
+++ b/src/System.Private.Reflection.Metadata/tests/RoundTripTests.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Need to use "extern alias", because both the writer and reader define types with same names.
+extern alias reader;
+extern alias writer;
+
+using System;
+using System.IO;
+using System.Linq;
+
+using Xunit;
+
+using Reader = reader.Internal.Metadata.NativeFormat;
+using Writer = writer.Internal.Metadata.NativeFormat.Writer;
+
+using TypeAttributes = System.Reflection.TypeAttributes;
+using MethodAttributes = System.Reflection.MethodAttributes;
+using CallingConventions = System.Reflection.CallingConventions;
+
+namespace System.Private.Reflection.Metadata.Tests
+{
+    /// <summary>
+    /// Tests for metadata roundtripping. We emit a metadata blob, and read it back
+    /// to check if it has expected values.
+    /// </summary>
+    public class RoundTripTests
+    {
+        /// <summary>
+        /// Builds a graph of simple metadata test data.
+        /// </summary>
+        private static Writer.ScopeDefinition BuildSimpleTestData()
+        {
+            // Scope for System.Runtime, 4.0.0.0
+            var systemRuntimeScope = new Writer.ScopeDefinition
+            {
+                Name = (Writer.ConstantStringValue)"System.Runtime",
+                MajorVersion = 4,
+            };
+
+            // Root namespace (".")
+            var rootNamespaceDefinition = new Writer.NamespaceDefinition
+            {
+                ParentScopeOrNamespace = systemRuntimeScope,
+            };
+            systemRuntimeScope.RootNamespaceDefinition = rootNamespaceDefinition;
+
+            // The <Module> type
+            var moduleTypeDefinition = new Writer.TypeDefinition
+            {
+                Flags = TypeAttributes.Abstract | TypeAttributes.Public,
+                Name = (Writer.ConstantStringValue)"<Module>",
+                NamespaceDefinition = rootNamespaceDefinition,
+            };
+            rootNamespaceDefinition.TypeDefinitions.Add(moduleTypeDefinition);
+
+            // System namespace
+            var systemNamespaceDefinition = new Writer.NamespaceDefinition
+            {
+                Name = (Writer.ConstantStringValue)"System",
+                ParentScopeOrNamespace = rootNamespaceDefinition,
+            };
+            rootNamespaceDefinition.NamespaceDefinitions.Add(systemNamespaceDefinition);
+
+            // System.Object type
+            var objectType = new Writer.TypeDefinition
+            {
+                Flags = TypeAttributes.Public | TypeAttributes.SequentialLayout,
+                Name = (Writer.ConstantStringValue)"Object",
+                NamespaceDefinition = systemNamespaceDefinition
+            };
+            systemNamespaceDefinition.TypeDefinitions.Add(objectType);
+
+            // System.ValueType type
+            var valueTypeType = new Writer.TypeDefinition
+            {
+                BaseType = objectType,
+                Flags = TypeAttributes.Public,
+                Name = (Writer.ConstantStringValue)"ValueType",
+                NamespaceDefinition = systemNamespaceDefinition
+            };
+            systemNamespaceDefinition.TypeDefinitions.Add(valueTypeType);
+
+            // System.Void type
+            var voidType = new Writer.TypeDefinition
+            {
+                BaseType = valueTypeType,
+                Flags = TypeAttributes.Public,
+                Name = (Writer.ConstantStringValue)"Void",
+                NamespaceDefinition = systemNamespaceDefinition
+            };
+            systemNamespaceDefinition.TypeDefinitions.Add(voidType);
+
+            // System.String type
+            var stringType = new Writer.TypeDefinition
+            {
+                BaseType = objectType,
+                Flags = TypeAttributes.Public,
+                Name = (Writer.ConstantStringValue)"String",
+                NamespaceDefinition = systemNamespaceDefinition
+            };
+            systemNamespaceDefinition.TypeDefinitions.Add(stringType);
+
+            // System.Object..ctor() method
+            var objectCtorMethod = new Writer.Method
+            {
+                Flags = MethodAttributes.Public
+                    | MethodAttributes.RTSpecialName
+                    | MethodAttributes.SpecialName,
+                Name = (Writer.ConstantStringValue)".ctor",
+                Signature = new Writer.MethodSignature
+                {
+                    CallingConvention = CallingConventions.HasThis,
+                    ReturnType = new Writer.ReturnTypeSignature
+                    {
+                        Type = voidType
+                    }
+                },
+            };
+            objectType.Methods.Add(objectCtorMethod);
+
+            // System.String..ctor() method
+            var stringCtorMethod = new Writer.Method
+            {
+                Flags = MethodAttributes.Public
+                    | MethodAttributes.RTSpecialName
+                    | MethodAttributes.SpecialName,
+                Name = (Writer.ConstantStringValue)".ctor",
+                Signature = new Writer.MethodSignature
+                {
+                    CallingConvention = CallingConventions.HasThis,
+                    ReturnType = new Writer.ReturnTypeSignature
+                    {
+                        Type = voidType
+                    }
+                },
+            };
+            stringType.Methods.Add(stringCtorMethod);
+
+            return systemRuntimeScope;
+        }
+
+        [Fact]
+        public unsafe static void TestSimpleRoundTripping()
+        {
+            var wr = new Writer.MetadataWriter();
+            wr.ScopeDefinitions.Add(BuildSimpleTestData());
+            var ms = new MemoryStream();
+            wr.Write(ms);
+            
+            fixed (byte* pBuffer = ms.ToArray())
+            {
+                var rd = new Reader.MetadataReader((IntPtr)pBuffer, (int)ms.Length);
+
+                // Validate the System.Runtime scope
+                Reader.ScopeDefinitionHandle scopeHandle = rd.ScopeDefinitions.Single();
+                Reader.ScopeDefinition systemRuntimeScope = scopeHandle.GetScopeDefinition(rd);
+                Assert.Equal(4, systemRuntimeScope.MajorVersion);
+                Assert.Equal("System.Runtime", systemRuntimeScope.Name.GetConstantStringValue(rd).Value);
+
+                // Validate the root namespace and <Module> type
+                Reader.NamespaceDefinition rootNamespace = systemRuntimeScope.RootNamespaceDefinition.GetNamespaceDefinition(rd);
+                Assert.Equal(1, rootNamespace.TypeDefinitions.Count());
+                Reader.TypeDefinition moduleType = rootNamespace.TypeDefinitions.Single().GetTypeDefinition(rd);
+                Assert.Equal("<Module>", moduleType.Name.GetConstantStringValue(rd).Value);
+                Assert.Equal(1, rootNamespace.NamespaceDefinitions.Count());
+
+                // Validate the System namespace
+                Reader.NamespaceDefinition systemNamespace = rootNamespace.NamespaceDefinitions.Single().GetNamespaceDefinition(rd);
+                Assert.Equal(4, systemNamespace.TypeDefinitions.Count());
+                foreach (var typeHandle in systemNamespace.TypeDefinitions)
+                {
+                    Reader.TypeDefinition type = typeHandle.GetTypeDefinition(rd);
+                    string typeName = type.Name.GetConstantStringValue(rd).Value;
+
+                    string baseTypeName = null;
+                    if (!type.BaseType.IsNull(rd))
+                    {
+                        baseTypeName = type.BaseType.ToTypeDefinitionHandle(rd).GetTypeDefinition(rd).Name.GetConstantStringValue(rd).Value;
+                    }
+
+                    switch (typeName)
+                    {
+                        case "Object":
+                            Assert.Null(baseTypeName);
+                            Assert.Equal(1, type.Methods.Count());
+                            break;
+                        case "Void":
+                            Assert.Equal("ValueType", baseTypeName);
+                            Assert.Equal(0, type.Methods.Count());
+                            break;
+                        case "String":
+                            Assert.Equal("Object", baseTypeName);
+                            Assert.Equal(1, type.Methods.Count());
+                            break;
+                        case "ValueType":
+                            Assert.Equal("Object", baseTypeName);
+                            Assert.Equal(0, type.Methods.Count());
+                            break;
+                        default:
+                            throw new NotImplementedException();
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public unsafe static void TestCommonTailOptimization()
+        {
+            var wr = new Writer.MetadataWriter();
+            wr.ScopeDefinitions.Add(BuildSimpleTestData());
+            var ms = new MemoryStream();
+            wr.Write(ms);
+
+            fixed (byte* pBuffer = ms.ToArray())
+            {
+                var rd = new Reader.MetadataReader((IntPtr)pBuffer, (int)ms.Length);
+
+                Reader.ScopeDefinitionHandle scopeHandle = rd.ScopeDefinitions.Single();
+                Reader.ScopeDefinition systemRuntimeScope = scopeHandle.GetScopeDefinition(rd);
+                Reader.NamespaceDefinition rootNamespace = systemRuntimeScope.RootNamespaceDefinition.GetNamespaceDefinition(rd);
+                Reader.NamespaceDefinition systemNamespace =
+                    rootNamespace.NamespaceDefinitions.Single(
+                        ns => ns.GetNamespaceDefinition(rd).Name.StringEquals("System", rd)
+                        ).GetNamespaceDefinition(rd);
+
+                // This validates the common tail optimization.
+                // Since both System.Object and System.String define a default constructor and the
+                // records are structurally equivalent, there should only be one metadata record
+                // representing a default .ctor in the blob.
+                Reader.TypeDefinition objectType = systemNamespace.TypeDefinitions.Single(
+                    t => t.GetTypeDefinition(rd).Name.StringEquals("Object", rd)
+                    ).GetTypeDefinition(rd);
+                Reader.TypeDefinition stringType = systemNamespace.TypeDefinitions.Single(
+                    t => t.GetTypeDefinition(rd).Name.StringEquals("String", rd)
+                    ).GetTypeDefinition(rd);
+
+                Reader.MethodHandle objectCtor = objectType.Methods.Single();
+                Reader.MethodHandle stringCtor = stringType.Methods.Single();
+
+                Assert.True(objectCtor.Equals(stringCtor));
+            }
+        }
+    }
+}

--- a/src/System.Private.Reflection.Metadata/tests/System.Private.Reflection.Metadata.Tests.csproj
+++ b/src/System.Private.Reflection.Metadata/tests/System.Private.Reflection.Metadata.Tests.csproj
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3A6D978E-156A-4BFF-B394-7F6F6BB22AE1}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Private.Reflection.Metadata.Tests</AssemblyName>
+    <RootNamespace>System.Private.Reflection.Metadata.Tests</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Private.Reflection.Metadata.csproj">
+      <Project>{45A617DF-FEC7-59C8-FD0D-BD27938DC940}</Project>
+      <Name>System.Private.Reflection.Metadata</Name>
+      <Aliases>reader</Aliases>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj">
+      <Project>{D66338D4-F9E4-4051-B302-232C6BFB6EF6}</Project>
+      <Name>ILCompiler.MetadataWriter</Name>
+      <Aliases>writer</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RoundTripTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Private.Reflection.Metadata/tests/System.Private.Reflection.Metadata.Tests.csproj
+++ b/src/System.Private.Reflection.Metadata/tests/System.Private.Reflection.Metadata.Tests.csproj
@@ -28,7 +28,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="RoundTripTests.cs" />
+
+    <!-- Disable the test for now. We can't build it because System.Private.Reflection.Metadata builds against
+         CoreLib and has a different System.Object, et al -->
+    <!--Compile Include="RoundTripTests.cs" /-->
+
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Private.Reflection.Metadata/tests/project.json
+++ b/src/System.Private.Reflection.Metadata/tests/project.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Console": "4.0.0-beta-23419",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.Tracing": "4.0.20",
+    "System.Linq": "4.0.0",
+    "System.IO.FileSystem": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "xunit": "2.1.0-beta3-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+  },
+  "frameworks": {
+    "dotnet": {}
+  }
+}


### PR DESCRIPTION
Whipped up a simple sanity test for metadata readers and writers. This is mostly a sanity test. We have plenty of runtime coverage for this, but it's always nice to have a unit test.

This will be useful to give people an idea how to use the metadata reader and writer APIs since this is a very self-contained sample.

There's a separate commit in it to disable the test from compiling because of issue tracked in WIP pull request #489.