### PR TITLE
Fix bugs around handling MDArray rank 1

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -68,7 +68,7 @@ namespace Internal.IL.Stubs
 
         private void EmitILForAccessor()
         {
-            Debug.Assert(_rank > 0);
+            Debug.Assert(!_method.OwningType.IsSzArray);
 
             var codeStream = _emitter.NewCodeStream();
             var context = _method.Context;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -295,10 +295,9 @@ namespace ILCompiler.DependencyAnalysis
             else if (_type is ArrayType)
             {
                 objectSize = 3 * pointerSize; // SyncBlock + EETypePtr + Length
-                int rank = ((ArrayType)_type).Rank;
-                if (rank > 1)
+                if (!_type.IsSzArray)
                     objectSize +=
-                        2 * _type.Context.GetWellKnownType(WellKnownType.Int32).GetElementSize() * rank;
+                        2 * _type.Context.GetWellKnownType(WellKnownType.Int32).GetElementSize() * ((ArrayType)_type).Rank;
             }
             else if (_type is PointerType)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -170,7 +170,7 @@ namespace ILCompiler
                 case TypeFlags.Array:
                     // mangledName = "Array<" + GetSignatureCPPTypeName(((ArrayType)type).ElementType) + ">";
                     mangledName = GetMangledTypeName(((ArrayType)type).ElementType) + "__Array";
-                    if (((ArrayType)type).Rank != 1)
+                    if (!type.IsSzArray)
                         mangledName += "Rank" + ((ArrayType)type).Rank.ToString();
                     break;
                 case TypeFlags.ByRef:

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -1022,7 +1022,7 @@ namespace ILCompiler.CppCodeGen
                 sb.Append("2 * sizeof(void*) + sizeof(int32_t) + 2,");       // EEType::_uBaseSize
             }
             else
-            if (type.IsArray && ((ArrayType)type).Rank == 1)
+            if (type.IsSzArray)
             {
                 sb.AppendLine();
                 sb.Append("{");
@@ -1041,7 +1041,6 @@ namespace ILCompiler.CppCodeGen
             else
             if (type.IsArray)
             {
-                Debug.Assert(((ArrayType)type).Rank > 1);
                 sb.AppendLine();
                 sb.Append("{");
                 sb.Indent();


### PR DESCRIPTION
Multidimensional array of rank 1 is not an SzArray.

Found one instance by reviewing code on EETypeNode and did a search of
how we use Rank in other places to find the rest.

The assert on ArrayMethodILEmitter would never kick in because of how
_rank is populated, so I switched it out for another assert in the same
spirit.