### PR TITLE
Fixes to switch back to using latest CLI

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -162,7 +162,7 @@ if "%__CleanBuild%"=="1" (
 )
 
 if not exist "%__DotNetCliPath%" (
-    for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& "%__SourceDir%\scripts\install-cli.ps1" -installdir "%__RootBinDir%\tools" -version "1.0.0.000973""') do (
+    for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& "%__SourceDir%\scripts\install-cli.ps1" -installdir "%__RootBinDir%\tools""') do (
         echo "" > nul
     )
 )

--- a/build.sh
+++ b/build.sh
@@ -99,11 +99,10 @@ install_dotnet_cli()
             __build_os_lowercase="ubuntu"
         fi
         
-        local __cli_version=1.0.0.000973
         local __build_arch_lowercase=$(echo "${__BuildArch}" | tr '[:upper:]' '[:lower:]')
-        local __cli_tarball=dotnet-${__build_os_lowercase}-${__build_arch_lowercase}.${__cli_version}.tar.gz
+        local __cli_tarball=dotnet-${__build_os_lowercase}-${__build_arch_lowercase}.latest.tar.gz
         local __cli_tarball_path=${__tools_dir}/${__cli_tarball}
-        download_file ${__cli_tarball_path} "https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/${__cli_version}/${__cli_tarball}"
+        download_file ${__cli_tarball_path} "https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/Latest/${__cli_tarball}"
         tar -xzf ${__cli_tarball_path} -C ${__cli_dir}
         export DOTNET_HOME=${__cli_dir}
         #

--- a/dir.props
+++ b/dir.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="CheckRoslyn" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="CheckRoslyn;OverrideBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="Exists('..\dir.props') And '$(RepoLocalBuild)'!='true'" Project="..\dir.props" />
 
   <!--
@@ -151,7 +151,6 @@
     <!-- list of directories to perform batch restore -->
   <ItemGroup>
     <DnuRestoreDir Include="&quot;$(MSBuildProjectDirectory)\src&quot;" />
-    <DnuRestoreDir Include="&quot;$(ToolsDir)&quot;" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -295,5 +294,20 @@
   <Target Name="CheckRoslyn" Condition="'$(UseRoslynCompiler)'=='true' and '$(MSBuildProjectFile)'!='build.proj'">
     <Warning Condition="!Exists('$(RoslynPropsFile)')"
              Text="The Roslyn targets do not exist- Roslyn will not be used for this build, but the package should be restored if you build again." />
+  </Target>
+
+
+  <Target Name="OverrideBuildTools">
+    <Error Condition="'$(BuildToolsVersion)'!='1.0.25-prerelease-00111'" Text="Confirm below project.json overrides are still compatibile with this version."></Error>
+    <PropertyGroup>
+      <!--
+          These overrides are for $(PackagesDir)\Microsoft.DotNet.BuildTools.1.0.25-prerelease-00111\lib\tool-runtime\project.json and test-runtime\project.json
+          This is similar to how CoreFX handles these files.
+      -->
+      <TestRuntimeProjectJson>$(ProjectDir)src/packaging/buildtools/test-runtime/project.json</TestRuntimeProjectJson>
+      <TestRuntimeProjectLockJson>$(ProjectDir)src/packaging/buildtools/test-runtime/project.lock.json</TestRuntimeProjectLockJson>
+      <ToolRuntimeProjectJson>$(ProjectDir)src/packaging/buildtools/tool-runtime/project.json</ToolRuntimeProjectJson>
+      <ToolRuntimeProjectLockJson>$(ProjectDir)src/packaging/buildtools/tool-runtime/project.lock.json</ToolRuntimeProjectLockJson>
+    </PropertyGroup>
   </Target>
 </Project>

--- a/src/AotPackageReference/project.lock.json
+++ b/src/AotPackageReference/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": true,
+  "locked": false,
   "version": 2,
   "targets": {
     ".NETCore,Version=v5.0": {
@@ -141,7 +141,7 @@
           "ref/netcore50/System.Reflection.dll": {}
         },
         "runtime": {
-          "lib/wpa81/_._": {}
+          "lib/win8/_._": {}
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -310,6 +310,708 @@
         }
       }
     },
+    ".NETCore,Version=v5.0/win7-x64": {
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23610"
+        }
+      },
+      "Microsoft.NETCore.Targets/1.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.1-rc2-23610"
+        }
+      },
+      "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.1-rc2-23610": {
+        "type": "package"
+      },
+      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23610": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netcore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "runtime.win7.System.Private.Uri/4.0.1-rc2-23610": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netcore50/System.Private.Uri.dll": {}
+        }
+      },
+      "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23610": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "runtime.win7.System.Threading/4.0.11-rc2-23610": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netcore50/System.Threading.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.21-rc2-23610",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "runtime.win7.System.Diagnostics.Debug": "4.0.11-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.21-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Linq.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7.System.Private.Uri": "4.0.1-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/_._": {}
+        }
+      },
+      "System.Reflection/4.1.0-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.1.0-rc2-23610",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.21-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.1-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "runtime.win7.System.Runtime.Extensions": "4.0.11-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.21-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "runtime.win7.System.Threading": "4.0.11-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    },
+    ".NETCore,Version=v5.0/win7-x86": {
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23610"
+        }
+      },
+      "Microsoft.NETCore.Targets/1.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets.UniversalWindowsPlatform": "5.0.1-rc2-23610"
+        }
+      },
+      "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.1-rc2-23610": {
+        "type": "package"
+      },
+      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23610": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netcore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "runtime.win7.System.Private.Uri/4.0.1-rc2-23610": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netcore50/System.Private.Uri.dll": {}
+        }
+      },
+      "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23610": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "runtime.win7.System.Threading/4.0.11-rc2-23610": {
+        "type": "package",
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netcore50/System.Threading.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.21-rc2-23610",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "runtime.win7.System.Diagnostics.Debug": "4.0.11-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.21-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Linq.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7.System.Private.Uri": "4.0.1-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/_._": {}
+        }
+      },
+      "System.Reflection/4.1.0-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.1.0-rc2-23610",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.21-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.1-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "runtime.win7.System.Runtime.Extensions": "4.0.11-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.21-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "runtime.win7.System.Threading": "4.0.11-rc2-23610"
+        },
+        "compile": {
+          "ref/netcore50/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/win8/_._": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-rc2-23610": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    },
     ".NETCore,Version=v5.0/win8-aot": {
       "Microsoft.NETCore.Platforms/1.0.1-rc2-23610": {
         "type": "package",
@@ -393,13 +1095,14 @@
       "System.Diagnostics.Debug/4.0.11-rc2-23610": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.0"
+          "System.Runtime": "4.0.0",
+          "runtime.win7.System.Diagnostics.Debug": "4.0.11-rc2-23610"
         },
         "compile": {
           "ref/netcore50/System.Diagnostics.Debug.dll": {}
         },
         "runtime": {
-          "lib/wpa81/_._": {}
+          "lib/win8/_._": {}
         }
       },
       "System.Diagnostics.Tracing/4.0.21-rc2-23610": {
@@ -471,6 +1174,9 @@
       },
       "System.Private.Uri/4.0.1-rc2-23610": {
         "type": "package",
+        "dependencies": {
+          "runtime.win7.System.Private.Uri": "4.0.1-rc2-23610"
+        },
         "compile": {
           "ref/netcore50/_._": {}
         }
@@ -568,13 +1274,14 @@
       "System.Runtime.Extensions/4.0.11-rc2-23610": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.20"
+          "System.Runtime": "4.0.20",
+          "runtime.win7.System.Runtime.Extensions": "4.0.11-rc2-23610"
         },
         "compile": {
           "ref/netcore50/System.Runtime.Extensions.dll": {}
         },
         "runtime": {
-          "lib/wpa81/_._": {}
+          "lib/win8/_._": {}
         }
       },
       "System.Runtime.Handles/4.0.1-rc2-23610": {
@@ -633,13 +1340,14 @@
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Threading.Tasks": "4.0.0",
+          "runtime.win7.System.Threading": "4.0.11-rc2-23610"
         },
         "compile": {
           "ref/netcore50/System.Threading.dll": {}
         },
         "runtime": {
-          "lib/wpa81/_._": {}
+          "lib/win8/_._": {}
         }
       },
       "System.Threading.Tasks/4.0.11-rc2-23610": {
@@ -658,42 +1366,37 @@
   },
   "libraries": {
     "Microsoft.NETCore.Platforms/1.0.1-rc2-23610": {
-      "type": "package",
       "sha512": "C3IacszKfYCeIWA1eeXj5HyTihfAbgTmpcuPaz8u2oiIFu1bgrUiP+d0065XGIqVcc442WUekG4WB27b1cIdyA==",
+      "type": "package",
       "files": [
-        "Microsoft.NETCore.Platforms.1.0.1-rc2-23610.nupkg",
         "Microsoft.NETCore.Platforms.1.0.1-rc2-23610.nupkg.sha512",
         "Microsoft.NETCore.Platforms.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.1-rc2-23610": {
-      "type": "package",
       "sha512": "NQpCNhDOCE9Tj+dE5tmdhRQMtGNM/UrEFOQC1vVr8KYr7oW9mYDxe6mBa8oJLsFLZOWYCiUz7YjRLkRKZnLObw==",
+      "type": "package",
       "files": [
-        "Microsoft.NETCore.Targets.1.0.1-rc2-23610.nupkg",
         "Microsoft.NETCore.Targets.1.0.1-rc2-23610.nupkg.sha512",
         "Microsoft.NETCore.Targets.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.1-rc2-23610": {
-      "type": "package",
       "sha512": "xiYU1QNjO6frz/3GzSFpFAe42iuXn4rrFG/8bkssE/ZYD0uViwmtOPK9zkriyIuX+IY0woKH95iRNpuyNBWByg==",
+      "type": "package",
       "files": [
-        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.5.0.1-rc2-23610.nupkg",
         "Microsoft.NETCore.Targets.UniversalWindowsPlatform.5.0.1-rc2-23610.nupkg.sha512",
         "Microsoft.NETCore.Targets.UniversalWindowsPlatform.nuspec",
         "runtime.json"
       ]
     },
     "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "uX/XQhAOk7Xqpem95HMMwFC8Zxntqytz2H6b/whp5aKIGmxyChoBEdjCePjAF+6aysclJGCsdomqd2x3H7DjEg==",
+      "type": "package",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Diagnostics.Debug.4.0.11-rc2-23610.nupkg",
         "runtime.win7.System.Diagnostics.Debug.4.0.11-rc2-23610.nupkg.sha512",
         "runtime.win7.System.Diagnostics.Debug.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Diagnostics.Debug.dll",
@@ -702,12 +1405,10 @@
       ]
     },
     "runtime.win7.System.Private.Uri/4.0.1-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "o4dLzUEAJA6rACk9PNOTlsVEbaBC0jWHqDlrdA68/6Ez2g09pv9I79AugP8KDYJoaYZInhY3tc1EvBmy70UPSA==",
+      "type": "package",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Private.Uri.4.0.1-rc2-23610.nupkg",
         "runtime.win7.System.Private.Uri.4.0.1-rc2-23610.nupkg.sha512",
         "runtime.win7.System.Private.Uri.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Private.Uri.dll",
@@ -716,26 +1417,22 @@
       ]
     },
     "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "g/CmuYtgQwmNjRZHjVnn+TOhhSGtjKHDD6BPBs6TSJzC0KaaEmkOhgdYScSeJ7+rKT2vJkXY7ywoqxheqGRmIg==",
+      "type": "package",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/netcore50/System.Runtime.Extensions.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Runtime.Extensions.4.0.11-rc2-23610.nupkg",
         "runtime.win7.System.Runtime.Extensions.4.0.11-rc2-23610.nupkg.sha512",
         "runtime.win7.System.Runtime.Extensions.nuspec",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
       ]
     },
     "runtime.win7.System.Threading/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "abFCFVOZ+8Eoeg3bLoYVBYBcUHrAZjZA5vSMmjbPEzxDqbp6HXIKjW+fmdPi/uxmsbQLrfmIHiiExr2ZTp8hAA==",
+      "type": "package",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Threading.4.0.11-rc2-23610.nupkg",
         "runtime.win7.System.Threading.4.0.11-rc2-23610.nupkg.sha512",
         "runtime.win7.System.Threading.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Threading.dll",
@@ -744,10 +1441,11 @@
       ]
     },
     "System.Collections/4.0.10": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
+      "type": "package",
       "files": [
+        "System.Collections.4.0.10.nupkg.sha512",
+        "System.Collections.nuspec",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -755,6 +1453,10 @@
         "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/de/System.Collections.xml",
         "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
@@ -762,26 +1464,20 @@
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
         "ref/dotnet/zh-hant/System.Collections.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
-        "System.Collections.4.0.10.nupkg",
-        "System.Collections.4.0.10.nupkg.sha512",
-        "System.Collections.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
       ]
     },
     "System.Collections/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "BnawDI+aox/pHRfnMKMLrg525ESEaniy9s68Vc+zHV71eIemcFgUfSPh1MLkZm1jeYo7kQvD5IST5tAhJ9+09A==",
