### PR TITLE
Put boilerplate code into MetadataTypeSystemContext

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataTypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataTypeSystemContext.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    public abstract partial class MetadataTypeSystemContext : TypeSystemContext
+    {
+        private static readonly string[] s_wellKnownTypeNames = new string[] {
+            "Void",
+            "Boolean",
+            "Char",
+            "SByte",
+            "Byte",
+            "Int16",
+            "UInt16",
+            "Int32",
+            "UInt32",
+            "Int64",
+            "UInt64",
+            "IntPtr",
+            "UIntPtr",
+            "Single",
+            "Double",
+
+            "ValueType",
+            "Enum",
+            "Nullable`1",
+
+            "Object",
+            "String",
+            "Array",
+            "MulticastDelegate",
+
+            "RuntimeTypeHandle",
+            "RuntimeMethodHandle",
+            "RuntimeFieldHandle",
+
+            "Exception",
+        };
+
+        private MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
+
+        public MetadataTypeSystemContext()
+        {
+        }
+
+        public MetadataTypeSystemContext(TargetDetails details)
+            : base(details)
+        {
+        }
+
+        public void SetSystemModule(ModuleDesc systemModule)
+        {
+            InitializeSystemModule(systemModule);
+
+            // Sanity check the name table
+            Debug.Assert(s_wellKnownTypeNames[(int)WellKnownType.MulticastDelegate - 1] == "MulticastDelegate");
+
+            // Initialize all well known types - it will save us from checking the name for each loaded type
+            for (int typeIndex = 0; typeIndex < _wellKnownTypes.Length; typeIndex++)
+            {
+                MetadataType type = systemModule.GetType("System", s_wellKnownTypeNames[typeIndex]);
+                type.SetWellKnownType((WellKnownType)(typeIndex + 1));
+                _wellKnownTypes[typeIndex] = type;
+            }
+        }
+
+        public override DefType GetWellKnownType(WellKnownType wellKnownType)
+        {
+            return _wellKnownTypes[(int)wellKnownType - 1];
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
-using System.Runtime.CompilerServices;
+
 using Internal.NativeFormat;
 
 namespace Internal.TypeSystem
@@ -112,12 +112,12 @@ namespace Internal.TypeSystem
             {
                 protected override int GetKeyHashCode(ArrayTypeKey key)
                 {
-                    return Internal.NativeFormat.TypeHashingAlgorithms.ComputeArrayTypeHashCode(key._elementType, key._rank);
+                    return TypeHashingAlgorithms.ComputeArrayTypeHashCode(key._elementType, key._rank);
                 }
 
                 protected override int GetValueHashCode(ArrayType value)
                 {
-                    return Internal.NativeFormat.TypeHashingAlgorithms.ComputeArrayTypeHashCode(value.ElementType, value.IsSzArray ? -1 : value.Rank);
+                    return TypeHashingAlgorithms.ComputeArrayTypeHashCode(value.ElementType, value.IsSzArray ? -1 : value.Rank);
                 }
 
                 protected override bool CompareKeyToValue(ArrayTypeKey key, ArrayType value)
@@ -633,7 +633,11 @@ namespace Internal.TypeSystem
         /// Abstraction to allow the type system context to affect the field layout
         /// algorithm used by types to lay themselves out.
         /// </summary>
-        public abstract FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type);
+        public virtual FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)
+        {
+            // Type system contexts that support computing field layout need to override this.
+            throw new NotSupportedException();
+        }
 
         /// <summary>
         /// Abstraction to allow the type system context to control the interfaces
@@ -665,12 +669,20 @@ namespace Internal.TypeSystem
         /// Abstraction to allow the type system context to control the interfaces
         /// algorithm used by metadata types.
         /// </summary>
-        public abstract RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type);
+        protected virtual RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type)
+        {
+            // Type system contexts that support computing runtime interfaces need to override this.
+            throw new NotSupportedException();
+        }
 
         /// <summary>
         /// Abstraction to allow the type system context to control the interfaces
         /// algorithm used by single dimensional array types.
         /// </summary>
