### PR TITLE
Refactor explicit FLS usage in the runtime

### DIFF
--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -73,8 +73,15 @@ extern "C" void * RhpHandleAlloc(void * pObject, int handleType);
 #define DLL_PROCESS_ATTACH      1
 extern "C" BOOL WINAPI RtuDllMain(HANDLE hPalInstance, DWORD dwReason, void* pvReserved);
 
+REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalInit();
+
 int __initialize_runtime()
 {
+    if (!PalInit())
+    {
+        return 1;
+    }
+
     RtuDllMain(NULL, DLL_PROCESS_ATTACH, NULL);
 
     RhpEnableConservativeStackReporting();

--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -788,6 +788,9 @@ REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalAllocateThunksFromTemplate(_In_ 
 
 REDHAWK_PALIMPORT UInt32 REDHAWK_PALAPI PalCompatibleWaitAny(UInt32_BOOL alertable, UInt32 timeout, UInt32 count, HANDLE* pHandles, UInt32_BOOL allowReentrantWait);
 
+REDHAWK_PALIMPORT void REDHAWK_PALAPI PalAttachThread(void* thread);
+REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalDetachThread(void* thread);
+
 #ifdef PLATFORM_UNIX
 REDHAWK_PALIMPORT Int32 __cdecl _stricmp(const char *string1, const char *string2);
 #endif // PLATFORM_UNIX

--- a/src/Native/Runtime/PalRedhawkCommon.h
+++ b/src/Native/Runtime/PalRedhawkCommon.h
@@ -100,6 +100,6 @@ struct PAL_LIMITED_CONTEXT
 #endif // _ARM_
 };
 
-
+void __stdcall RuntimeThreadShutdown(void* thread);
 
 #endif // __PAL_REDHAWK_COMMON_INCLUDED

--- a/src/Native/Runtime/PalRedhawkFunctions.h
+++ b/src/Native/Runtime/PalRedhawkFunctions.h
@@ -62,18 +62,6 @@ inline void PalExitProcess(UInt32 arg1)
     ExitProcess(arg1);
 }
 
-extern "C" void * __stdcall FlsGetValue(UInt32);
-inline void * PalFlsGetValue(UInt32 arg1)
-{
-    return FlsGetValue(arg1);
-}
-
-extern "C" UInt32_BOOL __stdcall FlsSetValue(UInt32, void *);
-inline UInt32_BOOL PalFlsSetValue(UInt32 arg1, void * arg2)
-{
-    return FlsSetValue(arg1, arg2);
-}
-
 extern "C" void __stdcall FlushProcessWriteBuffers();
 inline void PalFlushProcessWriteBuffers()
 {
@@ -234,12 +222,6 @@ inline UInt32 PalWaitForSingleObjectEx(HANDLE arg1, UInt32 arg2, UInt32_BOOL arg
 }
 
 #ifdef PAL_REDHAWK_INCLUDED
-extern "C" UInt32 __stdcall FlsAlloc(PFLS_CALLBACK_FUNCTION);
-inline UInt32 PalFlsAlloc(PFLS_CALLBACK_FUNCTION arg1)
-{
-    return FlsAlloc(arg1);
-}
-
 extern "C" void __stdcall GetNativeSystemInfo(SYSTEM_INFO *);
 inline void PalGetNativeSystemInfo(SYSTEM_INFO * arg1)
 {

--- a/src/Native/Runtime/startup.cpp
+++ b/src/Native/Runtime/startup.cpp
@@ -39,7 +39,6 @@ UInt32 _fls_index = FLS_OUT_OF_INDEXES;
 
 
 Int32 __stdcall RhpVectoredExceptionHandler(PEXCEPTION_POINTERS pExPtrs);
-void __stdcall FiberDetach(void* lpFlsData);
 void CheckForPalFallback();
 
 extern RhConfig * g_pRhConfig;
@@ -73,10 +72,6 @@ bool InitDLL(HANDLE hPalInstance)
     if (NULL == hRuntimeInstance)
         return false;
     STARTUP_TIMELINE_EVENT(NONGC_INIT_COMPLETE);
-
-    _fls_index = PalFlsAlloc(FiberDetach);
-    if (_fls_index == FLS_OUT_OF_INDEXES)
-        return false;
 
     // @TODO: currently we're always forcing a workstation GC.
     // @TODO: GC per-instance vs per-DLL state separation
@@ -214,13 +209,13 @@ void DllThreadDetach()
     }
 }
 
-void __stdcall FiberDetach(void* lpFlsData)
+void __stdcall RuntimeThreadShutdown(void* thread)
 {
     // Note: loader lock is *not* held here!
-    UNREFERENCED_PARAMETER(lpFlsData);
-    ASSERT(lpFlsData == PalFlsGetValue(_fls_index));
+    UNREFERENCED_PARAMETER(thread);
+    ASSERT((Thread*)thread == ThreadStore::GetCurrentThread());
 
-    ThreadStore::DetachCurrentThreadIfHomeFiber();
+    ThreadStore::DetachCurrentThread();
 }
 
 COOP_PINVOKE_HELPER(UInt32_BOOL, RhpRegisterModule, (ModuleHeader *pModuleHeader))

