### PR TITLE
Add exception handling assembly helpers to Windows build

### DIFF
--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -213,6 +213,16 @@ extern "C" void RhCollect()
 {
     throw "RhCollect";
 }
+
+#if !defined(_WIN32) || defined(CPPCODEGEN)
+extern "C" void RhpThrowEx(void * pEx)
+{
+    throw "RhpThrowEx";
+}
+extern "C" void RhpThrowHwEx()
+{
+    throw "RhpThrowHwEx";
+}
 extern "C" void RhpCallCatchFunclet()
 {
     throw "RhpCallCatchFunclet";
@@ -225,6 +235,8 @@ extern "C" void RhpCallFinallyFunclet()
 {
     throw "RhpCallFinallyFunclet";
 }
+#endif //. !_WIN32 || CPPCODEGEN
+
 extern "C" void RhpUniversalTransition()
 {
     throw "RhpUniversalTransition";
@@ -232,14 +244,6 @@ extern "C" void RhpUniversalTransition()
 extern "C" void RhpFailFastForPInvokeExceptionPreemp()
 {
     throw "RhpFailFastForPInvokeExceptionPreemp";
-}
-extern "C" void RhpThrowEx(void * pEx)
-{
-    throw "RhpThrowEx";
-}
-extern "C" void RhpThrowHwEx()
-{
-    throw "RhpThrowHwEx";
 }
 extern "C" void RhpEtwExceptionThrown()
 {

--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -77,6 +77,7 @@ if(WIN32)
 
   list(APPEND RUNTIME_SOURCES_ARCH_ASM
     ${ARCH_SOURCES_DIR}/GC.${ASM_SUFFIX}
+    ${ARCH_SOURCES_DIR}/ExceptionHandling.${ASM_SUFFIX}
     ${ARCH_SOURCES_DIR}/ManagedCalloutThunk.${ASM_SUFFIX}
   )
 

--- a/src/Native/Runtime/amd64/ExceptionHandling.asm
+++ b/src/Native/Runtime/amd64/ExceptionHandling.asm
@@ -332,7 +332,7 @@ NESTED_ENTRY RhpCallCatchFunclet, _TEXT
         mov     rax, [r8 + OFFSETOF__REGDISPLAY__pR15]
         mov     r15, [rax]
 
-if 0 ;; DBG  ;; @TODO: temporarily removed because trashing RBP breaks the debugger
+if 0 ;; _DEBUG  ;; @TODO: temporarily removed because trashing RBP breaks the debugger
         ;; trash the values at the old homes to make sure nobody uses them
         mov     r9, 0baaddeedh
         mov     rax, [r8 + OFFSETOF__REGDISPLAY__pRbx]
@@ -371,7 +371,7 @@ ALTERNATE_ENTRY RhpCallCatchFunclet2
 
         mov     r8, [rsp + 28h + 8*8h]                              ;; r8 <- dispatch context
 
-if DBG
+ifdef _DEBUG
         ;; Call into some C++ code to validate the pop of the ExInfo.  We only do this in debug because we 
         ;; have to spill all the preserved registers and then refill them after the call.
 
@@ -508,7 +508,7 @@ NESTED_ENTRY RhpCallFinallyFunclet, _TEXT
         movdqa  xmm14,[rdx + OFFSETOF__REGDISPLAY__Xmm + 8*10h]
         movdqa  xmm15,[rdx + OFFSETOF__REGDISPLAY__Xmm + 9*10h]
 
-if 0 ;; DBG  ;; @TODO: temporarily removed because trashing RBP breaks the debugger
+if 0 ;; _DEBUG ;; @TODO: temporarily removed because trashing RBP breaks the debugger
         ;; trash the values at the old homes to make sure nobody uses them
         mov     r9, 0baaddeedh
         mov     rax, [rdx + OFFSETOF__REGDISPLAY__pRbx]

--- a/src/Native/Runtime/amd64/GcProbe.asm
+++ b/src/Native/Runtime/amd64/GcProbe.asm
@@ -478,7 +478,7 @@ endm
 NESTED_ENTRY RhpGCProbeForEHJump, _TEXT
         EHJumpProbeProlog
 
-if DBG
+ifdef _DEBUG
         ;;
         ;; If we get here, then we have been hijacked for a real GC, and our SyncState must
         ;; reflect that we've been requested to synchronize.
@@ -488,7 +488,7 @@ if DBG
 
         call        PALDEBUGBREAK
 @@:
-endif ;; DBG
+endif ;; _DEBUG
 
         mov         rbx, rdx
         WaitForGCCompletion

--- a/src/Native/Runtime/arm/ExceptionHandling.asm
+++ b/src/Native/Runtime/arm/ExceptionHandling.asm
@@ -337,7 +337,7 @@ ClearSuccess_Catch
 
         ldr         r2, [sp, #rsp_offset_r2]                    ;; r2 <- REGDISPLAY*
 
-;; @TODO: add DBG-only validation code for ExInfo pop
+;; @TODO: add debug-only validation code for ExInfo pop
 
         INLINE_GETTHREAD r1, r3                                 ;; r1 <- Thread*, r3 <- trashed
 

--- a/src/Native/Runtime/i386/AllocFast.asm
+++ b/src/Native/Runtime/i386/AllocFast.asm
@@ -56,10 +56,10 @@ AllocFailed:
 
         PUSH_COOP_PINVOKE_FRAME edx
 
-if DBG
+ifdef _DEBUG
         ;; save the Thread pointer in ebx
         mov         ebx, edx
-endif ; DBG
+endif ; _DEBUG
 
         ;; Push alloc helper arguments (thread, size, flags, EEType).
         push        ecx                                             ; EEType

--- a/src/Native/Runtime/i386/GcProbe.asm
+++ b/src/Native/Runtime/i386/GcProbe.asm
@@ -107,14 +107,14 @@ PushProbeFrame macro BITMASK_REG_OR_VALUE
         push        esi                     ; ESI
         push        ebx                     ; EBX
         push        BITMASK_REG_OR_VALUE    ; register bitmask
-if DBG
+ifdef _DEBUG
         mov         eax, BITMASK_REG_OR_VALUE
         and         eax, DEFAULT_PROBE_SAVE_FLAGS
         cmp         eax, DEFAULT_PROBE_SAVE_FLAGS ; make sure we have at least the flags to match what the macro pushes
         je          @F
         call        PALDEBUGBREAK
 @@:
-endif ;; DBG
+endif ;; _DEBUG
         push        edx                     ; Thread *
         mov         eax, [ebp + 0]                      ; find previous EBP value
         push        eax                     ; m_FramePointer
@@ -496,7 +496,7 @@ RhpGCProbeForEHJump proc
 
         ClearHijackState
 
-if DBG
+ifdef _DEBUG
         ;;
         ;; If we get here, then we have been hijacked for a real GC, and our SyncState must
         ;; reflect that we've been requested to synchronize.
@@ -506,7 +506,7 @@ if DBG
 
         call        PALDEBUGBREAK
 @@:
-endif ;; DBG
+endif ;; _DEBUG
 
 
         PushProbeFrame  PROBE_SAVE_FLAGS_RAX_IS_GCREF

--- a/src/Native/Runtime/module.cpp
+++ b/src/Native/Runtime/module.cpp
@@ -555,12 +555,6 @@ bool Module::EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClauseOut)
     // For each clause, we have up to 4 integers:
     //      1)  try start offset
     //      2)  (try length << 2) | clauseKind
-    //
-    //      Local exceptions
-    //      3) if (typed || fault) { handler start offset }
-    //      4) if (typed)          { index into type table }
-    //
-    //      CLR exceptions
     //      3)  if (typed || fault || filter)    { handler start offset }
     //      4a) if (typed)                       { index into type table }
     //      4b) if (filter)                      { filter start offset }


### PR DESCRIPTION
Renamed DBG to _DEBUG define in several places to fix build breaks.