### PR TITLE
Clean CLI dir for clean builds

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
@@ -19,7 +19,7 @@ _Note_:
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r C:\corert\bin\Product\Windows_NT.x64.Debug\.nuget\publish1\toolchain.win7-x64.Microsoft.DotNet.AppDep.1.0.2-prerelease-00002\*.dll -out c:\corert\src\ILCompiler\reproNative\repro.obj`
+`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r C:\corert\bin\Product\Windows_NT.x64.Debug\.nuget\publish1\toolchain.win7-x64.Microsoft.DotNet.AppDep.1.0.4-prerelease-00001\*.dll -out c:\corert\src\ILCompiler\reproNative\repro.obj`
 
   - Build & run using **F5**
     - This will run the compiler. The output is `c:\corert\src\ILCompiler\reproNative\repro.obj` file.
@@ -42,7 +42,7 @@ _Note_:
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r C:\corert\bin\Product\Windows_NT.x64.Debug\.nuget\publish1\toolchain.win7-x64.Microsoft.DotNet.AppDep.1.0.2-prerelease-00002\*.dll -out c:\corert\src\ILCompiler\reproNative\repro.cpp -cpp`
+`c:\corert\src\ILCompiler\repro\bin\Debug\repro.exe -r c:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll -r C:\corert\bin\Product\Windows_NT.x64.Debug\.nuget\publish1\toolchain.win7-x64.Microsoft.DotNet.AppDep.1.0.4-prerelease-00001\*.dll -out c:\corert\src\ILCompiler\reproNative\repro.cpp -cpp`
 
     - `-nolinenumbers` command line option can be used to suppress generation of line number mappings in C++ files - useful for debugging
 

--- a/build.cmd
+++ b/build.cmd
@@ -152,6 +152,14 @@ set Platform=
 if NOT "%__DotNetCliPath%" == "" goto SetupManagedBuild
 
 set "__DotNetCliPath=%__RootBinDir%\tools\cli"
+if "%__CleanBuild%"=="1" (
+    if exist "%__DotNetCliPath%" (rmdir /s /q "%__DotNetCliPath%")
+    if exist "%__DotNetCliPath%" (
+        echo "Exiting... could not clean %__DotNetCliPath%"
+        exit /b 1
+    )
+)
+
 if not exist "%__DotNetCliPath%" (
     for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& "%__SourceDir%\scripts\install-cli.ps1" -installdir "%__RootBinDir%\tools""') do (
         echo "" > nul

--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,15 @@ install_dotnet_cli()
     echo "Installing the dotnet/cli..."
     local __tools_dir=${__scriptpath}/bin/tools
     local __cli_dir=${__tools_dir}/cli
-    
+    if [ ${__CleanBuild} == 1 ]; then
+        if [ -d "${__cli_dir}" ]; then
+            rm -rf "${__cli_dir}"
+        fi
+        if [ -d "${__cli_dir}" ]; then
+            echo "Exiting... could not clean ${__cli_dir}"
+            exit 1
+        fi
+    fi
     if [ ! -d "${__cli_dir}" ]; then
         mkdir -p "${__cli_dir}"
     fi
@@ -174,7 +182,7 @@ build_managed_corert()
     __buildproj=$__scriptpath/build.proj
     __buildlog=$__scriptpath/msbuild.$__BuildArch.log
 
-    if [ -n ${ToolchainMilestone:+1} ]; then
+    if [ -z "${ToolchainMilestone}" ]; then
         ToolchainMilestone=testing
     fi
 

--- a/tests/restore.cmd
+++ b/tests/restore.cmd
@@ -3,7 +3,7 @@
 call %~dp0testenv.cmd %*
 
 set CoreRT_AppDepSdkPkg=toolchain.win7-%CoreRT_BuildArch%.Microsoft.DotNet.AppDep
-set CoreRT_AppDepSdkVer=1.0.2-prerelease-00002
+set CoreRT_AppDepSdkVer=1.0.4-prerelease-00001
 
 setlocal EnableExtensions
 

--- a/tests/restore.sh
+++ b/tests/restore.sh
@@ -32,7 +32,7 @@ fi
 export CoreRT_ToolchainPkg=toolchain.${__BuildRid}-${CoreRT_BuildArch}.Microsoft.DotNet.ILCompiler.Development
 export CoreRT_ToolchainVer=1.0.2-prerelease-00001
 export CoreRT_AppDepSdkPkg=toolchain.${__BuildRid}-${CoreRT_BuildArch}.Microsoft.DotNet.AppDep
-export CoreRT_AppDepSdkVer=1.0.2-prerelease-00002
+export CoreRT_AppDepSdkVer=1.0.4-prerelease-00001
 
 __ScriptDir=$(cd "$(dirname "$0")"; pwd -P)
 __BuildStr=${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}


### PR DESCRIPTION
@gkhanna79 PTAL

@MichalStrehovsky, I've updated AppDep. The CLI builds should pick it up after the https://github.com/dotnet/cli/pull/752 goes in. Until then you want to try it out, you can add:

`--appdepsdkpath "%CoreRT_AppDepSdkDir%"` option to the `dotnet compile --native` command in runtest.cmd

Cc @smosier 