-        public abstract RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type);
+        protected virtual RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
+        {
+            // Type system contexts that support computing runtime interfaces need to override this.
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -19,43 +19,8 @@ using Internal.IL;
 
 namespace ILCompiler
 {
-    public class CompilerTypeSystemContext : TypeSystemContext, IMetadataStringDecoderProvider
+    public class CompilerTypeSystemContext : MetadataTypeSystemContext, IMetadataStringDecoderProvider
     {
-        private static readonly string[] s_wellKnownTypeNames = new string[] {
-            "Void",
-            "Boolean",
-            "Char",
-            "SByte",
-            "Byte",
-            "Int16",
-            "UInt16",
-            "Int32",
-            "UInt32",
-            "Int64",
-            "UInt64",
-            "IntPtr",
-            "UIntPtr",
-            "Single",
-            "Double",
-
-            "ValueType",
-            "Enum",
-            "Nullable`1",
-
-            "Object",
-            "String",
-            "Array",
-            "MulticastDelegate",
-
-            "RuntimeTypeHandle",
-            "RuntimeMethodHandle",
-            "RuntimeFieldHandle",
-
-            "Exception",
-        };
-
-        private MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
-
         private MetadataFieldLayoutAlgorithm _metadataFieldLayoutAlgorithm = new CompilerMetadataFieldLayoutAlgorithm();
         private MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
@@ -142,27 +107,6 @@ namespace ILCompiler
         {
             get;
             set;
-        }
-
-        public void SetSystemModule(EcmaModule systemModule)
-        {
-            InitializeSystemModule(systemModule);
-
-            // Sanity check the name table
-            Debug.Assert(s_wellKnownTypeNames[(int)WellKnownType.MulticastDelegate - 1] == "MulticastDelegate");
-
-            // Initialize all well known types - it will save us from checking the name for each loaded type
-            for (int typeIndex = 0; typeIndex < _wellKnownTypes.Length; typeIndex++)
-            {
-                MetadataType type = systemModule.GetKnownType("System", s_wellKnownTypeNames[typeIndex]);
-                type.SetWellKnownType((WellKnownType)(typeIndex + 1));
-                _wellKnownTypes[typeIndex] = type;
-            }
-        }
-
-        public override DefType GetWellKnownType(WellKnownType wellKnownType)
-        {
-            return _wellKnownTypes[(int)wellKnownType - 1];
         }
 
         public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name, bool throwIfNotFound)
@@ -294,7 +238,7 @@ namespace ILCompiler
             return _metadataFieldLayoutAlgorithm;
         }
 
-        public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
+        protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
         {
             if (_arrayOfTRuntimeInterfacesAlgorithm == null)
             {
@@ -303,7 +247,7 @@ namespace ILCompiler
             return _arrayOfTRuntimeInterfacesAlgorithm;
         }
 
-        public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type)
+        protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type)
         {
             return _metadataRuntimeInterfacesAlgorithm;
         }

--- a/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/Platform.cs
+++ b/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/Platform.cs
@@ -54,6 +54,8 @@ namespace System
 
     public class Array<T> : Array, System.Collections.Generic.IList<T> { }
 
+    public class Exception { }
+
     public class __ComObject : Private.CompilerServices.ICastable { }
 
     public delegate void Action();

