### PR TITLE
Allow formatting of C++ code

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppGenerationBuffer.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppGenerationBuffer.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace ILCompiler.Compiler.CppCodeGen
+{
+    /// <summary>
+    /// Similar to a StringBuilder but handles proper formatting of C/C++ code by supporting indentation.
+    /// 
+    /// Principle to remember: new lines have to be requested when the output needs to be on a new line.
+    /// When a new line is printed via <see cref="AppendLine"/> indentation is performed.
+    /// 
+    /// Use <see cref="Indent"/> and <see cref="Exdent"/> to increase/decrease the level of indentation.
+    /// </summary>
+    public class CppGenerationBuffer
+    {
+        /// <summary>
+        /// Initialize new instance
+        /// </summary>
+        public CppGenerationBuffer()
+        {
+            _builder = new StringBuilder();
+        }
+
+        /// <summary>
+        /// Level of indentation used so far.
+        /// </summary>
+        private int _indent;
+
+        /// <summary>
+        /// Builder where all additions are done.
+        /// </summary>
+        private StringBuilder _builder;
+
+        /// <summary>
+        /// Increase level of indentation by one.
+        /// </summary>
+        public void Indent()
+        {
+            _indent++;
+        }
+
+        /// <summary>
+        /// Decrease level of indentation by one.
+        /// </summary>
+        public void Exdent()
+        {
+            _indent--;
+        }
+
+        /// <summary>
+        /// Append string <param name="s"/> to content.
+        /// </summary>
+        /// <param name="s">String value to print.</param>
+        public void Append(string s)
+        {
+            _builder.Append(s);
+        }
+
+        /// <summary>
+        /// Append integer <param name="i"/> in decimal format to content.
+        /// </summary>
+        /// <param name="i">Integer value to print.</param>
+        public void Append(int i)
+        {
+            _builder.Append(i);
+        }
+
+        /// <summary>
+        /// Append character <param name="c"/> to content.
+        /// </summary>
+        /// <param name="c">Character value to print.</param>
+        public void Append(char c)
+        {
+            _builder.Append(c);
+        }
+
+        /// <summary>
+        /// Append an empty new line without emitting any indentation.
+        /// Useful to just skip a line.
+        /// </summary>
+        public void AppendEmptyLine()
+        {
+            _builder.AppendLine();
+        }
+
+        /// <summary>
+        /// Append an empty new line and the required number of tabs.
+        /// </summary>
+        public void AppendLine()
+        {
+            _builder.AppendLine();
+            for (int i = 0; i < _indent; i++)
+                _builder.Append('\t');
+        }
+
+        /// <summary>
+        /// Clear current content.
+        /// </summary>
+        public void Clear()
+        {
+            _builder.Clear();
+        }
+
+        /// <summary>
+        /// Export current content as a string.
+        /// </summary>
+        /// <returns>String representation of current content.</returns>
+        public override string ToString()
+        {
+            return _builder.ToString();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Linq;
-
+using ILCompiler.Compiler.CppCodeGen;
 using ILCompiler.SymbolReader;
 using ILCompiler.DependencyAnalysisFramework;
 
@@ -96,7 +96,7 @@ namespace ILCompiler.CppCodeGen
 
         public string GetCppMethodDeclaration(MethodDesc method, bool implementation, string externalMethodName = null, MethodSignature methodSignature = null)
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new CppGenerationBuffer();
 
             if (methodSignature == null)
                 methodSignature = method.Signature;
@@ -197,7 +197,7 @@ namespace ILCompiler.CppCodeGen
 
         public string GetCppMethodCallParamList(MethodDesc method)
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new CppGenerationBuffer();
 
             var methodSignature = method.Signature;
 
@@ -278,7 +278,7 @@ namespace ILCompiler.CppCodeGen
 
         private string CompileSpecialMethod(MethodDesc method, SpecialMethodKind kind)
         {
-            StringBuilder builder = new StringBuilder();
+            var builder = new CppGenerationBuffer();
             switch (kind)
             {
                 case SpecialMethodKind.PInvoke:
@@ -306,14 +306,18 @@ namespace ILCompiler.CppCodeGen
                             externCSignature = methodSignature;
                         }
 
-                        builder.AppendLine(GetCppMethodDeclaration(method, true));
-                        builder.AppendLine("{");
+                        builder.AppendLine();
+                        builder.Append(GetCppMethodDeclaration(method, true));
+                        builder.AppendLine();
+                        builder.Append("{");
+                        builder.Indent();
 
                         if (slotCastRequired)
                         {
                             AppendSlotTypeDef(builder, method);
                         }
 
+                        builder.AppendLine();
                         if (!method.Signature.ReturnType.IsVoid)
                         {
                             builder.Append("return ");
@@ -328,14 +332,27 @@ namespace ILCompiler.CppCodeGen
 
                         builder.Append("(");
                         builder.Append(GetCppMethodCallParamList(method));
-                        builder.AppendLine(");");
-                        builder.AppendLine("}");
+                        builder.Append(");");
+                        builder.Exdent();
+                        builder.AppendLine();
+                        builder.Append("}");
 
                         return builder.ToString();
                     }
 
                 default:
-                    return GetCppMethodDeclaration(method, true) + " { throw 0xC000C000; }" + Environment.NewLine;
+                    builder.AppendLine();
+                    builder.Append(GetCppMethodDeclaration(method, true));
+                    builder.AppendLine();
+                    builder.Append("{");
+                    builder.Indent();
+                    builder.AppendLine();
+                    builder.Append("throw 0xC000C000;");
+                    builder.Exdent();
+                    builder.AppendLine();
+                    builder.Append("}");
+
+                    return builder.ToString();
             }
         }
 
@@ -359,7 +376,6 @@ namespace ILCompiler.CppCodeGen
             if (methodIL == null)
                 return;
 
-            string methodCode;
             try
             {
                 var ilImporter = new ILImporter(_compilation, this, method, methodIL);
@@ -387,9 +403,19 @@ namespace ILCompiler.CppCodeGen
             {
                 _compilation.Log.WriteLine(e.Message + " (" + method + ")");
 
-                methodCode = GetCppMethodDeclaration(method, true) + " { throw 0xC000C000; }" + Environment.NewLine;
+                var builder = new CppGenerationBuffer();
+                builder.AppendLine();
+                builder.Append(GetCppMethodDeclaration(method, true));
+                builder.AppendLine();
+                builder.Append("{");
+                builder.Indent();
+                builder.AppendLine();
+                builder.Append("throw 0xC000C000;");
+                builder.Exdent();
+                builder.AppendLine();
+                builder.Append("}");
 
-                methodCodeNodeNeedingCode.SetCode(methodCode, Array.Empty<Object>());
+                methodCodeNodeNeedingCode.SetCode(builder.ToString(), Array.Empty<Object>());
             }
         }
 
@@ -405,10 +431,10 @@ namespace ILCompiler.CppCodeGen
 
         private Dictionary<TypeDesc, List<MethodDesc>> _methodLists;
 
-        private StringBuilder _statics;
-        private StringBuilder _gcStatics;
-        private StringBuilder _threadStatics;
-        private StringBuilder _gcThreadStatics;
+        private CppGenerationBuffer _statics;
+        private CppGenerationBuffer _gcStatics;
+        private CppGenerationBuffer _threadStatics;
+        private CppGenerationBuffer _gcThreadStatics;
 
         // Base classes and valuetypes has to be emitted before they are used.
         private HashSet<TypeDesc> _emittedTypes;
@@ -472,12 +498,17 @@ namespace ILCompiler.CppCodeGen
 
         private void OutputTypes(bool full)
         {
+            var sb = new CppGenerationBuffer();
             if (full)
             {
-                _statics = new StringBuilder();
-                _gcStatics = new StringBuilder();
-                _threadStatics = new StringBuilder();
-                _gcThreadStatics = new StringBuilder();
+                _statics = new CppGenerationBuffer();
+                _statics.Indent();
+                _gcStatics = new CppGenerationBuffer();
+                _gcStatics.Indent();
+                _threadStatics = new CppGenerationBuffer();
+                _threadStatics.Indent();
+                _gcThreadStatics = new CppGenerationBuffer();
+                _gcThreadStatics.Indent();
             }
 
             _emittedTypes = new HashSet<TypeDesc>();
@@ -491,34 +522,42 @@ namespace ILCompiler.CppCodeGen
                 if (_emittedTypes.Contains(t))
                     continue;
 
-                OutputType(t, full);
+                OutputType(sb, t, full);
             }
             _emittedTypes = null;
 
             if (full)
             {
-                Out.WriteLine();
-                Out.WriteLine("struct {");
-                Out.Write(_statics.ToString());
-                Out.WriteLine("} __statics;");
+                sb.AppendLine();
+                sb.Append("struct {");
+                // No need to indent or add a new line as _statics is already properly indented
+                sb.Append(_statics.ToString());
+                sb.AppendLine();
+                sb.Append("} __statics;");
 
                 // TODO: Register GC statics with GC
-                Out.WriteLine();
-                Out.WriteLine("struct {");
-                Out.Write(_gcStatics.ToString());
-                Out.WriteLine("} __gcStatics;");
+                sb.AppendLine();
+                sb.Append("struct {");
+                // No need to indent or add a new line as _gcStatics is already properly indented
+                sb.Append(_gcStatics.ToString());
+                sb.AppendLine();
+                sb.Append("} __gcStatics;");
 
-                Out.WriteLine();
+                sb.AppendLine();
                 // @TODO_SDM: do for real - note: the 'extra' series are just testing the init syntax for 0-length arrays, they should be removed
                 // TODO: preinitialized 0-length arrays are not supported in CLang
-                Out.WriteLine("#ifdef _MSC_VER");
-                Out.WriteLine("StaticGcDesc __gcStaticsDescs = { 1, { { sizeof(__gcStatics), 0 }, { 123, 456 }, { 789, 101112 } } };");
-                Out.WriteLine("#else");
-                Out.WriteLine("StaticGcDesc __gcStaticsDescs;");
-                Out.WriteLine("#endif");
+                sb.Append("#ifdef _MSC_VER");
+                sb.AppendLine();
+                sb.Append("StaticGcDesc __gcStaticsDescs = { 1, { { sizeof(__gcStatics), 0 }, { 123, 456 }, { 789, 101112 } } };");
+                sb.AppendLine();
+                sb.Append("#else");
+                sb.AppendLine();
+                sb.Append("StaticGcDesc __gcStaticsDescs;");
+                sb.AppendLine();
+                sb.Append("#endif");
 
-                Out.WriteLine();
-                Out.WriteLine("SimpleModuleHeader __module = { &__gcStatics, &__gcStaticsDescs };");
+                sb.AppendLine();
+                sb.Append("SimpleModuleHeader __module = { &__gcStatics, &__gcStaticsDescs };");
 
 
                 _statics = null;
@@ -526,9 +565,12 @@ namespace ILCompiler.CppCodeGen
                 _threadStatics = null;
                 _gcThreadStatics = null;
             }
+
+            Out.Write(sb.ToString());
+            sb.Clear();
         }
 
-        private void OutputType(TypeDesc t, bool full)
+        private void OutputType(CppGenerationBuffer sb, TypeDesc t, bool full)
         {
             _emittedTypes.Add(t);
 
@@ -541,7 +583,7 @@ namespace ILCompiler.CppCodeGen
                     {
                         if (!_emittedTypes.Contains(baseType))
                         {
-                            OutputType(baseType, full);
+                            OutputType(sb, baseType, full);
                         }
                     }
                 }
@@ -553,7 +595,7 @@ namespace ILCompiler.CppCodeGen
                     {
                         if (!_emittedTypes.Contains(fieldType))
                         {
-                            OutputType(fieldType, full);
+                            OutputType(sb, fieldType, full);
                         }
                     }
                 }
