### PR TITLE
Add early out for generic type definitions EETypes

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -130,6 +130,14 @@ namespace ILCompiler.DependencyAnalysis
             objData.Alignment = 16;
             objData.DefinedSymbols.Add(this);
 
+            // Todo: Generic Type Definition EETypes
+            //       Early-out just to prevent crashing at compile time...
+            if (_type.HasInstantiation && _type.IsTypeDefinition)
+            {
+                objData.EmitZeroPointer();
+                return objData.ToObjectData();
+            }
+            
             ComputeOptionalEETypeFields(factory);
             if (null == _optionalFieldsNode)
             {


### PR DESCRIPTION
Generic type definitions are not handled yet and crash the compiler.

Reflection has "LDTOKEN Nullable`1" in the code that triggers a crash.