+      "type": "package",
       "files": [
+        "System.Collections.4.0.11-rc2-23610.nupkg.sha512",
+        "System.Collections.nuspec",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -792,6 +1488,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Collections.dll",
+        "ref/dotnet5.1/System.Collections.xml",
         "ref/dotnet5.1/de/System.Collections.xml",
         "ref/dotnet5.1/es/System.Collections.xml",
         "ref/dotnet5.1/fr/System.Collections.xml",
@@ -799,10 +1499,10 @@
         "ref/dotnet5.1/ja/System.Collections.xml",
         "ref/dotnet5.1/ko/System.Collections.xml",
         "ref/dotnet5.1/ru/System.Collections.xml",
-        "ref/dotnet5.1/System.Collections.dll",
-        "ref/dotnet5.1/System.Collections.xml",
         "ref/dotnet5.1/zh-hans/System.Collections.xml",
         "ref/dotnet5.1/zh-hant/System.Collections.xml",
+        "ref/dotnet5.4/System.Collections.dll",
+        "ref/dotnet5.4/System.Collections.xml",
         "ref/dotnet5.4/de/System.Collections.xml",
         "ref/dotnet5.4/es/System.Collections.xml",
         "ref/dotnet5.4/fr/System.Collections.xml",
@@ -810,13 +1510,11 @@
         "ref/dotnet5.4/ja/System.Collections.xml",
         "ref/dotnet5.4/ko/System.Collections.xml",
         "ref/dotnet5.4/ru/System.Collections.xml",
-        "ref/dotnet5.4/System.Collections.dll",
-        "ref/dotnet5.4/System.Collections.xml",
         "ref/dotnet5.4/zh-hans/System.Collections.xml",
         "ref/dotnet5.4/zh-hant/System.Collections.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Collections.dll",
+        "ref/netcore50/System.Collections.xml",
         "ref/netcore50/de/System.Collections.xml",
         "ref/netcore50/es/System.Collections.xml",
         "ref/netcore50/fr/System.Collections.xml",
@@ -824,8 +1522,6 @@
         "ref/netcore50/ja/System.Collections.xml",
         "ref/netcore50/ko/System.Collections.xml",
         "ref/netcore50/ru/System.Collections.xml",
-        "ref/netcore50/System.Collections.dll",
-        "ref/netcore50/System.Collections.xml",
         "ref/netcore50/zh-hans/System.Collections.xml",
         "ref/netcore50/zh-hant/System.Collections.xml",
         "ref/win8/_._",
@@ -833,22 +1529,23 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
-        "System.Collections.4.0.11-rc2-23610.nupkg",
-        "System.Collections.4.0.11-rc2-23610.nupkg.sha512",
-        "System.Collections.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
-      "type": "package",
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
+      "type": "package",
       "files": [
+        "System.Diagnostics.Contracts.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Contracts.nuspec",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
         "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
@@ -856,8 +1553,6 @@
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
@@ -866,17 +1561,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
-        "System.Diagnostics.Contracts.4.0.0.nupkg",
-        "System.Diagnostics.Contracts.4.0.0.nupkg.sha512",
-        "System.Diagnostics.Contracts.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
       ]
     },
     "System.Diagnostics.Contracts/4.0.1-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "eF1tmSQK+9HABYKAXnFSagQXIyRgVWjyUJ0Hv1P9soDV5EERrBI9kI1Zx7LGtHfe03hYrN+x4TnTSYqr3jzddQ==",
+      "type": "package",
       "files": [
+        "System.Diagnostics.Contracts.4.0.1-rc2-23610.nupkg.sha512",
+        "System.Diagnostics.Contracts.nuspec",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -887,6 +1580,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Diagnostics.Contracts.dll",
+        "ref/dotnet5.1/System.Diagnostics.Contracts.xml",
         "ref/dotnet5.1/de/System.Diagnostics.Contracts.xml",
         "ref/dotnet5.1/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet5.1/fr/System.Diagnostics.Contracts.xml",
@@ -894,13 +1591,11 @@
         "ref/dotnet5.1/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet5.1/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet5.1/ru/System.Diagnostics.Contracts.xml",
-        "ref/dotnet5.1/System.Diagnostics.Contracts.dll",
-        "ref/dotnet5.1/System.Diagnostics.Contracts.xml",
         "ref/dotnet5.1/zh-hans/System.Diagnostics.Contracts.xml",
         "ref/dotnet5.1/zh-hant/System.Diagnostics.Contracts.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/netcore50/System.Diagnostics.Contracts.xml",
         "ref/netcore50/de/System.Diagnostics.Contracts.xml",
         "ref/netcore50/es/System.Diagnostics.Contracts.xml",
         "ref/netcore50/fr/System.Diagnostics.Contracts.xml",
@@ -908,8 +1603,6 @@
         "ref/netcore50/ja/System.Diagnostics.Contracts.xml",
         "ref/netcore50/ko/System.Diagnostics.Contracts.xml",
         "ref/netcore50/ru/System.Diagnostics.Contracts.xml",
-        "ref/netcore50/System.Diagnostics.Contracts.dll",
-        "ref/netcore50/System.Diagnostics.Contracts.xml",
         "ref/netcore50/zh-hans/System.Diagnostics.Contracts.xml",
         "ref/netcore50/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/win8/_._",
@@ -917,17 +1610,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
-        "System.Diagnostics.Contracts.4.0.1-rc2-23610.nupkg",
-        "System.Diagnostics.Contracts.4.0.1-rc2-23610.nupkg.sha512",
-        "System.Diagnostics.Contracts.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
+      "type": "package",
       "files": [
+        "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -935,6 +1626,10 @@
         "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
         "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
@@ -942,26 +1637,20 @@
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
-        "System.Diagnostics.Debug.4.0.10.nupkg",
-        "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
-        "System.Diagnostics.Debug.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
       ]
     },
     "System.Diagnostics.Debug/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "m6hTXaxs4jXsEfSTsWUUD8npnEhFMtuJDvTddk0GB7g8yCjliqVdySnmTTQ3/mWIWcWKG4R+uLE9SYfA/bGtjQ==",
+      "type": "package",
       "files": [
+        "System.Diagnostics.Debug.4.0.11-rc2-23610.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
@@ -970,6 +1659,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Diagnostics.Debug.dll",
+        "ref/dotnet5.1/System.Diagnostics.Debug.xml",
         "ref/dotnet5.1/de/System.Diagnostics.Debug.xml",
         "ref/dotnet5.1/es/System.Diagnostics.Debug.xml",
         "ref/dotnet5.1/fr/System.Diagnostics.Debug.xml",
@@ -977,10 +1670,10 @@
         "ref/dotnet5.1/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet5.1/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet5.1/ru/System.Diagnostics.Debug.xml",
-        "ref/dotnet5.1/System.Diagnostics.Debug.dll",
-        "ref/dotnet5.1/System.Diagnostics.Debug.xml",
         "ref/dotnet5.1/zh-hans/System.Diagnostics.Debug.xml",
         "ref/dotnet5.1/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/dotnet5.4/System.Diagnostics.Debug.dll",
+        "ref/dotnet5.4/System.Diagnostics.Debug.xml",
         "ref/dotnet5.4/de/System.Diagnostics.Debug.xml",
         "ref/dotnet5.4/es/System.Diagnostics.Debug.xml",
         "ref/dotnet5.4/fr/System.Diagnostics.Debug.xml",
@@ -988,13 +1681,11 @@
         "ref/dotnet5.4/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet5.4/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet5.4/ru/System.Diagnostics.Debug.xml",
-        "ref/dotnet5.4/System.Diagnostics.Debug.dll",
-        "ref/dotnet5.4/System.Diagnostics.Debug.xml",
         "ref/dotnet5.4/zh-hans/System.Diagnostics.Debug.xml",
         "ref/dotnet5.4/zh-hant/System.Diagnostics.Debug.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Debug.dll",
+        "ref/netcore50/System.Diagnostics.Debug.xml",
         "ref/netcore50/de/System.Diagnostics.Debug.xml",
         "ref/netcore50/es/System.Diagnostics.Debug.xml",
         "ref/netcore50/fr/System.Diagnostics.Debug.xml",
@@ -1002,8 +1693,6 @@
         "ref/netcore50/ja/System.Diagnostics.Debug.xml",
         "ref/netcore50/ko/System.Diagnostics.Debug.xml",
         "ref/netcore50/ru/System.Diagnostics.Debug.xml",
-        "ref/netcore50/System.Diagnostics.Debug.dll",
-        "ref/netcore50/System.Diagnostics.Debug.xml",
         "ref/netcore50/zh-hans/System.Diagnostics.Debug.xml",
         "ref/netcore50/zh-hant/System.Diagnostics.Debug.xml",
         "ref/win8/_._",
@@ -1011,17 +1700,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Diagnostics.Debug.4.0.11-rc2-23610.nupkg",
-        "System.Diagnostics.Debug.4.0.11-rc2-23610.nupkg.sha512",
-        "System.Diagnostics.Debug.nuspec"
+        "runtime.json"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
+      "type": "package",
       "files": [
+        "System.Diagnostics.Tracing.4.0.20.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1029,6 +1716,10 @@
         "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
         "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
@@ -1036,26 +1727,20 @@
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
-        "System.Diagnostics.Tracing.4.0.20.nupkg",
-        "System.Diagnostics.Tracing.4.0.20.nupkg.sha512",
-        "System.Diagnostics.Tracing.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
       ]
     },
     "System.Diagnostics.Tracing/4.0.21-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "qT8SpXMJrJjmQoyubMBmeJ3+6/xNGdYjH6fkRxKPjnNjAYSjxoelQQFRIKD0jWb3eXjBBR6hdziJ9s5UbfxspQ==",
+      "type": "package",
       "files": [
+        "System.Diagnostics.Tracing.4.0.21-rc2-23610.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1065,6 +1750,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.2/System.Diagnostics.Tracing.dll",
+        "ref/dotnet5.2/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.2/de/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.2/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.2/fr/System.Diagnostics.Tracing.xml",
@@ -1072,10 +1761,10 @@
         "ref/dotnet5.2/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.2/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.2/ru/System.Diagnostics.Tracing.xml",
-        "ref/dotnet5.2/System.Diagnostics.Tracing.dll",
-        "ref/dotnet5.2/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.2/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.2/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/dotnet5.3/System.Diagnostics.Tracing.dll",
+        "ref/dotnet5.3/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.3/de/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.3/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.3/fr/System.Diagnostics.Tracing.xml",
@@ -1083,10 +1772,10 @@
         "ref/dotnet5.3/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.3/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.3/ru/System.Diagnostics.Tracing.xml",
-        "ref/dotnet5.3/System.Diagnostics.Tracing.dll",
-        "ref/dotnet5.3/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.3/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.3/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/dotnet5.4/System.Diagnostics.Tracing.dll",
+        "ref/dotnet5.4/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.4/de/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.4/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.4/fr/System.Diagnostics.Tracing.xml",
@@ -1094,13 +1783,11 @@
         "ref/dotnet5.4/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.4/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.4/ru/System.Diagnostics.Tracing.xml",
-        "ref/dotnet5.4/System.Diagnostics.Tracing.dll",
-        "ref/dotnet5.4/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.4/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/dotnet5.4/zh-hant/System.Diagnostics.Tracing.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/netcore50/System.Diagnostics.Tracing.xml",
         "ref/netcore50/de/System.Diagnostics.Tracing.xml",
         "ref/netcore50/es/System.Diagnostics.Tracing.xml",
         "ref/netcore50/fr/System.Diagnostics.Tracing.xml",
@@ -1108,24 +1795,21 @@
         "ref/netcore50/ja/System.Diagnostics.Tracing.xml",
         "ref/netcore50/ko/System.Diagnostics.Tracing.xml",
         "ref/netcore50/ru/System.Diagnostics.Tracing.xml",
-        "ref/netcore50/System.Diagnostics.Tracing.dll",
-        "ref/netcore50/System.Diagnostics.Tracing.xml",
         "ref/netcore50/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/netcore50/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
-        "System.Diagnostics.Tracing.4.0.21-rc2-23610.nupkg",
-        "System.Diagnostics.Tracing.4.0.21-rc2-23610.nupkg.sha512",
-        "System.Diagnostics.Tracing.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
       ]
     },
     "System.Globalization/4.0.10": {
-      "type": "package",
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
+      "type": "package",
       "files": [
+        "System.Globalization.4.0.10.nupkg.sha512",
+        "System.Globalization.nuspec",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1133,6 +1817,10 @@
         "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/de/System.Globalization.xml",
         "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
@@ -1140,26 +1828,20 @@
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
         "ref/dotnet/zh-hant/System.Globalization.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
-        "System.Globalization.4.0.10.nupkg",
-        "System.Globalization.4.0.10.nupkg.sha512",
-        "System.Globalization.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
       ]
     },
     "System.Globalization/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "dKmA9sbhXTCKRysaiz9rAozPD3UPyKevazlPQc0QQIjR+89tS4+KB1nRcw1NgG8yhgcS611Bw64bSsKJXyd99Q==",