@@ -563,13 +605,14 @@ namespace ILCompiler.CppCodeGen
 
             int nesting = 0;
             int current = 0;
+            sb.AppendLine();
             for (;;)
             {
                 int sep = mangledName.IndexOf("::", current);
                 if (sep < 0)
                     break;
 
-                Out.Write("namespace " + mangledName.Substring(current, sep - current) + " { ");
+                sb.Append("namespace " + mangledName.Substring(current, sep - current) + " { ");
                 current = sep + 2;
 
                 nesting++;
@@ -577,22 +620,26 @@ namespace ILCompiler.CppCodeGen
 
             if (full)
             {
-                Out.Write("class " + mangledName.Substring(current));
+                sb.Append("class " + mangledName.Substring(current));
                 if (!t.IsValueType)
                 {
                     var baseType = t.BaseType;
                     if (baseType != null)
                     {
-                        Out.Write(" : public " + GetCppTypeName(baseType));
+                        sb.Append(" : public " + GetCppTypeName(baseType));
                     }
                 }
-                Out.WriteLine(" { public:");
+                sb.Append(" {");
+                sb.AppendLine();
+                sb.Append("public:");
+                sb.Indent();
 
                 // TODO: Enable once the dependencies are tracked for arrays
                 // if (((DependencyNode)_compilation.NodeFactory.ConstructedTypeSymbol(t)).Marked)
                 if (!t.IsPointer && !t.IsByRef)
                 {
-                    Out.WriteLine("static MethodTable * __getMethodTable();");
+                    sb.AppendLine();
+                    sb.Append("static MethodTable * __getMethodTable();");
                 }
 
                 List<MethodDesc> virtualSlots;
@@ -613,19 +660,22 @@ namespace ILCompiler.CppCodeGen
                     for (int slot = 0; slot < virtualSlots.Count; slot++)
                     {
                         MethodDesc virtualMethod = virtualSlots[slot];
-                        Out.WriteLine(GetCodeForVirtualMethod(virtualMethod, baseSlots + slot));
+                        sb.AppendLine();
+                        sb.Append(GetCodeForVirtualMethod(virtualMethod, baseSlots + slot));
                     }
                 }
                 if (t.IsDelegate)
                 {
-                    Out.WriteLine(GetCodeForDelegate(t));
+                    sb.AppendLine();
+                    sb.Append(GetCodeForDelegate(t));
                 }
 
-                OutputTypeFields(t);
+                OutputTypeFields(sb, t);
 
                 if (t.HasStaticConstructor)
                 {
-                    _statics.AppendLine("bool __cctor_" + GetCppTypeName(t).Replace("::", "__") + ";");
+                    _statics.AppendLine();
+                    _statics.Append("bool __cctor_" + GetCppTypeName(t).Replace("::", "__") + ";");
                 }
 
                 List<MethodDesc> methodList;
@@ -633,25 +683,30 @@ namespace ILCompiler.CppCodeGen
                 {
                     foreach (var m in methodList)
                     {
-                        OutputMethod(m);
+                        OutputMethod(sb, m);
                     }
                 }
-                Out.Write("};");
+                sb.Exdent();
+                sb.AppendLine();
+                sb.Append("};");
             }
             else
             {
-                Out.Write("class " + mangledName.Substring(current) + ";");
+                sb.Append("class " + mangledName.Substring(current) + ";");
             }
 
             while (nesting > 0)
             {
-                Out.Write(" };");
+                sb.Append("};");
                 nesting--;
             }
