### PR TITLE
Refactor memory allocation PInvokes

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.MemAllocFree.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.MemAllocFree.cs
@@ -8,35 +8,25 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal const int HEAP_ZERO_MEMORY = 0x8;
-    
     internal unsafe partial class Sys
     {
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_MemAlloc")]
         internal static extern IntPtr MemAlloc(UIntPtr sizeInBytes);
-                
-        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_MemAllocWithZeroInitialize")]
-        internal static extern IntPtr MemAllocWithZeroInitialize(UIntPtr sizeInBytes);
-        
+
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_MemFree")]
         internal static extern void MemFree(IntPtr ptr);
     }
     
     internal static IntPtr MemAlloc(UIntPtr sizeInBytes)
     {
-        return MemAlloc(sizeInBytes, 0); 
-    }
-    
-    internal static IntPtr MemAlloc(UIntPtr sizeInBytes, uint flags)
-    {
-        IntPtr allocatedMemory = (flags & HEAP_ZERO_MEMORY) == 0 ? Interop.Sys.MemAlloc(sizeInBytes) : Interop.Sys.MemAllocWithZeroInitialize(sizeInBytes);
+        IntPtr allocatedMemory = Interop.Sys.MemAlloc(sizeInBytes);
         if (allocatedMemory == IntPtr.Zero)
         {
             throw new OutOfMemoryException();
         }
         return allocatedMemory;
     }
-    
+
     internal static void MemFree(IntPtr allocatedMemory)
     {
         Interop.Sys.MemFree(allocatedMemory);

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.MemAllocWithZeroInitializeNoThrow.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.MemAllocWithZeroInitializeNoThrow.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal unsafe partial class Sys
+    {
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_MemAllocWithZeroInitialize")]
+        internal static extern IntPtr MemAllocWithZeroInitialize(UIntPtr sizeInBytes);
+
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_MemSet")]
+        internal static extern IntPtr MemSet(IntPtr ptr, int c, UIntPtr newSize);
+    }
+
+    internal static IntPtr MemAllocWithZeroInitializeNoThrow(UIntPtr sizeInBytes)
+    {
+        return Interop.Sys.MemAllocWithZeroInitialize(sizeInBytes);
+    }
+
+    internal static unsafe IntPtr MemReAllocWithZeroInitializeNoThrow(IntPtr ptr, UIntPtr oldSize, UIntPtr newSize)
+    {
+        IntPtr allocatedMemory = Interop.Sys.MemReAlloc(ptr, newSize);
+        if (allocatedMemory != IntPtr.Zero && (long) newSize > (long) oldSize)
+        {
+            IntPtr pBuffer = (IntPtr) (((byte *) allocatedMemory) + (long) oldSize);
+            Interop.Sys.MemSet(pBuffer, 0, (UIntPtr) ((long) newSize - (long) oldSize));
+        }
+        return allocatedMemory;
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.MemReAlloc.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.MemReAlloc.cs
@@ -12,28 +12,14 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_MemReAlloc")]
         internal static extern IntPtr MemReAlloc(IntPtr ptr, UIntPtr newSize);
-        
-        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_MemSet")]
-        internal static extern IntPtr MemSet(IntPtr ptr, int c, UIntPtr newSize);
     }
 
     internal unsafe static IntPtr MemReAlloc(IntPtr ptr, UIntPtr newSize)
-    {
-        return MemReAlloc(ptr, UIntPtr.Zero, newSize , 0);
-    }
-    
-    internal static unsafe IntPtr MemReAlloc(IntPtr ptr, UIntPtr oldSize, UIntPtr newSize, uint flags)
     {
         IntPtr allocatedMemory = Interop.Sys.MemReAlloc(ptr, newSize);
         if (allocatedMemory == IntPtr.Zero)
         {
             throw new OutOfMemoryException();
-        }
-        
-        if ((flags & HEAP_ZERO_MEMORY) != 0 && (int) newSize > (int) oldSize)
-        {
-            IntPtr pBuffer = (IntPtr) (((byte *) allocatedMemory) + (int) oldSize);
-            Interop.Sys.MemSet(pBuffer, 0, (UIntPtr) ((int) newSize - (int) oldSize));
         }
         return allocatedMemory;
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.MemAllocFree.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.MemAllocFree.cs
@@ -19,22 +19,17 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-heap-l1-1-0.dll")]
         internal static extern int HeapFree(IntPtr hHeap, UInt32 dwFlags, IntPtr lpMem);
     }
-    
+
     internal static IntPtr MemAlloc(UIntPtr sizeInBytes)
     {
-        return MemAlloc(sizeInBytes, 0);
-    }
-    
-    internal static IntPtr MemAlloc(UIntPtr sizeInBytes, uint flags)
-    {
-        IntPtr allocatedMemory = Interop.mincore.HeapAlloc(Interop.mincore.GetProcessHeap(), flags, sizeInBytes);
+        IntPtr allocatedMemory = Interop.mincore.HeapAlloc(Interop.mincore.GetProcessHeap(), 0, sizeInBytes);
         if (allocatedMemory == IntPtr.Zero)
         {
             throw new OutOfMemoryException();
         }
         return allocatedMemory;
-    }    
-    
+    }
+
     internal static void MemFree(IntPtr allocatedMemory)
     {
         Interop.mincore.HeapFree(Interop.mincore.GetProcessHeap(), 0, allocatedMemory);

--- a/src/Common/src/Interop/Windows/mincore/Interop.MemAllocWithZeroInitializeNoThrow.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.MemAllocWithZeroInitializeNoThrow.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static unsafe partial class mincore
+    {
+        internal const int HEAP_ZERO_MEMORY = 0x8;      // Flag to zero memory
+    }
+
+    internal static IntPtr MemAllocWithZeroInitializeNoThrow(UIntPtr sizeInBytes)
+    {
+        return Interop.mincore.HeapAlloc(Interop.mincore.GetProcessHeap(), Interop.mincore.HEAP_ZERO_MEMORY, sizeInBytes);
+    }
+
+    internal static IntPtr MemReAllocWithZeroInitializeNoThrow(IntPtr ptr, UIntPtr oldSize, UIntPtr newSize)
+    {
+        return Interop.mincore.HeapReAlloc(Interop.mincore.GetProcessHeap(), Interop.mincore.HEAP_ZERO_MEMORY, ptr, newSize);
+    }
+}

