### PR TITLE
Land jitinterface libs next to ILC for publish

### DIFF
--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -50,7 +50,7 @@
             <ILCompilerNativeFiles Include="jitinterface.so" Condition="'$(OSGroup)'=='Linux'" />
             <ILCompilerNativeFiles Include="jitinterface.dylib" Condition="'$(OSGroup)'=='OSX'" />
             <ILCompilerBinPlace Include="@(ILCompilerNativeFiles)">
-                <Text><![CDATA[        <file src="../%(Identity)" target="runtimes/$(NuPkgRid)/native/lib/dotnet/%(Identity)" /> ]]></Text>
+                <Text><![CDATA[        <file src="../%(Identity)" target="runtimes/$(NuPkgRid)/native/%(Identity)" /> ]]></Text>
             </ILCompilerBinPlace>
 
             <!-- IL.Compiler.SDK target files -->


### PR DESCRIPTION
There was some discussion this would eventually come with the JIT (or JIT like) package. Until then, let us make sure the file is at native's root so it doesn't get copied into a nested subfolder.