### PR TITLE
Workaround for missing debugging symbols for System.Private.* stuff

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
@@ -25,7 +25,7 @@ build.cmd clean
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`@c:\corert\bin\obj\Windows_NT.x64.Debug\ryujit.rsp`
+`-r:C:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll @c:\corert\bin\obj\Windows_NT.x64.Debug\ryujit.rsp`
 
   - Build & run using **F5**
     - This will run the compiler. The output is `c:\corert\src\ILCompiler\repro\obj\Debug\dnxcore50\native\repro.obj` file.
@@ -48,7 +48,7 @@ build.cmd clean
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`@c:\corert\bin\obj\Windows_NT.x64.Debug\cpp.rsp`
+`-r:C:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll @c:\corert\bin\obj\Windows_NT.x64.Debug\cpp.rsp`
 
     - `-nolinenumbers` command line option can be used to suppress generation of line number mappings in C++ files - useful for debugging
 

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -83,7 +83,7 @@ namespace ILCompiler
                 // HandleHelp writes to error, fails fast with crash dialog and lacks custom formatting.
                 syntax.HandleHelp = false;
                 syntax.HandleErrors = true;
-            
+
                 syntax.DefineOption("h|help", ref _help, "Help message for ILC");
                 syntax.DefineOptionList("r|reference", ref referenceFiles, "Reference file(s) for compilation");
                 syntax.DefineOption("o|out", ref _options.OutputFilePath, "Output file path");
@@ -100,7 +100,7 @@ namespace ILCompiler
                 Helpers.AppendExpandedPaths(_inputFilePaths, input, true);
 
             foreach (var reference in referenceFiles)
-                Helpers.AppendExpandedPaths(_referenceFilePaths, reference, true);
+                Helpers.AppendExpandedPaths(_referenceFilePaths, reference, false);
 
             return argSyntax;
         }


### PR DESCRIPTION
I have been running with this change to workaround issue #941. It is not perfect, but it is better than nothing until we come up with something better.