### PR TITLE
Take reflection tracing out of CoreRT

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeConstructedGenericType.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeConstructedGenericType.cs
@@ -8,7 +8,10 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 
 using Internal.Runtime.Augments;
+
+#if ENABLE_REFLECTION_TRACE
 using Internal.Reflection.Tracing;
+#endif
 
 namespace Internal.Reflection.Core.NonPortable
 {
@@ -72,8 +75,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_FullName(this);
+#endif
 
                 // Desktop quirk: open constructions don't have "fullNames".
                 if (this.InternalIsOpen)
@@ -109,8 +114,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_Namespace(this);
+#endif
 
                 return GetGenericTypeDefinition().Namespace;
             }

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeEENamedType.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeEENamedType.cs
@@ -7,7 +7,10 @@ using System.Diagnostics;
 using System.Collections.Generic;
 
 using Internal.Runtime.Augments;
+
+#if ENABLE_REFLECTION_TRACE
 using Internal.Reflection.Tracing;
+#endif
 
 namespace Internal.Reflection.Core.NonPortable
 {
@@ -53,8 +56,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_FullName(this);
+#endif
 
                 RuntimeType shadowNamedType = ShadowNamedTypeIfAvailable;
                 if (shadowNamedType != null)
@@ -69,8 +74,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_Namespace(this);
+#endif
 
                 RuntimeType shadowNamedType = ShadowNamedTypeIfAvailable;
                 if (shadowNamedType != null)

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeHasElementType.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeHasElementType.cs
@@ -8,7 +8,10 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 
 using Internal.Runtime.Augments;
+
+#if ENABLE_REFLECTION_TRACE
 using Internal.Reflection.Tracing;
+#endif
 
 namespace Internal.Reflection.Core.NonPortable
 {
@@ -32,8 +35,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_FullName(this);
+#endif
 
                 String elementFullName = GetElementType().FullName;
                 if (elementFullName == null)
@@ -46,8 +51,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_Namespace(this);
+#endif
 
                 return GetElementType().Namespace;
             }

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeType.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeType.cs
@@ -10,7 +10,10 @@ using System.Runtime.CompilerServices;
 
 using Internal.Runtime.Augments;
 using Internal.Reflection.Extensibility;
+
+#if ENABLE_REFLECTION_TRACE
 using Internal.Reflection.Tracing;
+#endif
 
 namespace Internal.Reflection.Core.NonPortable
 {
@@ -63,8 +66,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_AssemblyQualifiedName(this);
+#endif
 
                 String fullName = FullName;
                 if (fullName == null)   // Some Types (such as generic parameters) return null for FullName by design.
@@ -89,8 +94,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_FullName(this);
+#endif
 
                 Debug.Assert(!IsConstructedGenericType);
                 Debug.Assert(!IsGenericParameter);
@@ -172,8 +179,10 @@ namespace Internal.Reflection.Core.NonPortable
 
         public sealed override Type MakeArrayType()
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.Type_MakeArrayType(this);
+#endif
 
             // Do not implement this as a call to MakeArrayType(1) - they are not interchangable. MakeArrayType() returns a
             // vector type ("SZArray") while MakeArrayType(1) returns a multidim array of rank 1. These are distinct types
@@ -183,8 +192,10 @@ namespace Internal.Reflection.Core.NonPortable
 
         public sealed override Type MakeArrayType(int rank)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.Type_MakeArrayType(this);
+#endif
 
             if (rank <= 0)
                 throw new IndexOutOfRangeException();
@@ -198,8 +209,10 @@ namespace Internal.Reflection.Core.NonPortable
 
         public sealed override Type MakeGenericType(params Type[] instantiation)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.Type_MakeGenericType(this, instantiation);
+#endif
 
             if (instantiation == null)
                 throw new ArgumentNullException("instantiation");
@@ -235,8 +248,10 @@ namespace Internal.Reflection.Core.NonPortable
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_Name(this);
+#endif
 
                 RuntimeType rootCauseForFailure = null;
                 String name = this.InternalGetNameIfAvailable(ref rootCauseForFailure);
@@ -437,11 +452,13 @@ namespace Internal.Reflection.Core.NonPortable
             {
                 _debugName = "Constructing..."; // Protect against any inadvertent reentrancy.
                 String debugName;
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                 {
                     debugName = this.GetTraceString();  // If tracing on, call this.GetTraceString() which only gives you useful strings when metadata is available but doesn't pollute the ETW trace.
                 }
                 else
+#endif
                 {
                     debugName = this.ToString();
                 }

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -22,6 +22,9 @@
   <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
     <DefineConstants>CORERT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(IsProjectNLibrary)' == 'true'">
+    <DefineConstants>ENABLE_REFLECTION_TRACE;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsUnix)'=='true'">
     <DefineConstants>PLATFORM_UNIX;$(DefineConstants)</DefineConstants>
   </PropertyGroup>

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -12,6 +12,9 @@
   <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
     <DefineConstants>CORERT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(IsProjectNLibrary)' == 'true'">
+    <DefineConstants>ENABLE_REFLECTION_TRACE;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
 
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
@@ -122,10 +125,12 @@
     <Compile Include="Internal\Reflection\Core\Execution\ReflectionCoreExecution.cs" />
     <Compile Include="Internal\Reflection\Core\Execution\InvokerOptions.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(IsProjectNLibrary)' == 'true'">
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.cs" />
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.Events.cs" />
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Internal.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="Internal\Reflection\Tracing\ITraceableTypeMember.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
@@ -39,8 +39,10 @@ namespace System.Reflection.Runtime.Assemblies
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Assembly_CustomAttributes(this);
+#endif
 
                 foreach (QScopeDefinition scope in AllScopes)
                 {
@@ -61,8 +63,10 @@ namespace System.Reflection.Runtime.Assemblies
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Assembly_DefinedTypes(this);
+#endif
 
                 foreach (QScopeDefinition scope in AllScopes)
                 {
@@ -101,8 +105,10 @@ namespace System.Reflection.Runtime.Assemblies
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Assembly_FullName(this);
+#endif
 
                 return GetName().FullName;
             }
@@ -172,16 +178,20 @@ namespace System.Reflection.Runtime.Assemblies
 
         public sealed override AssemblyName GetName()
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.Assembly_GetName(this);
+#endif
 
             return Scope.Handle.ToRuntimeAssemblyName(Scope.Reader).ToAssemblyName();
         }
 
         public sealed override Type GetType(String name, bool throwOnError, bool ignoreCase)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.Assembly_GetType(this, name);
+#endif
 
             if (name == null)
                 throw new ArgumentNullException();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -33,8 +33,10 @@ namespace System.Reflection.Runtime.CustomAttributes
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.CustomAttributeData_ConstructorArguments(this);
+#endif
 
                 return new ReadOnlyCollection<CustomAttributeTypedArgument>(GetConstructorArguments(throwIfMissingMetadata: true));
             }
@@ -46,8 +48,10 @@ namespace System.Reflection.Runtime.CustomAttributes
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.CustomAttributeData_NamedArguments(this);
+#endif
 
                 return new ReadOnlyCollection<CustomAttributeNamedArgument>(GetNamedArguments(throwIfMissingMetadata: true));
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -67,8 +67,10 @@ namespace System.Reflection.Runtime.EventInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.EventInfo_AddMethod(this);
+#endif
 
                 foreach (MethodSemanticsHandle methodSemanticsHandle in _event.MethodSemantics)
                 {
@@ -94,8 +96,10 @@ namespace System.Reflection.Runtime.EventInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.EventInfo_CustomAttributes(this);
+#endif
 
                 foreach (CustomAttributeData cad in RuntimeCustomAttributeData.GetCustomAttributes(_definingTypeInfo.ReflectionDomain, _reader, _event.CustomAttributes))
                     yield return cad;
@@ -112,8 +116,10 @@ namespace System.Reflection.Runtime.EventInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.EventInfo_DeclaringType(this);
+#endif
 
                 return _contextTypeInfo.AsType();
             }
@@ -158,8 +164,10 @@ namespace System.Reflection.Runtime.EventInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.EventInfo_Name(this);
+#endif
 
                 return _event.Name.GetString(_reader);
             }
