### PR TITLE
Miscellaneous fixes for trivial issues found by adhoc testing

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1425,7 +1425,13 @@ namespace Internal.JitInterface
         }
 
         private void HandleException(_EXCEPTION_POINTERS* pExceptionPointers)
-        { throw new NotImplementedException("HandleException"); }
+        {
+            // This method is completely handled by the C++ wrapper to the JIT-EE interface,
+            // and should never reach the managed implementation.
+            Debug.Assert(false, "CorInfoImpl.HandleException should not be called");
+            throw new NotSupportedException("HandleException");
+        }
+
         private void ThrowExceptionForJitResult(HRESULT result)
         { throw new NotImplementedException("ThrowExceptionForJitResult"); }
         private void ThrowExceptionForHelper(ref CORINFO_HELPER_DESC throwHelper)

--- a/src/JitInterface/src/ThunkGenerator/ThunkInput.txt
+++ b/src/JitInterface/src/ThunkGenerator/ThunkInput.txt
@@ -250,7 +250,7 @@ FUNCTIONS
     HRESULT GetErrorHRESULT(struct _EXCEPTION_POINTERS *pExceptionPointers);
     ULONG GetErrorMessage(LPWSTR buffer, ULONG bufferLength);
     [ManualNativeWrapper] int FilterException(struct _EXCEPTION_POINTERS* pExceptionPointers);
-    void HandleException(struct _EXCEPTION_POINTERS* pExceptionPointers);
+    [ManualNativeWrapper] void HandleException(struct _EXCEPTION_POINTERS* pExceptionPointers);
     void ThrowExceptionForJitResult(HRESULT result);
     void ThrowExceptionForHelper(const CORINFO_HELPER_DESC* throwHelper);
     void getEEInfo(CORINFO_EE_INFO* pEEInfoOut);

--- a/src/Native/jitinterface/jitinterface.cpp
+++ b/src/Native/jitinterface/jitinterface.cpp
@@ -18,6 +18,10 @@ int JitInterfaceWrapper::FilterException(void* pExceptionPointers)
     return 1; // EXCEPTION_EXECUTE_HANDLER
 }
 
+void JitInterfaceWrapper::HandleException(void* pExceptionPointers)
+{
+}
+
 CORINFO_LOOKUP_KIND JitInterfaceWrapper::getLocationOfThisType(void* context)
 {
     CorInfoException* pException = nullptr;

--- a/src/Native/jitinterface/jitinterface.h
+++ b/src/Native/jitinterface/jitinterface.h
@@ -1111,15 +1111,7 @@ public:
         return _ret;
     }
     virtual int FilterException(void* pExceptionPointers);
-    virtual void HandleException(void* pExceptionPointers)
-    {
-        CorInfoException* pException = nullptr;
-        _pCorInfo->HandleException(&pException, pExceptionPointers);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-    }
+    virtual void HandleException(void* pExceptionPointers);
     virtual void ThrowExceptionForJitResult(int result)
     {
         CorInfoException* pException = nullptr;

--- a/src/System.Private.CoreLib/src/System/Object.cs
+++ b/src/System.Private.CoreLib/src/System/Object.cs
@@ -74,6 +74,10 @@ namespace System
         }
 #endif
 
+#if CORERT
+        // CORERT-TODO: RuntimeTypeHandle
+        // [Intrinsic]
+#endif
         public Type GetType()
         {
             return ReflectionCoreNonPortable.GetRuntimeTypeForEEType(EETypePtr);

--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -101,7 +101,9 @@ namespace System
             return RuntimeAugments.Callbacks.GetType(typeName, throwOnError, ignoreCase);
         }
 
-        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+#if CORERT
+        [Intrinsic]
+#endif
         public static Type GetTypeFromHandle(RuntimeTypeHandle handle)
         {
             return ReflectionCoreNonPortable.GetTypeForRuntimeTypeHandle(handle);


### PR DESCRIPTION
- Add intrisic attributes to Object.GetType/Type.GetTypeFromHandle (Object.GetType is commented out under TODO)
- Implement temporary marshalling for bool since it is used by every other Win32 API
- Implement HandleException method on JIT-EE interface