### PR TITLE
Added required nuspec for compiling arm/arm64

### DIFF
--- a/src/.nuget/toolchain.ubuntu.14.04-arm.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-arm.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.ubuntu.14.04-arm.Microsoft.DotNet.ILCompiler.Development</id>
+    <version>1.0.2-prerelease-00001</version>
+    <title>Microsoft .NET Native Toolchain - Development Version</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides the toolchain to compile managed code to native.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+    <dependencies>
+    </dependencies>
+  </metadata>
+  <files>
+      <file src="../ilc.dll" target="ilc.dll" />
+      <file src="../ilc.exe" target="ilc.exe" />
+      <file src="../ILCompiler.Compiler.dll" target="ILCompiler.Compiler.dll" />
+      <file src="../ILCompiler.DependencyAnalysisFramework.dll" target="ILCompiler.DependencyAnalysisFramework.dll" />
+      <file src="../ILCompiler.TypeSystem.dll" target="ILCompiler.TypeSystem.dll" />
+      <file src="../lib/libRuntime.a" target="libRuntime.a" />
+      <file src="../lib/libPortableRuntime.a" target="libPortableRuntime.a" />
+      <file src="../lib/libbootstrapper.a" target="libbootstrapper.a" />
+      <file src="../lib/libbootstrappercpp.a" target="libbootstrappercpp.a" />
+      <file src="../lib/libSystem.Private.CoreLib.Native.a" target="libSystem.Private.CoreLib.Native.a" />
+      <file src="../System.Private.Corelib.dll" target="System.Private.Corelib.dll" />
+      <file src="../ToolRuntime/*.dll" />
+      <file src="../ToolRuntime/*.so" />
+      <file src="../ToolRuntime/corerun" target="corerun" />
+      <file src="../../../../packages/toolchain.ubuntu.14.04-arm.Microsoft.DotNet.RyuJit/1.0.1-prerelease-00002/runtimes/ubuntu.14.04-arm/native/libryujit.so" target="ryujit.so" />
+      <file src="../../../../packages/toolchain.ubuntu.14.04-arm.Microsoft.DotNet.ObjectWriter/1.0.3-prerelease-00001/runtimes/ubuntu.14.04-arm/native/libobjwriter.so" target="objwriter.so" />
+      <file src="../../../../packages/Microsoft.DiaSymReader/1.0.6/lib/portable-net45+win8/Microsoft.DiaSymReader.dll" />
+  </files>
+</package>

