### PR TITLE
Allow static methods on interface types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -229,6 +229,9 @@ namespace ILCompiler.DependencyAnalysis
 
                     foreach (MethodDesc interfaceMethod in interfaceType.GetMethods())
                     {
+                        if (interfaceMethod.Signature.IsStatic)
+                            continue;
+
                         Debug.Assert(interfaceMethod.IsVirtual);
                         MethodDesc implMethod = VirtualFunctionResolution.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, _type.GetClosestMetadataType());
                         if (implMethod != null)


### PR DESCRIPTION
C# doesn't allow this, but ECMA-335 does.