### PR TITLE
There is no <alloca.h> header on NetBSD

### DIFF
--- a/src/Native/Bootstrap/common.h
+++ b/src/Native/Bootstrap/common.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
 #include <assert.h>
@@ -23,7 +24,6 @@
 
 #ifndef WIN32
 #include <pthread.h>
-#include <alloca.h>
 #endif
 
 using namespace std;


### PR DESCRIPTION
```
NAME
     alloca - memory allocator

LIBRARY
     Standard C Library (libc, -lc)

SYNOPSIS
     #include <stdlib.h>

     void *
     alloca(size_t size);

DESCRIPTION
     The alloca() function allocates size bytes of space in the stack frame of
     the caller.  This temporary space is automatically freed on return.
```