### PR TITLE
Prevent duplicate EETypeOptionalFieldsNode symbols from output obj files

### DIFF
--- a/src/Common/src/Internal/Runtime/EETypeOptionalFieldsBuilder.cs
+++ b/src/Common/src/Internal/Runtime/EETypeOptionalFieldsBuilder.cs
@@ -102,5 +102,39 @@ namespace Internal.Runtime
 
             return sb.ToString();
         }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (!(obj is EETypeOptionalFieldsBuilder))
+                return false;
+
+            EETypeOptionalFieldsBuilder other = obj as EETypeOptionalFieldsBuilder;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            for (EETypeOptionalFieldsElement eTag = 0; eTag < EETypeOptionalFieldsElement.Count; eTag++)
+            {
+                if (GetFieldValue(eTag, 0) != other.GetFieldValue(eTag, 0))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 31;
+
+            for (EETypeOptionalFieldsElement eTag = 0; eTag < EETypeOptionalFieldsElement.Count; eTag++)
+            {
+                hash = hash * 486187739 + (int)GetFieldValue(eTag, 0);
+            }
+
+            return hash;
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -63,6 +63,11 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {
+            // Ensure that no duplicate EETypeOptionalFieldsNodes are emitted by letting the node Factory
+            // pick a winner for each given EETypeOptionalFieldsBuilder
+            if (factory.EETypeOptionalFields(_fieldBuilder) != this)
+                return true;
+
             return !_fieldBuilder.IsAtLeastOneFieldUsed();
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -39,6 +39,10 @@ namespace ILCompiler.DependencyAnalysis
         // Nodefactory for which ObjectWriter is instantiated for.
         private NodeFactory _nodeFactory;
 
+#if DEBUG
+        static HashSet<string> _previouslyWrittenNodeNames = new HashSet<string>();
+#endif
+
         [DllImport(NativeObjectWriterFileName)]
         private static extern IntPtr InitObjWriter(string objectFilePath);
 
@@ -303,6 +307,9 @@ namespace ILCompiler.DependencyAnalysis
                     if (node.ShouldSkipEmittingObjectNode(factory))
                         continue;
 
+#if DEBUG
+                    Debug.Assert(_previouslyWrittenNodeNames.Add(node.GetName()), "Duplicate node name emitted to file", "Node {0} has already been written to the output object file {1}", node.GetName(), objectFilePath);
+#endif
                     ObjectNode.ObjectData nodeContents = node.GetData(factory);
 
                     if (currentSection != node.Section)


### PR DESCRIPTION
Add Equals and GetHashCode overrides for EETypeOptionalFieldsBuilder

Ensure duplicate EETypeOptionalFieldsNode objects are never emitted to the output object file by comparing the components of the EETypeOptionalFieldsBuilder when the NodeFactory gets / adds an instance. There may be duplicates during compilation since the dispatch map table index isn't known until later in compilation when we know the type will need an interface map.

Add a dynamic dependency from EETypeNode to its EETypeOptionalFieldsNode since the specific node can change with updated dispatch map data after the EETypeNode's static dependencies are already computed.

Add a debug Assert which validates no duplicate node names are ever written out since they must be uniquely named for the linker to work correctly.