### PR TITLE
Add a note for building on Windows 7

### DIFF
--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -8,6 +8,8 @@ The following pre-requisites need to be installed for building the repo:
 
 Install [Visual Studio 2015](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), including Visual C++ support.
 
+PowerShell 3.0 or later is required to run the build scripts. On Windows 7, you need to install [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Later versions of Windows come with the right version of PowerShell inbox.
+
 # Ubuntu (14.04)
 
 Install basic dependency packages:

--- a/build.cmd
+++ b/build.cmd
@@ -182,6 +182,10 @@ if not exist "%__DotNetCliPath%" (
 )
 if not exist "%__DotNetCliPath%" (
     echo DotNet CLI could not be downloaded or installed.
+
+    rem The script calls Invoke-WebRequest which is only available in PowerShell 3.
+    echo If you are running Windows 7, make sure you have PowerShell version 3.
+
     exit /b 1
 )
 


### PR DESCRIPTION
PowerShell 3 is needed on Windows 7 to download the CLI.

(I'm still not sure whether the repo can successfully build on 7. I only
have an x86 Windows 7 install and the build won't go far with that
because the CLI we download is x64.)

See issue #705.