### PR TITLE
Optimize string.Replace(char, char)

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -2714,6 +2714,9 @@ namespace System
         //
         private unsafe String ReplaceInternal(char oldChar, char newChar)
         {
+            if (oldChar == newChar)
+                return this;
+            
             int firstFoundIndex = -1;
 
             fixed (char* pChars = &_firstChar)


### PR DESCRIPTION
Returns the same string if the characters are the same.

Related PR in CoreCLR: dotnet/coreclr#3221