### PR TITLE
Changes required for refactored ILCompiler.SDK consumption.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -79,18 +79,18 @@ install_dotnet_cli()
     echo "Installing the dotnet/cli..."
     local __tools_dir=${__scriptpath}/bin/tools
     local __cli_dir=${__tools_dir}/cli
-    if [ ! -z "${__dotnetclipath}" ]; then
-        __cli_dir = ${__dotnetclipath}
-    else
-        __dotnetclipath=${__cli_dir}
-    fi
-
     
     if [ ! -d "${__cli_dir}" ]; then
         mkdir -p "${__cli_dir}"
     fi
     if [ ! -f "${__cli_dir}/bin/dotnet" ]; then
         local __build_os_lowercase=$(echo "${__BuildOS}" | tr '[:upper:]' '[:lower:]')
+
+        # For Linux, we currently only support Ubuntu.
+        if [ "${__build_os_lowercase}" == "linux" ]; then
+            __build_os_lowercase="ubuntu"
+        fi
+        
         local __build_arch_lowercase=$(echo "${__BuildArch}" | tr '[:upper:]' '[:lower:]')
         local __cli_tarball=dotnet-${__build_os_lowercase}-${__build_arch_lowercase}.latest.tar.gz
         local __cli_tarball_path=${__tools_dir}/${__cli_tarball}
@@ -108,6 +108,14 @@ install_dotnet_cli()
             export HOME=${__tools_dir}
         fi
     fi
+    
+    if [ ! -z "${__dotnetclipath}" ]; then
+        __cli_dir=${__dotnetclipath}
+        export DOTNET_HOME=${__cli_dir}
+    else
+        __dotnetclipath=${__cli_dir}
+    fi
+
     if [ ! -f "${__cli_dir}/bin/dotnet" ]; then
         echo "CLI could not be installed or not present."
         exit 1
@@ -234,7 +242,7 @@ __ToolNugetRuntimeId=ubuntu.14.04-x64
 __TestNugetRuntimeId=ubuntu.14.04-x64
 __buildmanaged=true
 __buildnative=true
-__dotnetclipath=""
+__dotnetclipath=
 
 # Workaround to enable nuget package restoration work successully on Mono
 export TZ=UTC 

--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -27,7 +27,7 @@ int32_t WideCharToMultiByte(uint32_t CodePage, uint32_t dwFlags, uint16_t* lpWid
     throw 42;
 }
 
-int32_t MultiByteToWideChar(uint32_t CodePage, uint32_t dwFlags, const uint8_t * lpMultiByteStr, int32_t cbMultiByte, uint16_t* lpWideCharStr, int32_t cchWideChar)
+extern "C" int32_t MultiByteToWideChar(uint32_t CodePage, uint32_t dwFlags, const uint8_t * lpMultiByteStr, int32_t cbMultiByte, uint16_t* lpWideCharStr, int32_t cchWideChar)
 {
     throw 42;
 }

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -136,9 +136,13 @@ goto :eof
     rmdir /s /q !__SourceFolder!\obj
 
     setlocal
+    set additionalCompilerFlags=
+    if /i "%CoreRT_BuildType%" == "debug" (
+        if /i "%__Mode%" == "cpp" set additionalCompilerFlags=--cppcompilerflags /D_DEBUG
+    )
     REM TODO: Add AppDepSDK argument after CLI build picks up: PR dotnet/cli #336
     call "!VS140COMNTOOLS!\..\..\VC\vcvarsall.bat" %CoreRT_BuildArch%
-    "%CoreRT_CliDir%\dotnet" compile --native --ilcpath "%CoreRT_ToolchainDir%" !__ExtraCompileArgs! !__SourceFolder! -c %CoreRT_BuildType%
+    "%CoreRT_CliDir%\dotnet" compile --native --ilcpath "%CoreRT_ToolchainDir%" !__ExtraCompileArgs! !__SourceFolder! -c %CoreRT_BuildType% %additionalCompilerFlags%
     endlocal
 
     set __SavedErrorLevel=%ErrorLevel%

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -74,7 +74,6 @@ CoreRT_TestRun=true
 CoreRT_TestCompileMode=ryujit
 CoreRT_TestExtRepo=
 CoreRT_BuildExtRepo=
-__dotnetclipath=""
 
 # Use uname to determine what the OS is.
 OSName=$(uname -s)
@@ -139,7 +138,7 @@ while [ "$1" != "" ]; do
             ;;
         -dotnetclipath) 
             shift
-            __dotnetclipath=$1
+            CoreRT_CliBinDir=$1/bin
             ;;
         *)
             ;;


### PR DESCRIPTION
Required for both Mac and Linux builds.

@schellap PTAL and publish new ILC* packages when this goes through.