+      "type": "package",
       "files": [
+        "System.Globalization.4.0.11-rc2-23610.nupkg.sha512",
+        "System.Globalization.nuspec",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1170,6 +1852,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Globalization.dll",
+        "ref/dotnet5.1/System.Globalization.xml",
         "ref/dotnet5.1/de/System.Globalization.xml",
         "ref/dotnet5.1/es/System.Globalization.xml",
         "ref/dotnet5.1/fr/System.Globalization.xml",
@@ -1177,10 +1863,10 @@
         "ref/dotnet5.1/ja/System.Globalization.xml",
         "ref/dotnet5.1/ko/System.Globalization.xml",
         "ref/dotnet5.1/ru/System.Globalization.xml",
-        "ref/dotnet5.1/System.Globalization.dll",
-        "ref/dotnet5.1/System.Globalization.xml",
         "ref/dotnet5.1/zh-hans/System.Globalization.xml",
         "ref/dotnet5.1/zh-hant/System.Globalization.xml",
+        "ref/dotnet5.4/System.Globalization.dll",
+        "ref/dotnet5.4/System.Globalization.xml",
         "ref/dotnet5.4/de/System.Globalization.xml",
         "ref/dotnet5.4/es/System.Globalization.xml",
         "ref/dotnet5.4/fr/System.Globalization.xml",
@@ -1188,13 +1874,11 @@
         "ref/dotnet5.4/ja/System.Globalization.xml",
         "ref/dotnet5.4/ko/System.Globalization.xml",
         "ref/dotnet5.4/ru/System.Globalization.xml",
-        "ref/dotnet5.4/System.Globalization.dll",
-        "ref/dotnet5.4/System.Globalization.xml",
         "ref/dotnet5.4/zh-hans/System.Globalization.xml",
         "ref/dotnet5.4/zh-hant/System.Globalization.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Globalization.dll",
+        "ref/netcore50/System.Globalization.xml",
         "ref/netcore50/de/System.Globalization.xml",
         "ref/netcore50/es/System.Globalization.xml",
         "ref/netcore50/fr/System.Globalization.xml",
@@ -1202,8 +1886,6 @@
         "ref/netcore50/ja/System.Globalization.xml",
         "ref/netcore50/ko/System.Globalization.xml",
         "ref/netcore50/ru/System.Globalization.xml",
-        "ref/netcore50/System.Globalization.dll",
-        "ref/netcore50/System.Globalization.xml",
         "ref/netcore50/zh-hans/System.Globalization.xml",
         "ref/netcore50/zh-hant/System.Globalization.xml",
         "ref/win8/_._",
@@ -1211,17 +1893,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
-        "System.Globalization.4.0.11-rc2-23610.nupkg",
-        "System.Globalization.4.0.11-rc2-23610.nupkg.sha512",
-        "System.Globalization.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
       ]
     },
     "System.IO/4.0.10": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
+      "type": "package",
       "files": [
+        "System.IO.4.0.10.nupkg.sha512",
+        "System.IO.nuspec",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1229,6 +1909,10 @@
         "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/de/System.IO.xml",
         "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
@@ -1236,26 +1920,20 @@
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
         "ref/dotnet/zh-hant/System.IO.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
-        "System.IO.4.0.10.nupkg",
-        "System.IO.4.0.10.nupkg.sha512",
-        "System.IO.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
       ]
     },
     "System.IO/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "/661ms6FT2LS+eVFM4p722JfHF70aafJSIWivb1hh9U2lVa0MfK6hyqjBRaDAukp0UsqjOs/NmRbXaKd74bFxA==",
+      "type": "package",
       "files": [
+        "System.IO.4.0.11-rc2-23610.nupkg.sha512",
+        "System.IO.nuspec",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1266,6 +1944,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.IO.dll",
+        "ref/dotnet5.1/System.IO.xml",
         "ref/dotnet5.1/de/System.IO.xml",
         "ref/dotnet5.1/es/System.IO.xml",
         "ref/dotnet5.1/fr/System.IO.xml",
@@ -1273,10 +1955,10 @@
         "ref/dotnet5.1/ja/System.IO.xml",
         "ref/dotnet5.1/ko/System.IO.xml",
         "ref/dotnet5.1/ru/System.IO.xml",
-        "ref/dotnet5.1/System.IO.dll",
-        "ref/dotnet5.1/System.IO.xml",
         "ref/dotnet5.1/zh-hans/System.IO.xml",
         "ref/dotnet5.1/zh-hant/System.IO.xml",
+        "ref/dotnet5.4/System.IO.dll",
+        "ref/dotnet5.4/System.IO.xml",
         "ref/dotnet5.4/de/System.IO.xml",
         "ref/dotnet5.4/es/System.IO.xml",
         "ref/dotnet5.4/fr/System.IO.xml",
@@ -1284,13 +1966,11 @@
         "ref/dotnet5.4/ja/System.IO.xml",
         "ref/dotnet5.4/ko/System.IO.xml",
         "ref/dotnet5.4/ru/System.IO.xml",
-        "ref/dotnet5.4/System.IO.dll",
-        "ref/dotnet5.4/System.IO.xml",
         "ref/dotnet5.4/zh-hans/System.IO.xml",
         "ref/dotnet5.4/zh-hant/System.IO.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.IO.dll",
+        "ref/netcore50/System.IO.xml",
         "ref/netcore50/de/System.IO.xml",
         "ref/netcore50/es/System.IO.xml",
         "ref/netcore50/fr/System.IO.xml",
@@ -1298,8 +1978,6 @@
         "ref/netcore50/ja/System.IO.xml",
         "ref/netcore50/ko/System.IO.xml",
         "ref/netcore50/ru/System.IO.xml",
-        "ref/netcore50/System.IO.dll",
-        "ref/netcore50/System.IO.xml",
         "ref/netcore50/zh-hans/System.IO.xml",
         "ref/netcore50/zh-hant/System.IO.xml",
         "ref/win8/_._",
@@ -1307,23 +1985,23 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
-        "System.IO.4.0.11-rc2-23610.nupkg",
-        "System.IO.4.0.11-rc2-23610.nupkg.sha512",
-        "System.IO.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
       ]
     },
     "System.Linq/4.0.0": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "type": "package",
       "files": [
+        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/de/System.Linq.xml",
         "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
@@ -1331,8 +2009,6 @@
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
         "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
@@ -1340,20 +2016,18 @@
         "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Linq.4.0.0.nupkg",
-        "System.Linq.4.0.0.nupkg.sha512",
-        "System.Linq.nuspec"
+        "ref/wpa81/_._"
       ]
     },
     "System.Linq/4.0.1-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "dfb6geDowf1+WP+CU/IC3ywFV2eACQ/1sL13pfuTGxOd9FTCLjhJSS0F+N1SghtLWPUBWjRsQD3MThw4oTIeLA==",
