### PR TITLE
Add reservation API to ObjectDataBuilder

### DIFF
--- a/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Debug = System.Diagnostics.Debug;
 
 namespace System.Collections.Generic
 {
-    //
-    // Helper class for building lists that avoids unnecessary allocation
-    //
+    /// <summary>
+    /// Helper class for building lists that avoids unnecessary allocation
+    /// </summary>
     internal struct ArrayBuilder<T>
     {
         private T[] _items;
@@ -69,6 +68,10 @@ namespace System.Collections.Generic
             get
             {
                 return _items[index];
+            }
+            set
+            {
+                _items[index] = value;
             }
         }
 


### PR DESCRIPTION
There are situations where ObjectDataBuilder callers might not know the
exact value to emit until later in the object data building process. The
current API surface requires them to precompute the value, which might
potentially be expensive. The new APIs allow to reserve space in the
object data blob and fill it with a value later.

I plan to use this for reflection blobs.