### PR TITLE
Add GetKnown[Method|Field|Type] extension methods

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/AddrOfIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/AddrOfIntrinsic.cs
@@ -27,13 +27,7 @@ namespace Internal.IL.Stubs
 
             codeStream.EmitLdArg(0);
 
-            var fptrField = target.Context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType.GetField("m_extraFunctionPointerOrData");
-            if (fptrField == null)
-            {
-                // TODO: Better exception type. Should be: "CoreLib doesn't have a required thing in it".
-                throw new NotImplementedException();
-            }
-
+            var fptrField = target.Context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType.GetKnownField("m_extraFunctionPointerOrData");
             codeStream.Emit(ILOpcode.ldfld, emitter.NewToken(fptrField));
 
             codeStream.Emit(ILOpcode.ret);

--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -30,7 +30,7 @@ namespace Internal.IL.Stubs
             
             // This helper field is needed to generate proper GC tracking. There is no direct way
             // to create interior pointer. 
-            _helperFieldToken = _emitter.NewToken(_method.Context.GetWellKnownType(WellKnownType.Object).GetField("m_pEEType"));
+            _helperFieldToken = _emitter.NewToken(_method.Context.GetWellKnownType(WellKnownType.Object).GetKnownField("m_pEEType"));
         }
 
         private void EmitLoadInteriorAddress(ILCodeStream codeStream, int offset)

--- a/src/Common/src/TypeSystem/IL/Stubs/InterlockedIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/InterlockedIntrinsic.cs
@@ -35,13 +35,8 @@ namespace Internal.IL.Stubs
                 parameters[i] = objectType;
 
             MethodSignature nonGenericSignature = new MethodSignature(MethodSignatureFlags.Static, 0, objectType, parameters);
-
-            MethodDesc nonGenericMethod = target.OwningType.GetMethod(target.Name, nonGenericSignature);
-
-            // TODO: Better exception type. Should be: "CoreLib doesn't have a required thing in it".
-            if (nonGenericMethod == null)
-                throw new NotImplementedException();
-
+            MethodDesc nonGenericMethod = target.OwningType.GetKnownMethod(target.Name, nonGenericSignature);
+            
             //
             // Emit the forwarder
             //

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeMarshallingILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeMarshallingILEmitter.cs
@@ -218,8 +218,8 @@ namespace Internal.IL.Stubs
                 TypeDesc byteType = context.GetWellKnownType(WellKnownType.Byte);
                 TypeDesc byteArrayType = byteType.MakeArrayType();
 
-                MethodDesc getLengthMethod = stringType.GetMethod("get_Length", null);
-                MethodDesc getCharsMethod = stringType.GetMethod("get_Chars", null);
+                MethodDesc getLengthMethod = stringType.GetKnownMethod("get_Length", null);
+                MethodDesc getCharsMethod = stringType.GetKnownMethod("get_Chars", null);
 
                 ILCodeLabel lStart = _emitter.NewCodeLabel();
                 ILCodeLabel lNext = _emitter.NewCodeLabel();
@@ -435,7 +435,7 @@ namespace Internal.IL.Stubs
                 TypeSystemContext context = method.Context;
                 MethodSignature ctorSignature = new MethodSignature(0, 0, context.GetWellKnownType(WellKnownType.Void),
                     new TypeDesc[] { context.GetWellKnownType(WellKnownType.String) });
