### PR TITLE
Reduce dependency on Ecma api surface

### DIFF
--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -281,5 +281,17 @@ namespace Internal.TypeSystem
         {
             return _typeDef.HasCustomAttribute(attributeNamespace, attributeName);
         }
+
+        public override MetadataType GetNestedType(string name)
+        {
+            // Return the result from the typical type definition.
+            return _typeDef.GetNestedType(name);
+        }
+
+        public override IEnumerable<MetadataType> GetNestedTypes()
+        {
+            // Return the result from the typical type definition.
+            return _typeDef.GetNestedTypes();
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace Internal.TypeSystem
 {
     /// <summary>
@@ -67,6 +69,16 @@ namespace Internal.TypeSystem
         /// Returns true if the type has given custom attribute.
         /// </summary>
         public abstract bool HasCustomAttribute(string attributeNamespace, string attributeName);
+
+        /// <summary>
+        /// Get all of the types nested in this type.
+        /// </summary>
+        public abstract IEnumerable<MetadataType> GetNestedTypes();
+
+        /// <summary>
+        /// Get a specific type nested in this type.
+        /// </summary>
+        public abstract MetadataType GetNestedType(string name);
     }
 
     public struct ClassLayoutMetadata

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -342,15 +342,4 @@ namespace Internal.TypeSystem.Ecma
             return new PInvokeMetadata(name, (PInvokeAttributes)import.Attributes);
         }
     }
