### PR TITLE
NetBSD: Fix build adding const to the 2nd parameter of iconv(3)

### DIFF
--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -334,7 +334,7 @@ int UTF8ToWideChar(const char* bytes, int len, wchar_t* buffer, int bufLen)
     size_t inbufbytesleft = len;
     size_t outbufbytesleft = bufLen;
 
-    int rc = iconv(cd, &inbuf, &inbufbytesleft, &outbuf, &outbufbytesleft);
+    int rc = iconv(cd, const_cast<const char **>(&inbuf), &inbufbytesleft, &outbuf, &outbufbytesleft);
     if (rc == -1)
     {
         fprintf(stderr, "iconv_open failed with %d\n", errno);
@@ -360,7 +360,7 @@ int WideCharToUTF8(const wchar_t* chars, int len, char* buffer, int bufLen)
     size_t inbufbytesleft = len;
     size_t outbufbytesleft = bufLen;
 
-    int rc = iconv(cd, &inbuf, &inbufbytesleft, &outbuf, &outbufbytesleft);
+    int rc = iconv(cd, const_cast<const char **>(&inbuf), &inbufbytesleft, &outbuf, &outbufbytesleft);
     if (rc == -1)
     {
         fprintf(stderr, "iconv_open failed with %d\n", errno);


### PR DESCRIPTION
```
NAME
     iconv_open, iconv_close, iconv - codeset conversion functions

LIBRARY
     Standard C Library (libc, -lc)

SYNOPSIS
     #include <iconv.h>

     iconv_t
     iconv_open(const char *dstname, const char *srcname);

     int
     iconv_close(iconv_t cd);

     size_t
     iconv(iconv_t cd, const char ** restrict src, size_t * restrict srcleft,
         char ** restrict dst, size_t * restrict dstleft);
```