-                MethodDesc exceptionCtor = method.Context.GetWellKnownType(WellKnownType.Exception).GetMethod(".ctor", ctorSignature);
+                MethodDesc exceptionCtor = method.Context.GetWellKnownType(WellKnownType.Exception).GetKnownMethod(".ctor", ctorSignature);
 
                 ILCodeStream codeStream = emitter.NewCodeStream();
                 codeStream.Emit(ILOpcode.ldstr, emitter.NewToken(message));

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -15,6 +15,7 @@ using ILCompiler.SymbolReader;
 
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
+using Internal.IL;
 
 namespace ILCompiler
 {
@@ -153,7 +154,7 @@ namespace ILCompiler
             // Initialize all well known types - it will save us from checking the name for each loaded type
             for (int typeIndex = 0; typeIndex < _wellKnownTypes.Length; typeIndex++)
             {
-                MetadataType type = systemModule.GetType("System", s_wellKnownTypeNames[typeIndex]);
+                MetadataType type = systemModule.GetKnownType("System", s_wellKnownTypeNames[typeIndex]);
                 type.SetWellKnownType((WellKnownType)(typeIndex + 1));
                 _wellKnownTypes[typeIndex] = type;
             }
@@ -292,7 +293,7 @@ namespace ILCompiler
         {
             if (_arrayOfTRuntimeInterfacesAlgorithm == null)
             {
-                _arrayOfTRuntimeInterfacesAlgorithm = new ArrayOfTRuntimeInterfacesAlgorithm(SystemModule.GetType("System", "Array`1"));
+                _arrayOfTRuntimeInterfacesAlgorithm = new ArrayOfTRuntimeInterfacesAlgorithm(SystemModule.GetKnownType("System", "Array`1"));
             }
             return _arrayOfTRuntimeInterfacesAlgorithm;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DelegateInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DelegateInfo.cs
@@ -6,6 +6,7 @@ using System;
 
 using Internal.IL.Stubs;
 using Internal.TypeSystem;
+using Internal.IL;
 
 namespace ILCompiler
 {
@@ -29,11 +30,11 @@ namespace ILCompiler
             {
                 this.ShuffleThunk = new DelegateShuffleThunk(target);
 
-                this.Ctor = systemDelegate.GetMethod("InitializeClosedStaticThunk", null);
+                this.Ctor = systemDelegate.GetKnownMethod("InitializeClosedStaticThunk", null);
             }
             else
             {
-                this.Ctor = systemDelegate.GetMethod("InitializeClosedInstance", null);
+                this.Ctor = systemDelegate.GetKnownMethod("InitializeClosedInstance", null);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using ILCompiler.DependencyAnalysisFramework;
+using Internal.IL;
 using Internal.Runtime;
 using Internal.TypeSystem;
 using System;
@@ -494,10 +495,7 @@ namespace ILCompiler.DependencyAnalysis
             if (!_type.IsNullable)
                 return;
 
-            var field = _type.GetField("value");
-
-            // Ensure the definition of Nullable<T> didn't change on us
-            Debug.Assert(field != null);
+            var field = _type.GetKnownField("value");
 
             // In the definition of Nullable<T>, the first field should be the boolean representing "hasValue"
             Debug.Assert(field.Offset > 0);
@@ -522,9 +520,8 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (itf == factory.ICastableInterface)
                 {
-                    var isInstMethod = itf.GetMethod("IsInstanceOfInterface", null);
-                    var getImplTypeMethod = itf.GetMethod("GetImplType", null);
-                    Debug.Assert(isInstMethod != null && getImplTypeMethod != null);
+                    var isInstMethod = itf.GetKnownMethod("IsInstanceOfInterface", null);
+                    var getImplTypeMethod = itf.GetKnownMethod("GetImplType", null);
 
                     int isInstMethodSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, isInstMethod);
                     int getImplTypeMethodSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, getImplTypeMethod);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -9,6 +9,7 @@ using ILCompiler.DependencyAnalysisFramework;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Internal.Runtime;
+using Internal.IL;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -321,8 +322,8 @@ namespace ILCompiler.DependencyAnalysis
             {
                 var entry = s_helperEntrypointNames[index];
 
-                var type = _context.SystemModule.GetType(entry[0], entry[1]);
-                var method = type.GetMethod(entry[2], null);
+                var type = _context.SystemModule.GetKnownType(entry[0], entry[1]);
+                var method = type.GetKnownMethod(entry[2], null);
 
                 symbol = MethodEntrypoint(method);
 
@@ -339,8 +340,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (_systemICastableType == null)
                 {
-                    _systemICastableType = _context.SystemModule.GetType("System.Runtime.CompilerServices", "ICastable");
-                    Debug.Assert(_systemICastableType != null);
+                    _systemICastableType = _context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "ICastable");
                 }
                 return _systemICastableType;
             }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -456,7 +456,7 @@ namespace ILCompiler.CppCodeGen
 
             if (type.IsDelegate)
             {
-                MethodDesc method = type.GetMethod("Invoke", null);
+                MethodDesc method = type.GetKnownMethod("Invoke", null);
 
                 var sig = method.Signature;
                 ExpandType(sig.ReturnType);
@@ -770,7 +770,7 @@ namespace ILCompiler.CppCodeGen
         {
             StringBuilder sb = new StringBuilder();
 
-            MethodDesc method = delegateType.GetMethod("Invoke", null);
+            MethodDesc method = delegateType.GetKnownMethod("Invoke", null);
 
             AppendSlotTypeDef(sb, method);
 

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -51,15 +51,15 @@ namespace Internal.IL.Stubs.StartupCode
             ILCodeStream codeStream = emitter.NewCodeStream();
             ILLocalVariable returnValue = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Int32));
 
-            TypeDesc startup = Context.SystemModule.GetType("Internal.Runtime.CompilerHelpers", "StartupCodeHelpers");
+            MetadataType startup = Context.GetHelperType("StartupCodeHelpers");
             
-            codeStream.Emit(ILOpcode.call, emitter.NewToken(startup.GetMethod("Initialize", null)));
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(startup.GetKnownMethod("Initialize", null)));
 
             // Initialize command line args
             string initArgsName = (Context.Target.OperatingSystem == TargetOS.Windows)
                                 ? "InitializeCommandLineArgsW"
                                 : "InitializeCommandLineArgs";
-            MethodDesc initArgs = startup.GetMethod(initArgsName, null);
+            MethodDesc initArgs = startup.GetKnownMethod(initArgsName, null);
             codeStream.Emit(ILOpcode.ldarg_0); // argc
             codeStream.Emit(ILOpcode.ldarg_1); // argv
             codeStream.Emit(ILOpcode.call, emitter.NewToken(initArgs));
@@ -67,8 +67,8 @@ namespace Internal.IL.Stubs.StartupCode
             // Call program Main
             if (_mainMethod.Signature.Length > 0)
             {
-                TypeDesc environ = Context.SystemModule.GetType("System", "Environment");
-                codeStream.Emit(ILOpcode.call, emitter.NewToken(environ.GetMethod("GetCommandLineArgs", null)));
+                TypeDesc environ = Context.SystemModule.GetKnownType("System", "Environment");
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(environ.GetKnownMethod("GetCommandLineArgs", null)));
             }
             codeStream.Emit(ILOpcode.call, emitter.NewToken(_mainMethod));
             if (_mainMethod.Signature.ReturnType.IsVoid)
@@ -77,7 +77,7 @@ namespace Internal.IL.Stubs.StartupCode
             }
             codeStream.EmitStLoc(returnValue);
 
-            codeStream.Emit(ILOpcode.call, emitter.NewToken(startup.GetMethod("Shutdown", null)));
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(startup.GetKnownMethod("Shutdown", null)));
 
             codeStream.EmitLdLoc(returnValue);
             codeStream.Emit(ILOpcode.ret);


### PR DESCRIPTION
The point is to have a single path through which the compiler locates
things in the core library(ies). This way we can have a different
failure mode when pieces the compiler expects are missing (CoreRT's
fault) vs. pieces the code being compiled expects are missing (user
error, usually).

Once we figure out the exception throwing story, the exception thrown
will be different so that we can handle/translate it properly.