### PR TITLE
Widen Boolean return values from internal runtime calls

### DIFF
--- a/src/Native/Runtime/EHHelpers.cpp
+++ b/src/Native/Runtime/EHHelpers.cpp
@@ -56,7 +56,7 @@ static Module * FindModuleRespectingReturnAddressHijacks(void * address)
     return pModule;
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhpEHEnumInitFromStackFrameIterator, (
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhpEHEnumInitFromStackFrameIterator, (
     StackFrameIterator* pFrameIter, void ** pMethodStartAddressOut, EHEnum* pEHEnum))
 {
     ICodeManager * pCodeManager = pFrameIter->GetCodeManager();
@@ -65,7 +65,7 @@ COOP_PINVOKE_HELPER(Boolean, RhpEHEnumInitFromStackFrameIterator, (
     return pCodeManager->EHEnumInit(pFrameIter->GetMethodInfo(), pMethodStartAddressOut, &pEHEnum->m_state);
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhpEHEnumNext, (EHEnum* pEHEnum, EHClause* pEHClause))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhpEHEnumNext, (EHEnum* pEHEnum, EHClause* pEHClause))
 {
     return pEHEnum->m_pCodeManager->EHEnumNext(&pEHEnum->m_state, pEHClause);
 }

--- a/src/Native/Runtime/GCHelpers.cpp
+++ b/src/Native/Runtime/GCHelpers.cpp
@@ -68,7 +68,7 @@ COOP_PINVOKE_HELPER(void, RhSetGcLatencyMode, (Int32 newLatencyMode))
     GCHeap::GetGCHeap()->SetGcLatencyMode(newLatencyMode);
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhIsServerGc, ())
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhIsServerGc, ())
 {
     return GCHeap::IsServerHeap();
 }
@@ -78,7 +78,7 @@ COOP_PINVOKE_HELPER(Int64, RhGetGcTotalMemoryHelper, ())
     return GCHeap::GetGCHeap()->GetTotalBytesInUse();
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhRegisterGcCallout, (GcRestrictedCalloutKind eKind, void * pCallout))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhRegisterGcCallout, (GcRestrictedCalloutKind eKind, void * pCallout))
 {
     return RestrictedCallouts::RegisterGcCallout(eKind, pCallout);
 }
@@ -88,7 +88,7 @@ COOP_PINVOKE_HELPER(void, RhUnregisterGcCallout, (GcRestrictedCalloutKind eKind,
     RestrictedCallouts::UnregisterGcCallout(eKind, pCallout);
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhIsPromoted, (OBJECTREF obj))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhIsPromoted, (OBJECTREF obj))
 {
     return GCHeap::GetGCHeap()->IsPromoted(obj) ? Boolean_true : Boolean_false;
 }

--- a/src/Native/Runtime/HandleTableHelpers.cpp
+++ b/src/Native/Runtime/HandleTableHelpers.cpp
@@ -51,7 +51,7 @@ COOP_PINVOKE_HELPER(void, RhHandleSet, (OBJECTHANDLE handle, Object *pObject))
     StoreObjectInHandle(handle, pObject);
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhRegisterRefCountedHandleCallback, (void * pCallout, EEType * pTypeFilter))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhRegisterRefCountedHandleCallback, (void * pCallout, EEType * pTypeFilter))
 {
     return RestrictedCallouts::RegisterRefCountedHandleCallback(pCallout, pTypeFilter);
 }

--- a/src/Native/Runtime/MiscHelpers.cpp
+++ b/src/Native/Runtime/MiscHelpers.cpp
@@ -151,7 +151,7 @@ COOP_PINVOKE_HELPER(HANDLE, RhGetModuleFromEEType, (EEType * pEEType))
     return NULL;
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhFindBlob, (HANDLE hOsModule, UInt32 blobId, UInt8 ** ppbBlob, UInt32 * pcbBlob))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhFindBlob, (HANDLE hOsModule, UInt32 blobId, UInt8 ** ppbBlob, UInt32 * pcbBlob))
 {
     // Search for the Redhawk module contained by the OS module.
     FOREACH_MODULE(pModule)
@@ -229,7 +229,7 @@ COOP_PINVOKE_HELPER(EEType *, RhpGetNullableEEType, (EEType * pEEType))
     return pEEType->GetNullableType();
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhpHasDispatchMap, (EEType * pEEType))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhpHasDispatchMap, (EEType * pEEType))
 {
     return pEEType->HasDispatchMap();
 }
@@ -478,7 +478,7 @@ FORCEINLINE bool CheckArraySlice(Array * pArray, Int32 index, Int32 length)
 // This function handles all cases of Array.Copy that do not require conversions or casting. It returns false if the copy cannot be performed, leaving
 // the handling of the complex cases or throwing appropriate exception to the higher level framework.
 //
