### PR TITLE
Add support for array interfaces

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -34,22 +34,6 @@ namespace Internal.TypeSystem
             return type.Context.GetPointerType(type);
         }
 
-        static public DefType GetClosestDefType(this TypeDesc type)
-        {
-            if (type is DefType)
-                return (DefType)type;
-            else
-                return type.BaseType;
-        }
-
-        static public MetadataType GetClosestMetadataType(this TypeDesc type)
-        {
-            if (type is MetadataType)
-                return (MetadataType)type;
-            else
-                return type.BaseType.GetClosestMetadataType();
-        }
-
         static public int GetElementSize(this TypeDesc type)
         {
             if (type.IsValueType)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -76,11 +76,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             _typeSymbols = new NodeCache<TypeDesc, EETypeNode>((TypeDesc type) =>
             {
+                Debug.Assert(type.IsTypeDefinition || !type.HasSameTypeDefinition(ArrayOfTClass), "Asking for Array<T> EEType");
                 return new EETypeNode(type, false);
             });
 
             _constructedTypeSymbols = new NodeCache<TypeDesc, EETypeNode>((TypeDesc type) =>
             {
+                Debug.Assert(type.IsTypeDefinition || !type.HasSameTypeDefinition(ArrayOfTClass), "Asking for Array<T> EEType");
                 return new EETypeNode(type, true);
             });
             
@@ -414,6 +416,19 @@ namespace ILCompiler.DependencyAnalysis
                 _helperEntrypointSymbols[index] = symbol;
             }
             return symbol;
+        }
+
+        private TypeDesc _systemArrayOfTClass;
+        public TypeDesc ArrayOfTClass
+        {
+            get
+            {
+                if (_systemArrayOfTClass == null)
+                {
+                    _systemArrayOfTClass = _context.SystemModule.GetKnownType("System", "Array`1");
+                }
+                return _systemArrayOfTClass;
+            }
         }
 
         private TypeDesc _systemICastableType;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -65,7 +65,7 @@ namespace ILCompiler.DependencyAnalysis
 
                         // TODO: Swap argument order instead
                         encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Arg0);