-            Out.WriteLine();
+
+            // Make some rooms between two type definitions
+            if (full)
+                sb.AppendEmptyLine();
         }
 
-        private void OutputTypeFields(TypeDesc t)
+        private void OutputTypeFields(CppGenerationBuffer sb, TypeDesc t)
         {
             bool explicitLayout = false;
             ClassLayoutMetadata classLayoutMetadata = default(ClassLayoutMetadata);
@@ -669,7 +724,11 @@ namespace ILCompiler.CppCodeGen
             int instanceFieldIndex = 0;
 
             if (explicitLayout)
-                Out.WriteLine("union {");
+            {
+                sb.AppendLine();
+                sb.Append("union {");
+                sb.Indent();
+            }
 
             foreach (var field in t.GetFields())
             {
@@ -679,48 +738,62 @@ namespace ILCompiler.CppCodeGen
                         continue;
 
                     TypeDesc fieldType = GetFieldTypeOrPlaceholder(field);
-                    StringBuilder builder;
+                    CppGenerationBuffer builder;
                     if (!fieldType.IsValueType)
                     {
-                        _gcStatics.Append(GetCppSignatureTypeName(fieldType));
                         builder = _gcStatics;
                     }
                     else
                     {
                         // TODO: Valuetype statics with GC references
-                        _statics.Append(GetCppSignatureTypeName(fieldType));
                         builder = _statics;
                     }
-                    builder.AppendLine(" " + GetCppStaticFieldName(field) + ";");
+                    builder.AppendLine();
+                    builder.Append(GetCppSignatureTypeName(fieldType));
+                    builder.Append(" ");
+                    builder.Append(GetCppStaticFieldName(field) + ";");
                 }
                 else
                 {
                     if (explicitLayout)
                     {
-                        Out.WriteLine("struct {");
+                        sb.AppendLine();
+                        sb.Append("struct {");
+                        sb.Indent();
                         int offset = classLayoutMetadata.Offsets[instanceFieldIndex].Offset;
                         if (offset > 0)
-                            Out.WriteLine("char __pad" + instanceFieldIndex + "[" + offset + "];");
+                        {
+                            sb.AppendLine();
+                            sb.Append("char __pad" + instanceFieldIndex + "[" + offset + "];");
+                        }
                     }
-                    Out.WriteLine(GetCppSignatureTypeName(GetFieldTypeOrPlaceholder(field)) + " " + GetCppFieldName(field) + ";");
+                    sb.AppendLine();
+                    sb.Append(GetCppSignatureTypeName(GetFieldTypeOrPlaceholder(field)) + " " + GetCppFieldName(field) + ";");
                     if (explicitLayout)
                     {
-                        Out.WriteLine("};");
+                        sb.Exdent();
+                        sb.AppendLine();
+                        sb.Append("};");
                     }
                     instanceFieldIndex++;
                 }
             }
 
             if (explicitLayout)
