### PR TITLE
Allocate ThreadStatics per thread

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaField.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.cs
@@ -155,8 +155,7 @@ namespace Internal.TypeSystem.Ecma
                     {
                         if (metadataReader.StringComparer.Equals(nameHandle, "ThreadStaticAttribute"))
                         {
-                            // TODO: Thread statics
-                            //flags |= FieldFlags.ThreadStatic;
+                            flags |= FieldFlags.ThreadStatic;
                         }
                     }
                 }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerMetadataFieldLayoutAlgorithm.cs
@@ -13,17 +13,23 @@ namespace ILCompiler
     {
         protected override void PrepareRuntimeSpecificStaticFieldLayout(TypeSystemContext context, ref ComputedStaticFieldLayout layout)
         {
-            // GC statics start with a pointer to the "EEType" that signals the size and GCDesc to the GC
+            // Thread/GC statics start with a pointer to the "EEType" that signals the size and GCDesc to the GC
             layout.GcStatics.Size = context.Target.PointerSize;
+            layout.ThreadStatics.Size = context.Target.PointerSize;
         }
 
         protected override void FinalizeRuntimeSpecificStaticFieldLayout(TypeSystemContext context, ref ComputedStaticFieldLayout layout)
         {
-            // If the size of GCStatics is equal to the size set in PrepareRuntimeSpecificStaticFieldLayout, we
-            // don't have any GC statics
+            // If the size of GC/Thread Statics is equal to the size set in PrepareRuntimeSpecificStaticFieldLayout, we
+            // don't have any GC/Thread statics
             if (layout.GcStatics.Size == context.Target.PointerSize)
             {
                 layout.GcStatics.Size = 0;
+            }
+
+            if (layout.ThreadStatics.Size == context.Target.PointerSize)
+            {
+                layout.ThreadStatics.Size = 0;
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -338,7 +338,9 @@ namespace ILCompiler.DependencyAnalysis
 
         private static readonly string[][] s_helperEntrypointNames = new string[][] {
             new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnGCStaticBase" },
-            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnNonGCStaticBase" }
+            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnNonGCStaticBase" },
+            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnThreadStaticBase" },
+            new string[] { "System.Runtime", "RuntimeImports", "RhGetThreadStaticField" },
         };
 
         private ISymbolNode[] _helperEntrypointSymbols;
@@ -465,5 +467,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         EnsureClassConstructorRunAndReturnGCStaticBase,
         EnsureClassConstructorRunAndReturnNonGCStaticBase,
+        EnsureClassConstructorRunAndReturnThreadStaticBase,
+        RhGetThreadStaticField,
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -96,7 +96,22 @@ namespace ILCompiler.DependencyAnalysis
                     break;
 
                 case ReadyToRunHelperId.GetThreadStaticBase:
-                    encoder.EmitINT3();
+                    {
+                        MetadataType target = (MetadataType)Target;
+
+                        if (!factory.TypeInitializationManager.HasLazyStaticConstructor(target))
+                        {
+                            encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.TypeThreadStaticsSymbol(target));
+                            encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.RhGetThreadStaticField));
+                        }
+                        else
+                        {
+                            // We need to trigger the cctor before returning the base
+                            encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.TypeCctorContextSymbol(target));
+                            encoder.EmitLEAQ(encoder.TargetRegister.Arg1, factory.TypeThreadStaticsSymbol(target));
+                            encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
+                        }
+                    }
                     break;
 
                 case ReadyToRunHelperId.GetGCStaticBase:

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -261,6 +261,9 @@ extern "C" void* __StringTableStart;
 extern "C" void* __StringTableEnd;
 extern "C" void* __EagerCctorStart;
 extern "C" void* __EagerCctorEnd;