@@ -169,8 +177,10 @@ namespace System.Reflection.Runtime.EventInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.EventInfo_RaiseMethod(this);
+#endif
 
                 foreach (MethodSemanticsHandle methodSemanticsHandle in _event.MethodSemantics)
                 {
@@ -196,8 +206,10 @@ namespace System.Reflection.Runtime.EventInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.EventInfo_RemoveMethod(this);
+#endif
 
                 foreach (MethodSemanticsHandle methodSemanticsHandle in _event.MethodSemantics)
                 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -61,8 +61,10 @@ namespace System.Reflection.Runtime.FieldInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.FieldInfo_CustomAttributes(this);
+#endif
 
                 ReflectionDomain reflectionDomain = _definingTypeInfo.ReflectionDomain;
                 IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(reflectionDomain, _reader, _field.CustomAttributes);
@@ -89,8 +91,10 @@ namespace System.Reflection.Runtime.FieldInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.FieldInfo_DeclaringType(this);
+#endif
 
                 return _contextTypeInfo.AsType();
             }
@@ -106,8 +110,10 @@ namespace System.Reflection.Runtime.FieldInfos
 
         public sealed override Object GetValue(Object obj)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.FieldInfo_GetValue(this, obj);
+#endif
 
             FieldAccessor fieldAccessor = this.FieldAccessor;
             return fieldAccessor.GetField(obj);