-                Out.WriteLine("};");
+            {
+                sb.Exdent();
+                sb.AppendLine();
+                sb.Append("};");
+            }
         }
 
-        private void OutputMethod(MethodDesc m)
+        private void OutputMethod(CppGenerationBuffer sb, MethodDesc m)
         {
-            Out.WriteLine(GetCppMethodDeclaration(m, false));
+            sb.AppendLine();
+            sb.Append(GetCppMethodDeclaration(m, false));
         }
 
-        private void AppendSlotTypeDef(StringBuilder sb, MethodDesc method)
+        private void AppendSlotTypeDef(CppGenerationBuffer sb, MethodDesc method)
         {
             MethodSignature methodSignature = method.Signature;
 
@@ -731,8 +804,9 @@ namespace ILCompiler.CppCodeGen
             AppendSignatureTypeDef(sb, "__slot__" + GetCppMethodName(method), methodSignature, thisArgument);
         }
 
-        internal void AppendSignatureTypeDef(StringBuilder sb, string name, MethodSignature methodSignature, TypeDesc thisArgument)
+        internal void AppendSignatureTypeDef(CppGenerationBuffer sb, string name, MethodSignature methodSignature, TypeDesc thisArgument)
         {
+            sb.AppendLine();
             sb.Append("typedef ");
             sb.Append(GetCppSignatureTypeName(methodSignature.ReturnType));
             sb.Append("(*");
@@ -762,52 +836,69 @@ namespace ILCompiler.CppCodeGen
                 if (i != argCount - 1)
                     sb.Append(", ");
             }
