### PR TITLE
Support for CFI unwind info

### DIFF
--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -3,8 +3,8 @@
     "NETStandard.Library": "1.0.0-rc2-23704",
     "System.IO.MemoryMappedFiles": "4.0.0-rc2-23616",
     "System.Reflection.Metadata": "1.1.0",
-    "Microsoft.DotNet.RyuJit": "1.0.3-prerelease-00001",
-    "Microsoft.DotNet.ObjectWriter": "1.0.4-prerelease-00001"
+    "Microsoft.DotNet.RyuJit": "1.0.4-prerelease-00001",
+    "Microsoft.DotNet.ObjectWriter": "1.0.5-prerelease-00001"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -99,6 +99,10 @@ namespace Internal.JitInterface
                     CorJitFlag.CORJIT_FLG_RELOC |
                     CorJitFlag.CORJIT_FLG_DEBUG_INFO |
                     CorJitFlag.CORJIT_FLG_PREJIT);
+                if (_compilation.Options.TargetOS != TargetOS.Windows)
+                {
+                    flags |= (uint) CorJitFlag.CORJIT_FLG_CFI_UNWIND;
+                }
 
                 if (!_compilation.Options.NoLineNumbers)
                 {

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -1373,6 +1373,7 @@ namespace Internal.JitInterface
         CORJIT_FLG_USE_AVX2            = 0x00000800,
         CORJIT_FLG_USE_AVX_512         = 0x00001000,
         CORJIT_FLG_FEATURE_SIMD        = 0x00002000,
+        CORJIT_FLG_CFI_UNWIND          = 0x00004000,
 
         CORJIT_FLG_READYTORUN          = 0x00010000, // Use version-resilient code generation
 

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -92,8 +92,8 @@
                 <Files>@(ILCompilerBinPlace -> '%(Text)', '')</Files>
                 <!-- TODO: Obtain this from project.lock.json -->
                 <Dependencies><![CDATA[
-        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.4-prerelease-00001" />
-        <dependency id="Microsoft.DotNet.RyuJit" version="1.0.3-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.5-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.RyuJit" version="1.0.4-prerelease-00001" />
         <dependency id="NETStandard.Library" version="1.0.0-rc2-23704" />
         <dependency id="System.Collections.Immutable" version="1.1.37" />
         <dependency id="System.IO.MemoryMappedFiles" version="4.0.0-rc2-23616" />


### PR DESCRIPTION
This enables to emit unwind data for Unix.
Unlike Windows UNWIND_INFO which has fully encoded binary,
RyuJit passes a pseudo CFI_CODE[] table to CoreRT.
This builds a map between offset and CFI_CODE blobs.
Then when we emit code for a particular code offset, we also
emit each CFI_CODE to ObjectWriter which will inject CFI
directive accordingly. Then the backend of LLVM layouts
eh_frame section per platform.
Some of refactoring with regard to nodename is made.