### PR TITLE
Make RhpByRefAssignRef usable for stack destinations

### DIFF
--- a/src/Native/Runtime/amd64/WriteBarriers.S
+++ b/src/Native/Runtime/amd64/WriteBarriers.S
@@ -251,6 +251,12 @@ LEAF_ENTRY RhpByRefAssignRef, _TEXT
     mov     rcx, [rsi]
     mov     [rdi], rcx
 
+    // Check whether the writes were even into the heap. If not there's no card update required.
+    cmp     rdi, [C_VAR(g_lowest_address)]
+    jb      RhpByRefAssignRef_NotInHeap
+    cmp     rdi, [C_VAR(g_highest_address)]
+    jae     RhpByRefAssignRef_NotInHeap
+
     // Update the shadow copy of the heap with the same value just written to the same heap. (A no-op unless
     // we're in a debug build and write barrier checking has been enabled).
     UPDATE_GC_SHADOW BASENAME, rcx, rdi

--- a/src/Native/Runtime/amd64/WriteBarriers.asm
+++ b/src/Native/Runtime/amd64/WriteBarriers.asm
@@ -414,6 +414,12 @@ LEAF_ENTRY RhpByRefAssignRef, _TEXT
     mov     rcx, [rsi]
     mov     [rdi], rcx
 
+    ;; Check whether the writes were even into the heap. If not there's no card update required.
+    cmp     rdi, [g_lowest_address]
+    jb      RhpByRefAssignRef_NotInHeap
+    cmp     rdi, [g_highest_address]
+    jae     RhpByRefAssignRef_NotInHeap
+
     ;; Update the shadow copy of the heap with the same value just written to the same heap. (A no-op unless
     ;; we're in a debug build and write barrier checking has been enabled).
     UPDATE_GC_SHADOW BASENAME, rcx, rdi


### PR DESCRIPTION
JIT uses this helper to update stack locations.