@@ -125,8 +131,10 @@ namespace System.Reflection.Runtime.FieldInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.FieldInfo_Name(this);
+#endif
 
                 return _field.Name.GetString(_reader);
             }
@@ -134,8 +142,10 @@ namespace System.Reflection.Runtime.FieldInfos
 
         public sealed override void SetValue(Object obj, Object value)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.FieldInfo_SetValue(this, obj, value);
+#endif
 
             FieldAccessor fieldAccessor = this.FieldAccessor;
             fieldAccessor.SetField(obj, value);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -48,8 +48,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override ParameterInfo[] GetParameters()
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodBase_GetParameters(this);
+#endif
 
             RuntimeParameterInfo[] runtimeParametersAndReturn = this.RuntimeParametersAndReturn;
             if (runtimeParametersAndReturn.Length == 1)
@@ -64,8 +66,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override Object Invoke(Object obj, Object[] parameters)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodBase_Invoke(this, obj, parameters);
+#endif
 
             if (parameters == null)
                 parameters = Array.Empty<Object>();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -62,8 +62,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override Delegate CreateDelegate(Type delegateType)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodInfo_CreateDelegate(this, delegateType);
+#endif
 
             // Legacy: The only difference between calling CreateDelegate(type) and CreateDelegate(type, null) is that the former
             // disallows closed instance delegates for V1.1 backward compatibility.
@@ -72,8 +74,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override Delegate CreateDelegate(Type delegateType, Object target)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodInfo_CreateDelegate(this, delegateType, target);
+#endif
 
             return CreateDelegate(delegateType, target, allowClosedInstanceDelegates: true);
         }
@@ -87,8 +91,11 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.MethodBase_DeclaringType(this);
+#endif
+
                 return this.RuntimeDeclaringType;
             }
         }
@@ -112,8 +119,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override ParameterInfo[] GetParameters()
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodBase_GetParameters(this);
+#endif
 
             RuntimeParameterInfo[] runtimeParameterInfos = this.GetRuntimeParametersAndReturn(this);
             if (runtimeParameterInfos.Length == 1)
@@ -126,8 +135,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override Object Invoke(Object obj, Object[] parameters)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodBase_Invoke(this, obj, parameters);
+#endif
 
             if (parameters == null)
                 parameters = Array.Empty<Object>();
@@ -161,8 +172,10 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.MethodBase_Name(this);
+#endif
                 return this.RuntimeName;
             }
         }
@@ -171,8 +184,10 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.MethodInfo_ReturnParameter(this);
+#endif
 
                 return this.GetRuntimeParametersAndReturn(this)[0];
             }
@@ -182,8 +197,10 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.MethodInfo_ReturnType(this);
+#endif
 
                 return ReturnParameter.ParameterType;
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -70,8 +70,10 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.MethodBase_CustomAttributes(this);
+#endif
 
                 return _common.CustomAttributes;
             }
@@ -103,8 +105,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override MethodInfo MakeGenericMethod(params Type[] typeArguments)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodInfo_MakeGenericMethod(this, typeArguments);
+#endif
 
             if (typeArguments == null)
                 throw new ArgumentNullException("typeArguments");

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -67,8 +67,10 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.MethodBase_CustomAttributes(this);
+#endif
 
                 return _common.CustomAttributes;
             }
