### PR TITLE
Enable native metadata generation

### DIFF
--- a/src/Common/src/Internal/Runtime/ModuleHeaders.cs
+++ b/src/Common/src/Internal/Runtime/ModuleHeaders.cs
@@ -51,6 +51,10 @@ namespace Internal.Runtime
         InterfaceDispatchTable      = 203,
         ModuleManagerIndirection    = 204,
         EagerCctor                  = 205,
+
+        // Sections 300 - 399 are reserved for RhFindBlob backwards compatibility
+        ReadonlyBlobRegionStart     = 300,
+        ReadonlyBlobRegionEnd       = 399,
     }
 
     [Flags]

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -166,6 +166,16 @@ namespace ILCompiler
             _compilationModuleGroup.AddWellKnownTypes();
             _compilationModuleGroup.AddCompilationRoots();
 
+            if (!_options.IsCppCodeGen && !_options.MultiFile)
+            {
+                // TODO: build a general purpose way to hook up pieces that would be part of the core library
+                //       if factoring of the core library respected how things are, versus how they would be in
+                //       a magic world (future customers of this mechanism will be interop and serialization).
+                var refExec = _typeSystemContext.GetModuleForSimpleName("System.Private.Reflection.Execution");
+                var exec = refExec.GetKnownType("Internal.Reflection.Execution", "ReflectionExecution");
+                AddCompilationRoot(exec.GetStaticConstructor(), "Reflection execution");
+            }
+
             if (_options.IsCppCodeGen)
             {
                 _cppWriter = new CppCodeGen.CppWriter(this);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a blob of native metadata describing assemblies, the types in them, and their members.
+    /// The data is used at runtime to e.g. support reflection.
+    /// </summary>
+    internal sealed class MetadataNode : ObjectNode, ISymbolNode
+    {
+        ObjectAndOffsetSymbolNode _endSymbol;
+
+        public MetadataNode()
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+        }
+
+        public ISymbolNode EndSymbol
+        {
+            get
+            {
+                return _endSymbol;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return "__embedded_metadata";
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "data";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node has no relocations.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            byte[] blob = factory.MetadataManager.GetMetadataBlob();
+            _endSymbol.SetSymbolOffset(blob.Length);
+
+            return new ObjectData(
+                blob,
+                Array.Empty<Relocation>(),
+                1,
+                new ISymbolNode[]
+                {
+                    this,
+                    _endSymbol
+                });
+        }
+    }
+}
+

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -28,6 +28,8 @@ namespace ILCompiler.DependencyAnalysis
             _compilationModuleGroup = compilationModuleGroup;
             TypeInitializationManager = typeInitManager;
             CreateNodeCaches();
+
+            MetadataManager = new MetadataGeneration();
         }
 
         public TargetDetails Target
@@ -39,6 +41,11 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         public TypeInitialization TypeInitializationManager
+        {
+            get; private set;
+        }
+
+        public MetadataGeneration MetadataManager
         {
             get; private set;
         }
@@ -545,6 +552,9 @@ namespace ILCompiler.DependencyAnalysis
             ReadyToRunHeader.Add(ReadyToRunSectionType.EagerCctor, EagerCctorTable, EagerCctorTable.StartSymbol, EagerCctorTable.EndSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.ModuleManagerIndirection, ModuleManagerIndirection, ModuleManagerIndirection);
             ReadyToRunHeader.Add(ReadyToRunSectionType.InterfaceDispatchTable, DispatchMapTable, DispatchMapTable.StartSymbol);
+
+            MetadataManager.AddToReadyToRunHeader(ReadyToRunHeader);
+            MetadataManager.AttachToDependencyGraph(graph);
         }
     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between EETypes and metadata records within the <see cref="MetadataNode"/>.
