### PR TITLE
Type system metadata tweaks

### DIFF
--- a/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
@@ -25,7 +25,7 @@ namespace Internal.TypeSystem
 
                     if (_offset == FieldAndOffset.InvalidOffset)
                     {
-                        // Must be a field that doesn't participate in layout (literal?)
+                        // Must be a field that doesn't participate in layout (literal or RVA mapped)
                         throw new BadImageFormatException();
                     }
                 }

--- a/src/Common/src/TypeSystem/Common/FieldDesc.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.cs
@@ -66,6 +66,11 @@ namespace Internal.TypeSystem
             get;
         }
 
+        public abstract bool IsLiteral
+        {
+            get;
+        }
+
         public abstract bool HasCustomAttribute(string attributeNamespace, string attributeName);
 
         public virtual FieldDesc GetTypicalFieldDefinition()

--- a/src/Common/src/TypeSystem/Common/FieldForInstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/FieldForInstantiatedType.cs
@@ -80,6 +80,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool IsLiteral
+        {
+            get
+            {
+                return _fieldDef.IsLiteral;
+            }
+        }
+
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
         {
             return _fieldDef.HasCustomAttribute(attributeNamespace, attributeName);

--- a/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
+++ b/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Internal.TypeSystem
+{
+    public abstract partial class GenericParameterDesc : TypeDesc
+    {
+    }
+}

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -112,6 +112,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override string Namespace
+        {
+            get
+            {
+                return _typeDef.Namespace;
+            }
+        }
+
         public override IEnumerable<MethodDesc> GetMethods()
         {
             foreach (var typicalMethodDef in _typeDef.GetMethods())
@@ -280,6 +288,15 @@ namespace Internal.TypeSystem
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
         {
             return _typeDef.HasCustomAttribute(attributeNamespace, attributeName);
+        }
+
+        public override MetadataType ContainingType
+        {
+            get
+            {
+                // Return the result from the typical type definition.
+                return _typeDef.ContainingType;
+            }
         }
 
         public override MetadataType GetNestedType(string name)

--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -161,7 +161,7 @@ namespace Internal.TypeSystem
 
             foreach (var field in type.GetFields())
             {
-                if (!field.IsStatic || field.HasRva)
+                if (!field.IsStatic || field.HasRva || field.IsLiteral)
                     continue;
 
                 numStaticFields++;
@@ -186,8 +186,8 @@ namespace Internal.TypeSystem
 
             foreach (var field in type.GetFields())
             {
-                // Nonstatic fields and RVA mapped fields don't participate in layout
-                if (!field.IsStatic || field.HasRva)
+                // Nonstatic fields, literal fields, and RVA mapped fields don't participate in layout
+                if (!field.IsStatic || field.HasRva || field.IsLiteral)
                     continue;
 
                 StaticsBlock* block =

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -27,6 +27,16 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
+        /// Gets the name of the type as represented in the metadata.
+        /// </summary>
+        public abstract string Name { get; }
+
+        /// <summary>
+        /// Gets the namespace of the type.
+        /// </summary>
+        public abstract string Namespace { get; }
+
+        /// <summary>
         /// Gets metadata that controls instance layout of this type.
         /// </summary>
         public abstract ClassLayoutMetadata GetClassLayout();
@@ -69,6 +79,11 @@ namespace Internal.TypeSystem
         /// Returns true if the type has given custom attribute.
         /// </summary>
         public abstract bool HasCustomAttribute(string attributeNamespace, string attributeName);
+
+        /// <summary>
+        /// Gets the containing type of this type or null if the type is not nested.
+        /// </summary>
+        public abstract MetadataType ContainingType { get; }
 
         /// <summary>
         /// Get all of the types nested in this type.

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -359,14 +359,6 @@ namespace Internal.TypeSystem
             }
         }
 
-        public virtual string Name
-        {
-            get
-            {
-                return null;
-            }
-        }
-
         public virtual bool HasStaticConstructor
         {
             get

--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -214,5 +214,14 @@ namespace Internal.TypeSystem
 
             return method;
         }
+
+        /// <summary>
+        /// Retrieves the namespace qualified name of a <see cref="MetadataType"/>.
+        /// </summary>
+        public static string GetFullName(this MetadataType metadataType)
+        {
+            string ns = metadataType.Namespace;
+            return ns.Length > 0 ? String.Concat(ns, ".", metadataType.Name) : metadataType.Name;
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaField.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.cs
@@ -213,7 +213,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public bool IsLiteral
+        public override bool IsLiteral
         {
             get
             {

--- a/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
 using System.Reflection.Metadata;
-using System.Threading;
-
-using Internal.TypeSystem;
 using Internal.NativeFormat;
 
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Ecma
 {
-    public sealed partial class EcmaGenericParameter : TypeDesc
+    public sealed partial class EcmaGenericParameter : GenericParameterDesc
     {
         private EcmaModule _module;
         private GenericParameterHandle _handle;

--- a/src/Common/src/TypeSystem/Ecma/MetadataExtensions.cs
+++ b/src/Common/src/TypeSystem/Ecma/MetadataExtensions.cs
@@ -110,7 +110,7 @@ namespace Internal.TypeSystem.Ecma
         // the other masks in the enum.
         private const TypeAttributes NestedMask = (TypeAttributes)0x00000006;
 
-        private static bool IsNested(TypeAttributes flags)
+        public static bool IsNested(this TypeAttributes flags)
         {
             return (flags & NestedMask) != 0;
         }

--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -29,8 +29,11 @@ namespace Internal.IL
             // but an intrinsic e.g. recognized by codegen.
 
             Debug.Assert(method.IsIntrinsic);
+            MetadataType owningType = method.OwningType as MetadataType;
+            if (owningType == null)
+                return null;
 
-            if (method.Name == "UncheckedCast" && method.OwningType.Name == "System.Runtime.CompilerServices.RuntimeHelpers")
+            if (method.Name == "UncheckedCast" && owningType.Name == "RuntimeHelpers" && owningType.Namespace == "System.Runtime.CompilerServices")
             {
                 return new ILStubMethodIL(new byte[] { (byte)ILOpcode.ldarg_0, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
             }

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -381,7 +381,8 @@ namespace ILCompiler
 
                 try
                 {
-                    if (Path.DirectorySeparatorChar != '\\' && _skipJitList.Contains(new TypeAndMethod(method.OwningType.Name, method.Name)))
+                    MetadataType owningType = method.OwningType as MetadataType;
+                    if (owningType != null && Path.DirectorySeparatorChar != '\\' && _skipJitList.Contains(new TypeAndMethod(owningType.GetFullName(), method.Name)))
                     {
                         throw new NotImplementedException("SkipJIT");
                     }

--- a/src/ILCompiler.Compiler/src/Compiler/IntrinsicMethods.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/IntrinsicMethods.cs
@@ -19,7 +19,9 @@ namespace ILCompiler
         public static IntrinsicMethodKind GetIntrinsicMethodClassification(MethodDesc method)
         {
             // TODO: make this reliable
-            if (method.Name == "InitializeArray" && method.OwningType.Name == "System.Runtime.CompilerServices.RuntimeHelpers")
+            MetadataType owningMdType = method.OwningType as MetadataType;
+
+            if (owningMdType != null && method.Name == "InitializeArray" && owningMdType.Name == "RuntimeHelpers" && owningMdType.Namespace == "System.Runtime.CompilerServices")
             {
                 return IntrinsicMethodKind.RuntimeHelpersInitializeArray;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -98,16 +98,16 @@ namespace ILCompiler
                 // they are compiled
                 lock (this)
                 {
-                    foreach (var t in ((EcmaType)type).Module.GetAllTypes())
+                    foreach (MetadataType t in ((EcmaType)type).Module.GetAllTypes())
                     {
-                        string name = t.Name;
+                        string name = t.GetFullName();
 
                         // Include encapsulating type
-                        TypeDesc containingType = ((EcmaType)t).ContainingType;
+                        MetadataType containingType = t.ContainingType;
                         while (containingType != null)
                         {
-                            name = containingType.Name + "_" + name;
-                            containingType = ((EcmaType)containingType).ContainingType;
+                            name = containingType.GetFullName() + "_" + name;
+                            containingType = containingType.ContainingType;
                         }
 
                         name = SanitizeName(name, true);
@@ -171,7 +171,7 @@ namespace ILCompiler
                     }
                     else
                     {
-                        mangledName = SanitizeName(type.Name, true);
+                        mangledName = SanitizeName(((MetadataType)type).GetFullName(), true);
                     }
                     break;
             }

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -33,6 +33,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\Common\ByRefType.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Common\GenericParameterDesc.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\Common\FieldForInstantiatedType.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.FieldLayout.cs" />

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/StaticFieldLayout.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/StaticFieldLayout.cs
@@ -50,6 +50,14 @@ namespace StaticFieldLayout
         static string string3;
     }
 
+    class LiteralFieldsDontAffectLayout
+    {
+        const int IntConstant = 0;
+        const string StringConstant = null;
+        static int Int1;
+        static string String1;
+    }
+
     class RvaTestClass
     {
         static void RvaTest()

--- a/src/ILCompiler.TypeSystem/tests/StaticFieldLayoutTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/StaticFieldLayoutTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 
 using Internal.TypeSystem;
 
@@ -192,6 +193,42 @@ namespace TypeSystemTests
                         Assert.Equal(0, field.Offset);
                         break;
                     case "string3":
+                        Assert.Equal(8, field.Offset);
+                        break;
+                    default:
+                        throw new Exception(field.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestLiteralFieldsDontAffectLayout()
+        {
+            //
+            // Test that literal fields are not laid out.
+            //
+
+            MetadataType t = _testModule.GetType("StaticFieldLayout", "LiteralFieldsDontAffectLayout");
+
+            Assert.Equal(4, t.GetFields().Count());
+
+            foreach (var field in t.GetFields())
+            {
+                if (!field.IsStatic)
+                    continue;
+
+                switch (field.Name)
+                {
+                    case "IntConstant":
+                    case "StringConstant":
+                        Assert.True(field.IsStatic);
+                        Assert.True(field.IsLiteral);
+                        Assert.Throws<BadImageFormatException>(() => field.Offset);
+                        break;
+                    case "Int1":
+                        Assert.Equal(0, field.Offset);
+                        break;
+                    case "String1":
                         Assert.Equal(8, field.Offset);
                         break;
                     default:

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1436,7 +1436,7 @@ namespace Internal.JitInterface
             {
                 EcmaType ecmaType = method.OwningType.GetTypeDefinition() as EcmaType;
                 if (ecmaType != null)
-                    *moduleName = (byte*)GetPin(StringToUTF8(ecmaType.Name));
+                    *moduleName = (byte*)GetPin(StringToUTF8(ecmaType.GetFullName()));
                 else
                     *moduleName = (byte*)GetPin(StringToUTF8("unknown"));
             }


### PR DESCRIPTION
- Move `Name` to MetadataType and separate `Namespace` from `Name`. Name can
be a MetadataString once we have it.
- Introduce GenerericParameterDesc in the type hierarchy. For now it
doesn't have anything.
- Move `ContainingType` to MetadataType
- Expose literal fields.