### PR TITLE
Clean up the ICompilationRootProvider interface

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/ICompilationRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ICompilationRootProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.TypeSystem;
-using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler
 {
@@ -12,8 +11,7 @@ namespace ILCompiler
     /// </summary>
     public interface ICompilationRootProvider
     {
-        void AddMethodCompilationRoot(MethodDesc method, string reason, string exportName = null);
-        void AddTypeCompilationRoot(TypeDesc type, string reason);
-        void AddMainMethodCompilationRoot(EcmaModule module);
+        void AddCompilationRoot(MethodDesc method, string reason, string exportName = null);
+        void AddCompilationRoot(TypeDesc type, string reason);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
@@ -85,7 +85,7 @@ namespace ILCompiler
                         if (method.ImplAttributes.HasFlag(System.Reflection.MethodImplAttributes.InternalCall))
                             continue;
 
-                        _rootProvider.AddMethodCompilationRoot(method, "Library module method");
+                        _rootProvider.AddCompilationRoot(method, "Library module method");
                     }
                 }
             }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -1132,7 +1132,7 @@ namespace ILCompiler.CppCodeGen
             }
         }
 
-        public void OutputCode(IEnumerable<DependencyNode> nodes)
+        public void OutputCode(IEnumerable<DependencyNode> nodes, MethodDesc entrypoint)
         {
             BuildMethodLists(nodes);
 
@@ -1209,10 +1209,8 @@ namespace ILCompiler.CppCodeGen
             Out.Write(sb.ToString());
             sb.Clear();
 
-            if (_compilation.StartupCodeMain != null)
+            if (entrypoint != null)
             {
-                var startupCodeMain = _compilation.StartupCodeMain;
-
                 // Stub for main method
                 sb.AppendLine();
                 if (_compilation.TypeSystemContext.Target.OperatingSystem == TargetOS.Windows)
@@ -1240,7 +1238,7 @@ namespace ILCompiler.CppCodeGen
                 sb.AppendEmptyLine();
                 sb.AppendLine();
                 sb.Append("int ret = ");
-                sb.Append(GetCppMethodDeclarationName(startupCodeMain.OwningType, GetCppMethodName(startupCodeMain)));
+                sb.Append(GetCppMethodDeclarationName(entrypoint.OwningType, GetCppMethodName(entrypoint)));
                 sb.Append("(argc-1, (intptr_t)(argv+1));");
 
                 sb.AppendEmptyLine();


### PR DESCRIPTION
AddMainMethodCompilationRoot method was kind of odd. It feels like a
single task is getting artificially split into two places. I'm putting
everything into compilation group.

The only reason why StartupCodeMain can't be an implementation detail of
the compilation group is because the CppWriter depends on it. We will
likely be able to make StartupCodeMain fully private to the compilation
group once CppCodegen can deal with export names and refer to it as
__managed_Main.