### PR TITLE
Cleanup relative path in compile elements to have a link

### DIFF
--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -19,7 +19,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\TypeSystem\CodeGen\MethodDesc.CodeGen.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\CodeGen\MethodDesc.CodeGen.cs" >
+      <Link>Utilities\MethodDesc.CodeGen.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\AlignmentHelper.cs">
       <Link>Utilities\AlignmentHelper.cs</Link>
     </Compile>
@@ -32,44 +34,120 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
       <Link>Utilities\LockFreeReaderHashtable.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ByRefType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\GenericParameterDesc.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldForInstantiatedType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.FieldLayout.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldLayoutAlgorithm.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedMethod.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.Interfaces.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.MethodImpls.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.Interfaces.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.MethodImpls.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataFieldLayoutAlgorithm.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataRuntimeInterfacesAlgorithm.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodForInstantiatedType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ParameterizedType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\PointerType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\PropertySignature.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\SignatureVariable.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TargetDetails.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ThreadSafeFlags.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeCast.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeFlags.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeHashingAlgorithms.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemContext.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemHelpers.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\WellKnownType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\VirtualFunctionResolution.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.Interfaces.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\DefType.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\DefType.FieldLayout.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Common\RuntimeInterfacesAlgorithm.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayType.cs" >
+      <Link>TypeSystem\Common\ArrayType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs" >
+      <Link>TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs" >
+      <Link>TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ByRefType.cs" >
+      <Link>TypeSystem\Common\ByRefType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\GenericParameterDesc.cs" >
+      <Link>TypeSystem\Common\GenericParameterDesc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldForInstantiatedType.cs" >
+      <Link>TypeSystem\Common\FieldForInstantiatedType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.cs" >
+      <Link>TypeSystem\Common\FieldDesc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.FieldLayout.cs" >
+      <Link>TypeSystem\Common\FieldDesc.FieldLayout.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldLayoutAlgorithm.cs" >
+      <Link>TypeSystem\Common\FieldLayoutAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedMethod.cs" >
+      <Link>TypeSystem\Common\InstantiatedMethod.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.cs" >
+      <Link>TypeSystem\Common\InstantiatedType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.Interfaces.cs" >
+      <Link>TypeSystem\Common\InstantiatedType.Interfaces.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.MethodImpls.cs" >
+      <Link>TypeSystem\Common\InstantiatedType.MethodImpls.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.cs" >
+      <Link>TypeSystem\Common\MetadataType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.Interfaces.cs" >
+      <Link>TypeSystem\Common\MetadataType.Interfaces.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.MethodImpls.cs" >
+      <Link>TypeSystem\Common\MetadataType.MethodImpls.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataFieldLayoutAlgorithm.cs" >
+      <Link>TypeSystem\Common\MetadataFieldLayoutAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataRuntimeInterfacesAlgorithm.cs" >
+      <Link>TypeSystem\Common\MetadataRuntimeInterfacesAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodForInstantiatedType.cs" >
+      <Link>TypeSystem\Common\MethodForInstantiatedType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ParameterizedType.cs" >
+      <Link>TypeSystem\Common\ParameterizedType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\PointerType.cs" >
+      <Link>TypeSystem\Common\PointerType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\PropertySignature.cs" >
+      <Link>TypeSystem\Common\PropertySignature.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\SignatureVariable.cs" >
+      <Link>TypeSystem\Common\SignatureVariable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TargetDetails.cs" >
+      <Link>TypeSystem\Common\TargetDetails.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ThreadSafeFlags.cs" >
+      <Link>TypeSystem\Common\ThreadSafeFlags.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeCast.cs" >
+      <Link>TypeSystem\Common\TypeCast.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeFlags.cs" >
+      <Link>TypeSystem\Common\TypeFlags.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeHashingAlgorithms.cs" >
+      <Link>TypeSystem\Common\TypeHashingAlgorithms.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemContext.cs" >
+      <Link>TypeSystem\Common\TypeSystemContext.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemHelpers.cs" >
+      <Link>TypeSystem\Common\TypeSystemHelpers.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\WellKnownType.cs" >
+      <Link>TypeSystem\Common\WellKnownType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.cs" >
+      <Link>TypeSystem\Common\MethodDesc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\VirtualFunctionResolution.cs" >
+      <Link>TypeSystem\Common\VirtualFunctionResolution.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.cs" >
+      <Link>TypeSystem\Common\TypeDesc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.Interfaces.cs" >
+      <Link>TypeSystem\Common\TypeDesc.Interfaces.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\DefType.cs" >
+      <Link>TypeSystem\Common\DefType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\DefType.FieldLayout.cs" >
+      <Link>TypeSystem\Common\DefType.FieldLayout.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\RuntimeInterfacesAlgorithm.cs" >
+      <Link>TypeSystem\Common\RuntimeInterfacesAlgorithm.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.cs">
       <Link>Ecma\EcmaField.cs</Link>
     </Compile>

