### PR TITLE
Dotnet cli change: rename dotnet init to dotnet new

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -27,7 +27,7 @@ This will result in the following:
 
 * Ensure that you have done a repo build per the instructions above.
 * Create a new folder and switch into it. 
-* Issue the command, `dotnet init`, on the command/shell prompt. This will add a template source file and corresponding project.json. If you get an error, please ensure the [pre-requisites](prerequisites-for-building.md) are installed. 
+* Issue the command, `dotnet new`, on the command/shell prompt. This will add a template source file and corresponding project.json. If you get an error, please ensure the [pre-requisites](prerequisites-for-building.md) are installed. 
 
 
 ## Using RyuJIT ##


### PR DESCRIPTION
Proposed in [cli #374](https://github.com/dotnet/cli/issues/374), implemented in [cli 568eb3a](https://github.com/piotrpMSFT/cli/commit/568eb3aae7008fa13409e06fbdc1642013f7106c).

Should this have a note for users who are still on the old naming scheme?