-            sb.AppendLine(");");
+            sb.Append(");");
         }
 
 
         private String GetCodeForDelegate(TypeDesc delegateType)
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new CppGenerationBuffer();
 
             MethodDesc method = delegateType.GetKnownMethod("Invoke", null);
 
             AppendSlotTypeDef(sb, method);
 
+            sb.AppendLine();
             sb.Append("static __slot__");
             sb.Append(GetCppMethodName(method));
             sb.Append(" __invoke__");
             sb.Append(GetCppMethodName(method));
-            sb.Append("(void * pThis) { return (__slot__");
+            sb.Append("(void * pThis)");
+            sb.AppendLine();
+            sb.Append("{");
+            sb.Indent();
+            sb.AppendLine();
+            sb.Append("return (__slot__");
             sb.Append(GetCppMethodName(method));
             sb.Append(")(((");
             sb.Append(GetCppSignatureTypeName(_compilation.TypeSystemContext.GetWellKnownType(WellKnownType.MulticastDelegate)));
             sb.Append(")pThis)->m_functionPointer);");
-            sb.AppendLine(" };");
+            sb.Exdent();
+            sb.AppendLine();
+            sb.Append("};");
 
             return sb.ToString();
         }
 
         private String GetCodeForVirtualMethod(MethodDesc method, int slot)
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new CppGenerationBuffer();
 
             AppendSlotTypeDef(sb, method);
 
+            sb.AppendLine();
             sb.Append("static __slot__");
             sb.Append(GetCppMethodName(method));
             sb.Append(" __getslot__");
             sb.Append(GetCppMethodName(method));
-            sb.Append("(void * pThis) { return (__slot__");
+            sb.Append("(void * pThis)");
+            sb.AppendLine();
+            sb.Append("{");
+            sb.Indent();
+            sb.AppendLine();
+            sb.Append(" return (__slot__");
             sb.Append(GetCppMethodName(method));
             sb.Append(")*((void **)(*((RawEEType **)pThis) + 1) + ");
             sb.Append(slot.ToString());
-            sb.AppendLine("); };");
+            sb.Append(");");
+            sb.Exdent();
+            sb.AppendLine();
+            sb.Append("};");
 
             return sb.ToString();
         }
 
