### PR TITLE
Provide copysign implmentation to be used on Linux

### DIFF
--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -34,15 +34,6 @@ extern "C"
     }
 }
 
-// UNIXTODO: Unix port of _ecvt_s and _copysign https://github.com/dotnet/corert/issues/670
-extern "C"
-{
-    void _copysign()
-    {
-        throw "_copysign";
-    }
-}
-
 extern "C"
 {
     void CoCreateGuid()

--- a/src/System.Private.CoreLib/src/System/Math.cs
+++ b/src/System.Private.CoreLib/src/System/Math.cs
@@ -165,6 +165,14 @@ namespace System
             return RuntimeImports.tanh(value);
         }
 
+        internal static double CopySign(double x, double y)
+        {
+            bool xNegative = x < 0;
+            bool yNegative = y < 0;
+            
+            return xNegative == yNegative ? x : -x;
+        }
+
 #if CORERT
         [Intrinsic]
 #endif
@@ -186,7 +194,12 @@ namespace System
                     flrTempVal -= 1.0;
                 }
             }
+
+#if !PLATFORM_UNIX
             flrTempVal = RuntimeImports._copysign(flrTempVal, a);
+#else
+            flrTempVal = CopySign(flrTempVal, a);
+#endif // !PLATFORM_UNIX
             return flrTempVal;
         }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -656,10 +656,12 @@ namespace System.Runtime
         internal static extern double fabs(double x);
 #endif // CORERT
 
+#if !PLATFORM_UNIX
         [Intrinsic]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "_copysign")]
         internal static extern double _copysign(double x, double y);
+#endif // !PLATFORM_UNIX
 
         [Intrinsic]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
when running on Windows we use _copysign which is not supported on Linux. Linux support copysign but if we need to switch to use copysign instead of _copysign we'll have to do a bigger change in NUTC too.
Considering copysign implementation is simple, we provide the implementation
to be used when running on Linux and it is not worth to pinvoke
to the system. we may consider later to use this implementation even in Windows
and git rid of the intrinsic method