--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -38,7 +38,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\src\Program.cs" />
+    <Compile Include="..\src\Program.cs" >
+      <Link>src\Program.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\CommandLine\CommandLineException.cs">

--- a/src/System.Private.DeveloperExperience.Console/src/System.Private.DeveloperExperience.Console.csproj
+++ b/src/System.Private.DeveloperExperience.Console/src/System.Private.DeveloperExperience.Console.csproj
@@ -34,15 +34,25 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
-    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Console.cs" />
-    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.HandleTypes.cs" />
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Console.cs" >
+      <Link>Interop\Windows\mincore\Interop.Console.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.HandleTypes.cs" >
+      <Link>Interop\Windows\mincore\Interop.HandleTypes.cs</Link>
+    </Compile>
     <Compile Include="Internal\DeveloperExperience\ConsolePal.Windows.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Libraries.cs" />
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Write.cs" />
-    <Compile Include="..\..\Common\src\Interop\Unix\libc\Interop.FileDescriptors.cs" />
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Libraries.cs" >
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Write.cs" >
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.Write.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\libc\Interop.FileDescriptors.cs" >
+      <Link>Interop\Unix\libc\Interop.FileDescriptors.cs</Link>
+    </Compile>
     <Compile Include="Internal\DeveloperExperience\ConsolePal.Unix.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.Interop/src/System.Private.Interop.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.csproj
@@ -63,9 +63,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\Common\src\Internal\NativeFormat\NativeFormatReader.cs" />
-    <Compile Include="..\..\Common\src\Internal\NativeFormat\NativeFormatReader.String.cs" />
-    
+    <Compile Include="..\..\Common\src\Internal\NativeFormat\NativeFormatReader.cs" >
+      <Link>Internal\NativeFormat\NativeFormatReader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Internal\NativeFormat\NativeFormatReader.String.cs" >
+      <Link>Internal\NativeFormat\NativeFormatReader.String.cs</Link>
+    </Compile>
+
     <Compile Include="Shared\__ComObject.cs" />
     <Compile Include="Shared\ComCallableObject.cs" />
     <Compile Include="Shared\ComException.cs" />

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -126,20 +126,48 @@
     <Compile Include="Internal\Reflection\Tracing\ITraceableTypeMember.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\System\CommonRuntimeTypes.cs" />
-    <Compile Include="..\..\Common\src\System\NotImplemented.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelList.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelDictionary.cs" />
-    <Compile Include="..\..\Common\src\System\Linq\LowLevelEnumerable.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\HashHelpers.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Generic\EnumerableExtensions.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Generic\Empty.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Concurrent\ConcurrentUnifier.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Concurrent\ConcurrentUnifierW.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Concurrent\ConcurrentUnifierWKeyed.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Concurrent\IKeyedItem.cs" />
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\DeveloperExperienceModeOnlyAttribute.cs" />
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\DeveloperExperienceState.cs" />
+    <Compile Include="..\..\Common\src\System\CommonRuntimeTypes.cs" >
+      <Link>System\CommonRuntimeTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\NotImplemented.cs" >
+      <Link>System\NotImplemented.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelList.cs" >
+      <Link>System\Collections\Generic\LowLevelList.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelDictionary.cs" >
+      <Link>System\Collections\Generic\LowLevelDictionary.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Linq\LowLevelEnumerable.cs" >
+      <Link>System\Linq\LowLevelEnumerable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\HashHelpers.cs" >
+      <Link>System\Collections\HashHelpers.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Generic\EnumerableExtensions.cs" >
+      <Link>System\Collections\Generic\EnumerableExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Generic\Empty.cs" >
+      <Link>System\Collections\Generic\Empty.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Concurrent\ConcurrentUnifier.cs" >
+      <Link>System\Collections\Concurrent\ConcurrentUnifier.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Concurrent\ConcurrentUnifierW.cs" >
+      <Link>System\Collections\Concurrent\ConcurrentUnifierW.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Concurrent\ConcurrentUnifierWKeyed.cs" >
+      <Link>System\Collections\Concurrent\ConcurrentUnifierWKeyed.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Concurrent\IKeyedItem.cs" >
+      <Link>System\Collections\Concurrent\IKeyedItem.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\DeveloperExperienceModeOnlyAttribute.cs" >
+      <Link>System\Runtime\CompilerServices\DeveloperExperienceModeOnlyAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\DeveloperExperienceState.cs" >
+      <Link>System\Runtime\CompilerServices\DeveloperExperienceState.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -103,16 +103,36 @@
     <Compile Include="Internal\Reflection\Execution\TypeLoaderDependencies.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\Internal\Reflection\Execution\Binder\DefaultBinder.cs" />
