### PR TITLE
Remove redundant code in gcrhscan.cpp

### DIFF
--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -40,6 +40,7 @@ set(COMMON_RUNTIME_SOURCES
     ../gc/gccommon.cpp
     ../gc/gceewks.cpp
     ../gc/gcwks.cpp
+    ../gc/gcscan.cpp
     ../gc/handletable.cpp
     ../gc/handletablecache.cpp
     ../gc/handletablecore.cpp

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -829,15 +829,6 @@ void GCToEEInterface::RestartEE(bool /*bFinishedGC*/)
     FireEtwGCRestartEEEnd_V1(GetClrInstanceId());
 }
 
-void GCToEEInterface::ScanStackRoots(Thread * /*pThread*/, promote_func* /*fn*/, ScanContext* /*sc*/)
-{
-    // TODO: Implement - Scan stack roots on given thread
-}
-
-void GCToEEInterface::ScanStaticGCRefsOpportunistically(promote_func* /*fn*/, ScanContext* /*sc*/)
-{
-}
-
 void GCToEEInterface::GcStartWork(int condemned, int /*max_gen*/)
 {
     // Invoke any registered callouts for the start of the collection.
@@ -882,12 +873,6 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int /*max_gen*/)
 void GCToEEInterface::AttachCurrentThread()
 {
     ThreadStore::AttachCurrentThread(false);
-}
-
-Thread * GCToEEInterface::GetThreadList(Thread * /*pThread*/)
-{
-    ASSERT(!"Intentionally not implemented"); // not used on this runtime
-    return nullptr;
 }
 
 void GCToEEInterface::SetGCSpecial(Thread * pThread)

--- a/src/Native/gc/env/gcenv.base.h
+++ b/src/Native/gc/env/gcenv.base.h
@@ -602,6 +602,8 @@ typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
 
 typedef void (CALLBACK *HANDLESCANPROC)(PTR_UNCHECKED_OBJECTREF pref, uintptr_t *pExtraInfo, uintptr_t param1, uintptr_t param2);
 
+typedef void enum_alloc_context_func(alloc_context*, void*);
+
 class GCToEEInterface
 {
 public:
@@ -620,10 +622,7 @@ public:
     // 
     // The stack roots enumeration callback
     //
-    static void ScanStackRoots(Thread * pThread, promote_func* fn, ScanContext* sc);
-
-    // Optional static GC refs scanning for better parallelization of server GC marking
-    static void ScanStaticGCRefsOpportunistically(promote_func* fn, ScanContext* sc);
+    static void GcScanRoots(promote_func* fn,  int condemned, int max_gen, ScanContext* sc);
 
     // 
     // Callbacks issues during GC that the execution engine can do its own bookeeping
@@ -655,12 +654,12 @@ public:
     static void EnablePreemptiveGC(Thread * pThread);
     static void DisablePreemptiveGC(Thread * pThread);
     static void SetGCSpecial(Thread * pThread);
-    static alloc_context * GetAllocContext(Thread * pThread);
     static bool CatchAtSafePoint(Thread * pThread);
+    static alloc_context * GetAllocContext(Thread * pThread);
 
     // ThreadStore functions
     static void AttachCurrentThread(); // does not acquire thread store lock
-    static Thread * GetThreadList(Thread * pThread);
+    static void GcEnumAllocContexts (enum_alloc_context_func* fn, void* param);
 };
 
 class FinalizerThread

--- a/src/Native/gc/env/gcenv.unix.cpp
+++ b/src/Native/gc/env/gcenv.unix.cpp
@@ -385,13 +385,9 @@ void GCToEEInterface::RestartEE(bool bFinishedGC)
     GCHeap::GetGCHeap()->SetGCInProgress(FALSE);
 }
 
-void GCToEEInterface::ScanStackRoots(Thread * pThread, promote_func* fn, ScanContext* sc)
+void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, ScanContext* sc)
 {
-    // TODO: Implement - Scan stack roots on given thread
-}
-
-void GCToEEInterface::ScanStaticGCRefsOpportunistically(promote_func* fn, ScanContext* sc)
-{
+    // TODO: Implement - Scan stack roots
 }
 
 void GCToEEInterface::GcStartWork(int condemned, int max_gen)

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -5764,7 +5764,7 @@ void gc_heap::fix_allocation_context (alloc_context* acontext, BOOL for_gc_p,
 
 //used by the heap verification for concurrent gc.
 //it nulls out the words set by fix_allocation_context for heap_verification
-void repair_allocation (alloc_context* acontext)
+void repair_allocation (alloc_context* acontext, void*)
 {
     uint8_t*  point = acontext->alloc_ptr;
 
@@ -5777,7 +5777,7 @@ void repair_allocation (alloc_context* acontext)
     }
 }
 
-void void_allocation (alloc_context* acontext)
+void void_allocation (alloc_context* acontext, void*)
 {
     uint8_t*  point = acontext->alloc_ptr;
 
@@ -5790,22 +5790,38 @@ void void_allocation (alloc_context* acontext)
     }
 }
 
