### PR TITLE
Fix HelloWorld RyuJIT OverflowException

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -379,6 +379,16 @@ namespace Internal.JitInterface
             }
         }
 
+        private CORINFO_CONTEXT_STRUCT* contextFromMethod(MethodDesc method)
+        {
+            return (CORINFO_CONTEXT_STRUCT*)(((ulong)ObjectToHandle(method)) | (ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_METHOD);
+        }
+
+        private CORINFO_CONTEXT_STRUCT* contextFromType(TypeDesc type)
+        {
+            return (CORINFO_CONTEXT_STRUCT*)(((ulong)ObjectToHandle(type)) | (ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_CLASS);
+        }
+
         private MethodDesc methodFromContext(CORINFO_CONTEXT_STRUCT* contextStruct)
         {
             if (((ulong)contextStruct & (ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_MASK) == (ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_CLASS)
@@ -1843,9 +1853,17 @@ namespace Internal.JitInterface
             pResult.kind = CORINFO_CALL_KIND.CORINFO_CALL;
             pResult._nullInstanceCheck = (uint)(((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0) ? 1 : 0);
 
-            // TODO: Generics
-            // pResult.contextHandle;
-            // pResult._exactContextNeedsRuntimeLookup
+            // TODO: Support Generics
+            if (targetMethod.HasInstantiation)
+            {
+                pResult.contextHandle = contextFromMethod(targetMethod);
+            }
+            else
+            {
+                pResult.contextHandle = contextFromType(targetMethod.OwningType);
+            }
+
+            pResult._exactContextNeedsRuntimeLookup = 0;
 
             // TODO: CORINFO_VIRTUALCALL_STUB
             // TODO: CORINFO_CALL_CODE_POINTER

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -123,12 +123,34 @@ extern "C" void* __ldelema_ref(System::Array * pArray, unsigned idx, MethodTable
     return &(((Object **)(pArray->GetArrayData()))[idx]);
 }
 
+void PrintStringObject(System::String *pStringToPrint)
+{
+    // Get the number of characters in managed string (stored as UTF16)
+    int32_t length = *((int32_t*)((char*)(pStringToPrint)+sizeof(intptr_t)));
+
+    // Get the pointer to the start of the character array
+    uint16_t *pString = (uint16_t*)((char*)(pStringToPrint)+sizeof(intptr_t) + sizeof(int32_t));
+    
+    // Loop to display the string
+    int32_t index = 0;
+    while (index < length)
+    {
+        putwchar(*pString);
+        pString++;
+        index++;
+    }   
+}
 extern "C" void __not_yet_implemented(System::String * pMethodName, System::String * pMessage)
 {
     printf("ILCompiler failed generating code for this method; execution cannot continue.\n");
     printf("This is likely because of a feature that is not yet implemented in the compiler.\n");
-    wprintf(L"Method: %ls\n", (wchar_t*)((char*)(pMethodName)+12));
-    wprintf(L"Reason: %ls\n", (wchar_t*)((char*)(pMessage)+12));
+    printf("Method: ");
+    PrintStringObject(pMethodName);
+    printf("\n\n");
+    printf("Reason: ");
+    PrintStringObject(pMessage);
+    printf("\n");
+
     exit(-1);
 }
 


### PR DESCRIPTION
Since Generics context is not yet supported, we were not setting the contextHandle in getCallInfo JITEE interface implementation. Thus, when JIT would get the calling details, it would get a bogus value for contextHandle and later pass on that values to other calls to the JITEE interface. In this case, initClass was being passed the bogus value that it attempted to operate upon assuming its a valid generics context and resulted in OverflowException.

The fix is to set the contextHandle to zero and detect this state to fallback to use a helper for class initialization instead of going down the wrong path.

@jkotas @davidwrighton PTAL