### PR TITLE
Exception handling on Windows

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace ILCompiler.DependencyAnalysis
 {
     public class BlobNode : ObjectNode, ISymbolNode
@@ -53,7 +55,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            return new ObjectData(_data, null, _alignment, new ISymbolNode[] { this });
+            return new ObjectData(_data, Array.Empty<Relocation>(), _alignment, new ISymbolNode[] { this });
         }
 
         public override string GetName()

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/INodeWithCodeInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/INodeWithCodeInfo.cs
@@ -24,5 +24,10 @@ namespace ILCompiler.DependencyAnalysis
         {
             get;
         }
+
+        ObjectNode.ObjectData EHInfo
+        {
+            get;
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
@@ -12,6 +12,8 @@ namespace ILCompiler.DependencyAnalysis
 {
     public enum RelocType
     {
+        IMAGE_REL_BASED_ABSOLUTE = 0x00,
+        IMAGE_REL_BASED_HIGHLOW = 0x03,
         IMAGE_REL_BASED_DIR64 = 0x0A,
         IMAGE_REL_BASED_REL32 = 0x10,
     }

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -5,7 +5,7 @@
     "System.Reflection.Metadata": "1.1.0",
     "System.CommandLine": "0.1.0-e160208-1",
     "Microsoft.DotNet.RyuJit": "1.0.5-prerelease-00001",
-    "Microsoft.DotNet.ObjectWriter": "1.0.7-prerelease-00001"
+    "Microsoft.DotNet.ObjectWriter": "1.0.8-prerelease-00001"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -96,6 +96,7 @@ void __range_check_fail()
 extern "C" void RhpReversePInvoke2(ReversePInvokeFrame* pRevFrame);
 extern "C" void RhpReversePInvokeReturn(ReversePInvokeFrame* pRevFrame);
 extern "C" int32_t RhpEnableConservativeStackReporting();
+extern "C" bool RhpRegisterCoffModule(void * pModule);
 extern "C" void * RhpHandleAlloc(void * pObject, int handleType);
 
 #define DLL_PROCESS_ATTACH      1
@@ -270,6 +271,10 @@ extern "C" void RhReRegisterForFinalize()
 
 extern "C" void InitializeModules(void ** modules, int count);
 
+#ifdef _WIN32
+extern "C" void* WINAPI GetModuleHandleW(const wchar_t *);
+#endif
+
 #if defined(_WIN32)
 extern "C" int __managed__Main(int argc, wchar_t* argv[]);
 int wmain(int argc, wchar_t* argv[])
@@ -279,6 +284,10 @@ int main(int argc, char* argv[])
 #endif
 {
     if (__initialize_runtime() != 0) return -1;
+
+#if defined(_WIN32) && !defined(CPPCODEGEN)
+    if (!RhpRegisterCoffModule(GetModuleHandleW(NULL))) return -1;
+#endif
 
     ReversePInvokeFrame frame; __reverse_pinvoke(&frame);
 

--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -69,6 +69,7 @@ if(WIN32)
   list(APPEND COMMON_RUNTIME_SOURCES
     windows/PalRedhawkCommon.cpp
     windows/PalRedhawkMinWin.cpp
+    windows/CoffNativeCodeManager.cpp
   )
 
   if(CLR_CMAKE_PLATFORM_ARCH_AMD64)

--- a/src/Native/Runtime/ICodeManager.h
+++ b/src/Native/Runtime/ICodeManager.h
@@ -52,12 +52,6 @@ enum EHClauseKind
 {
     EH_CLAUSE_TYPED = 0,
     EH_CLAUSE_FAULT = 1,
-
-    // Local Exceptions
-    EH_CLAUSE_METHOD_BOUNDARY = 2,
-    EH_CLAUSE_FAIL_FAST = 3,
-
-    // CLR Exceptions
     EH_CLAUSE_FILTER = 2,
     EH_CLAUSE_UNUSED = 3,
 };

--- a/src/Native/Runtime/inc/rhbinder.h
+++ b/src/Native/Runtime/inc/rhbinder.h
@@ -665,14 +665,8 @@ enum RhEHClauseKind
 {
     RH_EH_CLAUSE_TYPED              = 0,
     RH_EH_CLAUSE_FAULT              = 1,
-
-    // local exceptions
-    RH_EH_CLAUSE_METHOD_BOUNDARY    = 2,    // /eh:rh
-    RH_EH_CLAUSE_FAIL_FAST          = 3,    // /eh:rh
-
-    // CLR exceptions
-    RH_EH_CLAUSE_FILTER             = 2,    // /eh:clr
-    RH_EH_CLAUSE_UNUSED             = 3,    // /eh:clr
+    RH_EH_CLAUSE_FILTER             = 2,
+    RH_EH_CLAUSE_UNUSED             = 3
 };
 
 // Structure used to store offsets information of thread static fields, and mainly used

--- a/src/Native/Runtime/module.cpp
+++ b/src/Native/Runtime/module.cpp
@@ -567,7 +567,8 @@ bool Module::EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClauseOut)
         pEHClauseOut->m_handlerOffset = VarInt::ReadUnsigned(pEnumState->pEHInfo);
         pEHClauseOut->m_filterOffset = VarInt::ReadUnsigned(pEnumState->pEHInfo);
         break;
-    case EH_CLAUSE_FAIL_FAST:
+    default:
+        ASSERT_UNCONDITIONALLY("Unexpected EHClauseKind");
         break;
     }
 

--- a/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
@@ -1,0 +1,504 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#include "common.h"
+
+#include <windows.h>
+
+#include "CommonTypes.h"
+#include "CommonMacros.h"
+#include "daccess.h"
+#include "PalRedhawkCommon.h"
+#include "regdisplay.h"
+#include "ICodemanager.h"
+#include "CoffNativeCodeManager.h"
+#include "varint.h"
+
+#include "CommonMacros.inl"
+
+#define UBF_FUNC_KIND_MASK      0x03
+#define UBF_FUNC_KIND_ROOT      0x00
+#define UBF_FUNC_KIND_HANDLER   0x01
+#define UBF_FUNC_KIND_FILTER    0x02
+
+#define UBF_FUNC_HAS_EHINFO     0x04
+
+#if defined(_TARGET_AMD64_)
+
+//
+// The following structures are defined in Windows x64 unwind info specification
+// http://www.bing.com/search?q=msdn+Exception+Handling+x64
+//
+
+typedef union _UNWIND_CODE {
+    struct {
+        uint8_t CodeOffset;
+        uint8_t UnwindOp : 4;
+        uint8_t OpInfo : 4;
+    };
+
+    uint16_t FrameOffset;
+} UNWIND_CODE, *PUNWIND_CODE;
+
+#define UNW_FLAG_NHANDLER 0x0
+#define UNW_FLAG_EHANDLER 0x1
+#define UNW_FLAG_UHANDLER 0x2
+#define UNW_FLAG_CHAININFO 0x4
+
+typedef struct _UNWIND_INFO {
+    uint8_t Version : 3;
+    uint8_t Flags : 5;
+    uint8_t SizeOfProlog;
+    uint8_t CountOfUnwindCodes;
+    uint8_t FrameRegister : 4;
+    uint8_t FrameOffset : 4;
+    UNWIND_CODE UnwindCode[1];
+} UNWIND_INFO, *PUNWIND_INFO;
+
+typedef DPTR(struct _UNWIND_INFO)      PTR_UNWIND_INFO;
+typedef DPTR(union _UNWIND_CODE)       PTR_UNWIND_CODE;
+
+#endif // _TARGET_AMD64_
+
+static PTR_VOID GetUnwindDataBlob(TADDR moduleBase, PTR_RUNTIME_FUNCTION pRuntimeFunction, /* out */ size_t * pSize)
+{
+#if defined(_TARGET_AMD64_)
+    PTR_UNWIND_INFO pUnwindInfo(dac_cast<PTR_UNWIND_INFO>(moduleBase + pRuntimeFunction->UnwindInfoAddress));
+
+    size_t size = offsetof(UNWIND_INFO, UnwindCode) + sizeof(UNWIND_CODE) * pUnwindInfo->CountOfUnwindCodes;
+
+    // Chained unwind info is not supported at this time
+    ASSERT((pUnwindInfo->Flags & UNW_FLAG_CHAININFO) == 0);
+
+    if (pUnwindInfo->Flags & (UNW_FLAG_EHANDLER | UNW_FLAG_UHANDLER))
+    {
+        // Personality routine
+        size = ALIGN_UP(size, sizeof(DWORD)) + sizeof(DWORD);
+    }
+
+    *pSize = size;
+
+    return pUnwindInfo;
+
+#elif defined(_TARGET_ARM_)
+
+    // if this function uses packed unwind data then at least one of the two least significant bits
+    // will be non-zero.  if this is the case then there will be no xdata record to enumerate.
+    ASSERT((pRuntimeFunction->UnwindData & 0x3) == 0);
+
+    // compute the size of the unwind info
+    PTR_TADDR xdata = dac_cast<PTR_TADDR>(pRuntimeFunction->UnwindData + moduleBase);
+
+    ULONG epilogScopes = 0;
+    ULONG unwindWords = 0;
+    ULONG size = 0;
+
+    if ((xdata[0] >> 23) != 0)
+    {
+        size = 4;
+        epilogScopes = (xdata[0] >> 23) & 0x1f;
+        unwindWords = (xdata[0] >> 28) & 0x0f;
+    }
+    else
+    {
+        size = 8;
+        epilogScopes = xdata[1] & 0xffff;
+        unwindWords = (xdata[1] >> 16) & 0xff;
+    }
+
+    if (!(xdata[0] & (1 << 21)))
+        size += 4 * epilogScopes;
+
+    size += 4 * unwindWords;
+
+    if ((xdata[0] & (1 << 20)) != 0)
+    {
+        // Personality routine
+        size += 4;
+    }
+
+    *pSize = size;
+    return xdata;
+#else
+    #error unexpected target architecture
+#endif
+}
+
+
+CoffNativeCodeManager::CoffNativeCodeManager(TADDR moduleBase, PTR_RUNTIME_FUNCTION pRuntimeFunctionTable, UInt32 nRuntimeFunctionTable)
+    : m_moduleBase(moduleBase), m_pRuntimeFunctionTable(pRuntimeFunctionTable), m_nRuntimeFunctionTable(nRuntimeFunctionTable)
+{
+}
+
+CoffNativeCodeManager::~CoffNativeCodeManager()
+{
+}
+
+static int LookupUnwindInfoForMethod(UInt32 relativePc,
+                                     PTR_RUNTIME_FUNCTION pRuntimeFunctionTable,
+                                     int low,
+                                     int high)
+{
+#ifdef TARGET_ARM
+    relativePc |= THUMB_CODE;
+#endif 
+
+    // Entries are sorted and terminated by sentinel value (DWORD)-1
+
+    // Binary search the RUNTIME_FUNCTION table
+    // Use linear search once we get down to a small number of elements
+    // to avoid Binary search overhead.
+    while (high - low > 10) 
+    {
+       int middle = low + (high - low) / 2;
+
+       PTR_RUNTIME_FUNCTION pFunctionEntry = pRuntimeFunctionTable + middle;
+       if (relativePc < pFunctionEntry->BeginAddress) 
+       {
+           high = middle - 1;
+       } 
+       else 
+       {
+           low = middle;
+       }
+    }
+
+    for (int i = low; i <= high; ++i)
+    {
+        // This is safe because of entries are terminated by sentinel value (DWORD)-1
+        PTR_RUNTIME_FUNCTION pNextFunctionEntry = pRuntimeFunctionTable + (i + 1);
+
+        if (relativePc < pNextFunctionEntry->BeginAddress)
+        {
+            PTR_RUNTIME_FUNCTION pFunctionEntry = pRuntimeFunctionTable + i;
+            if (relativePc >= pFunctionEntry->BeginAddress)
+            {
+                return i;
+            }
+            break;
+        }
+    }
+
+    return -1;
+}
+
+struct CoffNativeMethodInfo
+{
+    PTR_RUNTIME_FUNCTION mainRuntimeFunction;
+    PTR_RUNTIME_FUNCTION runtimeFunction;
+    bool executionAborted;
+};
+
+// Ensure that CoffNativeMethodInfo fits into the space reserved by MethodInfo
+static_assert(sizeof(CoffNativeMethodInfo) <= sizeof(MethodInfo), "CoffNativeMethodInfo too big");
+
+bool CoffNativeCodeManager::FindMethodInfo(PTR_VOID        ControlPC, 
+                                    MethodInfo *    pMethodInfoOut,
+                                    UInt32 *        pCodeOffset)
+{
+    CoffNativeMethodInfo * pMethodInfo = (CoffNativeMethodInfo *)pMethodInfoOut;
+
+    TADDR relativePC = dac_cast<TADDR>(ControlPC) - m_moduleBase;
+
+    int MethodIndex = LookupUnwindInfoForMethod((UInt32)relativePC, m_pRuntimeFunctionTable,
+        0, m_nRuntimeFunctionTable - 1);
+    if (MethodIndex < 0)
+        return false;
+
+    PTR_RUNTIME_FUNCTION pRuntimeFunction = m_pRuntimeFunctionTable + MethodIndex;
+
+    pMethodInfo->runtimeFunction = pRuntimeFunction;
+
+    // The runtime function could correspond to a funclet.  We need to get to the 
+    // runtime function of the main method.
+    for (;;)
+    {
+        size_t unwindDataBlobSize;
+        PTR_VOID pUnwindDataBlob = GetUnwindDataBlob(m_moduleBase, pRuntimeFunction, &unwindDataBlobSize);
+
+        uint8_t unwindBlockFlags = *(dac_cast<DPTR(uint8_t)>(pUnwindDataBlob) + unwindDataBlobSize);
+        if ((unwindBlockFlags & UBF_FUNC_KIND_MASK) == UBF_FUNC_KIND_ROOT)
+            break;
+
+        pRuntimeFunction--;
+    }
+
+    pMethodInfo->mainRuntimeFunction = pRuntimeFunction;
+
+    pMethodInfo->executionAborted = false;
+
+    *pCodeOffset = (UInt32)(relativePC - pMethodInfo->mainRuntimeFunction->BeginAddress);
+
+    return true;
+}
+
+bool CoffNativeCodeManager::IsFunclet(MethodInfo * pMethInfo)
+{
+    CoffNativeMethodInfo * pMethodInfo = (CoffNativeMethodInfo *)pMethInfo;
+
+    size_t unwindDataBlobSize;
+    PTR_VOID pUnwindDataBlob = GetUnwindDataBlob(m_moduleBase, pMethodInfo->runtimeFunction, &unwindDataBlobSize);
+
+    uint8_t unwindBlockFlags = *(dac_cast<DPTR(uint8_t)>(pUnwindDataBlob) + unwindDataBlobSize);
+
+    // A funclet will have an entry in funclet to main method map
+    return (unwindBlockFlags & UBF_FUNC_KIND_MASK) != UBF_FUNC_KIND_ROOT;
+}
+
+PTR_VOID CoffNativeCodeManager::GetFramePointer(MethodInfo *   pMethodInfo,
+                                         REGDISPLAY *   pRegisterSet)
+{
+    // If the method has EHinfo then it is guaranteed to have a frame pointer.
+    CoffNativeMethodInfo * pNativeMethodInfo = (CoffNativeMethodInfo *)pMethodInfo;
+
+    // Get to unwind info
+    PTR_UNWIND_INFO pUnwindInfo(dac_cast<PTR_UNWIND_INFO>(m_moduleBase + pNativeMethodInfo->runtimeFunction->UnwindInfoAddress));
+
+    if (pUnwindInfo->FrameRegister != 0)
+    {
+        return (PTR_VOID)pRegisterSet->GetFP();
+    }
+
+    return NULL;
+}
+
+// void EnumGCRefs(PTR_VOID pGCInfo, UINT32 curOffs, REGDISPLAY * pRD, GCEnumContext * hCallback, bool executionAborted);
+
+void CoffNativeCodeManager::EnumGcRefs(MethodInfo *    pMethodInfo, 
+                                UInt32          codeOffset,
+                                REGDISPLAY *    pRegisterSet,
+                                GCEnumContext * hCallback)
+{
+    // @TODO: CORERT: PInvoke transitions
+
+#if 0
+    CoffNativeMethodInfo * pNativeMethodInfo = (CoffNativeMethodInfo *)pMethodInfo;
+
+    SIZE_T nUnwindDataSize;
+    PTR_VOID pUnwindData = GetUnwindDataBlob(dac_cast<TADDR>(m_pvStartRange), &pNativeMethodInfo->mainRuntimeFunction, &nUnwindDataSize);
+
+    // GCInfo immediatelly follows unwind data
+    PTR_VOID pGCInfo = dac_cast<PTR_VOID>(dac_cast<TADDR>(pUnwindData) + nUnwindDataSize + 1);
+
+    ::EnumGCRefs(pGCInfo, codeOffset, pRegisterSet, hCallback, pNativeMethodInfo->executionAborted);
+#endif
+}
+
+UIntNative CoffNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(MethodInfo * pMethodInfo, REGDISPLAY * pRegisterSet)
+{
+    // @TODO: CORERT: GetConservativeUpperBoundForOutgoingArgs
+    assert(false);
+    return false;
+}
+
+bool CoffNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
+                                      UInt32          codeOffset,
+                                      REGDISPLAY *    pRegisterSet,                 // in/out
+                                      PTR_VOID *      ppPreviousTransitionFrame)    // out
+{
+    CoffNativeMethodInfo * pNativeMethodInfo = (CoffNativeMethodInfo *)pMethodInfo;
+
+    // @TODO: CORERT: PInvoke transitions
+    *ppPreviousTransitionFrame = NULL;
+
+    CONTEXT context;
+    KNONVOLATILE_CONTEXT_POINTERS contextPointers;
+
+#ifdef _DEBUG
+    memset(&context, 0xDD, sizeof(context));
+    memset(&contextPointers, 0xDD, sizeof(contextPointers));
+#endif
+
+#define FOR_EACH_NONVOLATILE_REGISTER(F) \
+    F(Rax) F(Rcx) F(Rdx) F(Rbx) F(Rbp) F(Rsi) F(Rdi) F(R8) F(R9) F(R10) F(R11) F(R12) F(R13) F(R14) F(R15)
+
+#define REGDISPLAY_TO_CONTEXT(reg) \
+    contextPointers.reg = (PDWORD64) pRegisterSet->p##reg; \
+    if (pRegisterSet->p##reg != NULL) context.reg = *(pRegisterSet->p##reg);
+
+#define CONTEXT_TO_REGDISPLAY(reg) \
+    pRegisterSet->p##reg = (PTR_UIntNative) contextPointers.reg;
+
+    FOR_EACH_NONVOLATILE_REGISTER(REGDISPLAY_TO_CONTEXT);
+
+    memcpy(&context.Xmm6, pRegisterSet->Xmm, sizeof(pRegisterSet->Xmm));
+
+    context.Rsp = pRegisterSet->SP;
+    context.Rip = pRegisterSet->IP;
+
+    SIZE_T  EstablisherFrame;
+    PVOID   HandlerData;
+
+    RtlVirtualUnwind(NULL,
+                    dac_cast<TADDR>(m_moduleBase),
+                    pRegisterSet->IP,
+                    (PRUNTIME_FUNCTION)pNativeMethodInfo->runtimeFunction,
+                    &context,
+                    &HandlerData,
+                    &EstablisherFrame,
+                    &contextPointers);
+
+    pRegisterSet->SP = context.Rsp;
+    pRegisterSet->IP = context.Rip;
+
+    pRegisterSet->pIP = PTR_PCODE(pRegisterSet->SP - sizeof(TADDR));
+
+    memcpy(pRegisterSet->Xmm, &context.Xmm6, sizeof(pRegisterSet->Xmm));
+
+    FOR_EACH_NONVOLATILE_REGISTER(CONTEXT_TO_REGDISPLAY);
+
+#undef FOR_EACH_NONVOLATILE_REGISTER
+#undef REGDISPLAY_TO_CONTEXT
+#undef CONTEXT_TO_REGDISPLAY
+
+    return true;
+}
+
+bool CoffNativeCodeManager::GetReturnAddressHijackInfo(MethodInfo *    pMethodInfo,
+                                                UInt32          codeOffset,
+                                                REGDISPLAY *    pRegisterSet,       // in
+                                                PTR_PTR_VOID *  ppvRetAddrLocation, // out
+                                                GCRefKind *     pRetValueKind)      // out
+{
+    // @TODO: CORERT: GetReturnAddressHijackInfo
+    return false;
+}
+
+void CoffNativeCodeManager::UnsynchronizedHijackMethodLoops(MethodInfo * pMethodInfo)
+{
+    // @TODO: CORERT: UnsynchronizedHijackMethodLoops
+}
+
+void CoffNativeCodeManager::RemapHardwareFaultToGCSafePoint(MethodInfo * pMethodInfo, UInt32 * pCodeOffset)
+{
+    // GCInfo decoder needs to know whether execution of the method is aborted 
+    // while querying for gc-info.  But ICodeManager::EnumGCRef() doesn't receive any
+    // flags from mrt. Call to this method is used as a cue to mark the method info
+    // as execution aborted. Note - if pMethodInfo was cached, this scheme would not work.
+    //
+    // If the method has EH, then JIT will make sure the method is fully interruptible
+    // and we will have GC-info available at the faulting address as well.
+
+    CoffNativeMethodInfo * pNativeMethodInfo = (CoffNativeMethodInfo *)pMethodInfo;
+    pNativeMethodInfo->executionAborted = true;
+
+    return;
+}
+
+struct CoffEHEnumState
+{
+    PTR_UInt8 pEHInfo;
+    UInt32 uClause;
+    UInt32 nClauses;
+};
+
+// Ensure that CoffEHEnumState fits into the space reserved by EHEnumState
+static_assert(sizeof(CoffEHEnumState) <= sizeof(EHEnumState), "CoffEHEnumState too big");
+
+bool CoffNativeCodeManager::EHEnumInit(MethodInfo * pMethodInfo, PTR_VOID * pMethodStartAddress, EHEnumState * pEHEnumStateOut)
+{
+    assert(pMethodInfo != NULL);
+    assert(pMethodStartAddress != NULL);
+    assert(pEHEnumStateOut != NULL);
+
+    CoffNativeMethodInfo * pNativeMethodInfo = (CoffNativeMethodInfo *)pMethodInfo;
+    CoffEHEnumState * pEnumState = (CoffEHEnumState *)pEHEnumStateOut;
+
+    size_t unwindDataBlobSize;
+    PTR_VOID pUnwindDataBlob = GetUnwindDataBlob(m_moduleBase, pNativeMethodInfo->mainRuntimeFunction, &unwindDataBlobSize);
+
+    uint8_t unwindBlockFlags = *(dac_cast<DPTR(uint8_t)>(pUnwindDataBlob) + unwindDataBlobSize);
+
+    // return if there is no EH info associated with this method
+    if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) == 0)
+    {
+        return false;
+    }
+
+    *pMethodStartAddress = dac_cast<PTR_VOID>(m_moduleBase + pNativeMethodInfo->mainRuntimeFunction->BeginAddress);
+
+    pEnumState->pEHInfo = dac_cast<PTR_UInt8>(pUnwindDataBlob) + unwindDataBlobSize + 1;
+    pEnumState->uClause = 0;
+    pEnumState->nClauses = VarInt::ReadUnsigned(pEnumState->pEHInfo);
+
+    return true;
+}
+
+bool CoffNativeCodeManager::EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClauseOut)
+{
+    assert(pEHEnumState != NULL);
+    assert(pEHClauseOut != NULL);
+
+    CoffEHEnumState * pEnumState = (CoffEHEnumState *)pEHEnumState;
+    if (pEnumState->uClause >= pEnumState->nClauses)
+        return false;
+    pEnumState->uClause++;
+
+    pEHClauseOut->m_tryStartOffset = VarInt::ReadUnsigned(pEnumState->pEHInfo);
+
+    UInt32 tryEndDeltaAndClauseKind = VarInt::ReadUnsigned(pEnumState->pEHInfo);
+    pEHClauseOut->m_clauseKind = (EHClauseKind)(tryEndDeltaAndClauseKind & 0x3);
+    pEHClauseOut->m_tryEndOffset = pEHClauseOut->m_tryStartOffset + (tryEndDeltaAndClauseKind >> 2);
+
+    // For each clause, we have up to 4 integers:
+    //      1)  try start offset
+    //      2)  (try length << 2) | clauseKind
+    //      3)  if (typed || fault || filter)    { handler start offset }
+    //      4a) if (typed)                       { type RVA }
+    //      4b) if (filter)                      { filter start offset }
+    //
+    // The first two integers have already been decoded
+
+    switch (pEHClauseOut->m_clauseKind)
+    {
+    case EH_CLAUSE_TYPED:
+        pEHClauseOut->m_handlerOffset = VarInt::ReadUnsigned(pEnumState->pEHInfo);
+
+        // Read target type
+        {
+            // @TODO: CORERT: Compress EHInfo using type table index scheme
+            // https://github.com/dotnet/corert/issues/972
+            UInt32 typeRVA = *((PTR_UInt32&)pEnumState->pEHInfo)++;
+            pEHClauseOut->m_pTargetType = dac_cast<PTR_VOID>(m_moduleBase + typeRVA);
+        }
+        break;
+    case EH_CLAUSE_FAULT:
+        pEHClauseOut->m_handlerOffset = VarInt::ReadUnsigned(pEnumState->pEHInfo);
+        break;
+    case EH_CLAUSE_FILTER:
+        pEHClauseOut->m_handlerOffset = VarInt::ReadUnsigned(pEnumState->pEHInfo);
+        pEHClauseOut->m_filterOffset = VarInt::ReadUnsigned(pEnumState->pEHInfo);
+        break;
+    default:
+        UNREACHABLE_MSG("unexpected EHClauseKind");
+    }
+
+    return true;
+}
+
+extern "C" bool __stdcall RegisterCodeManager(ICodeManager * pCodeManager, PTR_VOID pvStartRange, UInt32 cbRange);
+
+extern "C"
+bool RhpRegisterCoffModule(void * pModule)
+{
+    PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER)pModule;
+    PIMAGE_NT_HEADERS pNTHeaders = (PIMAGE_NT_HEADERS)((TADDR)pModule + pDosHeader->e_lfanew);
+
+    IMAGE_DATA_DIRECTORY * pRuntimeFunctions = &(pNTHeaders->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXCEPTION]);
+
+    CoffNativeCodeManager * pCoffNativeCodeManager = new (nothrow) CoffNativeCodeManager((TADDR)pModule,
+        dac_cast<PTR_RUNTIME_FUNCTION>((TADDR)pModule + pRuntimeFunctions->VirtualAddress),
+        pRuntimeFunctions->Size / sizeof(RUNTIME_FUNCTION));
+
+    // @TODO: CORERT: Register the code manager only for the range that contains managed code. E.g. It is required for
+    // proper handling of hardware exceptions in unmanaged runtime code.
+    // https://github.com/dotnet/corert/issues/973
+
+    if (!RegisterCodeManager(pCoffNativeCodeManager, pModule, pNTHeaders->OptionalHeader.SizeOfImage))
+    {
+        delete pCoffNativeCodeManager;
+        return false;
+    }
+
+    return true;
+}