--- a/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
@@ -14,65 +14,9 @@ using System.IO;
 
 namespace MetadataTransformTests
 {
-    class TestTypeSystemContext : TypeSystemContext
+    class TestTypeSystemContext : MetadataTypeSystemContext
     {
-        static readonly string[] s_wellKnownTypeNames = new string[] {
-            "Void",
-            "Boolean",
-            "Char",
-            "SByte",
-            "Byte",
-            "Int16",
-            "UInt16",
-            "Int32",
-            "UInt32",
-            "Int64",
-            "UInt64",
-            "IntPtr",
-            "UIntPtr",
-            "Single",
-            "Double",
-
-            "ValueType",
-            "Enum",
-            "Nullable`1",
-
-            "Object",
-            "String",
-            "Array",
-            "MulticastDelegate",
-
-            "RuntimeTypeHandle",
-            "RuntimeMethodHandle",
-            "RuntimeFieldHandle",
-        };
-
-        MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
-
-        EcmaModule _systemModule;
-
         Dictionary<string, EcmaModule> _modules = new Dictionary<string, EcmaModule>(StringComparer.OrdinalIgnoreCase);
-
-        public override DefType GetWellKnownType(WellKnownType wellKnownType)
-        {
-            return _wellKnownTypes[(int)wellKnownType - 1];
-        }
-
-        public void SetSystemModule(EcmaModule systemModule)
-        {
-            _systemModule = systemModule;
-
-            // Sanity check the name table
-            Debug.Assert(s_wellKnownTypeNames[(int)WellKnownType.MulticastDelegate - 1] == "MulticastDelegate");
-
-            // Initialize all well known types - it will save us from checking the name for each loaded type
-            for (int typeIndex = 0; typeIndex < _wellKnownTypes.Length; typeIndex++)
-            {
-                MetadataType type = _systemModule.GetType("System", s_wellKnownTypeNames[typeIndex]);
-                type.SetWellKnownType((WellKnownType)(typeIndex + 1));
-                _wellKnownTypes[typeIndex] = type;
-            }
-        }
 
         public EcmaModule GetModuleForSimpleName(string simpleName)
         {
@@ -93,21 +37,6 @@ namespace MetadataTransformTests
         public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name, bool throwIfNotFound)
         {
             return GetModuleForSimpleName(name.Name);
-        }
-
-        public override FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -88,6 +88,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataRuntimeInterfacesAlgorithm.cs" >
       <Link>TypeSystem\Common\MetadataRuntimeInterfacesAlgorithm.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataTypeSystemContext.cs" >
+      <Link>TypeSystem\Common\MetadataTypeSystemContext.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\MethodForInstantiatedType.cs" >
       <Link>TypeSystem\Common\MethodForInstantiatedType.cs</Link>
     </Compile>

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/Platform.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/Platform.cs
@@ -53,6 +53,8 @@ namespace System
     public class Attribute { }
 
     public class Array<T> : Array, System.Collections.Generic.IList<T> { }
+
+    public class Exception { }
 }
 
 namespace System.Collections

--- a/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
@@ -16,43 +16,8 @@ using System.IO;
 
 namespace TypeSystemTests
 {
-    class TestTypeSystemContext : TypeSystemContext
+    class TestTypeSystemContext : MetadataTypeSystemContext
     {
-        static readonly string[] s_wellKnownTypeNames = new string[] {
-            "Void",
-            "Boolean",
-            "Char",
-            "SByte",
-            "Byte",
-            "Int16",
-            "UInt16",
-            "Int32",
-            "UInt32",
-            "Int64",
-            "UInt64",
-            "IntPtr",
-            "UIntPtr",
-            "Single",
-            "Double",
-
-            "ValueType",
-            "Enum",
-            "Nullable`1",
-
-            "Object",
-            "String",
-            "Array",
-            "MulticastDelegate",
-
-            "RuntimeTypeHandle",
-            "RuntimeMethodHandle",
-            "RuntimeFieldHandle",
-        };
-
-        MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
-
-        ModuleDesc _systemModule;
-
         Dictionary<string, ModuleDesc> _modules = new Dictionary<string, ModuleDesc>(StringComparer.OrdinalIgnoreCase);
 
         MetadataFieldLayoutAlgorithm _metadataFieldLayout = new TestMetadataFieldLayoutAlgorithm();
@@ -62,27 +27,6 @@ namespace TypeSystemTests
         public TestTypeSystemContext(TargetArchitecture arch)
             : base(new TargetDetails(arch, TargetOS.Unknown))
         {
-        }
-
-        public override DefType GetWellKnownType(WellKnownType wellKnownType)
-        {
-            return _wellKnownTypes[(int)wellKnownType - 1];
-        }
-
-        public void SetSystemModule(ModuleDesc systemModule)
-        {
-            _systemModule = systemModule;
-
-            // Sanity check the name table
-            Debug.Assert(s_wellKnownTypeNames[(int)WellKnownType.MulticastDelegate - 1] == "MulticastDelegate");
-
-            // Initialize all well known types - it will save us from checking the name for each loaded type
-            for (int typeIndex = 0; typeIndex < _wellKnownTypes.Length; typeIndex++)
-            {
-                MetadataType type = _systemModule.GetType("System", s_wellKnownTypeNames[typeIndex]);
-                type.SetWellKnownType((WellKnownType)(typeIndex + 1));
-                _wellKnownTypes[typeIndex] = type;
-            }
         }
 
         public ModuleDesc GetModuleForSimpleName(string simpleName)
@@ -111,16 +55,16 @@ namespace TypeSystemTests
             return _metadataFieldLayout;
         }
 
-        public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
+        protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
         {
             if (_arrayOfTRuntimeInterfacesAlgorithm == null)
             {
-                _arrayOfTRuntimeInterfacesAlgorithm = new ArrayOfTRuntimeInterfacesAlgorithm(_systemModule.GetType("System", "Array`1"));
+                _arrayOfTRuntimeInterfacesAlgorithm = new ArrayOfTRuntimeInterfacesAlgorithm(SystemModule.GetType("System", "Array`1"));
             }
             return _arrayOfTRuntimeInterfacesAlgorithm;
         }
 
-        public override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type)
+        protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForMetadataType(MetadataType type)
         {
             return _metadataRuntimeInterfacesAlgorithm;
         }


### PR DESCRIPTION
There is a bunch of boilerplate code every user of the type system needs
to copy to actually use the type system. The actions are specific to
metadata based worlds - which means they fundamentally can't be in
TypeSystemContext. But they can be in a MetadataTypeSystemContext.

I'm also adding a throwing implementation for the various algorithm
retrieval methods. There are in fact uses of the type system (outside of
tests) that work just fine without providing an implementation. We
shouldn't force type system users to provide one.