### PR TITLE
Trivial change to make StringBuilder.Length setter faster for larger values

### DIFF
--- a/src/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -387,8 +387,8 @@ namespace System.Text
                 // if the specified length is greater than the current length
                 if (delta > 0)
                 {
-                    // the end of the string value of the current StringBuilder object is padded with the Unicode NULL character
-                    Append('\0', delta);        // We could improve on this, but who does this anyway?
+                    // just set the Capacity to the new value
+                    Capacity = value;
                 }
                 // if the specified length is less than or equal to the current length
                 else

--- a/src/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -387,8 +387,8 @@ namespace System.Text
                 // if the specified length is greater than the current length
                 if (delta > 0)
                 {
-                    // just set the Capacity to the new value
                     Capacity = value;
+                    m_ChunkLength += value;
                 }
                 // if the specified length is less than or equal to the current length
                 else


### PR DESCRIPTION
Instead of appending a bunch of null chars when the length is set to something higher, just forward it to the Capacity setter. Cleaner, more performant, and readable.

Related CoreCLR pull request: dotnet/coreclr#3277