### PR TITLE
Remove CORERT TODOs from System.Monitor.Lock

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -1496,6 +1496,9 @@ namespace Internal.IL
                 Append(thisPtr.Value.Name);
                 Append(")->");
                 Append(_writer.GetCppFieldName(field));
+
+                // TODO: Remove
+                _writer.GetCppSignatureTypeName(owningType);
             }
 
             Finish();
@@ -1547,6 +1550,9 @@ namespace Internal.IL
                 Append(thisPtr.Value.Name);
                 Append(")->");
                 Append(_writer.GetCppFieldName(field));
+
+                // TODO: Remove
+                _writer.GetCppSignatureTypeName(owningType);
             }
 
             Finish();
@@ -1595,6 +1601,9 @@ namespace Internal.IL
                 Append(thisPtr.Value.Name);
                 Append(")->");
                 Append(_writer.GetCppFieldName(field));
+
+                // TODO: Remove
+                _writer.GetCppSignatureTypeName(owningType);
             }
             Append("=");
             if (!fieldType.IsValueType)

--- a/src/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -26,7 +26,15 @@ namespace System.Threading
         // overloads operator == to do the right thing, and b) Lock is sealed, so we
         // don't need to waste time traversing the inheritence heirarchy.
         //
-        internal static bool IsLock(object obj) { return obj.EETypePtr == typeof(Lock).TypeHandle.ToEETypePtr(); }
+        internal static bool IsLock(object obj)
+        {
+#if CORERT
+            // CORERT-TODO
+            return obj is Lock;
+#else
+            return obj.EETypePtr == typeof(Lock).TypeHandle.ToEETypePtr();
+#endif
+        }
 
         //
         // m_state layout:

--- a/src/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -60,27 +60,17 @@ namespace System.Threading
 
         public static void Enter(Object obj)
         {
-#if CORERT
-            // CORERT-TODO locks
-            return;
-#else
             Lock lck = GetLock(obj);
             if (lck.TryAcquire(0))
                 return;
             TryAcquireContended(lck, obj, Timeout.Infinite);
-            return;
-#endif
         }
 
         public static void Enter(Object obj, ref bool lockTaken)
         {
             if (lockTaken)
                 throw new ArgumentException(SR.Argument_MustBeFalse, "lockTaken");
-#if CORERT
-            // CORERT-TODO locks
-            lockTaken = true;
-            return;
-#else
+
             Lock lck = GetLock(obj);
             if (lck.TryAcquire(0))
             {
@@ -89,30 +79,19 @@ namespace System.Threading
             }
             TryAcquireContended(lck, obj, Timeout.Infinite);
             lockTaken = true;
-            return;
-#endif
         }
 
         public static bool TryEnter(Object obj)
         {
-#if CORERT
-            // CORERT-TODO locks
-            return true;
-#else
             return GetLock(obj).TryAcquire(0);
-#endif
         }
 
         public static void TryEnter(Object obj, ref bool lockTaken)
         {
             if (lockTaken)
                 throw new ArgumentException(SR.Argument_MustBeFalse, "lockTaken");
-#if CORERT 
-            // CORERT-TODO locks
-            lockTaken = true;
-#else
+
             lockTaken = GetLock(obj).TryAcquire(0);
-#endif
         }
 
         public static bool TryEnter(Object obj, int millisecondsTimeout)
@@ -120,15 +99,10 @@ namespace System.Threading
             if (millisecondsTimeout < -1)
                 throw new ArgumentOutOfRangeException("millisecondsTimeout", SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
 
-#if CORERT 
-            // CORERT-TODO locks
-            return true;
-#else
             Lock lck = GetLock(obj);
             if (lck.TryAcquire(0))
                 return true;
             return TryAcquireContended(lck, obj, millisecondsTimeout);
-#endif
         }
 
         public static void TryEnter(Object obj, int millisecondsTimeout, ref bool lockTaken)
@@ -138,11 +112,6 @@ namespace System.Threading
             if (millisecondsTimeout < -1)
                 throw new ArgumentOutOfRangeException("millisecondsTimeout", SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
 
-#if CORERT
-            // CORERT-TODO locks
-            lockTaken = true;
-            return;
-#else
             Lock lck = GetLock(obj);
             if (lck.TryAcquire(0))
             {
@@ -150,8 +119,6 @@ namespace System.Threading
                 return;
             }
             lockTaken = TryAcquireContended(lck, obj, millisecondsTimeout);
-            return;
-#endif
         }
 
         public static bool TryEnter(Object obj, TimeSpan timeout)
@@ -161,15 +128,10 @@ namespace System.Threading
                 throw new ArgumentOutOfRangeException("timeout", SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
             int millisecondsTimeout = (int)tm;
 
-#if CORERT
-            // CORERT-TODO locks
-            return true;
-#else
             Lock lck = GetLock(obj);
             if (lck.TryAcquire(0))
                 return true;
             return lck.TryAcquire(millisecondsTimeout);
-#endif
         }
 
         public static void TryEnter(Object obj, TimeSpan timeout, ref bool lockTaken)
@@ -181,11 +143,6 @@ namespace System.Threading
                 throw new ArgumentOutOfRangeException("timeout", SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
             int millisecondsTimeout = (int)tm;
 
-#if CORERT
-            // CORERT-TODO locks
-            lockTaken = true;
-            return;
-#else
             Lock lck = GetLock(obj);
             if (lck.TryAcquire(0))
             {
@@ -194,17 +151,11 @@ namespace System.Threading
             }
 
             lockTaken = TryAcquireContended(lck, obj, millisecondsTimeout);
-            return;
-#endif
         }
 
         public static void Exit(Object obj)
         {
-#if CORERT
-            // CORERT-TODO locks
-#else
             GetLock(obj).Release();
-#endif
         }
 
         public static bool IsEntered(Object obj)


### PR DESCRIPTION
ManagedThreadId was the last major block for these. A low-priority CORERT TODO for Lock.IsLock and workaround for known dependency tracking issue in CppCodeGen needed to keep the system working.