### PR TITLE
Match CoreCLR GetHashCode on IntPtr and UIntPtr

### DIFF
--- a/src/System.Private.CoreLib/src/System/Intptr.cs
+++ b/src/System.Private.CoreLib/src/System/Intptr.cs
@@ -241,8 +241,12 @@ namespace System
 
         public unsafe override int GetHashCode()
         {
-            // QUESTION: This HashCode seems to neglect the high order bits in calculating the hashcode?
-            return unchecked((int)((long)_value));
+#if BIT64
+            long l = (long)_value;
+            return (unchecked((int)l) ^ (int)(l >> 32));
+#else
+            return unchecked((int)_value);
+#endif
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/UIntptr.cs
+++ b/src/System.Private.CoreLib/src/System/UIntptr.cs
@@ -176,8 +176,12 @@ namespace System
 
         public unsafe override int GetHashCode()
         {
-            // QUESTION: This HashCode seems to neglect the high order bits in calculating the hashcode?
-            return unchecked((int)((long)_value)) & 0x7fffffff;
+#if BIT64
+            ulong l = (ulong)_value;
+            return (unchecked((int)l) ^ (int)(l >> 32));
+#else
+            return unchecked((int)_value);
+#endif
         }
 
         [NonVersionable]


### PR DESCRIPTION
The behavior of GetHashCode on IntPtr and UIntPtr changed to
respect the upper 32 bits in CoreCLR. This change matches that behavior.

Fix #978