### PR TITLE
Remove unnecessary ref parameters from String.cs

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -1271,7 +1271,7 @@ namespace System
             }
 
             int[] sepList = new int[Length];
-            int numReplaces = MakeSeparatorList(separator, ref sepList);
+            int numReplaces = MakeSeparatorList(separator, sepList);
 
             // Handle the special case of no replaces.
             if (0 == numReplaces)
@@ -1326,7 +1326,7 @@ namespace System
 
             int[] sepList = new int[Length];
             int[] lengthList = new int[Length];
-            int numReplaces = MakeSeparatorList(separator, ref sepList, ref lengthList);
+            int numReplaces = MakeSeparatorList(separator, sepList, lengthList);
 
             //Handle the special case of no replaces.
             if (0 == numReplaces)
@@ -1438,7 +1438,7 @@ namespace System
         // Args: separator  -- A string containing all of the split characters.
         //       sepList    -- an array of ints for split char indicies.
         //--------------------------------------------------------------------    
-        private unsafe int MakeSeparatorList(char[] separator, ref int[] sepList)
+        private unsafe int MakeSeparatorList(char[] separator, int[] sepList)
         {
             int foundCount = 0;
 
@@ -1487,7 +1487,7 @@ namespace System
         //       sepList    -- an array of ints for split string indicies.
         //       lengthList -- an array of ints for split string lengths.
         //--------------------------------------------------------------------    
-        private unsafe int MakeSeparatorList(String[] separators, ref int[] sepList, ref int[] lengthList)
+        private unsafe int MakeSeparatorList(String[] separators, int[] sepList, int[] lengthList)
         {
             int foundCount = 0;
             int sepListCount = sepList.Length;


### PR DESCRIPTION
For some reason, there seems to be some code in `String.Split` that takes ref parameters, even though they aren't actually assigned to. This PR removes the `ref` annotations from the methods and their callers.

Related CoreCLR pull request: dotnet/coreclr#3274