### PR TITLE
Fix handling of nested TypeReference records

### DIFF
--- a/src/ILCompiler.MetadataTransform/tests/ILCompiler.MetadataTransform.Tests.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/ILCompiler.MetadataTransform.Tests.csproj
@@ -44,6 +44,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MockPolicy.cs" />
     <Compile Include="MultifileMetadataPolicy.cs" />
     <Compile Include="NativeFormatExtensions.cs" />
     <Compile Include="SimpleTests.cs" />

--- a/src/ILCompiler.MetadataTransform/tests/MockPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/MockPolicy.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using ILCompiler.Metadata;
+using Internal.TypeSystem;
+
+namespace MetadataTransformTests
+{
+    struct MockPolicy : IMetadataPolicy
+    {
+        private Func<MetadataType, bool> _typeGeneratesMetadata;
+        private Func<MethodDesc, bool> _methodGeneratesMetadata;
+        private Func<FieldDesc, bool> _fieldGeneratesMetadata;
+
+        private Func<MetadataType, bool> _isBlockedType;
+
+        public MockPolicy(
+            Func<MetadataType, bool> typeGeneratesMetadata,
+            Func<MethodDesc, bool> methodGeneratesMetadata = null,
+            Func<FieldDesc, bool> fieldGeneratesMetadata = null,
+            Func<MetadataType, bool> isBlockedType = null)
+        {
+            _typeGeneratesMetadata = typeGeneratesMetadata;
+            _methodGeneratesMetadata = methodGeneratesMetadata;
+            _fieldGeneratesMetadata = fieldGeneratesMetadata;
+            _isBlockedType = isBlockedType;
+        }
+
+        public bool GeneratesMetadata(MethodDesc methodDef)
+        {
+            if (_methodGeneratesMetadata != null)
+                return _methodGeneratesMetadata(methodDef);
+            return false;
+        }
+
+        public bool GeneratesMetadata(FieldDesc fieldDef)
+        {
+            if (_fieldGeneratesMetadata != null)
+                return _fieldGeneratesMetadata(fieldDef);
+            return false;
+        }
+
+        public bool GeneratesMetadata(MetadataType typeDef)
+        {
+            return _typeGeneratesMetadata(typeDef);
+        }
+
+        public bool IsBlocked(MetadataType typeDef)
+        {
+            if (_isBlockedType != null)
+                return _isBlockedType(typeDef);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
If we have type X that is nested under type Y and:
- Y generates full metadata, and
- X doesn't generate metadata, but we need a TypeReference to it (e.g.
to support DeveloperExperience metadata for MissingMetadataExceptions)

The transform was attempting to set the TypeDefinition as the
ParentNamespaceOrType of the reference. This is not allowed as per the
metadata format. We need to generate a TypeReference for the owning
type.