-
-    public static class EcmaMethodExtensions
-    {
-        public static bool IsPublic(this EcmaMethod method) { return (method.Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public; }
-        public static bool IsPrivate(this EcmaMethod method) { return (method.Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Private; }
-        public static bool IsStatic(this EcmaMethod method) { return (method.Attributes & MethodAttributes.Static) != 0; }
-        public static bool IsFinal(this EcmaMethod method) { return (method.Attributes & MethodAttributes.Final) != 0; }
-        public static bool IsHideBySig(this EcmaMethod method) { return (method.Attributes & MethodAttributes.HideBySig) != 0; }
-        public static bool IsAbstract(this EcmaMethod method) { return (method.Attributes & MethodAttributes.Abstract) != 0; }
-        public static bool IsSpecialName(this EcmaMethod method) { return (method.Attributes & MethodAttributes.SpecialName) != 0; }
-    }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -339,15 +339,15 @@ namespace Internal.TypeSystem.Ecma
             return null;
         }
 
-        public IEnumerable<TypeDesc> GetNestedTypes()
+        public override IEnumerable<MetadataType> GetNestedTypes()
         {
             foreach (var handle in _typeDefinition.GetNestedTypes())
             {
-                yield return (TypeDesc)this.Module.GetObject(handle);
+                yield return (MetadataType)this.Module.GetObject(handle);
             }
         }
 
-        public TypeDesc GetNestedType(string name)
+        public override MetadataType GetNestedType(string name)
         {
             var metadataReader = this.MetadataReader;
             var stringComparer = metadataReader.StringComparer;
@@ -355,7 +355,7 @@ namespace Internal.TypeSystem.Ecma
             foreach (var handle in _typeDefinition.GetNestedTypes())
             {
                 if (stringComparer.Equals(metadataReader.GetTypeDefinition(handle).Name, name))
-                    return (TypeDesc)this.Module.GetObject(handle);
+                    return (MetadataType)this.Module.GetObject(handle);
             }
 
             return null;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/JumpStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/JumpStubNode.cs
@@ -4,7 +4,6 @@
 using System;
 using ILCompiler.DependencyAnalysis.X64;
 using Internal.TypeSystem;
-using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis
 {

--- a/src/ILCompiler.TypeSystem/tests/ArchitectureSpecificFieldLayoutTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/ArchitectureSpecificFieldLayoutTests.cs
@@ -16,11 +16,11 @@ namespace TypeSystemTests
     public class ArchitectureSpecificFieldLayoutTests
     {
         TestTypeSystemContext _contextX86;
-        EcmaModule _testModuleX86;
+        ModuleDesc _testModuleX86;
         TestTypeSystemContext _contextX64;
-        EcmaModule _testModuleX64;
+        ModuleDesc _testModuleX64;
         TestTypeSystemContext _contextARM;
-        EcmaModule _testModuleARM;
+        ModuleDesc _testModuleARM;
 
         public ArchitectureSpecificFieldLayoutTests()
         {

--- a/src/ILCompiler.TypeSystem/tests/HashcodeTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/HashcodeTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 
-using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem;
 using Internal.NativeFormat;
 
@@ -14,7 +13,7 @@ namespace TypeSystemTests
     public class HashcodeTests
     {
         TestTypeSystemContext _context;
-        EcmaModule _testModule;
+        ModuleDesc _testModule;
 
         public HashcodeTests()
         {
@@ -57,7 +56,7 @@ namespace TypeSystemTests
         {
             DefType systemArrayType = _context.GetWellKnownType(WellKnownType.Array);
             MetadataType nonNestedType = (MetadataType)_testModule.GetType("Hashcode", "NonNestedType");
-            TypeDesc nestedType = ((EcmaType)nonNestedType).GetNestedType("NestedType");
+            TypeDesc nestedType = nonNestedType.GetNestedType("NestedType");
 
             int expectedNonNestedTypeHashcode = TypeHashingAlgorithms.ComputeNameHashCode("Hashcode.NonNestedType");
             int expectedNestedTypeNameHashcode = TypeHashingAlgorithms.ComputeNameHashCode("NestedType");

--- a/src/ILCompiler.TypeSystem/tests/InstanceFieldLayoutTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/InstanceFieldLayoutTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem;
 
 using Xunit;
@@ -16,7 +15,7 @@ namespace TypeSystemTests
     public class InstanceFieldLayoutTests
     {
         TestTypeSystemContext _context;
-        EcmaModule _testModule;
+        ModuleDesc _testModule;
 
         public InstanceFieldLayoutTests()
         {

--- a/src/ILCompiler.TypeSystem/tests/InterfacesTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/InterfacesTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 
-using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem;
 
 using Xunit;
@@ -13,7 +12,7 @@ namespace TypeSystemTests
     public class InterfacesTests
     {
         TestTypeSystemContext _context;
-        EcmaModule _testModule;
+        ModuleDesc _testModule;
 
         public InterfacesTests()
         {

--- a/src/ILCompiler.TypeSystem/tests/StaticFieldLayoutTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/StaticFieldLayoutTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 
-using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem;
 
 using Xunit;
@@ -13,7 +12,7 @@ namespace TypeSystemTests
     public class StaticFieldLayoutTests
     {
         TestTypeSystemContext _context;
-        EcmaModule _testModule;
+        ModuleDesc _testModule;
 
         public StaticFieldLayoutTests()
         {

--- a/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Debug = System.Diagnostics.Debug;
 
 using Internal.TypeSystem;
-using Internal.TypeSystem.Ecma;
 using System.Reflection.PortableExecutable;
 using System.IO;
 
@@ -51,9 +50,9 @@ namespace TypeSystemTests
 
         MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
 
-        EcmaModule _systemModule;
+        ModuleDesc _systemModule;
 
-        Dictionary<string, EcmaModule> _modules = new Dictionary<string, EcmaModule>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, ModuleDesc> _modules = new Dictionary<string, ModuleDesc>(StringComparer.OrdinalIgnoreCase);
 
         MetadataFieldLayoutAlgorithm _metadataFieldLayout = new TestMetadataFieldLayoutAlgorithm();
         MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
@@ -69,7 +68,7 @@ namespace TypeSystemTests
             return _wellKnownTypes[(int)wellKnownType - 1];
         }
 
-        public void SetSystemModule(EcmaModule systemModule)
+        public void SetSystemModule(ModuleDesc systemModule)
         {
             _systemModule = systemModule;
 
@@ -85,18 +84,18 @@ namespace TypeSystemTests
             }
         }
 
-        public EcmaModule GetModuleForSimpleName(string simpleName)
+        public ModuleDesc GetModuleForSimpleName(string simpleName)
         {
-            EcmaModule existingModule;
+            ModuleDesc existingModule;
             if (_modules.TryGetValue(simpleName, out existingModule))
                 return existingModule;
 
             return CreateModuleForSimpleName(simpleName);
         }
 
-        public EcmaModule CreateModuleForSimpleName(string simpleName)
+        public ModuleDesc CreateModuleForSimpleName(string simpleName)
         {
-            EcmaModule module = new EcmaModule(this, new PEReader(File.OpenRead(simpleName + ".dll")));
+            ModuleDesc module = new Internal.TypeSystem.Ecma.EcmaModule(this, new PEReader(File.OpenRead(simpleName + ".dll")));
             _modules.Add(simpleName, module);
             return module;
         }

--- a/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 
-using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem;
 
 using Xunit;
@@ -14,7 +13,7 @@ namespace TypeSystemTests
     public class VirtualFunctionOverrideTests
     {
         TestTypeSystemContext _context;
-        EcmaModule _testModule;
+        ModuleDesc _testModule;
         DefType _stringType;
         DefType _voidType;
 


### PR DESCRIPTION
- Remove unused EcmaMethod extension methods
- Move Nested types api from EcmaType to MetadataType
- Remove nearly all dependency on the Ecma type system api from tests