### PR TITLE
Add some support for constrained calls in CppCodegen

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -809,8 +809,13 @@ namespace Internal.IL
                     _pendingPrefix &= ~Prefix.Constrained;
                     constrained = _constrained;
 
-                    // TODO:
-                    throw new NotImplementedException();
+                    bool forceUseRuntimeLookup;
+                    MethodDesc directMethod = constrained.GetClosestMetadataType().TryResolveConstraintMethodApprox(method.OwningType, method, out forceUseRuntimeLookup);
+                    if (directMethod == null || forceUseRuntimeLookup)
+                        throw new NotImplementedException();
+
+                    method = directMethod;
+                    opcode = ILOpcode.call;
                 }
             }
 


### PR DESCRIPTION
Apparently this is all we needed to be able to support "typeof(Foo)" in
CppCodegen.