+extern "C" void* __ThreadStaticRegionStart;
+extern "C" void* __ThreadStaticRegionEnd;
+
 extern "C" void* GetModuleSection(int id, int* length)
 {
     struct ModuleSectionSymbol
@@ -276,10 +279,12 @@ extern "C" void* GetModuleSection(int id, int* length)
         { System::String::__getMethodTable(), sizeof(void*) },
         { nullptr, 0 },
         { nullptr, 0 },
+        { nullptr, 0 },
 #else
         { &__EEType_System_Private_CoreLib_System_String, sizeof(void*) },
         { &__StringTableStart, (size_t)((uint8_t*)&__StringTableEnd - (uint8_t*)&__StringTableStart) },
         { &__EagerCctorStart, (size_t)((uint8_t*)&__EagerCctorEnd - (uint8_t*)&__EagerCctorStart) },
+        { &__ThreadStaticRegionStart, (size_t)((uint8_t*)&__ThreadStaticRegionEnd - (uint8_t*)&__ThreadStaticRegionStart) },
 #endif
     };
 
@@ -293,6 +298,7 @@ SimpleModuleHeader __module = { NULL, NULL /* &__gcStatics, &__gcStaticsDescs */
 extern "C" void* __InterfaceDispatchMapTable;
 extern "C" void* __GCStaticRegionStart;
 extern "C" void* __GCStaticRegionEnd;
+
 int __statics_fixup()
 {
     for (void** currentBlock = &__GCStaticRegionStart; currentBlock < &__GCStaticRegionEnd; currentBlock++)
@@ -301,7 +307,6 @@ int __statics_fixup()
         // TODO: OOM handling
         *currentBlock = RhpHandleAlloc(gcBlock, 2 /* Normal */);
     }
-
     return 0;
 }
 

--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -274,6 +274,76 @@ PTR_ExInfo Thread::GetCurExInfo()
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifndef DACCESS_COMPILE
+#if defined(CORERT)
+EXTERN_C REDHAWK_API void* REDHAWK_CALLCONV RhpHandleAlloc(void* pObject, int type);
+EXTERN_C REDHAWK_API void REDHAWK_CALLCONV RhHandleFree(void*);
+EXTERN_C void* GetModuleSection(int id, int* length);
+EXTERN_C Object* RhNewObject(PTR_EEType);
+
+// API to obtain the thread static field
+COOP_PINVOKE_HELPER(Object*, RhGetThreadStaticField, (void** pModuleFieldTypePtr))
+{
+    int nByteLength = 0;
+    void** pModuleStart = (void**) GetModuleSection(3 /* ThreadStaticRegionStart */, &nByteLength);
+    if (nByteLength == 0)
+    {
+        return NULL;
+    }
+
+    int nIndex = pModuleFieldTypePtr - pModuleStart;
+    return ThreadStore::RawGetCurrentThread()->GetThreadStaticField(pModuleStart, nIndex, nByteLength);
+}
+
+// Allocate and construct a thread static field on demand.
+Object* Thread::GetThreadStaticField(void** pModuleStart, Int32 nIndex, Int32 nByteLength)
+{
+    EnsureThreadStaticStorage(nByteLength);
+
+    ASSERT(nByteLength == m_uThreadStaticLength * sizeof(void*));
+
+    if (m_pThreadStaticBase[nIndex] == NULL)
+    {
+        Object* gcBlock = RhNewObject((PTR_EEType) pModuleStart[nIndex]);
+        m_pThreadStaticBase[nIndex] = RhpHandleAlloc(gcBlock, 2 /* Normal */);
+    }
+
+    return *((Object**) m_pThreadStaticBase[nIndex]);
+}
+
+// Create storage for thread statics in the base array.
+void Thread::EnsureThreadStaticStorage(Int32 nByteLength)
+{
+    if (m_pThreadStaticBase != NULL)
+    {
+        return;
+    }
+
+    ASSERT(nByteLength > 0)
+    
+    int nCount = nByteLength / sizeof(void*);
+    m_pThreadStaticBase = new (nothrow) void*[nCount](); // zero-init ctor.
+    m_uThreadStaticLength = nCount;
+}
+
+// When the thread is destroyed, destroy its thread statics as well.
+void Thread::DestroyThreadStatics()
+{
+    if (m_uThreadStaticLength == 0)
+    {
+        return;
+    }
+
+    for (int i = 0; i < m_uThreadStaticLength; ++i)
+    {
+        if (m_pThreadStaticBase[i] != NULL)
+        {
+            RhHandleFree(m_pThreadStaticBase[i]);
+        }
+    }
+
+    delete[] m_pThreadStaticBase;
+}
+#endif // CORERT
 
 void Thread::Construct()
 {
@@ -284,6 +354,11 @@ void Thread::Construct()
 
     m_numDynamicTypesTlsCells = 0;
     m_pDynamicTypesTlsCells = NULL;
+
+#if defined(CORERT)
+    m_pThreadStaticBase = NULL;
+    m_uThreadStaticLength = 0;
+#endif
 
     // NOTE: We do not explicitly defer to the GC implementation to initialize the alloc_context.  The 
     // alloc_context will be initialized to 0 via the static initialization of tls_CurrentThread. If the
@@ -396,6 +471,10 @@ void Thread::Destroy()
         }
         delete[] m_pDynamicTypesTlsCells;
     }