--- a/src/Native/Runtime/windows/CoffNativeCodeManager.h
+++ b/src/Native/Runtime/windows/CoffNativeCodeManager.h
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#if defined(_TARGET_AMD64_)
+struct T_RUNTIME_FUNCTION {
+    uint32_t BeginAddress;
+    uint32_t EndAddress;
+    uint32_t UnwindInfoAddress;
+};
+#elif defined(_TARGET_ARM_)
+struct T_RUNTIME_FUNCTION {
+    uint32_t BeginAddress;
+    uint32_t UnwindData;
+};
+#elif defined(_TARGET_ARM64_)
+struct T_RUNTIME_FUNCTION {
+    uint32_t BeginAddress;
+    union {
+        uint32_t UnwindData;
+        struct {
+            uint32_t Flag : 2;
+            uint32_t FunctionLength : 11;
+            uint32_t RegF : 3;
+            uint32_t RegI : 4;
+            uint32_t H : 1;
+            uint32_t CR : 2;
+            uint32_t FrameSize : 9;
+        } PackedUnwindData;
+    };
+};
+#else
+#error unexpected target architecture
+#endif
+
+typedef DPTR(T_RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
+
+class CoffNativeCodeManager : public ICodeManager
+{
+    TADDR m_moduleBase;
+    PTR_RUNTIME_FUNCTION m_pRuntimeFunctionTable;
+    UInt32 m_nRuntimeFunctionTable;
+
+public:
+    CoffNativeCodeManager(TADDR moduleBase, PTR_RUNTIME_FUNCTION pRuntimeFunctionTable, UInt32 nRuntimeFunctionTable);
+    ~CoffNativeCodeManager();
+
+    //
+    // Code manager methods
+    //
+
+    bool FindMethodInfo(PTR_VOID        ControlPC, 
+                        MethodInfo *    pMethodInfoOut,
+                        UInt32 *        pCodeOffset);
+
+    bool IsFunclet(MethodInfo * pMethodInfo);
+
+    PTR_VOID GetFramePointer(MethodInfo *   pMethodInfo,
+                             REGDISPLAY *   pRegisterSet);
+
+    void EnumGcRefs(MethodInfo *    pMethodInfo, 
+                    UInt32          codeOffset,
+                    REGDISPLAY *    pRegisterSet,
+                    GCEnumContext * hCallback);
+
+    bool UnwindStackFrame(MethodInfo *    pMethodInfo,
+                          UInt32          codeOffset,
+                          REGDISPLAY *    pRegisterSet,                 // in/out
+                          PTR_VOID *      ppPreviousTransitionFrame);   // out
+
+    UIntNative GetConservativeUpperBoundForOutgoingArgs(MethodInfo *   pMethodInfo,
+                                                        REGDISPLAY *   pRegisterSet);
+
+    bool GetReturnAddressHijackInfo(MethodInfo *    pMethodInfo,
+                                    UInt32          codeOffset,
+                                    REGDISPLAY *    pRegisterSet,       // in
+                                    PTR_PTR_VOID *  ppvRetAddrLocation, // out
+                                    GCRefKind *     pRetValueKind);     // out
+
+    void UnsynchronizedHijackMethodLoops(MethodInfo * pMethodInfo);
+
+    void RemapHardwareFaultToGCSafePoint(MethodInfo * pMethodInfo, UInt32 * pCodeOffset);
+
+    bool EHEnumInit(MethodInfo * pMethodInfo, PTR_VOID * pMethodStartAddress, EHEnumState * pEHEnumState);
+
+    bool EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClause);
+};

