### PR TITLE
Add abstraction for string encoding of the underlying OS to GCToOSInterface

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -183,6 +183,7 @@ if(WIN32)
     if(IS_64BIT_BUILD)
         add_definitions(-D_WIN64=1)
     endif()
+    add_definitions(-DUNICODE=1)
     add_compile_options($<$<CONFIG:Debug>:-DDEBUG>)
     add_compile_options(/Zi) # enable debugging information
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /PDBCOMPRESS") #shrink pdb size

--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -38,6 +38,8 @@
 // we have to (in which case these definitions will move to CommonTypes.h).
 typedef WCHAR *             LPWSTR;
 typedef const WCHAR *       LPCWSTR;
+typedef char *              LPSTR;
+typedef const char *        LPCSTR;
 typedef void *              HINSTANCE;
 
 typedef void *              LPSECURITY_ATTRIBUTES;
@@ -691,7 +693,7 @@ REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalGetThreadContext(HANDLE hThread, _Out_ 
 
 REDHAWK_PALIMPORT Int32 REDHAWK_PALAPI PalGetProcessCpuCount();
 
-REDHAWK_PALIMPORT UInt32 REDHAWK_PALAPI PalReadFileContents(_In_ const WCHAR *, _Out_ char * buff, _In_ UInt32 maxBytesToRead);
+REDHAWK_PALIMPORT UInt32 REDHAWK_PALAPI PalReadFileContents(_In_ const TCHAR *, _Out_ char * buff, _In_ UInt32 maxBytesToRead);
 
 // Retrieves the entire range of memory dedicated to the calling thread's stack.  This does
 // not get the current dynamic bounds of the stack, which can be significantly smaller than 
@@ -810,9 +812,15 @@ REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalAllocateThunksFromTemplate(_In_ 
 
 REDHAWK_PALIMPORT UInt32 REDHAWK_PALAPI PalCompatibleWaitAny(UInt32_BOOL alertable, UInt32 timeout, UInt32 count, HANDLE* pHandles, UInt32_BOOL allowReentrantWait);
 
-#ifndef _MSC_VER
-REDHAWK_PALIMPORT Int32 __cdecl _wcsicmp(const wchar_t *string1, const wchar_t *string2);
-#endif // _MSC_VER
+#ifdef PLATFORM_UNIX
+REDHAWK_PALIMPORT Int32 __cdecl _stricmp(const char *string1, const char *string2);
+#endif // PLATFORM_UNIX
+
+#ifdef UNICODE
+#define _tcsicmp _wcsicmp
+#else
+#define _tcsicmp _stricmp
+#endif
 
 #include "PalRedhawkInline.h"
 

--- a/src/Native/Runtime/PalRedhawkFunctions.h
+++ b/src/Native/Runtime/PalRedhawkFunctions.h
@@ -111,11 +111,19 @@ inline UInt32 PalGetCurrentThreadId()
     return GetCurrentThreadId();
 }
 
+#ifdef UNICODE
 extern "C" UInt32 __stdcall GetEnvironmentVariableW(LPCWSTR, LPWSTR, UInt32);
-inline UInt32 PalGetEnvironmentVariableW(LPCWSTR arg1, LPWSTR arg2, UInt32 arg3)
+inline UInt32 PalGetEnvironmentVariable(LPCWSTR arg1, LPWSTR arg2, UInt32 arg3)
 {
     return GetEnvironmentVariableW(arg1, arg2, arg3);
 }
+#else
+extern "C" UInt32 __stdcall GetEnvironmentVariableA(LPCSTR, LPSTR, UInt32);
+inline UInt32 PalGetEnvironmentVariable(LPCSTR arg1, LPSTR arg2, UInt32 arg3)
+{
+    return GetEnvironmentVariableA(arg1, arg2, arg3);
+}
+#endif
 
 extern "C" UInt32 __stdcall GetLastError();
 inline UInt32 PalGetLastError()

--- a/src/Native/Runtime/Profiling.cpp
+++ b/src/Native/Runtime/Profiling.cpp
@@ -80,7 +80,7 @@ void RuntimeInstance::WriteProfileInfo()
             else
                 basicName += 1; // skip past the '\'
             size_t basicNameLength = wcslen(basicName);
-            size_t dirNameLength = PalGetEnvironmentVariableW(L"LOCALAPPDATA", profileName, MAX_PATH);
+            size_t dirNameLength = PalGetEnvironmentVariable(L"LOCALAPPDATA", profileName, MAX_PATH);
 
             // make sure the names are not so long as to cause trouble
             const size_t MAX_SAFE_LENGTH = MAX_PATH - 50;

--- a/src/Native/Runtime/RhConfig.cpp
+++ b/src/Native/Runtime/RhConfig.cpp
@@ -27,15 +27,15 @@
 
 #include <string.h>
 
-UInt32 RhConfig::ReadConfigValue(_In_z_ const WCHAR *wszName, UInt32 uiDefaultValue)
+UInt32 RhConfig::ReadConfigValue(_In_z_ const TCHAR *wszName, UInt32 uiDefaultValue)
 {
-    WCHAR wszBuffer[CONFIG_VAL_MAXLEN + 1]; // 8 hex digits plus a nul terminator.
+    TCHAR wszBuffer[CONFIG_VAL_MAXLEN + 1]; // 8 hex digits plus a nul terminator.
     const UInt32 cchBuffer = sizeof(wszBuffer) / sizeof(wszBuffer[0]);
 
     UInt32 cchResult = 0;
 
 #ifdef RH_ENVIRONMENT_VARIABLE_CONFIG_ENABLED
-    cchResult = PalGetEnvironmentVariableW(wszName, wszBuffer, cchBuffer);
+    cchResult = PalGetEnvironmentVariable(wszName, wszBuffer, cchBuffer);
 #endif // RH_ENVIRONMENT_VARIABLE_CONFIG_ENABLED
 
     //if the config key wasn't found in the environment 
@@ -51,13 +51,13 @@ UInt32 RhConfig::ReadConfigValue(_In_z_ const WCHAR *wszName, UInt32 uiDefaultVa
     {
         uiResult <<= 4;
 
-        WCHAR ch = wszBuffer[i];
-        if ((ch >= L'0') && (ch <= L'9'))
-            uiResult += ch - L'0';
-        else if ((ch >= L'a') && (ch <= L'f'))
-            uiResult += (ch - L'a') + 10;
-        else if ((ch >= L'A') && (ch <= L'F'))
-            uiResult += (ch - L'A') + 10;
+        TCHAR ch = wszBuffer[i];
+        if ((ch >= _T('0')) && (ch <= _T('9')))
+            uiResult += ch - _T('0');
+        else if ((ch >= _T('a')) && (ch <= _T('f')))
+            uiResult += (ch - _T('a')) + 10;
+        else if ((ch >= _T('A')) && (ch <= _T('F')))
+            uiResult += (ch - _T('A')) + 10;
         else
             return uiDefaultValue; // parse error, return default
     }
@@ -70,7 +70,7 @@ UInt32 RhConfig::ReadConfigValue(_In_z_ const WCHAR *wszName, UInt32 uiDefaultVa
 //if the file is not avaliable, or unreadable zero will always be returned
 //cchOuputBuffer is the maximum number of characters to write to outputBuffer
 //cchOutputBuffer must be a size >= CONFIG_VAL_MAXLEN + 1
-UInt32 RhConfig::GetIniVariable(_In_z_ const WCHAR* configName, _Out_writes_all_(cchBuff) WCHAR* outputBuffer, _In_ UInt32 cchOuputBuffer)
+UInt32 RhConfig::GetIniVariable(_In_z_ const TCHAR* configName, _Out_writes_all_(cchBuff) TCHAR* outputBuffer, _In_ UInt32 cchOuputBuffer)
 {
     //the buffer needs to be big enough to read the value buffer + null terminator
     if (cchOuputBuffer < CONFIG_VAL_MAXLEN + 1)
@@ -93,7 +93,7 @@ UInt32 RhConfig::GetIniVariable(_In_z_ const WCHAR* configName, _Out_writes_all_
     //find the first name which matches (case insensitive to be compat with environment variable counterpart)
     for (int iSettings = 0; iSettings < RCV_Count; iSettings++)
     {
-        if (_wcsicmp(configName, ((ConfigPair*)g_iniSettings)[iSettings].Key) == 0)
+        if (_tcsicmp(configName, ((ConfigPair*)g_iniSettings)[iSettings].Key) == 0)
         {
             bool nullTerm = FALSE;
 
@@ -127,7 +127,7 @@ void RhConfig::ReadConfigIni()
 {
     if (g_iniSettings == NULL)
     {
-        WCHAR* configPath = GetConfigPath();
+        TCHAR* configPath = GetConfigPath();
 
         //if we couldn't determine the path to the config set g_iniSettings to CONGIF_NOT_AVAIL
         if (configPath == NULL)
@@ -219,15 +219,19 @@ void RhConfig::ReadConfigIni()
 }
 
 //returns the path to the runtime configuration ini
-_Ret_maybenull_z_ WCHAR* RhConfig::GetConfigPath()
+_Ret_maybenull_z_ TCHAR* RhConfig::GetConfigPath()
 {
-
-    WCHAR* exePathBuff;
+    TCHAR* exePathBuff;
 
     //get the path to rhconfig.ini, this file is expected to live along side the app 
     //to build the path get the process executable module full path strip off the file name and 
     //append rhconfig.ini
+#ifdef PLATFORM_UNIX
+    // UNIXTODO: Implement RhConfig::GetConfigPath!
+    Int32 pathLen = 0; exePathBuff = NULL;
+#else
     Int32 pathLen = PalGetModuleFileName(&exePathBuff, NULL);
+#endif
 
     if (pathLen <= 0)
     {
@@ -249,7 +253,7 @@ _Ret_maybenull_z_ WCHAR* RhConfig::GetConfigPath()
         return NULL;
     }
 
-    WCHAR* configPath = new (nothrow) WCHAR[iLastBackslash + 1 + wcslen(CONFIG_INI_FILENAME) + 1];
+    TCHAR* configPath = new (nothrow) TCHAR[iLastBackslash + 1 + wcslen(CONFIG_INI_FILENAME) + 1];
     if (configPath != NULL)
     {
         //copy the path base and file name

--- a/src/Native/Runtime/RhConfig.h
+++ b/src/Native/Runtime/RhConfig.h
@@ -37,8 +37,8 @@ private:
     struct ConfigPair
     {
     public:
-        WCHAR Key[CONFIG_KEY_MAXLEN + 1];  //maxlen + null terminator
-        WCHAR Value[CONFIG_VAL_MAXLEN + 1]; //maxlen + null terminator
+        TCHAR Key[CONFIG_KEY_MAXLEN + 1];  //maxlen + null terminator
+        TCHAR Value[CONFIG_VAL_MAXLEN + 1]; //maxlen + null terminator
     };
 
     //g_iniSettings is a buffer of ConfigPair structs which when initialized is of length RCV_Count
@@ -61,7 +61,7 @@ public:
     {                                                   \
         if (m_uiConfigValuesRead & (1 << RCV_##_name))  \
             return m_uiConfigValues[RCV_##_name];       \
-        UInt32 uiValue = ReadConfigValue(L"RH_" L ## #_name, defaultVal); \
+        UInt32 uiValue = ReadConfigValue(_T("RH_") _T(#_name), defaultVal); \
         m_uiConfigValues[RCV_##_name] = uiValue;        \
         m_uiConfigValuesRead |= 1 << RCV_##_name;       \
         return uiValue;                                 \
@@ -85,7 +85,7 @@ public:
 
 private:
 
-    UInt32 ReadConfigValue(_In_z_ const WCHAR *wszName, UInt32 uiDefault);
+    UInt32 ReadConfigValue(_In_z_ const TCHAR *wszName, UInt32 uiDefault);
 
     enum RhConfigValue
     {
@@ -105,7 +105,7 @@ private:
 #define CONFIG_FILE_MAXLEN RCV_Count * sizeof(ConfigPair) + 2000  
 
 private:
-    _Ret_maybenull_z_ WCHAR* GetConfigPath();
+    _Ret_maybenull_z_ TCHAR* GetConfigPath();
 
     //Parses one line of rhconfig.ini and populates values in the passed in configPair
     //returns: true if the parsing was successful, false if the parsing failed. 
@@ -122,7 +122,7 @@ private:
     //lazily reads the file so if the file is not yet read, it will read it on first called
     //if the file is not avaliable, or unreadable zero will always be returned
     //cchOuputBuffer is the maximum number of characters to write to outputBuffer
-    UInt32 GetIniVariable(_In_z_ const WCHAR* configName, _Out_writes_all_(cchBuff) WCHAR* outputBuffer, _In_ UInt32 cchOuputBuffer);
+    UInt32 GetIniVariable(_In_z_ const TCHAR* configName, _Out_writes_all_(cchBuff) TCHAR* outputBuffer, _In_ UInt32 cchOuputBuffer);
 
     static bool priv_isspace(char c)
     {

--- a/src/Native/Runtime/gcenv.h
+++ b/src/Native/Runtime/gcenv.h
@@ -9,9 +9,6 @@
 #pragma warning( disable: 4127 )  // conditional expression is constant -- common in GC
 #endif
 
-typedef wchar_t WCHAR;
-#define W(str) L##str
-
 #include "sal.h"
 #include "gcenv.structs.h"
 #include "gcenv.os.h"
@@ -75,7 +72,7 @@ public:
         return m_Length;
     }
 
-    static SIZE_T GetOffsetOfNumComponents()
+    static size_t GetOffsetOfNumComponents()
     {
         return offsetof(ArrayBase, m_Length);
     }

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -803,8 +803,8 @@ UInt32 RedhawkGCInterface::GetGCDescSize(void * pType)
 
 COOP_PINVOKE_HELPER(void, RhpCopyObjectContents, (Object* pobjDest, Object* pobjSrc))
 {
-    SIZE_T cbDest = pobjDest->GetSize() - sizeof(ObjHeader);
-    SIZE_T cbSrc = pobjSrc->GetSize() - sizeof(ObjHeader);
+    size_t cbDest = pobjDest->GetSize() - sizeof(ObjHeader);
+    size_t cbSrc = pobjSrc->GetSize() - sizeof(ObjHeader);
     if (cbSrc != cbDest)
         return;
 
@@ -830,9 +830,9 @@ COOP_PINVOKE_HELPER(void, RhpBox, (Object * pObj, void * pData))
     // cbObject includes ObjHeader (sync block index) and the EEType* field from Object and is rounded up to
     // suit GC allocation alignment requirements. cbFields on the other hand is just the raw size of the field
     // data.
-    SIZE_T cbFieldPadding = pEEType->get_ValueTypeFieldPadding();
-    SIZE_T cbObject = pEEType->get_BaseSize();
-    SIZE_T cbFields = cbObject - (sizeof(ObjHeader) + sizeof(EEType*) + cbFieldPadding);
+    size_t cbFieldPadding = pEEType->get_ValueTypeFieldPadding();
+    size_t cbObject = pEEType->get_BaseSize();
+    size_t cbFields = cbObject - (sizeof(ObjHeader) + sizeof(EEType*) + cbFieldPadding);
     
     UInt8 * pbFields = (UInt8*)pObj + sizeof(EEType*);
 
@@ -861,8 +861,8 @@ COOP_PINVOKE_HELPER(void, RhUnbox, (Object * pObj, void * pData, EEType * pUnbox
 
         // Clear the value (in case there were GC references we wish to stop reporting).
         EEType * pEEType = pUnboxToEEType->GetNullableType();
-        SIZE_T cbFieldPadding = pEEType->get_ValueTypeFieldPadding();
-        SIZE_T cbFields = pEEType->get_BaseSize() - (sizeof(ObjHeader) + sizeof(EEType*) + cbFieldPadding);
+        size_t cbFieldPadding = pEEType->get_ValueTypeFieldPadding();
+        size_t cbFields = pEEType->get_BaseSize() - (sizeof(ObjHeader) + sizeof(EEType*) + cbFieldPadding);
         GCSafeZeroMemory((UInt8*)pData + pUnboxToEEType->GetNullableValueOffset(), cbFields);
 
         return;
@@ -887,8 +887,8 @@ COOP_PINVOKE_HELPER(void, RhUnbox, (Object * pObj, void * pData, EEType * pUnbox
         pData = (UInt8*)pData + pUnboxToEEType->GetNullableValueOffset();
     }
 
-    SIZE_T cbFieldPadding = pEEType->get_ValueTypeFieldPadding();
-    SIZE_T cbFields = pEEType->get_BaseSize() - (sizeof(ObjHeader) + sizeof(EEType*) + cbFieldPadding);
+    size_t cbFieldPadding = pEEType->get_ValueTypeFieldPadding();
+    size_t cbFields = pEEType->get_BaseSize() - (sizeof(ObjHeader) + sizeof(EEType*) + cbFieldPadding);
     UInt8 * pbFields = (UInt8*)pObj + sizeof(EEType*);
 
     if (pEEType->HasReferenceFields())
@@ -1339,7 +1339,7 @@ void StompWriteBarrierResize(bool /*bReqUpperBoundsCheck*/)
 {
 }
 
-VOID LogSpewAlways(const char * /*fmt*/, ...)
+void LogSpewAlways(const char * /*fmt*/, ...)
 {
 }
 
@@ -1371,7 +1371,7 @@ uint32_t CLRConfig::GetConfigValue(ConfigDWORDInfo eType)
     }
 }
 
-HRESULT CLRConfig::GetConfigValue(ConfigStringInfo /*eType*/, wchar_t * * outVal)
+HRESULT CLRConfig::GetConfigValue(ConfigStringInfo /*eType*/, TCHAR * * outVal)
 {
     *outVal = NULL;
     return 0;

--- a/src/Native/Runtime/gcrhscan.cpp
+++ b/src/Native/Runtime/gcrhscan.cpp
@@ -37,7 +37,7 @@ void EnumAllStaticGCRefs(EnumGcRefCallbackFunc * fn, EnumGcRefScanContext * sc)
  * Scan all stack and statics roots
  */
  
-VOID GCToEEInterface::GcScanRoots(EnumGcRefCallbackFunc * fn,  int condemned, int max_gen, EnumGcRefScanContext * sc)
+void GCToEEInterface::GcScanRoots(EnumGcRefCallbackFunc * fn,  int condemned, int max_gen, EnumGcRefScanContext * sc)
 {
     // STRESS_LOG1(LF_GCROOTS, LL_INFO10, "GCScan: Phase = %s\n", sc->promotion ? "promote" : "relocate");
 

--- a/src/Native/Runtime/windows/PalRedhawkCommon.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkCommon.cpp
@@ -291,7 +291,7 @@ REDHAWK_PALEXPORT Int32 PalGetProcessCpuCount()
 //Reads the entire contents of the file into the specified buffer, buff
 //returns the number of bytes read if the file is successfully read
 //returns 0 if the file is not found, size is greater than maxBytesToRead or the file couldn't be opened or read
-REDHAWK_PALEXPORT UInt32 PalReadFileContents(_In_z_ WCHAR* fileName, _Out_writes_all_(cchBuff) char* buff, _In_ UInt32 cchBuff)
+REDHAWK_PALEXPORT UInt32 PalReadFileContents(_In_z_ TCHAR* fileName, _Out_writes_all_(cchBuff) char* buff, _In_ UInt32 cchBuff)
 {
     WIN32_FILE_ATTRIBUTE_DATA attrData;
 

--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -1336,22 +1336,20 @@ uint32_t GCToOSInterface::GetLogicalCpuCount()
     return g_cLogicalCpus;
 }
 
-bool __SwitchToThread(uint32_t dwSleepMSec, uint32_t dwSwitchCount);
-
 // Causes the calling thread to sleep for the specified number of milliseconds
 // Parameters:
 //  sleepMSec   - time to sleep before switching to another thread
 void GCToOSInterface::Sleep(uint32_t sleepMSec)
 {
-    __SwitchToThread(sleepMSec, 0);
+    PalSleep(sleepMSec);
 }
 
 // Causes the calling thread to yield execution to another thread that is ready to run on the current processor.
 // Parameters:
 //  switchCount - number of times the YieldThread was called in a loop
-void GCToOSInterface::YieldThread(uint32_t switchCount)
+void GCToOSInterface::YieldThread(uint32_t /*switchCount*/)
 {
-    __SwitchToThread(0, switchCount);
+    PalSwitchToThread();
 }
 
 // Reserve virtual memory range.
@@ -1645,17 +1643,6 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     CloseHandle(gc_thread);
 
     return true;
-}
-
-// Open a file
-// Parameters:
-//  filename - name of the file to open
-//  mode     - mode to open the file in (like in the CRT fopen)
-// Return:
-//  FILE* of the opened file
-FILE* GCToOSInterface::OpenFile(const WCHAR* filename, const WCHAR* mode)
-{
-    return _wfopen(filename, mode);
 }
 
 // Initialize the critical section

--- a/src/Native/gc/env/common.h
+++ b/src/Native/gc/env/common.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 #include <wchar.h>
 #include <assert.h>
 #include <stdarg.h>

--- a/src/Native/gc/env/gcenv.base.h
+++ b/src/Native/gc/env/gcenv.base.h
@@ -37,18 +37,6 @@
 typedef uint32_t BOOL;
 typedef uint32_t DWORD;
 typedef void* LPVOID;
-typedef uint32_t UINT;
-typedef int32_t LONG;
-typedef uintptr_t ULONG_PTR;
-typedef void VOID;
-typedef void* PVOID;
-typedef void * LPSECURITY_ATTRIBUTES;
-typedef void const * LPCVOID;
-typedef wchar_t * PWSTR, *LPWSTR;
-typedef const wchar_t *LPCWSTR, *PCWSTR;
-typedef size_t SIZE_T;
-
-typedef void * HANDLE;
 
 // -----------------------------------------------------------------------------------------------------------
 // HRESULT subset.
@@ -113,6 +101,18 @@ inline HRESULT HRESULT_FROM_WIN32(unsigned long x)
 #define swprintf_s swprintf
 #endif
 
+#ifdef UNICODE
+#define _tcslen wcslen
+#define _tcscpy wcscpy
+#define _stprintf_s swprintf_s
+#define _tfopen _wfopen
+#else
+#define _tcslen strlen
+#define _tcscpy strcpy
+#define _stprintf_s sprintf_s
+#define _tfopen fopen
+#endif
+
 #define WINAPI __stdcall
 
 typedef DWORD (WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
@@ -141,14 +141,14 @@ typedef DWORD (WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
 
  #elif defined(_AMD64_)
   
-  extern "C" VOID
+  extern "C" void
   _mm_pause (
-      VOID
+      void
       );
   
-  extern "C" VOID
+  extern "C" void
   _mm_mfence (
-      VOID
+      void
       );
   
   #pragma intrinsic(_mm_pause)
@@ -530,7 +530,7 @@ namespace ETW
 
 #define LOG(x)
 
-VOID LogSpewAlways(const char *fmt, ...);
+void LogSpewAlways(const char *fmt, ...);
 
 #define LL_INFO10 4
 
@@ -581,7 +581,7 @@ public:
     typedef CLRConfigTypes ConfigStringInfo;
 
     static uint32_t GetConfigValue(ConfigDWORDInfo eType);
-    static HRESULT GetConfigValue(ConfigStringInfo /*eType*/, wchar_t * * outVal);
+    static HRESULT GetConfigValue(ConfigStringInfo /*eType*/, TCHAR * * outVal);
 };
 
 inline bool FitsInU1(uint64_t val)

--- a/src/Native/gc/env/gcenv.os.h
+++ b/src/Native/gc/env/gcenv.os.h
@@ -257,18 +257,6 @@ public:
     // Return:
     //  Time stamp in milliseconds
     static uint32_t GetLowPrecisionTimeStamp();
-
-    //
-    // File
-    //
-
-    // Open a file
-    // Parameters:
-    //  filename - name of the file to open
-    //  mode     - mode to open the file in (like in the CRT fopen)
-    // Return:
-    //  FILE* of the opened file
-    static FILE* OpenFile(const WCHAR* filename, const WCHAR* mode);
 };
 
 #endif // __GCENV_OS_H__

--- a/src/Native/gc/env/gcenv.structs.h
+++ b/src/Native/gc/env/gcenv.structs.h
@@ -33,6 +33,20 @@ typedef void * HANDLE;
 
 #ifdef PLATFORM_UNIX
 
+typedef char TCHAR;
+#define _T(s) s
+
+#else
+
+#ifndef _INC_WINDOWS
+typedef wchar_t TCHAR;
+#define _T(s) L##s
+#endif
+
+#endif
+
+#ifdef PLATFORM_UNIX
+
 class EEThreadId
 {
     pthread_t m_id;

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -168,7 +168,7 @@ size_t GetHighPrecisionTimeStamp()
 GCStatistics g_GCStatistics;
 GCStatistics g_LastGCStatistics;
 
-WCHAR* GCStatistics::logFileName = NULL;
+TCHAR* GCStatistics::logFileName = NULL;
 FILE*  GCStatistics::logFile = NULL;
 
 void GCStatistics::AddGCStats(const gc_mechanisms& settings, size_t timeInMSec)
@@ -9507,21 +9507,22 @@ void gc_heap::adjust_ephemeral_limits ()
 FILE* CreateLogFile(const CLRConfig::ConfigStringInfo & info, BOOL is_config)
 {
     FILE* logFile;
-    LPWSTR  temp_logfile_name = NULL;
+    TCHAR * temp_logfile_name = NULL;
     CLRConfig::GetConfigValue(info, &temp_logfile_name);
 
-    WCHAR logfile_name[MAX_LONGPATH+1];
+    TCHAR logfile_name[MAX_LONGPATH+1];
     if (temp_logfile_name != 0)
     {
-        wcscpy(logfile_name, temp_logfile_name);
+        _tcscpy(logfile_name, temp_logfile_name);
     }
 
-    size_t logfile_name_len = wcslen(logfile_name);
-    WCHAR* szPid = logfile_name + logfile_name_len;
+    size_t logfile_name_len = _tcslen(logfile_name);
+    TCHAR* szPid = logfile_name + logfile_name_len;
     size_t remaining_space = MAX_LONGPATH + 1 - logfile_name_len;
-    swprintf_s(szPid, remaining_space, W(".%d%s"), GCToOSInterface::GetCurrentProcessId(), (is_config ? W(".config.log") : W(".log")));
 
-    logFile = GCToOSInterface::OpenFile(logfile_name, W("wb"));
+    _stprintf_s(szPid, remaining_space, _T(".%d%s"), GCToOSInterface::GetCurrentProcessId(), (is_config ? _T(".config.log") : _T(".log")));
+
+    logFile = _tfopen(logfile_name, _T("wb"));
 
     delete temp_logfile_name;
 
@@ -9614,9 +9615,8 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
     GCStatistics::logFileName = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_GCMixLog);
     if (GCStatistics::logFileName != NULL)
     {
-        GCStatistics::logFile = GCToOSInterface::OpenFile((LPCWSTR)GCStatistics::logFileName, W("a"));
+        GCStatistics::logFile = _tfopen(GCStatistics::logFileName, T("a"));
     }
-
 #endif // GC_STATS
 
     HRESULT hres = S_OK;

--- a/src/Native/gc/gcpriv.h
+++ b/src/Native/gc/gcpriv.h
@@ -611,7 +611,7 @@ struct GCStatistics
     : public StatisticsBase
 {
     // initialized to the contents of COMPLUS_GcMixLog, or NULL, if not present
-    static WCHAR* logFileName;
+    static TCHAR* logFileName;
     static FILE*  logFile;
 
     // number of times we executed a background GC, a foreground GC, or a

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -250,7 +250,7 @@ void StompWriteBarrierResize(bool /*bReqUpperBoundsCheck*/)
 {
 }
 
-VOID LogSpewAlways(const char * /*fmt*/, ...)
+void LogSpewAlways(const char * /*fmt*/, ...)
 {
 }
 
@@ -282,7 +282,7 @@ uint32_t CLRConfig::GetConfigValue(ConfigDWORDInfo eType)
     }
 }
 
-HRESULT CLRConfig::GetConfigValue(ConfigStringInfo /*eType*/, wchar_t * * outVal)
+HRESULT CLRConfig::GetConfigValue(ConfigStringInfo /*eType*/, TCHAR * * outVal)
 {
     *outVal = NULL;
     return 0;

--- a/src/Native/gc/sample/gcenv.h
+++ b/src/Native/gc/sample/gcenv.h
@@ -16,9 +16,6 @@
 #define _ASSERTE(_expr) ASSERT(_expr)
 #endif
 
-typedef wchar_t WCHAR;
-#define W(s) L##s
-
 #include "gcenv.structs.h"
 #include "gcenv.base.h"
 #include "gcenv.ee.h"

--- a/src/Native/gc/sample/gcenv.windows.cpp
+++ b/src/Native/gc/sample/gcenv.windows.cpp
@@ -414,17 +414,6 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     return true;
 }
 
-// Open a file
-// Parameters:
-//  filename - name of the file to open
-//  mode     - mode to open the file in (like in the CRT fopen)
-// Return:
-//  FILE* of the opened file
-FILE* GCToOSInterface::OpenFile(const WCHAR* filename, const WCHAR* mode)
-{
-    return _wfopen(filename, mode);
-}
-
 // Initialize the critical section
 void CLRCriticalSection::Initialize()
 {


### PR DESCRIPTION
It is modeled after TCHAR used for similar purpose in Windows SDK. It allows us to eliminate need for Unicode conversions in the Unix runtime.

The change was motivated by discussion in https://github.com/dotnet/corert/pull/724