### PR TITLE
Remove NumberFormatInfo workaround

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -161,14 +161,7 @@ namespace System.Globalization
                     // be thrown out of a .cctor stack that will need this.
                     NumberFormatInfo nfi = new NumberFormatInfo();
                     nfi.m_isInvariant = true;
-#if CORERT
-                    // CORERT-TODO CultureInfo
-                    nfi.isReadOnly = true;
-                    s_invariantInfo = nfi;
-#else
                     s_invariantInfo = ReadOnly(nfi);
-#endif // CORERT
-
                 }
                 return s_invariantInfo;
             }


### PR DESCRIPTION
The workaround was there because ReadOnly calls into MemberwiseClone and
we didn't have a complete enough runtime that would have the
implementation of it.

We've had such runtime for a while now, time to remove workaround.