### PR TITLE
Portable IL PDB support

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -125,6 +125,10 @@ namespace ILCompiler.DependencyAnalysis
 
         public string[] BuildFileInfoMap(IEnumerable<DependencyNode> nodes)
         {
+            // TODO: DebugInfo on Unix https://github.com/dotnet/corert/issues/608
+            if (_targetPlatform.OperatingSystem != TargetOS.Windows)
+                return null;
+
             ArrayBuilder<string> debugFileInfos = new ArrayBuilder<string>();
             foreach (DependencyNode node in nodes)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/SymbolReader/PdbSymbolReader.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SymbolReader/PdbSymbolReader.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace ILCompiler.SymbolReader
+{
+    /// <summary>
+    ///  IL sequence point record
+    /// </summary>
+    public struct ILSequencePoint
+    {
+        public int Offset;
+        public string Document;
+        public int LineNumber;
+        // TODO: The remaining info
+    }
+
+    /// <summary>
+    ///  IL local variable debug record
+    /// </summary>
+    public struct ILLocalVariable
+    {
+        public int Slot;
+        public string Name;
+        public bool CompilerGenerated;
+    }
+
+    /// <summary>
+    /// Abstraction for reading Pdb files
+    /// </summary>
+    public abstract class PdbSymbolReader : IDisposable
+    {
+        public abstract IEnumerable<ILSequencePoint> GetSequencePointsForMethod(int methodToken);
+        public abstract IEnumerable<ILLocalVariable> GetLocalVariableNamesForMethod(int methodToken);
+        public abstract void Dispose();
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/SymbolReader/PortablePdbSymbolReader.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SymbolReader/PortablePdbSymbolReader.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILCompiler.SymbolReader
+{
+    /// <summary>
+    ///  Provides PdbSymbolReader for portable PDB via System.Reflection.Metadata
+    /// </summary>
+    internal class PortablePdbSymbolReader : PdbSymbolReader
+    {
+        private static unsafe MetadataReader TryOpenMetadataFile(string filePath, MetadataStringDecoder stringDecoder, out MemoryMappedViewAccessor mappedViewAccessor)
+        {
+            MemoryMappedFile mappedFile = null;
+            MemoryMappedViewAccessor accessor = null;
+
+            try
+            {
+                mappedFile = MemoryMappedFile.CreateFromFile(filePath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+                accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+                var safeBuffer = accessor.SafeMemoryMappedViewHandle;
+
+                // Check whether this is a real metadata file to avoid thrown and caught exceptions
+                // for non-portable .pdbs
+                if (safeBuffer.Read<byte>(0) != 'B' || // COR20MetadataSignature
+                    safeBuffer.Read<byte>(1) != 'S' ||
+                    safeBuffer.Read<byte>(2) != 'J' ||
+                    safeBuffer.Read<byte>(3) != 'B')
+                {
+                    mappedViewAccessor = null;
+                    return null;
+                }
+
+                var metadataReader = new MetadataReader((byte*)safeBuffer.DangerousGetHandle(), (int)safeBuffer.ByteLength, MetadataReaderOptions.Default, stringDecoder);
+
+                // MemoryMappedFile does not need to be kept around. MemoryMappedViewAccessor is enough.
+
+                mappedViewAccessor = accessor;
+                accessor = null;
+
+                return metadataReader;
+            }
+            finally
+            {
+                if (accessor != null)
+                    accessor.Dispose();
+                if (mappedFile != null)
+                    mappedFile.Dispose();
+            }
+        }
+
+        public static PdbSymbolReader TryOpen(string pdbFilename, MetadataStringDecoder stringDecoder)
+        {
+            MemoryMappedViewAccessor mappedViewAccessor;
+            MetadataReader reader = TryOpenMetadataFile(pdbFilename, stringDecoder, out mappedViewAccessor);
+            if (reader == null)
+                return null;
+
+            return new PortablePdbSymbolReader(reader, mappedViewAccessor);
+        }
+
+        private MetadataReader _reader;
+        private MemoryMappedViewAccessor _mappedViewAccessor;
+
+        private PortablePdbSymbolReader(MetadataReader reader, MemoryMappedViewAccessor mappedViewAccessor)
+        {
+            _reader = reader;
+            _mappedViewAccessor = mappedViewAccessor;
+        }
+
+        public override void Dispose()
+        {
+            _mappedViewAccessor.Dispose();
+        }
+
+        public override IEnumerable<ILSequencePoint> GetSequencePointsForMethod(int methodToken)
+        {
+            var debugInformationHandle = ((MethodDefinitionHandle)MetadataTokens.EntityHandle(methodToken)).ToDebugInformationHandle();
+
+            var debugInformation = _reader.GetMethodDebugInformation(debugInformationHandle);
+
+            var sequencePoints = debugInformation.GetSequencePoints();
+
+            foreach (var sequencePoint in sequencePoints)
+            {
+                if (sequencePoint.StartLine == 0xFEEFEE)
+                    continue;
+
+                var url = _reader.GetString(_reader.GetDocument(sequencePoint.Document).Name);
+
+                yield return new ILSequencePoint() { Document = url, LineNumber = sequencePoint.StartLine, Offset = sequencePoint.Offset };
+            }
+        }
+
+        //
+        // Gather the local details in a scope and then recurse to child scopes
+        //
+        private void ProbeScopeForLocals(List<ILLocalVariable> variables, LocalScopeHandle localScopeHandle)
+        {
+            var localScope = _reader.GetLocalScope(localScopeHandle);
+
+            foreach (var localVariableHandle in localScope.GetLocalVariables())
+            {
+                var localVariable = _reader.GetLocalVariable(localVariableHandle);
+
+                var name = _reader.GetString(localVariable.Name);
+                bool compilerGenerated = (localVariable.Attributes & LocalVariableAttributes.DebuggerHidden) != 0;
+
+                variables.Add(new ILLocalVariable() { Slot = localVariable.Index, Name = name, CompilerGenerated = compilerGenerated });
+            }
+
+            var children = localScope.GetChildren();
+            while (children.MoveNext())
+            {
+                ProbeScopeForLocals(variables, children.Current);
+            }
+        }
+
+        //
+        // Recursively scan the scopes for a method stored in a PDB and gather the local slots
+        // and names for all of them.  This assumes a CSC-like compiler that doesn't re-use
+        // local slots in the same method across scopes.
+        //
+        public override IEnumerable<ILLocalVariable> GetLocalVariableNamesForMethod(int methodToken)
+        {
+            var debugInformationHandle = MetadataTokens.MethodDefinitionHandle(methodToken).ToDebugInformationHandle();
+
+            var localScopes = _reader.GetLocalScopes(debugInformationHandle);
+
+            var variables = new List<ILLocalVariable>();
+            foreach (var localScopeHandle in localScopes)
+            {
+                ProbeScopeForLocals(variables, localScopeHandle);
+            }
+            return variables;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text;
 using System.Linq;
 
+using ILCompiler.SymbolReader;
 using ILCompiler.DependencyAnalysisFramework;
 
 using Internal.TypeSystem;

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -8,30 +8,15 @@ using System.Diagnostics;
 using System.Globalization;
 
 using Internal.TypeSystem;
-using Internal.IL.Stubs;
 
 using ILCompiler;
 using ILCompiler.CppCodeGen;
+using ILCompiler.SymbolReader;
 
 using ILCompiler.DependencyAnalysis;
 
 namespace Internal.IL
 {
-    public struct ILSequencePoint
-    {
-        public int Offset;
-        public string Document;
-        public int LineNumber;
-        // TODO: The remaining info
-    }
-
-    public struct ILLocalVariable
-    {
-        public int Slot;
-        public string Name;
-        public bool CompilerGenerated;
-    }
-
     internal partial class ILImporter
     {
         private Compilation _compilation;

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -71,7 +71,9 @@
     <Compile Include="Compiler\MemoryHelper.cs" />
     <Compile Include="Compiler\MethodExtensions.cs" />
     <Compile Include="Compiler\NameMangler.cs" />
-    <Compile Include="Compiler\PdbSymbolProvider.cs" />
+    <Compile Include="Compiler\SymbolReader\PdbSymbolReader.cs" />
+    <Compile Include="Compiler\SymbolReader\PortablePdbSymbolReader.cs" />
+    <Compile Include="Compiler\SymbolReader\UnmanagedPdbSymbolReader.cs" />
     <Compile Include="Compiler\VirtualMethodCallHelper.cs" />
     <Compile Include="CppCodeGen\CppWriter.cs" />
   </ItemGroup>

--- a/src/ILCompiler.Compiler/src/project.json
+++ b/src/ILCompiler.Compiler/src/project.json
@@ -17,7 +17,7 @@
     "System.Reflection.Extensions": "4.0.0",
     "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
-    "System.Reflection.Metadata": "1.0.22",
+    "System.Reflection.Metadata": "1.1.0",
     "Microsoft.DiaSymReader": "1.0.6"
   },
   "frameworks": {

--- a/src/ILCompiler/desktop/project.json
+++ b/src/ILCompiler/desktop/project.json
@@ -18,7 +18,7 @@
     "System.Console": "4.0.0-rc2-23616",
     "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
-    "System.Reflection.Metadata": "1.0.22",
+    "System.Reflection.Metadata": "1.1.0",
     "Microsoft.DiaSymReader": "1.0.6"
   },
   "frameworks": {

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -18,7 +18,7 @@
     "System.Console": "4.0.0-rc2-23616",
     "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
-    "System.Reflection.Metadata": "1.0.22",
+    "System.Reflection.Metadata": "1.1.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23616",
     "Microsoft.DotNet.RyuJit": "1.0.3-prerelease-00001",
     "Microsoft.DotNet.ObjectWriter": "1.0.3-prerelease-00001"

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -14,6 +14,7 @@ using Internal.TypeSystem;
 using Internal.IL;
 
 using ILCompiler;
+using ILCompiler.SymbolReader;
 using ILCompiler.DependencyAnalysis;
 
 namespace Internal.JitInterface

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -102,16 +102,16 @@
         <dependency id="System.Collections" version="4.0.10" />
         <dependency id="System.Collections.Concurrent" version="4.0.10" />
         <dependency id="System.Collections.Immutable" version="1.1.37" />
-        <dependency id="System.Console" version="4.0.0-beta-23419" />
+        <dependency id="System.Console" version="4.0.0-rc2-23616" />
         <dependency id="System.Diagnostics.Debug" version="4.0.10" />
         <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
         <dependency id="System.IO" version="4.0.10" />
         <dependency id="System.IO.FileSystem" version="4.0.0" />
-        <dependency id="System.IO.MemoryMappedFiles" version="4.0.0-beta-23419" />
+        <dependency id="System.IO.MemoryMappedFiles" version="4.0.0-rc2-23616" />
         <dependency id="System.Linq" version="4.0.0" />
         <dependency id="System.Reflection" version="4.0.10" />
         <dependency id="System.Reflection.Extensions" version="4.0.0" />
-        <dependency id="System.Reflection.Metadata" version="1.0.22" />
+        <dependency id="System.Reflection.Metadata" version="1.1.0" />
         <dependency id="System.Reflection.Primitives" version="4.0.0" />
         <dependency id="System.Resources.ResourceManager" version="4.0.0" />
         <dependency id="System.Runtime" version="4.0.20" />


### PR DESCRIPTION
Add support for reading portable IL PDB using System.Reflection.Metadata.dll. We will try to open the IL PDB file using the portable pdb reader first, and fallback to the unmanaged diasymreader for non-portable pdbs.

Fixes #49