@@ -78,8 +80,10 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.MethodBase_DeclaringType(this);
+#endif
 
                 return _common.DeclaringType;
             }
@@ -87,8 +91,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override Object Invoke(Object[] parameters)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.ConstructorInfo_Invoke(this, parameters);
+#endif
 
             if (parameters == null)
                 parameters = Array.Empty<Object>();
@@ -114,8 +120,10 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.MethodBase_Name(this);
+#endif
 
                 return _common.Name;
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -89,8 +89,10 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.PropertyInfo_CustomAttributes(this);
+#endif
 
                 foreach (CustomAttributeData cad in RuntimeCustomAttributeData.GetCustomAttributes(_definingTypeInfo.ReflectionDomain, _reader, _property.CustomAttributes))
                     yield return cad;
@@ -107,8 +109,10 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.PropertyInfo_DeclaringType(this);
+#endif
 
                 return _contextTypeInfo.AsType();
             }
@@ -135,8 +139,10 @@ namespace System.Reflection.Runtime.PropertyInfos
 
         public sealed override Object GetConstantValue()
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.PropertyInfo_GetConstantValue(this);
+#endif
 
             if (!(_definingTypeInfo.ReflectionDomain is ExecutionDomain))
                 throw new NotSupportedException(); // Cannot instantiate a boxed enum on a non-execution domain.
@@ -174,8 +180,10 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.PropertyInfo_GetMethod(this);
+#endif
 
                 return Getter;
             }
@@ -183,8 +191,10 @@ namespace System.Reflection.Runtime.PropertyInfos
 
         public sealed override Object GetValue(Object obj, Object[] index)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.PropertyInfo_GetValue(this, obj, index);
+#endif
 
             if (_lazyGetterInvoker == null)
             {
@@ -211,8 +221,10 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.PropertyInfo_Name(this);
+#endif
 
                 return _property.Name.GetString(_reader);
             }
@@ -222,8 +234,10 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.PropertyInfo_PropertyType(this);
+#endif
 
                 TypeContext typeContext = _contextTypeInfo.TypeContext;
                 Handle typeHandle = _property.Signature.GetPropertySignature(_reader).Type;
@@ -235,8 +249,10 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.PropertyInfo_SetMethod(this);
+#endif
 
                 return Setter;
             }
@@ -244,8 +260,10 @@ namespace System.Reflection.Runtime.PropertyInfos
 
         public sealed override void SetValue(Object obj, Object value, Object[] index)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.PropertyInfo_SetValue(this, obj, value, index);
+#endif
 
             if (_lazySetterInvoker == null)
             {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -31,8 +31,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_CustomAttributes(this);
+#endif
 
                 return GenericTypeDefinitionTypeInfo.CustomAttributes;
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -46,8 +46,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_CustomAttributes(this);
+#endif
 
                 return _asType.CustomAttributes;
             }
@@ -57,8 +59,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaringMethod(this);
+#endif
 
                 return _asType.DeclaringMethod;
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -63,8 +63,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_CustomAttributes(this);
+#endif
 
                 IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(this.ReflectionDomain, _reader, _typeDefinition.CustomAttributes);
                 foreach (CustomAttributeData cad in customAttributes)
@@ -84,8 +86,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaredNestedTypes(this);
+#endif
 
                 foreach (TypeDefinitionHandle nestedTypeHandle in _typeDefinition.NestedTypes)
                 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -51,8 +51,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_AssemblyQualifiedName(this);
+#endif
 
                 return AsType().AssemblyQualifiedName;
             }
@@ -75,8 +77,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_BaseType(this);
+#endif
 
                 // If this has a RuntimeTypeHandle, let the underlying runtime engine have the first crack. If it refuses, fall back to metadata.
                 RuntimeTypeHandle typeHandle;
@@ -115,8 +119,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_CustomAttributes(this);
+#endif
 
                 Debug.Assert(IsArray || IsByRef || IsPointer);
                 return Empty<CustomAttributeData>.Enumerable;
@@ -127,8 +133,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaredConstructors(this);
+#endif
 
                 return GetDeclaredConstructorsInternal(this.AnchoringTypeDefinitionForDeclaredMembers);
             }