+      "type": "package",
       "files": [
-        "lib/dotnet5.4/System.Linq.dll",
+        "System.Linq.4.0.1-rc2-23610.nupkg.sha512",
+        "System.Linq.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/dotnet5.4/System.Linq.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.dll",
         "lib/win8/_._",
@@ -1361,6 +2035,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Linq.dll",
+        "ref/dotnet5.1/System.Linq.xml",
         "ref/dotnet5.1/de/System.Linq.xml",
         "ref/dotnet5.1/es/System.Linq.xml",
         "ref/dotnet5.1/fr/System.Linq.xml",
@@ -1368,13 +2046,11 @@
         "ref/dotnet5.1/ja/System.Linq.xml",
         "ref/dotnet5.1/ko/System.Linq.xml",
         "ref/dotnet5.1/ru/System.Linq.xml",
-        "ref/dotnet5.1/System.Linq.dll",
-        "ref/dotnet5.1/System.Linq.xml",
         "ref/dotnet5.1/zh-hans/System.Linq.xml",
         "ref/dotnet5.1/zh-hant/System.Linq.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
         "ref/netcore50/de/System.Linq.xml",
         "ref/netcore50/es/System.Linq.xml",
         "ref/netcore50/fr/System.Linq.xml",
@@ -1382,51 +2058,46 @@
         "ref/netcore50/ja/System.Linq.xml",
         "ref/netcore50/ko/System.Linq.xml",
         "ref/netcore50/ru/System.Linq.xml",
-        "ref/netcore50/System.Linq.dll",
-        "ref/netcore50/System.Linq.xml",
         "ref/netcore50/zh-hans/System.Linq.xml",
         "ref/netcore50/zh-hant/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Linq.4.0.1-rc2-23610.nupkg",
-        "System.Linq.4.0.1-rc2-23610.nupkg.sha512",
-        "System.Linq.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Private.Uri/4.0.0": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
+      "type": "package",
       "files": [
+        "System.Private.Uri.4.0.0.nupkg.sha512",
+        "System.Private.Uri.nuspec",
         "lib/DNXCore50/System.Private.Uri.dll",
         "lib/netcore50/System.Private.Uri.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "System.Private.Uri.4.0.0.nupkg",
-        "System.Private.Uri.4.0.0.nupkg.sha512",
-        "System.Private.Uri.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
     "System.Private.Uri/4.0.1-rc2-23610": {
-      "type": "package",
       "sha512": "R3IKeuu6eDXENxtKPxUVcbpRQ/HSDGvZ/4qCVoNNy+KZt8Ebu4JZlGO/ou9NvoKUNodjKVhWdaHmWvzjpiGmGw==",
+      "type": "package",
       "files": [
+        "System.Private.Uri.4.0.1-rc2-23610.nupkg.sha512",
+        "System.Private.Uri.nuspec",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtime.json",
-        "System.Private.Uri.4.0.1-rc2-23610.nupkg",
-        "System.Private.Uri.4.0.1-rc2-23610.nupkg.sha512",
-        "System.Private.Uri.nuspec"
+        "runtime.json"
       ]
     },
     "System.Reflection/4.0.0": {
-      "type": "package",
       "sha512": "g96Rn8XuG7y4VfxPj/jnXroRJdQ8L3iN3k3zqsuzk4k3Nq4KMXARYiIO4BLW4GwX06uQpuYwRMcAC/aF117knQ==",
+      "type": "package",
       "files": [
+        "License.rtf",
+        "System.Reflection.4.0.0.nupkg.sha512",
+        "System.Reflection.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
@@ -1435,7 +2106,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "License.rtf",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/de/System.Reflection.xml",
         "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
@@ -1443,13 +2117,11 @@
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
         "ref/dotnet/zh-hant/System.Reflection.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.xml",
         "ref/netcore50/de/System.Reflection.xml",
         "ref/netcore50/es/System.Reflection.xml",
         "ref/netcore50/fr/System.Reflection.xml",
@@ -1457,25 +2129,21 @@
         "ref/netcore50/ja/System.Reflection.xml",
         "ref/netcore50/ko/System.Reflection.xml",
         "ref/netcore50/ru/System.Reflection.xml",
-        "ref/netcore50/System.Reflection.dll",
-        "ref/netcore50/System.Reflection.xml",
         "ref/netcore50/zh-hans/System.Reflection.xml",
         "ref/netcore50/zh-hant/System.Reflection.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Reflection.4.0.0.nupkg",
-        "System.Reflection.4.0.0.nupkg.sha512",
-        "System.Reflection.nuspec"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.Reflection/4.1.0-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "JpwnSdKxPaGCTItZqPtk0rqKVsnWXOQNrgXt7NwQc3EuoontZHRQPTpVY+tTLcuzPEHMcKnZCEFf0sQT97zr9Q==",
+      "type": "package",
       "files": [
+        "System.Reflection.4.1.0-rc2-23610.nupkg.sha512",
+        "System.Reflection.nuspec",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1487,6 +2155,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Reflection.dll",
+        "ref/dotnet5.1/System.Reflection.xml",
         "ref/dotnet5.1/de/System.Reflection.xml",
         "ref/dotnet5.1/es/System.Reflection.xml",
         "ref/dotnet5.1/fr/System.Reflection.xml",
@@ -1494,10 +2166,10 @@
         "ref/dotnet5.1/ja/System.Reflection.xml",
         "ref/dotnet5.1/ko/System.Reflection.xml",
         "ref/dotnet5.1/ru/System.Reflection.xml",
-        "ref/dotnet5.1/System.Reflection.dll",
-        "ref/dotnet5.1/System.Reflection.xml",
         "ref/dotnet5.1/zh-hans/System.Reflection.xml",
         "ref/dotnet5.1/zh-hant/System.Reflection.xml",
+        "ref/dotnet5.4/System.Reflection.dll",
+        "ref/dotnet5.4/System.Reflection.xml",
         "ref/dotnet5.4/de/System.Reflection.xml",
         "ref/dotnet5.4/es/System.Reflection.xml",
         "ref/dotnet5.4/fr/System.Reflection.xml",
@@ -1505,14 +2177,12 @@
         "ref/dotnet5.4/ja/System.Reflection.xml",
         "ref/dotnet5.4/ko/System.Reflection.xml",
         "ref/dotnet5.4/ru/System.Reflection.xml",
-        "ref/dotnet5.4/System.Reflection.dll",
-        "ref/dotnet5.4/System.Reflection.xml",
         "ref/dotnet5.4/zh-hans/System.Reflection.xml",
         "ref/dotnet5.4/zh-hant/System.Reflection.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net46/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.xml",
         "ref/netcore50/de/System.Reflection.xml",
         "ref/netcore50/es/System.Reflection.xml",
         "ref/netcore50/fr/System.Reflection.xml",
@@ -1520,8 +2190,6 @@
         "ref/netcore50/ja/System.Reflection.xml",
         "ref/netcore50/ko/System.Reflection.xml",
         "ref/netcore50/ru/System.Reflection.xml",
-        "ref/netcore50/System.Reflection.dll",
-        "ref/netcore50/System.Reflection.xml",
         "ref/netcore50/zh-hans/System.Reflection.xml",
         "ref/netcore50/zh-hant/System.Reflection.xml",
         "ref/win8/_._",
@@ -1529,23 +2197,23 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
-        "System.Reflection.4.1.0-rc2-23610.nupkg",
-        "System.Reflection.4.1.0-rc2-23610.nupkg.sha512",
-        "System.Reflection.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
+      "type": "package",
       "files": [
+        "System.Reflection.Extensions.4.0.0.nupkg.sha512",
+        "System.Reflection.Extensions.nuspec",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
         "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
@@ -1553,8 +2221,6 @@
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
@@ -1563,17 +2229,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
-        "System.Reflection.Extensions.4.0.0.nupkg",
-        "System.Reflection.Extensions.4.0.0.nupkg.sha512",
-        "System.Reflection.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
       ]
     },
     "System.Reflection.Extensions/4.0.1-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "XHjhvKdMCK4j8f9iPFtRhJLoPjjpbGGZtu88RWZMldYKvbLqHx7rOtkZLwQu9jF2UbJPTGcKNUdpYbAOZcR1cg==",
+      "type": "package",
       "files": [
+        "System.Reflection.Extensions.4.0.1-rc2-23610.nupkg.sha512",
+        "System.Reflection.Extensions.nuspec",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1584,6 +2248,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Reflection.Extensions.dll",
+        "ref/dotnet5.1/System.Reflection.Extensions.xml",
         "ref/dotnet5.1/de/System.Reflection.Extensions.xml",
         "ref/dotnet5.1/es/System.Reflection.Extensions.xml",
         "ref/dotnet5.1/fr/System.Reflection.Extensions.xml",
@@ -1591,13 +2259,11 @@
         "ref/dotnet5.1/ja/System.Reflection.Extensions.xml",
         "ref/dotnet5.1/ko/System.Reflection.Extensions.xml",
         "ref/dotnet5.1/ru/System.Reflection.Extensions.xml",
-        "ref/dotnet5.1/System.Reflection.Extensions.dll",
-        "ref/dotnet5.1/System.Reflection.Extensions.xml",
         "ref/dotnet5.1/zh-hans/System.Reflection.Extensions.xml",
         "ref/dotnet5.1/zh-hant/System.Reflection.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Extensions.dll",
+        "ref/netcore50/System.Reflection.Extensions.xml",
         "ref/netcore50/de/System.Reflection.Extensions.xml",
         "ref/netcore50/es/System.Reflection.Extensions.xml",
         "ref/netcore50/fr/System.Reflection.Extensions.xml",
@@ -1605,8 +2271,6 @@
         "ref/netcore50/ja/System.Reflection.Extensions.xml",
         "ref/netcore50/ko/System.Reflection.Extensions.xml",
         "ref/netcore50/ru/System.Reflection.Extensions.xml",
-        "ref/netcore50/System.Reflection.Extensions.dll",
-        "ref/netcore50/System.Reflection.Extensions.xml",
         "ref/netcore50/zh-hans/System.Reflection.Extensions.xml",
         "ref/netcore50/zh-hant/System.Reflection.Extensions.xml",
         "ref/win8/_._",
@@ -1614,23 +2278,23 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
-        "System.Reflection.Extensions.4.0.1-rc2-23610.nupkg",
-        "System.Reflection.Extensions.4.0.1-rc2-23610.nupkg.sha512",
-        "System.Reflection.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "type": "package",
       "files": [
+        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
         "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
@@ -1638,8 +2302,6 @@
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
@@ -1648,17 +2310,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
-        "System.Reflection.Primitives.4.0.0.nupkg",
-        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
-        "System.Reflection.Primitives.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
       ]
     },
     "System.Reflection.Primitives/4.0.1-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "QHAGYX8GPpypQi9OcmvJazS8FsOSrs3JkAln9+MQtKkyLTwuifl/H/u9x27OG7qQ5Y+iCbkPjA2T0/extnQ/tw==",
+      "type": "package",
       "files": [
+        "System.Reflection.Primitives.4.0.1-rc2-23610.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1669,6 +2329,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Reflection.Primitives.dll",
+        "ref/dotnet5.1/System.Reflection.Primitives.xml",
         "ref/dotnet5.1/de/System.Reflection.Primitives.xml",
         "ref/dotnet5.1/es/System.Reflection.Primitives.xml",
         "ref/dotnet5.1/fr/System.Reflection.Primitives.xml",
@@ -1676,13 +2340,11 @@
         "ref/dotnet5.1/ja/System.Reflection.Primitives.xml",
         "ref/dotnet5.1/ko/System.Reflection.Primitives.xml",
         "ref/dotnet5.1/ru/System.Reflection.Primitives.xml",
-        "ref/dotnet5.1/System.Reflection.Primitives.dll",
-        "ref/dotnet5.1/System.Reflection.Primitives.xml",
         "ref/dotnet5.1/zh-hans/System.Reflection.Primitives.xml",
         "ref/dotnet5.1/zh-hant/System.Reflection.Primitives.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
         "ref/netcore50/de/System.Reflection.Primitives.xml",
         "ref/netcore50/es/System.Reflection.Primitives.xml",
         "ref/netcore50/fr/System.Reflection.Primitives.xml",
@@ -1690,8 +2352,6 @@
         "ref/netcore50/ja/System.Reflection.Primitives.xml",
         "ref/netcore50/ko/System.Reflection.Primitives.xml",
         "ref/netcore50/ru/System.Reflection.Primitives.xml",
-        "ref/netcore50/System.Reflection.Primitives.dll",
-        "ref/netcore50/System.Reflection.Primitives.xml",
         "ref/netcore50/zh-hans/System.Reflection.Primitives.xml",
         "ref/netcore50/zh-hant/System.Reflection.Primitives.xml",
         "ref/win8/_._",
@@ -1699,17 +2359,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
-        "System.Reflection.Primitives.4.0.1-rc2-23610.nupkg",
-        "System.Reflection.Primitives.4.0.1-rc2-23610.nupkg.sha512",
-        "System.Reflection.Primitives.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
+      "type": "package",
       "files": [
+        "System.Reflection.TypeExtensions.4.0.0.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1717,6 +2375,10 @@
         "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
@@ -1724,26 +2386,20 @@
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "System.Reflection.TypeExtensions.4.0.0.nupkg",
-        "System.Reflection.TypeExtensions.4.0.0.nupkg.sha512",
-        "System.Reflection.TypeExtensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
       ]
     },
     "System.Reflection.TypeExtensions/4.1.0-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "DKk4KeEbYnFZcaVbCzLXMmsNLquONfezIp+y6bVAvCZWuBmXRmH3BXZOpOXofNpnYuVvw8IaRN3WNvj8kAGG/g==",
+      "type": "package",
       "files": [
+        "System.Reflection.TypeExtensions.4.1.0-rc2-23610.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1751,6 +2407,10 @@
         "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.4/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet5.4/System.Reflection.TypeExtensions.xml",
         "ref/dotnet5.4/de/System.Reflection.TypeExtensions.xml",
         "ref/dotnet5.4/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet5.4/fr/System.Reflection.TypeExtensions.xml",
@@ -1758,32 +2418,28 @@
         "ref/dotnet5.4/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet5.4/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet5.4/ru/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.4/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet5.4/System.Reflection.TypeExtensions.xml",
         "ref/dotnet5.4/zh-hans/System.Reflection.TypeExtensions.xml",
         "ref/dotnet5.4/zh-hant/System.Reflection.TypeExtensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "System.Reflection.TypeExtensions.4.1.0-rc2-23610.nupkg",
-        "System.Reflection.TypeExtensions.4.1.0-rc2-23610.nupkg.sha512",
-        "System.Reflection.TypeExtensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "type": "package",
       "files": [
+        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
         "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
@@ -1791,8 +2447,6 @@
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
@@ -1801,17 +2455,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
-        "System.Resources.ResourceManager.4.0.0.nupkg",
-        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
-        "System.Resources.ResourceManager.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
       ]
     },
     "System.Resources.ResourceManager/4.0.1-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "098Owx+/waXdzvqQxWsyYqmFFIboriTtSoy/CG4VOAlLtVz0afhaM5gRzuv3pS+Q7hgt+kEkDD5Ob7ztHN1xog==",
+      "type": "package",
       "files": [
+        "System.Resources.ResourceManager.4.0.1-rc2-23610.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1822,6 +2474,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Resources.ResourceManager.dll",
+        "ref/dotnet5.1/System.Resources.ResourceManager.xml",
         "ref/dotnet5.1/de/System.Resources.ResourceManager.xml",
         "ref/dotnet5.1/es/System.Resources.ResourceManager.xml",
         "ref/dotnet5.1/fr/System.Resources.ResourceManager.xml",
@@ -1829,13 +2485,11 @@
         "ref/dotnet5.1/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet5.1/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet5.1/ru/System.Resources.ResourceManager.xml",
-        "ref/dotnet5.1/System.Resources.ResourceManager.dll",
-        "ref/dotnet5.1/System.Resources.ResourceManager.xml",
         "ref/dotnet5.1/zh-hans/System.Resources.ResourceManager.xml",
         "ref/dotnet5.1/zh-hant/System.Resources.ResourceManager.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
         "ref/netcore50/de/System.Resources.ResourceManager.xml",
         "ref/netcore50/es/System.Resources.ResourceManager.xml",
         "ref/netcore50/fr/System.Resources.ResourceManager.xml",
@@ -1843,8 +2497,6 @@
         "ref/netcore50/ja/System.Resources.ResourceManager.xml",
         "ref/netcore50/ko/System.Resources.ResourceManager.xml",
         "ref/netcore50/ru/System.Resources.ResourceManager.xml",
-        "ref/netcore50/System.Resources.ResourceManager.dll",
-        "ref/netcore50/System.Resources.ResourceManager.xml",
         "ref/netcore50/zh-hans/System.Resources.ResourceManager.xml",
         "ref/netcore50/zh-hant/System.Resources.ResourceManager.xml",
         "ref/win8/_._",
@@ -1852,17 +2504,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
-        "System.Resources.ResourceManager.4.0.1-rc2-23610.nupkg",
-        "System.Resources.ResourceManager.4.0.1-rc2-23610.nupkg.sha512",
-        "System.Resources.ResourceManager.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
       ]
     },
     "System.Runtime/4.0.20": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
+      "type": "package",
       "files": [
+        "System.Runtime.4.0.20.nupkg.sha512",
+        "System.Runtime.nuspec",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1870,6 +2520,10 @@
         "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/de/System.Runtime.xml",
         "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
@@ -1877,26 +2531,20 @@
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
         "ref/dotnet/zh-hant/System.Runtime.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.4.0.20.nupkg",
-        "System.Runtime.4.0.20.nupkg.sha512",
-        "System.Runtime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
       ]
     },
     "System.Runtime/4.0.21-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "34P12WPl55HxjncGTtFDp5OobPz/U6h+DgFwX4H8TqzEZFEVci5EIHgWiHah/FdN9e/OutFJDXgfX8k4Yr2E0g==",
+      "type": "package",
       "files": [
+        "System.Runtime.4.0.21-rc2-23610.nupkg.sha512",
+        "System.Runtime.nuspec",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1907,6 +2555,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Runtime.dll",
+        "ref/dotnet5.1/System.Runtime.xml",
         "ref/dotnet5.1/de/System.Runtime.xml",
         "ref/dotnet5.1/es/System.Runtime.xml",
         "ref/dotnet5.1/fr/System.Runtime.xml",
@@ -1914,10 +2566,10 @@
         "ref/dotnet5.1/ja/System.Runtime.xml",
         "ref/dotnet5.1/ko/System.Runtime.xml",
         "ref/dotnet5.1/ru/System.Runtime.xml",
-        "ref/dotnet5.1/System.Runtime.dll",
-        "ref/dotnet5.1/System.Runtime.xml",
         "ref/dotnet5.1/zh-hans/System.Runtime.xml",
         "ref/dotnet5.1/zh-hant/System.Runtime.xml",
+        "ref/dotnet5.3/System.Runtime.dll",
+        "ref/dotnet5.3/System.Runtime.xml",
         "ref/dotnet5.3/de/System.Runtime.xml",
         "ref/dotnet5.3/es/System.Runtime.xml",
         "ref/dotnet5.3/fr/System.Runtime.xml",
@@ -1925,10 +2577,10 @@
         "ref/dotnet5.3/ja/System.Runtime.xml",
         "ref/dotnet5.3/ko/System.Runtime.xml",
         "ref/dotnet5.3/ru/System.Runtime.xml",
-        "ref/dotnet5.3/System.Runtime.dll",
-        "ref/dotnet5.3/System.Runtime.xml",
         "ref/dotnet5.3/zh-hans/System.Runtime.xml",
         "ref/dotnet5.3/zh-hant/System.Runtime.xml",
+        "ref/dotnet5.4/System.Runtime.dll",
+        "ref/dotnet5.4/System.Runtime.xml",
         "ref/dotnet5.4/de/System.Runtime.xml",
         "ref/dotnet5.4/es/System.Runtime.xml",
         "ref/dotnet5.4/fr/System.Runtime.xml",
@@ -1936,13 +2588,11 @@
         "ref/dotnet5.4/ja/System.Runtime.xml",
         "ref/dotnet5.4/ko/System.Runtime.xml",
         "ref/dotnet5.4/ru/System.Runtime.xml",
-        "ref/dotnet5.4/System.Runtime.dll",
-        "ref/dotnet5.4/System.Runtime.xml",
         "ref/dotnet5.4/zh-hans/System.Runtime.xml",
         "ref/dotnet5.4/zh-hant/System.Runtime.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.xml",
         "ref/netcore50/de/System.Runtime.xml",
         "ref/netcore50/es/System.Runtime.xml",
         "ref/netcore50/fr/System.Runtime.xml",
@@ -1950,8 +2600,6 @@
         "ref/netcore50/ja/System.Runtime.xml",
         "ref/netcore50/ko/System.Runtime.xml",
         "ref/netcore50/ru/System.Runtime.xml",
-        "ref/netcore50/System.Runtime.dll",
-        "ref/netcore50/System.Runtime.xml",
         "ref/netcore50/zh-hans/System.Runtime.xml",
         "ref/netcore50/zh-hant/System.Runtime.xml",
         "ref/win8/_._",
@@ -1959,17 +2607,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.4.0.21-rc2-23610.nupkg",
-        "System.Runtime.4.0.21-rc2-23610.nupkg.sha512",
-        "System.Runtime.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
+      "type": "package",
       "files": [
+        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -1977,6 +2623,10 @@
         "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
         "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
@@ -1984,26 +2634,20 @@
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
-        "System.Runtime.Extensions.4.0.10.nupkg",
-        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
-        "System.Runtime.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
       ]
     },
     "System.Runtime.Extensions/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "mug+g1mx/Oj2vDk3P61tw0Wu3TjH+GxC5HbJ0+BbhtuClh8ErtEjoDcY3DIefQaRWIdfdm+N679C/hgq1/b0xg==",
+      "type": "package",
       "files": [
+        "System.Runtime.Extensions.4.0.11-rc2-23610.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
@@ -2012,6 +2656,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Runtime.Extensions.dll",
+        "ref/dotnet5.1/System.Runtime.Extensions.xml",
         "ref/dotnet5.1/de/System.Runtime.Extensions.xml",
         "ref/dotnet5.1/es/System.Runtime.Extensions.xml",
         "ref/dotnet5.1/fr/System.Runtime.Extensions.xml",
@@ -2019,10 +2667,10 @@
         "ref/dotnet5.1/ja/System.Runtime.Extensions.xml",
         "ref/dotnet5.1/ko/System.Runtime.Extensions.xml",
         "ref/dotnet5.1/ru/System.Runtime.Extensions.xml",
-        "ref/dotnet5.1/System.Runtime.Extensions.dll",
-        "ref/dotnet5.1/System.Runtime.Extensions.xml",
         "ref/dotnet5.1/zh-hans/System.Runtime.Extensions.xml",
         "ref/dotnet5.1/zh-hant/System.Runtime.Extensions.xml",
+        "ref/dotnet5.4/System.Runtime.Extensions.dll",
+        "ref/dotnet5.4/System.Runtime.Extensions.xml",
         "ref/dotnet5.4/de/System.Runtime.Extensions.xml",
         "ref/dotnet5.4/es/System.Runtime.Extensions.xml",
         "ref/dotnet5.4/fr/System.Runtime.Extensions.xml",
@@ -2030,13 +2678,11 @@
         "ref/dotnet5.4/ja/System.Runtime.Extensions.xml",
         "ref/dotnet5.4/ko/System.Runtime.Extensions.xml",
         "ref/dotnet5.4/ru/System.Runtime.Extensions.xml",
-        "ref/dotnet5.4/System.Runtime.Extensions.dll",
-        "ref/dotnet5.4/System.Runtime.Extensions.xml",
         "ref/dotnet5.4/zh-hans/System.Runtime.Extensions.xml",
         "ref/dotnet5.4/zh-hant/System.Runtime.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Runtime.Extensions.dll",
+        "ref/netcore50/System.Runtime.Extensions.xml",
         "ref/netcore50/de/System.Runtime.Extensions.xml",
         "ref/netcore50/es/System.Runtime.Extensions.xml",
         "ref/netcore50/fr/System.Runtime.Extensions.xml",
@@ -2044,8 +2690,6 @@
         "ref/netcore50/ja/System.Runtime.Extensions.xml",
         "ref/netcore50/ko/System.Runtime.Extensions.xml",
         "ref/netcore50/ru/System.Runtime.Extensions.xml",
-        "ref/netcore50/System.Runtime.Extensions.dll",
-        "ref/netcore50/System.Runtime.Extensions.xml",
         "ref/netcore50/zh-hans/System.Runtime.Extensions.xml",
         "ref/netcore50/zh-hant/System.Runtime.Extensions.xml",
         "ref/win8/_._",
@@ -2053,17 +2697,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Runtime.Extensions.4.0.11-rc2-23610.nupkg",
-        "System.Runtime.Extensions.4.0.11-rc2-23610.nupkg.sha512",
-        "System.Runtime.Extensions.nuspec"
+        "runtime.json"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
+      "type": "package",
       "files": [
+        "System.Runtime.Handles.4.0.0.nupkg.sha512",
+        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2071,6 +2713,10 @@
         "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/de/System.Runtime.Handles.xml",
         "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
@@ -2078,26 +2724,20 @@
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
-        "System.Runtime.Handles.4.0.0.nupkg",
-        "System.Runtime.Handles.4.0.0.nupkg.sha512",
-        "System.Runtime.Handles.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
       ]
     },
     "System.Runtime.Handles/4.0.1-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "E/2NQjB3NJNHW4cIiea2GS/WxuOb3JbDrddVGo3X5xlhIamLESGRSsd0PrDzZWb+fEF0DZX92urXWVBhWE/jbQ==",
+      "type": "package",
       "files": [
+        "System.Runtime.Handles.4.0.1-rc2-23610.nupkg.sha512",
+        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2105,6 +2745,10 @@
         "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.4/System.Runtime.Handles.dll",
+        "ref/dotnet5.4/System.Runtime.Handles.xml",
         "ref/dotnet5.4/de/System.Runtime.Handles.xml",
         "ref/dotnet5.4/es/System.Runtime.Handles.xml",
         "ref/dotnet5.4/fr/System.Runtime.Handles.xml",
@@ -2112,26 +2756,20 @@
         "ref/dotnet5.4/ja/System.Runtime.Handles.xml",
         "ref/dotnet5.4/ko/System.Runtime.Handles.xml",
         "ref/dotnet5.4/ru/System.Runtime.Handles.xml",
-        "ref/dotnet5.4/System.Runtime.Handles.dll",
-        "ref/dotnet5.4/System.Runtime.Handles.xml",
         "ref/dotnet5.4/zh-hans/System.Runtime.Handles.xml",
         "ref/dotnet5.4/zh-hant/System.Runtime.Handles.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
-        "System.Runtime.Handles.4.0.1-rc2-23610.nupkg",
-        "System.Runtime.Handles.4.0.1-rc2-23610.nupkg.sha512",
-        "System.Runtime.Handles.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
+      "type": "package",
       "files": [
+        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2139,6 +2777,10 @@
         "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
         "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
@@ -2146,26 +2788,20 @@
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
-        "System.Runtime.InteropServices.4.0.20.nupkg",
-        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
-        "System.Runtime.InteropServices.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
       ]
     },
     "System.Runtime.InteropServices/4.0.21-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "QfJ9UyBo7xPCKvKn7ZVEHDnMPNkpgJXa2GgR5tU4ER+8Ja32ZkPADweQqqGsSnyxeilj5A/LcWMo9axSC7Zuwg==",
+      "type": "package",
       "files": [
+        "System.Runtime.InteropServices.4.0.21-rc2-23610.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2175,6 +2811,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.2/System.Runtime.InteropServices.dll",
+        "ref/dotnet5.2/System.Runtime.InteropServices.xml",
         "ref/dotnet5.2/de/System.Runtime.InteropServices.xml",
         "ref/dotnet5.2/es/System.Runtime.InteropServices.xml",
         "ref/dotnet5.2/fr/System.Runtime.InteropServices.xml",
@@ -2182,10 +2822,10 @@
         "ref/dotnet5.2/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet5.2/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet5.2/ru/System.Runtime.InteropServices.xml",
-        "ref/dotnet5.2/System.Runtime.InteropServices.dll",
-        "ref/dotnet5.2/System.Runtime.InteropServices.xml",
         "ref/dotnet5.2/zh-hans/System.Runtime.InteropServices.xml",
         "ref/dotnet5.2/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/dotnet5.3/System.Runtime.InteropServices.dll",
+        "ref/dotnet5.3/System.Runtime.InteropServices.xml",
         "ref/dotnet5.3/de/System.Runtime.InteropServices.xml",
         "ref/dotnet5.3/es/System.Runtime.InteropServices.xml",
         "ref/dotnet5.3/fr/System.Runtime.InteropServices.xml",
@@ -2193,10 +2833,10 @@
         "ref/dotnet5.3/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet5.3/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet5.3/ru/System.Runtime.InteropServices.xml",
-        "ref/dotnet5.3/System.Runtime.InteropServices.dll",
-        "ref/dotnet5.3/System.Runtime.InteropServices.xml",
         "ref/dotnet5.3/zh-hans/System.Runtime.InteropServices.xml",
         "ref/dotnet5.3/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/dotnet5.4/System.Runtime.InteropServices.dll",
+        "ref/dotnet5.4/System.Runtime.InteropServices.xml",
         "ref/dotnet5.4/de/System.Runtime.InteropServices.xml",
         "ref/dotnet5.4/es/System.Runtime.InteropServices.xml",
         "ref/dotnet5.4/fr/System.Runtime.InteropServices.xml",
@@ -2204,13 +2844,11 @@
         "ref/dotnet5.4/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet5.4/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet5.4/ru/System.Runtime.InteropServices.xml",
-        "ref/dotnet5.4/System.Runtime.InteropServices.dll",
-        "ref/dotnet5.4/System.Runtime.InteropServices.xml",
         "ref/dotnet5.4/zh-hans/System.Runtime.InteropServices.xml",
         "ref/dotnet5.4/zh-hant/System.Runtime.InteropServices.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Runtime.InteropServices.dll",
+        "ref/netcore50/System.Runtime.InteropServices.xml",
         "ref/netcore50/de/System.Runtime.InteropServices.xml",
         "ref/netcore50/es/System.Runtime.InteropServices.xml",
         "ref/netcore50/fr/System.Runtime.InteropServices.xml",
@@ -2218,24 +2856,21 @@
         "ref/netcore50/ja/System.Runtime.InteropServices.xml",
         "ref/netcore50/ko/System.Runtime.InteropServices.xml",
         "ref/netcore50/ru/System.Runtime.InteropServices.xml",
-        "ref/netcore50/System.Runtime.InteropServices.dll",
-        "ref/netcore50/System.Runtime.InteropServices.xml",
         "ref/netcore50/zh-hans/System.Runtime.InteropServices.xml",
         "ref/netcore50/zh-hant/System.Runtime.InteropServices.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
-        "System.Runtime.InteropServices.4.0.21-rc2-23610.nupkg",
-        "System.Runtime.InteropServices.4.0.21-rc2-23610.nupkg.sha512",
-        "System.Runtime.InteropServices.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
       ]
     },
     "System.Text.Encoding/4.0.10": {
-      "type": "package",
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
+      "type": "package",
       "files": [
+        "System.Text.Encoding.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.nuspec",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2243,6 +2878,10 @@
         "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/de/System.Text.Encoding.xml",
         "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
@@ -2250,26 +2889,20 @@
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
-        "System.Text.Encoding.4.0.10.nupkg",
-        "System.Text.Encoding.4.0.10.nupkg.sha512",
-        "System.Text.Encoding.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
       ]
     },
     "System.Text.Encoding/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "bF+2wAnjkgFX4KYWWd1W1q6bVLpFOG7mJtnz9prhT0IRamDcQFW4xIb9uN0fQDcpkk+qH5zUvMyf9lMhfhUMWw==",
+      "type": "package",
       "files": [
+        "System.Text.Encoding.4.0.11-rc2-23610.nupkg.sha512",
+        "System.Text.Encoding.nuspec",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2280,6 +2913,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Text.Encoding.dll",
+        "ref/dotnet5.1/System.Text.Encoding.xml",
         "ref/dotnet5.1/de/System.Text.Encoding.xml",
         "ref/dotnet5.1/es/System.Text.Encoding.xml",
         "ref/dotnet5.1/fr/System.Text.Encoding.xml",
@@ -2287,10 +2924,10 @@
         "ref/dotnet5.1/ja/System.Text.Encoding.xml",
         "ref/dotnet5.1/ko/System.Text.Encoding.xml",
         "ref/dotnet5.1/ru/System.Text.Encoding.xml",
-        "ref/dotnet5.1/System.Text.Encoding.dll",
-        "ref/dotnet5.1/System.Text.Encoding.xml",
         "ref/dotnet5.1/zh-hans/System.Text.Encoding.xml",
         "ref/dotnet5.1/zh-hant/System.Text.Encoding.xml",
+        "ref/dotnet5.4/System.Text.Encoding.dll",
+        "ref/dotnet5.4/System.Text.Encoding.xml",
         "ref/dotnet5.4/de/System.Text.Encoding.xml",
         "ref/dotnet5.4/es/System.Text.Encoding.xml",
         "ref/dotnet5.4/fr/System.Text.Encoding.xml",
@@ -2298,13 +2935,11 @@
         "ref/dotnet5.4/ja/System.Text.Encoding.xml",
         "ref/dotnet5.4/ko/System.Text.Encoding.xml",
         "ref/dotnet5.4/ru/System.Text.Encoding.xml",
-        "ref/dotnet5.4/System.Text.Encoding.dll",
-        "ref/dotnet5.4/System.Text.Encoding.xml",
         "ref/dotnet5.4/zh-hans/System.Text.Encoding.xml",
         "ref/dotnet5.4/zh-hant/System.Text.Encoding.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Text.Encoding.dll",
+        "ref/netcore50/System.Text.Encoding.xml",
         "ref/netcore50/de/System.Text.Encoding.xml",
         "ref/netcore50/es/System.Text.Encoding.xml",
         "ref/netcore50/fr/System.Text.Encoding.xml",
@@ -2312,8 +2947,6 @@
         "ref/netcore50/ja/System.Text.Encoding.xml",
         "ref/netcore50/ko/System.Text.Encoding.xml",
         "ref/netcore50/ru/System.Text.Encoding.xml",
-        "ref/netcore50/System.Text.Encoding.dll",
-        "ref/netcore50/System.Text.Encoding.xml",
         "ref/netcore50/zh-hans/System.Text.Encoding.xml",
         "ref/netcore50/zh-hant/System.Text.Encoding.xml",
         "ref/win8/_._",
@@ -2321,16 +2954,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
-        "System.Text.Encoding.4.0.11-rc2-23610.nupkg",
-        "System.Text.Encoding.4.0.11-rc2-23610.nupkg.sha512",
-        "System.Text.Encoding.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
-      "type": "package",
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
+      "type": "package",
       "files": [
+        "System.Text.Encoding.Extensions.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2338,6 +2970,10 @@
         "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
@@ -2345,26 +2981,20 @@
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
-        "System.Text.Encoding.Extensions.4.0.10.nupkg",
-        "System.Text.Encoding.Extensions.4.0.10.nupkg.sha512",
-        "System.Text.Encoding.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "Zh28daQhoRaujc2GCoC2tRF/ah4Cs0tUaqeyWOeW0QuK1U5GHIVpypC/sPSoMQYJJhw4orQCJi9MfKF3MSt12g==",
+      "type": "package",
       "files": [
+        "System.Text.Encoding.Extensions.4.0.11-rc2-23610.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2375,6 +3005,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet5.1/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.1/de/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.1/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.1/fr/System.Text.Encoding.Extensions.xml",
@@ -2382,10 +3016,10 @@
         "ref/dotnet5.1/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.1/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.1/ru/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet5.1/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet5.1/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.1/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.1/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet5.4/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet5.4/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.4/de/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.4/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.4/fr/System.Text.Encoding.Extensions.xml",
@@ -2393,13 +3027,11 @@
         "ref/dotnet5.4/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.4/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.4/ru/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet5.4/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet5.4/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.4/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/dotnet5.4/zh-hant/System.Text.Encoding.Extensions.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/netcore50/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/de/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/es/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/fr/System.Text.Encoding.Extensions.xml",
@@ -2407,8 +3039,6 @@
         "ref/netcore50/ja/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/ko/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/ru/System.Text.Encoding.Extensions.xml",
-        "ref/netcore50/System.Text.Encoding.Extensions.dll",
-        "ref/netcore50/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/win8/_._",
@@ -2416,17 +3046,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
-        "System.Text.Encoding.Extensions.4.0.11-rc2-23610.nupkg",
-        "System.Text.Encoding.Extensions.4.0.11-rc2-23610.nupkg.sha512",
-        "System.Text.Encoding.Extensions.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
       ]
     },
     "System.Threading/4.0.10": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
+      "type": "package",
       "files": [
+        "System.Threading.4.0.10.nupkg.sha512",
+        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2434,6 +3062,10 @@
         "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/de/System.Threading.xml",
         "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
@@ -2441,26 +3073,20 @@
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
         "ref/dotnet/zh-hant/System.Threading.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
-        "System.Threading.4.0.10.nupkg",
-        "System.Threading.4.0.10.nupkg.sha512",
-        "System.Threading.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
       ]
     },
     "System.Threading/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "7965oAqhJlHIg5lwsV9LGJYlK9iYhfgmNgKZHyfHYTIGKmMIK6qu8PlbW1Gw9gvZTf1sQggNTgLuo4KgqZWxVw==",
+      "type": "package",
       "files": [
+        "System.Threading.4.0.11-rc2-23610.nupkg.sha512",
+        "System.Threading.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
@@ -2469,6 +3095,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Threading.dll",
+        "ref/dotnet5.1/System.Threading.xml",
         "ref/dotnet5.1/de/System.Threading.xml",
         "ref/dotnet5.1/es/System.Threading.xml",
         "ref/dotnet5.1/fr/System.Threading.xml",
@@ -2476,10 +3106,10 @@
         "ref/dotnet5.1/ja/System.Threading.xml",
         "ref/dotnet5.1/ko/System.Threading.xml",
         "ref/dotnet5.1/ru/System.Threading.xml",
-        "ref/dotnet5.1/System.Threading.dll",
-        "ref/dotnet5.1/System.Threading.xml",
         "ref/dotnet5.1/zh-hans/System.Threading.xml",
         "ref/dotnet5.1/zh-hant/System.Threading.xml",
+        "ref/dotnet5.4/System.Threading.dll",
+        "ref/dotnet5.4/System.Threading.xml",
         "ref/dotnet5.4/de/System.Threading.xml",
         "ref/dotnet5.4/es/System.Threading.xml",
         "ref/dotnet5.4/fr/System.Threading.xml",
@@ -2487,13 +3117,11 @@
         "ref/dotnet5.4/ja/System.Threading.xml",
         "ref/dotnet5.4/ko/System.Threading.xml",
         "ref/dotnet5.4/ru/System.Threading.xml",
-        "ref/dotnet5.4/System.Threading.dll",
-        "ref/dotnet5.4/System.Threading.xml",
         "ref/dotnet5.4/zh-hans/System.Threading.xml",
         "ref/dotnet5.4/zh-hant/System.Threading.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Threading.dll",
+        "ref/netcore50/System.Threading.xml",
         "ref/netcore50/de/System.Threading.xml",
         "ref/netcore50/es/System.Threading.xml",
         "ref/netcore50/fr/System.Threading.xml",
@@ -2501,8 +3129,6 @@
         "ref/netcore50/ja/System.Threading.xml",
         "ref/netcore50/ko/System.Threading.xml",
         "ref/netcore50/ru/System.Threading.xml",
-        "ref/netcore50/System.Threading.dll",
-        "ref/netcore50/System.Threading.xml",
         "ref/netcore50/zh-hans/System.Threading.xml",
         "ref/netcore50/zh-hant/System.Threading.xml",
         "ref/win8/_._",
@@ -2510,17 +3136,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Threading.4.0.11-rc2-23610.nupkg",
-        "System.Threading.4.0.11-rc2-23610.nupkg.sha512",
-        "System.Threading.nuspec"
+        "runtime.json"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
+      "type": "package",
       "files": [
+        "System.Threading.Tasks.4.0.10.nupkg.sha512",
+        "System.Threading.Tasks.nuspec",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2528,6 +3152,10 @@
         "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/de/System.Threading.Tasks.xml",
         "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
@@ -2535,26 +3163,20 @@
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
-        "System.Threading.Tasks.4.0.10.nupkg",
-        "System.Threading.Tasks.4.0.10.nupkg.sha512",
-        "System.Threading.Tasks.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
       ]
     },
     "System.Threading.Tasks/4.0.11-rc2-23610": {
-      "type": "package",
-      "serviceable": true,
       "sha512": "1ZLKN/lUjDcpHjIJp4zVibXVnNxJ1dgt0uR4TVqE6+Y21QO/JTj4DG/HzbHXoptViC/q53JmYYF9YTz3BJ8iqQ==",
+      "type": "package",
       "files": [
+        "System.Threading.Tasks.4.0.11-rc2-23610.nupkg.sha512",
+        "System.Threading.Tasks.nuspec",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2565,6 +3187,10 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/dotnet5.1/System.Threading.Tasks.dll",
+        "ref/dotnet5.1/System.Threading.Tasks.xml",
         "ref/dotnet5.1/de/System.Threading.Tasks.xml",
         "ref/dotnet5.1/es/System.Threading.Tasks.xml",
         "ref/dotnet5.1/fr/System.Threading.Tasks.xml",
@@ -2572,10 +3198,10 @@
         "ref/dotnet5.1/ja/System.Threading.Tasks.xml",
         "ref/dotnet5.1/ko/System.Threading.Tasks.xml",
         "ref/dotnet5.1/ru/System.Threading.Tasks.xml",
-        "ref/dotnet5.1/System.Threading.Tasks.dll",
-        "ref/dotnet5.1/System.Threading.Tasks.xml",
         "ref/dotnet5.1/zh-hans/System.Threading.Tasks.xml",
         "ref/dotnet5.1/zh-hant/System.Threading.Tasks.xml",
+        "ref/dotnet5.4/System.Threading.Tasks.dll",
+        "ref/dotnet5.4/System.Threading.Tasks.xml",
         "ref/dotnet5.4/de/System.Threading.Tasks.xml",
         "ref/dotnet5.4/es/System.Threading.Tasks.xml",
         "ref/dotnet5.4/fr/System.Threading.Tasks.xml",
@@ -2583,13 +3209,11 @@
         "ref/dotnet5.4/ja/System.Threading.Tasks.xml",
         "ref/dotnet5.4/ko/System.Threading.Tasks.xml",
         "ref/dotnet5.4/ru/System.Threading.Tasks.xml",
-        "ref/dotnet5.4/System.Threading.Tasks.dll",
-        "ref/dotnet5.4/System.Threading.Tasks.xml",
         "ref/dotnet5.4/zh-hans/System.Threading.Tasks.xml",
         "ref/dotnet5.4/zh-hant/System.Threading.Tasks.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "ref/netcore50/System.Threading.Tasks.xml",
         "ref/netcore50/de/System.Threading.Tasks.xml",
         "ref/netcore50/es/System.Threading.Tasks.xml",
         "ref/netcore50/fr/System.Threading.Tasks.xml",
@@ -2597,8 +3221,6 @@
         "ref/netcore50/ja/System.Threading.Tasks.xml",
         "ref/netcore50/ko/System.Threading.Tasks.xml",
         "ref/netcore50/ru/System.Threading.Tasks.xml",
-        "ref/netcore50/System.Threading.Tasks.dll",
-        "ref/netcore50/System.Threading.Tasks.xml",
         "ref/netcore50/zh-hans/System.Threading.Tasks.xml",
         "ref/netcore50/zh-hant/System.Threading.Tasks.xml",
         "ref/win8/_._",
@@ -2606,30 +3228,27 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
-        "System.Threading.Tasks.4.0.11-rc2-23610.nupkg",
-        "System.Threading.Tasks.4.0.11-rc2-23610.nupkg.sha512",
-        "System.Threading.Tasks.nuspec"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
       ]
     }
   },
   "projectFileDependencyGroups": {
     "": [
       "Microsoft.NETCore.Platforms >= 1.0.1-rc2-23610",
-      "System.Runtime >= 4.0.20",
+      "System.Collections >= 4.0.10",
+      "System.Diagnostics.Tracing >= 4.0.20",
+      "System.Globalization >= 4.0.10",
+      "System.IO >= 4.0.10",
+      "System.Private.Uri >= 4.0.0",
       "System.Reflection >= 4.0.0",
       "System.Reflection.Primitives >= 4.0.0",
-      "System.Runtime.Extensions >= 4.0.10",
-      "System.Diagnostics.Tracing >= 4.0.20",
-      "System.Collections >= 4.0.10",
-      "System.Resources.ResourceManager >= 4.0.0",
-      "System.Threading.Tasks >= 4.0.10",
-      "System.Text.Encoding.Extensions >= 4.0.10",
       "System.Reflection.TypeExtensions >= 4.0.0",
+      "System.Resources.ResourceManager >= 4.0.0",
+      "System.Runtime >= 4.0.20",
+      "System.Runtime.Extensions >= 4.0.10",
       "System.Runtime.InteropServices >= 4.0.20",
-      "System.Private.Uri >= 4.0.0",
-      "System.IO >= 4.0.10",
-      "System.Globalization >= 4.0.10"
+      "System.Text.Encoding.Extensions >= 4.0.10",
+      "System.Threading.Tasks >= 4.0.10"
     ],
     ".NETCore,Version=v5.0": []
   }

