### PR TITLE
Emit Finalizers and OptionalFields for partial EETypes

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -162,10 +162,11 @@ namespace ILCompiler.DependencyAnalysis
             {
                 OutputVirtualSlots(factory, ref objData, _type, _type);
                 OutputInterfaceMap(factory, ref objData);
-                OutputFinalizerMethod(factory, ref objData);
-                OutputOptionalFields(factory, ref objData);
-                OutputNullableTypeParameter(factory, ref objData);
             }
+
+            OutputFinalizerMethod(factory, ref objData);
+            OutputOptionalFields(factory, ref objData);
+            OutputNullableTypeParameter(factory, ref objData);
 
             return objData.ToObjectData();
         }
@@ -361,6 +362,13 @@ namespace ILCompiler.DependencyAnalysis
 
         private void OutputVirtualSlotAndInterfaceCount(NodeFactory factory, ref ObjectDataBuilder objData)
         {
+            if (!_constructed)
+            {
+                objData.EmitShort(0);
+                objData.EmitShort(0);
+                return;
+            }
+
             int virtualSlotCount = 0;
             TypeDesc currentTypeSlice = _type;
 


### PR DESCRIPTION
EETypes that are not constructed do not have VTables / Interface maps.
Correctly write out the 0 entry count for virtuals and interfaces when
emitting a partial EEType.
Always write the finalizer, optional fields, and nullable type parameter
if these components are used when emitting a partial EEType.