--- a/src/.nuget/toolchain.ubuntu.14.04-arm.Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-arm.Microsoft.DotNet.ILCompiler.nuspec
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.ubuntu.14.04-arm.Microsoft.DotNet.ILCompiler</id>
+    <version>1.0.2-prerelease-00001</version>
+    <title>Microsoft .NET Native Toolchain</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides the toolchain to compile managed code to native.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+    <dependencies>
+        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.3-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.RyuJit" version="1.0.1-prerelease-00002" />
+        <dependency id="System.AppContext" version="4.0.0" />
+        <dependency id="System.Collections" version="4.0.10" />
+        <dependency id="System.Collections.Concurrent" version="4.0.10" />
+        <dependency id="System.Collections.Immutable" version="1.1.37" />
+        <dependency id="System.Console" version="4.0.0-beta-23419" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
+        <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
+        <dependency id="System.IO" version="4.0.10" />
+        <dependency id="System.IO.FileSystem" version="4.0.0" />
+        <dependency id="System.Linq" version="4.0.0" />
+        <dependency id="System.Reflection" version="4.0.10" />
+        <dependency id="System.Reflection.Extensions" version="4.0.0" />
+        <dependency id="System.Reflection.Metadata" version="1.0.22" />
+        <dependency id="System.Reflection.Primitives" version="4.0.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.0" />
+        <dependency id="System.Runtime" version="4.0.20" />
+        <dependency id="System.Runtime.Extensions" version="4.0.10" />
+        <dependency id="System.Runtime.InteropServices" version="4.0.20" />
+        <dependency id="System.Text.Encoding" version="4.0.10" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.10" />
+        <dependency id="System.Threading" version="4.0.10" />
+        <dependency id="System.Threading.Tasks" version="4.0.10" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="../ilc.exe" target="runtimes/any/lib/dotnet/ilc.exe" />
+    <file src="../ILCompiler.Compiler.dll" target="runtimes/any/lib/dotnet/ILCompiler.Compiler.dll" />
+    <file src="../ILCompiler.DependencyAnalysisFramework.dll" target="runtimes/any/lib/dotnet/ILCompiler.DependencyAnalysisFramework.dll" />
+    <file src="../ILCompiler.TypeSystem.dll" target="runtimes/any/lib/dotnet/ILCompiler.TypeSystem.dll" />
+    <file src="../lib/libRuntime.a" target="runtimes/ubuntu.14.04-arm/native/sdk/libRuntime.a" />
+    <file src="../lib/libPortableRuntime.a" target="runtimes/ubuntu.14.04-arm/native/sdk/libPortableRuntime.a" />
+    <file src="../lib/libbootstrapper.a" target="runtimes/ubuntu.14.04-arm/native/sdk/libbootstrapper.a" />
+    <file src="../lib/libbootstrappercpp.a" target="runtimes/ubuntu.14.04-arm/native/sdk/libbootstrappercpp.a" />
+    <file src="../lib/libSystem.Private.CoreLib.Native.a" target="runtimes/ubuntu.14.04-arm/native/sdk/libSystem.Private.CoreLib.Native.a" />
+    <file src="../System.Private.Corelib.dll" target="runtimes/ubuntu.14.04-arm/native/sdk/System.Private.Corelib.dll" />
+  </files>
+</package>

--- a/src/.nuget/toolchain.ubuntu.14.04-arm64.Microsoft.DotNet.ILCompiler.Development.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-arm64.Microsoft.DotNet.ILCompiler.Development.nuspec
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.ubuntu.14.04-arm64.Microsoft.DotNet.ILCompiler.Development</id>
+    <version>1.0.2-prerelease-00001</version>
+    <title>Microsoft .NET Native Toolchain - Development Version</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides the toolchain to compile managed code to native.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+    <dependencies>
+    </dependencies>
+  </metadata>
+  <files>
+      <file src="../ilc.dll" target="ilc.dll" />
+      <file src="../ilc.exe" target="ilc.exe" />
+      <file src="../ILCompiler.Compiler.dll" target="ILCompiler.Compiler.dll" />
+      <file src="../ILCompiler.DependencyAnalysisFramework.dll" target="ILCompiler.DependencyAnalysisFramework.dll" />
+      <file src="../ILCompiler.TypeSystem.dll" target="ILCompiler.TypeSystem.dll" />
+      <file src="../lib/libRuntime.a" target="libRuntime.a" />
+      <file src="../lib/libPortableRuntime.a" target="libPortableRuntime.a" />
+      <file src="../lib/libbootstrapper.a" target="libbootstrapper.a" />
+      <file src="../lib/libbootstrappercpp.a" target="libbootstrappercpp.a" />
+      <file src="../lib/libSystem.Private.CoreLib.Native.a" target="libSystem.Private.CoreLib.Native.a" />
+      <file src="../System.Private.Corelib.dll" target="System.Private.Corelib.dll" />
+      <file src="../ToolRuntime/*.dll" />
+      <file src="../ToolRuntime/*.so" />
+      <file src="../ToolRuntime/corerun" target="corerun" />
+      <file src="../../../../packages/toolchain.ubuntu.14.04-arm64.Microsoft.DotNet.RyuJit/1.0.1-prerelease-00002/runtimes/ubuntu.14.04-arm64/native/libryujit.so" target="ryujit.so" />
+      <file src="../../../../packages/toolchain.ubuntu.14.04-arm64.Microsoft.DotNet.ObjectWriter/1.0.3-prerelease-00001/runtimes/ubuntu.14.04-arm64/native/libobjwriter.so" target="objwriter.so" />
+      <file src="../../../../packages/Microsoft.DiaSymReader/1.0.6/lib/portable-net45+win8/Microsoft.DiaSymReader.dll" />
+  </files>
+</package>

