### PR TITLE
Improve performance of MethodIL provider

### DIFF
--- a/src/Common/src/TypeSystem/IL/EcmaMethodIL.cs
+++ b/src/Common/src/TypeSystem/IL/EcmaMethodIL.cs
@@ -27,31 +27,13 @@ namespace Internal.IL
             var rva = method.MetadataReader.GetMethodDefinition(method.Handle).RelativeVirtualAddress;
             if (rva == 0)
                 return null;
-            return new EcmaMethodIL(method.Module, method.Module.PEReader.GetMethodBody(rva));
+            return new EcmaMethodIL(method.Module, rva);
         }
 
-        public EcmaMethodIL(EcmaModule module, MethodBodyBlock methodBody)
+        private EcmaMethodIL(EcmaModule module, int rva)
         {
             _module = module;
-            _methodBody = methodBody;
-        }
-
-        // Avoid unnecessary copy
-        private static byte[] DangerousGetUnderlyingArray(ImmutableArray<byte> array)
-        {
-            var union = new ByteArrayUnion();
-            union.ImmutableArray = array;
-            return union.UnderlyingArray;
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        private struct ByteArrayUnion
-        {
-            [FieldOffset(0)]
-            internal byte[] UnderlyingArray;
-
-            [FieldOffset(0)]
-            internal ImmutableArray<byte> ImmutableArray;
+            _methodBody = module.PEReader.GetMethodBody(rva);
         }
 
         public override byte[] GetILBytes()
@@ -59,7 +41,7 @@ namespace Internal.IL
             if (_ilBytes != null)
                 return _ilBytes;
 
-            byte[] ilBytes = DangerousGetUnderlyingArray(_methodBody.GetILContent());
+            byte[] ilBytes = _methodBody.GetILBytes();
             return (_ilBytes = ilBytes);
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -235,9 +235,9 @@ namespace ILCompiler.DependencyAnalysis
 
         private IntPtr _nativeObjectWriter = IntPtr.Zero;
 
-        public ObjectWriter(string outputPath, NodeFactory factory)
+        public ObjectWriter(string objectFilePath, NodeFactory factory)
         {
-            _nativeObjectWriter = InitObjWriter(outputPath);
+            _nativeObjectWriter = InitObjWriter(objectFilePath);
             if (_nativeObjectWriter == IntPtr.Zero)
             {
                 throw new IOException("Fail to initialize Native Object Writer");
@@ -274,9 +274,9 @@ namespace ILCompiler.DependencyAnalysis
             Dispose(false);
         }
 
-        public static void EmitObject(string OutputPath, IEnumerable<DependencyNode> nodes, NodeFactory factory)
+        public static void EmitObject(string objectFilePath, IEnumerable<DependencyNode> nodes, NodeFactory factory)
         {
-            using (ObjectWriter objectWriter = new ObjectWriter(OutputPath, factory))
+            using (ObjectWriter objectWriter = new ObjectWriter(objectFilePath, factory))
             {
                 string currentSection = "";
 

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -35,6 +35,8 @@ namespace ILCompiler.CppCodeGen
         {
             _compilation = compilation;
 
+            _out = new StreamWriter(File.Create(compilation.Options.OutputFilePath));
+
             SetWellKnownTypeSignatureName(WellKnownType.Void, "void");
             SetWellKnownTypeSignatureName(WellKnownType.Boolean, "uint8_t");
             SetWellKnownTypeSignatureName(WellKnownType.Char, "uint16_t");
@@ -394,9 +396,11 @@ namespace ILCompiler.CppCodeGen
         {
             get
             {
-                return _compilation.Out;
+                return _out;
             }
         }
+
+        private StreamWriter _out;
 
         private Dictionary<TypeDesc, List<MethodDesc>> _methodLists;
 

--- a/src/ILCompiler.Compiler/src/project.json
+++ b/src/ILCompiler.Compiler/src/project.json
@@ -6,6 +6,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.FileSystem": "4.0.0",
+    "System.IO.MemoryMappedFiles": "4.0.0-beta-23419",
     "System.Collections": "4.0.10",
     "System.Text.Encoding": "4.0.10",
     "System.Runtime.InteropServices": "4.0.20",

--- a/src/ILCompiler/desktop/project.json
+++ b/src/ILCompiler/desktop/project.json
@@ -6,6 +6,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.FileSystem": "4.0.0",
+    "System.IO.MemoryMappedFiles": "4.0.0-beta-23419",
     "System.Collections": "4.0.10",
     "System.Text.Encoding": "4.0.10",
     "System.Runtime.InteropServices": "4.0.20",

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -6,6 +6,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.FileSystem": "4.0.0",
+    "System.IO.MemoryMappedFiles": "4.0.0-beta-23419",
     "System.Collections": "4.0.10",
     "System.Text.Encoding": "4.0.10",
     "System.Runtime.InteropServices": "4.0.20",
@@ -20,7 +21,7 @@
     "System.Reflection.Metadata": "1.0.22",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23409",
     "Microsoft.DotNet.RyuJit": "1.0.2-prerelease-00002",
-    "Microsoft.DotNet.ObjectWriter": "1.0.3-prerelease-00001",
+    "Microsoft.DotNet.ObjectWriter": "1.0.3-prerelease-00001"
   },
   "frameworks": {
     "dotnet": {

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -99,6 +99,7 @@
         <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
         <dependency id="System.IO" version="4.0.10" />
         <dependency id="System.IO.FileSystem" version="4.0.0" />
+        <dependency id="System.IO.MemoryMappedFiles" version="4.0.0-beta-23419" />
         <dependency id="System.Linq" version="4.0.0" />
         <dependency id="System.Reflection" version="4.0.10" />
         <dependency id="System.Reflection.Extensions" version="4.0.0" />


### PR DESCRIPTION
- Explicitly use memory mapped files for Ecma metadata reader. System.Reflection.Metadata has
heuristic that tries to save virtual address space. This heuristic does not work well for us
since it can make IL access very slow (call to OS for each method IL query). Explicitly using
memory mapped files gives us reliably the desired performance characteristics.
- Implement caching in MethodILProvider.
- Refactor command line parsing - move TypeSystemContext instantiation from the driver .exe into the compiler

These performance improvements bring hello world native compilation from multiple seconds back to sub second range (with release build of RyuJIT and NGened compiler).