--- a/src/Common/src/Interop/Windows/mincore/Interop.MemReAlloc.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.MemReAlloc.cs
@@ -11,17 +11,12 @@ internal static partial class Interop
     internal static unsafe partial class mincore
     {
         [DllImport("api-ms-win-core-heap-l1-1-0.dll")]
-        internal static unsafe extern IntPtr HeapReAlloc(IntPtr hHeap, UInt32 dwFlags, IntPtr lpMem, UIntPtr dwBytes);        
+        internal static unsafe extern IntPtr HeapReAlloc(IntPtr hHeap, UInt32 dwFlags, IntPtr lpMem, UIntPtr dwBytes);
     }
 
     internal unsafe static IntPtr MemReAlloc(IntPtr ptr, UIntPtr newSize)
     {
-        return MemReAlloc(ptr, UIntPtr.Zero, newSize, 0);
-    }
-    
-    internal static IntPtr MemReAlloc(IntPtr ptr, UIntPtr oldSize, UIntPtr newSize, uint flags)
-    {
-        IntPtr allocatedMemory = Interop.mincore.HeapReAlloc(Interop.mincore.GetProcessHeap(), flags, ptr, newSize);
+        IntPtr allocatedMemory = Interop.mincore.HeapReAlloc(Interop.mincore.GetProcessHeap(), 0, ptr, newSize);
         if (allocatedMemory == IntPtr.Zero)
         {
             throw new OutOfMemoryException();

--- a/src/System.Private.Interop/src/Interop/Interop.Memory.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.Memory.cs
@@ -27,14 +27,14 @@ namespace System.Runtime.InteropServices
             return Marshal.ReAllocHGlobal(ptr, unchecked( (IntPtr) (long)(ulong)newSize));
         }
 
-         internal static IntPtr MemAlloc(UIntPtr sizeInBytes, uint flags)
+        internal static IntPtr MemAllocWithZeroInitializeNoThrow(UIntPtr sizeInBytes)
         {
-            return MemAlloc(sizeInBytes);
+            throw new NotSupportedException();
         }
 
-        internal static IntPtr MemReAlloc(IntPtr ptr, UIntPtr oldSize, UIntPtr newSize ,uint flags)
+        internal static IntPtr MemReAllocWithZeroInitializeNoThrow(IntPtr ptr, UIntPtr oldSize, UIntPtr newSize)
         {
-            return MemReAlloc(ptr, newSize);
+            throw new NotSupportedException();
         }
 
 #else
@@ -49,16 +49,6 @@ namespace System.Runtime.InteropServices
             return Interop.MemAlloc((UIntPtr)(void *) sizeInBytes);
         }
 
-        internal static IntPtr MemAlloc(UIntPtr sizeInBytes, uint flags)
-        {
-            return Interop.MemAlloc(sizeInBytes, flags);
-        }
-        
-        internal static unsafe IntPtr MemAlloc(IntPtr sizeInBytes, uint flags)
-        {
-            return Interop.MemAlloc((UIntPtr)(void *)sizeInBytes, flags);
-        }
-        
         public static unsafe void MemFree(IntPtr ptr)
         {
             Interop.MemFree(ptr);
@@ -74,14 +64,14 @@ namespace System.Runtime.InteropServices
             return Interop.MemReAlloc(ptr, (UIntPtr)(void *)newSize);
         }
 