--- a/src/ILCompiler.Compiler/src/project.json
+++ b/src/ILCompiler.Compiler/src/project.json
@@ -1,28 +1,13 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.IO": "4.0.10",
-    "System.IO.FileSystem": "4.0.0",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.IO.MemoryMappedFiles": "4.0.0-rc2-23616",
-    "System.Collections": "4.0.10",
-    "System.Text.Encoding": "4.0.10",
-    "System.Runtime.InteropServices": "4.0.20",
-    "System.Reflection": "4.0.10",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Text.Encoding.Extensions": "4.0.10",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.1.0",
     "Microsoft.DiaSymReader": "1.0.6"
   },
   "frameworks": {
-    "dnxcore50": { },
-    "dotnet": {
+    "dnxcore50": {
       "imports": "portable-net452"
     }
   }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/project.json
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/project.json
@@ -1,22 +1,10 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.IO": "4.0.10",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Collections.Immutable": "1.1.37",
-    "System.Collections": "4.0.0",
-    "System.Text.Encoding": "4.0.0",
-    "System.Runtime.InteropServices": "4.0.0",
-    "System.Reflection": "4.0.10",
-    "System.Runtime.Extensions": "4.0.0",
-    "System.Threading": "4.0.0",
-    "System.Text.Encoding.Extensions": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
     "System.Xml.ReaderWriter": "4.0.0"
   },
   "frameworks": {
-    "dotnet": {}
+    "dnxcore50": {}
   }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/tests/project.json
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/project.json
@@ -1,21 +1,13 @@
 {
   "dependencies": {
-    "System.Collections": "4.0.10",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Collections.Immutable": "1.1.37",
-    "System.Console": "4.0.0-rc2-23616",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.Diagnostics.Tracing": "4.0.20",
-    "System.Linq": "4.0.0",
-    "System.IO.FileSystem": "4.0.0",
-    "System.Reflection": "4.0.10",
-    "System.Runtime": "4.0.20",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Threading.Tasks": "4.0.10",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dotnet": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/ILCompiler.MetadataTransform/src/project.json
+++ b/src/ILCompiler.MetadataTransform/src/project.json
@@ -1,22 +1,9 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.IO": "4.0.10",
-    "System.Collections": "4.0.0",
-    "System.Text.Encoding": "4.0.10",
-    "System.Runtime.InteropServices": "4.0.0",
-    "System.Reflection": "4.0.10",
-    "System.Runtime.Extensions": "4.0.0",
-    "System.Threading": "4.0.0",
-    "System.Text.Encoding.Extensions": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Linq": "4.0.0",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Reflection.Metadata": "1.0.22"
   },
   "frameworks": {
-    "dotnet": {}
+    "dnxcore50": {}
   }
 }

