### PR TITLE
Make hashing using TypeHashingAlgorithms ubiquitous in the type system

### DIFF
--- a/src/Common/src/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedMethod.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using Internal.NativeFormat;
 
 namespace Internal.TypeSystem
 {
@@ -21,6 +22,11 @@ namespace Internal.TypeSystem
 
             Debug.Assert(instantiation.Length > 0);
             _instantiation = instantiation;
+        }
+
+        protected override int ComputeHashCode()
+        {
+            return TypeHashingAlgorithms.ComputeMethodHashcode(OwningType.GetHashCode(), Instantiation.ComputeGenericInstanceHashCode(TypeHashingAlgorithms.ComputeNameHashCode(Name)));
         }
 
         public override TypeSystemContext Context

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -96,11 +96,9 @@ namespace Internal.TypeSystem
     {
         public static readonly TypeDesc[] EmptyTypes = new TypeDesc[0];
 
-        public override int GetHashCode()
-        {
-            // Inherited types are expected to override
-            return RuntimeHelpers.GetHashCode(this);
-        }
+        /// Inherited types are required to override, and should use the algorithms
+        /// in TypeHashingAlgorithms in their implementation.
+        public abstract override int GetHashCode();
 
         public override bool Equals(Object o)
         {

--- a/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
+++ b/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
@@ -131,5 +131,18 @@ namespace Internal.NativeFormat
             }
             return (hashcode + _rotl(hashcode, 15));
         }
