### PR TITLE
NetBSD: Fix build with forced casting pointer to function to void*

### DIFF
--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -717,7 +717,7 @@ void RedhawkGCInterface::ScanStackRoots(Thread *pThread, GcScanRootFunction pfnS
     sContext.m_pfnCallback = pfnScanCallback;
     sContext.m_pContext = pContext;
 
-    pThread->GcScanRoots(ScanRootsCallbackWrapper, &sContext);
+    pThread->GcScanRoots(reinterpret_cast<void*>(ScanRootsCallbackWrapper), &sContext);
 #else
     UNREFERENCED_PARAMETER(pThread);
     UNREFERENCED_PARAMETER(pfnScanCallback);
@@ -735,7 +735,7 @@ void RedhawkGCInterface::ScanStaticRoots(GcScanRootFunction pfnScanCallback, voi
     sContext.m_pfnCallback = pfnScanCallback;
     sContext.m_pContext = pContext;
 
-    GetRuntimeInstance()->EnumAllStaticGCRefs(ScanRootsCallbackWrapper, &sContext);
+    GetRuntimeInstance()->EnumAllStaticGCRefs(reinterpret_cast<void*>(ScanRootsCallbackWrapper), &sContext);
 #else
     UNREFERENCED_PARAMETER(pfnScanCallback);
     UNREFERENCED_PARAMETER(pContext);

--- a/src/Native/Runtime/gcrhscan.cpp
+++ b/src/Native/Runtime/gcrhscan.cpp
@@ -30,7 +30,7 @@
 
 void EnumAllStaticGCRefs(EnumGcRefCallbackFunc * fn, EnumGcRefScanContext * sc)
 {
-    GetRuntimeInstance()->EnumAllStaticGCRefs(fn, sc);
+    GetRuntimeInstance()->EnumAllStaticGCRefs(reinterpret_cast<void*>(fn), sc);
 }
 
 /*
@@ -65,7 +65,7 @@ VOID GCToEEInterface::GcScanRoots(EnumGcRefCallbackFunc * fn,  int condemned, in
 #if defined(FEATURE_EVENT_TRACE) && !defined(DACCESS_COMPILE)
             sc->dwEtwRootKind = kEtwGCRootKindStack;
 #endif
-            pThread->GcScanRoots(fn, sc);
+            pThread->GcScanRoots(reinterpret_cast<void*>(fn), sc);
 
 #if defined(FEATURE_EVENT_TRACE) && !defined(DACCESS_COMPILE)
             sc->dwEtwRootKind = kEtwGCRootKindOther;

--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -540,9 +540,9 @@ EXTERN_C void FASTCALL RhpGcProbeHijackByref();
 
 static void* NormalHijackTargets[3]     = 
 {
-    RhpGcProbeHijackScalar, // GCRK_Scalar = 0,
-    RhpGcProbeHijackObject, // GCRK_Object  = 1,
-    RhpGcProbeHijackByref   // GCRK_Byref  = 2,
+    reinterpret_cast<void*>(RhpGcProbeHijackScalar), // GCRK_Scalar = 0,
+    reinterpret_cast<void*>(RhpGcProbeHijackObject), // GCRK_Object  = 1,
+    reinterpret_cast<void*>(RhpGcProbeHijackByref)   // GCRK_Byref  = 2,
 };
 
 #ifdef FEATURE_GC_STRESS
@@ -552,9 +552,9 @@ EXTERN_C void FASTCALL RhpGcStressHijackByref();
 
 static void* GcStressHijackTargets[3]   = 
 { 
-    RhpGcStressHijackScalar, // GCRK_Scalar = 0,
-    RhpGcStressHijackObject, // GCRK_Object  = 1,
-    RhpGcStressHijackByref   // GCRK_Byref  = 2,
+    reinterpret_cast<void*>(RhpGcStressHijackScalar), // GCRK_Scalar = 0,
+    reinterpret_cast<void*>(RhpGcStressHijackObject), // GCRK_Object  = 1,
+    reinterpret_cast<void*>(RhpGcStressHijackByref)   // GCRK_Byref  = 2,
 };
 #endif // FEATURE_GC_STRESS
 

--- a/src/Native/gc/env/gcenv.interlocked.inl
+++ b/src/Native/gc/env/gcenv.interlocked.inl
@@ -193,7 +193,7 @@ __forceinline T Interlocked::CompareExchangePointer(T volatile *destination, T e
     return (T)(TADDR)_InterlockedCompareExchange((long volatile *)(void* volatile *)destination, (long)(void*)exchange, (long)(void*)comparand);
 #endif
 #else
-    return (T)(TADDR)__sync_val_compare_and_swap((void* volatile *)destination, comparand, exchange);
+    return (T)(TADDR)__sync_val_compare_and_swap((void* volatile *)destination, (void*)comparand, (void*)exchange);
 #endif
 }
 

--- a/src/Native/gc/env/gcenv.interlocked.inl
+++ b/src/Native/gc/env/gcenv.interlocked.inl
@@ -188,7 +188,7 @@ __forceinline T Interlocked::CompareExchangePointer(T volatile *destination, T e
 {
 #ifdef _MSC_VER
 #ifdef BIT64
-    return (T)(TADDR)_InterlockedCompareExchangePointer((void* volatile *)destination, exchange, comparand);
+    return (T)(TADDR)_InterlockedCompareExchangePointer((void* volatile *)destination, (void*)exchange, (void*)comparand);
 #else
     return (T)(TADDR)_InterlockedCompareExchange((long volatile *)(void* volatile *)destination, (long)(void*)exchange, (long)(void*)comparand);
 #endif


### PR DESCRIPTION
Normally it's illegal to cast pointer to function to pointer to data.
With assumption that we know what we are doing enforce it with
`reinterpret_cast<void*>()`.

This closes #718 "Clash with pointers to data and pointers to functions"
Thanks to Kyungwoo Lee (Microsoft) and Jan Kotas (Microsoft) for help.