### PR TITLE
Fix logic around invalid offsets in EmbeddedObjectNode

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
@@ -2,23 +2,37 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using ILCompiler.DependencyAnalysisFramework;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler.DependencyAnalysis
 {
     public abstract class EmbeddedObjectNode : DependencyNodeCore<NodeFactory>
     {
-        public const int InvalidOffset = 1;
+        private const int InvalidOffset = int.MinValue;
+
+        private int _offset;
+
+        public EmbeddedObjectNode()
+        {
+            _offset = InvalidOffset;
+        }
 
         public int Offset
         {
-            get;
-            set;
+            get
+            {
+                Debug.Assert(_offset != InvalidOffset);
+                return _offset;
+            }
+            set
+            {
+                Debug.Assert(_offset == InvalidOffset || _offset == value);
+                _offset = value;
+            }
         }
 
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapIndirectionNode.cs
@@ -16,7 +16,6 @@ namespace ILCompiler.DependencyAnalysis
         public InterfaceDispatchMapIndirectionNode(TypeDesc type)
         {
             _type = type;
-            base.Offset = InvalidOffset;
         }
 
         public override bool StaticDependenciesAreComputed
@@ -31,20 +30,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                if (Offset == InvalidOffset)
-                {
-                    throw new InvalidOperationException("MangledName called before Offset was initialized.");
-                }
-                
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__DispatchMap_Pointer_" + base.Offset.ToString(CultureInfo.InvariantCulture);
-            }
-        }
-
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return Offset;
+                return NodeFactory.NameMangler.CompilationUnitPrefix + "__DispatchMap_Pointer_" + Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
@@ -15,7 +15,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public StringIndirectionNode(string data)
         {
-            base.Offset = InvalidOffset;
             _data = data;
         }
 
@@ -31,20 +30,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                if (base.Offset == InvalidOffset)
-                {
-                    throw new InvalidOperationException("MangledName called before Offset was initialized.");
-                }
-
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__str" + base.Offset.ToString(CultureInfo.InvariantCulture);
-            }
-        }
-
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return base.Offset;
+                return NodeFactory.NameMangler.CompilationUnitPrefix + "__str" + Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 


### PR DESCRIPTION
* 1 is a valid offset.
* Offset validity should be enforced at the EmbeddedObjectNode level.
* ISymbolNode.Offset explicit implementation is unnecessary.