--- a/src/ILCompiler.MetadataTransform/tests/project.json
+++ b/src/ILCompiler.MetadataTransform/tests/project.json
@@ -1,21 +1,13 @@
 {
   "dependencies": {
-    "System.Collections": "4.0.10",
-    "System.Console": "4.0.0-rc2-23616",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.Diagnostics.Tracing": "4.0.20",
-    "System.Linq": "4.0.0",
-    "System.IO.FileSystem": "4.0.0",
-    "System.Reflection": "4.0.10",
-    "System.Runtime": "4.0.20",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Threading.Tasks": "4.0.10",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Reflection.Metadata": "1.0.22",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dotnet": {}
+    "dnxcore50": { 
+        "imports": "portable-net451+win8"
+    }
   }
 }

--- a/src/ILCompiler.MetadataWriter/src/project.json
+++ b/src/ILCompiler.MetadataWriter/src/project.json
@@ -1,21 +1,8 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.IO": "4.0.10",
-    "System.Collections": "4.0.0",
-    "System.Text.Encoding": "4.0.0",
-    "System.Runtime.InteropServices": "4.0.0",
-    "System.Reflection": "4.0.10",
-    "System.Runtime.Extensions": "4.0.0",
-    "System.Threading": "4.0.0",
-    "System.Text.Encoding.Extensions": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Linq": "4.0.0"
+    "NETStandard.Library": "1.0.0-rc2-23704",
   },
   "frameworks": {
-    "dotnet": {}
+    "dnxcore50": {}
   }
 }

