### PR TITLE
Expose Debugger.NotifyOfCrossThreadDependency

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
@@ -30,7 +30,7 @@ namespace System.Diagnostics
             throw new PlatformNotSupportedException();
         }
 
-        internal static void NotifyOfCrossThreadDependency()
+        public static void NotifyOfCrossThreadDependency()
         {
             // nothing to do...yet
         }


### PR DESCRIPTION
It's being exposed in the contract.  It'll remain a nop for now in CoreRT.

Part of https://github.com/dotnet/corefx/issues/5868