-                        encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.NecessaryTypeSymbol(target));
+                        encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.ConstructedTypeSymbol(target));
                         encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetNewArrayHelperForType(target)));
                     }
                     break;

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.IL;
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler
+{
+    static class TypeExtensions
+    {
+        static public MetadataType GetClosestMetadataType(this TypeDesc type)
+        {
+            if (type.IsSzArray && !((ArrayType)type).ElementType.IsPointer)
+            {
+                MetadataType arrayType = type.Context.SystemModule.GetKnownType("System", "Array`1");
+                return arrayType.MakeInstantiatedType(new Instantiation(new TypeDesc[] { ((ArrayType)type).ElementType }));
+            }
+            else if (type.IsArray)
+            {
+                return (MetadataType)type.Context.GetWellKnownType(WellKnownType.Array);
+            }
+
+            Debug.Assert(type is MetadataType);
+            return (MetadataType)type;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Compiler\SymbolReader\PdbSymbolReader.cs" />
     <Compile Include="Compiler\SymbolReader\PortablePdbSymbolReader.cs" />
     <Compile Include="Compiler\SymbolReader\UnmanagedPdbSymbolReader.cs" />
+    <Compile Include="Compiler\TypeExtensions.cs" />
     <Compile Include="Compiler\TypeInitialization.cs" />
     <Compile Include="Compiler\VirtualMethodCallHelper.cs" />
     <Compile Include="CppCodeGen\CppGenerationBuffer.cs" />

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1869,7 +1869,13 @@ namespace Internal.JitInterface
                 // can simply do a static look up
                 pResult.lookup.lookupKind.needsRuntimeLookup = false;
 
-                pResult.lookup.constLookup.handle = (CORINFO_GENERIC_STRUCT_*)ObjectToHandle(_compilation.NodeFactory.NecessaryTypeSymbol(td));
+                if (td.IsArray && !td.IsSzArray)
+                {
+                    // TODO: Use CORINFO_TOKENKIND_NewObj to track that this is because of CORINFO_HELP_NEW_MDARR.
+                    pResult.lookup.constLookup.handle = (CORINFO_GENERIC_STRUCT_*)ObjectToHandle(_compilation.NodeFactory.ConstructedTypeSymbol(td));
+                }
+                else
+                    pResult.lookup.constLookup.handle = (CORINFO_GENERIC_STRUCT_*)ObjectToHandle(_compilation.NodeFactory.NecessaryTypeSymbol(td));
                 pResult.lookup.constLookup.accessType = InfoAccessType.IAT_VALUE;
             }
 

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -219,6 +219,13 @@ Object * __load_string_literal(const char * string)
 }
 #endif // CPPCODEGEN
 
+#ifdef CPPCODEGEN
+extern "C" void * g_pSystemArrayEETypeTemporaryWorkaround = 0;
+#else
+extern "C" void * __EEType_System_Private_CoreLib_System_Array;
+extern "C" void * g_pSystemArrayEETypeTemporaryWorkaround = &__EEType_System_Private_CoreLib_System_Array;
+#endif
+
 #if !defined(_WIN32) || defined(CPPCODEGEN)
 extern "C" void RhpThrowEx(void * pEx)
 {

--- a/src/Native/Runtime/inc/eetype.inl
+++ b/src/Native/Runtime/inc/eetype.inl
@@ -563,11 +563,19 @@ inline void EEType::set_RelatedParameterType(EEType * pParameterType)
         + (fHasSealedVirtuals ? sizeof(Int32) : 0);
 }
 
+#ifdef CORERT
+extern "C" void * g_pSystemArrayEETypeTemporaryWorkaround;
+#endif
+
 #if !defined(BINDER) && !defined(DACCESS_COMPILE)
 // get the base type of an array EEType - this is special because the base type of arrays is not explicitly
 // represented - instead the classlib has a common one for all arrays
 inline EEType * EEType::GetArrayBaseType()
 {
+#ifdef CORERT
+    return (EEType*)g_pSystemArrayEETypeTemporaryWorkaround;
+#endif
+
     RuntimeInstance * pRuntimeInstance = GetRuntimeInstance();
     Module * pModule = NULL;
     if (pRuntimeInstance->IsInStandaloneExeMode())

--- a/tests/src/Simple/Interfaces/Interfaces.cs
+++ b/tests/src/Simple/Interfaces/Interfaces.cs
@@ -18,6 +18,9 @@ public class BringUpTest
         if (TestMultipleInterfaces() == Fail)
             return Fail;
 
+        if (TestArrayInterfaces() == Fail)
+            return Fail;
+
         return Pass;
     }
 
@@ -232,6 +235,54 @@ public class BringUpTest
         {
             return "TestClass";
         }
+    }
+    #endregion
+
+    #region Array Interfaces Test
+    private static int TestArrayInterfaces()
+    {
+        {
+            object stringArray = new string[] { "A", "B", "C", "D" };
+
+            Console.WriteLine("Testing IEnumerable<T> on array...");
+            string result = String.Empty;
+            foreach (var s in (System.Collections.Generic.IEnumerable<string>)stringArray)
+                result += s;
+
+            if (result != "ABCD")
+            {
+                Console.WriteLine("Failed.");
+                return Fail;
+            }
+        }
+
+        {
+            object stringArray = new string[] { "A", "B", "C", "D" };
+
+            Console.WriteLine("Testing IEnumerable on array...");
+            string result = String.Empty;
+            foreach (var s in (System.Collections.IEnumerable)stringArray)
+                result += s;
+
+            if (result != "ABCD")
+            {
+                Console.WriteLine("Failed.");
+                return Fail;
+            }
+        }
+
+        {
+            object intArray = new int[5, 5];
+
+            Console.WriteLine("Testing IList on MDArray...");
+            if (((System.Collections.IList)intArray).Count != 25)
+            {
+                Console.WriteLine("Failed.");
+                return Fail;
+            }
+        }
+
+        return Pass;
     }
     #endregion
 }


### PR DESCRIPTION
* `GetClosestMetadataType` type was one of the methods we ported from
NUTC. In NUTC, it takes advantage of arrays having
`System.Array<T>` as their base type. The CoreRT type system
derives arrays off `System.Array`. The implementation of
`GetClosestMetadataType` needed tweaking.
* Use `GetClosestMedatadataType` where appropriate
* Be more rigorous at tracking constructed arrays.
* Runtime workaround to make EEType::GetArrayBaseType work.

Fixes #915.