-void gc_heap::fix_allocation_contexts (BOOL for_gc_p)
-{
-    CNameSpace::GcFixAllocContexts ((void*)(size_t)for_gc_p, __this);
-    fix_youngest_allocation_area (for_gc_p);
-    fix_large_allocation_area (for_gc_p);
-}
-
 void gc_heap::repair_allocation_contexts (BOOL repair_p)
 {
-    CNameSpace::GcEnumAllocContexts (repair_p ? repair_allocation : void_allocation);
+    GCToEEInterface::GcEnumAllocContexts (repair_p ? repair_allocation : void_allocation, NULL);
 
     alloc_context* acontext = generation_alloc_context (youngest_generation);
     if (repair_p)
-        repair_allocation (acontext);
+        repair_allocation (acontext, NULL);
     else
-        void_allocation (acontext);
+        void_allocation (acontext, NULL);
+}
+
+struct fix_alloc_context_args
+{
+    BOOL for_gc_p;
+    void* heap;
+};
+
+void fix_alloc_context(alloc_context* acontext, void* param)
+{
+    fix_alloc_context_args* args = (fix_alloc_context_args*)param;
+    GCHeap::GetGCHeap()->FixAllocContext(acontext, FALSE, (void*)(size_t)(args->for_gc_p), args->heap);
+}
+
+void gc_heap::fix_allocation_contexts(BOOL for_gc_p)
+{
+    fix_alloc_context_args args;
+    args.for_gc_p = for_gc_p;
+    args.heap = __this;
+    GCToEEInterface::GcEnumAllocContexts(fix_alloc_context, &args);
+
+    fix_youngest_allocation_area(for_gc_p);
+    fix_large_allocation_area(for_gc_p);
 }
 
 void gc_heap::fix_older_allocation_area (generation* older_gen)

--- a/src/Native/gc/gcscan.h
+++ b/src/Native/gc/gcscan.h
@@ -39,16 +39,11 @@ struct DhContext
 // something like GCDomain....
 // </TODO>
 
-typedef void enum_alloc_context_func(alloc_context*);
-
 class CNameSpace
 {
     friend struct ::_DacGlobals;
 
   public:
-
-    // Called on gc start
-    static void GcStartDoWork();
 
     static void GcScanSizedRefs(promote_func* fn, int condemned, int max_gen, ScanContext* sc);
 
@@ -99,10 +94,6 @@ class CNameSpace
 
     // post-promotions callback some roots were demoted
     static void GcDemote (int condemned, int max_gen, ScanContext* sc);
-
-    static void GcEnumAllocContexts (enum_alloc_context_func* fn);
-
-    static void GcFixAllocContexts (void* arg, void *heap);
     
     static size_t AskForMoreReservedMemory (size_t old_size, size_t need_size);
 

--- a/src/Native/gc/sample/GCSample.cpp
+++ b/src/Native/gc/sample/GCSample.cpp
@@ -26,11 +26,11 @@
 //      static void SuspendEE(SUSPEND_REASON reason);
 //      static void RestartEE(bool bFinishedGC); //resume threads.
 //
-// * Enumeration of threads that are running managed code:
-//      static Thread * GetThreadList(Thread * pThread);
+// * Enumeration of thread-local allocators:
+//      static void GcEnumAllocContexts (enum_alloc_context_func* fn, void* param);
 //
-// * Scanning of stack roots of given thread:
-//      static void ScanStackRoots(Thread * pThread, promote_func* fn, ScanContext* sc);
+// * Scanning of stack roots:
+//      static void GcScanRoots(promote_func* fn,  int condemned, int max_gen, ScanContext* sc);
 //
 //  The sample has trivial implementation for these methods. It is single threaded, and there are no stack roots to 
 //  be reported. There are number of other callbacks that GC calls to optionally allow the execution engine to do its 

--- a/src/Native/gc/sample/gcenv.cpp
+++ b/src/Native/gc/sample/gcenv.cpp
@@ -136,13 +136,9 @@ void GCToEEInterface::RestartEE(bool bFinishedGC)
     GCHeap::GetGCHeap()->SetGCInProgress(FALSE);
 }
 
-void GCToEEInterface::ScanStackRoots(Thread * pThread, promote_func* fn, ScanContext* sc)
+void GCToEEInterface::GcScanRoots(promote_func* fn,  int condemned, int max_gen, ScanContext* sc)
 {
     // TODO: Implement - Scan stack roots on given thread
-}
-
-void GCToEEInterface::ScanStaticGCRefsOpportunistically(promote_func* fn, ScanContext* sc)
-{
 }
 
 void GCToEEInterface::GcStartWork(int condemned, int max_gen)
@@ -202,10 +198,15 @@ void GCToEEInterface::AttachCurrentThread()
     ThreadStore::AttachCurrentThread();
 }
 
-Thread * GCToEEInterface::GetThreadList(Thread * pThread)
+void GCToEEInterface::GcEnumAllocContexts (enum_alloc_context_func* fn, void* param)
 {
-    return ThreadStore::GetThreadList(pThread);
+    Thread * pThread = NULL;
+    while ((pThread = ThreadStore::GetThreadList(pThread)) != NULL)
+    {
+        fn(pThread->GetAllocContext(), param);
+    }
 }
+
 
 void FinalizerThread::EnableFinalization()
 {


### PR DESCRIPTION
- Add gc\gcscan.cpp to the build and remove code that was redundant with it from runtime\gcrhscan.cpp
- Move the entire stack root scanning to the EE side of GCToEEInterface