-        internal static IntPtr MemReAlloc(IntPtr ptr, UIntPtr oldSize, UIntPtr newSize ,uint flags)
+        internal static IntPtr MemAllocWithZeroInitializeNoThrow(UIntPtr sizeInBytes)
         {
-            return Interop.MemReAlloc(ptr, oldSize, newSize , flags);
+            return Interop.MemAllocWithZeroInitializeNoThrow(sizeInBytes);
         }
-        
-        internal static unsafe IntPtr MemReAlloc(IntPtr ptr, IntPtr oldSize, IntPtr newSize ,uint flags)
+
+        internal static IntPtr MemReAllocWithZeroInitializeNoThrow(IntPtr ptr, UIntPtr oldSize, UIntPtr newSize)
         {
-            return Interop.MemReAlloc(ptr, (UIntPtr)(void *) oldSize, (UIntPtr)(void *) newSize , flags);
+            return Interop.MemReAllocWithZeroInitializeNoThrow(ptr, oldSize, newSize);
         }
 #endif //CORECLR
 

--- a/src/System.Private.Interop/src/Shared/McgComHelpers.cs
+++ b/src/System.Private.Interop/src/Shared/McgComHelpers.cs
@@ -210,11 +210,6 @@ namespace System.Runtime.InteropServices
             if (pBlock == null)
             {
                 pBlock =(void*) ExternalInterop.MemAlloc(new UIntPtr((uint)size));
-
-                if (pBlock == null)
-                {
-                    throw new OutOfMemoryException();
-                }
             }
 
             return pBlock;

--- a/src/System.Private.Interop/src/Shared/RCWWalker.cs
+++ b/src/System.Private.Interop/src/Shared/RCWWalker.cs
@@ -1190,7 +1190,6 @@ namespace System.Runtime.InteropServices
         internal const int DefaultCapacity = 100;       // Default initial capacity of this list
         internal const int ShrinkHintThreshold = 5;     // The number of hints we've seen before we really
                                                         // shrink the list
-        internal const int HEAP_ZERO_MEMORY = 0x8;      // Flag to zero memory
 
         /// <summary>
         /// Reset the list of handles to be used by the current GC
@@ -1211,7 +1210,7 @@ namespace System.Runtime.InteropServices
                 //
                 m_capacity = DefaultCapacity;
                 uint newCapacity = (uint)(sizeof(IntPtr) * m_capacity);
-                m_pHandles = (IntPtr*)ExternalInterop.MemAlloc(new UIntPtr(newCapacity) , HEAP_ZERO_MEMORY);
+                m_pHandles = (IntPtr*)ExternalInterop.MemAllocWithZeroInitializeNoThrow(new UIntPtr(newCapacity));
 
                 if (m_pHandles == null)
                     return false;
@@ -1304,10 +1303,9 @@ namespace System.Runtime.InteropServices
             int newCapacity = m_capacity * 2;
 
             // NOTE: Call must be used instead of StdCall to avoid deadlock
-            IntPtr* pNewHandles = (IntPtr*)ExternalInterop.MemReAlloc((IntPtr)m_pHandles,
+            IntPtr* pNewHandles = (IntPtr*)ExternalInterop.MemReAllocWithZeroInitializeNoThrow((IntPtr)m_pHandles,
                                                                       new UIntPtr( (uint) (sizeof(IntPtr) * m_capacity)),
-                                                                      new UIntPtr( (uint) (sizeof(IntPtr) * newCapacity)),
-                                                                      HEAP_ZERO_MEMORY);
+                                                                      new UIntPtr( (uint) (sizeof(IntPtr) * newCapacity)));
 
             if (pNewHandles == null)
                 return false;
@@ -1348,11 +1346,9 @@ namespace System.Runtime.InteropServices
             // If this fails, we don't really care (very unlikely to fail, though)
             // NOTE: Call must be used instead of StdCall to avoid deadlock
             //
-            IntPtr* pNewHandles = (IntPtr*)ExternalInterop.MemReAlloc((IntPtr) m_pHandles, 
+            IntPtr* pNewHandles = (IntPtr*)ExternalInterop.MemReAllocWithZeroInitializeNoThrow((IntPtr) m_pHandles, 
                                                                         new UIntPtr((uint)(sizeof(IntPtr) * m_capacity)),
-                                                                        new UIntPtr((uint)(sizeof(IntPtr) * newCapacity)), 
-                                                                        HEAP_ZERO_MEMORY);
-
+                                                                        new UIntPtr((uint)(sizeof(IntPtr) * newCapacity)));
             if (pNewHandles == null)
                 return false;
 

