### PR TITLE
Initial support for Interlocked on arm/arm64

### DIFF
--- a/src/Native/Runtime/arm/Interlocked.S
+++ b/src/Native/Runtime/arm/Interlocked.S
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+//
+
+// TODO: Implement InterLocked routines
+#include <unixasmmacros.inc>
+
+// WARNING: Code in EHHelpers.cpp makes assumptions about this helper, in particular:
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpLockCmpXchg32AVLocation
+// - Function "UnwindWriteBarrierToCaller" assumes the stack contains just the pushed return address
+// r0 = destination address
+// r1 = value
+// r2 = comparand
+LEAF_ENTRY RhpLockCmpXchg32, _TEXT
+ALTERNATE_ENTRY RhpLockCmpXchg32AVLocation
+    bx      lr
+LEAF_END RhpLockCmpXchg32, _TEXT
+
+
+// WARNING: Code in EHHelpers.cpp makes assumptions about this helper, in particular:
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpLockCmpXchg64AVLocation
+// - Function "UnwindWriteBarrierToCaller" assumes the stack contains just the pushed return address
+// r0 = destination address
+// r1 = value
+// r2 = comparand
+LEAF_ENTRY RhpLockCmpXchg64, _TEXT
+ALTERNATE_ENTRY RhpLockCmpXchg64AVLocation
+	bx	lr
+LEAF_END RhpLockCmpXchg64, _TEXT

--- a/src/Native/Runtime/arm64/Interlocked.S
+++ b/src/Native/Runtime/arm64/Interlocked.S
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+//
+
+#include <unixasmmacros.inc>
+
+// WARNING: Code in EHHelpers.cpp makes assumptions about this helper, in particular:
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpLockCmpXchg32AVLocation
+// - Function "UnwindWriteBarrierToCaller" assumes the stack contains just the pushed return address
+// x0 = destination address
+// w1 = value
+// w2 = comparand
+LEAF_ENTRY RhpLockCmpXchg32, _TEXT
+    mov     x8, x0          // Save value of x0 into x8 as x0 is used for the return value
+ALTERNATE_ENTRY RhpLockCmpXchg32AVLocation
+1: // loop
+    ldaxr   w0, [x8]        // w0 = *x8
+    cmp     w0, w2 
+    bne     2f              // if (w0 != w2) goto exit
+    stlxr   w9, w1, [x8]    // if (w0 == w2) { try *x8 = w1 and goto loop if failed or goto exit }
+    cbnz    w9, 1b
+2: // exit
+    ret
+LEAF_END RhpLockCmpXchg32, _TEXT
+
+// WARNING: Code in EHHelpers.cpp makes assumptions about this helper, in particular:
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpLockCmpXchg64AVLocation
+// - Function "UnwindWriteBarrierToCaller" assumes the stack contains just the pushed return address
+// x0 = destination address
+// x1 = value
+// x2 = comparand
+LEAF_ENTRY RhpLockCmpXchg64, _TEXT
+    mov     x8, x0          // Save value of x0 into x8 as x0 is used for the return value
+ALTERNATE_ENTRY RhpLockCmpXchg64AVLocation
+1: // loop
+    ldaxr   x0, [x8]        // x0 = *x8
+    cmp     x0, x2 
+    bne     2f              // if (x0 != x2) goto exit
+    stlxr   w9, x1, [x8]    // if (x0 == x2) { try *x8 = x1 and goto loop if failed or goto exit }
+    cbnz    w9, 1b
+2: // exit
+    ret
+LEAF_END RhpLockCmpXchg64, _TEXT

--- a/src/Native/Runtime/unix/unixasmmacrosarm.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm.inc
@@ -20,6 +20,11 @@
 C_FUNC(\Name):
 .endm
 
+.macro ALTERNATE_ENTRY Name
+        .global C_FUNC(\Name)
+C_FUNC(\Name):
+.endm
+
 .macro LEAF_ENTRY Name, Section
         .thumb_func
         .global C_FUNC(\Name)

--- a/src/Native/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm64.inc
@@ -19,6 +19,11 @@
 C_FUNC(\Name):
 .endm
 
+.macro ALTERNATE_ENTRY Name
+        .global C_FUNC(\Name)
+C_FUNC(\Name):
+.endm
+
 .macro LEAF_ENTRY Name, Section
         .global C_FUNC(\Name)
         .type \Name, %function


### PR DESCRIPTION
Added initial implementation for RhpLockCmpXchg32 and RhpLockCmpXchg64 for arm64. The arm version is not implemented yet.

I'm not sure about the meaning of AV and the alternate entries RhpLockCmpXchg32AVLocation and RhpLockCmpXchg64AVLocation.

