### PR TITLE
Initial MetadataTransform commit

### DIFF
--- a/src/Common/src/TypeSystem/Common/PropertySignature.cs
+++ b/src/Common/src/TypeSystem/Common/PropertySignature.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Internal.TypeSystem
+{
+    public struct PropertySignature
+    {
+        private TypeDesc[] _parameters;
+
+        public readonly bool IsStatic;
+
+        public readonly TypeDesc ReturnType;
+
+        [System.Runtime.CompilerServices.IndexerName("Parameter")]
+        public TypeDesc this[int index]
+        {
+            get
+            {
+                return _parameters[index];
+            }
+        }
+
+        public int Length
+        {
+            get
+            {
+                return _parameters.Length;
+            }
+        }
+
+        public PropertySignature(bool isStatic, TypeDesc[] parameters, TypeDesc returnType)
+        {
+            IsStatic = isStatic;
+            _parameters = parameters;
+            ReturnType = returnType;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -178,6 +178,36 @@ namespace Internal.TypeSystem.Ecma
             return new MethodSignature(flags, arity, returnType, parameters);
         }
 
+        public PropertySignature ParsePropertySignature()
+        {
+            SignatureHeader header = _reader.ReadSignatureHeader();
+            if (header.Kind != SignatureKind.Property)
+                throw new BadImageFormatException();
+
+            bool isStatic = !header.IsInstance;
+
+            int count = _reader.ReadCompressedInteger();
+
+            TypeDesc returnType = ParseType();
+            TypeDesc[] parameters;
+
+            if (count > 0)
+            {
+                // Get all of the parameters.
+                parameters = new TypeDesc[count];
+                for (int i = 0; i < count; i++)
+                {
+                    parameters[i] = ParseType();
+                }
+            }
+            else
+            {
+                parameters = TypeDesc.EmptyTypes;
+            }
+
+            return new PropertySignature(isStatic, parameters, returnType);
+        }
+
         public TypeDesc ParseFieldSignature()
         {
             if (_reader.ReadSignatureHeader().Kind != SignatureKind.Field)

--- a/src/ILCompiler.MetadataTransform/MetadataTransform.sln
+++ b/src/ILCompiler.MetadataTransform/MetadataTransform.sln
@@ -1,0 +1,46 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.MetadataTransform", "src\ILCompiler.MetadataTransform.csproj", "{A965EA82-219D-48F7-AD51-BC030C16CC6F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.MetadataWriter", "..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj", "{D66338D4-F9E4-4051-B302-232C6BFB6EF6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.TypeSystem", "..\ILCompiler.TypeSystem\src\ILCompiler.TypeSystem.csproj", "{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.MetadataTransform.Tests", "tests\ILCompiler.MetadataTransform.Tests.csproj", "{B4B713D9-68A1-4EB3-8164-4DC8BE69BCBC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrimaryMetadataAssembly", "tests\PrimaryMetadataAssembly\PrimaryMetadataAssembly.csproj", "{C29B7395-F925-4B0E-972D-187D2D4BFEC7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4B713D9-68A1-4EB3-8164-4DC8BE69BCBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4B713D9-68A1-4EB3-8164-4DC8BE69BCBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4B713D9-68A1-4EB3-8164-4DC8BE69BCBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4B713D9-68A1-4EB3-8164-4DC8BE69BCBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C29B7395-F925-4B0E-972D-187D2D4BFEC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C29B7395-F925-4B0E-972D-187D2D4BFEC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C29B7395-F925-4B0E-972D-187D2D4BFEC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C29B7395-F925-4B0E-972D-187D2D4BFEC7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{A965EA82-219D-48F7-AD51-BC030C16CC6F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <AssemblyName>ILCompiler.MetadataTransform</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <ExcludeResourcesImport>true</ExcludeResourcesImport>
+    <CLSCompliant>false</CLSCompliant>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj">
+      <Project>{D66338D4-F9E4-4051-B302-232C6BFB6EF6}</Project>
+      <Name>ILCompiler.MetadataWriter</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ILCompiler.TypeSystem\src\ILCompiler.TypeSystem.csproj">
+      <Project>{1a9df196-43a9-44bb-b2c6-d62aa56b0e49}</Project>
+      <Name>ILCompiler.TypeSystem</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ILCompiler\Metadata\EntityMap.cs" />
+    <Compile Include="ILCompiler\Metadata\IMetadataPolicy.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.Namespace.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.Scope.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.String.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.Type.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
@@ -29,8 +29,11 @@
     <Compile Include="ILCompiler\Metadata\EntityMap.cs" />
     <Compile Include="ILCompiler\Metadata\IMetadataPolicy.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.Field.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.Method.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Namespace.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Parameter.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.Property.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Scope.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.String.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Type.cs" />

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
@@ -30,6 +30,7 @@
     <Compile Include="ILCompiler\Metadata\IMetadataPolicy.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Namespace.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.Parameter.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Scope.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.String.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Type.cs" />

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/EntityMap.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/EntityMap.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Internal.Metadata.NativeFormat.Writer;
+
+namespace ILCompiler.Metadata
+{
+    internal struct EntityMap<TEntity, TRecord>
+    {
+        private Dictionary<TEntity, TRecord> _map;
+
+        public EntityMap(IEqualityComparer<TEntity> comparer)
+        {
+            _map = new Dictionary<TEntity, TRecord>(comparer);
+        }
+
+        public TRecord GetOrCreate<TConcreteEntity, TConcreteRecord>(TConcreteEntity entity, Action<TConcreteEntity, TConcreteRecord> initializer)
+            where TConcreteEntity : TEntity
+            where TConcreteRecord : TRecord, new()
+        {
+            TRecord record;
+            if (!_map.TryGetValue(entity, out record))
+            {
+                // We are externalizing the allocation instead of having a 'creator' delegate
+                // because initializer might end up recursing into GetOrCreate for the same entity.
+                // EntityMap needs to be ready to return a pointer to the currently initialized record.
+
+                // The transform doesn't care that the record is not fully initialized yet
+                // since we're not reading it at this stage.
+
+                // Example:
+                //
+                // class FooAttribute : Attribute
+                // {
+                //     [FooAttribute]
+                //     public FooAttribute()
+                //     {
+                //     }
+                // }
+                //
+                // In here, while we're emitting the record for FooAttribute..ctor, we need
+                // a pointer to the record for FooAttribute..ctor because that's what the
+                // constructor of the custom attribute applied to the constructor.
+
+                TConcreteRecord concreteRecord = new TConcreteRecord();
+                _map.Add(entity, concreteRecord);
+
+                initializer(entity, concreteRecord);
+
+                return concreteRecord;
+            }
+
+            return record;
+        }
+    }    
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cts = Internal.TypeSystem;
+
+namespace ILCompiler.Metadata
+{
+    /// <summary>
+    /// Controls metadata generation policy. Decides what types and members will get metadata.
+    /// </summary>
+    public interface IMetadataPolicy
+    {
+        /// <summary>
+        /// Returns true if the type should generate TypeDefinition metadata. If false,
+        /// the type should generate a TypeReference.
+        /// </summary>
+        /// <param name="typeDef">Uninstantiated type definition to check.</param>
+        bool GeneratesMetadata(Cts.MetadataType typeDef);
+
+        /// <summary>
+        /// Returns true if a type should be blocked from generating any metadata.
+        /// Blocked interfaces are skipped from interface lists, and custom attributes referring to
+        /// blocked types are dropped from metadata.
+        /// </summary>
+        bool IsBlocked(Cts.MetadataType typeDef);
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Internal.Metadata.NativeFormat.Writer;
-
 using Cts = Internal.TypeSystem;
 
 namespace ILCompiler.Metadata

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Internal.Metadata.NativeFormat.Writer;
+
 using Cts = Internal.TypeSystem;
 
 namespace ILCompiler.Metadata
@@ -11,11 +13,25 @@ namespace ILCompiler.Metadata
     public interface IMetadataPolicy
     {
         /// <summary>
-        /// Returns true if the type should generate TypeDefinition metadata. If false,
-        /// the type should generate a TypeReference.
+        /// Returns true if the type should generate <see cref="TypeDefinition"/> metadata. If false,
+        /// the type should generate a <see cref="TypeReference"/>.
         /// </summary>
         /// <param name="typeDef">Uninstantiated type definition to check.</param>
         bool GeneratesMetadata(Cts.MetadataType typeDef);
+
+        /// <summary>
+        /// Returns true if the method should generate <see cref="Method"/> metadata. If false,
+        /// the method should generate a <see cref="MemberReference"/> when needed.
+        /// </summary>
+        /// <param name="methodDef">Uninstantiated method definition to check.</param>
+        bool GeneratesMetadata(Cts.MethodDesc methodDef);
+
+        /// <summary>
+        /// Returns true if the field should generate <see cref="Field"/> metadata. If false,
+        /// the field should generate a <see cref="MemberReference"/> when needed.
+        /// </summary>
+        /// <param name="fieldDef">Uninstantiated field definition to check.</param>
+        bool GeneratesMetadata(Cts.FieldDesc fieldDef);
 
         /// <summary>
         /// Returns true if a type should be blocked from generating any metadata.

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Field.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Field.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+using FieldAttributes = System.Reflection.FieldAttributes;
+
+namespace ILCompiler.Metadata
+{
+    public partial class Transform<TPolicy>
+    {
+        private EntityMap<Cts.FieldDesc, MetadataRecord> _fields =
+            new EntityMap<Cts.FieldDesc, MetadataRecord>(EqualityComparer<Cts.FieldDesc>.Default);
+
+        private Action<Cts.FieldDesc, Field> _initFieldDef;
+        private Action<Cts.FieldDesc, MemberReference> _initFieldRef;
+
+        private MetadataRecord HandleField(Cts.FieldDesc field)
+        {
+            MetadataRecord rec;
+
+            if (_policy.GeneratesMetadata(field))
+            {
+                rec = HandleFieldDefinition(field);
+            }
+            else
+            {
+                rec = _fields.GetOrCreate(field, _initFieldRef ?? (_initFieldRef = InitializeFieldReference));
+            }
+
+            Debug.Assert(rec is Field || rec is MemberReference);
+
+            return rec;
+        }
+
+        private Field HandleFieldDefinition(Cts.FieldDesc field)
+        {
+            Debug.Assert(_policy.GeneratesMetadata(field));
+            return (Field)_fields.GetOrCreate(field, _initFieldDef ?? (_initFieldDef = InitializeFieldDefinition));
+        }
+
+        private void InitializeFieldDefinition(Cts.FieldDesc entity, Field record)
+        {
+            record.Name = HandleString(entity.Name);
+            record.Signature = new FieldSignature
+            {
+                Type = HandleType(entity.FieldType),
+                // TODO: CustomModifiers
+            };
+            record.Flags = GetFieldAttributes(entity);
+
+            // TODO: CustomAttributes
+            // TODO: DefaultValue
+            // TODO: Offset
+        }
+
+        private void InitializeFieldReference(Cts.FieldDesc entity, MemberReference record)
+        {
+            record.Name = HandleString(entity.Name);
+            record.Parent = HandleType(entity.OwningType);
+            record.Signature = new FieldSignature
+            {
+                Type = HandleType(entity.FieldType),
+                // TODO: CustomModifiers
+            };
+        }
+
+        private FieldAttributes GetFieldAttributes(Cts.FieldDesc field)
+        {
+            FieldAttributes result;
+
+            var ecmaField = field as Cts.Ecma.EcmaField;
+            if (ecmaField != null)
+            {
+                var fieldDefinition = ecmaField.MetadataReader.GetFieldDefinition(ecmaField.Handle);
+                result = fieldDefinition.Attributes;
+            }
+            else
+            {
+                result = 0;
+
+                if (field.IsStatic)
+                    result |= FieldAttributes.Static;
+                if (field.IsInitOnly)
+                    result |= FieldAttributes.InitOnly;
+                if (field.IsLiteral)
+                    result |= FieldAttributes.Literal;
+                if (field.HasRva)
+                    result |= FieldAttributes.HasFieldRVA;
+
+                // Not set: Visibility, NotSerialized, SpecialName, RTSpecialName, HasFieldMarshal, HasDefault
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Field.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Field.cs
@@ -41,6 +41,7 @@ namespace ILCompiler.Metadata
 
         private Field HandleFieldDefinition(Cts.FieldDesc field)
         {
+            Debug.Assert(field.GetTypicalFieldDefinition() == field);
             Debug.Assert(_policy.GeneratesMetadata(field));
             return (Field)_fields.GetOrCreate(field, _initFieldDef ?? (_initFieldDef = InitializeFieldDefinition));
         }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Method.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Method.cs
@@ -10,21 +10,166 @@ using Cts = Internal.TypeSystem;
 using Ecma = System.Reflection.Metadata;
 
 using Debug = System.Diagnostics.Debug;
-using CallingConventions = System.Reflection.CallingConventions;
+using MethodAttributes = System.Reflection.MethodAttributes;
+using MethodImplAttributes = System.Reflection.MethodImplAttributes;
 
 namespace ILCompiler.Metadata
 {
     public partial class Transform<TPolicy>
     {
+        private EntityMap<Cts.MethodDesc, MetadataRecord> _methods
+            = new EntityMap<Cts.MethodDesc, MetadataRecord>(EqualityComparer<Cts.MethodDesc>.Default);
+
+        private Action<Cts.MethodDesc, Method> _initMethodDef;
+        private Action<Cts.MethodDesc, MemberReference> _initMethodRef;
+
         private MetadataRecord HandleMethod(Cts.MethodDesc method)
         {
-            throw new NotImplementedException();
+            // TODO: MethodSpecs
+            Debug.Assert(method.IsTypicalMethodDefinition);
+
+            MetadataRecord rec;
+
+            if (_policy.GeneratesMetadata(method))
+            {
+                rec = HandleMethodDefinition(method);
+            }
+            else
+            {
+                rec = _methods.GetOrCreate(method, _initMethodRef ?? (_initMethodRef = InitializeMethodReference));
+            }
+
+            Debug.Assert(rec is Method || rec is MemberReference);
+
+            return rec;
         }
 
         private Method HandleMethodDefinition(Cts.MethodDesc method)
         {
+            Debug.Assert(method.IsMethodDefinition);
             Debug.Assert(_policy.GeneratesMetadata(method));
-            throw new NotImplementedException();
+            return (Method)_methods.GetOrCreate(method, _initMethodDef ?? (_initMethodDef = InitializeMethodDefinition));
+        }
+
+        private void InitializeMethodDefinition(Cts.MethodDesc entity, Method record)
+        {
+            record.Name = HandleString(entity.Name);
+            record.Signature = HandleMethodSignature(entity.Signature);
+
+            if (entity.HasInstantiation)
+            {
+                var genericParams = new List<GenericParameter>(entity.Instantiation.Length);
+                foreach (var p in entity.Instantiation)
+                    genericParams.Add(HandleGenericParameter((Cts.GenericParameterDesc)p));
+                record.GenericParameters = genericParams;
+            }
+
+            if (entity.Signature.Length > 0)
+            {
+                List<Parameter> parameters = new List<Parameter>(entity.Signature.Length);
+                for (ushort i = 0; i < entity.Signature.Length; i++)
+                {
+                    parameters.Add(new Parameter
+                    {
+                        Sequence = i
+                    });
+                }
+
+                var ecmaEntity = entity as Cts.Ecma.EcmaMethod;
+                if (ecmaEntity != null)
+                {
+                    Ecma.MetadataReader reader = ecmaEntity.MetadataReader;
+                    Ecma.MethodDefinition methodDef = reader.GetMethodDefinition(ecmaEntity.Handle);
+                    Ecma.ParameterHandleCollection paramHandles = methodDef.GetParameters();
+
+                    Debug.Assert(paramHandles.Count == entity.Signature.Length);
+
+                    int i = 0;
+                    foreach (var paramHandle in paramHandles)
+                    {
+                        Ecma.Parameter param = reader.GetParameter(paramHandle);
+                        parameters[i].Flags = param.Attributes;
+                        parameters[i].Name = HandleString(reader.GetString(param.Name));
+                        
+                        // TODO: CustomAttributes
+                        // TODO: DefaultValue
+
+                        i++;
+                    }
+                }
+
+                record.Parameters = parameters;
+            }
+
+            record.Flags = GetMethodAttributes(entity);
+            record.ImplFlags = GetMethodImplAttributes(entity);
+            
+            //TODO: MethodImpls
+            //TODO: RVA
+            //TODO: CustomAttributes
+        }
+
+        private void InitializeMethodReference(Cts.MethodDesc entity, MemberReference record)
+        {
+            record.Name = HandleString(entity.Name);
+            record.Parent = HandleType(entity.OwningType);
+            record.Signature = HandleMethodSignature(entity.Signature);
+        }
+
+        private MethodSignature HandleMethodSignature(Cts.MethodSignature signature)
+        {
+            List<ParameterTypeSignature> parameters;
+            if (signature.Length > 0)
+            {
+                parameters = new List<ParameterTypeSignature>(signature.Length);
+                for (int i = 0; i < signature.Length; i++)
+                {
+                    parameters.Add(HandleParameterTypeSignature(signature[i]));
+                }
+            }
+            else
+            {
+                parameters = null;
+            }
+            
+            return new MethodSignature
+            {
+                // TODO: CallingConvention
+                GenericParameterCount = signature.GenericParameterCount,
+                Parameters = parameters,
+                ReturnType = new ReturnTypeSignature
+                {
+                    // TODO: CustomModifiers
+                    Type = HandleType(signature.ReturnType)
+                },
+                // TODO-NICE: VarArgParameters
+            };
+        }
+
+        private MethodAttributes GetMethodAttributes(Cts.MethodDesc method)
+        {
+            var ecmaMethod = method as Cts.Ecma.EcmaMethod;
+            if (ecmaMethod != null)
+            {
+                Ecma.MetadataReader reader = ecmaMethod.MetadataReader;
+                Ecma.MethodDefinition methodDef = reader.GetMethodDefinition(ecmaMethod.Handle);
+                return methodDef.Attributes;
+            }
+            else
+                throw new NotImplementedException();
+        }
+
+        private MethodImplAttributes GetMethodImplAttributes(Cts.MethodDesc method)
+        {
+            var ecmaMethod = method as Cts.Ecma.EcmaMethod;
+            if (ecmaMethod != null)
+            {
+                Ecma.MetadataReader reader = ecmaMethod.MetadataReader;
+                Ecma.MethodDefinition methodDef = reader.GetMethodDefinition(ecmaMethod.Handle);
+                return methodDef.ImplAttributes;
+            }
+            else
+                throw new NotImplementedException();
         }
     }
 }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Method.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Method.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+using Ecma = System.Reflection.Metadata;
+
+using Debug = System.Diagnostics.Debug;
+using CallingConventions = System.Reflection.CallingConventions;
+
+namespace ILCompiler.Metadata
+{
+    public partial class Transform<TPolicy>
+    {
+        private MetadataRecord HandleMethod(Cts.MethodDesc method)
+        {
+            throw new NotImplementedException();
+        }
+
+        private Method HandleMethodDefinition(Cts.MethodDesc method)
+        {
+            Debug.Assert(_policy.GeneratesMetadata(method));
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Namespace.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Namespace.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+
+namespace ILCompiler.Metadata
+{
+    public partial class Transform<TPolicy>
+    {
+        private Dictionary<NamespaceKey, NamespaceDefinition> _namespaceDefs = new Dictionary<NamespaceKey, NamespaceDefinition>();
+
+        private NamespaceDefinition HandleNamespaceDefinition(Cts.ModuleDesc parentScope, string namespaceString)
+        {
+            NamespaceDefinition rootNamespace = HandleScopeDefinition(parentScope).RootNamespaceDefinition;
+
+            if (String.IsNullOrEmpty(namespaceString))
+            {
+                return rootNamespace;
+            }
+
+            NamespaceDefinition result;
+            NamespaceKey key = new NamespaceKey(parentScope, namespaceString);
+            if (_namespaceDefs.TryGetValue(key, out result))
+            {
+                return result;
+            }
+
+            NamespaceDefinition currentNamespace = rootNamespace;
+            string currentNamespaceName = String.Empty;
+            foreach (var segment in namespaceString.Split('.'))
+            {
+                string nextNamespaceName = currentNamespaceName;
+                if (nextNamespaceName.Length > 0)
+                    nextNamespaceName = nextNamespaceName + '.';
+                nextNamespaceName += segment;
+                NamespaceDefinition nextNamespace;
+                key = new NamespaceKey(parentScope, nextNamespaceName);
+                if (!_namespaceDefs.TryGetValue(key, out nextNamespace))
+                {
+                    nextNamespace = new NamespaceDefinition
+                    {
+                        Name = HandleString(segment.Length == 0 ? null : segment),
+                        ParentScopeOrNamespace = currentNamespace
+                    };
+
+                    _namespaceDefs.Add(key, nextNamespace);
+                    currentNamespace.NamespaceDefinitions.Add(nextNamespace);
+                }
+                currentNamespace = nextNamespace;
+                currentNamespaceName = nextNamespaceName;
+            }
+
+            return currentNamespace;
+        }
+
+        private Dictionary<NamespaceKey, NamespaceReference> _namespaceRefs = new Dictionary<NamespaceKey, NamespaceReference>();
+
+        private NamespaceReference HandleNamespaceReference(Cts.ModuleDesc parentScope, string namespaceString)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal struct NamespaceKey : IEquatable<NamespaceKey>
+    {
+        public readonly Cts.ModuleDesc Module;
+        public readonly string Namespace;
+
+        public NamespaceKey(Cts.ModuleDesc module, string namespaceName)
+        {
+            Module = module;
+            Namespace = namespaceName;
+        }
+
+        public bool Equals(NamespaceKey other)
+        {
+            return Module == other.Module && Namespace == other.Namespace;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is NamespaceKey)
+                return Equals((NamespaceKey)obj);
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return Namespace.GetHashCode();
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Parameter.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Parameter.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+
+using GenericParameterKind = Internal.Metadata.NativeFormat.GenericParameterKind;
+
+namespace ILCompiler.Metadata
+{
+    public partial class Transform<TPolicy>
+    {
+
+        #region Generic Parameters
+
+        private GenericParameter HandleGenericParameter(Cts.GenericParameterDesc genParam)
+        {
+            var result = new GenericParameter
+            {
+                Kind = genParam.Kind == Cts.GenericParameterKind.Type ?
+                    GenericParameterKind.GenericTypeParameter : GenericParameterKind.GenericMethodParameter,
+                Number = checked((ushort)genParam.Index),
+            };
+
+            // TODO: need to expose variance/constraints on GenericParameterDesc to make this
+            //       useful without a cast. We cannot pretend those are not there.
+            throw new System.NotImplementedException();
+        }
+
+        #endregion
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Parameter.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Parameter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using Internal.Metadata.NativeFormat.Writer;
 
 using Cts = Internal.TypeSystem;
@@ -11,6 +13,20 @@ namespace ILCompiler.Metadata
 {
     public partial class Transform<TPolicy>
     {
+        private EntityMap<Cts.TypeDesc, ParameterTypeSignature> _paramSigs =
+            new EntityMap<Cts.TypeDesc, ParameterTypeSignature>(EqualityComparer<Cts.TypeDesc>.Default);
+        private Action<Cts.TypeDesc, ParameterTypeSignature> _initParamSig;
+
+        private ParameterTypeSignature HandleParameterTypeSignature(Cts.TypeDesc parameter)
+        {
+            return _paramSigs.GetOrCreate(parameter, _initParamSig ?? (_initParamSig = InitializeParameterTypeSignature));
+        }
+
+        private void InitializeParameterTypeSignature(Cts.TypeDesc entity, ParameterTypeSignature record)
+        {
+            // TODO: CustomModifiers
+            record.Type = HandleType(entity);
+        }
 
         #region Generic Parameters
 

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Property.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Property.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+using Ecma = System.Reflection.Metadata;
+
+using Debug = System.Diagnostics.Debug;
+using MethodSemanticsAttributes = Internal.Metadata.NativeFormat.MethodSemanticsAttributes;
+
+namespace ILCompiler.Metadata
+{
+    public partial class Transform<TPolicy>
+    {
+        private Property HandleProperty(Cts.Ecma.EcmaModule module, Ecma.PropertyDefinitionHandle property)
+        {
+            Ecma.MetadataReader reader = module.MetadataReader;
+
+            Ecma.PropertyDefinition propDef = reader.GetPropertyDefinition(property);
+            Ecma.BlobReader sigBlobReader = reader.GetBlobReader(propDef.Signature);
+            Ecma.SignatureHeader sigHeader = sigBlobReader.ReadSignatureHeader();
+
+            Ecma.PropertyAccessors acc = propDef.GetAccessors();
+            Cts.MethodDesc getterMethod = acc.Getter.IsNil ? null : module.GetMethod(acc.Getter);
+            Cts.MethodDesc setterMethod = acc.Setter.IsNil ? null : module.GetMethod(acc.Setter);
+
+            bool getterReflectable = getterMethod != null && _policy.GeneratesMetadata(getterMethod);
+            bool setterReflectable = setterMethod != null && _policy.GeneratesMetadata(setterMethod);
+
+            if (!getterReflectable && !setterReflectable)
+                return null;
+
+            Property result = new Property
+            {
+                Name = HandleString(reader.GetString(propDef.Name)),
+                Flags = propDef.Attributes,
+                Signature = new PropertySignature
+                {
+                    // TODO: CallingConvention
+                    // TODO: CustomModifiers
+                    // TODO: Parameters
+                    // TODO: Type
+                },
+            };
+
+            if (getterReflectable)
+            {
+                result.MethodSemantics.Add(new MethodSemantics
+                {
+                    Attributes = MethodSemanticsAttributes.Getter,
+                    Method = HandleMethodDefinition(getterMethod),
+                });
+            }
+
+            if (setterReflectable)
+            {
+                result.MethodSemantics.Add(new MethodSemantics
+                {
+                    Attributes = MethodSemanticsAttributes.Setter,
+                    Method = HandleMethodDefinition(setterMethod),
+                });
+            }
+
+            // TODO: DefaultValue
+            // TODO: CustomAttributes
+
+            return result;
+        }
+
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -25,11 +25,10 @@ namespace ILCompiler.Metadata
 
         private void InitializeScopeDefinition(Cts.ModuleDesc module, ScopeDefinition scopeDefinition)
         {
-            // TODO: IAssemblyDesc
-            var ecmaModule = module as Cts.Ecma.EcmaModule;
-            if (ecmaModule != null)
+            var assemblyDesc = module as Cts.IAssemblyDesc;
+            if (assemblyDesc != null)
             {
-                var assemblyName = ecmaModule.GetName();
+                var assemblyName = assemblyDesc.GetName();
 
                 scopeDefinition.Name = HandleString(assemblyName.Name);
                 scopeDefinition.Culture = HandleString(assemblyName.CultureName);
@@ -53,7 +52,7 @@ namespace ILCompiler.Metadata
             }
             else
             {
-                throw new NotImplementedException();
+                throw new NotImplementedException("Multi-module assemblies");
             }
 
             scopeDefinition.RootNamespaceDefinition = new NamespaceDefinition
@@ -73,11 +72,10 @@ namespace ILCompiler.Metadata
 
         private void InitializeScopeReference(Cts.ModuleDesc module, ScopeReference scopeReference)
         {
-            // TODO: IAssemblyDesc
-            var ecmaModule = module as Cts.Ecma.EcmaModule;
-            if (ecmaModule != null)
+            var assemblyDesc = module as Cts.IAssemblyDesc;
+            if (assemblyDesc != null)
             {
-                var assemblyName = ecmaModule.GetName();
+                var assemblyName = assemblyDesc.GetName();
 
                 scopeReference.Name = HandleString(assemblyName.Name);
                 scopeReference.Culture = HandleString(assemblyName.CultureName);
@@ -95,11 +93,14 @@ namespace ILCompiler.Metadata
                     scopeReference.Flags |= (AssemblyFlags)((int)AssemblyContentType.WindowsRuntime << 9);
                 }
 
-                scopeReference.PublicKeyOrToken = assemblyName.GetPublicKey();
+                if ((assemblyName.Flags & AssemblyNameFlags.PublicKey) != 0)
+                    scopeReference.PublicKeyOrToken = assemblyName.GetPublicKey();
+                else
+                    scopeReference.PublicKeyOrToken = assemblyName.GetPublicKeyToken();
             }
             else
             {
-                throw new NotImplementedException();
+                throw new NotImplementedException("Multi-module assemblies");
             }
         }
     }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+using AssemblyFlags = Internal.Metadata.NativeFormat.AssemblyFlags;
+using AssemblyNameFlags = System.Reflection.AssemblyNameFlags;
+using AssemblyContentType = System.Reflection.AssemblyContentType;
+
+namespace ILCompiler.Metadata
+{
+    public partial class Transform<TPolicy>
+    {
+        private EntityMap<Cts.ModuleDesc, ScopeDefinition> _scopeDefs;
+        private Action<Cts.ModuleDesc, ScopeDefinition> _initScopeDef;
+
+        private ScopeDefinition HandleScopeDefinition(Cts.ModuleDesc module)
+        {
+            return _scopeDefs.GetOrCreate(module, _initScopeDef ?? (_initScopeDef = InitializeScopeDefinition));
+        }
+
+        private void InitializeScopeDefinition(Cts.ModuleDesc module, ScopeDefinition scopeDefinition)
+        {
+            // TODO: IAssemblyDesc
+            var ecmaModule = module as Cts.Ecma.EcmaModule;
+            if (ecmaModule != null)
+            {
+                var assemblyName = ecmaModule.GetName();
+
+                scopeDefinition.Name = HandleString(assemblyName.Name);
+                scopeDefinition.Culture = HandleString(assemblyName.CultureName);
+                scopeDefinition.MajorVersion = checked((ushort)assemblyName.Version.Major);
+                scopeDefinition.MinorVersion = checked((ushort)assemblyName.Version.Minor);
+                scopeDefinition.BuildNumber = checked((ushort)assemblyName.Version.Build);
+                scopeDefinition.RevisionNumber = checked((ushort)assemblyName.Version.Revision);
+
+                Debug.Assert((int)AssemblyFlags.PublicKey == (int)AssemblyNameFlags.PublicKey);
+                Debug.Assert((int)AssemblyFlags.Retargetable == (int)AssemblyNameFlags.Retargetable);
+                scopeDefinition.Flags = (AssemblyFlags)assemblyName.Flags;
+
+                if (assemblyName.ContentType == AssemblyContentType.WindowsRuntime)
+                {
+                    scopeDefinition.Flags |= (AssemblyFlags)((int)AssemblyContentType.WindowsRuntime << 9);
+                }
+
+                scopeDefinition.PublicKey = assemblyName.GetPublicKey();
+
+                // TODO: custom attributes
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+
+            scopeDefinition.RootNamespaceDefinition = new NamespaceDefinition
+            {
+                Name = null,
+                ParentScopeOrNamespace = scopeDefinition,
+            };
+        }
+
+        private EntityMap<Cts.ModuleDesc, ScopeReference> _scopeRefs;
+        private Action<Cts.ModuleDesc, ScopeReference> _initScopeRef;
+
+        private ScopeReference HandleScopeReference(Cts.ModuleDesc module)
+        {
+            return _scopeRefs.GetOrCreate(module, _initScopeRef ?? (_initScopeRef = InitializeScopeReference));
+        }
+
+        private void InitializeScopeReference(Cts.ModuleDesc module, ScopeReference scopeReference)
+        {
+            // TODO: IAssemblyDesc
+            var ecmaModule = module as Cts.Ecma.EcmaModule;
+            if (ecmaModule != null)
+            {
+                var assemblyName = ecmaModule.GetName();
+
+                scopeReference.Name = HandleString(assemblyName.Name);
+                scopeReference.Culture = HandleString(assemblyName.CultureName);
+                scopeReference.MajorVersion = checked((ushort)assemblyName.Version.Major);
+                scopeReference.MinorVersion = checked((ushort)assemblyName.Version.Minor);
+                scopeReference.BuildNumber = checked((ushort)assemblyName.Version.Build);
+                scopeReference.RevisionNumber = checked((ushort)assemblyName.Version.Revision);
+
+                Debug.Assert((int)AssemblyFlags.PublicKey == (int)AssemblyNameFlags.PublicKey);
+                Debug.Assert((int)AssemblyFlags.Retargetable == (int)AssemblyNameFlags.Retargetable);
+                scopeReference.Flags = (AssemblyFlags)assemblyName.Flags;
+
+                if (assemblyName.ContentType == AssemblyContentType.WindowsRuntime)
+                {
+                    scopeReference.Flags |= (AssemblyFlags)((int)AssemblyContentType.WindowsRuntime << 9);
+                }
+
+                scopeReference.PublicKeyOrToken = assemblyName.GetPublicKey();
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Internal.Metadata.NativeFormat.Writer;
 
 using Cts = Internal.TypeSystem;
@@ -15,7 +16,8 @@ namespace ILCompiler.Metadata
 {
     public partial class Transform<TPolicy>
     {
-        private EntityMap<Cts.ModuleDesc, ScopeDefinition> _scopeDefs;
+        private EntityMap<Cts.ModuleDesc, ScopeDefinition> _scopeDefs
+            = new EntityMap<Cts.ModuleDesc, ScopeDefinition>(EqualityComparer<Cts.ModuleDesc>.Default);
         private Action<Cts.ModuleDesc, ScopeDefinition> _initScopeDef;
 
         private ScopeDefinition HandleScopeDefinition(Cts.ModuleDesc module)
@@ -48,11 +50,11 @@ namespace ILCompiler.Metadata
 
                 scopeDefinition.PublicKey = assemblyName.GetPublicKey();
 
-                // TODO: custom attributes
+                // TODO: CustomAttributes
             }
             else
             {
-                throw new NotImplementedException("Multi-module assemblies");
+                throw new NotSupportedException("Multi-module assemblies");
             }
 
             scopeDefinition.RootNamespaceDefinition = new NamespaceDefinition
@@ -100,7 +102,7 @@ namespace ILCompiler.Metadata
             }
             else
             {
-                throw new NotImplementedException("Multi-module assemblies");
+                throw new NotSupportedException("Multi-module assemblies");
             }
         }
     }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.String.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.String.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.Metadata.NativeFormat.Writer;
+
+namespace ILCompiler.Metadata
+{
+    public partial class Transform<TPolicy>
+    {
+        private Dictionary<string, ConstantStringValue> _strings = new Dictionary<string, ConstantStringValue>(StringComparer.Ordinal);
+
+        private ConstantStringValue HandleString(string s)
+        {
+            ConstantStringValue result;
+            if (!_strings.TryGetValue(s, out result))
+            {
+                result = (ConstantStringValue)s;
+                _strings.Add(s, result);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.String.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.String.cs
@@ -14,6 +14,9 @@ namespace ILCompiler.Metadata
 
         private ConstantStringValue HandleString(string s)
         {
+            if (s == null)
+                return null;
+
             ConstantStringValue result;
             if (!_strings.TryGetValue(s, out result))
             {

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Internal.Metadata.NativeFormat.Writer;
+
+using Ecma = System.Reflection.Metadata;
+using Cts = Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+using TypeAttributes = System.Reflection.TypeAttributes;
+
+namespace ILCompiler.Metadata
+{
+    partial class Transform<TPolicy>
+    {
+        private EntityMap<Cts.TypeDesc, MetadataRecord> _types =
+            new EntityMap<Cts.TypeDesc, MetadataRecord>(EqualityComparer<Cts.TypeDesc>.Default);
+
+        private Action<Cts.MetadataType, TypeDefinition> _initTypeDef;
+        private Action<Cts.MetadataType, TypeReference> _initTypeRef;
+        private Action<Cts.ArrayType, TypeSpecification> _initSzArray;
+        private Action<Cts.ArrayType, TypeSpecification> _initArray;
+        private Action<Cts.ByRefType, TypeSpecification> _initByRef;
+        private Action<Cts.PointerType, TypeSpecification> _initPointer;
+        private Action<Cts.InstantiatedType, TypeSpecification> _initTypeInst;
+
+        public override MetadataRecord HandleType(Cts.TypeDesc type)
+        {
+            MetadataRecord rec;
+
+            if (type.IsSzArray)
+            {
+                var arrayType = (Cts.ArrayType)type;
+                rec = _types.GetOrCreate(arrayType, _initSzArray ?? (_initSzArray = InitializeSzArray));
+            }
+            else if (type.IsArray)
+            {
+                var arrayType = (Cts.ArrayType)type;
+                rec = _types.GetOrCreate(arrayType, _initArray ?? (_initArray = InitializeArray));
+            }
+            else if (type.IsByRef)
+            {
+                var byRefType = (Cts.ByRefType)type;
+                rec = _types.GetOrCreate(byRefType, _initByRef ?? (_initByRef = InitializeByRef));
+            }
+            else if (type.IsPointer)
+            {
+                var pointerType = (Cts.PointerType)type;
+                rec = _types.GetOrCreate(pointerType, _initPointer ?? (_initPointer = InitializePointer));
+            }
+            else if (type is Cts.GenericParameterDesc)
+            {
+                throw new NotImplementedException();
+            }
+            else if (type is Cts.InstantiatedType)
+            {
+                var instType = (Cts.InstantiatedType)type;
+                rec = _types.GetOrCreate(instType, _initTypeInst ?? (_initTypeInst = InitializeTypeInstance));
+            }
+            else
+            {
+                var metadataType = (Cts.MetadataType)type;
+                if (_policy.GeneratesMetadata(metadataType))
+                {
+                    rec = _types.GetOrCreate(metadataType, _initTypeDef ?? (_initTypeDef = InitializeTypeDef));
+                }
+                else
+                {
+                    rec = _types.GetOrCreate(metadataType, _initTypeRef ?? (_initTypeRef = InitializeTypeRef));
+                }
+            }
+
+            Debug.Assert(rec is TypeDefinition || rec is TypeReference || rec is TypeSpecification);
+
+            return rec;
+        }
+
+        private void InitializeSzArray(Cts.ArrayType entity, TypeSpecification record)
+        {
+            record.Signature = new SZArraySignature
+            {
+                ElementType = HandleType(entity.ElementType),
+            };
+        }
+
+        private void InitializeArray(Cts.ArrayType entity, TypeSpecification record)
+        {
+            record.Signature = new ArraySignature
+            {
+                ElementType = HandleType(entity.ElementType),
+                Rank = entity.Rank,
+                // TODO: sizes and lower bounds
+            };
+        }
+
+        private void InitializeByRef(Cts.ByRefType entity, TypeSpecification record)
+        {
+            record.Signature = new ByReferenceSignature
+            {
+                Type = HandleType(entity.ParameterType)
+            };
+        }
+
+        private void InitializePointer(Cts.PointerType entity, TypeSpecification record)
+        {
+            record.Signature = new PointerSignature
+            {
+                Type = HandleType(entity.ParameterType)
+            };
+        }
+
+        private void InitializeTypeInstance(Cts.InstantiatedType entity, TypeSpecification record)
+        {
+            var args = new List<MetadataRecord>(entity.Instantiation.Length);
+            for (int i = 0; i < entity.Instantiation.Length; i++)
+            {
+                args[i] = HandleType(entity.Instantiation[i]);
+            }
+
+            record.Signature = new TypeInstantiationSignature
+            {
+                GenericType = HandleType(entity.GetTypeDefinition()),
+                GenericTypeArguments = args
+            };
+        }
+
+        private void InitializeTypeRef(Cts.MetadataType entity, TypeReference record)
+        {
+            if (entity.ContainingType != null)
+            {
+                record.ParentNamespaceOrType = HandleType(entity.ContainingType);
+            }
+            else
+            {
+                // TODO: Lift Module to MetadataType and remove the cast
+                record.ParentNamespaceOrType = HandleNamespaceDefinition(((Cts.Ecma.EcmaType)entity).Module, entity.Namespace);
+            }
+
+            record.TypeName = HandleString(entity.Name);
+        }
+
+        private void InitializeTypeDef(Cts.MetadataType entity, TypeDefinition record)
+        {
+            if (entity.ContainingType != null)
+            {
+                var enclosingType = (TypeDefinition)HandleType(entity.ContainingType);
+                record.EnclosingType = enclosingType;
+                enclosingType.NestedTypes.Add(record);
+
+                // TODO: NamespaceDefinition?
+            }
+            else
+            {
+                // TODO: Lift Module to MetadataType and remove the cast
+                var namespaceDefinition = HandleNamespaceDefinition(((Cts.Ecma.EcmaType)entity).Module, entity.Namespace);
+                record.NamespaceDefinition = namespaceDefinition;
+                namespaceDefinition.TypeDefinitions.Add(record);
+            }
+
+            record.Name = HandleString(entity.Name);
+
+            Cts.ClassLayoutMetadata layoutMetadata = entity.GetClassLayout();
+            record.Size = checked((uint)layoutMetadata.Size);
+            record.PackingSize = checked((uint)layoutMetadata.PackingSize);
+            record.Flags = GetTypeAttributes(entity);
+
+            if (entity.HasBaseType)
+                record.BaseType = HandleType(entity.BaseType);
+
+            record.Interfaces = entity.ExplicitlyImplementedInterfaces
+                .Where(i => !IsBlocked(i))
+                .Select(i => HandleType(i)).ToList();
+
+            // TODO: GenericParameters
+            // TODO: CustomAttributes
+        }
+
+        private TypeAttributes GetTypeAttributes(Cts.MetadataType type)
+        {
+            TypeAttributes result;
+
+            var ecmaType = type as Cts.Ecma.EcmaType;
+            if (ecmaType != null)
+            {
+                Ecma.TypeDefinition ecmaRecord = ecmaType.MetadataReader.GetTypeDefinition(ecmaType.Handle);
+                result = ecmaRecord.Attributes;
+            }
+            else
+            {
+                result = 0;
+
+                if (type.IsExplicitLayout)
+                    result |= TypeAttributes.ExplicitLayout;
+                if (type.IsSequentialLayout)
+                    result |= TypeAttributes.SequentialLayout;
+                if (type.IsInterface)
+                    result |= TypeAttributes.Interface;
+                if (type.IsSealed)
+                    result |= TypeAttributes.Sealed;
+                if (type.IsBeforeFieldInit)
+                    result |= TypeAttributes.BeforeFieldInit;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -100,7 +100,8 @@ namespace ILCompiler.Metadata
             {
                 ElementType = HandleType(entity.ElementType),
                 Rank = entity.Rank,
-                // TODO: sizes and lower bounds
+                // TODO: LowerBounds
+                // TODO: Sizes
             };
         }
 
@@ -242,7 +243,7 @@ namespace ILCompiler.Metadata
                         record.Properties.Add(prop);
                 }
 
-                // Events
+                // TODO: Events
 
                 // TODO: CustomAttributes
             }
@@ -272,6 +273,9 @@ namespace ILCompiler.Metadata
                     result |= TypeAttributes.Sealed;
                 if (type.IsBeforeFieldInit)
                     result |= TypeAttributes.BeforeFieldInit;
+
+                // Not set: Abstract, Ansi/Unicode/Auto, HasSecurity, Import, visibility, Serializable,
+                //          WindowsRuntime, HasSecurity, SpecialName, RTSpecialName
             }
 
             return result;

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+
+namespace ILCompiler.Metadata
+{
+    public abstract class Transform
+    {
+        public abstract MetadataRecord HandleType(Cts.TypeDesc type);
+
+        // TODO: HandleTypeForwarder
+    }
+
+    public partial class Transform<TPolicy> : Transform
+        where TPolicy : struct, IMetadataPolicy
+    {
+        private TPolicy _policy;
+
+        public Transform(TPolicy policy)
+        {
+            _policy = policy;
+        }
+
+        private bool IsBlocked(Cts.TypeDesc type)
+        {
+            if (type.IsArray || type.IsByRef || type.IsPointer)
+                return IsBlocked(((Cts.ParameterizedType)type).ParameterType);
+
+            if (type is Cts.InstantiatedType)
+            {
+                if (IsBlocked(type.GetTypeDefinition()))
+                    return true;
+
+                foreach (var arg in type.Instantiation)
+                    if (IsBlocked(arg))
+                        return true;
+
+                return false;
+            }
+
+            return _policy.IsBlocked((Cts.MetadataType)type);
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/project.json
+++ b/src/ILCompiler.MetadataTransform/src/project.json
@@ -1,0 +1,22 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.20",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Reflection.Primitives": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.IO": "4.0.10",
+    "System.Collections": "4.0.0",
+    "System.Text.Encoding": "4.0.0",
+    "System.Runtime.InteropServices": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Runtime.Extensions": "4.0.0",
+    "System.Threading": "4.0.0",
+    "System.Text.Encoding.Extensions": "4.0.0",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Reflection.Metadata": "1.0.22"
+  },
+  "frameworks": {
+    "dotnet": {}
+  }
+}

--- a/src/ILCompiler.MetadataTransform/tests/ILCompiler.MetadataTransform.Tests.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/ILCompiler.MetadataTransform.Tests.csproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B4B713D9-68A1-4EB3-8164-4DC8BE69BCBC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>ILCompiler.MetadataTransform.Tests</AssemblyName>
+    <RootNamespace>ILCompiler.MetadataTransform.Tests</RootNamespace>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ILCompiler.TypeSystem\src\ILCompiler.TypeSystem.csproj">
+      <Project>{1a9df196-43a9-44bb-b2c6-d62aa56b0e49}</Project>
+      <Name>ILCompiler.TypeSystem</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\src\ILCompiler.MetadataTransform.csproj">
+      <Project>{a965ea82-219d-48f7-ad51-bc030c16cc6f}</Project>
+      <Name>ILCompiler.MetadataTransform</Name>
+    </ProjectReference>
+    <ProjectReference Include="PrimaryMetadataAssembly\PrimaryMetadataAssembly.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SingleFileMetadataPolicy.cs" />
+    <Compile Include="TestTypeSystemContext.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/ILCompiler.MetadataTransform/tests/ILCompiler.MetadataTransform.Tests.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/ILCompiler.MetadataTransform.Tests.csproj
@@ -23,6 +23,10 @@
       <Project>{a965ea82-219d-48f7-ad51-bc030c16cc6f}</Project>
       <Name>ILCompiler.MetadataTransform</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj">
+      <Project>{D66338D4-F9E4-4051-B302-232C6BFB6EF6}</Project>
+      <Name>ILCompiler.MetadataWriter</Name>
+    </ProjectReference>
     <ProjectReference Include="PrimaryMetadataAssembly\PrimaryMetadataAssembly.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
@@ -34,6 +38,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SimpleTests.cs" />
     <Compile Include="SingleFileMetadataPolicy.cs" />
     <Compile Include="TestTypeSystemContext.cs" />
   </ItemGroup>

--- a/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/Platform.cs
+++ b/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/Platform.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable 649
+
+namespace System
+{
+    // Dummy core types to allow us compiling this assembly as a core library so that the type
+    // system tests don't have a dependency on a real core library.
+
+    // We might need to bring in some extra things (Interface lists? Other virtual methods on Object?),
+    // but let's postpone that until actually needed.
+    
+    public class Object
+    {
+        internal IntPtr m_pEEType;
+        public virtual string ToString() { return null; }
+
+        ~Object()
+        {
+        }
+    }
+
+    public struct Void { }
+    public struct Boolean { }
+    public struct Char { }
+    public struct SByte { }
+    public struct Byte { }
+    public struct Int16 { }
+    public struct UInt16 { }
+    public struct Int32 { }
+    public struct UInt32 { }
+    public struct Int64 { }
+    public struct UInt64 { }
+    public struct IntPtr { }
+    public struct UIntPtr { }
+    public struct Single { }
+    public struct Double { }
+    public abstract class ValueType { }
+    public abstract class Enum : ValueType { }
+    public struct Nullable<T> where T : struct { }
+    
+    public sealed class String { }
+    public abstract class Array : System.Collections.IList { }
+    public abstract class Delegate { }
+    public abstract class MulticastDelegate : Delegate { }
+
+    public struct RuntimeTypeHandle { }
+    public struct RuntimeMethodHandle { }
+    public struct RuntimeFieldHandle { }
+
+    public class Attribute { }
+
+    public class Array<T> : Array, System.Collections.Generic.IList<T> { }
+}
+
+namespace System.Collections
+{
+    interface IList
+    { }
+}
+
+namespace System.Collections.Generic
+{
+    interface IList<T>
+    {
+
+    }
+}
+
+namespace System.Runtime.InteropServices
+{
+    public enum LayoutKind
+    {
+        Sequential = 0, // 0x00000008,
+        Explicit = 2, // 0x00000010,
+        Auto = 3, // 0x00000000,
+    }
+
+    public sealed class StructLayoutAttribute : Attribute
+    {
+        internal LayoutKind _val;
+
+        public StructLayoutAttribute(LayoutKind layoutKind)
+        {
+            _val = layoutKind;
+        }
+
+        public LayoutKind Value { get { return _val; } }
+        public int Pack;
+        public int Size;
+    }
+
+    public sealed class FieldOffsetAttribute : Attribute
+    {
+        private int _val;
+        public FieldOffsetAttribute(int offset)
+        {
+            _val = offset;
+        }
+        public int Value { get { return _val; } }
+    }
+}
+

--- a/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/PrimaryMetadataAssembly.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/PrimaryMetadataAssembly.csproj
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AssemblyName>PrimaryMetadataAssembly</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IsCoreAssembly>true</IsCoreAssembly>
+    <!--
+      Need to avoid target platform being empty because that would drag in an mscorlib design-time
+      facade into the references and break us.
+    -->
+    <TargetPlatformIdentifier>Portable</TargetPlatformIdentifier>
+    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
+    <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
+    <ProjectGuid>{C29B7395-F925-4B0E-972D-187D2D4BFEC7}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Platform.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/ILCompiler.MetadataTransform/tests/SimpleTests.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SimpleTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Cts = Internal.TypeSystem;
+using Internal.NativeFormat;
+
+using Xunit;
+
+namespace MetadataTransformTests
+{
+    public class SimpleTests
+    {
+        TestTypeSystemContext _context;
+        Cts.Ecma.EcmaModule _testModule;
+
+        public SimpleTests()
+        {
+            _context = new TestTypeSystemContext();
+            var systemModule = _context.CreateModuleForSimpleName("PrimaryMetadataAssembly");
+            _context.SetSystemModule(systemModule);
+
+            _testModule = systemModule;
+        }
+
+        [Fact]
+        public void SimpleTest()
+        {
+            var transform = new ILCompiler.Metadata.Transform<SingleFileMetadataPolicy>(new SingleFileMetadataPolicy());
+
+            foreach (var type in _testModule.GetAllTypes())
+            {
+                transform.HandleType(type);
+            }
+
+
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using ILCompiler.Metadata;
+using Internal.TypeSystem;
+
+namespace ILCompiler.MetadataTransform.Tests
+{
+    struct SingleFileMetadataPolicy : IMetadataPolicy
+    {
+        public bool GeneratesMetadata(MetadataType typeDef)
+        {
+            return true;
+        }
+
+        public bool IsBlocked(MetadataType typeDef)
+        {
+            return false;
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using ILCompiler.Metadata;
 using Internal.TypeSystem;
 
@@ -8,6 +9,16 @@ namespace ILCompiler.MetadataTransform.Tests
 {
     struct SingleFileMetadataPolicy : IMetadataPolicy
     {
+        public bool GeneratesMetadata(MethodDesc methodDef)
+        {
+            return true;
+        }
+
+        public bool GeneratesMetadata(FieldDesc fieldDef)
+        {
+            return true;
+        }
+
         public bool GeneratesMetadata(MetadataType typeDef)
         {
             return true;

--- a/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
@@ -5,7 +5,7 @@ using System;
 using ILCompiler.Metadata;
 using Internal.TypeSystem;
 
-namespace ILCompiler.MetadataTransform.Tests
+namespace MetadataTransformTests
 {
     struct SingleFileMetadataPolicy : IMetadataPolicy
     {

--- a/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
@@ -11,7 +11,7 @@ using Internal.TypeSystem.Ecma;
 using System.Reflection.PortableExecutable;
 using System.IO;
 
-namespace TypeSystemTests
+namespace MetadataTransformTests
 {
     class TestTypeSystemContext : TypeSystemContext
     {
@@ -51,11 +51,6 @@ namespace TypeSystemTests
         EcmaModule _systemModule;
 
         Dictionary<string, EcmaModule> _modules = new Dictionary<string, EcmaModule>(StringComparer.OrdinalIgnoreCase);
-
-        public TestTypeSystemContext(TargetArchitecture arch)
-            : base(new TargetDetails(arch, TargetOS.Unknown))
-        {
-        }
 
         public override DefType GetWellKnownType(WellKnownType wellKnownType)
         {

--- a/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Debug = System.Diagnostics.Debug;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+using System.Reflection.PortableExecutable;
+using System.IO;
+
+namespace TypeSystemTests
+{
+    class TestTypeSystemContext : TypeSystemContext
+    {
+        static readonly string[] s_wellKnownTypeNames = new string[] {
+            "Void",
+            "Boolean",
+            "Char",
+            "SByte",
+            "Byte",
+            "Int16",
+            "UInt16",
+            "Int32",
+            "UInt32",
+            "Int64",
+            "UInt64",
+            "IntPtr",
+            "UIntPtr",
+            "Single",
+            "Double",
+
+            "ValueType",
+            "Enum",
+            "Nullable`1",
+
+            "Object",
+            "String",
+            "Array",
+            "MulticastDelegate",
+
+            "RuntimeTypeHandle",
+            "RuntimeMethodHandle",
+            "RuntimeFieldHandle",
+        };
+
+        MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
+
+        EcmaModule _systemModule;
+
+        Dictionary<string, EcmaModule> _modules = new Dictionary<string, EcmaModule>(StringComparer.OrdinalIgnoreCase);
+
+        public TestTypeSystemContext(TargetArchitecture arch)
+            : base(new TargetDetails(arch, TargetOS.Unknown))
+        {
+        }
+
+        public override DefType GetWellKnownType(WellKnownType wellKnownType)
+        {
+            return _wellKnownTypes[(int)wellKnownType - 1];
+        }
+
+        public void SetSystemModule(EcmaModule systemModule)
+        {
+            _systemModule = systemModule;
+
+            // Sanity check the name table
+            Debug.Assert(s_wellKnownTypeNames[(int)WellKnownType.MulticastDelegate - 1] == "MulticastDelegate");
+
+            // Initialize all well known types - it will save us from checking the name for each loaded type
+            for (int typeIndex = 0; typeIndex < _wellKnownTypes.Length; typeIndex++)
+            {
+                MetadataType type = _systemModule.GetType("System", s_wellKnownTypeNames[typeIndex]);
+                type.SetWellKnownType((WellKnownType)(typeIndex + 1));
+                _wellKnownTypes[typeIndex] = type;
+            }
+        }
+
+        public EcmaModule GetModuleForSimpleName(string simpleName)
+        {
+            EcmaModule existingModule;
+            if (_modules.TryGetValue(simpleName, out existingModule))
+                return existingModule;
+
+            return CreateModuleForSimpleName(simpleName);
+        }
+
+        public EcmaModule CreateModuleForSimpleName(string simpleName)
+        {
+            EcmaModule module = new EcmaModule(this, new PEReader(File.OpenRead(simpleName + ".dll")));
+            _modules.Add(simpleName, module);
+            return module;
+        }
+
+        public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name)
+        {
+            return GetModuleForSimpleName(name.Name);
+        }
+
+        public override FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/tests/project.json
+++ b/src/ILCompiler.MetadataTransform/tests/project.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Console": "4.0.0-beta-23419",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.Tracing": "4.0.20",
+    "System.Linq": "4.0.0",
+    "System.IO.FileSystem": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "System.Reflection.Metadata": "1.0.22",
+    "xunit": "2.1.0-beta3-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+  },
+  "frameworks": {
+    "dotnet": {}
+  }
+}

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -29,6 +29,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\ModuleDesc.cs">
       <Link>ModuleDesc.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\PropertySignature.cs">
+      <Link>PropertySignature.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
       <Link>Utilities\LockFreeReaderHashtable.cs</Link>
     </Compile>


### PR DESCRIPTION
This transforms the type system object model into the metadata writer
object model. The metadata writer object model can be directly
serialized to a binary blob by the MetadataWriter and used by reflection
at runtime.

Lots of things are not implemented. There are either TODOs or throws in
appropriate places.

I just want to get a few eyes on this before I continue.