### PR TITLE
Remove Encoding workaround

### DIFF
--- a/src/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -288,13 +288,7 @@ namespace System.Text
             if (s_encodings == null)
                 Interlocked.CompareExchange<EncodingCache>(ref s_encodings, new EncodingCache(), null);
 
-#if CORERT
-            // CORERT-TODO: For now, always return UTF8 encoding
-            // https://github.com/dotnet/corert/issues/213
-            return UTF8;
-#else
             return s_encodings.GetOrAdd(codepage);
-#endif
         }
 
         private sealed class EncodingCache : ConcurrentUnifier<int, Encoding>
@@ -418,13 +412,7 @@ namespace System.Text
             // Otherwise, the code below will throw exception when trying to call
             // EncodingTable.GetCodePageFromName().
             //
-#if CORERT
-            // CORERT-TODO: For now, always return UTF8 encoding
-            // https://github.com/dotnet/corert/issues/213
-            return UTF8;
-#else
             return GetEncoding(EncodingTable.GetCodePageFromName(name));
-#endif
         }
 
         // Returns an Encoding object for a given name or a given code page value.


### PR DESCRIPTION
This was needed either because of constrained calls or interface calls.
We now have both. Let's exercise those features.

Fixes #213.