### PR TITLE
Replace PAL printing functions by CRT ones

### DIFF
--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -752,27 +752,6 @@ inline UInt8 * PalNtCurrentTeb()
 EXTERN_C void * __cdecl _alloca(size_t);
 #pragma intrinsic(_alloca)
 
-//
-// Export PAL blessed versions of *printf functions we use (mostly debug only).
-//
-REDHAWK_PALIMPORT void __cdecl PalPrintf(_In_z_ _Printf_format_string_ const char * szFormat, ...);
-REDHAWK_PALIMPORT void __cdecl PalFlushStdout();
-
-#ifndef DACCESS_COMPILE
-REDHAWK_PALIMPORT int __cdecl PalSprintf(_Out_writes_z_(cchBuffer) char * szBuffer, size_t cchBuffer, _In_z_ _Printf_format_string_ const char * szFormat, ...);
-REDHAWK_PALIMPORT int __cdecl PalVSprintf(_Out_writes_z_(cchBuffer) char * szBuffer, size_t cchBuffer, _In_z_ _Printf_format_string_ const char * szFormat, va_list args);
-#else
-#define PalSprintf sprintf_s
-#define PalVSprintf vsprintf_s
-#endif
-
-// An annoying side-effect of enabling full compiler warnings is that it complains about constant expressions
-// in control flow predicates. These happen to be useful in certain macros, such as the va_start definitions
-// below. The following macros will allow the warning to be turned off for the duration of the macro expansion
-// only. If this finds broader use we can consider moving them to a more global location.
-#define ALLOW_CONSTANT_EXPR_BEGIN __pragma(warning(push)) __pragma(warning(disable:4127))
-#define ALLOW_CONSTANT_EXPR_END __pragma(warning(pop))
-
 REDHAWK_PALIMPORT _Ret_maybenull_ _Post_writable_byte_size_(size) void* REDHAWK_PALAPI PalVirtualAlloc(_In_opt_ void* pAddress, UIntNative size, UInt32 allocationType, UInt32 protect);
 REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalVirtualFree(_In_ void* pAddress, UIntNative size, UInt32 freeType);
 REDHAWK_PALIMPORT void REDHAWK_PALAPI PalSleep(UInt32 milliseconds);

