### PR TITLE
Stubbed out implementation of RuntimeType

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
@@ -168,9 +168,11 @@ namespace ILCompiler
                     mangledName = "memset"; // TODO: Null reference handling
                     break;
 
-                case JitHelperId.GetRuntimeTypeHandle: // TODO: Reflection
-                case JitHelperId.GetRuntimeMethodHandle:
-                case JitHelperId.GetRuntimeFieldHandle:
+                case JitHelperId.GetRuntimeTypeHandle:
+                    methodDesc = context.GetHelperEntryPoint("LdTokenHelpers", "GetRuntimeTypeHandle");
+                    break;
+                case JitHelperId.GetRuntimeMethodHandle: // TODO: Reflection
+                case JitHelperId.GetRuntimeFieldHandle: // TODO: Reflection
                     mangledName = "__fail_fast";
                     break;
 

--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -64,4 +64,9 @@ extern "C"
     {
         throw "GetNativeSystemInfo";
     }
+
+    void OutputDebugStringW()
+    {
+        throw "OutputDebugStringW";
+    }
 }

--- a/src/System.Private.CoreLib/src/Internal/Reflection/CoreRT/ReflectionCoreNonPortable.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/CoreRT/ReflectionCoreNonPortable.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime;
+
+using Internal.TypeSystem;
+
+namespace Internal.Reflection.Core.NonPortable
+{
+    public static class ReflectionCoreNonPortable
+    {
+        public static RuntimeType GetArrayType(RuntimeType elementType)
+        {
+            // CORERT-TODO: Reflection
+            throw new NotSupportedException();
+        }
+
+        public static RuntimeType GetMultiDimArrayType(RuntimeType elementType, int rank)
+        {
+            // CORERT-TODO: Reflection
+            throw new NotImplementedException();
+        }
+
+        public static RuntimeType GetByRefType(RuntimeType targetType)
+        {
+            // CORERT-TODO: Reflection
+            throw new NotImplementedException();
+        }
+
+        public static RuntimeType GetConstructedGenericType(RuntimeType genericTypeDefinition, RuntimeType[] genericTypeArguments)
+        {
+            // CORERT-TODO: Reflection
+            throw new NotImplementedException();
+        }
+
+        public static RuntimeType GetPointerType(RuntimeType targetType)
+        {
+            // CORERT-TODO: Reflection
+            throw new NotImplementedException();
+        }
+
+        private class RuntimeTypeHashtable : LockFreeReaderHashtable<EETypePtr, RuntimeType>
+        {
+            protected override int GetKeyHashCode(EETypePtr key)
+            {
+                return key.GetHashCode();
+            }
+
+            protected override int GetValueHashCode(RuntimeType value)
+            {
+                return value.ToEETypePtr().GetHashCode();
+            }
+
+            protected override bool CompareKeyToValue(EETypePtr key, RuntimeType value)
+            {
+                return RuntimeImports.AreTypesEquivalent(key, value.ToEETypePtr());
+            }
+
+            protected override bool CompareValueToValue(RuntimeType value1, RuntimeType value2)
+            {
+                return RuntimeImports.AreTypesEquivalent(value1.ToEETypePtr(), value2.ToEETypePtr());
+            }
+
+            protected override RuntimeType CreateValueFromKey(EETypePtr key)
+            {
+                return new RuntimeType(key);
+            }
+        }
+
+        static private readonly RuntimeTypeHashtable g_runtimeTypeFactory = new RuntimeTypeHashtable();
+
+        internal static RuntimeType GetRuntimeTypeForEEType(EETypePtr eeType)
+        {
+            return g_runtimeTypeFactory.GetOrCreateValue(eeType);
+        }
+
+        public static RuntimeType GetTypeForRuntimeTypeHandle(RuntimeTypeHandle runtimeTypeHandle)
+        {
+            return runtimeTypeHandle.RuntimeType;
+        }
+
+        public static TypeLoadException CreateTypeLoadException(String message, String typeName)
+        {
+            return new TypeLoadException(message, typeName);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Reflection/CoreRT/RuntimeType.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/CoreRT/RuntimeType.cs
@@ -1,0 +1,376 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+
+using Internal.Runtime.Augments;
+using Internal.Reflection.Extensibility;
+
+namespace Internal.Reflection.Core.NonPortable
+{
+    [DebuggerDisplay("{_debugName}")]
+    public class RuntimeType : ExtensibleType, IEquatable<RuntimeType>
+    {
+        private EETypePtr _pEEType;
+
+        public RuntimeType()
+        {
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+        }
+
+        internal RuntimeType(EETypePtr pEEType)
+            : base()
+        {
+            _pEEType = pEEType;
+        }
+
+        internal EETypePtr ToEETypePtr()
+        {
+            return _pEEType;
+        }
+
+        public override bool Equals(Object obj)
+        {
+            return Object.ReferenceEquals(this, obj);
+        }
+
+        public bool Equals(RuntimeType obj)
+        {
+            return Object.ReferenceEquals(this, obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return _pEEType.GetHashCode();
+        }
+
+        public sealed override String AssemblyQualifiedName
+        {
+            get
+            {
+                String fullName = FullName;
+                if (fullName == null)   // Some Types (such as generic parameters) return null for FullName by design.
+                    return null;
+
+                String assemblyName = InternalFullNameOfAssembly;
+                return fullName + ", " + assemblyName;
+            }
+        }
+
+        //
+        // Left unsealed as nested and generic parameter types must override this.
+        //
+        public override Type DeclaringType
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        //
+        // Left unsealed as this is only correct for named types. Other type flavors must override this.
+        //
+        public override String FullName
+        {
+            get
+            {
+                Debug.Assert(!IsConstructedGenericType);
+                Debug.Assert(!IsGenericParameter);
+                Debug.Assert(!HasElementType);
+
+                String name = Name;
+
+                Type declaringType = this.DeclaringType;
+                if (declaringType != null)
+                {
+                    String declaringTypeFullName = declaringType.FullName;
+                    return declaringTypeFullName + "+" + name;
+                }
+
+                String ns = Namespace;
+                if (ns == null)
+                    return name;
+                return ns + "." + name;
+            }
+        }
+
+        //
+        // Left unsealed as generic parameter types must override this.
+        //
+        public override int GenericParameterPosition
+        {
+            get
+            {
+                Debug.Assert(!IsGenericParameter);
+                throw new InvalidOperationException(SR.Arg_NotGenericParameter);
+            }
+        }
+
+        public sealed override Type[] GenericTypeArguments
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public override bool IsArray
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public override bool IsByRef
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public override bool IsConstructedGenericType
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public override bool IsGenericParameter
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public override bool IsPointer
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+
+        //
+        // Left unsealed as array types must override this.
+        //
+        public override int GetArrayRank()
+        {
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+        }
+
+        public override Type GetElementType()
+        {
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+        }
+
+        //
+        // Left unsealed as IsGenericType types must override this.
+        //
+        public override Type GetGenericTypeDefinition()
+        {
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+        }
+
+        public sealed override Type MakeArrayType()
+        {
+            // Do not implement this as a call to MakeArrayType(1) - they are not interchangable. MakeArrayType() returns a
+            // vector type ("SZArray") while MakeArrayType(1) returns a multidim array of rank 1. These are distinct types
+            // in the ECMA model and in CLR Reflection.
+            return ReflectionCoreNonPortable.GetArrayType(this);
+        }
+
+        public sealed override Type MakeArrayType(int rank)
+        {
+            if (rank <= 0)
+                throw new IndexOutOfRangeException();
+            return ReflectionCoreNonPortable.GetMultiDimArrayType(this, rank);
+        }
+
+        public sealed override Type MakeByRefType()
+        {
+            return ReflectionCoreNonPortable.GetByRefType(this);
+        }
+
+        public sealed override Type MakeGenericType(params Type[] instantiation)
+        {
+            if (instantiation == null)
+                throw new ArgumentNullException("instantiation");
+
+            if (!(this.InternalIsGenericTypeDefinition))
+                throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericTypeDefinition, this));
+
+            // We intentionally don't validate the number of arguments or their suitability to the generic type's constraints.
+            // In a pay-for-play world, this can cause needless MissingMetadataExceptions. There is no harm in creating
+            // the Type object for an inconsistent generic type - no EEType will ever match it so any attempt to "invoke" it
+            // will throw an exception.
+            RuntimeType[] genericTypeArguments = new RuntimeType[instantiation.Length];
+            for (int i = 0; i < instantiation.Length; i++)
+            {
+                genericTypeArguments[i] = instantiation[i] as RuntimeType;
+                if (genericTypeArguments[i] == null)
+                {
+                    if (instantiation[i] == null)
+                        throw new ArgumentNullException();
+                    else
+                        throw new PlatformNotSupportedException(SR.PlatformNotSupported_MakeGenericType); // "PlatformNotSupported" because on desktop, passing in a foreign type is allowed and creates a RefEmit.TypeBuilder
+                }
+            }
+            return ReflectionCoreNonPortable.GetConstructedGenericType(this, genericTypeArguments);
+        }
+
+        public sealed override Type MakePointerType()
+        {
+            return ReflectionCoreNonPortable.GetPointerType(this);
+        }
+
+        public override String Name
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public override String Namespace
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public override RuntimeTypeHandle TypeHandle
+        {
+            get
+            {
+                return new RuntimeTypeHandle(this);
+            }
+        }
+
+        public override String ToString()
+        {
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+        }
+
+        public bool InternalTryGetTypeHandle(out RuntimeTypeHandle typeHandle)
+        {
+            typeHandle = new RuntimeTypeHandle(this);
+            return true;
+        }
+
+        public virtual bool InternalIsGenericTypeDefinition
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public virtual bool InternalIsOpen
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public String InternalNameIfAvailable
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public virtual String InternalFullNameOfAssembly
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public virtual bool InternalViolatesTypeIdentityRules
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public virtual String InternalGetNameIfAvailable(ref RuntimeType rootCauseForFailure)
+        {
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+        }
+
+        public virtual RuntimeType InternalRuntimeElementType
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public virtual RuntimeType[] InternalRuntimeGenericTypeArguments
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public virtual bool InternalIsMultiDimArray
+        {
+            get
+            {
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+            }
+        }
+
+        public virtual bool InternalIsEqual(Object obj)
+        {
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+        }
+
+        public RUNTIMETYPEINFO InternalGetLatchedRuntimeTypeInfo<RUNTIMETYPEINFO>(Func<RuntimeType, RUNTIMETYPEINFO> factory) where RUNTIMETYPEINFO : class
+        {
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeType
+        }
+
+        //
+        // Note: This can be (and is) called multiple times. We do not do this work in the constructor as calling ToString()
+        // in the constructor causes some serious recursion issues.
+        //
+        public void EstablishDebugName()
+        {
+            bool populateDebugNames = DeveloperExperienceState.DeveloperExperienceModeEnabled;
+#if DEBUG
+            populateDebugNames = true;
+#endif
+            if (!populateDebugNames)
+                return;
+
+            if (_debugName == null)
+            {
+                _debugName = "Constructing..."; // Protect against any inadvertent reentrancy.
+                String debugName = this.ToString();
+                if (debugName == null)
+                    debugName = "";
+                _debugName = debugName;
+            }
+            return;
+        }
+
+        private String _debugName;
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -217,7 +217,11 @@ namespace Internal.Runtime.Augments
 
         public static RuntimeTypeHandle CreateRuntimeTypeHandle(IntPtr ldTokenResult)
         {
+#if CORERT // CORERT-TODO: RuntimeTypeHandle
+            throw new NotImplementedException();
+#else
             return new RuntimeTypeHandle(new EETypePtr(ldTokenResult));
+#endif
         }
 
         public unsafe static IntPtr GetThreadStaticFieldAddress(RuntimeTypeHandle typeHandle, IntPtr fieldCookie)
@@ -787,8 +791,7 @@ namespace Internal.Runtime.Augments
 
         public unsafe static RuntimeTypeHandle GetRuntimeTypeHandleFromObjectReference(object obj)
         {
-            IntPtr type = obj.EETypePtr.RawValue;
-            return *((RuntimeTypeHandle*)&type);
+            return new RuntimeTypeHandle(obj.EETypePtr);
         }
 
         public static int GetCorElementType(RuntimeTypeHandle type)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LdTokenHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LdTokenHelpers.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.Reflection.Core.NonPortable;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    /// <summary>
+    /// These methods are used to implement ldtoken instruction.
+    /// </summary>
+    internal static class LdTokenHelpers
+    {
+        private static RuntimeTypeHandle GetRuntimeTypeHandle(IntPtr pEEType)
+        {
+            return new RuntimeTypeHandle(ReflectionCoreNonPortable.GetRuntimeTypeForEEType(new EETypePtr(pEEType)));
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/LowLevelUTF8Encoding.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/LowLevelUTF8Encoding.cs
@@ -11,7 +11,6 @@ using System.Text;
 
 namespace Internal.Runtime.CompilerHelpers
 {
-    // !!!!
     // This code is primarily copied from UTF8Encoding.cs' GetCharCount and GetChars
     // but has all the string literals removed. The code is used for runtime startup and
     // primarily for loading static string literals. So do not put anything here

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/FixupRuntimeTypeHandle.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/FixupRuntimeTypeHandle.cs
@@ -8,17 +8,26 @@ namespace Internal.Runtime.CompilerServices
 {
     public unsafe struct FixupRuntimeTypeHandle
     {
+#if !CORERT
         private IntPtr _value;
+#endif
 
         public FixupRuntimeTypeHandle(RuntimeTypeHandle runtimeTypeHandle)
         {
+#if CORERT
+            throw new NotImplementedException(); // CORERT-TODO: RuntimeTypeHandle
+#else
             _value = *(IntPtr*)&runtimeTypeHandle;
+#endif
         }
 
         public RuntimeTypeHandle RuntimeTypeHandle
         {
             get
             {
+#if CORERT
+                throw new NotImplementedException(); // CORERT-TODO: RuntimeTypeHandle
+#else
                 // Managed debugger uses this logic to figure out the interface's type
                 // Update managed debugger too whenever this is changed.
                 // See CordbObjectValue::WalkPtrAndTypeData in debug\dbi\values.cpp
@@ -33,6 +42,7 @@ namespace Internal.Runtime.CompilerServices
                     *(IntPtr*)&returnValue = _value;
                     return returnValue;
                 }
+#endif
             }
         }
     }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
@@ -26,12 +26,12 @@ namespace Internal.Runtime.CompilerServices
         private readonly short _resolveType;
         private readonly int _handle;
         private readonly IntPtr _methodHandleOrSlotOrCodePointer;
-        private readonly RuntimeTypeHandle _declaringType;
+        private readonly EETypePtr _declaringType;
 
         public OpenMethodResolver(RuntimeTypeHandle declaringTypeOfSlot, int slot, int handle)
         {
             _resolveType = DispatchResolve;
-            _declaringType = declaringTypeOfSlot;
+            _declaringType = declaringTypeOfSlot.ToEETypePtr();
             _methodHandleOrSlotOrCodePointer = new IntPtr(slot);
             _handle = handle;
         }
@@ -40,7 +40,7 @@ namespace Internal.Runtime.CompilerServices
         {
             _resolveType = GVMResolve;
             _methodHandleOrSlotOrCodePointer = *(IntPtr*)&gvmSlot;
-            _declaringType = declaringTypeOfSlot;
+            _declaringType = declaringTypeOfSlot.ToEETypePtr();
             _handle = handle;
         }
 
@@ -48,7 +48,7 @@ namespace Internal.Runtime.CompilerServices
         {
             _resolveType = OpenNonVirtualResolve;
             _methodHandleOrSlotOrCodePointer = codePointer;
-            _declaringType = declaringType;
+            _declaringType = declaringType.ToEETypePtr();
             _handle = handle;
         }
 
@@ -64,7 +64,7 @@ namespace Internal.Runtime.CompilerServices
         {
             get
             {
-                return _declaringType;
+                return new RuntimeTypeHandle(_declaringType);
             }
         }
 
@@ -98,7 +98,7 @@ namespace Internal.Runtime.CompilerServices
         {
             if (_resolveType == DispatchResolve)
             {
-                return RuntimeImports.RhResolveDispatch(thisObject, _declaringType.ToEETypePtr(), (ushort)_methodHandleOrSlotOrCodePointer.ToInt32());
+                return RuntimeImports.RhResolveDispatch(thisObject, _declaringType, (ushort)_methodHandleOrSlotOrCodePointer.ToInt32());
             }
             else if (_resolveType == GVMResolve)
             {

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -20,10 +20,7 @@
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
-    <!-- CORERT-TODO: For now, drop DEBUG define comming from central location - asserts compiled 
-         into DEBUG builds use interfaces that we are not able to handle yet -->
-    <!-- <DefineConstants>CORERT;$(DefineConstants)</DefineConstants> -->
-    <DefineConstants>CORERT</DefineConstants>
+    <DefineConstants>CORERT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <DefineConstants>AMD64;BIT64;$(DefineConstants)</DefineConstants>
@@ -48,10 +45,15 @@
   <ItemGroup>
     <Compile Include="Internal\Diagnostics\ExceptionExtensions.cs" />
     <Compile Include="Internal\Diagnostics\StackTraceHelper.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\LowLevelUTF8Encoding.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\StartupCodeHelpers.cs" />
-    <Compile Include="Internal\Runtime\CompilerHelpers\ThrowHelpers.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\LdTokenHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\MathHelpers.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\ThrowHelpers.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="Internal\Runtime\CompilerServices\FixupRuntimeTypeHandle.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\FunctionPointerOps.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\GenericMethodDescriptor.cs" />
@@ -67,6 +69,9 @@
     <Compile Include="Internal\Runtime\Augments\DesktopSupportCallbacks.cs" />
     <Compile Include="Internal\Runtime\Augments\DynamicDelegateAugments.cs" />
     <Compile Include="Internal\Runtime\Augments\EnumInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsProjectNLibrary)' == 'true'">
     <Compile Include="Internal\Runtime\Augments\ReflectionTraceCallbacks.cs" />
     <Compile Include="Internal\Runtime\Augments\ReflectionTraceConnector.cs" />
     <Compile Include="Internal\Reflection\Core\NonPortable\BlockedRuntimeTypeNameGenerator.cs" />
@@ -89,11 +94,21 @@
     <Compile Include="Internal\Reflection\Core\NonPortable\RuntimeType.cs" />
     <Compile Include="Internal\Reflection\Core\NonPortable\RuntimeTypeUnifier.cs" />
     <Compile Include="Internal\Reflection\Core\NonPortable\RuntimeTypeUnifier.Internals.cs" />
-    <Compile Include="Internal\Reflection\Extensibility\ExtensibleType.cs" />
-    <Compile Include="Internal\Runtime\Augments\WinRTInterop.cs" />
-    <Compile Include="Internal\Reflection\ExplicitScopeAttribute.cs" />
     <Compile Include="Internal\Reflection\Core\NonPortable\ReflectionCoreNonPortable.cs" />
     <Compile Include="Internal\Reflection\MetadataTransformedAttribute.cs" />
+    <Compile Include="Internal\Reflection\ExplicitScopeAttribute.cs" />
+    <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.cs" />
+    <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.Events.cs" />
+    <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Internal.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">
+    <Compile Include="Internal\Reflection\CoreRT\RuntimeType.cs" />
+    <Compile Include="Internal\Reflection\CoreRT\ReflectionCoreNonPortable.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Internal\Reflection\Extensibility\ExtensibleType.cs" />
+    <Compile Include="Internal\Runtime\Augments\WinRTInterop.cs" />
     <Compile Include="Interop\Interop.manual.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeWaitHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\Win32SafeHandles.cs" />
@@ -483,11 +498,6 @@
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.FormatProvider.FormatAndParse.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.cs" />
-    <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.Events.cs" />
-    <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Internal.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\..\Common\src\System\Collections\LowLevelComparer.cs" />
     <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelList.cs" />
     <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelDictionary.cs" />
@@ -505,6 +515,7 @@
     <Compile Include="..\..\Common\src\System\NotImplemented.cs" />
     <Compile Include="..\..\Common\src\System\CommonRuntimeTypes.cs" />
     <Compile Include="..\..\Common\src\System\__HResults.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs" />
     <Compile Include="CoverageSupport.cs" />
   </ItemGroup>
   <!-- For now, link Runtime.Base into System.Private.CoreLib for CoreRT until there is proper multifile build -->

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -57,13 +57,7 @@ namespace System
             // canonical delegates which use calling convention converter thunks to marshal arguments
             // for the delegate call. If we execute this version of GetThunk, we can at least assert
             // that the current delegate type is a generic type.
-            unsafe
-            {
-                fixed (IntPtr* pTargetEEType = &this.m_pEEType)
-                {
-                    Debug.Assert(Internal.Runtime.Augments.RuntimeAugments.IsGenericType(*(RuntimeTypeHandle*)pTargetEEType));
-                }
-            }
+            Debug.Assert(RuntimeImports.RhGetEETypeClassification(this.EETypePtr) == RuntimeImports.RhEETypeClassification.Generic);
 #endif
             return TypeLoaderExports.GetDelegateThunk(this, whichThunk);
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -277,14 +277,14 @@ namespace System.Runtime
                         result = RuntimeAugments.TypeLoaderCallbacks.GenericLookupFromContextAndSignature(context, signature, out auxResult);
                         break;
                     case SignatureKind.GenericVirtualMethod:
-                        result = Internal.Runtime.CompilerServices.GenericVirtualMethodSupport.GVMLookupForSlot(*(RuntimeTypeHandle*)&context, *(RuntimeMethodHandle*)&signature);
+                        result = Internal.Runtime.CompilerServices.GenericVirtualMethodSupport.GVMLookupForSlot(new RuntimeTypeHandle(new EETypePtr(context)), *(RuntimeMethodHandle*)&signature);
                         break;
                     case SignatureKind.OpenInstanceResolver:
                         result = Internal.Runtime.CompilerServices.OpenMethodResolver.ResolveMethodWorker(signature, contextObject);
                         break;
                     case SignatureKind.DefaultConstructor:
                         {
-                            result = RuntimeAugments.Callbacks.TryGetDefaultConstructorForType(*(RuntimeTypeHandle*)&context);
+                            result = RuntimeAugments.Callbacks.TryGetDefaultConstructorForType(new RuntimeTypeHandle(new EETypePtr(context)));
                             if (result == IntPtr.Zero)
                                 result = RuntimeAugments.GetFallbackDefaultConstructor();
                         }

--- a/src/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
@@ -10,12 +10,25 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
 using Internal.Runtime.Augments;
+using Internal.Reflection.Core.NonPortable;
 
 namespace System
 {
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct RuntimeTypeHandle
     {
+#if CORERT
+        internal RuntimeTypeHandle(RuntimeType type)
+        {
+            _type = type;
+        }
+
+        internal RuntimeTypeHandle(EETypePtr pEEType)
+        {
+            // CORERT-TODO: RuntimeTypeHandle
+            throw new NotImplementedException();
+        }
+#else
         //
         // Caution: There can be and are multiple EEType for the "same" type (e.g. int[]). That means
         // you can't use the raw IntPtr value for comparisons. 
@@ -25,6 +38,7 @@ namespace System
         {
             _value = pEEType.RawValue;
         }
+#endif
 
         public override bool Equals(Object obj)
         {
@@ -47,6 +61,9 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(RuntimeTypeHandle handle)
         {
+#if CORERT
+            return Object.ReferenceEquals(_type, handle._type);
+#else
             if (_value == handle._value)
             {
                 return true;
@@ -59,6 +76,7 @@ namespace System
             {
                 return RuntimeImports.AreTypesEquivalent(this.ToEETypePtr(), handle.ToEETypePtr());
             }
+#endif
         }
 
         public static bool operator ==(object left, RuntimeTypeHandle right)
@@ -91,7 +109,11 @@ namespace System
 
         internal EETypePtr ToEETypePtr()
         {
+#if CORERT
+            return _type.ToEETypePtr();
+#else
             return new EETypePtr(_value);
+#endif
         }
 
         internal RuntimeImports.RhEETypeClassification Classification
@@ -106,7 +128,11 @@ namespace System
         {
             get
             {
+#if CORERT
+                return _type == null;
+#else
                 return _value == new IntPtr(0);
+#endif
             }
         }
 
@@ -138,11 +164,29 @@ namespace System
         {
             get
             {
+#if CORERT
+                return ToEETypePtr().RawValue;
+#else
                 return _value;
+#endif
             }
         }
 
+#if CORERT
+        internal RuntimeType RuntimeType
+        {
+            get
+            {
+                return _type;
+            }
+        }
+#endif
+
+#if CORERT
+        private RuntimeType _type;
+#else
         private IntPtr _value;
+#endif
     }
 }
 

--- a/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -1315,7 +1315,7 @@ namespace System.Text
             if (encoder != null)
             {
                 Contract.Assert(!encoder.MustFlush || ch == 0,
-                    "[UTF8Encoding.GetBytes] Expected no mustflush or 0 leftover ch " + ch.ToString("X2", FormatProvider.InvariantCulture));
+                    "[UTF8Encoding.GetBytes] Expected no mustflush or 0 leftover ch");
 
                 encoder.surrogateChar = ch;
                 encoder.m_charsUsed = (int)(pSrc - chars);

--- a/src/System.Private.CoreLib/src/System/TypeLoadException.cs
+++ b/src/System.Private.CoreLib/src/System/TypeLoadException.cs
@@ -75,36 +75,5 @@ namespace System
         }
 
         private String _typeName;
-        //// This is called from inside the EE. 
-        //[System.Security.SecurityCritical]  // auto-generated
-        //private TypeLoadException(String className,
-        //                          String assemblyName,
-        //                          String messageArg,
-        //                          int    resourceId)
-        //: base(null)
-        //{
-        //    SetErrorCode(__HResults.COR_E_TYPELOAD);
-        //    ClassName  = className;
-        //    AssemblyName = assemblyName;
-        //    MessageArg = messageArg;
-        //    ResourceId = resourceId;
-
-        //    // Set the _message field eagerly; debuggers look at this field to 
-        //    // display error info. They don't call the Message property.
-        //    SetMessageField();   
-        //}
-
-        //[System.Security.SecurityCritical]  // auto-generated
-        //[DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        //[SuppressUnmanagedCodeSecurity]
-        //private static extern void GetTypeLoadExceptionMessage(int resourceId, StringHandleOnStack retString);
-
-        //// If ClassName != null, GetMessage will construct on the fly using it
-        //// and ResourceId (mscorrc.dll). This allows customization of the
-        //// class name format depending on the language environment.
-        //private String  ClassName;
-        //private String  AssemblyName;
-        //private String  MessageArg;
-        //internal int    ResourceId;
     }
 }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
@@ -54,7 +54,9 @@ namespace Internal.Reflection.Execution
             ReflectionExecutionDomainCallbacksImplementation runtimeCallbacks = new ReflectionExecutionDomainCallbacksImplementation(executionDomain, executionEnvironment);
             RuntimeAugments.Initialize(runtimeCallbacks);
 
+#if !CORERT
             ReflectionTracingInitializer.Initialize();
+#endif
 
             DefaultAssemblyNamesForGetType =
                 new String[]

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -13,6 +13,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
 
+  <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
+    <DefineConstants>CORERT;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
   <!-- Setup the right references -->
   <ItemGroup>
     <ProjectReference Include="..\..\AotPackageReference\AotPackageReference.depproj">
@@ -64,7 +68,7 @@
     <Compile Include="Internal\Reflection\Execution\ExecutionEnvironmentImplementation.MetadataTable.cs" />
     <Compile Include="Internal\Reflection\Execution\ExecutionEnvironmentImplementation.ManifestResources.cs" />
     <Compile Include="Internal\Reflection\Execution\ReflectionExecutionDomainCallbacksImplementation.cs" />
-    <Compile Include="Internal\Reflection\Execution\ReflectionTraceCallbacksImplementation.cs" />
+    <Compile Include="Internal\Reflection\Execution\ReflectionTraceCallbacksImplementation.cs" Condition="'$(IsProjectNLibrary)' == 'true'" />
     <Compile Include="Internal\Reflection\Execution\MetadataReaderExtensions.cs" />
     <Compile Include="Internal\Reflection\Execution\MetadataNameExtensions.cs" />
     <Compile Include="Internal\Reflection\Execution\EnumInfoImplementation.cs" />

--- a/tests/src/Simple/Formatting/Formatting.cmd
+++ b/tests/src/Simple/Formatting/Formatting.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+%~dp0\bin\%1\dnxcore50\native\%~n0.exe
+set ErrorCode=%ERRORLEVEL%
+IF "%ErrorCode%"=="100" (
+    echo %~n0: pass
+    EXIT /b 0
+) ELSE (
+    echo %~n0: fail
+    EXIT /b 1
+)
+endlocal

--- a/tests/src/Simple/Formatting/Formatting.cs
+++ b/tests/src/Simple/Formatting/Formatting.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal class Program
+{
+    private static int Main(string[] args)
+    {
+        string s123 = 123.ToString();
+        if (s123 != "123")
+        {
+            Console.WriteLine("Unexpected: " + s123);
+            return 1;
+        }
+
+        Console.WriteLine("{0}", "Hi");
+        return 100;
+    }
+}

--- a/tests/src/Simple/Formatting/Formatting.sh
+++ b/tests/src/Simple/Formatting/Formatting.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+$1/bin/$3/dnxcore50/native/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/Formatting/no_cpp
+++ b/tests/src/Simple/Formatting/no_cpp
@@ -1,0 +1,1 @@
+Skip this test for cpp codegen mode

--- a/tests/src/Simple/Formatting/project.json
+++ b/tests/src/Simple/Formatting/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "System.Console": "4.0.0-beta-*",
+        "System.Runtime": "4.0.21-beta-*"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
- Add a stubbed out implementation of RuntimeType that just wraps EETypePtr.
- Change RuntimeTypeHandle to conform to RyuJIT conventions

These changes make the typical non-reflection uses of typeof() and System.Type work.

Fixes #743