+
+#if defined(CORERT)
+    DestroyThreadStatics();
+#endif
 
     RedhawkGCInterface::ReleaseAllocContext(GetAllocContext());
 

--- a/src/Native/Runtime/thread.h
+++ b/src/Native/Runtime/thread.h
@@ -90,6 +90,10 @@ struct ThreadBuffer
     // Thread Statics Storage for dynamic types
     UInt32          m_numDynamicTypesTlsCells;
     PTR_UInt8*      m_pDynamicTypesTlsCells;
+#if defined(CORERT)
+    PTR_PTR_VOID    m_pThreadStaticBase;                            // base address of thread statics handles
+    UInt32          m_uThreadStaticLength;
+#endif
 };
 
 struct ReversePInvokeFrame
@@ -123,6 +127,13 @@ public:
 private:
 
     void Construct();
+#if defined(CORERT)
+public:
+    Object* GetThreadStaticField(void** pModuleStart, Int32 nIndex, Int32 nByteLength);
+private:
+    void EnsureThreadStaticStorage(Int32 nByteLength);
+    void DestroyThreadStatics();
+#endif
 
     void SetState(ThreadStateFlags flags);
     void ClearState(ThreadStateFlags flags);

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -44,6 +44,12 @@ namespace System.Runtime.CompilerServices
             return gcStaticBase;
         }
 
+        private unsafe static object CheckStaticClassConstructionReturnThreadStaticBase(StaticClassConstructionContext* context, IntPtr threadStaticBase)
+        {
+            EnsureClassConstructorRun(context);
+            return RuntimeImports.RhGetThreadStaticField(threadStaticBase);
+        }
+
         private unsafe static IntPtr CheckStaticClassConstructionReturnNonGCStaticBase(StaticClassConstructionContext* context, IntPtr nonGcStaticBase)
         {
             EnsureClassConstructorRun(context);

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -520,6 +520,10 @@ namespace System.Runtime
         internal static extern IntPtr RhGetModuleFromEEType(IntPtr pEEType);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhGetThreadStaticField")]
+        internal static extern object RhGetThreadStaticField(IntPtr pModuleFieldTypePtr);
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetThreadStaticFieldAddress")]
         internal static unsafe extern byte* RhGetThreadStaticFieldAddress(EETypePtr pEEType, IntPtr fieldCookie);
 


### PR DESCRIPTION
@jkotas, PTAL.

Tested this change with background tasks and simple delay loops. Creating 4 tasks instead of 3 promptly triggered the GC.

```
class Example
{
    static object locker = new object();

    static void Delay(int count)
    {
        for (int i = 0; i < count * 1000; ++i)
        {
            Console.Write("");
        }
    }

    static void Main(string[] args)
    {
        Task[] tasks = new Task[3];
        for (int i = 0; i < tasks.Length; ++i)
        {
            tasks[i] = Task.Factory.StartNew((ipos) =>
            {
                int pos = (int)ipos;
                if (pos == 1) Delay(10000);
                if (pos == 2) Delay(1000);
                lock (locker)
                {
                    if (pos == 2) Delay(10000);
                    Console.WriteLine(pos);
                }
            }, i);
        }
        for (int i = 0; i < tasks.Length; ++i)
        {
            tasks[i].Wait();
        }
    }
}
```

```
0
2
1
```