### PR TITLE
Emit PDB local var debug information

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/INodeWithDebugInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/INodeWithDebugInfo.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Internal.JitInterface;
+
 namespace ILCompiler.DependencyAnalysis
 {
     public struct DebugLocInfo
@@ -19,12 +23,33 @@ namespace ILCompiler.DependencyAnalysis
             ColNumber = colNumber;
         }
     }
-
+    
     public interface INodeWithDebugInfo
     {
         DebugLocInfo[] DebugLocInfos
         {
             get;
+        }
+
+        DebugVarInfo[] DebugVarInfos
+        {
+            get;
+        }
+    }
+     
+    public struct DebugVarInfo
+    {
+        public readonly string Name;
+        public readonly uint TypeIndex;
+        public readonly bool IsParam;
+        public List<NativeVarInfo> Ranges;
+
+        public DebugVarInfo(string name, bool isParam, uint typeIndex)
+        {
+            this.Name = name;
+            this.TypeIndex = typeIndex;
+            this.IsParam = isParam;
+            this.Ranges = new List<NativeVarInfo>();
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -14,6 +14,7 @@ namespace ILCompiler.DependencyAnalysis
         private ObjectData _methodCode;
         private FrameInfo[] _frameInfos;
         private DebugLocInfo[] _debugLocInfos;
+        private DebugVarInfo[] _debugVarInfos;
 
         public MethodCodeNode(MethodDesc method)
         {
@@ -98,10 +99,24 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        public DebugVarInfo[] DebugVarInfos
+        {
+            get
+            {
+                return _debugVarInfos;
+            }
+        }        
+
         public void InitializeDebugLocInfos(DebugLocInfo[] debugLocInfos)
         {
             Debug.Assert(_debugLocInfos == null);
             _debugLocInfos = debugLocInfos;
+        }
+
+        public void InitializeDebugVarInfos(DebugVarInfo[] debugVarInfos)
+        {
+            Debug.Assert(_debugVarInfos == null);
+            _debugVarInfos = debugVarInfos;
         }
     }
 }

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -4,7 +4,7 @@
     "System.IO.MemoryMappedFiles": "4.0.0-rc2-23704",
     "System.Reflection.Metadata": "1.1.0",
     "Microsoft.DotNet.RyuJit": "1.0.4-prerelease-00001",
-    "Microsoft.DotNet.ObjectWriter": "1.0.6-prerelease-00001"
+    "Microsoft.DotNet.ObjectWriter": "1.0.7-prerelease-00001"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -96,7 +96,7 @@
                 <Files>@(ILCompilerBinPlace -> '%(Text)', '')</Files>
                 <!-- TODO: Obtain this from project.lock.json -->
                 <Dependencies><![CDATA[
-        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.6-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.7-prerelease-00001" />
         <dependency id="Microsoft.DotNet.RyuJit" version="1.0.4-prerelease-00001" />
         <dependency id="NETStandard.Library" version="1.0.0-rc2-23704" />
         <dependency id="System.Collections.Immutable" version="1.1.37" />


### PR DESCRIPTION
This change enables displaying local var and parameter values during
debugging coreRT apps on Windows.