### PR TITLE
NetBSD: Include <cstdarg> for va_list, va_start

### DIFF
--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -33,6 +33,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/time.h>
+#include <cstdarg>
 
 #if !HAVE_SYSCONF && !HAVE_SYSCTL
 #error Neither sysconf nor sysctl is present on the current system


### PR DESCRIPTION
```
NAME
     stdarg, va_arg, va_copy, va_end, va_start - variable argument lists

SYNOPSIS
     #include <stdarg.h>

     void
     va_start(va_list ap, last);

     type
     va_arg(va_list ap, type);

     void
     va_copy(va_list dest, va_list src);

     void
     va_end(va_list ap);

STANDARDS
     The va_start(), va_arg(), va_copy(), and va_end() macros conform to
     ISO/IEC 9899:1999 (``ISO C99'').

HISTORY
     The va_start(), va_arg() and va_end() macros were introduced in ANSI
     X3.159-1989 (``ANSI C89'').  The va_copy() macro was introduced in
     ISO/IEC 9899:1999 (``ISO C99'')
```