### PR TITLE
Compiling Arm again

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -90,8 +90,10 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     add_compile_options(-Wno-null-arithmetic)
     add_compile_options(-Wno-null-conversion)
 
-    # Allow 16 byte compare-exchange
-    add_compile_options(-mcx16)
+    if (CLR_CMAKE_PLATFORM_UNIX_TARGET_AMD64)
+        # Allow 16 byte compare-exchange
+        add_compile_options(-mcx16)
+    endif()
 
     # Disable strict warning on unused functions.
     add_compile_options(-Wno-unused-function)

--- a/src/Native/Runtime/arm/StubDispatch.S
+++ b/src/Native/Runtime/arm/StubDispatch.S
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <unixasmmacros.inc>
+
+// TODO: Implement Arm support

--- a/src/Native/Runtime/arm64/StubDispatch.S
+++ b/src/Native/Runtime/arm64/StubDispatch.S
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <unixasmmacros.inc>
+
+// TODO: Implement Arm64 support

--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -156,7 +156,7 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArray, (EEType * pArrayEEType, int numElement
     {
         // Perform the size computation using 64-bit integeres to detect overflow
         uint64_t size64 = (uint64_t)pArrayEEType->get_BaseSize() + ((uint64_t)numElements * (uint64_t)pArrayEEType->get_ComponentSize());
-        size64 = ALIGN_UP(size, sizeof(UIntNative));
+        size64 = ALIGN_UP(size64, sizeof(UIntNative));
 
         size = (size_t)size64;
         if (size != size64)


### PR DESCRIPTION
I've fixed some issues compiling for 32-bit as well as re-enabling cross compilation for Arm/Arm64.

The Arm64 bit code does not compile yet as there were quite a few changes in the past few weeks. This will be the subject of another PR.

The only thing that is open to question is the use of the -mcx16 flag for x86 which does not exist when compiling for Arm. Can someone enlighten me to where this is actually needed in the code?