### PR TITLE
Multi-module compilation preparation

### DIFF
--- a/src/Common/src/Internal/Runtime/ModuleHeaders.cs
+++ b/src/Common/src/Internal/Runtime/ModuleHeaders.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+namespace Internal.Runtime
+{
+    //
+    // Please keep the data structures in this file in sync with the native version at
+    //  src/Native/Runtime/inc/ModuleHeaders.h
+    //
+    
+    //
+    // ModuleHeaderSection IDs are used by the runtime to look up specific global data sections
+    // from each module linked into the final binary. New sections should be added at the bottom
+    // of the enum and deprecated sections should not be removed to preserve ID stability.
+    //
+    // Eventually this will be reconciled with ReadyToRunSectionType from 
+    // https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h
+    //
+    enum ModuleHeaderSection
+    {
+        StringTable                 = 200,
+        GCStaticRegion              = 201,
+        ThreadStaticRegion          = 202,
+        InterfaceDispatchTable      = 203,
+        ModuleIndirectionCell       = 204,
+        EagerCctor                  = 205,
+    }
+
+    [Flags]
+    enum ModuleInfoFlags : int
+    {
+        HasEndPointer               = 0x1,
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler
+{
+    public abstract class CompilationModuleGroup
+    {
+        protected CompilerTypeSystemContext _typeSystemContext;
+        protected ICompilationRootProvider _rootProvider;
+
+        protected CompilationModuleGroup(CompilerTypeSystemContext typeSystemContext, ICompilationRootProvider rootProvider)
+        {
+            _typeSystemContext = typeSystemContext;
+            _rootProvider = rootProvider;
+        }
+
+        public abstract bool IsTypeInCompilationGroup(TypeDesc type);
+        public abstract bool IsMethodInCompilationGroup(MethodDesc method);
+
+        public virtual void AddCompilationRoots()
+        {
+            foreach (var inputFile in _typeSystemContext.InputFilePaths)
+            {
+                var module = _typeSystemContext.GetModuleFromPath(inputFile.Value);
+
+                if (module.PEReader.PEHeaders.IsExe)
+                    _rootProvider.AddMainMethodCompilationRoot(module);
+
+                AddCompilationRootsForRuntimeExports(module);
+            }
+        }
+
+        public void AddWellKnownTypes()
+        {
+            var stringType = _typeSystemContext.GetWellKnownType(WellKnownType.String);
+
+            if (IsTypeInCompilationGroup(stringType))
+            {
+                _rootProvider.AddTypeCompilationRoot(stringType, "String type is always generated");
+            }
+        }
+
+        protected void AddCompilationRootsForRuntimeExports(EcmaModule module)
+        {
+            foreach (var type in module.GetAllTypes())
+            {
+                foreach (var method in type.GetMethods())
+                {
+                    if (method.HasCustomAttribute("System.Runtime", "RuntimeExportAttribute"))
+                    {
+                        string exportName = ((EcmaMethod)method).GetAttributeStringValue("System.Runtime", "RuntimeExportAttribute");
+                        _rootProvider.AddMethodCompilationRoot(method, "Runtime export", exportName);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -62,6 +62,8 @@ namespace ILCompiler
 
         private MetadataStringDecoder _metadataStringDecoder;
 
+        private bool _multifileCompilation = false;
+        
         private class ModuleData
         {
             public string SimpleName;
@@ -127,9 +129,10 @@ namespace ILCompiler
         }
         private SimpleNameHashtable _simpleNameHashtable = new SimpleNameHashtable();
 
-        public CompilerTypeSystemContext(TargetDetails details)
+        public CompilerTypeSystemContext(TargetDetails details, bool multifileCompilation)
             : base(details)
         {
+            _multifileCompilation = multifileCompilation;
         }
 
         public IReadOnlyDictionary<string, string> InputFilePaths

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
@@ -4,9 +4,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
 using System.Text;
-using System.Threading.Tasks;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -24,12 +23,30 @@ namespace ILCompiler.DependencyAnalysis
         private ObjectAndOffsetSymbolNode _startSymbol;
         private ObjectAndOffsetSymbolNode _endSymbol;
         private IComparer<TEmbedded> _sorter;
+        private string _section;
 
-        public ArrayOfEmbeddedDataNode(string startSymbolMangledName, string endSymbolMangledName, IComparer<TEmbedded> nodeSorter)
+        public ArrayOfEmbeddedDataNode(string startSymbolMangledName, string endSymbolMangledName, IComparer<TEmbedded> nodeSorter, string section = "data")
         {
             _startSymbol = new ObjectAndOffsetSymbolNode(this, 0, startSymbolMangledName);
             _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, endSymbolMangledName);
             _sorter = nodeSorter;
+            _section = section;
+        }
+
+        internal ObjectAndOffsetSymbolNode StartSymbol
+        {
+            get
+            {
+                return _startSymbol;
+            }
+        }
+
+        internal ObjectAndOffsetSymbolNode EndSymbol
+        {
+            get
+            {
+                return _endSymbol;
+            }
         }
 
         public void AddEmbeddedObject(TEmbedded symbol)
@@ -38,6 +55,12 @@ namespace ILCompiler.DependencyAnalysis
             {
                 _nestedNodesList.Add(symbol);
             }
+        }
+
+        public int IndexOfEmbeddedObject(TEmbedded symbol)
+        {
+            Debug.Assert(_sorter == null);
+            return _nestedNodesList.IndexOf(symbol);
         }
 
         public override string GetName()
@@ -49,7 +72,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return "data";
+                return _section;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -34,6 +34,8 @@ namespace ILCompiler.DependencyAnalysis
     ///                 |
     /// UInt32          | Hash code
     ///                 |
+    /// [Pointer Size]  | Pointer to containing Module indirection cell
+    ///                 |
     /// X * [Ptr Size]  | VTable entries (optional)
     ///                 |
     /// Y * [Ptr Size]  | Pointers to interface map data structures (optional)
@@ -112,9 +114,9 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public void SetDispatchMapIndex(uint index)
+        public void SetDispatchMapIndex(int index)
         {
-            _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldsElement.DispatchMap, index);
+            _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldsElement.DispatchMap, checked((uint)index));
         }
 
         int ISymbolNode.Offset
@@ -156,6 +158,7 @@ namespace ILCompiler.DependencyAnalysis
             OutputVirtualSlotAndInterfaceCount(factory, ref objData);
 
             objData.EmitInt(_type.GetHashCode());
+            objData.EmitPointerReloc(factory.ModuleIndirectionCell);
 
             if (_constructed)
             {
@@ -249,7 +252,7 @@ namespace ILCompiler.DependencyAnalysis
         /// <param name="pointerSize">The size of a pointer in bytes in the target architecture</param>
         public static int GetVTableOffset(int pointerSize)
         {
-            return 16 + pointerSize;
+            return 16 + 2 * pointerSize;
         }
 
         private void OutputComponentSize(ref ObjectDataBuilder objData)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
@@ -13,6 +13,8 @@ namespace ILCompiler.DependencyAnalysis
 {
     public abstract class EmbeddedObjectNode : DependencyNodeCore<NodeFactory>
     {
+        public const int InvalidOffset = 1;
+
         public int Offset
         {
             get;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         private MetadataType _type;
 
-        public GCStaticsNode(MetadataType type, NodeFactory factory)
+        public GCStaticsNode(MetadataType type)
         {
             _type = type;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapIndirectionNode.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    class InterfaceDispatchMapIndirectionNode : EmbeddedObjectNode, ISymbolNode
+    {
+        TypeDesc _type;
+
+        public InterfaceDispatchMapIndirectionNode(TypeDesc type)
+        {
+            _type = type;
+            base.Offset = InvalidOffset;
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                if (Offset == InvalidOffset)
+                {
+                    throw new InvalidOperationException("MangledName called before Offset was initialized.");
+                }
+                
+                return NodeFactory.NameMangler.CompilationUnitPrefix + "__DispatchMap_Pointer_" + base.Offset.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return Offset;
+            }
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
+        {
+            builder.RequirePointerAlignment();
+            builder.EmitPointerReloc(factory.InterfaceDispatchMap(_type));
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return new DependencyListEntry[] { new DependencyListEntry(context.DispatchMapTable, "Dispatch Map Table"),
+                                               new DependencyListEntry(context.InterfaceDispatchMap(_type), "Referenced interface dispatch map")};
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModuleHeaderItemNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModuleHeaderItemNode.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.Runtime;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    class ModuleHeaderItemNode : EmbeddedObjectNode, ISymbolNode
+    {
+        ModuleHeaderSection _dataItem;
+        ISymbolNode _startNode;
+        ISymbolNode _endNode;
+
+        public ModuleHeaderItemNode(ModuleHeaderSection dataItem, ISymbolNode startNode, ISymbolNode endNode = null)
+        {
+            _dataItem = dataItem;
+            _startNode = startNode;
+            _endNode = endNode;
+        }
+
+        public string MangledName
+        {
+            get
+            {
+                return NodeFactory.NameMangler.CompilationUnitPrefix + "__ModuleHeaderItem_" + Enum.GetName(typeof(ModuleHeaderSection), _dataItem);
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private ModuleInfoFlags ComputeFlags()
+        {
+            ModuleInfoFlags flags = 0;
+
+            if (_endNode != null)
+            {
+                flags |= ModuleInfoFlags.HasEndPointer;
+            }
+
+            return flags;
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
+        {
+            builder.RequirePointerAlignment();
+            builder.EmitInt((int)_dataItem);
+            builder.EmitInt((int)ComputeFlags());
+            builder.EmitPointerReloc(_startNode);
+
+            if (_endNode != null)
+            {
+                builder.EmitPointerReloc(_endNode);
+            }
+            else
+            {
+                builder.EmitZeroPointer();
+            }
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            var dependencies = new DependencyList();
+
+            dependencies.Add(new DependencyListEntry(_startNode, "ModuleHeaderItemNode"));
+
+            if (_endNode != null)
+            {
+                dependencies.Add(new DependencyListEntry(_endNode, "ModuleHeaderItemNode"));
+            }
+
+            return dependencies;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModuleHeaderNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModuleHeaderNode.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public class ModuleHeaderNode : ObjectNode, ISymbolNode
+    {
+        public static readonly string SectionName = ".modules$I";
+
+        public override string Section
+        {
+            get
+            {
+                return SectionName;
+            }
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return NodeFactory.NameMangler.CompilationUnitPrefix + "__Module";
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory);
+            objData.RequirePointerAlignment();
+            objData.DefinedSymbols.Add(this);
+            ObjectAndOffsetSymbolNode startNode = new ObjectAndOffsetSymbolNode(this, 0, "__modules_a");
+            ObjectAndOffsetSymbolNode endNode = new ObjectAndOffsetSymbolNode(this, 0, "__modules_z");
+
+            if (factory.Target.OperatingSystem != Internal.TypeSystem.TargetOS.Windows)
+            {
+                // Temporary work-around for Linux / OSX until CLI is updated
+                objData.DefinedSymbols.Add(startNode);
+            }
+
+            objData.EmitPointerReloc(factory.ModuleGlobalData.StartSymbol);
+            objData.EmitPointerReloc(factory.ModuleGlobalData.EndSymbol);
+
+            if (factory.Target.OperatingSystem != Internal.TypeSystem.TargetOS.Windows)
+            {
+                // Temporary work-around for Linux / OSX until CLI is updated
+                endNode.SetSymbolOffset(objData.CountBytes);
+                objData.DefinedSymbols.Add(endNode);
+                objData.EmitZeroPointer();
+            }
+
+            return objData.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -82,6 +82,13 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         [DllImport(NativeObjectWriterFileName)]
+        private static extern bool CreateDataSection(IntPtr objWriter, string sectionName, bool readOnly);
+        public void CreateDataSection(string sectionName, bool readOnly)
+        {
+            CreateDataSection(_nativeObjectWriter, sectionName, readOnly);
+        }
+
+        [DllImport(NativeObjectWriterFileName)]
         private static extern void EmitAlignment(IntPtr objWriter, int byteAlignment);
         public void EmitAlignment(int byteAlignment)
         {
@@ -472,6 +479,8 @@ namespace ILCompiler.DependencyAnalysis
         {
             using (ObjectWriter objectWriter = new ObjectWriter(objectFilePath, factory))
             {
+                objectWriter.CreateDataSection(ModuleHeaderNode.SectionName, true);
+
                 // Build file info map.
                 objectWriter.BuildFileInfoMap(nodes);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
@@ -38,10 +38,12 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                if (_id.HasValue)
-                    return NodeFactory.NameMangler.CompilationUnitPrefix + "__str_table_entry_" + _id.Value.ToString(CultureInfo.InvariantCulture);
-                else
-                    return NodeFactory.NameMangler.CompilationUnitPrefix + "__str_table_entry_" + _data;
+                if (!_id.HasValue)
+                {
+                    throw new InvalidOperationException("MangledName called before String Id was initialized.");
+                }
+
+                return NodeFactory.NameMangler.CompilationUnitPrefix + "__str_table_entry_" + _id.Value.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public StringIndirectionNode(string data)
         {
-            base.Offset = 1; // 1 is not a valid offset, so when the wrapper object emitter sets offsets, it will become more reasonable
+            base.Offset = InvalidOffset;
             _data = data;
         }
 
@@ -31,10 +31,12 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                if (base.Offset != 1)
-                    return NodeFactory.NameMangler.CompilationUnitPrefix + "__str" + base.Offset.ToString(CultureInfo.InvariantCulture);
-                else
-                    return NodeFactory.NameMangler.CompilationUnitPrefix + "__str" + _data;
+                if (base.Offset == InvalidOffset)
+                {
+                    throw new InvalidOperationException("MangledName called before Offset was initialized.");
+                }
+
+                return NodeFactory.NameMangler.CompilationUnitPrefix + "__str" + base.Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/ICompilationRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ICompilationRootProvider.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Provides a means to root types / methods at the compiler driver layer
+    /// </summary>
+    public interface ICompilationRootProvider
+    {
+        void AddMethodCompilationRoot(MethodDesc method, string reason, string exportName = null);
+        void AddTypeCompilationRoot(TypeDesc type, string reason);
+        void AddMainMethodCompilationRoot(EcmaModule module);
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler
+{
+    class MultiFileCompilationModuleGroup : CompilationModuleGroup
+    {
+        private HashSet<EcmaModule> _compilationModuleSet;
+
+        public MultiFileCompilationModuleGroup(CompilerTypeSystemContext typeSystemContext, ICompilationRootProvider rootProvider) : base(typeSystemContext, rootProvider)
+        { }
+
+        public override bool IsTypeInCompilationGroup(TypeDesc type)
+        {
+            if (type.ContainsGenericVariables)
+                return true;
+
+            EcmaType ecmaType = type as EcmaType;
+
+            if (ecmaType == null)
+                return true;
+
+            if (!IsModuleInCompilationGroup(ecmaType.EcmaModule))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public override bool IsMethodInCompilationGroup(MethodDesc method)
+        {
+            if (method.GetTypicalMethodDefinition().ContainsGenericVariables)
+                return true;
+
+            return IsTypeInCompilationGroup(method.OwningType);
+        }
+
+        public override void AddCompilationRoots()
+        {
+            base.AddCompilationRoots();
+
+            bool buildingLibrary = true;
+            foreach (var module in InputModules)
+            {
+                if (module.PEReader.PEHeaders.IsExe)
+                {
+                    buildingLibrary = false;
+                    break;
+                }
+            }
+
+            if (buildingLibrary)
+            {
+                foreach (var module in InputModules)
+                {
+                    AddCompilationRootsForMultifileLibrary(module);
+                }
+            }
+        }
+
+        private void AddCompilationRootsForMultifileLibrary(EcmaModule module)
+        {
+            foreach (TypeDesc type in module.GetAllTypes())
+            {
+                // Skip delegates (since their Invoke methods have no IL) and uninstantiated generic types
+                if (type.IsDelegate || type.ContainsGenericVariables)
+                    continue;
+
+                EcmaType ecmaType = type as EcmaType;
+
+                if (ecmaType.Attributes.HasFlag(System.Reflection.TypeAttributes.Public))
+                {
+                    foreach (EcmaMethod method in ecmaType.GetMethods())
+                    {
+                        // Skip methods with no IL and uninstantiated generic methods
+                        if (method.IsIntrinsic || method.IsAbstract || method.ContainsGenericVariables)
+                            continue;
+
+                        if (method.ImplAttributes.HasFlag(System.Reflection.MethodImplAttributes.InternalCall))
+                            continue;
+
+                        _rootProvider.AddMethodCompilationRoot(method, "Library module method");
+                    }
+                }
+            }
+        }
+
+        private bool IsModuleInCompilationGroup(EcmaModule module)
+        {
+            return InputModules.Contains(module);
+        }
+
+        private HashSet<EcmaModule> InputModules
+        {
+            get
+            {
+                if (_compilationModuleSet == null)
+                {
+                    HashSet<EcmaModule> newCompilationModuleSet = new HashSet<EcmaModule>();
+
+                    foreach (var path in _typeSystemContext.InputFilePaths)
+                    {
+                        newCompilationModuleSet.Add(_typeSystemContext.GetModuleFromPath(path.Value));
+                    }
+
+                    lock (this)
+                    {
+                        if (_compilationModuleSet == null)
+                        {
+                            _compilationModuleSet = newCompilationModuleSet;
+                        }
+                    }
+                }
+
+                return _compilationModuleSet;
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Text;
 
 using Internal.TypeSystem;
@@ -365,7 +366,7 @@ namespace ILCompiler
                     }
                     else
                     {
-                        _compilationUnitPrefix = "";
+                        _compilationUnitPrefix = SanitizeName(Path.GetFileNameWithoutExtension(_compilation.Options.OutputFilePath));
                     }
                 }
                 return _compilationUnitPrefix;

--- a/src/ILCompiler.Compiler/src/Compiler/SingleFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleFileCompilationModuleGroup.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler
+{
+    class SingleFileCompilationModuleGroup : CompilationModuleGroup
+    {
+        public SingleFileCompilationModuleGroup(CompilerTypeSystemContext typeSystemContext, ICompilationRootProvider rootProvider) : base(typeSystemContext, rootProvider)
+        { }
+
+        public override bool IsTypeInCompilationGroup(TypeDesc type)
+        {
+            return true;
+        }
+
+        public override bool IsMethodInCompilationGroup(MethodDesc method)
+        {
+            return true;
+        }
+
+        public override void AddCompilationRoots()
+        {
+            base.AddCompilationRoots();
+
+            AddCompilationRootsForRuntimeExports((EcmaModule)_typeSystemContext.SystemModule);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -34,6 +34,7 @@
     </Compile>
     <Compile Include="Compiler\AsmStringWriter.cs" />
     <Compile Include="Compiler\Compilation.cs" />
+    <Compile Include="Compiler\CompilationModuleGroup.cs" />
     <Compile Include="Compiler\CompilerMetadataFieldLayoutAlgorithm.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.cs" />
     <Compile Include="Compiler\DelegateInfo.cs" />
@@ -44,10 +45,13 @@
     <Compile Include="Compiler\DependencyAnalysis\EmbeddedPointerIndirectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchMapTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchMapIndirectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\JumpStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodCodeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedPointersNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ModuleHeaderItemNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ModuleHeaderNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ModuleIndirectionCell.cs" />
     <Compile Include="Compiler\DependencyAnalysis\StringDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\StringIndirectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\AddrMode.cs" />
@@ -79,10 +83,13 @@
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchMapNode.cs" />
     <Compile Include="Compiler\FormattingHelpers.cs" />
+    <Compile Include="Compiler\ICompilationRootProvider.cs" />
     <Compile Include="Compiler\JitHelper.cs" />
     <Compile Include="Compiler\MemoryHelper.cs" />
     <Compile Include="Compiler\MethodExtensions.cs" />
+    <Compile Include="Compiler\MultiFileCompilationModuleGroup.cs" />
     <Compile Include="Compiler\NameMangler.cs" />
+    <Compile Include="Compiler\SingleFileCompilationModuleGroup.cs" />
     <Compile Include="Compiler\SymbolReader\PdbSymbolReader.cs" />
     <Compile Include="Compiler\SymbolReader\PortablePdbSymbolReader.cs" />
     <Compile Include="Compiler\SymbolReader\UnmanagedPdbSymbolReader.cs" />
@@ -104,6 +111,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\Internal\Runtime\EETypeBuilderHelpers.cs">
       <Link>Common\EEType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Internal\Runtime\ModuleHeaders.cs">
+      <Link>Common\ModuleHeaders.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\Internal\NativeFormat\NativeFormatWriter.Primitives.cs">
       <Link>Common\NativeFormat\NativeFormatWriter.Primitives.cs</Link>

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -65,6 +65,7 @@ namespace ILCompiler
 #endif
 
             _options.TargetArchitecture = TargetArchitecture.X64;
+            _options.MultiFile = false;
         }
 
         // TODO: Use System.CommandLine for command line parsing
@@ -92,6 +93,7 @@ namespace ILCompiler
                 syntax.DefineOption("fulllog", ref _options.FullLog, "Save detailed log of dependency analysis");
                 syntax.DefineOption("verbose", ref _options.Verbose, "Enable verbose logging");
                 syntax.DefineOption("systemmodule", ref _options.SystemModuleName, "System module name (default: System.Private.CoreLib)");
+                syntax.DefineOption("multifile", ref _options.MultiFile, "Compile only input files (do not compile referenced assemblies)");
                 syntax.DefineParameterList("in", ref inputFiles, "Input file(s) to compile");
             });
             foreach (var input in inputFiles)

--- a/src/Native/Runtime/AsmOffsets.h
+++ b/src/Native/Runtime/AsmOffsets.h
@@ -33,7 +33,13 @@ ASM_OFFSET(    4,     8, Array, m_Length)
 ASM_OFFSET(    0,     0, EEType, m_usComponentSize)
 ASM_OFFSET(    2,     2, EEType, m_usFlags)
 ASM_OFFSET(    4,     4, EEType, m_uBaseSize)
+#if defined(CORERT)
+// If this ever changes, you must update src\ILCompiler.Compiler\src\Compiler\DependencyAnalysis\EETypeNode.cs GetVTableOffset()
+// to reflect the updated VTable offset
+ASM_OFFSET(   18,    20, EEType, m_VTable)
+#else
 ASM_OFFSET(   14,    18, EEType, m_VTable)
+#endif
 
 ASM_OFFSET(    0,     0, Thread, m_rgbAllocContextBuffer)
 ASM_OFFSET(   28,    38, Thread, m_ThreadStateFlags)

--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -20,6 +20,7 @@ set(COMMON_RUNTIME_SOURCES
     MathHelpers.cpp
     MiscHelpers.cpp
     module.cpp
+    ModuleManager.cpp
     ObjectLayout.cpp
     OptionalFieldsRuntime.cpp
     portable.cpp

--- a/src/Native/Runtime/MiscHelpers.cpp
+++ b/src/Native/Runtime/MiscHelpers.cpp
@@ -563,3 +563,13 @@ COOP_PINVOKE_HELPER(void*, RhGetUniversalTransitionThunk, ())
 {
     return (void*)RhpUniversalTransition;
 }
+
+COOP_PINVOKE_HELPER(void*, RhpGetModuleSection, (ModuleManager* pModule, Int32 headerId, Int32* length))
+{
+    return pModule->GetModuleSection((ModuleHeaderSection)headerId, length);
+}
+
+COOP_PINVOKE_HELPER(void*, RhpCreateModuleManager, (void* pHeaderStart, void* pHeaderEnd))
+{
+    return ModuleManager::Create(pHeaderStart, pHeaderEnd);
+}

--- a/src/Native/Runtime/ModuleManager.cpp
+++ b/src/Native/Runtime/ModuleManager.cpp
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#include "common.h"
+#include "CommonTypes.h"
+#include "CommonMacros.h"
+#include "daccess.h"
+#include "PalRedhawkCommon.h"
+#include "PalRedhawk.h"
+#include "holder.h"
+#include "ModuleManager.h"
+
+/* static */
+ModuleManager * ModuleManager::Create(void * pHeaderStart, void * pHeaderEnd)
+{
+    ASSERT(pHeaderStart < pHeaderEnd);
+    if (pHeaderStart >= pHeaderEnd)
+        return nullptr;
+
+    NewHolder<ModuleManager> pNewModule = new (nothrow) ModuleManager(pHeaderStart, pHeaderEnd);
+    if (nullptr == pNewModule)
+        return nullptr;
+
+    pNewModule.SuppressRelease();
+    return pNewModule;
+}
+
+void * ModuleManager::GetModuleSection(ModuleHeaderSection sectionId, int * length)
+{
+    void * pSectionStart = nullptr;
+    ModuleInfoRow * pCurrent = (ModuleInfoRow *)m_pHeaderStart;
+
+    // TODO: Binary search
+    for (; pCurrent < m_pHeaderEnd; pCurrent ++)
+    {
+        if ((int32_t)sectionId == pCurrent->SectionId)
+        {
+            pSectionStart = pCurrent->Start;
+            *length = pCurrent->GetLength();;
+        }
+         
+    }
+
+    return pSectionStart;
+}
+
+DispatchMap** ModuleManager::GetDispatchMapLookupTable()
+{
+    if (m_pDispatchMapTable == nullptr)
+    {
+        int length = 0;
+        DispatchMap ** pNewDispatchMapTable = (DispatchMap **)GetModuleSection(ModuleHeaderSection::InterfaceDispatchTable, &length);
+        PalInterlockedCompareExchangePointer((void **)&m_pDispatchMapTable, pNewDispatchMapTable, nullptr);
+    }
+
+    return m_pDispatchMapTable;
+}
+
+bool ModuleManager::ModuleInfoRow::HasEndPointer()
+{
+    return Flags & (int32_t)ModuleInfoFlags::HasEndPointer;
+}
+
+int ModuleManager::ModuleInfoRow::GetLength()
+{
+    if (HasEndPointer())
+    {
+        return (int)((PTR_UInt8)End - (PTR_UInt8)Start);
+    }
+    else
+    {
+        return sizeof(void*);
+    }
+}

--- a/src/Native/Runtime/ModuleManager.h
+++ b/src/Native/Runtime/ModuleManager.h
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#pragma once
+#include "ModuleHeaders.h"
+
+class DispatchMap;
+
+class ModuleManager
+{
+    void *                      m_pHeaderStart;
+    void *                      m_pHeaderEnd;
+
+    DispatchMap**               m_pDispatchMapTable;
+
+    ModuleManager(void * pHeaderStart, void * pHeaderEnd) : m_pHeaderStart(pHeaderStart), m_pHeaderEnd(pHeaderEnd), m_pDispatchMapTable(nullptr) {}
+
+public:
+    static ModuleManager * Create(void * pHeaderStart, void * pHeaderEnd);
+    void * GetModuleSection(ModuleHeaderSection sectionId, int * length);
+    DispatchMap ** GetDispatchMapLookupTable();
+
+private:
+    
+    struct ModuleInfoRow
+    {
+        int32_t SectionId;
+        int32_t Flags;
+        void * Start;
+        void * End;
+
+        bool HasEndPointer();
+        int GetLength();
+    };
+};

--- a/src/Native/Runtime/inc/ModuleHeaders.h
+++ b/src/Native/Runtime/inc/ModuleHeaders.h
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// Please keep the data structures in this file in sync with the managed version at
+//  src/Common/src/Internal/Runtime/ModuleHeaders.cs
+//
+
+//
+// ModuleHeaderSection IDs are used by the runtime to look up specific global data sections
+// from each module linked into the final binary. New sections should be added at the bottom
+// of the enum and deprecated sections should not be removed to preserve ID stability.
+//
+// Eventually this will be reconciled with ReadyToRunSectionType from 
+// https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h
+//
+enum class ModuleHeaderSection
+{
+    StringTable                 = 200,
+    GCStaticRegion              = 201,
+    ThreadStaticRegion          = 202,
+    InterfaceDispatchTable      = 203,
+    ModuleIndirectionCell       = 204,
+    EagerCctor                  = 205,
+};
+
+enum class ModuleInfoFlags
+{
+    HasEndPointer               = 0x1,
+};

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -12,7 +12,7 @@
 class MdilModule;
 class EEType;
 class OptionalFields;
-
+class ModuleManager;
 
 
 //-------------------------------------------------------------------------------------------------
@@ -214,6 +214,9 @@ private:
     UInt16              m_usNumVtableSlots;
     UInt16              m_usNumInterfaces;
     UInt32              m_uHashCode;
+#if defined(CORERT)
+    ModuleManager**     m_ppModuleManager;
+#endif
 
     TgtPTR_Void         m_VTable[];  // make this explicit so the binder gets the right alignment
 

--- a/src/Native/Runtime/inc/eetype.inl
+++ b/src/Native/Runtime/inc/eetype.inl
@@ -151,10 +151,6 @@ inline bool EEType::HasDispatchMap()
     return true;
 }
 
-#ifdef CORERT
-extern "C" void * g_pDispatchMapTemporaryWorkaround;
-#endif
-
 inline DispatchMap * EEType::GetDispatchMap()
 {
     if (!HasInterfaces())
@@ -177,7 +173,7 @@ inline DispatchMap * EEType::GetDispatchMap()
     RuntimeInstance * pRuntimeInstance = GetRuntimeInstance();
 
 #ifdef CORERT
-	return (DispatchMap*)((void**)g_pDispatchMapTemporaryWorkaround)[idxDispatchMap];
+    return (*m_ppModuleManager)->GetDispatchMapLookupTable()[idxDispatchMap];
 #endif
 
     Module * pModule = pRuntimeInstance->FindModuleByReadOnlyDataAddress(this);

--- a/src/Native/Runtime/module.h
+++ b/src/Native/Runtime/module.h
@@ -4,6 +4,7 @@
 #include "ICodeManager.h"
 
 #include "SectionMethodList.h"
+#include "ModuleManager.h"
 
 struct StaticGcDesc;
 typedef SPTR(StaticGcDesc) PTR_StaticGcDesc;
@@ -178,4 +179,3 @@ private:
     ReaderWriterLock            m_loopHijackMapLock;
     MapSHash<UInt32, void*>     m_loopHijackIndexToTargetMap;
 };
-

--- a/src/Runtime.Base/src/System/Runtime/EEType.cs
+++ b/src/Runtime.Base/src/System/Runtime/EEType.cs
@@ -42,7 +42,9 @@ namespace System.Runtime
         private UInt16 _usNumVtableSlots;
         private UInt16 _usNumInterfaces;
         private UInt32 _uHashCode;
-
+#if CORERT
+        private IntPtr _ppModuleManager;
+#endif
         // vtable follows
 
 #pragma warning restore

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
@@ -5,11 +5,13 @@
 using System.Runtime.CompilerServices;
 using System.Security;
 using Internal.NativeFormat;
+using Internal.Runtime;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Text;
 using System;
 using System.Runtime;
+using System.Collections.Generic;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -20,8 +22,19 @@ namespace Internal.Runtime.CompilerHelpers
     {
         internal static void Initialize()
         {
-            InitializeStringTable();
-            RunEagerClassConstructors();
+            IntPtr[] modules = CreateModuleManagers();
+
+            foreach (var moduleManager in modules)
+            {
+                InitializeGlobalTablesForModule(moduleManager);
+            }
+
+            // These two loops look funny but it's important to initialize the global tables before running
+            // the first class constructor to prevent them calling into another uninitialized module
+            foreach (var moduleManager in modules)
+            {
+                InitializeEagerClassConstructorsForModule(moduleManager);
+            }
         }
 
         internal static void Shutdown()
@@ -50,25 +63,102 @@ namespace Internal.Runtime.CompilerHelpers
             Environment.SetCommandLineArgs(args);
         }
 
-        private static unsafe void InitializeStringTable()
+        private static unsafe IntPtr[] CreateModuleManagers()
         {
-            int length = 0;
-            IntPtr strEETypePtr = GetModuleSection((int)ModuleSectionIds.StringEETypePtr, out length);
-            Contract.Assert(length == IntPtr.Size);
+            IntPtr* modulesSectionStart;
+            IntPtr* modulesSectionEnd;
+            GetModulesSection(out modulesSectionStart, out modulesSectionEnd);
 
-            IntPtr strTableStart = GetModuleSection((int)ModuleSectionIds.StringFixupStart, out length);
-            Contract.Assert(length % IntPtr.Size == 0);
+            // Count the number of modules so we can allocate an array to hold the ModuleManager objects.
+            // At this stage of startup, complex collection classes will not work.
+            int moduleCount = 0;
+            for (IntPtr* current = modulesSectionStart; current < modulesSectionEnd; current++)
+            {
+                IntPtr* moduleHeaderStart = (IntPtr*)*current;
 
-            IntPtr strTableEnd = (IntPtr)((byte*)strTableStart + length);
+                if (moduleHeaderStart != null)
+                {
+                    moduleCount++;
+                    current++;
+                }
+            }
 
-            for (IntPtr* tab = (IntPtr*)strTableStart; tab < (IntPtr*)strTableEnd; tab++)
+            IntPtr[] modules = new IntPtr[moduleCount];
+            int i = 0;
+            for (IntPtr* current = modulesSectionStart; current < modulesSectionEnd; current++)
+            {
+                IntPtr* moduleHeaderStart = (IntPtr*)*current;
+
+                if (moduleHeaderStart != null)
+                {
+                    // Module headers are always emitted in pairs
+                    Contract.Assert(current + 1 < modulesSectionEnd);
+
+                    IntPtr* moduleHeaderEnd = (IntPtr*)*(current + 1);
+                    modules[i] = CreateModuleManager((IntPtr)moduleHeaderStart, (IntPtr)moduleHeaderEnd);
+                    
+                    current++;
+                    i++;
+                }
+            }
+
+            return modules;
+        }
+
+        /// <summary>
+        /// Each managed module linked into the final binary may have its own global tables for strings,
+        /// statics, etc that need initializing. InitializeGlobalTables walks through the modules
+        /// and offers each a chance to initialize its global tables.
+        /// </summary>
+        private static unsafe void InitializeGlobalTablesForModule(IntPtr moduleManager)
+        {
+            // Configure the module indirection cell with the newly created ModuleManager. This allows EETypes to find
+            // their interface dispatch map tables.
+            int length;
+            IntPtr* section = (IntPtr*)GetModuleSection(moduleManager, ModuleHeaderSection.ModuleIndirectionCell, out length);
+            *section = moduleManager;
+
+            // Initialize strings if any are present
+            IntPtr stringSection = GetModuleSection(moduleManager, ModuleHeaderSection.StringTable, out length);
+            if (stringSection != IntPtr.Zero)
+            {
+                Contract.Assert(length % IntPtr.Size == 0);
+                InitializeStringTable(stringSection, length);
+            }
+
+            // Initialize statics if any are present
+            IntPtr staticsSection = GetModuleSection(moduleManager, ModuleHeaderSection.GCStaticRegion, out length);
+            if (staticsSection != IntPtr.Zero)
+            {
+                Contract.Assert(length % IntPtr.Size == 0);
+                InitializeStatics(staticsSection, length);
+            }
+        }
+
+        private static unsafe void InitializeEagerClassConstructorsForModule(IntPtr moduleManager)
+        {
+            int length;
+
+            // Run eager class constructors if any are present
+            IntPtr eagerClassConstructorSection = GetModuleSection(moduleManager, ModuleHeaderSection.EagerCctor, out length);
+            if (eagerClassConstructorSection != IntPtr.Zero)
+            {
+                Contract.Assert(length % IntPtr.Size == 0);
+                RunEagerClassConstructors(eagerClassConstructorSection, length);
+            }
+        }
+        
+        private static unsafe void InitializeStringTable(IntPtr stringTableStart, int length)
+        {
+            IntPtr stringTableEnd = (IntPtr)((byte*)stringTableStart + length);
+            for (IntPtr* tab = (IntPtr*)stringTableStart; tab < (IntPtr*)stringTableEnd; tab++)
             {
                 byte* bytes = (byte*)*tab;
                 int len = (int)NativePrimitiveDecoder.DecodeUnsigned(ref bytes);
                 int count = LowLevelUTF8Encoding.GetCharCount(bytes, len);
                 Contract.Assert(count >= 0);
 
-                string newStr = RuntimeImports.RhNewArrayAsString(new EETypePtr(strEETypePtr), count);
+                string newStr = RuntimeImports.RhNewArrayAsString(EETypePtr.EETypePtrOf<string>(), count);
                 fixed (char* dest = newStr)
                 {
                     int newCount = LowLevelUTF8Encoding.GetChars(bytes, len, dest, count);
@@ -83,17 +173,23 @@ namespace Internal.Runtime.CompilerHelpers
         {
         }
 
-        private static unsafe void RunEagerClassConstructors()
+        private static unsafe void RunEagerClassConstructors(IntPtr cctorTableStart, int length)
         {
-            int length = 0;
-            IntPtr cctorTableStart = GetModuleSection((int)ModuleSectionIds.EagerCctorStart, out length);
-            Debug.Assert(length % IntPtr.Size == 0);
-
             IntPtr cctorTableEnd = (IntPtr)((byte*)cctorTableStart + length);
 
             for (IntPtr* tab = (IntPtr*)cctorTableStart; tab < (IntPtr*)cctorTableEnd; tab++)
             {
                 Call(*tab);
+            }
+        }
+
+        private static unsafe void InitializeStatics(IntPtr gcStaticRegionStart, int length)
+        {
+            IntPtr gcStaticRegionEnd = (IntPtr)((byte*)gcStaticRegionStart + length);
+            for (IntPtr* block = (IntPtr*)gcStaticRegionStart; block < (IntPtr*)gcStaticRegionEnd; block++)
+            {
+                object obj = RuntimeImports.RhNewObject(new EETypePtr(*block));
+                *block = RuntimeImports.RhHandleAlloc(obj, GCHandleType.Normal);
             }
         }
 
@@ -104,18 +200,20 @@ namespace Internal.Runtime.CompilerHelpers
             for (; str[len] != 0; len++) { }
             return len;
         }
-
-
-        internal enum ModuleSectionIds
-        {
-            StringEETypePtr,
-            StringFixupStart,
-            EagerCctorStart,
-        };
-
-        [RuntimeImport(".", "GetModuleSection")]
+        
+        [RuntimeImport(".", "RhpGetModuleSection")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [SecurityCritical] // required to match contract
-        private static extern IntPtr GetModuleSection(int id, out int length);
+        private static extern IntPtr GetModuleSection(IntPtr module, ModuleHeaderSection section, out int length);
+
+        [RuntimeImport(".", "RhpCreateModuleManager")]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [SecurityCritical] // required to match contract
+        private static unsafe extern IntPtr CreateModuleManager(IntPtr headerStart, IntPtr headerEnd);
+
+        [RuntimeImport(".", "RhpGetModulesSection")]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [SecurityCritical] // required to match contract
+        internal static unsafe extern void GetModulesSection(out IntPtr* start, out IntPtr* end);
     }
 }

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -673,6 +673,9 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\EEType.Constants.cs" >
       <Link>Internal\Runtime\EEType.Constants.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Internal\Runtime\ModuleHeaders.cs" >
+      <Link>Internal\Runtime\ModuleHeaders.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(InPlaceRuntime)' == 'true'">
     <Compile Include="$(BaseIntermediateOutputPath)\Native\$(BinDirOSGroup).$(BinDirPlatform).$(BinDirConfiguration)\Runtime\Full\AsmOffsets.cs" />


### PR DESCRIPTION
Add a new command-line switch to ILC: /multifile. When specified, only
the assemblies passed as input will have methods compiled. Referenced
types / methods from other assemblies are not compiled into the output
object file. This switch is most likely temporary as we hone our
compilation story and implementation.

Each managed module adds pointers to the start and end of a module
global data header to a custom section of the object file, .modules$I.
These entries are merged (on Windows, OSX / Linux needs a tweak to CLI
first) at link time producing a list of module headers.

In StartupCodeHelpers.cs, initialize global tables from each module
using the list of pointers that was written to .modules$I. This data is
discovered through two exports (__modules_a and __modules_z) which
through linker section merging, are placed either side of the module
header pointers in the final binary.

Alter interface dispatch to store its dispatch map table as an
ArrayOfEmbeddedDataNode and place it in the module header list. This
allows each module's EETypes to continue using index-based lookup of
dispatch maps.

Add a new field to EETypes which points at a ModuleInfo* through an
indirection cell. This indirection cell is filled in at runtime
initialization and allows a type to find its dispatch map table.

ModuleHeaderSection.cs|h files define the section headers currently
supported

Moved the module info lookup out of the bootstrapping code and into the
runtime