### PR TITLE
Workaround 1 MSBuild issue and fix targeting framework

### DIFF
--- a/src/ILCompiler/desktop/App.config
+++ b/src/ILCompiler/desktop/App.config
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.UnmanagedMemoryStream" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -12,7 +12,11 @@
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <BaseNuGetRuntimeIdentifier>win7</BaseNuGetRuntimeIdentifier>
+    <!-- AutoGenerateBindingRedirects is not honoring the unification
+         table, and thus breaking unification by explicitly listing
+         bindingRedirects for assemblies that only differ by revision -->
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -55,6 +59,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
@@ -63,13 +68,13 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish0\jitinterface.dll">
+    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish1\jitinterface.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish0\objwriter.dll">
+    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish1\objwriter.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish0\ryujit.dll">
+    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish1\ryujit.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/ILCompiler/desktop/project.json
+++ b/src/ILCompiler/desktop/project.json
@@ -7,7 +7,7 @@
     "Microsoft.DiaSymReader": "1.0.6"
   },
   "frameworks": {
-    "dnxcore50": { 
+    "net46": { 
         "imports": "portable-net451+win8"
     }
   },


### PR DESCRIPTION
@ericstj suggested the fix/workaround and the changes. @ericstj @jkotas, PTAL.

There were a couple of bugs in MSBuild that Eric St John repro'ed with a local standalone project. The below workaround should unblock VS dev flow.

1. Use net46 for desktop project so it doesn't collide with the DNX assembly references.
2.  1 exposed this problem: MSBuild emitting assembly redirects for assemblies that differed only in minors in the unification table.

PS: @ericstj, thanks for debugging the issue and providing the fix.
