### PR TITLE
Pin CLI for breaking compile-native

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -100,9 +100,9 @@ install_dotnet_cli()
         fi
         
         local __build_arch_lowercase=$(echo "${__BuildArch}" | tr '[:upper:]' '[:lower:]')
-        local __cli_tarball=dotnet-${__build_os_lowercase}-${__build_arch_lowercase}.latest.tar.gz
+        local __cli_tarball=dotnet-${__build_os_lowercase}-${__build_arch_lowercase}.1.0.1.001252.tar.gz
         local __cli_tarball_path=${__tools_dir}/${__cli_tarball}
-        download_file ${__cli_tarball_path} "https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/Latest/${__cli_tarball}"
+        download_file ${__cli_tarball_path} "https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/1.0.1.001252/${__cli_tarball}"
         tar -xzf ${__cli_tarball_path} -C ${__cli_dir}
         export DOTNET_HOME=${__cli_dir}
         #

--- a/src/scripts/install-cli.ps1
+++ b/src/scripts/install-cli.ps1
@@ -14,8 +14,8 @@ $ProgressPreference="SilentlyContinue"
 
 $Feed="https://dotnetcli.blob.core.windows.net/dotnet"
 $Channel="dev"
-$DotNetFileName="dotnet-win-" + $TargetPlatform + ".latest.zip"
-$DotNetUrl="$Feed/$Channel/Binaries/Latest"
+$DotNetFileName="dotnet-win-" + $TargetPlatform + ".1.0.1.001200.zip"
+$DotNetUrl="$Feed/$Channel/Binaries/1.0.1.001200"
 
 function say($str)
 {


### PR DESCRIPTION
PR https://github.com/dotnet/cli/pull/1363 is ready to go and if merged will break our CI and dev flow. Pinning CLI version temporarily. https://github.com/dotnet/corert/pull/859 will re-enable it.