### PR TITLE
Refactor AppDep and ILCompiler.SDK packages

### DIFF
--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -445,14 +445,6 @@ int __statics_fixup()
     return 0;
 }
 
-#ifdef PLATFORM_UNIX
-// Placeholder of functions not yet implemented on Unix
-extern "C" void CoCreateGuid() { }
-extern "C" void CoGetApartmentType() { }
-extern "C" void CreateEventExW() { }
-extern "C" void GetNativeSystemInfo() { }
-#endif
-
 int main(int argc, char * argv[]) {
     if (__initialize_runtime() != 0) return -1;
     __register_module(&__module);

--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <stdint.h>
 
 int UTF8ToWideCharLen(char* bytes, int len)
 {
@@ -15,3 +16,58 @@ int UTF8ToWideChar(char* bytes, int len, unsigned short* buffer, int bufLen)
         buffer[i] = bytes[i];
     return len;
 }
+
+void LCMapStringEx(void*, uint32_t, void*, int32_t, intptr_t, int32_t, intptr_t, intptr_t, intptr_t)
+{
+    throw 42;
+}
+
+int32_t WideCharToMultiByte(uint32_t CodePage, uint32_t dwFlags, uint16_t* lpWideCharStr, int32_t cchWideChar, intptr_t lpMultiByteStr, int32_t cbMultiByte, intptr_t lpDefaultChar, intptr_t lpUsedDefaultChar)
+{
+    throw 42;
+}
+
+int32_t MultiByteToWideChar(uint32_t CodePage, uint32_t dwFlags, const uint8_t * lpMultiByteStr, int32_t cbMultiByte, uint16_t* lpWideCharStr, int32_t cchWideChar)
+{
+    throw 42;
+}
+
+void CoTaskMemFree(void* m)
+{
+    free(m);
+}
+
+intptr_t CoTaskMemAlloc(intptr_t size)
+{
+    return (intptr_t)malloc(size);
+}
+
+int32_t CompareStringEx(int16_t*, uint32_t, int16_t*, int32_t, int16_t*, int32_t, void*, void*, intptr_t)
+{
+	throw 42;
+}
+
+int32_t CompareStringOrdinal(int16_t*, int32_t, int16_t*, int32_t, int32_t)
+{
+	throw 42;
+}
+
+int32_t FindNLSStringEx(int16_t*, uint32_t, int16_t*, int32_t, int16_t*, int32_t, int32_t*, void*, void*, intptr_t)
+{
+	throw 42;
+}
+
+int32_t GetLocaleInfoEx(intptr_t, uint32_t, intptr_t, int32_t)
+{
+	throw 42;
+}
+
+int32_t ResolveLocaleName(intptr_t, intptr_t, int32_t)
+{
+	throw 42;
+}
+
+extern "C" void CoCreateGuid() { }
+extern "C" void CoGetApartmentType() { }
+extern "C" void CreateEventExW() { }
+extern "C" void GetNativeSystemInfo() { }

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -19,7 +19,7 @@
         <!-- Property needed for creating nupkgs -->
         <PropertyGroup>
             <ToolchainMilestone Condition="'$(ToolchainMilestone)'==''">prerelease</ToolchainMilestone>
-            <ToolchainVersion>1.0.3-$(ToolchainMilestone)-00002</ToolchainVersion>
+            <ToolchainVersion>1.0.4-$(ToolchainMilestone)-00001</ToolchainVersion>
             <RuntimeSdkVersion>$(ToolchainVersion)</RuntimeSdkVersion>
             <NuPkgRid>$(NuPkgRuntimeOS)-$(NuPkgRuntimePlatform)</NuPkgRid>
             
@@ -60,14 +60,37 @@
             <ILCompilerSdkFiles Include="bootstrappercpp" />
             <ILCompilerSdkFiles Include="System.Private.CoreLib.Native" Condition="'$(OsEnvironment)'!='Windows_NT'" />
 
+            <!-- ILCompiler.SDK Cpp Codegen support files -->
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/env/etmdummy.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/env/gcenv.base.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/env/gcenv.object.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/env/gcenv.sync.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/gc.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/gcdesc.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/sample/gcenv.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/gcimpl.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/gcpriv.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/gcrecord.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/gcscan.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/handletable.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/handletable.inl" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/handletablepriv.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/gc/objecthandle.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/Bootstrap/common.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/Bootstrap/platform.h" />
+
             <ILCompilerSdkFilesManaged Include="System.Private.CoreLib" />
+
             <ILCompilerSdkBinPlace Include="@(ILCompilerSdkFiles)">
                 <Text><![CDATA[        <file src="../lib/$(LibPrefix)%(Identity).$(StaticLibExt)" target="runtimes/$(NuPkgRid)/native/sdk/$(LibPrefix)%(Identity).$(StaticLibExt)" /> ]]></Text>
             </ILCompilerSdkBinPlace>
             <ILCompilerSdkBinPlace Include="@(ILCompilerSdkFilesManaged)">
                 <Text><![CDATA[        <file src="../%(Identity).dll" target="runtimes/$(NuPkgRid)/native/sdk/%(Identity).dll" /> ]]></Text>
             </ILCompilerSdkBinPlace>
-
+            <ILCompilerSdkBinPlace Include="@(ILCompilerSdkCppCodegenFiles)">
+                <Text><![CDATA[        <file src="../../../../src/%(Identity)" target="runtimes/$(NuPkgRid)/native/inc/%(Filename)%(Extension)" /> ]]></Text>
+            </ILCompilerSdkBinPlace>
+            
             <!-- ILCompiler nuspec file -->
             <NuSpecFile Include="$(ToolchainPackageName)">
                 <Stage>0</Stage>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -24,6 +24,7 @@ if /i "%1" == "/buildextrepo" (set CoreRT_BuildExtRepo=%2&shift&shift&goto ArgLo
 if /i "%1" == "/mode" (set CoreRT_TestCompileMode=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/runtest" (set CoreRT_TestRun=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/nocache" (set CoreRT_NuGetOptions=-nocache&shift&goto ArgLoop)
+if /i "%1" == "/dotnetclipath" (set CoreRT_CliDir=%2\bin&shift&shift&goto ArgLoop)
 
 echo Invalid command line argument: %1
 goto :Usage

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -74,6 +74,7 @@ CoreRT_TestRun=true
 CoreRT_TestCompileMode=ryujit
 CoreRT_TestExtRepo=
 CoreRT_BuildExtRepo=
+__dotnetclipath=""
 
 # Use uname to determine what the OS is.
 OSName=$(uname -s)
@@ -96,9 +97,8 @@ case $OSName in
         ;;
 esac
 
-for i in "$@"
-    do
-        lowerI="$(echo $i | awk '{print tolower($0)}')"
+while [ "$1" != "" ]; do
+        lowerI="$(echo $1 | awk '{print tolower($0)}')"
         case $lowerI in
         -?|-h|--help)
             usage
@@ -124,22 +124,27 @@ for i in "$@"
             ;;
         -extrepo)
             shift
-            CoreRT_TestExtRepo=$i
+            CoreRT_TestExtRepo=$1
             ;;
         -mode)
             shift
-            CoreRT_TestCompileMode=$i
+            CoreRT_TestCompileMode=$1
             ;;
         -runtest)
             shift
-            CoreRT_TestRun=$i
+            CoreRT_TestRun=$1
             ;;
         -nocache)
             CoreRT_NuGetOptions=-nocache
             ;;
+        -dotnetclipath) 
+            shift
+            __dotnetclipath=$1
+            ;;
         *)
             ;;
     esac
+    shift
 done
 
 __BuildStr=${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}


### PR DESCRIPTION
This change does the following:

1) Moves headers from AppDep to native\sdk\inc and native\sdk\inc\common folders in ILCompiler.SDK
2) Update ILCompiler.SDK nuget package authoring for the same
3) Move the stub code (from lxstubs.cpp and osxstubs.cpp) into bootstrapper
4) Add support to the build and test scripts for consuming CLI from a custom location. This is enabling me to test the corresponding change in CLI repo alongwith this one.

Still to do:

1) Validate and test for Unix builds

Corresponding CLI PR is https://github.com/dotnet/cli/pull/632.

@schellap @jkotas PTAL.