+    /// </summary>
+    internal sealed class TypeMetadataMapNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+
+        public TypeMetadataMapNode()
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+        }
+
+        public ISymbolNode EndSymbol
+        {
+            get
+            {
+                return _endSymbol;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return "__type_to_metadata_map";
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override string Section
+        {
+            get
+            {
+                return "data";
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory);
+
+            foreach (var mappingEntry in factory.MetadataManager.GetTypeDefinitionMapping())
+            {
+                var node = (EETypeNode)factory.ConstructedTypeSymbol(mappingEntry.Entity);
+                if (node.Marked)
+                {
+                    // TODO: this format got very inefficient due to not being able to use RVAs
+                    //       replace with a hash table
+
+                    builder.EmitPointerReloc(node);
+                    builder.EmitInt(mappingEntry.MetadataHandle);
+
+                    if (factory.Target.PointerSize == 8)
+                        builder.EmitInt(0); // Pad
+                }
+            }
+
+            _endSymbol.SetSymbolOffset(builder.CountBytes);
+            
+            builder.DefinedSymbols.Add(this);
+            builder.DefinedSymbols.Add(_endSymbol);
+
+            return builder.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -1,0 +1,191 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+using Internal.Metadata.NativeFormat.Writer;
+
+using ILCompiler.Metadata;
+using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysisFramework;
+
+using Debug = System.Diagnostics.Debug;
+using ReadyToRunSectionType = Internal.Runtime.ReadyToRunSectionType;
+using ReflectionMapBlob = Internal.Runtime.ReflectionMapBlob;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// This class is responsible for managing native metadata to be emitted into the compiled
+    /// module. It also helps facilitate mappings between generated runtime structures or code,
+    /// and the native metadata.
+    /// </summary>
+    public class MetadataGeneration
+    {
+        private byte[] _metadataBlob;
+        private List<MetadataMapping<MetadataType>> _typeMappings = new List<MetadataMapping<MetadataType>>();
+
+        private HashSet<ModuleDesc> _modulesSeen = new HashSet<ModuleDesc>();
+        private HashSet<MetadataType> _typeDefinitionsGenerated = new HashSet<MetadataType>();
+
+        public void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
+        {
+            graph.NewMarkedNode += Graph_NewMarkedNode;
+        }
+
+        private static ReadyToRunSectionType BlobIdToReadyToRunSection(ReflectionMapBlob blobId)
+        {
+            var result = (ReadyToRunSectionType)((int)blobId + (int)ReadyToRunSectionType.ReadonlyBlobRegionStart);
+            Debug.Assert(result <= ReadyToRunSectionType.ReadonlyBlobRegionEnd);
+            return result;
+        }
+
+        public void AddToReadyToRunHeader(ReadyToRunHeaderNode header)
+        {
+            var metadataNode = new MetadataNode();
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.EmbeddedMetadata), metadataNode, metadataNode, metadataNode.EndSymbol);
+
+            var typeMapNode = new TypeMetadataMapNode();
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.TypeMap), typeMapNode, typeMapNode, typeMapNode.EndSymbol);
+        }
+
+        private void Graph_NewMarkedNode(DependencyNodeCore<NodeFactory> obj)
+        {
+            var eetypeNode = obj as EETypeNode;
+            if (eetypeNode != null)
+            {
+                AddGeneratedType(eetypeNode.Type);
+                return;
+            }
+
+            var methodNode = obj as MethodCodeNode;
+            if (methodNode != null)
+            {
+                AddGeneratedType(methodNode.Method.OwningType);
+                return;
+            }
+        }
+
+        private void AddGeneratedType(TypeDesc type)
+        {
+            Debug.Assert(_metadataBlob == null, "Created a new EEType after metadata generation finished");
+
+            if (type.IsTypeDefinition)
+            {
+                var mdType = type as MetadataType;
+                if (mdType != null)
+                {
+                    _typeDefinitionsGenerated.Add(mdType);
+                    _modulesSeen.Add(mdType.Module);
+                }
+            }
+
+            // TODO: track generic types, array types, etc.
+        }
+
+        private void EnsureMetadataGenerated()
+        {
+            if (_metadataBlob != null)
+                return;
+
+            var transformed = MetadataTransform.Run(new DummyMetadataPolicy(this), _modulesSeen);
+
+            // TODO: DeveloperExperienceMode: Use transformed.Transform.HandleType() to generate
+            //       TypeReference records for _typeDefinitionsGenerated that don't have metadata.
+            //       (To be used in MissingMetadataException messages)
+
+            // Generate metadata blob
+            var writer = new MetadataWriter();
+            writer.ScopeDefinitions.AddRange(transformed.Scopes);
+            var ms = new MemoryStream();
+            writer.Write(ms);
+            _metadataBlob = ms.ToArray();
+
+            // Generate type definition mappings
+            foreach (var definition in _typeDefinitionsGenerated)
+            {
+                MetadataRecord record = transformed.GetTransformedTypeDefinition(definition);
+
+                // Reflection requires that we maintain type identity. Even if we only generated a TypeReference record,
+                // if there is an EEType for it, we also need a mapping table entry for it.
+                if (record == null)
+                    record = transformed.GetTransformedTypeReference(definition);
+
+                if (record != null)
+                    _typeMappings.Add(new MetadataMapping<MetadataType>(definition, writer.GetRecordHandle(record)));
+            }
+        }
+
+        public byte[] GetMetadataBlob()
+        {
+            EnsureMetadataGenerated();
+            return _metadataBlob;
+        }
+
+        public IEnumerable<MetadataMapping<MetadataType>> GetTypeDefinitionMapping()
+        {
+            EnsureMetadataGenerated();
+            return _typeMappings;
+        }
+
+        private struct DummyMetadataPolicy : IMetadataPolicy
+        {
+            private MetadataGeneration _parent;
+
+            public DummyMetadataPolicy(MetadataGeneration parent)
+            {
+                _parent = parent;
+            }
+
+            public bool GeneratesMetadata(FieldDesc fieldDef)
+            {
+                // Literal fields are fine even for this very dummy policy. Maybe Enum.Parse/ToString will work.
+                if (fieldDef.IsLiteral)
+                {
+                    MetadataType owningType = (MetadataType)fieldDef.OwningType as MetadataType;
+                    return _parent._typeDefinitionsGenerated.Contains(owningType);
+                }
+                return false;
+            }
+
+            public bool GeneratesMetadata(MethodDesc methodDef)
+            {
+                return false;
+            }
+
+            public bool GeneratesMetadata(MetadataType typeDef)
+            {
+                // Metadata consistency: if a nested type generates metadata, the containing type is
+                // required to generate metadata, or metadata generation will fail.
+                foreach (var nested in typeDef.GetNestedTypes())
+                {
+                    if (GeneratesMetadata(nested))
+                        return true;
+                }
+
+                return _parent._typeDefinitionsGenerated.Contains(typeDef);
+            }
+
+            public bool IsBlocked(MetadataType typeDef)
+            {
+                return false;
+            }
+        }
+    }
+
+    public struct MetadataMapping<TEntity>
+    {
+        public readonly TEntity Entity;
+        public readonly int MetadataHandle;
+
+        public MetadataMapping(TEntity entity, int metadataHandle)
+        {
+            Entity = entity;
+            MetadataHandle = metadataHandle;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -23,12 +23,23 @@
       <Project>{dac23e9f-f826-4577-ae7a-0849ff83280c}</Project>
       <Name>ILCompiler.DependencyAnalysisFramework</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\ILCompiler.MetadataTransform\src\ILCompiler.MetadataTransform.csproj">
+      <Project>{a965ea82-219d-48f7-ad51-bc030c16cc6f}</Project>
+      <Name>ILCompiler.MetadataTransform</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj">
+      <Project>{d66338d4-f9e4-4051-b302-232c6bfb6ef6}</Project>
+      <Name>ILCompiler.MetadataWriter</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\ILCompiler.TypeSystem\src\ILCompiler.TypeSystem.csproj">
       <Project>{1a9df196-43a9-44bb-b2c6-d62aa56b0e49}</Project>
       <Name>ILCompiler.TypeSystem</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs">
+      <Link>Common\MetadataBlob.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\EETypePtrOfIntrinsic.cs">
       <Link>IL\Stubs\EETypePtrOfIntrinsic.cs</Link>
     </Compile>
@@ -46,6 +57,7 @@
     <Compile Include="Compiler\DependencyAnalysis\IMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\JumpStubNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\MetadataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodCodeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedPointersNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunHeaderNode.cs" />
@@ -75,6 +87,7 @@
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64JumpStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64UnboxingStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ThreadStaticsNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\TypeMetadataMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\UnboxingStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\VirtualMethodUseNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\Register.cs" />
@@ -85,6 +98,7 @@
     <Compile Include="Compiler\ICompilationRootProvider.cs" />
     <Compile Include="Compiler\JitHelper.cs" />
     <Compile Include="Compiler\MemoryHelper.cs" />
+    <Compile Include="Compiler\MetadataGeneration.cs" />
     <Compile Include="Compiler\MethodExtensions.cs" />
     <Compile Include="Compiler\MultiFileCompilationModuleGroup.cs" />
     <Compile Include="Compiler\NameMangler.cs" />

--- a/src/ILCompiler/ILCompiler.sln
+++ b/src/ILCompiler/ILCompiler.sln
@@ -20,6 +20,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "desktop", "desktop\desktop.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.CoreLib", "..\System.Private.CoreLib\src\System.Private.CoreLib.csproj", "{BE95C560-B508-4588-8907-F9FC5BC1A0CF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.MetadataWriter", "..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj", "{D66338D4-F9E4-4051-B302-232C6BFB6EF6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.MetadataTransform", "..\ILCompiler.MetadataTransform\src\ILCompiler.MetadataTransform.csproj", "{A965EA82-219D-48F7-AD51-BC030C16CC6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -54,6 +58,14 @@ Global
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x64.Build.0 = Debug|x64
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x64.ActiveCfg = Release|x64
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x64.Build.0 = Release|x64
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Debug|x64.Build.0 = Debug|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Release|x64.ActiveCfg = Release|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Release|x64.Build.0 = Release|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Debug|x64.Build.0 = Debug|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Release|x64.ActiveCfg = Release|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Native/Runtime/MiscHelpers.cpp
+++ b/src/Native/Runtime/MiscHelpers.cpp
@@ -135,6 +135,9 @@ COOP_PINVOKE_HELPER(HANDLE, RhGetModuleFromPointer, (PTR_VOID pPointerVal))
 
 COOP_PINVOKE_HELPER(HANDLE, RhGetModuleFromEEType, (EEType * pEEType))
 {
+#if CORERT
+    return (HANDLE)(pEEType->GetModuleManager());
+#else
     // For dynamically created types, return the module handle that contains the template type
     if (pEEType->IsDynamicType())
         pEEType = pEEType->get_DynamicTemplateType();
@@ -149,10 +152,27 @@ COOP_PINVOKE_HELPER(HANDLE, RhGetModuleFromEEType, (EEType * pEEType))
     // We should never get here (an EEType not located in any module) so fail fast to indicate the bug.
     RhFailFast();
     return NULL;
+#endif // !CORERT
 }
 
 COOP_PINVOKE_HELPER(Boolean, RhFindBlob, (HANDLE hOsModule, UInt32 blobId, UInt8 ** ppbBlob, UInt32 * pcbBlob))
 {
+#if CORERT
+    ReadyToRunSectionType section =
+        (ReadyToRunSectionType)((UInt32)ReadyToRunSectionType::ReadonlyBlobRegionStart + blobId);
+    ASSERT(section <= ReadyToRunSectionType::ReadonlyBlobRegionEnd);
+
+    ModuleManager* pModule = (ModuleManager*)hOsModule;
+
+    int length;
+    void* pBlob;
+    pBlob = pModule->GetModuleSection(section, &length);
+
+    *ppbBlob = (UInt8*)pBlob;
+    *pcbBlob = (UInt32)length;
+
+    return pBlob != NULL;
+#else
     // Search for the Redhawk module contained by the OS module.
     FOREACH_MODULE(pModule)
     {
@@ -193,6 +213,7 @@ COOP_PINVOKE_HELPER(Boolean, RhFindBlob, (HANDLE hOsModule, UInt32 blobId, UInt8
     RhFailFast();
 
     return FALSE;
+#endif // !CORERT
 }
 
 // This helper is not called directly but is used by the implementation of RhpCheckCctor to locate the

--- a/src/Native/Runtime/inc/ModuleHeaders.h
+++ b/src/Native/Runtime/inc/ModuleHeaders.h
@@ -46,6 +46,10 @@ enum class ReadyToRunSectionType
     InterfaceDispatchTable      = 203,
     ModuleManagerIndirection    = 204,
     EagerCctor                  = 205,
+
+    // Sections 300 - 399 are reserved for RhFindBlob backwards compatibility
+    ReadonlyBlobRegionStart     = 300,
+    ReadonlyBlobRegionEnd       = 399,
 };
 
 enum class ModuleInfoFlags

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -444,6 +444,11 @@ public:
     bool IsGeneric()
         { return (m_usFlags & IsGenericFlag) != 0; }
 
+#if defined(CORERT)
+    ModuleManager* GetModuleManager()
+         { return *m_ppModuleManager; }
+#endif
+
 #ifndef BINDER
     DispatchMap *GetDispatchMap();
 

--- a/src/Native/Runtime/inc/eetype.inl
+++ b/src/Native/Runtime/inc/eetype.inl
@@ -173,7 +173,7 @@ inline DispatchMap * EEType::GetDispatchMap()
     RuntimeInstance * pRuntimeInstance = GetRuntimeInstance();
 
 #ifdef CORERT
-    return (*m_ppModuleManager)->GetDispatchMapLookupTable()[idxDispatchMap];
+    return GetModuleManager()->GetDispatchMapLookupTable()[idxDispatchMap];
 #endif
 
     Module * pModule = pRuntimeInstance->FindModuleByReadOnlyDataAddress(this);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
@@ -17,6 +17,11 @@ namespace Internal.Runtime.CompilerHelpers
     [McgIntrinsics]
     internal static class StartupCodeHelpers
     {
+        public static IntPtr[] Modules
+        {
+            get; private set;
+        }
+
         [RuntimeExport("InitializeModules")] // TODO: Change to NativeCallable
         internal static void InitializeModules(IntPtr moduleHeaders, int count)
         {
@@ -26,6 +31,10 @@ namespace Internal.Runtime.CompilerHelpers
             {
                 InitializeGlobalTablesForModule(moduleManager);
             }
+
+            // We are now at a stage where we can use GC statics - publish the list of modules
+            // so that the eager constructors can access it.
+            Modules = modules;
 
             // These two loops look funny but it's important to initialize the global tables before running
             // the first class constructor to prevent them calling into another uninitialized module

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -507,9 +507,21 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhFindBlob")]
         internal static unsafe extern bool RhFindBlob(IntPtr hOsModule, uint blobId, byte** ppbBlob, uint* pcbBlob);
 
+#if CORERT
+        internal static uint RhGetLoadedModules(IntPtr[] resultArray)
+        {
+            IntPtr[] loadedModules = Internal.Runtime.CompilerHelpers.StartupCodeHelpers.Modules;
+            if (resultArray != null)
+            {
+                Array.Copy(loadedModules, resultArray, Math.Min(loadedModules.Length, resultArray.Length));
+            }
+            return (uint)loadedModules.Length;
+        }
+#else
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetLoadedModules")]
         internal static extern uint RhGetLoadedModules(IntPtr[] resultArray);
+#endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetModuleFromPointer")]

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -303,6 +303,8 @@ namespace Internal.Reflection.Execution
         //
         public unsafe sealed override bool IsReflectionBlocked(RuntimeTypeHandle runtimeTypeHandle)
         {
+            return false;
+#if false
             // For generic types, use the generic type definition
             runtimeTypeHandle = GetTypeDefinition(runtimeTypeHandle);
 
@@ -327,6 +329,7 @@ namespace Internal.Reflection.Execution
             }
             // Entry not found, must not be blocked
             return false;
+#endif
         }
 
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -282,7 +282,7 @@ namespace Internal.Reflection.Execution
                 foreach (var ptrEntry in mapTable)
                 {
                     var pCurrentEntry = (TypeMapEntry*)ptrEntry;
-                    RuntimeTypeHandle entryTypeHandle = RvaToRuntimeTypeHandle(moduleHandle, pCurrentEntry->EETypeRva);
+                    RuntimeTypeHandle entryTypeHandle = RuntimeAugments.CreateRuntimeTypeHandle(pCurrentEntry->EEType);
                     if (entryTypeHandle.Equals(runtimeTypeHandle) && pCurrentEntry->TypeDefinitionHandle.IsTypeDefinitionHandle())
                     {
                         metadataReader = GetMetadataReaderForModule(moduleHandle);
@@ -354,7 +354,7 @@ namespace Internal.Reflection.Execution
                 TypeMapEntry* pCurrentEntry = (TypeMapEntry*)ptrEntry;
                 if (pCurrentEntry->TypeDefinitionHandle == typeDefHandle.AsInt())
                 {
-                    runtimeTypeHandle = RvaToRuntimeTypeHandle(moduleHandle, pCurrentEntry->EETypeRva);
+                    runtimeTypeHandle = RuntimeAugments.CreateRuntimeTypeHandle(pCurrentEntry->EEType);
                     return true;
                 }
             }
@@ -381,7 +381,7 @@ namespace Internal.Reflection.Execution
                 foreach (var ptrEntry in mapTable)
                 {
                     var pCurrentEntry = (TypeMapEntry*)ptrEntry;
-                    RuntimeTypeHandle entryTypeHandle = RvaToRuntimeTypeHandle(moduleHandle, pCurrentEntry->EETypeRva);
+                    RuntimeTypeHandle entryTypeHandle = RuntimeAugments.CreateRuntimeTypeHandle(pCurrentEntry->EEType);
                     if (entryTypeHandle.Equals(runtimeTypeHandle) && pCurrentEntry->TypeDefinitionHandle.IsTypeReferenceHandle())
                     {
                         metadataReader = GetMetadataReaderForModule(moduleHandle);
@@ -421,7 +421,7 @@ namespace Internal.Reflection.Execution
                 TypeMapEntry* pCurrentEntry = (TypeMapEntry*)ptrEntry;
                 if (pCurrentEntry->TypeDefinitionHandle == typeRefHandle.AsInt())
                 {
-                    runtimeTypeHandle = RvaToRuntimeTypeHandle(moduleHandle, pCurrentEntry->EETypeRva);
+                    runtimeTypeHandle = RuntimeAugments.CreateRuntimeTypeHandle(pCurrentEntry->EEType);
                     return true;
                 }
             }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MetadataTable.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MetadataTable.cs
@@ -174,7 +174,7 @@ namespace Internal.Reflection.Execution
         [StructLayout(LayoutKind.Sequential)]
         struct TypeMapEntry
         {
-            public uint EETypeRva;
+            public IntPtr EEType;
             public int TypeDefinitionHandle;
         }
 

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -41,6 +41,8 @@
             <ILCompilerFiles Include="ilc.exe" />
             <ILCompilerFiles Include="ILCompiler.Compiler.dll" />
             <ILCompilerFiles Include="ILCompiler.DependencyAnalysisFramework.dll" />
+            <ILCompilerFiles Include="ILCompiler.MetadataTransform.dll" />
+            <ILCompilerFiles Include="ILCompiler.MetadataWriter.dll" />
             <ILCompilerFiles Include="ILCompiler.TypeSystem.dll" />
             <ILCompilerBinPlace Include="@(ILCompilerFiles)">
                 <Text><![CDATA[        <file src="$(RelativeProductBinDir)/%(Identity)" target="runtimes/any/lib/dotnet/%(Identity)" /> ]]></Text>


### PR DESCRIPTION
* Add code to generate a metadata blob containing type definition
metadata for all types that had an EEType generated in the current
compilation.
* Hook up Reflection.Execution by rooting the static constructor on
ReflectionExecution (this constructor is eager - just rooting it makes
it run).
* Add mock implementation of RhFindBlob that lets us find blob 13 -
metadata blob

This should be enough to support `Type.GetType("SomeType,
SomeAssembly")`. It's not enough to support things like
`foo.GetType().GetTypeInfo().FullName` - we need mapping table
generation for that.

Remaining work:
- [x] MetadataTransform bugfix to handle emission of TypeReferences to nested types that have a full TypeDefinition (#918)
- [x] Workarounds to Reflection.Execution around unimplemented features (delegates to valuetypes and multicast delegate invocation) (#917)

Not needed to pass CI, but needed to light up the feature:
- [x] Implement support for array interfaces - #915