--- a/src/.nuget/toolchain.ubuntu.14.04-arm64.Microsoft.DotNet.ILCompiler.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-arm64.Microsoft.DotNet.ILCompiler.nuspec
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.ubuntu.14.04-arm64.Microsoft.DotNet.ILCompiler</id>
+    <version>1.0.2-prerelease-00001</version>
+    <title>Microsoft .NET Native Toolchain</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides the toolchain to compile managed code to native.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+    <dependencies>
+        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.3-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.RyuJit" version="1.0.1-prerelease-00002" />
+        <dependency id="System.AppContext" version="4.0.0" />
+        <dependency id="System.Collections" version="4.0.10" />
+        <dependency id="System.Collections.Concurrent" version="4.0.10" />
+        <dependency id="System.Collections.Immutable" version="1.1.37" />
+        <dependency id="System.Console" version="4.0.0-beta-23419" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
+        <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
+        <dependency id="System.IO" version="4.0.10" />
+        <dependency id="System.IO.FileSystem" version="4.0.0" />
+        <dependency id="System.Linq" version="4.0.0" />
+        <dependency id="System.Reflection" version="4.0.10" />
+        <dependency id="System.Reflection.Extensions" version="4.0.0" />
+        <dependency id="System.Reflection.Metadata" version="1.0.22" />
+        <dependency id="System.Reflection.Primitives" version="4.0.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.0" />
+        <dependency id="System.Runtime" version="4.0.20" />
+        <dependency id="System.Runtime.Extensions" version="4.0.10" />
+        <dependency id="System.Runtime.InteropServices" version="4.0.20" />
+        <dependency id="System.Text.Encoding" version="4.0.10" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.10" />
+        <dependency id="System.Threading" version="4.0.10" />
+        <dependency id="System.Threading.Tasks" version="4.0.10" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="../ilc.exe" target="runtimes/any/lib/dotnet/ilc.exe" />
+    <file src="../ILCompiler.Compiler.dll" target="runtimes/any/lib/dotnet/ILCompiler.Compiler.dll" />
+    <file src="../ILCompiler.DependencyAnalysisFramework.dll" target="runtimes/any/lib/dotnet/ILCompiler.DependencyAnalysisFramework.dll" />
+    <file src="../ILCompiler.TypeSystem.dll" target="runtimes/any/lib/dotnet/ILCompiler.TypeSystem.dll" />
+    <file src="../lib/libRuntime.a" target="runtimes/ubuntu.14.04-arm64/native/sdk/libRuntime.a" />
+    <file src="../lib/libPortableRuntime.a" target="runtimes/ubuntu.14.04-arm64/native/sdk/libPortableRuntime.a" />
+    <file src="../lib/libbootstrapper.a" target="runtimes/ubuntu.14.04-arm64/native/sdk/libbootstrapper.a" />
+    <file src="../lib/libbootstrappercpp.a" target="runtimes/ubuntu.14.04-arm64/native/sdk/libbootstrappercpp.a" />
+    <file src="../lib/libSystem.Private.CoreLib.Native.a" target="runtimes/ubuntu.14.04-arm64/native/sdk/libSystem.Private.CoreLib.Native.a" />
+    <file src="../System.Private.Corelib.dll" target="runtimes/ubuntu.14.04-arm64/native/sdk/System.Private.Corelib.dll" />
+  </files>
+</package>


### PR DESCRIPTION
The ILCompiler.nuspect is functional while the ILCompiler.Development.nuspec is not as it depends on the downloaded package to contain the required ryujit and objwriter shared libraries. They are copies of the Linux x64 files.

What is the process to get a copy of the shared libraries in nuget?