### PR TITLE
Include --native-subdirectory support

### DIFF
--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -254,7 +254,7 @@
         <WriteLinesToFile File="$(Stage0ProjectJsonFile)" Lines="$(Stage0ProjectJsonLines)" Overwrite="true" />
         <WriteLinesToFile File="$(Stage0ProjectDir)/Program.cs" Lines="class Program { public static void Main() { } }" Overwrite="true" />
         <Exec Command="&quot;$(DnuToolPath)&quot; restore -s &quot;$(ProductPackageDir)&quot; $(DnuRestoreSource) &quot;$(Stage0ProjectDir)&quot; --runtime &quot;$(NuPkgRid)&quot;" />
-        <Exec Command="&quot;$(DnuToolPath)&quot; publish &quot;$(Stage0ProjectDir)&quot; -o &quot;$(Stage0PublishDir)&quot; -f &quot;dnxcore50&quot; --runtime &quot;$(NuPkgRid)&quot;" />
+        <Exec Command="&quot;$(DnuToolPath)&quot; publish &quot;$(Stage0ProjectDir)&quot; --native-subdirectory -o &quot;$(Stage0PublishDir)&quot; -f &quot;dnxcore50&quot; --runtime &quot;$(NuPkgRid)&quot;" />
 
         <!-- =================== self-host ================= -->
         <!-- Use stage0 ilc.exe/corerun to compile stage1 runtime libs -->
@@ -300,7 +300,7 @@
         <WriteLinesToFile File="$(Stage1ProjectJsonFile)" Lines="$(Stage1ProjectJsonLines)" Overwrite="true" />
         <WriteLinesToFile File="$(Stage1ProjectDir)/Program.cs" Lines="class Program { public static void Main() { } }" Overwrite="true" />
         <Exec Command="&quot;$(DnuToolPath)&quot; restore -s &quot;$(ProductPackageDir)&quot; $(DnuRestoreSource) &quot;$(Stage1ProjectDir)&quot; --runtime &quot;$(NuPkgRid)&quot;" />
-        <Exec Command="&quot;$(DnuToolPath)&quot; publish &quot;$(Stage1ProjectDir)&quot; -o &quot;$(Stage1PublishDir)&quot; -f &quot;dnxcore50&quot; --runtime &quot;$(NuPkgRid)&quot;" />
+        <Exec Command="&quot;$(DnuToolPath)&quot; publish &quot;$(Stage1ProjectDir)&quot; --native-subdirectory -o &quot;$(Stage1PublishDir)&quot; -f &quot;dnxcore50&quot; --runtime &quot;$(NuPkgRid)&quot;" />
 
     </Target>
 </Project>


### PR DESCRIPTION
This should help in publishing libs/headers in appropriate folders. Helps cross compilation support as well.

**Note** The CI should pass once https://github.com/dotnet/cli/pull/675 is ready to go.

Cc @gkhanna79