--- a/src/ILCompiler.TypeSystem/src/project.json
+++ b/src/ILCompiler.TypeSystem/src/project.json
@@ -1,21 +1,9 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.IO": "4.0.10",
-    "System.Collections": "4.0.0",
-    "System.Text.Encoding": "4.0.10",
-    "System.Runtime.InteropServices": "4.0.0",
-    "System.Reflection": "4.0.10",
-    "System.Runtime.Extensions": "4.0.0",
-    "System.Threading": "4.0.0",
-    "System.Text.Encoding.Extensions": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Reflection.Metadata": "1.0.22"
   },
   "frameworks": {
-    "dotnet": {}
+    "dnxcore50": {}
   }
 }

--- a/src/ILCompiler.TypeSystem/tests/project.json
+++ b/src/ILCompiler.TypeSystem/tests/project.json
@@ -1,22 +1,13 @@
 {
   "dependencies": {
-    "System.Collections": "4.0.10",
-    "System.Collections.Concurrent": "4.0.10",
-    "System.Console": "4.0.0-rc2-23616",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.Diagnostics.Tracing": "4.0.20",
-    "System.Linq": "4.0.0",
-    "System.IO.FileSystem": "4.0.0",
-    "System.Reflection": "4.0.10",
-    "System.Runtime": "4.0.20",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Threading.Tasks": "4.0.10",
+    "NETStandard.Library": "1.0.0-rc2-23704", 
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "System.Reflection.Metadata": "1.0.22"
   },
   "frameworks": {
-    "dotnet": {}
-  }
+    "dnxcore50": { 
+       "imports": "portable-net451+win8"
+    }
+  },
 }

--- a/src/ILCompiler/desktop/project.json
+++ b/src/ILCompiler/desktop/project.json
@@ -1,30 +1,17 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.IO": "4.0.10",
-    "System.IO.FileSystem": "4.0.0",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.IO.MemoryMappedFiles": "4.0.0-rc2-23616",
-    "System.Collections": "4.0.10",
-    "System.Text.Encoding": "4.0.10",
-    "System.Runtime.InteropServices": "4.0.20",
-    "System.Reflection": "4.0.10",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Text.Encoding.Extensions": "4.0.10",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Console": "4.0.0-rc2-23616",
-    "System.AppContext": "4.0.0",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.1.0",
     "Microsoft.DiaSymReader": "1.0.6"
   },
   "frameworks": {
-    "net46": {}
+    "dnxcore50": { 
+        "imports": "portable-net451+win8"
+    }
   },
   "runtimes": {
-    "win-x64": {}
+    "win7-x64": {}
   }
 }

--- a/src/ILCompiler/repro/project.json
+++ b/src/ILCompiler/repro/project.json
@@ -1,20 +1,6 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.IO": "4.0.10",
-    "System.IO.FileSystem": "4.0.0",
-    "System.Collections": "4.0.0",
-    "System.Text.Encoding": "4.0.0",
-    "System.Runtime.InteropServices": "4.0.10",
-    "System.Reflection": "4.0.0",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.0",
-    "System.Text.Encoding.Extensions": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Console": "4.0.0-rc2-23616"
+    "NETStandard.Library": "1.0.0-rc2-23704"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -1,31 +1,13 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Reflection.Primitives": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.IO": "4.0.10",
-    "System.IO.FileSystem": "4.0.0",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.IO.MemoryMappedFiles": "4.0.0-rc2-23616",
-    "System.Collections": "4.0.10",
-    "System.Text.Encoding": "4.0.10",
-    "System.Runtime.InteropServices": "4.0.20",
-    "System.Reflection": "4.0.10",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Text.Encoding.Extensions": "4.0.10",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Console": "4.0.0-rc2-23616",
-    "System.AppContext": "4.0.0",
-    "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.1.0",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23616",
     "Microsoft.DotNet.RyuJit": "1.0.3-prerelease-00001",
     "Microsoft.DotNet.ObjectWriter": "1.0.4-prerelease-00001"
   },
   "frameworks": {
-    "dnxcore50": { },
-    "dotnet": {
+    "dnxcore50": {
       "imports": "portable-net452"
     }
   }

--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -186,6 +186,9 @@ if(WIN32)
     add_definitions(-DUNICODE=1)
     add_compile_options($<$<CONFIG:Debug>:-DDEBUG>)
     add_compile_options(/Zi) # enable debugging information
+    add_compile_options($<$<CONFIG:Debug>:/MTd>)
+    add_compile_options($<$<CONFIG:Release>:/MT>)
+    add_compile_options($<$<CONFIG:RelWithDefInfo>:/MT>)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /PDBCOMPRESS") #shrink pdb size
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG")
 else(WIN32)

--- a/src/System.Private.Reflection.Metadata/tests/project.json
+++ b/src/System.Private.Reflection.Metadata/tests/project.json
@@ -1,20 +1,13 @@
 {
   "dependencies": {
-    "System.Collections": "4.0.10",
-    "System.Console": "4.0.0-rc2-23616",
-    "System.Diagnostics.Debug": "4.0.10",
-    "System.Diagnostics.Tracing": "4.0.20",
-    "System.Linq": "4.0.0",
-    "System.IO.FileSystem": "4.0.0",
-    "System.Reflection": "4.0.10",
-    "System.Runtime": "4.0.20",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Threading.Tasks": "4.0.10",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "dotnet": {}
+    "net46": {},
+    "dnxcore50": { 
+        "imports": "portable-net451+win8"
+    }
   }
 }

--- a/src/packaging/buildtools/test-runtime/project.json
+++ b/src/packaging/buildtools/test-runtime/project.json
@@ -1,0 +1,27 @@
+{
+    "dependencies": {
+      "NETStandard.Library": "1.0.0-rc2-23704",
+      "Microsoft.NETCore.TestHost": "1.0.0-rc2-23704",
+      "Microsoft.NETCore.Console": "1.0.0-rc2-23704",
+      "System.IO.Compression": "4.1.0-rc2-23713",
+      "coveralls.io": "1.4",
+      "OpenCover": "4.6.166",
+      "ReportGenerator": "2.3.1",
+
+      "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0023",
+      "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0023",
+
+      "xunit": "2.1.0",
+      "xunit.console.netcore": "1.0.2-prerelease-00101",
+      "xunit.runner.utility": "2.1.0"
+    },
+    "frameworks": {
+       "dnxcore50": {
+         "imports": "portable-net45+win8"
+       }
+    },
+    "runtimes": {
+       "win7-x64": { },
+       "win7-x86": { }
+    }
+}

--- a/src/packaging/buildtools/tool-runtime/project.json
+++ b/src/packaging/buildtools/tool-runtime/project.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "NETStandard.Library": "1.0.0-rc2-23704",
+    "Microsoft.NETCore.TestHost": "1.0.0-beta-23328",
+    "Microsoft.Cci": "4.0.0-beta-23328",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-beta-23328",
+    "System.Diagnostics.TraceSource": "4.0.0-beta-23328",
+  },
+  "frameworks": {
+    "dnxcore50": { 
+      "imports": "portable-net45+win8"
+    },
+  },
+  "runtimes": {
+    "win7-x64": { },
+    "win7-x86": { },
+    "ubuntu.14.04-x64": { },
+    "osx.10.10-x64": { },
+  }
+}
+

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -19,7 +19,7 @@
         <!-- Property needed for creating nupkgs -->
         <PropertyGroup>
             <ToolchainMilestone Condition="'$(ToolchainMilestone)'==''">prerelease</ToolchainMilestone>
