### PR TITLE
Use full class constructor runner

### DIFF
--- a/src/Common/src/Internal/Runtime/EETypeOptionalFieldsBuilder.cs
+++ b/src/Common/src/Internal/Runtime/EETypeOptionalFieldsBuilder.cs
@@ -119,7 +119,9 @@ namespace Internal.Runtime
 
             for (EETypeOptionalFieldsElement eTag = 0; eTag < EETypeOptionalFieldsElement.Count; eTag++)
             {
-                if (GetFieldValue(eTag, 0) != other.GetFieldValue(eTag, 0))
+                int index = (int)eTag;
+                if (_rgFields[index]._fieldPresent != other._rgFields[index]._fieldPresent ||
+                    (_rgFields[index]._fieldPresent && _rgFields[index]._value != other._rgFields[index]._value))
                     return false;
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -326,8 +326,8 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         private static readonly string[][] s_helperEntrypointNames = new string[][] {
-            new string[] { "System.Runtime.CompilerServices", "CctorHelper", "CheckStaticClassConstructionReturnGCStaticBase" },
-            new string[] { "System.Runtime.CompilerServices", "CctorHelper", "CheckStaticClassConstructionReturnNonGCStaticBase" }
+            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnGCStaticBase" },
+            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnNonGCStaticBase" }
         };
 
         private ISymbolNode[] _helperEntrypointSymbols;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -86,6 +86,7 @@ namespace ILCompiler.DependencyAnalysis
                         else
                         {
                             // We need to trigger the cctor before returning the base
+                            // TODO: Inline the fast path ("class constructor already ran, nothing to do")
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.TypeCctorContextSymbol(target));
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg1, factory.TypeNonGCStaticsSymbol(target));
                             encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnNonGCStaticBase));
@@ -111,6 +112,7 @@ namespace ILCompiler.DependencyAnalysis
                         else
                         {
                             // We need to trigger the cctor before returning the base
+                            // TODO: Inline the fast path ("class constructor already ran, nothing to do")
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.TypeCctorContextSymbol(target));
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg1, factory.TypeGCStaticsSymbol(target));
                             AddrMode loadFromRdx = new AddrMode(encoder.TargetRegister.Arg1, null, 0, 0, AddrModeSize.Int64);

--- a/src/ILCompiler.Compiler/src/Compiler/TypeInitialization.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeInitialization.cs
@@ -37,7 +37,9 @@ namespace ILCompiler
         private static bool HasEagerConstructorAttribute(TypeDesc type)
         {
             MetadataType mdType = type as MetadataType;
-            return mdType != null && mdType.HasCustomAttribute("System.Runtime.CompilerServices", "EagerOrderedStaticConstructorAttribute");
+            return mdType != null && (
+                mdType.HasCustomAttribute("System.Runtime.CompilerServices", "EagerOrderedStaticConstructorAttribute")
+                || mdType.HasCustomAttribute("System.Runtime.CompilerServices", "EagerStaticClassConstructionAttribute"));
         }
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -308,7 +308,7 @@ namespace Internal.Runtime.Augments
         public unsafe static void EnsureClassConstructorRun(IntPtr staticClassConstructionContext)
         {
             StaticClassConstructionContext* context = (StaticClassConstructionContext*)staticClassConstructionContext;
-            ClassConstructorRunner.EnsureClassConstructorRun(null, context);
+            ClassConstructorRunner.EnsureClassConstructorRun(context);
         }
 
         public static bool GetMdArrayRankTypeHandleIfSupported(int rank, out RuntimeTypeHandle mdArrayTypeHandle)

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.CompilerServices
                 return;
             unsafe
             {
-                ClassConstructorRunner.EnsureClassConstructorRun(null, (StaticClassConstructionContext*)pStaticClassConstructionContext);
+                ClassConstructorRunner.EnsureClassConstructorRun((StaticClassConstructionContext*)pStaticClassConstructionContext);
             }
         }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
@@ -29,8 +29,7 @@ namespace System.Runtime.CompilerServices
         public volatile int initialized;
     }
 
-#if CORERT 
-    // CORERT-TODO: Use full cctor helper instead
+#if false
     [McgIntrinsics]
     internal sealed class CctorHelper
     {
@@ -99,26 +98,6 @@ namespace System.Runtime.CompilerServices
                 // If we get here some other thread changed the initialization state to a non-zero value
                 // before we could. Loop at try again.
             }
-        }
-
-        private static object CheckStaticClassConstructionReturnGCStaticBase(ref StaticClassConstructionContext context, object gcStaticBase)
-        {
-            // CORERT-TODO: Early out if initializer was set to anything. The runner doesn't handle recursion and assumes it's access from
-            //              a different thread and deadlocks itself. CoreRT will cause recursion for things like trying to get a static
-            //              base from the CCtor (which means that pretty much all cctors will deadlock).
-            if (context.initialized == 0)
-                CheckStaticClassConstruction(ref context);
-            return gcStaticBase;
-        }
-
-        private static IntPtr CheckStaticClassConstructionReturnNonGCStaticBase(ref StaticClassConstructionContext context, IntPtr nonGcStaticBase)
-        {
-            // CORERT-TODO: Early out if initializer was set to anything. The runner doesn't handle recursion and assumes it's access from
-            //              a different thread and deadlocks itself. CoreRT will cause recursion for things like trying to get a static
-            //              base from the CCtor (which means that pretty much all cctors will deadlock).
-            if (context.initialized == 0)
-                CheckStaticClassConstruction(ref context);
-            return nonGcStaticBase;
         }
 
         // Intrinsic to call the cctor given a pointer to the code (this method's body is ignored and replaced


### PR DESCRIPTION
Switch to the class constructor runner from .NET Native for UWP apps.

Also fixing a bug in EETypeOptionalFieldsBuilder I hit when I enabled this.