### PR TITLE
Fix up comments about what interface lists may contain duplicates

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataRuntimeInterfacesAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataRuntimeInterfacesAlgorithm.cs
@@ -18,6 +18,9 @@ namespace Internal.TypeSystem
         {
             MetadataType type = (MetadataType)_type;
 
+            // TODO: need to implement deduplication
+            // https://github.com/dotnet/corert/issues/208
+
             if (type.IsInterface)
             {
                 // For interfaces, the set of interfaces implemented directly matches the

--- a/src/Common/src/TypeSystem/Common/MetadataType.Interfaces.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.Interfaces.cs
@@ -11,7 +11,7 @@ namespace Internal.TypeSystem
     public abstract partial class MetadataType : DefType
     {
         /// <summary>
-        /// The interfaces explicitly declared as implemented by this MetadataType. Duplicates are not permitted.
+        /// The interfaces explicitly declared as implemented by this MetadataType in the type's metadata.
         /// These correspond to the InterfaceImpls of a type in metadata
         /// </summary>
         public abstract DefType[] ExplicitlyImplementedInterfaces

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.Interfaces.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.Interfaces.cs
@@ -43,8 +43,6 @@ namespace Internal.TypeSystem.Ecma
                 implementedInterfaces[i++] = (DefType)_module.GetType(interfaceImplementation.Interface);
             }
 
-            // TODO Add duplicate detection
-
             return (_implementedInterfaces = implementedInterfaces);
         }
     }


### PR DESCRIPTION
This was switched around. ExplicitlyImplementedInterfaces is the list
that is coming directly from the metadata and can have duplicates.
RuntimeInterfaces may not have duplicates.