--- a/src/Native/Runtime/threadstore.h
+++ b/src/Native/Runtime/threadstore.h
@@ -39,7 +39,7 @@ public:
     static PTR_Thread       GetSuspendingThread();
     static void             AttachCurrentThread();
     static void             AttachCurrentThread(bool fAcquireThreadStoreLock);
-    static void             DetachCurrentThreadIfHomeFiber();
+    static void             DetachCurrentThread();
 #ifdef DACCESS_COMPILE
     static PTR_Thread       GetThreadFromTEB(TADDR pvTEB);
 #endif // DACCESS_COMPILE

--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -40,6 +40,9 @@ uint32_t PalEventWrite(REGHANDLE arg1, const EVENT_DESCRIPTOR * arg2, uint32_t a
 
 extern "C" UInt32 __stdcall NtGetCurrentProcessorNumber();
 
+// Index for the fiber local storage of the attached thread pointer
+static UInt32 g_flsIndex = FLS_OUT_OF_INDEXES;
+
 static DWORD g_dwPALCapabilities;
 
 GCSystemInfo g_SystemInfo;
@@ -58,6 +61,22 @@ bool InitializeSystemInfo()
 
 extern bool PalQueryProcessorTopology();
 
+// This is called when each *fiber* is destroyed. When the home fiber of a thread is destroyed,
+// it means that the thread itself is destroyed.
+// Since we receive that notification outside of the Loader Lock, it allows us to safely acquire
+// the ThreadStore lock in the RuntimeThreadShutdown.
+void __stdcall FiberDetachCallback(void* lpFlsData)
+{
+    ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);
+    ASSERT(lpFlsData == FlsGetValue(g_flsIndex));
+
+    if (lpFlsData != NULL)
+    {
+        // The current fiber is the home fiber of a thread, so the thread is shutting down
+        RuntimeThreadShutdown(lpFlsData);
+    }
+}
+
 // The Redhawk PAL must be initialized before any of its exports can be called. Returns true for a successful
 // initialization and false on failure.
 REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalInit()
@@ -67,6 +86,14 @@ REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalInit()
     if (!PalQueryProcessorTopology())
         return false;
 
+    // We use fiber detach callbacks to run our thread shutdown code because the fiber detach
+    // callback is made without the OS loader lock
+    g_flsIndex = FlsAlloc(FiberDetachCallback);
+    if (g_flsIndex == FLS_OUT_OF_INDEXES)
+    {
+        return false;
+    }
+
     return true;
 }
 
@@ -74,6 +101,56 @@ REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalInit()
 REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalHasCapability(PalCapability capability)
 {
     return (g_dwPALCapabilities & (DWORD)capability) == (DWORD)capability;
+}
+
+// Attach thread to PAL. 
+// It can be called multiple times for the same thread.
+// It fails fast if a different thread was already registered with the current fiber
+// or if the thread was already registered with a different fiber.
+// Parameters:
+//  thread        - thread to attach
+extern "C" void PalAttachThread(void* thread)
+{
+    void* threadFromCurrentFiber = FlsGetValue(g_flsIndex);
+
+    if (threadFromCurrentFiber != NULL)
+    {
+        ASSERT_UNCONDITIONALLY("Multiple threads encountered from a single fiber");
+        RhFailFast();
+    }
+
+    // Associate the current fiber with the current thread.  This makes the current fiber the thread's "home"
+    // fiber.  This fiber is the only fiber allowed to execute managed code on this thread.  When this fiber
+    // is destroyed, we consider the thread to be destroyed.
+    FlsSetValue(g_flsIndex, thread);
+}
+
+// Detach thread from PAL.
+// It fails fast if some other thread value was attached to PAL.
+// Parameters:
+//  thread        - thread to detach
+// Return:
+//  true if the thread was detached, false if there was no attached thread
+extern "C" bool PalDetachThread(void* thread)
+{
+    ASSERT(g_flsIndex != FLS_OUT_OF_INDEXES);
+    void* threadFromCurrentFiber = FlsGetValue(g_flsIndex);
+
+    if (threadFromCurrentFiber == NULL)
+    {
+        // we've seen this thread, but not this fiber.  It must be a "foreign" fiber that was 
+        // borrowing this thread.
+        return false;
+    }
+
+    if (threadFromCurrentFiber != thread)
+    {
+        ASSERT_UNCONDITIONALLY("Detaching a thread from the wrong fiber");
+        RhFailFast();
+    }
+
+    FlsSetValue(g_flsIndex, NULL);
+    return true;
 }
 
 REDHAWK_PALEXPORT unsigned int REDHAWK_PALAPI PalGetCurrentProcessorNumber()


### PR DESCRIPTION
This change replaces explicit FLS usage for thread shutdown notification in the runtime into a
general thread shutdown callback registration mechanism.
The implementation using the FLS on Windows is moved to the PalRedhawkWinMin.cpp.
On Unix, it is implemented using TLS, since there are no fibers.