-        private void AppendVirtualSlots(StringBuilder sb, TypeDesc implType, TypeDesc declType)
+        private void AppendVirtualSlots(CppGenerationBuffer sb, TypeDesc implType, TypeDesc declType)
         {
             var baseType = declType.BaseType;
             if (baseType != null)
@@ -822,6 +913,7 @@ namespace ILCompiler.CppCodeGen
                     MethodDesc declMethod = virtualSlots[i];
                     MethodDesc implMethod = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(declMethod, implType.GetClosestMetadataType());
 
+                    sb.AppendLine();
                     if (implMethod.IsAbstract)
                     {
                         sb.Append("NULL,");
@@ -840,7 +932,7 @@ namespace ILCompiler.CppCodeGen
 
         private String GetCodeForType(TypeDesc type)
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new CppGenerationBuffer();
 
             int totalSlots = 0;
 
@@ -867,56 +959,100 @@ namespace ILCompiler.CppCodeGen
 
             sb.Append("MethodTable * ");
             sb.Append(GetCppTypeName(type));
-            sb.AppendLine("::__getMethodTable() {");
+            sb.Append("::__getMethodTable()");
+            sb.AppendLine();
+            sb.Append("{");
+            sb.Indent();
 
+            sb.AppendLine();
             sb.Append("static struct {");
+            sb.Indent();
             // sb.Append(GCDesc);
+            sb.AppendLine();
             sb.Append("RawEEType EEType;");
             if (totalSlots != 0)
             {
+                sb.AppendLine();
                 sb.Append("void * slots[");
                 sb.Append(totalSlots);
                 sb.Append("];");
             }
-            sb.AppendLine("} mt = {");
+            sb.Exdent();
+            sb.AppendLine();
+            sb.Append("} mt = {");
+            sb.Indent();
             // gcdesc
             if (type.IsString)
             {
                 // String has non-standard layout
-                sb.Append("{ sizeof(uint16_t), 0x");                            // EEType::_usComponentSize
+                sb.AppendLine();
+                sb.Append("{");
+                sb.Indent();
+                sb.AppendLine();
+                sb.Append("sizeof(uint16_t),");
+                sb.AppendLine();
+                sb.Append("0x");                             // EEType::_usComponentSize
                 sb.Append(flags.ToString("x4", CultureInfo.InvariantCulture));  // EEType::_usFlags
-                sb.Append(", 2 * sizeof(void*) + sizeof(int32_t) + 2, ");       // EEType::_uBaseSize
+                sb.Append(",");
+                sb.AppendLine();
+                sb.Append("2 * sizeof(void*) + sizeof(int32_t) + 2,");       // EEType::_uBaseSize
             }
             else
             if (type.IsArray && ((ArrayType)type).Rank == 1)
             {
-                sb.Append("{ sizeof(");
+                sb.AppendLine();
+                sb.Append("{");
+                sb.Indent();
+                sb.AppendLine();
+                sb.Append("sizeof(");
                 sb.Append(GetCppSignatureTypeName(((ArrayType)type).ElementType)); // EEType::_usComponentSize
-                sb.Append("), 0x");
+                sb.Append("),");
+                sb.AppendLine();
+                sb.Append("0x");
                 sb.Append(flags.ToString("x4", CultureInfo.InvariantCulture));  // EEType::_usFlags
-                sb.Append(", 3 * sizeof(void*), "); // EEType::_uBaseSize
+                sb.Append(",");
+                sb.AppendLine();
+                sb.Append("3 * sizeof(void*),"); // EEType::_uBaseSize
             }
             else
             if (type.IsArray)
             {
                 Debug.Assert(((ArrayType)type).Rank > 1);
-                sb.Append("{ sizeof(");
+                sb.AppendLine();
+                sb.Append("{");
+                sb.Indent();
+                sb.AppendLine();
+                sb.Append("sizeof(");
                 sb.Append(GetCppSignatureTypeName(((ArrayType)type).ElementType)); // EEType::_usComponentSize
-                sb.Append("), 0x");
+                sb.Append("),");
+                sb.AppendLine();
+                sb.Append("0x");
                 sb.Append(flags.ToString("x4", CultureInfo.InvariantCulture));  // EEType::_usFlags
-                sb.Append(", 3 * sizeof(void*) + ");                            // EEType::_uBaseSize
+                sb.Append(",");
+                sb.AppendLine();
+                sb.Append("3 * sizeof(void*) + ");                            // EEType::_uBaseSize
                 sb.Append(((ArrayType)type).Rank.ToString());
-                sb.Append("* sizeof(int32_t) * 2, ");
+                sb.Append("* sizeof(int32_t) * 2,");
             }
             else
             {
                 // sizeof(void*) == size of object header
-                sb.Append("{ 0, 0x");                                           // EEType::_usComponentSize
+                sb.AppendLine();
+                sb.Append("{");
+                sb.Indent();
+                sb.AppendLine();
+                sb.Append("0,");
+                sb.AppendLine();
+                sb.Append("0x");                                           // EEType::_usComponentSize
                 sb.Append(flags.ToString("x", CultureInfo.InvariantCulture));   // EEType::_usFlags
-                sb.Append(", AlignBaseSize(sizeof(void*)+sizeof(");             // EEType::_uBaseSize
+                sb.Append(",");
+                sb.AppendLine();
+                sb.Append("AlignBaseSize(sizeof(void*)+sizeof(");             // EEType::_uBaseSize
                 sb.Append(GetCppTypeName(type));
-                sb.Append(")), ");
+                sb.Append(")),");
             }
+
+            sb.AppendLine();
 
             // base type
             if (type.IsArray)
@@ -937,15 +1073,22 @@ namespace ILCompiler.CppCodeGen
                     sb.Append("NULL");
                 }
             }