--- a/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -105,11 +105,8 @@ namespace System.Runtime
         {
             RH_EH_CLAUSE_TYPED = 0,
             RH_EH_CLAUSE_FAULT = 1,
-
-#region CLR Exceptions
             RH_EH_CLAUSE_FILTER = 2,
             RH_EH_CLAUSE_UNUSED = 3,
-#endregion
         }
 
         private struct RhEHClause

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -96,7 +96,7 @@
                 <Files>@(ILCompilerBinPlace -> '%(Text)', '')</Files>
                 <!-- TODO: Obtain this from project.lock.json -->
                 <Dependencies><![CDATA[
-        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.7-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.8-prerelease-00001" />
         <dependency id="Microsoft.DotNet.RyuJit" version="1.0.5-prerelease-00001" />
         <dependency id="NETStandard.Library" version="1.0.0-rc2-23704" />
         <dependency id="System.Collections.Immutable" version="1.1.37" />

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -184,11 +184,13 @@ __BuildOsLowcase=$(echo "${CoreRT_BuildOS}" | tr '[:upper:]' '[:lower:]')
 
 for json in $(find src -iname 'project.json')
 do
-    __restore=1
-    run_test_dir ${json} ${__restore} "Jit"
-    __restore=0
-    if [ ! -e `dirname ${json}`/no_cpp ]; then
-        run_test_dir ${json} ${__restore} "Cpp"
+    if [ ! -e `dirname ${json}`/no_unix ]; then
+        __restore=1
+        run_test_dir ${json} ${__restore} "Jit"
+        __restore=0
+        if [ ! -e `dirname ${json}`/no_cpp ]; then
+            run_test_dir ${json} ${__restore} "Cpp"
+        fi
     fi
 done
 

--- a/tests/src/Simple/Exceptions/Exceptions.cmd
+++ b/tests/src/Simple/Exceptions/Exceptions.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+"%1\%2"
+set ErrorCode=%ERRORLEVEL%
+IF "%ErrorCode%"=="100" (
+    echo %~n0: pass
+    EXIT /b 0
+) ELSE (
+    echo %~n0: fail
+    EXIT /b 1
+)
+endlocal

--- a/tests/src/Simple/Exceptions/Exceptions.cs
+++ b/tests/src/Simple/Exceptions/Exceptions.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+public class BringUpTest
+{
+    const int Pass = 100;
+    const int Fail = -1;
+
+    public static int Main()
+    {
+        try
+        {
+            try
+            {
+                throw new Exception();
+            }
+            catch (OutOfMemoryException)
+            {
+                return Fail;
+            }
+        }
+        catch
+        {
+            Console.WriteLine("Exception caught!");
+        }
+        return Pass;
+    }
+}

--- a/tests/src/Simple/Exceptions/Exceptions.sh
+++ b/tests/src/Simple/Exceptions/Exceptions.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+$1/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/Exceptions/no_cpp
+++ b/tests/src/Simple/Exceptions/no_cpp
@@ -1,0 +1,1 @@
+Skip this test for cpp codegen mode

--- a/tests/src/Simple/Exceptions/no_unix
+++ b/tests/src/Simple/Exceptions/no_unix
@@ -1,0 +1,1 @@
+Skip this test on unix

--- a/tests/src/Simple/Exceptions/project.json
+++ b/tests/src/Simple/Exceptions/project.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23819"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
- Add CoffNativeCodeManager that is able to decode the Windows OS native unwind info
- Append EH info to the Windows OS unwind info blob in the compiler