### PR TITLE
Add validation for PowerShell accessibility, and update prerequisites…

### DIFF
--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -9,6 +9,7 @@ The following pre-requisites need to be installed for building the repo:
 Install [Visual Studio 2015](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), including Visual C++ support.
 
 PowerShell 3.0 or later is required to run the build scripts. On Windows 7, you need to install [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Later versions of Windows come with the right version of PowerShell inbox.
+PowerShell also needs to be available from the PATH environment variable. Typically it should be %SYSTEMROOT%\System32\WindowsPowerShell\v1.0\.
 
 # Ubuntu (14.04)
 

--- a/build.cmd
+++ b/build.cmd
@@ -92,6 +92,15 @@ if not exist "%__LogsDir%" md "%__LogsDir%"
 :: Check prerequisites
 echo Checking pre-requisites...
 echo.
+
+:: Validate that PowerShell is accessibile.
+for %%X in (powershell.exe) do (set __PSDir=%%~$PATH:X)
+if defined __PSDir goto EvaluatePS
+echo PowerShell is a prerequisite to build this repository.
+echo See: https://github.com/dotnet/corert/blob/master/Documentation/prerequisites-for-building.md
+exit /b 1
+
+:EvaluatePS
 :: Eval the output from probe-win1.ps1
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& ""%__SourceDir%\Native\probe-win.ps1"""') do %%a
 


### PR DESCRIPTION
… documentation.

- Added validation that PowerShell is accessible to the build script.
- Documented that PowerShell must be accessible from the PATH variable.

CC @jkotas As requested, similar fix as done in CoreCLR #3355 / #3356.