@@ -138,8 +146,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaredEvents(this);
+#endif
 
                 return GetDeclaredEventsInternal(this.AnchoringTypeDefinitionForDeclaredMembers, null);
             }
@@ -149,8 +159,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaredFields(this);
+#endif
 
                 return GetDeclaredFieldsInternal(this.AnchoringTypeDefinitionForDeclaredMembers, null);
             }
@@ -160,8 +172,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaredMembers(this);
+#endif
 
                 return GetDeclaredMembersInternal(
                     this.DeclaredMethods,
@@ -177,8 +191,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaredMethods(this);
+#endif
 
                 return GetDeclaredMethodsInternal(this.AnchoringTypeDefinitionForDeclaredMembers, null);
             }
@@ -191,8 +207,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaredNestedTypes(this);
+#endif
 
                 Debug.Assert(!(this is RuntimeNamedTypeInfo));
                 return Empty<TypeInfo>.Enumerable;
@@ -203,8 +221,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaredProperties(this);
+#endif
 
                 return GetDeclaredPropertiesInternal(this.AnchoringTypeDefinitionForDeclaredMembers, null);
             }
@@ -229,8 +249,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_FullName(this);
+#endif
 
                 return AsType().FullName;
             }
@@ -266,8 +288,10 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override EventInfo GetDeclaredEvent(String name)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_GetDeclaredEvent(this, name);
+#endif
 
             if (name == null)
                 throw new ArgumentNullException("name");
@@ -278,8 +302,10 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override FieldInfo GetDeclaredField(String name)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_GetDeclaredField(this, name);
+#endif
 
             if (name == null)
                 throw new ArgumentNullException("name");
@@ -290,8 +316,10 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override MethodInfo GetDeclaredMethod(String name)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_GetDeclaredMethod(this, name);
+#endif
 
             if (name == null)
                 throw new ArgumentNullException("name");
@@ -302,8 +330,10 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override PropertyInfo GetDeclaredProperty(String name)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_GetDeclaredProperty(this, name);
+#endif
 
             if (name == null)
                 throw new ArgumentNullException("name");
@@ -484,8 +514,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_Namespace(this);
+#endif
 
                 return AsType().Namespace;
             }
@@ -531,40 +563,50 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override Type MakeArrayType()
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_MakeArrayType(this);
+#endif
 
             return AsType().MakeArrayType();
         }
 
         public sealed override Type MakeArrayType(int rank)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_MakeArrayType(this, rank);
+#endif
 
             return AsType().MakeArrayType(rank);
         }
 
         public sealed override Type MakeByRefType()
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_MakeByRefType(this);
+#endif
 
             return AsType().MakeByRefType();
         }
 
         public sealed override Type MakeGenericType(params Type[] typeArguments)
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_MakeGenericType(this, typeArguments);
+#endif
 
             return AsType().MakeGenericType(typeArguments);
         }
 
         public sealed override Type MakePointerType()
         {
+#if ENABLE_REFLECTION_TRACE
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.TypeInfo_MakePointerType(this);
+#endif
 
             return AsType().MakePointerType();
         }
@@ -581,8 +623,10 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_Name(this);
+#endif
 
                 return this.InternalName;
             }
@@ -825,9 +869,11 @@ namespace System.Reflection.Runtime.TypeInfos
             {
                 _debugName = "Constructing..."; // Protect against any inadvertent reentrancy.
                 String debugName;
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     debugName = this.GetTraceString();  // If tracing on, call this.GetTraceString() which only gives you useful strings when metadata is available but doesn't pollute the ETW trace.
                 else
+#endif
                     debugName = this.ToString();
                 if (debugName == null)
                     debugName = "";

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Types/RuntimeInspectionOnlyNamedType.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Types/RuntimeInspectionOnlyNamedType.cs
@@ -77,8 +77,10 @@ namespace System.Reflection.Runtime.Types
         {
             get
             {
+#if ENABLE_REFLECTION_TRACE
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.Type_Namespace(this);
+#endif
 
                 return EscapeIdentifier(NamespaceChain.NameSpace);
             }


### PR DESCRIPTION
This didn't pan out to be that useful in .NET Native for UWP. We might
want to completely delete it at some point.