-COOP_PINVOKE_HELPER(Boolean, RhpArrayCopy, (Array * pSourceArray, Int32 sourceIndex, Array * pDestinationArray, Int32 destinationIndex, Int32 length))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhpArrayCopy, (Array * pSourceArray, Int32 sourceIndex, Array * pDestinationArray, Int32 destinationIndex, Int32 length))
 {
     if (pSourceArray == NULL || pDestinationArray == NULL)
         return false;
@@ -530,7 +530,7 @@ COOP_PINVOKE_HELPER(Boolean, RhpArrayCopy, (Array * pSourceArray, Int32 sourceIn
 // the handling of the complex cases or throwing apppropriate exception to the higher level framework. It is only allowed to return false for illegal 
 // calls as the BCL side has fallback for "complex cases" only.
 //
-COOP_PINVOKE_HELPER(Boolean, RhpArrayClear, (Array * pArray, Int32 index, Int32 length))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhpArrayClear, (Array * pArray, Int32 index, Int32 length))
 {
     if (pArray == NULL)
         return false;

--- a/src/Native/Runtime/StackFrameIterator.cpp
+++ b/src/Native/Runtime/StackFrameIterator.cpp
@@ -1544,7 +1544,7 @@ StackFrameIterator::ReturnAddressCategory StackFrameIterator::CategorizeUnadjust
 
 #ifndef DACCESS_COMPILE
 
-COOP_PINVOKE_HELPER(Boolean, RhpSfiInit, (StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhpSfiInit, (StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx))
 {
     Thread * pCurThread = ThreadStore::GetCurrentThread();
 
@@ -1566,7 +1566,7 @@ COOP_PINVOKE_HELPER(Boolean, RhpSfiInit, (StackFrameIterator* pThis, PAL_LIMITED
     return isValid ? Boolean_true : Boolean_false;
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhpSfiNext, (StackFrameIterator* pThis, UInt32* puExCollideClauseIdx, Boolean* pfUnwoundReversePInvoke))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhpSfiNext, (StackFrameIterator* pThis, UInt32* puExCollideClauseIdx, Boolean* pfUnwoundReversePInvoke))
 {
     // The stackwalker is intolerant to hijacked threads, as it is largely expecting to be called from C++
     // where the hijack state of the thread is invariant.  Because we've exposed the iterator out to C#, we 

--- a/src/Native/Runtime/StackFrameIterator.h
+++ b/src/Native/Runtime/StackFrameIterator.h
@@ -17,8 +17,8 @@ struct EHEnum
     EHEnumState m_state;
 };
 
-EXTERN_C Boolean FASTCALL RhpSfiInit(StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx);
-EXTERN_C Boolean FASTCALL RhpSfiNext(StackFrameIterator* pThis, UInt32* puExCollideClauseIdx, Boolean* pfUnwoundReversePInvoke);
+EXTERN_C Boolean_RetVal FASTCALL RhpSfiInit(StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx);
+EXTERN_C Boolean_RetVal FASTCALL RhpSfiNext(StackFrameIterator* pThis, UInt32* puExCollideClauseIdx, Boolean* pfUnwoundReversePInvoke);
 
 struct PInvokeTransitionFrame;
 typedef DPTR(PInvokeTransitionFrame) PTR_PInvokeTransitionFrame;
@@ -27,8 +27,8 @@ typedef DPTR(PAL_LIMITED_CONTEXT) PTR_PAL_LIMITED_CONTEXT;
 class StackFrameIterator
 {
     friend class AsmOffsets;
-    friend Boolean FASTCALL RhpSfiInit(StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx);
-    friend Boolean FASTCALL RhpSfiNext(StackFrameIterator* pThis, UInt32* puExCollideClauseIdx, Boolean* pfUnwoundReversePInvoke);
+    friend Boolean_RetVal FASTCALL RhpSfiInit(StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx);
+    friend Boolean_RetVal FASTCALL RhpSfiNext(StackFrameIterator* pThis, UInt32* puExCollideClauseIdx, Boolean* pfUnwoundReversePInvoke);
 
 public:
     StackFrameIterator() {}

--- a/src/Native/Runtime/inc/CommonTypes.h
+++ b/src/Native/Runtime/inc/CommonTypes.h
@@ -35,6 +35,13 @@ typedef unsigned char       Boolean;
 #define Boolean_false 0
 #define Boolean_true 1
 
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+// Small return values are widened on x86 and amd64
+typedef UInt32 Boolean_RetVal;
+#else
+typedef Boolean Boolean_RetVal;
+#endif
+
 typedef UInt32              UInt32_BOOL;    // windows 4-byte BOOL, 0 -> false, everything else -> true
 #define UInt32_FALSE        0
 #define UInt32_TRUE         1

--- a/src/Native/Runtime/threadstore.cpp
+++ b/src/Native/Runtime/threadstore.cpp
@@ -425,7 +425,7 @@ PTR_Thread ThreadStore::GetThreadFromTEB(TADDR pTEB)
 #ifndef DACCESS_COMPILE
 
 // internal static extern unsafe bool RhGetExceptionsForCurrentThread(Exception[] outputArray, out int writtenCountOut);
-COOP_PINVOKE_HELPER(Boolean, RhGetExceptionsForCurrentThread, (Array* pOutputArray, Int32* pWrittenCountOut))
+COOP_PINVOKE_HELPER(Boolean_RetVal, RhGetExceptionsForCurrentThread, (Array* pOutputArray, Int32* pWrittenCountOut))
 {
     return GetThreadStore()->GetExceptionsForCurrentThread(pOutputArray, pWrittenCountOut);
 }


### PR DESCRIPTION
RyuJIT expects small scalar types to be extended to full register width.