### PR TITLE
Re-Implement ManagedThreadId class

### DIFF
--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -286,6 +286,10 @@ extern "C" void RhpEtwExceptionThrown()
 {
     throw "RhpEtwExceptionThrown";
 }
+extern "C" void RhReRegisterForFinalize()
+{
+    throw "RhReRegisterForFinalize";
+}
 
 #ifndef CPPCODEGEN
 SimpleModuleHeader __module = { NULL, NULL /* &__gcStatics, &__gcStaticsDescs */ };

--- a/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
+++ b/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
@@ -17,7 +17,6 @@ internal partial class Interop
         CreateEventManualReset = 0x1u,
         MutexModifyState = 0x1u,
         CreateEventInitialSet = 0x2u,
-        DuplicateSameAccess = 0x2u,
         SemaphoreModifyState = 0x2u,
         EventModifyState = 0x2u,
         FileTypeChar = 0x2u,
@@ -409,14 +408,6 @@ internal partial class Interop
         [DllImport("api-ms-win-core-synch-l1-1-0.dll", EntryPoint = "CreateSemaphoreExW", CharSet = CharSet.Unicode)]
         internal static extern IntPtr CreateSemaphoreEx(IntPtr lpSemaphoreAttributes, int lInitialCount, int lMaximumCount, string lpName, uint dwFlags, uint dwDesiredAccess);
 
-        [DllImport("api-ms-win-core-handle-l1-1-0.dll", EntryPoint = "DuplicateHandle", CharSet = CharSet.Unicode)]
-        internal static extern int PInvoke_DuplicateHandle(IntPtr hSourceProcessHandle, IntPtr hSourceHandle, IntPtr hTargetProcessHandle, out IntPtr lpTargetHandle, uint dwDesiredAccess, bool bInheritHandle, uint dwOptions);
-
-        internal static bool DuplicateHandle(IntPtr hSourceProcessHandle, IntPtr hSourceHandle, IntPtr hTargetProcessHandle, out IntPtr lpTargetHandle, uint dwDesiredAccess, bool bInheritHandle, uint dwOptions)
-        {
-            return PInvoke_DuplicateHandle(hSourceProcessHandle, hSourceHandle, hTargetProcessHandle, out lpTargetHandle, dwDesiredAccess, bInheritHandle, dwOptions) != 0;
-        }
-
         [DllImport("api-ms-win-core-timezone-l1-1-0.dll")]
         internal extern static uint EnumDynamicTimeZoneInformation(uint dwIndex, out _TIME_DYNAMIC_ZONE_INFORMATION lpTimeZoneInformation);
 
@@ -767,21 +758,6 @@ internal partial class Interop
                     _EXCEPTION_RECORD* pExceptionRecord,
                     _CONTEXT* pContextRecord,
                     uint dwFlags);
-
-
-        //
-        // GetCurrentProcess and GetCurrentThread just return constants.  To avoid making an expensive p/invoke just to 
-        // get a constant, we implement these manually here.
-        //
-        internal static IntPtr GetCurrentProcess()
-        {
-            return (IntPtr)(-1);
-        }
-
-        internal static IntPtr GetCurrentThread()
-        {
-            return (IntPtr)(-2);
-        }
 
         private readonly static System.Threading.WaitHandle s_sleepHandle = new System.Threading.ManualResetEvent(false);
         static internal void Sleep(uint milliseconds)

--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -84,8 +84,6 @@ namespace System
             }
         }
 
-        internal const int ManagedThreadIdNone = 0;
-
         public static bool HasShutdownStarted
         {
             get

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.NonPortable.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.NonPortable.cs
@@ -34,6 +34,6 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        private const int ManagedThreadIdNone = Environment.ManagedThreadIdNone;
+        private const int ManagedThreadIdNone = ManagedThreadId.ManagedThreadIdNone;
     }
 }

--- a/src/System.Private.CoreLib/src/System/Threading/ManagedThreadId.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ManagedThreadId.cs
@@ -14,108 +14,95 @@ using System.Runtime;
 using System.Runtime.InteropServices;
 using System.Security;
 
