### PR TITLE
Delete call to RhEnableShutdownFinalization

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
@@ -21,7 +21,6 @@ namespace Internal.Runtime.CompilerHelpers
         {
             InitializeStringTable();
             RunEagerClassConstructors();
-            RuntimeImports.RhEnableShutdownFinalization(0xffffffffu);
         }
 
         internal static void Shutdown()

--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -120,7 +120,9 @@ namespace System
 #endif
 
 #if CORERT
-        // Moved to startup sequence in StartupCodeHelpers.Initialize().
+        // .NET Core abandoned shutdown finalization.
+        // See discussion in https://github.com/dotnet/corefx/issues/5205
+        // We should get rid of this in Project N too.
 #else
         static Environment()
         {


### PR DESCRIPTION
Shutdown finalization was abandoned for .NET core.

See discussion in pull request #889 and dotnet/corefx#5205.