--- a/src/System.Private.Interop/src/System.Private.Interop.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.csproj
@@ -183,12 +183,15 @@
     <Compile Include="System\__HResults.cs" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.MemAllocFree.cs"  Condition=" '$(IsProjectKLibrary)' != 'true' ">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(IsProjectKLibrary)' != 'true'">
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.MemAllocFree.cs">
       <Link>Interop\Windows\mincore\Interop.MemAllocFree.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.MemReAlloc.cs" Condition=" '$(IsProjectKLibrary)' != 'true' ">
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.MemReAlloc.cs">
       <Link>Interop\Windows\mincore\Interop.MemReAlloc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.MemAllocWithZeroInitializeNoThrow.cs">
+      <Link>Interop\Windows\mincore\Interop.MemAllocWithZeroInitializeNoThrow.cs</Link>
     </Compile>
   </ItemGroup>
 
@@ -198,16 +201,17 @@
     <Compile Include="Interop\Interop.Common.Unix.cs" />
   -->
 
-  <ItemGroup Condition="'$(TargetsUnix)'=='true'">
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.MemAllocFree.cs" Condition=" '$(IsProjectKLibrary)' != 'true' ">
+  <ItemGroup Condition="'$(TargetsUnix)'=='true' and '$(IsProjectKLibrary)' != 'true'">
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.MemAllocFree.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.MemAllocFree.cs</Link>
     </Compile>
-
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.MemReAlloc.cs" Condition=" '$(IsProjectKLibrary)' != 'true' ">
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.MemReAlloc.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.MemReAlloc.cs</Link>
     </Compile>
-    
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Libraries.cs" >
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.MemAllocWithZeroInitializeNoThrow.cs">
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.MemAllocWithZeroInitializeNoThrow.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Libraries.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
@@ -649,12 +649,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static IntPtr AllocHGlobal(IntPtr cb)
         {
-            IntPtr pNewMem = ExternalInterop.MemAlloc(cb);
-            if (pNewMem == IntPtr.Zero)
-            {
-                throw new OutOfMemoryException();
-            }
-            return pNewMem;
+            return ExternalInterop.MemAlloc(cb);
         }
 
         public static IntPtr AllocHGlobal(int cb)
@@ -672,12 +667,7 @@ namespace System.Runtime.InteropServices
 
         public unsafe static IntPtr ReAllocHGlobal(IntPtr pv, IntPtr cb)
         {
-            IntPtr pNewMem = ExternalInterop.MemReAlloc(pv, cb);
-            if (pNewMem == IntPtr.Zero)
-            {
-                throw new OutOfMemoryException();
-            }
-            return pNewMem;
+            return ExternalInterop.MemReAlloc(pv, cb);
         }
 
         private unsafe static void ConvertToAnsi(string source, IntPtr pbNativeBuffer, int cbNativeBuffer)
@@ -790,15 +780,8 @@ namespace System.Runtime.InteropServices
                     throw new ArgumentOutOfRangeException("s");
 
                 IntPtr hglobal = ExternalInterop.MemAlloc(new IntPtr(nb));
-                if (hglobal == IntPtr.Zero)
-                {
-                    throw new OutOfMemoryException();
-                }
-                else
-                {
-                    ConvertToAnsi(s, hglobal, nb);
-                    return hglobal;
-                }
+                ConvertToAnsi(s, hglobal, nb);
+                return hglobal;
             }
         }
 
@@ -817,19 +800,11 @@ namespace System.Runtime.InteropServices
                     throw new ArgumentOutOfRangeException("s");
 
                 IntPtr hglobal = ExternalInterop.MemAlloc(new UIntPtr((uint)nb));
-
-                if (hglobal == IntPtr.Zero)
+                fixed (char* firstChar = s)
                 {
-                    throw new OutOfMemoryException();
+                    InteropExtensions.Memcpy(hglobal, new IntPtr(firstChar), nb);
                 }
-                else
-                {
-                    fixed (char* firstChar = s)
-                    {
-                        InteropExtensions.Memcpy(hglobal, new IntPtr(firstChar), nb);
-                    }
-                    return hglobal;
-                }
+                return hglobal;
             }
         }
 


### PR DESCRIPTION
- Changed RCWWalker back to use non-throwing version. It was a bug introduced earlier - it is not ok to use throwing version in RCWWalker because of the code is executing during GC.
- Made Windows-specific HEAP_ZERO_MEMORY flag to be used in Windows-specific implementation only
- Split the regular ones from the very special flavor used by RCWWalker that does not throw exceptions and zero initializes memory
- Removed some unnecessary null checks for out of memory