-#pragma warning disable 0420
-
-
 namespace System.Threading
 {
     internal class ManagedThreadId
     {
         [ThreadStatic]
+        private static ManagedThreadId t_currentThreadId;
+        [ThreadStatic]
         private static int t_currentManagedThreadId;
+
+        // We have to avoid the static constructors on the ManagedThreadId class, otherwise we can run into stack overflow as first time Current property get called, 
+        // the runtime will ensure running the static constructor and this process will call the Current property again (when taking any lock) 
+        //      System::Environment.get_CurrentManagedThreadId
+        //      System::Threading::Lock.Acquire
+        //      System::Runtime::CompilerServices::ClassConstructorRunner::Cctor.GetCctor
+        //      System::Runtime::CompilerServices::ClassConstructorRunner.EnsureClassConstructorRun
+        //      System::Threading::ManagedThreadId.get_Current
+        //      System::Environment.get_CurrentManagedThreadId
+
+        private static ManagedThreadId s_recycledIdsList;
+        private static int s_maxUsedThreadId;
+
+        private int _managedThreadId;
+        private ManagedThreadId _next; // Linked list of recycled ids
+
+        internal const int ManagedThreadIdNone = 0;
 
         public static int Current
         {
             get
             {
                 int currentManagedThreadId = t_currentManagedThreadId;
-                if (currentManagedThreadId == Environment.ManagedThreadIdNone)
+                if (currentManagedThreadId == ManagedThreadIdNone)
                     return MakeForCurrentThread();
                 else
                     return currentManagedThreadId;
             }
         }
 
-        private static volatile ManagedThreadId s_list;
-        private static int s_nextThreadId;
-
-        private readonly int _managedThreadId; // The ID represented by this object.
-        private volatile int _lock;            // 1 if a thread is trying to recycle this ID; 0 otherwise.
-        private IntPtr _nativeThreadHandle;    // A handle to the thread that currently owns this ID; the thread may be dead.
-        private ManagedThreadId _next;
-
-        public ManagedThreadId(int id)
-        {
-            _managedThreadId = id;
-        }
-
-
         private static int MakeForCurrentThread()
         {
-            //
-            // Get the current thread handle.  We need to use DuplicateHandle, because GetCurrentThread returns a pseudo-handle
-            // that cannot be used outside of this thread.
-            //
-            IntPtr thisNativeThreadHandle;
-            Interop.mincore.DuplicateHandle(
-                Interop.mincore.GetCurrentProcess(),
-                Interop.mincore.GetCurrentThread(),
-                Interop.mincore.GetCurrentProcess(),
-                out thisNativeThreadHandle,
-                0,
-                false,
-                (uint)Interop.Constants.DuplicateSameAccess);
+            ManagedThreadId newManagedThreadId = null;
 
-            //
-            // First, search for a dead thread, so we can reuse its thread ID
-            //
-            for (ManagedThreadId current = s_list; current != null; current = current._next)
+            // Try to pop a recycled id from the list
+            for (;;)
             {
-                //
-                // Try to take the lock on this ID.  If another thread already has it, just move on to the next ID.
-                //
-                if (Interlocked.Exchange(ref current._lock, 1) != 0)
-                    continue;
+                var recycledId = Volatile.Read(ref s_recycledIdsList);
+                if (recycledId == null)
+                    break;
 
-                try
+                if (Interlocked.CompareExchange(ref s_recycledIdsList, recycledId._next, recycledId) == recycledId)
                 {
-                    //
-                    // Does the ID currently belong to a dead thread?
-                    //
-                    if (LowLevelThread.WaitForSingleObject(current._nativeThreadHandle, 0) == (uint)Interop.Constants.WaitObject0)
-                    {
-                        //
-                        // The thread is dead.  We can claim this ID by swapping in our own thread handle.
-                        //
-                        Interop.mincore.CloseHandle(current._nativeThreadHandle);
-                        current._nativeThreadHandle = thisNativeThreadHandle;
-
-                        t_currentManagedThreadId = current._managedThreadId;
-                        return current._managedThreadId;
-                    }
-                }
-                finally
-                {
-                    //
-                    // Release the lock.
-                    //
-                    current._lock = 0;
+                    GC.ReRegisterForFinalize(recycledId);
+                    newManagedThreadId = recycledId;
+                    break;
                 }
             }
 
-            //
-            // We couldn't find a dead thread, so we can't reuse a thread ID.  Create a new one.
-            //
-            ManagedThreadId newManagedThreadId = new ManagedThreadId(Interlocked.Increment(ref s_nextThreadId));
-            newManagedThreadId._nativeThreadHandle = thisNativeThreadHandle;
-            while (true)
+            if (newManagedThreadId == null)
             {
-                ManagedThreadId oldList = s_list;
-                newManagedThreadId._next = oldList;
-                if (Interlocked.CompareExchange(ref s_list, newManagedThreadId, oldList) == oldList)
+                newManagedThreadId = new ManagedThreadId(Interlocked.Increment(ref s_maxUsedThreadId));
+            }
+
+            t_currentThreadId = newManagedThreadId;
+            t_currentManagedThreadId = newManagedThreadId._managedThreadId;
+            return t_currentManagedThreadId;
+        }
+
+        private ManagedThreadId(int managedThreadId)
+        {
+            _managedThreadId = managedThreadId;
+        }
+
+        ~ManagedThreadId()
+        {
+            if (_managedThreadId == ManagedThreadIdNone) // already finalized
+            {
+                return;
+            }
+
+            // Push the recycled id into the list of recycled ids
+            for (;;)
+            {
+                var previousRecycledId = Volatile.Read(ref s_recycledIdsList);
+
+                _next = previousRecycledId;
+
+                if (Interlocked.CompareExchange(ref s_recycledIdsList, this, previousRecycledId) == previousRecycledId)
                 {
-                    t_currentManagedThreadId = newManagedThreadId._managedThreadId;
-                    return newManagedThreadId._managedThreadId;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
The purpose of the reimplementation is to remove the dependency on the OS
so make it work on non-Windows platforms