-            <ToolchainVersion>1.0.4-$(ToolchainMilestone)-00001</ToolchainVersion>
+            <ToolchainVersion>1.0.5-$(ToolchainMilestone)-00001</ToolchainVersion>
             <RuntimeSdkVersion>$(ToolchainVersion)</RuntimeSdkVersion>
             <NuPkgRid>$(NuPkgRuntimeOS)-$(NuPkgRuntimePlatform)</NuPkgRid>
             
@@ -85,41 +85,21 @@
             
             <!-- ILCompiler nuspec file -->
             <NuSpecFile Include="$(ToolchainPackageName)">
-                <Stage>0</Stage>
+                <Stage>1</Stage>
                 <Version>$(ToolchainVersion)</Version>
                 <Title>Microsoft .NET Native Toolchain</Title>
                 <Description>Provides the toolchain to compile managed code to native.</Description>
                 <Files>@(ILCompilerBinPlace -> '%(Text)', '')</Files>
                 <!-- TODO: Obtain this from project.lock.json -->
                 <Dependencies><![CDATA[
-        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
         <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.4-prerelease-00001" />
         <dependency id="Microsoft.DotNet.RyuJit" version="1.0.3-prerelease-00001" />
-        <dependency id="System.AppContext" version="4.0.0" />
-        <dependency id="System.Collections" version="4.0.10" />
-        <dependency id="System.Collections.Concurrent" version="4.0.10" />
+        <dependency id="NETStandard.Library" version="1.0.0-rc2-23704" />
         <dependency id="System.Collections.Immutable" version="1.1.37" />
-        <dependency id="System.Console" version="4.0.0-rc2-23616" />
-        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
-        <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
-        <dependency id="System.IO" version="4.0.10" />
-        <dependency id="System.IO.FileSystem" version="4.0.0" />
         <dependency id="System.IO.MemoryMappedFiles" version="4.0.0-rc2-23616" />
-        <dependency id="System.Linq" version="4.0.0" />
-        <dependency id="System.Reflection" version="4.0.10" />
-        <dependency id="System.Reflection.Extensions" version="4.0.0" />
         <dependency id="System.Reflection.Metadata" version="1.1.0" />
-        <dependency id="System.Reflection.Primitives" version="4.0.0" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.0" />
-        <dependency id="System.Runtime" version="4.0.20" />
-        <dependency id="System.Runtime.Extensions" version="4.0.10" />
-        <dependency id="System.Runtime.InteropServices" version="4.0.20" />
-        <dependency id="System.Text.Encoding" version="4.0.10" />
-        <dependency id="System.Text.Encoding.Extensions" version="4.0.10" />
-        <dependency id="System.Threading" version="4.0.10" />
-        <dependency id="System.Threading.Tasks" version="4.0.10" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.0" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0-beta-23504" />
+        <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
                     ]]></Dependencies>
             </NuSpecFile>
             
@@ -218,52 +198,6 @@
         <RemoveDir Directories="$(ProductPackageDir)" />
         <MakeDir Directories="$(ProductPackageDir)" Condition="!Exists('$(ProductPackageDir)')" />
 
-        <!-- =================== stage0 ==================== -->
-        <!-- Write the runtime.json redirection package and the runtime platform file -->
-        <WriteLinesToFile File="%(NuSpecCollection.RuntimeJsonFile)" Lines="%(NuSpecCollection.RuntimeJsonLines)" Overwrite="true" Condition="'%(NuSpecCollection.Stage)'=='0'" />
-        <WriteLinesToFile File="%(NuSpecCollection.PlatformFile)" Lines="%(NuSpecCollection.PlatformLines)" Overwrite="true" Condition="'%(NuSpecCollection.Stage)'=='0'" />
-        <WriteLinesToFile File="%(NuSpecCollection.RedirFile)" Lines="%(NuSpecCollection.RedirLines)" Overwrite="true" Condition="'%(NuSpecCollection.Stage)'=='0'" />
-
-        <ItemGroup>
-            <Stage0NuSpecs Include="%(NuSpecCollection.PlatformFile)" Condition="'%(NuSpecCollection.Stage)'=='0'"  />
-            <Stage0NuSpecs Include="%(NuSpecCollection.RedirFile)" Condition="'%(NuSpecCollection.Stage)'=='0'" />
-        </ItemGroup>
-
-        <Exec Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(Stage0NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -BasePath &quot;$(RepoPath)&quot; -OutputDirectory &quot;$(ProductPackageDir)&quot;" />
-
-        <PropertyGroup>
-            <Stage0ProjectDir>$(ProductPackageDir)stage0/</Stage0ProjectDir>
-            <Stage0PublishDir>$(ProductPackageDir)publish0/</Stage0PublishDir>
-            <Stage0ProjectJsonFile>$(Stage0ProjectDir)project.json</Stage0ProjectJsonFile>
-            <Stage0ProjectJsonLines><![CDATA[
-{
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true,
-    },
-
-    "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1-beta-23504",
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
-        "Microsoft.NETCore.TestHost": "1.0.0-beta-23504",
-        "toolchain.$(NuPkgRid).$(ToolchainPackageName)": "$(ToolchainVersion)",
-    },
-
-    "frameworks": {
-        "dnxcore50": { }
-    }
-}]]>
-            </Stage0ProjectJsonLines>
-        </PropertyGroup>
-        <MakeDir Directories="$(Stage0ProjectDir)" Condition="!Exists('$(Stage0ProjectDir)')" />
-        <WriteLinesToFile File="$(Stage0ProjectJsonFile)" Lines="$(Stage0ProjectJsonLines)" Overwrite="true" />
-        <WriteLinesToFile File="$(Stage0ProjectDir)/Program.cs" Lines="class Program { public static void Main() { } }" Overwrite="true" />
-        <Exec Command="&quot;$(DnuToolPath)&quot; restore -s &quot;$(ProductPackageDir)&quot; $(DnuRestoreSource) &quot;$(Stage0ProjectDir)&quot; --runtime &quot;$(NuPkgRid)&quot;" />
-        <Exec Command="&quot;$(DnuToolPath)&quot; publish &quot;$(Stage0ProjectDir)&quot; --native-subdirectory -o &quot;$(Stage0PublishDir)&quot; -f &quot;dnxcore50&quot; --runtime &quot;$(NuPkgRid)&quot;" />
-
-        <!-- =================== self-host ================= -->
-        <!-- Use stage0 ilc.exe/corerun to compile stage1 runtime libs -->
-
         <!-- =================== stage1 ==================== -->
         <!-- Write the runtime.json redirection package and the runtime platform file -->
         <WriteLinesToFile File="%(NuSpecCollection.RuntimeJsonFile)" Lines="%(NuSpecCollection.RuntimeJsonLines)" Overwrite="true" Condition="'%(NuSpecCollection.Stage)'=='1'" />
@@ -289,14 +223,15 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1-beta-23504",
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "Microsoft.NETCore.TestHost": "1.0.0-beta-23504",
         "toolchain.$(NuPkgRid).$(RuntimeSdkPackageName)": "$(RuntimeSdkVersion)",
     },
 
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": {
+            "imports": "portable-net451+win8"
+        }
     }
 }]]>
             </Stage1ProjectJsonLines>
@@ -304,7 +239,7 @@
         <MakeDir Directories="$(Stage1ProjectDir)" Condition="!Exists('$(Stage1ProjectDir)')" />
         <WriteLinesToFile File="$(Stage1ProjectJsonFile)" Lines="$(Stage1ProjectJsonLines)" Overwrite="true" />
         <WriteLinesToFile File="$(Stage1ProjectDir)/Program.cs" Lines="class Program { public static void Main() { } }" Overwrite="true" />
-        <Exec Command="&quot;$(DnuToolPath)&quot; restore -s &quot;$(ProductPackageDir)&quot; $(DnuRestoreSource) &quot;$(Stage1ProjectDir)&quot; --runtime &quot;$(NuPkgRid)&quot;" />
+        <Exec Command="&quot;$(DnuToolPath)&quot; restore --quiet -s &quot;$(ProductPackageDir)&quot; $(DnuRestoreSource) &quot;$(Stage1ProjectDir)&quot; --runtime &quot;$(NuPkgRid)&quot;" />
         <Exec Command="&quot;$(DnuToolPath)&quot; publish &quot;$(Stage1ProjectDir)&quot; --native-subdirectory -o &quot;$(Stage1PublishDir)&quot; -f &quot;dnxcore50&quot; --runtime &quot;$(NuPkgRid)&quot;" />
 
     </Target>

--- a/src/scripts/install-cli.ps1
+++ b/src/scripts/install-cli.ps1
@@ -4,8 +4,7 @@
 
 param (
     [string] $InstallDir = $null,
-    [string] $TargetPlatform = "x64",
-    [string] $Version = "Latest"
+    [string] $TargetPlatform = "x64"
 )
 
 # The below code is from dotnet/cli install.ps1
@@ -15,8 +14,8 @@ $ProgressPreference="SilentlyContinue"
 
 $Feed="https://dotnetcli.blob.core.windows.net/dotnet"
 $Channel="dev"
-$DotNetFileName="dotnet-win-" + $TargetPlatform + ".$Version.zip"
-$DotNetUrl="$Feed/$Channel/Binaries/$Version"
+$DotNetFileName="dotnet-win-" + $TargetPlatform + ".latest.zip"
+$DotNetUrl="$Feed/$Channel/Binaries/Latest"
 
 function say($str)
 {

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -71,7 +71,7 @@ for /f "delims=" %%a in ('dir /s /aD /b src\*') do (
     set __SourceFileName=%%~na
     set __RelativePath=!__SourceFolder:%CoreRT_TestRoot%=!
     if exist "!__SourceFolder!\project.json" (
-        %CoreRT_CliDir%\dotnet restore !__SourceFolder!
+        %CoreRT_CliDir%\dotnet restore --quiet !__SourceFolder!
 
         set __Mode=Jit
         call :CompileFile !__SourceFolder! !__SourceFileName! %__LogDir%\!__RelativePath!

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -23,7 +23,7 @@ runtest()
 
 restore()
 {
-    ${CoreRT_CliBinDir}/dotnet restore $1
+    ${CoreRT_CliBinDir}/dotnet restore --quiet $1
 }
 
 compiletest()

--- a/tests/src/Simple/Add1/project.json
+++ b/tests/src/Simple/Add1/project.json
@@ -5,8 +5,7 @@
     },
 
     "dependencies": {
-        "System.Console": "4.0.0-beta-*",
-        "System.Runtime": "4.0.21-beta-*"
+        "NETStandard.Library": "1.0.0-rc2-23704"
     },
 
     "frameworks": {

--- a/tests/src/Simple/Hello/project.json
+++ b/tests/src/Simple/Hello/project.json
@@ -5,8 +5,7 @@
     },
 
     "dependencies": {
-        "System.Console": "4.0.0-beta-*",
-        "System.Runtime": "4.0.21-beta-*"
+        "NETStandard.Library": "1.0.0-rc2-23704"
     },
 
     "frameworks": {

--- a/tests/src/Simple/Interfaces/project.json
+++ b/tests/src/Simple/Interfaces/project.json
@@ -5,8 +5,7 @@
     },
 
     "dependencies": {
-        "System.Console": "4.0.0-beta-*",
-        "System.Runtime": "4.0.21-beta-*"
+        "NETStandard.Library": "1.0.0-rc2-23704"
     },
 
     "frameworks": {


### PR DESCRIPTION
- Updated a bunch of project.json files to be compatible.
- Removed stage0 as no one is self-hosting right now and it just slows down builds.
- Specified overrides for msbuild tools since they still use old project.json syntax. Also removed it from default dotnet restoration.

@gkhanna79 PTAL.

Cc @anurse, @piotrpMSFT, @brthor, @Sridhar-MS -- NuGet broke us pretty bad, but with this PR we are back to using the latest CLI drops to make changes that are consumed in both the repos.