### PR TITLE
support _cvrt_s crt call on Linux

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.FormatProvider.FormatAndParse.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.FormatProvider.FormatAndParse.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal unsafe partial class Sys
+    {
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_DoubleToString")]
+        internal static unsafe extern int DoubleToString(double value, byte *format, byte *buffer, int bufferLength);
+    }
+}

--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -37,11 +37,6 @@ extern "C"
 // UNIXTODO: Unix port of _ecvt_s and _copysign https://github.com/dotnet/corert/issues/670
 extern "C"
 {
-    void _ecvt_s()
-    {
-        throw "ecvt_s";
-    }
-
     void _copysign()
     {
         throw "_copysign";

--- a/src/Native/System.Private.CoreLib.Native/CMakeLists.txt
+++ b/src/Native/System.Private.CoreLib.Native/CMakeLists.txt
@@ -4,6 +4,7 @@ set(NATIVE_SOURCES
     pal_environment.cpp
     pal_memory.cpp
     pal_io.cpp
+    pal_cruntime.cpp
 )
 
 add_library(System.Private.CoreLib.Native

--- a/src/Native/System.Private.CoreLib.Native/pal_cruntime.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_cruntime.cpp
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <stdlib.h>
+#include <assert.h>
+#include <stdio.h>
+
+
+extern "C" int CoreLibNative_DoubleToString(double value, char *format, char *buffer, int bufferLength)
+{
+    assert(buffer != NULL && format != NULL);
+    
+    // return number of characters written to the buffer. if the return value greater than bufferLength 
+    // means the number of characters would be written to the buffer if there is enough space
+    return snprintf(buffer, bufferLength, format, value);
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -448,6 +448,7 @@
       <Compile Include="System\Globalization\CultureData.Win32.cs" />
       <Compile Include="System\Globalization\TextInfo.Win32.cs" />
       <Compile Include="System\Globalization\CalendarData.Win32.cs" />
+      <Compile Include="System\Globalization\FormatProvider.FormatAndParse.Win32.cs" />
       <Compile Include="..\..\Common\src\Interop\Windows\Interop.BOOL.cs" />
       <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Globalization.cs" />
 
@@ -475,9 +476,11 @@
     <Compile Include="System\Globalization\CultureData.Dummy.cs" />
     <Compile Include="System\Globalization\TextInfo.Dummy.cs" />
     <Compile Include="System\Globalization\CalendarData.Dummy.cs" />
+    <Compile Include="System\Globalization\FormatProvider.FormatAndParse.Unix.cs" />
     <Compile Include="System\Environment.Unix.cs" />
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Environment.cs" />
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Libraries.cs" />
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.FormatProvider.FormatAndParse.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.cs" />

--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.FormatAndParse.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.FormatAndParse.Unix.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime;
+using System.Globalization;
+using System.Diagnostics;
+
+namespace System.Globalization
+{
+    internal partial class FormatProvider
+    {
+        private partial class Number
+        {
+            // buffer size to hold digits (40), decimal point, number sign, exponent, exponent symbol 'e', exponent sign and null.
+            private const int  MAX_BUFFER_SIZE = 50;  
+           
+            private static unsafe void DoubleToNumber(double value, int precision, ref NumberBuffer number)
+            {
+                Debug.Assert(precision > 0 && precision < 40);
+                
+                number.precision = precision;
+                if (DoubleHelper.Exponent(value) == 0x7ff)
+                {
+                    number.scale = DoubleHelper.Mantissa(value) != 0 ? SCALE_NAN : SCALE_INF;
+                    number.sign = DoubleHelper.Sign(value);
+                    number.digits[0] = '\0';
+                    return;
+                }
+                
+                byte* tempBuffer = stackalloc byte[MAX_BUFFER_SIZE];
+                char* dst = number.digits;
+
+                number.scale = 0;
+                number.sign = false;
+                *dst = '\0';             
+
+                if (value < 0.0)
+                {
+                    number.sign = true;
+                }
+                
+                if (value == 0.0)
+                {
+                    for (int j=0; j<precision; j++)
+                    {
+                        dst[j] = '0';
+                    }
+                    dst[precision] = '\0';
+                    return;
+                }
+
+                //
+                // Get the number formatted as a string in the form x.xxxxxxexxxx
+                //
+
+                // "%.40e"
+                byte *format = stackalloc byte[6];
+                format[0] = (byte) '%';
+                format[1] = (byte) '.';
+                format[2] = (byte) '4';
+                format[3] = (byte) '0';
+                format[4] = (byte) 'e';
+                format[5] = 0; 
+
+                int tempBufferLength = Interop.Sys.DoubleToString(value, format, tempBuffer, MAX_BUFFER_SIZE);
+                Debug.Assert(tempBufferLength > 0 && MAX_BUFFER_SIZE > tempBufferLength);
+
+                //
+                // Calculate the exponent value
+                //
+                
+                int exponentIndex = tempBufferLength - 1;
+                while (tempBuffer[exponentIndex] != (byte) 'e' && exponentIndex > 0)
+                {
+                    exponentIndex--;
+                }
+                
+                Debug.Assert(exponentIndex > 0 && (exponentIndex < tempBufferLength - 1));
+
+                int i = exponentIndex + 1;
+                int exponentSign = 1;
+                if (tempBuffer[i] == '-')
+                {
+                    exponentSign = -1;
+                    i++;
+                }
+                else if (tempBuffer[i] == '+')
+                {
+                    i++;
+                }
+                
+                int exponentValue = 0;
+                while (i < tempBufferLength) 
+                {
+                    Debug.Assert(tempBuffer[i] >= (byte) '0' && tempBuffer[i] <= (byte) '9');
+                    exponentValue = exponentValue * 10 + (tempBuffer[i] - (byte)'0');
+                    i++;
+                }
+                exponentValue *= exponentSign;
+
+                //
+                // Determine decimal location.
+                // 
+
+                if (exponentValue == 0)
+                {
+                    number.scale = 1;
+                }
+                else
+                {
+                    number.scale = exponentValue + 1;
+                }
+                
+                //
+                // Copy the string from the temp buffer upto precision characters, removing the sign, and decimal as required.
+                // 
+
+                i = 0;
+                int mantissaIndex = 0;
+                while (i < precision &&  mantissaIndex < exponentIndex)
+                {
+                    if (tempBuffer[mantissaIndex] >= (byte) '0' &&  tempBuffer[mantissaIndex] <= (byte) '9')
+                    {
+                        dst[i] = (char) tempBuffer[mantissaIndex];
+                        i++;
+                    }
+                    mantissaIndex++;
+                }
+                
+                while (i < precision)
+                {
+                    dst[i] = '0'; // append zeros as needed
+                    i++;
+                }
+                
+                dst[i] = '\0';
+
+                //
+                // Round if needed
+                //
+                
+                if (mantissaIndex >= exponentIndex || tempBuffer[mantissaIndex] < (byte) '5')
+                {
+                    return; // rounding is not needed
+                }
+                
+                i=precision-1;
+                while (dst[i] == '9' && i > 0)
+                {
+                    dst[i] = '0';
+                    i--;
+                }
+                
+                if (i == 0 && dst[i] == '9')
+                {
+                    dst[i] = '1';
+                    number.scale++;
+                }
+                else
+                { 
+                    dst[i]++;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.FormatAndParse.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.FormatAndParse.Win32.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Runtime;
+
+namespace System.Globalization
+{
+    internal partial class FormatProvider
+    {
+        private partial class Number
+        {
+            private static unsafe void DoubleToNumber(double value, int precision, ref NumberBuffer number)
+            {
+                number.precision = precision;
+                if (DoubleHelper.Exponent(value) == 0x7ff)
+                {
+                    number.scale = DoubleHelper.Mantissa(value) != 0 ? SCALE_NAN : SCALE_INF;
+                    number.sign = DoubleHelper.Sign(value);
+                    number.digits[0] = '\0';
+                }
+                else
+                {
+                    byte* src = stackalloc byte[_CVTBUFSIZE];
+                    int sign;
+                    fixed (NumberBuffer* pNumber = &number)
+                    {
+                        RuntimeImports._ecvt_s(src, _CVTBUFSIZE, value, precision, &pNumber->scale, &sign);
+                    }
+                    number.sign = sign != 0;
+
+                    char* dst = number.digits;
+                    if ((char)*src != '0')
+                    {
+                        while (*src != 0)
+                            *dst++ = (char)*src++;
+                    }
+                    *dst = '\0';
+                }
+            }
+        }
+    }
+}
+
+

--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.FormatAndParse.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.FormatAndParse.cs
@@ -1096,35 +1096,6 @@ namespace System.Globalization
                 return s.Equals(nfi.NaNSymbol);
             }
 
-            private static unsafe void DoubleToNumber(double value, int precision, ref NumberBuffer number)
-            {
-                number.precision = precision;
-                if (DoubleHelper.Exponent(value) == 0x7ff)
-                {
-                    number.scale = DoubleHelper.Mantissa(value) != 0 ? SCALE_NAN : SCALE_INF;
-                    number.sign = DoubleHelper.Sign(value);
-                    number.digits[0] = '\0';
-                }
-                else
-                {
-                    byte* src = stackalloc byte[_CVTBUFSIZE];
-                    int sign;
-                    fixed (NumberBuffer* pNumber = &number)
-                    {
-                        RuntimeImports._ecvt_s(src, _CVTBUFSIZE, value, precision, &pNumber->scale, &sign);
-                    }
-                    number.sign = sign != 0;
-
-                    char* dst = number.digits;
-                    if ((char)*src != '0')
-                    {
-                        while (*src != 0)
-                            *dst++ = (char)*src++;
-                    }
-                    *dst = '\0';
-                }
-            }
-
             #region Decimal Number Formatting Helpers
             private static unsafe bool NumberBufferToDecimal(Number.NumberBuffer number, ref Decimal value)
             {


### PR DESCRIPTION
Linux has ecvt but we cannot use it because it is not thread safe. other alternative on Linux is ecvt_r but unfortunately it is not supported on OSX. to work around the issue is to provide the implementation on Linux.  