### PR TITLE
Add support for eager static constructors

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -42,6 +42,7 @@ namespace ILCompiler
     {
         private readonly CompilerTypeSystemContext _typeSystemContext;
         private readonly CompilationOptions _options;
+        private readonly TypeInitialization _typeInitManager;
 
         private NodeFactory _nodeFactory;
         private DependencyAnalyzerBase<NodeFactory> _dependencyGraph;
@@ -61,6 +62,8 @@ namespace ILCompiler
             _typeSystemContext.SetSystemModule(_typeSystemContext.GetModuleForSimpleName(options.SystemModuleName));
 
             _nameMangler = new NameMangler(this);
+
+            _typeInitManager = new TypeInitialization();
         }
 
         public CompilerTypeSystemContext TypeSystemContext
@@ -132,7 +135,7 @@ namespace ILCompiler
         {
             NodeFactory.NameMangler = NameMangler;
 
-            _nodeFactory = new NodeFactory(_typeSystemContext, _options.IsCppCodeGen);
+            _nodeFactory = new NodeFactory(_typeSystemContext, _typeInitManager, _options.IsCppCodeGen);
 
             // Choose which dependency graph implementation to use based on the amount of logging requested.
             if (_options.DgmlLog == null)
@@ -328,6 +331,11 @@ namespace ILCompiler
         {
             return _nodeFactory.ReadOnlyDataBlob(NameMangler.GetMangledFieldName(field),
                 ((EcmaField)field).GetFieldRvaData(), _typeSystemContext.Target.PointerSize);
+        }
+
+        public bool HasLazyStaticConstructor(TypeDesc type)
+        {
+            return _typeInitManager.HasLazyStaticConstructor(type);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents an array of pointers to symbols. <typeparamref name="TTarget"/> is the type
+    /// of node each pointer within the vector points to.
+    /// </summary>
+    public sealed class ArrayOfEmbeddedPointersNode<TTarget> : ArrayOfEmbeddedDataNode<EmbeddedPointerIndirectionNode<TTarget>>
+        where TTarget : ISymbolNode
+    {
+        private int _nextId;
+        private string _startSymbolMangledName;
+
+        public ArrayOfEmbeddedPointersNode(string startSymbolMangledName, string endSymbolMangledName, IComparer<TTarget> nodeSorter)
+            : base(
+                  startSymbolMangledName,
+                  endSymbolMangledName,
+                  nodeSorter != null ? new PointerIndirectionNodeComparer(nodeSorter) : null)
+        {
+            _startSymbolMangledName = startSymbolMangledName;
+        }
+
+        public EmbeddedObjectNode NewNode(TTarget target)
+        {
+            return new SimpleEmbeddedPointerIndirectionNode(this, target);
+        }
+
+        public EmbeddedObjectNode NewNodeWithSymbol(TTarget target)
+        {
+            int id = System.Threading.Interlocked.Increment(ref _nextId);
+            return new EmbeddedPointerIndirectionWithSymbolNode(this, target, id);
+        }
+
+        private class PointerIndirectionNodeComparer : IComparer<EmbeddedPointerIndirectionNode<TTarget>>
+        {
+            private IComparer<TTarget> _innerComparer;
+
+            public PointerIndirectionNodeComparer(IComparer<TTarget> innerComparer)
+            {
+                _innerComparer = innerComparer;
+            }
+
+            public int Compare(EmbeddedPointerIndirectionNode<TTarget> x, EmbeddedPointerIndirectionNode<TTarget> y)
+            {
+                return _innerComparer.Compare(x.Target, y.Target);
+            }
+        }
+
+        private class SimpleEmbeddedPointerIndirectionNode : EmbeddedPointerIndirectionNode<TTarget>
+        {
+            protected ArrayOfEmbeddedPointersNode<TTarget> _parentNode;
+
+            public SimpleEmbeddedPointerIndirectionNode(ArrayOfEmbeddedPointersNode<TTarget> futureParent, TTarget target)
+                : base(target)
+            {
+                _parentNode = futureParent;
+            }
+
+            public override string GetName()
+            {
+                return "Embedded pointer to " + Target.MangledName;
+            }
+
+            protected override void OnMarked(NodeFactory context)
+            {
+                // We don't want the child in the parent collection unless it's necessary.
+                // Only when this node gets marked, the parent node becomes the actual parent.
+                _parentNode.AddEmbeddedObject(this);
+            }
+
+            public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+            {
+                return new[]
+                {
+                    new DependencyListEntry(Target, "reloc"),
+                    new DependencyListEntry(_parentNode, "Pointer region")
+                };
+            }
+        }
+
+        private class EmbeddedPointerIndirectionWithSymbolNode : SimpleEmbeddedPointerIndirectionNode, ISymbolNode
+        {
+            private int _id;
+
+            public EmbeddedPointerIndirectionWithSymbolNode(ArrayOfEmbeddedPointersNode<TTarget> futureParent, TTarget target, int id)
+                : base(futureParent, target)
+            {
+                _id = id;
+            }
+
+            public string MangledName
+            {
+                get
+                {
+                    return String.Concat(_parentNode._startSymbolMangledName, "_", _id.ToStringInvariant());
+                }
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    internal class CppMethodCodeNode : DependencyNodeCore<NodeFactory>, ISymbolNode
+    internal class CppMethodCodeNode : DependencyNodeCore<NodeFactory>, IMethodNode
     {
         private MethodDesc _method;
         private string _methodCode;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -450,13 +450,13 @@ namespace ILCompiler.DependencyAnalysis
         /// </summary>
         private void ComputeOptionalEETypeFields(NodeFactory factory)
         {
-            ComputeRareFlags();
+            ComputeRareFlags(factory);
             ComputeNullableValueOffset();
             ComputeICastableVirtualMethodSlots(factory);
             ComputeValueTypeFieldPadding();
         }
 
-        void ComputeRareFlags()
+        void ComputeRareFlags(NodeFactory factory)
         {
             uint flags = 0;
 
@@ -465,7 +465,7 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (uint)EETypeRareFlags.IsNullableFlag;
             }
 
-            if (_type.HasStaticConstructor)
+            if (factory.TypeInitializationManager.HasLazyStaticConstructor(_type))
             {
                 flags |= (uint)EETypeRareFlags.HasCctorFlag;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// An <see cref="EmbeddedObjectNode"/> whose sole value is a pointer to a different <see cref="ISymbolNode"/>.
+    /// <typeparamref name="TTarget"/> represents the node type this pointer points to.
+    /// </summary>
+    public abstract class EmbeddedPointerIndirectionNode<TTarget> : EmbeddedObjectNode
+        where TTarget : ISymbolNode
+    {
+        private TTarget _targetNode;
+
+        /// <summary>
+        /// Target symbol this node points to.
+        /// </summary>
+        public TTarget Target
+        {
+            get
+            {
+                return _targetNode;
+            }
+        }
+
+        internal EmbeddedPointerIndirectionNode(TTarget target)
+        {
+            _targetNode = target;
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            dataBuilder.RequirePointerAlignment();
+            dataBuilder.EmitPointerReloc(Target);
+        }
+
+        // At minimum, Target needs to be reported as a static dependency by inheritors.
+        public abstract override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context);
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -48,8 +48,18 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
-            return new DependencyListEntry[] { new DependencyListEntry(context.GCStaticsRegion, "GCStatics Region"),
-                                               new DependencyListEntry(GetGCStaticEETypeNode(context), "GCStatic EEType")};
+            DependencyListEntry[] result;
+            if (context.TypeInitializationManager.HasEagerStaticConstructor(_type))
+            {
+                result = new DependencyListEntry[3];
+                result[2] = new DependencyListEntry(context.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
+            }
+            else
+                result = new DependencyListEntry[2];
+
+            result[0] = new DependencyListEntry(context.GCStaticsRegion, "GCStatics Region");
+            result[1] = new DependencyListEntry(GetGCStaticEETypeNode(context), "GCStatic EEType");
+            return result;
         }
 
         int ISymbolNode.Offset

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodNode.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// A dependency analysis node that represents a method.
+    /// </summary>
+    public interface IMethodNode : ISymbolNode
+    {
+        MethodDesc Method { get; }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -8,7 +8,7 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    internal class MethodCodeNode : ObjectNode, INodeWithFrameInfo, INodeWithDebugInfo, ISymbolNode
+    internal class MethodCodeNode : ObjectNode, IMethodNode, INodeWithFrameInfo, INodeWithDebugInfo
     {
         private MethodDesc _method;
         private ObjectData _methodCode;
@@ -70,6 +70,19 @@ namespace ILCompiler.DependencyAnalysis
             {
                 return 0;
             }
+        }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory context)
+        {
+            TypeDesc owningType = _method.OwningType;
+            if (context.TypeInitializationManager.HasEagerStaticConstructor(owningType))
+            {
+                var result = new DependencyList();
+                result.Add(context.EagerCctorIndirection(owningType.GetStaticConstructor()), "Eager .cctor");
+                return result;
+            }
+
+            return null;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -77,7 +77,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.GetNonGCStaticBase:
                     {
                         MetadataType target = (MetadataType)Target;
-                        if (!target.HasStaticConstructor)
+                        if (!factory.TypeInitializationManager.HasLazyStaticConstructor(target))
                         {
                             Debug.Assert(Id == ReadyToRunHelperId.GetNonGCStaticBase);
                             encoder.EmitLEAQ(encoder.TargetRegister.Result, factory.TypeNonGCStaticsSymbol(target));
@@ -100,7 +100,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.GetGCStaticBase:
                     {
                         MetadataType target = (MetadataType)Target;
-                        if (!target.HasStaticConstructor)
+                        if (!factory.TypeInitializationManager.HasLazyStaticConstructor(target))
                         {
                             encoder.EmitLEAQ(encoder.TargetRegister.Result, factory.TypeGCStaticsSymbol(target));
                             AddrMode loadFromRax = new AddrMode(encoder.TargetRegister.Result, null, 0, 0, AddrModeSize.Int64);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -48,8 +48,18 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
-            return new DependencyListEntry[] { new DependencyListEntry(context.ThreadStaticsRegion, "ThreadStatics Region"),
-                                               new DependencyListEntry(GetGCStaticEETypeNode(context), "ThreadStatic EEType")};
+            DependencyListEntry[] result;
+            if (context.TypeInitializationManager.HasEagerStaticConstructor(_type))
+            {
+                result = new DependencyListEntry[3];
+                result[2] = new DependencyListEntry(context.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
+            }
+            else
+                result = new DependencyListEntry[2];
+
+            result[0] = new DependencyListEntry(context.ThreadStaticsRegion, "ThreadStatics Region");
+            result[1] = new DependencyListEntry(GetGCStaticEETypeNode(context), "ThreadStatic EEType");
+            return result;
         }
 
         int ISymbolNode.Offset

--- a/src/ILCompiler.Compiler/src/Compiler/FormattingHelpers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/FormattingHelpers.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+
+namespace ILCompiler
+{
+    static class FormattingHelpers
+    {
+        public static string ToStringInvariant(this int value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/TypeInitialization.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeInitialization.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Manages policies around static constructors (.cctors) and static data initialization.
+    /// </summary>
+    public class TypeInitialization
+    {
+        // Eventually, this class will also manage preinitialization (interpreting cctors at compile
+        // time and converting them to blobs of preinitialized data), and the various
+        // System.Runtime.CompilerServices.PreInitializedAttribute/InitDataBlobAttribute/etc. placed on
+        // types and their members by toolchain components.
+
+        /// <summary>
+        /// Returns true if '<paramref name="type"/>' has a lazily executed static constructor.
+        /// A lazy static constructor gets executed on first access to type's members.
+        /// </summary>
+        public bool HasLazyStaticConstructor(TypeDesc type)
+        {
+            return type.HasStaticConstructor && !HasEagerConstructorAttribute(type);
+        }
+
+        /// <summary>
+        /// Returns true if '<paramref name="type"/>' has a static constructor that is eagerly
+        /// executed at process startup time.
+        /// </summary>
+        public bool HasEagerStaticConstructor(TypeDesc type)
+        {
+            return type.HasStaticConstructor && HasEagerConstructorAttribute(type);
+        }
+
+        private static bool HasEagerConstructorAttribute(TypeDesc type)
+        {
+            MetadataType mdType = type as MetadataType;
+            return mdType != null && mdType.HasCustomAttribute("System.Runtime.CompilerServices", "EagerOrderedStaticConstructorAttribute");
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -41,10 +41,13 @@
     <Compile Include="Compiler\DependencyAnalysis\CppMethodCodeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EETypeOptionalFieldsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EmbeddedObjectNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\EmbeddedPointerIndirectionNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\IMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchMapTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\JumpStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodCodeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedPointersNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\StringDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\StringIndirectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\AddrMode.cs" />
@@ -73,6 +76,7 @@
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64Emitter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchMapNode.cs" />
+    <Compile Include="Compiler\FormattingHelpers.cs" />
     <Compile Include="Compiler\JitHelper.cs" />
     <Compile Include="Compiler\MemoryHelper.cs" />
     <Compile Include="Compiler\MethodExtensions.cs" />
@@ -80,6 +84,7 @@
     <Compile Include="Compiler\SymbolReader\PdbSymbolReader.cs" />
     <Compile Include="Compiler\SymbolReader\PortablePdbSymbolReader.cs" />
     <Compile Include="Compiler\SymbolReader\UnmanagedPdbSymbolReader.cs" />
+    <Compile Include="Compiler\TypeInitialization.cs" />
     <Compile Include="Compiler\VirtualMethodCallHelper.cs" />
     <Compile Include="CppCodeGen\CppGenerationBuffer.cs" />
     <Compile Include="CppCodeGen\CppWriter.cs" />

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1037,7 +1037,7 @@ namespace Internal.JitInterface
             MethodDesc md = HandleToObject(method);
             TypeDesc type = fd != null ? fd.OwningType : typeFromContext(context);
 
-            if (!type.HasStaticConstructor)
+            if (!_compilation.HasLazyStaticConstructor(type))
             {
                 return CorInfoInitClassResult.CORINFO_INITCLASS_NOT_REQUIRED;
             }

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -255,6 +255,8 @@ void * g_pDispatchMapTemporaryWorkaround;
 
 extern "C" void* __StringTableStart;
 extern "C" void* __StringTableEnd;
+extern "C" void* __EagerCctorStart;
+extern "C" void* __EagerCctorEnd;
 extern "C" void* GetModuleSection(int id, int* length)
 {
     struct ModuleSectionSymbol
@@ -269,9 +271,11 @@ extern "C" void* GetModuleSection(int id, int* length)
 #ifdef CPPCODEGEN
         { System::String::__getMethodTable(), sizeof(void*) },
         { nullptr, 0 },
+        { nullptr, 0 },
 #else
         { &__EEType_System_Private_CoreLib_System_String, sizeof(void*) },
         { &__StringTableStart, (size_t)((uint8_t*)&__StringTableEnd - (uint8_t*)&__StringTableStart) },
+        { &__EagerCctorStart, (size_t)((uint8_t*)&__EagerCctorEnd - (uint8_t*)&__EagerCctorStart) },
 #endif
     };
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
@@ -11,6 +11,8 @@ using System.Text;
 using System;
 using System.Runtime;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace Internal.Runtime.CompilerHelpers
 {
     internal static class StartupCodeHelpers
@@ -18,6 +20,7 @@ namespace Internal.Runtime.CompilerHelpers
         internal static void Initialize()
         {
             InitializeStringTable();
+            RunEagerClassConstructors();
             RuntimeImports.RhEnableShutdownFinalization(0xffffffffu);
         }
 
@@ -76,6 +79,20 @@ namespace Internal.Runtime.CompilerHelpers
             }
         }
 
+        private static unsafe void RunEagerClassConstructors()
+        {
+            int length = 0;
+            IntPtr cctorTableStart = GetModuleSection((int)ModuleSectionIds.EagerCctorStart, out length);
+            Debug.Assert(length % IntPtr.Size == 0);
+
+            IntPtr cctorTableEnd = (IntPtr)((byte*)cctorTableStart + length);
+
+            for (IntPtr* tab = (IntPtr*)cctorTableStart; tab < (IntPtr*)cctorTableEnd; tab++)
+            {
+                CalliIntrinsics.Call<int>(*tab);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe int CStrLen(byte* str)
         {
@@ -88,7 +105,8 @@ namespace Internal.Runtime.CompilerHelpers
         internal enum ModuleSectionIds
         {
             StringEETypePtr,
-            StringFixupStart
+            StringFixupStart,
+            EagerCctorStart,
         };
 
         [RuntimeImport(".", "GetModuleSection")]


### PR DESCRIPTION
This looks like a lot of code just to support a rarely used feature,
but a lot of this is plumbing that will let me delete some existing code
in a subsequent commit. Some of this will also be needed to support
the various preinitialized data attributes/general type preinitialization.

* Redirecting uses of HasStaticConstructor to go through the TypeInitialization class (exposing higher level APIs "HasLazyCctor" and "HasEagerCctor")
* Emitting a new table with an array of eager class constructors
* Augmenting GC/nonGC/ThreadStatic and Method nodes to depend on an entry in the eager cctor table if the owning type has a cctor
* Startup code addition to iterate over the list of eager cctors and call them one by one

Reusable code:
* ArrayOfEmbeddedPointers: we have a buch of places where we just want an array of pointers. This will let us e.g. delete StringIndirectionNode.

Missing features: ordering the eager cctors. I want to think a bit about
how we parse custom attribute blobs before I implement that.

Fixes #471.