### PR TITLE
Move InterfaceDispatchMapTable to data section

### DIFF
--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -173,5 +173,16 @@ namespace Internal.TypeSystem
                     throw new NotImplementedException();
             }
         }
+
+        /// <summary>
+        /// Returns True if compiling for Windows
+        /// </summary>
+        public bool IsWindows
+        {
+            get
+            {
+                return OperatingSystem == TargetOS.Windows;
+            }
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -96,7 +96,10 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return "data";
+                if (_type.Context.Target.IsWindows)
+                    return "rdata";
+                else
+                    return "data";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -13,17 +13,22 @@ namespace ILCompiler.DependencyAnalysis
     internal class EETypeOptionalFieldsNode : ObjectNode, ISymbolNode
     {
         EETypeOptionalFieldsBuilder _fieldBuilder = new EETypeOptionalFieldsBuilder();
+        TargetDetails _target;
 
-        public EETypeOptionalFieldsNode(EETypeOptionalFieldsBuilder fieldBuilder)
+        public EETypeOptionalFieldsNode(EETypeOptionalFieldsBuilder fieldBuilder, TargetDetails target)
         {
             _fieldBuilder = fieldBuilder;
+            _target = target;
         }
 
         public override string Section
         {
             get
             {
-                return "data";
+                if (_target.IsWindows)
+                    return "rdata";
+                else
+                    return "data";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -14,6 +15,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         private int[] _runLengths; // First is offset to first gc field, second is length of gc static run, third is length of non-gc data, etc
         private int _targetPointerSize;
+        private TargetDetails _target;
 
         public GCStaticEETypeNode(bool[] gcDesc, NodeFactory factory)
         {
@@ -35,6 +37,7 @@ namespace ILCompiler.DependencyAnalysis
             runLengths.Add(currentPointerCount);
             _runLengths = runLengths.ToArray();
             _targetPointerSize = factory.Target.PointerSize;
+            _target = factory.Target;
         }
 
         public override string GetName()
@@ -46,7 +49,10 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return "data";
+                if (_target.IsWindows)
+                    return "rdata";
+                else
+                    return "data";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -61,7 +61,10 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return "data";
+                if (_type.Context.Target.IsWindows)
+                    return "rdata";
+                else
+                    return "data";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapTableNode.cs
@@ -2,15 +2,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
     public class InterfaceDispatchMapTableNode : ObjectNode, ISymbolNode
     {
         List<InterfaceDispatchMapNode> _dispatchMaps = new List<InterfaceDispatchMapNode>();
-        
-        public InterfaceDispatchMapTableNode()
+        TargetDetails _target;
+
+        public InterfaceDispatchMapTableNode(TargetDetails target)
         {
+            _target = target;
         }
 
         public string MangledName
@@ -38,7 +41,10 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return "rdata";
+                if (_target.IsWindows)
+                    return "rdata";
+                else
+                    return "data";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -22,6 +22,7 @@ namespace ILCompiler.DependencyAnalysis
             _target = context.Target;
             _context = context;
             _cppCodeGen = cppCodeGen;
+            DispatchMapTable = new InterfaceDispatchMapTableNode(this.Target);
             CreateNodeCaches();
         }
 
@@ -146,7 +147,7 @@ namespace ILCompiler.DependencyAnalysis
 
             _typeOptionalFields = new NodeCache<EETypeOptionalFieldsBuilder, EETypeOptionalFieldsNode>((EETypeOptionalFieldsBuilder fieldBuilder) =>
             {
-                return new EETypeOptionalFieldsNode(fieldBuilder);
+                return new EETypeOptionalFieldsNode(fieldBuilder, this.Target);
             });
 
             _interfaceDispatchCells = new NodeCache<MethodDesc, InterfaceDispatchCellNode>((MethodDesc method) =>
@@ -397,7 +398,7 @@ namespace ILCompiler.DependencyAnalysis
             NameMangler.CompilationUnitPrefix + "__str_fixup_end", 
             null);
 
-        public InterfaceDispatchMapTableNode DispatchMapTable = new InterfaceDispatchMapTableNode();
+        public InterfaceDispatchMapTableNode DispatchMapTable;
 
         public Dictionary<TypeDesc, List<MethodDesc>> VirtualSlots = new Dictionary<TypeDesc, List<MethodDesc>>();
 


### PR DESCRIPTION
Linking on Mac generates a warning that InterfaceDispatchMapTable disables PIE (Unix's version of ASLR).  Placing the table in the rdata section caused pointers across to the data section where the maps live.