-    <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs" />
-    <Compile Include="..\..\Common\src\System\CommonRuntimeTypes.cs" />
-    <Compile Include="..\..\Common\src\System\NotImplemented.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelList.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelDictionary.cs" />
-    <Compile Include="..\..\Common\src\System\Linq\LowLevelEnumerable.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\HashHelpers.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Generic\Empty.cs" />
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\DeveloperExperienceModeOnlyAttribute.cs" />
+    <Compile Include="..\..\Common\src\Internal\Reflection\Execution\Binder\DefaultBinder.cs" >
+      <Link>Internal\Reflection\Execution\Binder\DefaultBinder.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs" >
+      <Link>Internal\Runtime\MetadataBlob.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\CommonRuntimeTypes.cs" >
+      <Link>System\CommonRuntimeTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\NotImplemented.cs" >
+      <Link>System\NotImplemented.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelList.cs" >
+      <Link>System\Collections\Generic\LowLevelList.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelDictionary.cs" >
+      <Link>System\Collections\Generic\LowLevelDictionary.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Linq\LowLevelEnumerable.cs" >
+      <Link>System\Linq\LowLevelEnumerable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\HashHelpers.cs" >
+      <Link>System\Collections\HashHelpers.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Collections\Generic\Empty.cs" >
+      <Link>System\Collections\Generic\Empty.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\DeveloperExperienceModeOnlyAttribute.cs" >
+      <Link>System\Runtime\CompilerServices\DeveloperExperienceModeOnlyAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Private.Reflection/src/System.Private.Reflection.csproj
+++ b/src/System.Private.Reflection/src/System.Private.Reflection.csproj
@@ -36,8 +36,12 @@
     <Compile Include="..\..\Common\src\System\SR.Core.cs">
       <Link>Resources\Common</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\System\NotImplemented.cs" />
-    <Compile Include="..\..\Common\src\System\__HResults.cs" />
+    <Compile Include="..\..\Common\src\System\NotImplemented.cs" >
+      <Link>System\NotImplemented.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\__HResults.cs" >
+      <Link>System\__HResults.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Reflection\AmbiguousMatchException.cs" />

--- a/src/System.Private.StackTraceGenerator/src/System.Private.StackTraceGenerator.csproj
+++ b/src/System.Private.StackTraceGenerator/src/System.Private.StackTraceGenerator.csproj
@@ -28,8 +28,12 @@
     <Compile Include="Internal\Dia\DiaInterfaces.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\System\NotImplemented.cs" />
-    <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgIntrinsicsAttribute.cs" />
+    <Compile Include="..\..\Common\src\System\NotImplemented.cs" >
+      <Link>System\NotImplemented.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgIntrinsicsAttribute.cs" >
+      <Link>System\Runtime\InteropServices\McgIntrinsicsAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.Threading/src/System.Private.Threading.csproj
+++ b/src/System.Private.Threading/src/System.Private.Threading.csproj
@@ -94,10 +94,14 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\System\__HResults.cs" />
+    <Compile Include="..\..\Common\src\System\__HResults.cs" >
+      <Link>System\__HResults.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgIntrinsicsAttribute.cs" />
+    <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgIntrinsicsAttribute.cs" >
+      <Link>System\Runtime\InteropServices\McgIntrinsicsAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
without the link, VS will show all relative path elements in the root of the
project explorer. adding link will organize the view and also avoid a conflic
with the same file names