+
+        /// <summary>
+        /// Produce a hashcode for a specific method
+        /// </summary>
+        /// <param name="typeHashcode">Hashcode of the type that owns the method</param>
+        /// <param name="nameOrNameAndGenericArgumentsHashcode">Hashcode of either the name of the method (for non-generic methods) or the GenericInstanceHashCode of the name+generic arguments of the method.</param>
+        /// <returns></returns>
+        public static int ComputeMethodHashcode(int typeHashcode, int nameOrNameAndGenericArgumentsHashcode)
+        {
+            // TODO! This hash combining function isn't good, but it matches logic used in the past
+            // consider changing to a better combining function once all uses use this function
+            return typeHashcode ^ nameOrNameAndGenericArgumentsHashcode;
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Internal.NativeFormat;
 
 namespace Internal.TypeSystem
 {
@@ -326,11 +327,14 @@ namespace Internal.TypeSystem
         {
             private MethodDesc _methodDef;
             private Instantiation _instantiation;
+            private int _hashcode;
 
             public InstantiatedMethodKey(MethodDesc methodDef, Instantiation instantiation)
             {
                 _methodDef = methodDef;
                 _instantiation = instantiation;
+                _hashcode = TypeHashingAlgorithms.ComputeMethodHashcode(methodDef.OwningType.GetHashCode(),
+                    instantiation.ComputeGenericInstanceHashCode(TypeHashingAlgorithms.ComputeNameHashCode(methodDef.Name)));
             }
 
             public MethodDesc MethodDef
@@ -353,12 +357,12 @@ namespace Internal.TypeSystem
             {
                 protected override int GetKeyHashCode(InstantiatedMethodKey key)
                 {
-                    return key._instantiation.ComputeGenericInstanceHashCode(key._methodDef.GetHashCode());
+                    return key._hashcode;
                 }
 
                 protected override int GetValueHashCode(InstantiatedMethod value)
                 {
-                    return value.Instantiation.ComputeGenericInstanceHashCode(value.GetMethodDefinition().GetHashCode());
+                    return value.GetHashCode();
                 }
 
                 protected override bool CompareKeyToValue(InstantiatedMethodKey key, InstantiatedMethod value)
@@ -402,7 +406,9 @@ namespace Internal.TypeSystem
 
                 protected override InstantiatedMethod CreateValueFromKey(InstantiatedMethodKey key)
                 {
-                    return new InstantiatedMethod(key.MethodDef, key.Instantiation);
+                    InstantiatedMethod returnValue = new InstantiatedMethod(key.MethodDef, key.Instantiation);
+                    returnValue.SetHashCode(key._hashcode);
+                    return returnValue;
                 }
             }
         }
@@ -423,11 +429,13 @@ namespace Internal.TypeSystem
         {
             private MethodDesc _typicalMethodDef;
             private InstantiatedType _instantiatedType;
+            private int _hashcode;
 
             public MethodForInstantiatedTypeKey(MethodDesc typicalMethodDef, InstantiatedType instantiatedType)
             {
                 _typicalMethodDef = typicalMethodDef;
                 _instantiatedType = instantiatedType;
+                _hashcode = TypeHashingAlgorithms.ComputeMethodHashcode(instantiatedType.GetHashCode(), TypeHashingAlgorithms.ComputeNameHashCode(typicalMethodDef.Name));
             }
 
             public MethodDesc TypicalMethodDef
@@ -450,12 +458,12 @@ namespace Internal.TypeSystem
             {
                 protected override int GetKeyHashCode(MethodForInstantiatedTypeKey key)
                 {
-                    return key._typicalMethodDef.GetHashCode() ^ key._instantiatedType.GetHashCode();
+                    return key._hashcode;
                 }
 
                 protected override int GetValueHashCode(MethodForInstantiatedType value)
                 {
-                    return value.GetTypicalMethodDefinition().GetHashCode() ^ value.OwningType.GetHashCode();
+                    return value.GetHashCode();
                 }
 
                 protected override bool CompareKeyToValue(MethodForInstantiatedTypeKey key, MethodForInstantiatedType value)
@@ -473,7 +481,9 @@ namespace Internal.TypeSystem
 
                 protected override MethodForInstantiatedType CreateValueFromKey(MethodForInstantiatedTypeKey key)
                 {
-                    return new MethodForInstantiatedType(key.TypicalMethodDef, key.InstantiatedType);
+                    MethodForInstantiatedType returnValue = new MethodForInstantiatedType(key.TypicalMethodDef, key.InstantiatedType);
+                    returnValue.SetHashCode(key._hashcode);
+                    return returnValue;
                 }
             }
         }

--- a/src/Common/src/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
@@ -298,6 +298,7 @@ namespace Internal.TypeSystem
         private TValue CreateValueAndEnsureValueIsInTable(TKey key)
         {
             TValue newValue = CreateValueFromKey(key);
+            Debug.Assert(GetValueHashCode(newValue) == GetKeyHashCode(key));
 
             return AddOrGetExisting(newValue);
         }

--- a/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
@@ -23,10 +23,20 @@ namespace Internal.TypeSystem.Ecma
             _handle = handle;
         }
 
-        // TODO: Use stable hashcode based on the type name?
-        // public override int GetHashCode()
-        // {
-        // }
+        public override int GetHashCode()
+        {
+            // TODO: Determine what a the right hash function should be. Use stable hashcode based on the type name?
+            // For now, use the same hash as a SignatureVariable type.
+            GenericParameter parameter = _module.MetadataReader.GetGenericParameter(_handle);
+            if (parameter.Parent.Kind == HandleKind.MethodDefinition)
+            {
+                return parameter.Index * 0x7822381 + 0x54872645;
+            }
+            else
+            {
+                return parameter.Index * 0x5498341 + 0x832424;
+            }
+        }
 
         public override TypeSystemContext Context
         {

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Debug = System.Diagnostics.Debug;
 
 using Internal.TypeSystem;
+using Internal.NativeFormat;
 
 namespace Internal.TypeSystem.Ecma
 {
@@ -26,6 +27,7 @@ namespace Internal.TypeSystem.Ecma
         private string _name;
         private TypeDesc[] _genericParameters;
         private MetadataType _baseType;
+        private int _hashcode;
 
         internal EcmaType(EcmaModule module, TypeDefinitionHandle handle)
         {
@@ -40,6 +42,26 @@ namespace Internal.TypeSystem.Ecma
             // Initialize name eagerly in debug builds for convenience
             this.ToString();
 #endif
+        }
+
+        public override int GetHashCode()
+        {
+            if (_hashcode != 0)
+            {
+                return _hashcode;
+            }
+            int nameHash = TypeHashingAlgorithms.ComputeNameHashCode(Name);
+            TypeDesc containingType = ContainingType;
+            if (containingType == null)
+            {
+                _hashcode = nameHash;
+            }
+            else
+            {
+                _hashcode = TypeHashingAlgorithms.ComputeNestedTypeHashCode(containingType.GetHashCode(), nameHash);
+            }
+
+            return _hashcode;
         }
 
         EntityHandle EcmaModule.IEntityHandleObject.Handle

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/CoreTestAssembly.csproj
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/CoreTestAssembly.csproj
@@ -26,6 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Hashcode.cs" />
     <Compile Include="InterfaceArrangements.cs" />
     <Compile Include="Platform.cs" />
     <Compile Include="InstanceFieldLayout.cs" />

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/Hashcode.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/Hashcode.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Hashcode
+{
+    class NonNestedType
+    {
+        class NestedType
+        {
+
+        }
+
+        void GenericMethod<T>()
+        { }
+    }
+
+    class GenericType<X,Y>
+    {
+        void GenericMethod<T>()
+        {
+        }
+    }
+}

--- a/src/ILCompiler.TypeSystem/tests/HashcodeTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/HashcodeTests.cs
@@ -51,5 +51,122 @@ namespace TypeSystemTests
 
             Assert.Equal(TypeHashingAlgorithms.ComputeArrayTypeHashCode(objectType.GetHashCode(), 1), objectArray.GetHashCode());
         }
+
+        [Fact]
+        public void TestNonGenericTypes()
+        {
+            DefType systemArrayType = _context.GetWellKnownType(WellKnownType.Array);
+            MetadataType nonNestedType = (MetadataType)_testModule.GetType("Hashcode", "NonNestedType");
+            TypeDesc nestedType = ((EcmaType)nonNestedType).GetNestedType("NestedType");
+
+            int expectedNonNestedTypeHashcode = TypeHashingAlgorithms.ComputeNameHashCode("Hashcode.NonNestedType");
+            int expectedNestedTypeNameHashcode = TypeHashingAlgorithms.ComputeNameHashCode("NestedType");
+            int expectedNestedTypeHashcode = TypeHashingAlgorithms.ComputeNestedTypeHashCode(expectedNonNestedTypeHashcode, expectedNestedTypeNameHashcode);
+
+            Assert.Equal(expectedNonNestedTypeHashcode, nonNestedType.GetHashCode());
+            Assert.Equal(expectedNestedTypeHashcode, nestedType.GetHashCode());
+        }
+
+        [Fact]
+        void TestGenericTypes()
+        {
+            MetadataType ilistType = (MetadataType)_testModule.GetType("System.Collections.Generic", "IList`1");
+            DefType systemArrayType = _context.GetWellKnownType(WellKnownType.Array);
+            DefType ilistOfSystemArray = ilistType.MakeInstantiatedType(new Instantiation(new TypeDesc[] { systemArrayType }));
+
+            int expectedIListOfTHashcode = TypeHashingAlgorithms.ComputeNameHashCode("System.Collections.Generic.IList`1");
+            int expectedSystemArrayHashcode = TypeHashingAlgorithms.ComputeNameHashCode("System.Array");
+            Assert.Equal(expectedIListOfTHashcode, ilistType.GetHashCode());
+            Assert.Equal(TypeHashingAlgorithms.ComputeGenericInstanceHashCode(expectedIListOfTHashcode, new int[] { expectedSystemArrayHashcode }), ilistOfSystemArray.GetHashCode());
+        }
+
+        [Fact]
+        public void TestInstantiatedMethods()
+        {
+            MetadataType nonNestedType = (MetadataType)_testModule.GetType("Hashcode", "NonNestedType");
+            MetadataType genericType = (MetadataType)_testModule.GetType("Hashcode", "GenericType`2");
+            DefType intType = _context.GetWellKnownType(WellKnownType.Int32);
+            DefType stringType = _context.GetWellKnownType(WellKnownType.String);
+
+            MetadataType genericTypeOfIntString = genericType.MakeInstantiatedType(new Instantiation(new TypeDesc[] { intType, stringType }));
+            MetadataType genericTypeOfStringInt = genericType.MakeInstantiatedType(new Instantiation(new TypeDesc[] { stringType, intType }));
+
+            // build up expected hash codes for the above
+            int expHashNonNestedType = TypeHashingAlgorithms.ComputeNameHashCode("Hashcode.NonNestedType");
+            Assert.Equal(expHashNonNestedType, nonNestedType.GetHashCode());
+            int expHashGenType = TypeHashingAlgorithms.ComputeNameHashCode("Hashcode.GenericType`2");
+            Assert.Equal(expHashGenType, genericType.GetHashCode());
+            int expHashInt = TypeHashingAlgorithms.ComputeNameHashCode("System.Int32");
+            Assert.Equal(expHashInt, intType.GetHashCode());
+            int expHashString = TypeHashingAlgorithms.ComputeNameHashCode("System.String");
+            Assert.Equal(expHashString, stringType.GetHashCode());
+            int expHashGenTypeOfIS = TypeHashingAlgorithms.ComputeGenericInstanceHashCode(expHashGenType, new int[] { expHashInt, expHashString });
+            Assert.Equal(expHashGenTypeOfIS, genericTypeOfIntString.GetHashCode());
+            int expHashGenTypeOfSI = TypeHashingAlgorithms.ComputeGenericInstanceHashCode(expHashGenType, new int[] { expHashString, expHashInt });
+            Assert.Equal(expHashGenTypeOfSI, genericTypeOfStringInt.GetHashCode());
+
+            // Test that instantiated method's have the right hashes
+
+            int genMethodNameHash = TypeHashingAlgorithms.ComputeNameHashCode("GenericMethod");
+            int genMethodNameAndIHash = TypeHashingAlgorithms.ComputeGenericInstanceHashCode(genMethodNameHash, new int[] { expHashInt });
+            int genMethodNameAndSHash = TypeHashingAlgorithms.ComputeGenericInstanceHashCode(genMethodNameHash, new int[] { expHashString });
+
+
+            Action<MetadataType, int> testSequence = (MetadataType typeWithGenericMethod, int expectedTypeHash) =>
+            {
+                // Uninstantiated Generic method
+                MethodDesc genMethod = typeWithGenericMethod.GetMethod("GenericMethod", null);
+                Assert.Equal(TypeHashingAlgorithms.ComputeMethodHashcode(expectedTypeHash, genMethodNameHash), genMethod.GetHashCode());
+
+                // Instantiated over int
+                MethodDesc genMethodI = _context.GetInstantiatedMethod(genMethod, new Instantiation(new TypeDesc[] { intType }));
+                Assert.Equal(TypeHashingAlgorithms.ComputeMethodHashcode(expectedTypeHash, genMethodNameAndIHash), genMethodI.GetHashCode());
+
+                // Instantiated over string
+                MethodDesc genMethodS = _context.GetInstantiatedMethod(genMethod, new Instantiation(new TypeDesc[] { stringType }));
+                Assert.Equal(TypeHashingAlgorithms.ComputeMethodHashcode(expectedTypeHash, genMethodNameAndSHash), genMethodS.GetHashCode());
+
+                // Assert they aren't the same as the other hashes
+                Assert.NotEqual(genMethodI.GetHashCode(), genMethodS.GetHashCode());
+                Assert.NotEqual(genMethodI.GetHashCode(), genMethod.GetHashCode());
+                Assert.NotEqual(genMethodS.GetHashCode(), genMethod.GetHashCode());
+            };
+
+            // Test cases on non-generic type
+            testSequence(nonNestedType, expHashNonNestedType);
+
+            // Test cases on generic type
+            testSequence(genericType, expHashGenType);
+
+            // Test cases on instantiated generic type
+            testSequence(genericTypeOfIntString, expHashGenTypeOfIS);
+            testSequence(genericTypeOfStringInt, expHashGenTypeOfSI);
+        }
+
+        [Fact]
+        public void TestPointerTypes()
+        {
+            DefType intType = _context.GetWellKnownType(WellKnownType.Int32);
+
+            int expHashInt = TypeHashingAlgorithms.ComputeNameHashCode("System.Int32");
+            Assert.Equal(expHashInt, intType.GetHashCode());
+
+            int expHashIntPointer = TypeHashingAlgorithms.ComputePointerTypeHashCode(expHashInt);
+            TypeDesc intPointerType = _context.GetPointerType(intType);
+            Assert.Equal(expHashIntPointer, intPointerType.GetHashCode());
+        }
+
+        [Fact]
+        public void TestByRefTypes()
+        {
+            DefType intType = _context.GetWellKnownType(WellKnownType.Int32);
+
+            int expHashInt = TypeHashingAlgorithms.ComputeNameHashCode("System.Int32");
+            Assert.Equal(expHashInt, intType.GetHashCode());
+
+            int expHashIntByRef = TypeHashingAlgorithms.ComputeByrefTypeHashCode(expHashInt);
+            TypeDesc intByRefType = _context.GetByRefType(intType);
+            Assert.Equal(expHashIntByRef, intByRefType.GetHashCode());
+        }
     }
 }


### PR DESCRIPTION
- Add hashing to InstantiatedMethod
- TypeDesc now throws in its default implementations of GetHashCode()
- MethodDesc now implements the non-Generic method algorithm for computing hashcode. InstantiatedMethod's have a custom hashcode implementation
- EcmaMethod/EcmaType now use a TypeHashingAlgorithms hash code
- TypeHashingAlgorithms now has method hashcode building function
- Tests for a variety of hash codes
- Add Assert to LockFreeReaderHashtable to verify that the hashcodes for keys and values are in sync