--- a/src/Native/Runtime/assert.cpp
+++ b/src/Native/Runtime/assert.cpp
@@ -27,7 +27,7 @@ void Assert(const char * expr, const char * file, UInt32 line_num, const char * 
 #else
     if (g_pRhConfig->GetBreakOnAssert())
     {
-        PalPrintf(
+        printf(
             "--------------------------------------------------\n"
             "Debug Assertion Violation\n\n"
             "%s%s%s"
@@ -41,7 +41,7 @@ void Assert(const char * expr, const char * file, UInt32 line_num, const char * 
 
         // Flush standard output before failing fast to make sure the assertion failure message
         // is retained when tests are being run with redirected stdout.
-        PalFlushStdout();
+        fflush(stdout);
 
         // If there's no debugger attached, we just FailFast
         if (!PalIsDebuggerPresent())
@@ -54,7 +54,7 @@ void Assert(const char * expr, const char * file, UInt32 line_num, const char * 
 
     char buffer[4096];
 
-    PalSprintf(buffer, COUNTOF(buffer),
+    sprintf_s(buffer, COUNTOF(buffer),
            "--------------------------------------------------\n"
            "Debug Assertion Violation\n\n"
            "%s%s%s"

--- a/src/Native/Runtime/gcdump.cpp
+++ b/src/Native/Runtime/gcdump.cpp
@@ -99,13 +99,13 @@ size_t FASTCALL   GCDump::DumpInfoHeader (PTR_UInt8      gcInfo,
     unsigned epilogCount = pHeader->GetEpilogCount();
     bool     epilogAtEnd = pHeader->IsEpilogAtEnd();
 
-    gcPrintf("   prologSize:     %d\r\n", pHeader->GetPrologSize());
+    gcPrintf("   prologSize:     %d\n", pHeader->GetPrologSize());
     if (pHeader->HasVaryingEpilogSizes())
-        gcPrintf("   epilogSize:     (varies)\r\n");
+        gcPrintf("   epilogSize:     (varies)\n");
     else
-        gcPrintf("   epilogSize:     %d\r\n", pHeader->GetFixedEpilogSize());
+        gcPrintf("   epilogSize:     %d\n", pHeader->GetFixedEpilogSize());
 
-    gcPrintf("   epilogCount:    %d %s\r\n", epilogCount, epilogAtEnd ? "[end]" : "");
+    gcPrintf("   epilogCount:    %d %s\n", epilogCount, epilogAtEnd ? "[end]" : "");
     const char * returnKind = "????";
     unsigned reversePinvokeFrameOffset = 0;     // it can't be 0 because [ebp+0] is the previous ebp
     switch (pHeader->GetReturnKind())
@@ -121,19 +121,19 @@ size_t FASTCALL   GCDump::DumpInfoHeader (PTR_UInt8      gcInfo,
             //ASSERT("Unexpected return kind")
             break;
     }
-    gcPrintf("   returnKind:     %s\r\n", returnKind);
+    gcPrintf("   returnKind:     %s\n", returnKind);
     gcPrintf("   frameKind:      %s", pHeader->HasFramePointer() ? "EBP" : "ESP");
 #ifdef _TARGET_AMD64_
     if (pHeader->HasFramePointer())
         gcPrintf(" offset: %d", pHeader->GetFramePointerOffset());
 #endif // _AMD64_
-    gcPrintf("\r\n");
-    gcPrintf("   frameSize:      %d\r\n", pHeader->GetFrameSize());
+    gcPrintf("\n");
+    gcPrintf("   frameSize:      %d\n", pHeader->GetFrameSize());
 
     if (pHeader->HasDynamicAlignment()) {
-        gcPrintf("   alignment:      %d\r\n", (1 << pHeader->GetDynamicAlignment()));
+        gcPrintf("   alignment:      %d\n", (1 << pHeader->GetDynamicAlignment()));
         if (pHeader->GetParamPointerReg() != RN_NONE) {
-            gcPrintf("   paramReg:       %d\r\n", pHeader->GetParamPointerReg());
+            gcPrintf("   paramReg:       %d\n", pHeader->GetParamPointerReg());
         }
     }
 
@@ -148,14 +148,14 @@ size_t FASTCALL   GCDump::DumpInfoHeader (PTR_UInt8      gcInfo,
         }
         mask = (CalleeSavedRegMask)(mask << 1);
     }
-    gcPrintf("\r\n");
+    gcPrintf("\n");
 
 #ifdef _TARGET_ARM_
-    gcPrintf("   parmRegsPushedCount: %d\r\n", pHeader->ParmRegsPushedCount());
+    gcPrintf("   parmRegsPushedCount: %d\n", pHeader->ParmRegsPushedCount());
 #endif
 
 #ifdef _TARGET_X86_
-    gcPrintf("   returnPopSize:  %d\r\n", pHeader->GetReturnPopSize());
+    gcPrintf("   returnPopSize:  %d\n", pHeader->GetReturnPopSize());
     if (pHeader->HasStackChanges())
     {
         // @TODO: need to read the stack changes string that follows
@@ -165,7 +165,7 @@ size_t FASTCALL   GCDump::DumpInfoHeader (PTR_UInt8      gcInfo,
 
     if (reversePinvokeFrameOffset != 0)
     {
-        gcPrintf("   reversePinvokeFrameOffset: 0x%02x\r\n", reversePinvokeFrameOffset);
+        gcPrintf("   reversePinvokeFrameOffset: 0x%02x\n", reversePinvokeFrameOffset);
     }
 
 
@@ -181,7 +181,7 @@ size_t FASTCALL   GCDump::DumpInfoHeader (PTR_UInt8      gcInfo,
                 gcPrintf("(%u bytes) ", VarInt::ReadUnsigned(gcInfo));
             previousOffset = newOffset;
         }
-        gcPrintf("\r\n");
+        gcPrintf("\n");
     }
 
     return gcInfo - gcInfoStart;
@@ -191,7 +191,7 @@ void GCDump::PrintLocalSlot(UInt32 slotNum, GCInfoHeader const * pHeader)
 {
     // @TODO: print both EBP/ESP offsets where appropriate
 #ifdef _TARGET_ARM_
-    gcPrintf("local slot 0n%d, [R7+%02X] \r\n", slotNum, 
+    gcPrintf("local slot 0n%d, [R7+%02X] \n", slotNum, 
                 ((GCInfoHeader*)pHeader)->GetFrameSize() - ((slotNum + 1) * POINTER_SIZE));
 #else
     const char* regAndSign = "EBP-";
@@ -207,7 +207,7 @@ void GCDump::PrintLocalSlot(UInt32 slotNum, GCInfoHeader const * pHeader)
         offset = (slotNum * POINTER_SIZE);
     }
 # endif
-    gcPrintf("local slot 0n%d, [%s%02X] \r\n", slotNum, regAndSign, offset);
+    gcPrintf("local slot 0n%d, [%s%02X] \n", slotNum, regAndSign, offset);
 #endif
 }
 
@@ -252,7 +252,7 @@ void GCDump::DumpCallsiteString(UInt32 callsiteOffset, PTR_UInt8 pbCallsiteStrin
                 if (b & CSR_MASK_RBP) { gcPrintf("RBP "); count++; }
                 if (b & CSR_MASK_R12) { gcPrintf("R12 "); count++; }
 #endif // _ARM_
-                gcPrintf("\r\n");
+                gcPrintf("\n");
             }
             break;
 
@@ -285,7 +285,7 @@ void GCDump::DumpCallsiteString(UInt32 callsiteOffset, PTR_UInt8 pbCallsiteStrin
                 case CSR_NUM_R15: regName = "R15"; break;
 #endif // _ARM_
                 }
-                gcPrintf("%02x          | 3  %s%s%s \r\n", b, regName, interior, pinned);
+                gcPrintf("%02x          | 3  %s%s%s \n", b, regName, interior, pinned);
                 count++; 
             }
             break;
@@ -362,7 +362,7 @@ void GCDump::DumpCallsiteString(UInt32 callsiteOffset, PTR_UInt8 pbCallsiteStrin
                     gcPrintf("   ");
                 }
 
-                gcPrintf("| 6  [%s%s%02X]%s%s\r\n", baseReg, sign, offset, interior, pinned);
+                gcPrintf("| 6  [%s%s%02X]%s%s\n", baseReg, sign, offset, interior, pinned);
                 count++; 
 
                 while (mask > 0)
@@ -373,7 +373,7 @@ void GCDump::DumpCallsiteString(UInt32 callsiteOffset, PTR_UInt8 pbCallsiteStrin
                         if (!first)
                             gcPrintf("      ");
 
-                        gcPrintf("            |    [%s%s%02X]%s%s\r\n", baseReg, sign, offset, interior, pinned);
+                        gcPrintf("            |    [%s%s%02X]%s%s\n", baseReg, sign, offset, interior, pinned);
                         count++; 
                     }
                     mask >>= 1;
@@ -384,7 +384,7 @@ void GCDump::DumpCallsiteString(UInt32 callsiteOffset, PTR_UInt8 pbCallsiteStrin
     }
     while (!last);
 
-    //gcPrintf("\r\n");
+    //gcPrintf("\n");
 }
 
 
@@ -450,7 +450,7 @@ size_t   FASTCALL   GCDump::DumpGCTable (PTR_UInt8              gcInfo,
         DumpCallsiteString(curOffset, pTables->pbCallsiteInfoBlob + infoOffset, &header);
     }
 
-    gcPrintf("-------\r\n");
+    gcPrintf("-------\n");
 
     return 0;
 }

--- a/src/Native/Runtime/module.cpp
+++ b/src/Native/Runtime/module.cpp
@@ -128,7 +128,7 @@ Module * Module::Create(ModuleHeader *pModuleHeader)
 
 #ifdef _DEBUG
 #ifdef LOG_MODULE_LOAD_VERIFICATION
-    PalPrintf("\r\nModule: 0x%p\r\n", pNewModule->m_hOsModuleHandle);
+    printf("\nModule: 0x%p\n", pNewModule->m_hOsModuleHandle);
 #endif // LOG_MODULE_LOAD_VERIFICATION
     //
     // Run through every byte of every method in the module and do some sanity-checking. Exclude stub code.
@@ -158,7 +158,7 @@ Module * Module::Create(ModuleHeader *pModuleHeader)
     
 
 #ifdef LOG_MODULE_LOAD_VERIFICATION
-        PalPrintf("0x%08x: %3d 0x%08x 0x%08x\r\n", 
+        printf("0x%08x: %3d 0x%08x 0x%08x\n", 
             uTextSectionOffset, uMethodIndex, uMethodStartSectionOffset, uMethodSize);
 #endif // LOG_MODULE_LOAD_VERIFICATION
 
@@ -238,7 +238,7 @@ Module * Module::Create(ModuleHeader *pModuleHeader)
         pNewModule->UnsynchronizedHijackAllLoops();
 
 #ifdef LOG_MODULE_LOAD_VERIFICATION
-    PalPrintf("0x%08x: --- 0x%08x \r\n", (uTextSectionOffset + uMethodSize), 
+    printf("0x%08x: --- 0x%08x \n", (uTextSectionOffset + uMethodSize), 
                                          (uMethodStartSectionOffset + uMethodSize));
 #endif // LOG_MODULE_LOAD_VERIFICATION
 #endif // _DEBUG

--- a/src/Native/Runtime/startup.cpp
+++ b/src/Native/Runtime/startup.cpp
@@ -200,11 +200,9 @@ bool UninitDLL(HANDLE /*hModDLL*/)
         AppendInt64(buffer, &len, g_registerModuleTraces[i].End.QuadPart);
     }
 
-    buffer[len++] = '\r';
     buffer[len++] = '\n';
 
-    UInt32 cchWritten;
-    PalWriteFile(PalGetStdHandle(STD_OUTPUT_HANDLE), buffer, len, &cchWritten, NULL);
+    fwrite(buffer, len, 1, stdout);
 #endif // PROFILE_STARTUP
     return true;
 }

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -144,8 +144,6 @@ pthread_mutex_t g_flushProcessWriteBuffersMutex;
 extern bool PalQueryProcessorTopology();
 bool InitializeFlushProcessWriteBuffers();
 
-REDHAWK_PALEXPORT void __cdecl PalPrintf(_In_z_ _Printf_format_string_ const char * szFormat, ...);
-
 void TimeSpecAdd(timespec* time, uint32_t milliseconds)
 {
     time->tv_nsec += milliseconds * tccMilliSecondsToNanoSeconds;
@@ -963,34 +961,6 @@ extern "C" void _mm_pause()
 extern "C" Int32 _stricmp(const char *string1, const char *string2)
 {
     return strcasecmp(string1, string2);
-}
-
-REDHAWK_PALEXPORT void __cdecl PalPrintf(_In_z_ _Printf_format_string_ const char * szFormat, ...)
-{
-#if defined(_DEBUG)
-    va_list args;
-    va_start(args, szFormat);
-    vprintf(szFormat, args);
-#endif
-}
-
-REDHAWK_PALEXPORT void __cdecl PalFlushStdout()
-{
-#if defined(_DEBUG)
-    fflush(stdout);
-#endif
-}
-
-REDHAWK_PALEXPORT int __cdecl PalSprintf(_Out_writes_z_(cchBuffer) char * szBuffer, size_t cchBuffer, _In_z_ _Printf_format_string_ const char * szFormat, ...)
-{
-    va_list args;
-    va_start(args, szFormat);
-    return vsnprintf(szBuffer, cchBuffer, szFormat, args);
-}
-
-REDHAWK_PALEXPORT int __cdecl PalVSprintf(_Out_writes_z_(cchBuffer) char * szBuffer, size_t cchBuffer, _In_z_ _Printf_format_string_ const char * szFormat, va_list args)
-{
-    return vsnprintf(szBuffer, cchBuffer, szFormat, args);
 }
 
 // Given the OS handle of a loaded module, compute the upper and lower virtual address bounds (inclusive).

--- a/src/Native/Runtime/windows/PalRedhawkCommon.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkCommon.cpp
@@ -31,48 +31,6 @@
 #define REDHAWK_PALAPI __stdcall
 
 
-#ifdef APP_LOCAL_RUNTIME
-#ifdef _DEBUG
-EXTERN_C WINBASEAPI HANDLE WINAPI GetStdHandle(
-        _In_  DWORD nStdHandle
-        );
-#endif // _DEBUG
-#endif // APP_LOCAL_RUNTIME
-
-REDHAWK_PALEXPORT void __cdecl PalPrintf(_In_z_ _Printf_format_string_ const char * szFormat, ...)
-{
-#if defined(_DEBUG) 
-    char buffer[8*1024];
-
-    va_list args;
-    va_start(args, szFormat);
-    int cch = _vsprintf_s_l(buffer, COUNTOF(buffer), szFormat, NULL, args);
-
-    // we have to use WriteConsole directly because the "app" CRT doesn't allow us to print to the console
-    DWORD cchWritten;
-    WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), buffer, (DWORD)cch, &cchWritten, NULL);
-#endif
-}
-
-REDHAWK_PALEXPORT void __cdecl PalFlushStdout()
-{
-#if defined(_DEBUG)
-    FlushFileBuffers(GetStdHandle(STD_OUTPUT_HANDLE));
-#endif
-}
-
-REDHAWK_PALEXPORT int __cdecl PalSprintf(_Out_writes_z_(cchBuffer) char * szBuffer, size_t cchBuffer, _In_z_ _Printf_format_string_ const char * szFormat, ...)
-{
-    va_list args;
-    va_start(args, szFormat);
-    return _vsprintf_s_l(szBuffer, cchBuffer, szFormat, NULL, args);
-}
-
-REDHAWK_PALEXPORT int __cdecl PalVSprintf(_Out_writes_z_(cchBuffer) char * szBuffer, size_t cchBuffer, _In_z_ _Printf_format_string_ const char * szFormat, va_list args)
-{
-    return _vsprintf_s_l(szBuffer, cchBuffer, szFormat, NULL, args);
-}
-
 // Given the OS handle of a loaded module, compute the upper and lower virtual address bounds (inclusive).
 REDHAWK_PALEXPORT void REDHAWK_PALAPI PalGetModuleBounds(HANDLE hOsHandle, _Out_ UInt8 ** ppLowerBound, _Out_ UInt8 ** ppUpperBound)
 {

--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -58,7 +58,6 @@ bool InitializeSystemInfo()
 }
 
 extern bool PalQueryProcessorTopology();
-REDHAWK_PALEXPORT void __cdecl PalPrintf(_In_z_ _Printf_format_string_ const char * szFormat, ...);
 
 // The Redhawk PAL must be initialized before any of its exports can be called. Returns true for a successful
 // initialization and false on failure.
@@ -965,13 +964,13 @@ UInt32 CountBits(size_t bfBitfield)
 #ifdef _DEBUG
 void DumpCacheTopology(_In_reads_(cRecords) SYSTEM_LOGICAL_PROCESSOR_INFORMATION * pProcInfos, UInt32 cRecords)
 {
-    PalPrintf("----------------\n");
+    printf("----------------\n");
     for (UInt32 i = 0; i < cRecords; i++)
     {
         switch (pProcInfos[i].Relationship)
         {
         case RelationProcessorCore:
-            PalPrintf("    [%2d] Core: %d threads                    0x%04x mask, flags = %d\n",
+            printf("    [%2d] Core: %d threads                    0x%04zx mask, flags = %d\n",
                 i, CountBits(pProcInfos[i].ProcessorMask), pProcInfos[i].ProcessorMask,
                 pProcInfos[i].ProcessorCore.Flags);
             break;
@@ -985,34 +984,34 @@ void DumpCacheTopology(_In_reads_(cRecords) SYSTEM_LOGICAL_PROCESSOR_INFORMATION
             case CacheTrace:        pszCacheType = "[Trace  ]"; break;
             default:                pszCacheType = "[Unk    ]"; break;
             }
-            PalPrintf("    [%2d] Cache: %s 0x%08x bytes  0x%04x mask\n", i, pszCacheType,
+            printf("    [%2d] Cache: %s 0x%08x bytes  0x%04zx mask\n", i, pszCacheType,
                 pProcInfos[i].Cache.Size, pProcInfos[i].ProcessorMask);
             break;
 
         case RelationNumaNode:
-            PalPrintf("    [%2d] NumaNode: #%02d                      0x%04x mask\n",
+            printf("    [%2d] NumaNode: #%02d                      0x%04zx mask\n",
                 i, pProcInfos[i].NumaNode.NodeNumber, pProcInfos[i].ProcessorMask);
             break;
         case RelationProcessorPackage:
-            PalPrintf("    [%2d] Package:                           0x%04x mask\n",
+            printf("    [%2d] Package:                           0x%04zx mask\n",
                 i, pProcInfos[i].ProcessorMask);
             break;
         case RelationAll:
         case RelationGroup:
         default:
-            PalPrintf("    [%2d] unknown: %d\n", i, pProcInfos[i].Relationship);
+            printf("    [%2d] unknown: %d\n", i, pProcInfos[i].Relationship);
             break;
         }
     }
-    PalPrintf("----------------\n");
+    printf("----------------\n");
 }
 void DumpCacheTopologyResults(UInt32 maxCpuId, CpuVendor cpuVendor, _In_reads_(cRecords) SYSTEM_LOGICAL_PROCESSOR_INFORMATION * pProcInfos, UInt32 cRecords)
 {
     DumpCacheTopology(pProcInfos, cRecords);
-    PalPrintf("maxCpuId: %d, %s\n", maxCpuId, (cpuVendor == CpuIntel) ? "CpuIntel" : ((cpuVendor == CpuAMD) ? "CpuAMD" : "CpuUnknown"));
-    PalPrintf("               g_cLogicalCpus:          %d %d          :CLR_GetLogicalCpuCount\n", g_cLogicalCpus, CLR_GetLogicalCpuCount(pProcInfos, cRecords));
-    PalPrintf("        g_cbLargestOnDieCache: 0x%08x 0x%08x :CLR_LargestOnDieCache(TRUE)\n", g_cbLargestOnDieCache, CLR_GetLargestOnDieCacheSize(TRUE, pProcInfos, cRecords));
-    PalPrintf("g_cbLargestOnDieCacheAdjusted: 0x%08x 0x%08x :CLR_LargestOnDieCache(FALSE)\n", g_cbLargestOnDieCacheAdjusted, CLR_GetLargestOnDieCacheSize(FALSE, pProcInfos, cRecords));
+    printf("maxCpuId: %d, %s\n", maxCpuId, (cpuVendor == CpuIntel) ? "CpuIntel" : ((cpuVendor == CpuAMD) ? "CpuAMD" : "CpuUnknown"));
+    printf("               g_cLogicalCpus:          %d %d          :CLR_GetLogicalCpuCount\n", g_cLogicalCpus, CLR_GetLogicalCpuCount(pProcInfos, cRecords));
+    printf("        g_cbLargestOnDieCache: 0x%08zx 0x%08zx :CLR_LargestOnDieCache(TRUE)\n", g_cbLargestOnDieCache, CLR_GetLargestOnDieCacheSize(TRUE, pProcInfos, cRecords));
+    printf("g_cbLargestOnDieCacheAdjusted: 0x%08zx 0x%08zx :CLR_LargestOnDieCache(FALSE)\n", g_cbLargestOnDieCacheAdjusted, CLR_GetLargestOnDieCacheSize(FALSE, pProcInfos, cRecords));
 }
 #endif // _DEBUG
 

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -394,9 +394,8 @@ void log_va_msg(const char *fmt, va_list args)
     static char rgchBuffer[BUFFERSIZE];
     char *  pBuffer  = &rgchBuffer[0];
 
-    pBuffer[0] = '\r';
-    pBuffer[1] = '\n';
-    int buffer_start = 2;
+    pBuffer[0] = '\n';
+    int buffer_start = 1;
     int pid_len = sprintf_s (&pBuffer[buffer_start], BUFFERSIZE - buffer_start, "[%5d]", GCToOSInterface::GetCurrentThreadIdForLogging());
     buffer_start += pid_len;
     memset(&pBuffer[buffer_start], '-', BUFFERSIZE - buffer_start);
@@ -413,9 +412,8 @@ void log_va_msg(const char *fmt, va_list args)
         char index_str[8];
         memset (index_str, '-', 8);
         sprintf_s (index_str, _countof(index_str), "%d", (int)gc_buffer_index);
-        gc_log_buffer[gc_log_buffer_offset] = '\r';
-        gc_log_buffer[gc_log_buffer_offset + 1] = '\n';
-        memcpy (gc_log_buffer + (gc_log_buffer_offset + 2), index_str, 8);
+        gc_log_buffer[gc_log_buffer_offset] = '\n';
+        memcpy (gc_log_buffer + (gc_log_buffer_offset + 1), index_str, 8);
 
         gc_buffer_index++;
         if (gc_buffer_index > max_gc_buffers)
@@ -465,9 +463,8 @@ void log_va_msg_config(const char *fmt, va_list args)
     static char rgchBuffer[BUFFERSIZE];
     char *  pBuffer  = &rgchBuffer[0];
 
-    pBuffer[0] = '\r';
-    pBuffer[1] = '\n';
-    int buffer_start = 2;
+    pBuffer[0] = '\n';
+    int buffer_start = 1;
     int msg_len = _vsnprintf (&pBuffer[buffer_start], BUFFERSIZE - buffer_start, fmt, args );
     assert (msg_len != -1);
     msg_len += buffer_start;


### PR DESCRIPTION
This change replaces PalPrintf, PalSprintf, PalFlushStdout and PalFileWrite to stdout
by the CRT printf, sprintf_s, fflush and fwrite.

This change revealed few incorrect C formatting specifiers in the printf format strings
that I have fixed too.