-            sb.AppendLine("},");
+            sb.Exdent();
+            sb.AppendLine();
+            sb.Append("},");
 
             // virtual slots
             if (((DependencyNode)_compilation.NodeFactory.ConstructedTypeSymbol(type)).Marked)
                 AppendVirtualSlots(sb, type, type);
 
-            sb.AppendLine("};");
-            sb.AppendLine("return (MethodTable *)&mt.EEType;");
-            sb.AppendLine("}");
+            sb.Exdent();
+            sb.AppendLine();
+            sb.Append("};");
+            sb.AppendLine();
+            sb.Append("return (MethodTable *)&mt.EEType;");
+            sb.Exdent();
+            sb.AppendLine();
+            sb.Append("}");
 
             return sb.ToString();
         }
@@ -990,10 +1133,14 @@ namespace ILCompiler.CppCodeGen
             Out.WriteLine("#include \"common.h\"");
             Out.WriteLine();
 
+            Out.Write("/* Forward type definitions */");
             OutputTypes(false);
             Out.WriteLine();
-            OutputTypes(true);
             Out.WriteLine();
+            Out.Write("/* Type definitions  */");
+            OutputTypes(true);
+
+            var sb = new CppGenerationBuffer();
 
             foreach (var externC in _externCSignatureMap)
             {
@@ -1001,9 +1148,12 @@ namespace ILCompiler.CppCodeGen
                 // TODO: hacky special-case
                 if (importName != "memmove" && importName != "malloc") // some methods are already declared by the CRT headers
                 {
-                    Out.WriteLine(GetCppMethodDeclaration(null, false, importName, externC.Value));
+                    sb.AppendLine();
+                    sb.Append(GetCppMethodDeclaration(null, false, importName, externC.Value));
                 }
             }
+            Out.Write(sb.ToString());
+            sb.Clear();
 
             foreach (var t in _cppSignatureNames.Keys)
             {
@@ -1011,7 +1161,8 @@ namespace ILCompiler.CppCodeGen
                 // if (((DependencyNode)_compilation.NodeFactory.ConstructedTypeSymbol(t)).Marked)
                 if (!t.IsPointer && !t.IsByRef)
                 {
-                    Out.WriteLine(GetCodeForType(t));
+                    sb.AppendLine();
+                    sb.Append(GetCodeForType(t));
                 }
 
                 List<MethodDesc> methodList;
@@ -1020,65 +1171,92 @@ namespace ILCompiler.CppCodeGen
                     foreach (var m in methodList)
                     {
                         var methodCodeNode = (CppMethodCodeNode)_compilation.NodeFactory.MethodEntrypoint(m);
-                        Out.WriteLine(methodCodeNode.CppCode);
+                        sb.AppendLine();
+                        sb.Append(methodCodeNode.CppCode);
 
                         var alternateName = _compilation.NodeFactory.GetSymbolAlternateName(methodCodeNode);
                         if (alternateName != null)
                         {
-                            Out.WriteLine(GetCppMethodDeclaration(m, true, alternateName));
-                            Out.WriteLine("{");
-                            Out.Write("    ");
+                            sb.AppendLine();
+                            sb.Append(GetCppMethodDeclaration(m, true, alternateName));
+                            sb.AppendLine();
+                            sb.Append("{");
+                            sb.Indent();
+                            sb.AppendLine();
                             if (!m.Signature.ReturnType.IsVoid)
                             {
-                                Out.Write("return ");
+                                sb.Append("return ");
                             }
-                            Out.Write(GetCppTypeName(m.OwningType));
-                            Out.Write("::");
-                            Out.Write(GetCppMethodName(m));
-                            Out.Write("(");
-                            Out.Write(GetCppMethodCallParamList(m));
-                            Out.WriteLine(");");
-                            Out.WriteLine("}");
+                            sb.Append(GetCppTypeName(m.OwningType));
+                            sb.Append("::");
+                            sb.Append(GetCppMethodName(m));
+                            sb.Append("(");
+                            sb.Append(GetCppMethodCallParamList(m));
+                            sb.Append(");");
+                            sb.Exdent();
+                            sb.AppendLine();
+                            sb.Append("}");
                         }
                     }
                 }
             }
+            Out.Write(sb.ToString());
+            sb.Clear();
 
             if (_compilation.StartupCodeMain != null)
             {
                 var startupCodeMain = _compilation.StartupCodeMain;
 
                 // Stub for main method
+                sb.AppendLine();
                 if (_compilation.TypeSystemContext.Target.OperatingSystem == TargetOS.Windows)
                 {
                     // TODO: Use wmain and wchar_t
-                    Out.WriteLine("int main(int argc, char * argv[]) { ");
+                    sb.Append("int main(int argc, char * argv[]) {");
                 }
                 else
                 {
-                    Out.WriteLine("int main(int argc, char * argv[]) { ");
+                    sb.Append("int main(int argc, char * argv[]) {");
                 }
+                sb.Indent();
 
+                sb.AppendLine();
+                sb.Append("if (__initialize_runtime() != 0)");
+                sb.Indent();
+                sb.AppendLine();
+                sb.Append("return -1;");
+                sb.Exdent();
+                sb.AppendEmptyLine();
+                sb.AppendLine();
+                sb.Append("__register_module(&__module);");
+                sb.AppendLine();
+                sb.Append("ReversePInvokeFrame frame;");
+                sb.AppendLine();
+                sb.Append("__reverse_pinvoke(&frame);");
 
-                Out.WriteLine("if (__initialize_runtime() != 0) return -1;");
-                Out.WriteLine("__register_module(&__module);");
-                Out.WriteLine("ReversePInvokeFrame frame; __reverse_pinvoke(&frame);");
-                Out.WriteLine();
+                sb.AppendEmptyLine();
+                sb.AppendLine();
+                sb.Append("int ret = ");
+                sb.Append(GetCppTypeName(startupCodeMain.OwningType));
+                sb.Append("::");
+                sb.Append(GetCppMethodName(startupCodeMain));
+                sb.Append("(argc-1, (intptr_t)(argv+1));");
 
-                Out.Write("int ret = ");
-                Out.Write(GetCppTypeName(startupCodeMain.OwningType));
-                Out.Write("::");
-                Out.Write(GetCppMethodName(startupCodeMain));
-                Out.WriteLine("(argc-1,(intptr_t)(argv+1));");
-                Out.WriteLine();
-
-                Out.WriteLine("__reverse_pinvoke_return(&frame);");
-                Out.WriteLine("__shutdown_runtime();");
-
-                Out.WriteLine("return ret;");
-                Out.WriteLine("}");
+                sb.AppendEmptyLine();
+                sb.AppendLine();
+                sb.Append("__reverse_pinvoke_return(&frame);");
+                sb.AppendLine();
+                sb.Append("__shutdown_runtime();");
+                
+                sb.AppendLine();
+                sb.Append("return ret;");
+                sb.Exdent();
+                sb.AppendLine();
+                sb.Append("}");
             }
 
+            Out.Write(sb.ToString());
+            sb.Clear();
             Out.Dispose();
         }
     }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Compiler\SymbolReader\PortablePdbSymbolReader.cs" />
     <Compile Include="Compiler\SymbolReader\UnmanagedPdbSymbolReader.cs" />
     <Compile Include="Compiler\VirtualMethodCallHelper.cs" />
+    <Compile Include="CppCodeGen\CppGenerationBuffer.cs" />
     <Compile Include="CppCodeGen\CppWriter.cs" />
     <Compile Include="IL\Stubs\StartupCode\StartupCodeMainMethod.cs" />
   </ItemGroup>


### PR DESCRIPTION
Added ability to indent properly the C++ generated code.
No 2 instructions on the same line.

I'm not sure if there are specific rules for formatting C++ code so the way I've formatted it might be subject to discussion.

See issue #833. 

Size wise on my simple hello world, there is a size increase of about 5%. I did not benchmark the time spent in ilc nor to perform the C++ compilation.