### PR TITLE
Update metadata records for qualified members

### DIFF
--- a/src/Common/src/Internal/Metadata/NativeFormat/MdBinaryReaderGen.cs
+++ b/src/Common/src/Internal/Metadata/NativeFormat/MdBinaryReaderGen.cs
@@ -621,6 +621,36 @@ namespace Internal.Metadata.NativeFormat
             return offset;
         } // Read
 
+        public static uint Read(this NativeReader reader, uint offset, out QualifiedFieldHandle handle)
+        {
+            uint value;
+            offset = reader.DecodeUnsigned(offset, out value);
+            handle = new QualifiedFieldHandle((int)value);
+            handle._Validate();
+            return offset;
+        } // Read
+
+        public static uint Read(this NativeReader reader, uint offset, out QualifiedFieldHandle[] values)
+        {
+            uint count;
+            offset = reader.DecodeUnsigned(offset, out count);
+            if (count == 0)
+            {
+                values = s_emptyQualifiedFieldHandleArray;
+            }
+            else
+            {
+                values = new QualifiedFieldHandle[count];
+                for (uint i = 0; i < count; ++i)
+                {
+                    QualifiedFieldHandle tmp;
+                    offset = reader.Read(offset, out tmp);
+                    values[i] = tmp;
+                }
+            }
+            return offset;
+        } // Read
+
         public static uint Read(this NativeReader reader, uint offset, out MethodInstantiationHandle handle)
         {
             uint value;
@@ -2290,6 +2320,8 @@ namespace Internal.Metadata.NativeFormat
         private static MethodHandle[] s_emptyMethodHandleArray = new MethodHandle[0];
 
         private static QualifiedMethodHandle[] s_emptyQualifiedMethodHandleArray = new QualifiedMethodHandle[0];
+
+        private static QualifiedFieldHandle[] s_emptyQualifiedFieldHandleArray = new QualifiedFieldHandle[0];
 
         private static MethodInstantiationHandle[] s_emptyMethodInstantiationHandleArray = new MethodInstantiationHandle[0];
 

--- a/src/Common/src/Internal/Metadata/NativeFormat/NativeFormatReaderCommonGen.cs
+++ b/src/Common/src/Internal/Metadata/NativeFormat/NativeFormatReaderCommonGen.cs
@@ -126,17 +126,18 @@ namespace Internal.Metadata.NativeFormat
         PointerSignature = 0x33,
         Property = 0x34,
         PropertySignature = 0x35,
-        QualifiedMethod = 0x36,
-        ReturnTypeSignature = 0x37,
-        SZArraySignature = 0x38,
-        ScopeDefinition = 0x39,
-        ScopeReference = 0x3a,
-        TypeDefinition = 0x3b,
-        TypeForwarder = 0x3c,
-        TypeInstantiationSignature = 0x3d,
-        TypeReference = 0x3e,
-        TypeSpecification = 0x3f,
-        TypeVariableSignature = 0x40,
+        QualifiedField = 0x36,
+        QualifiedMethod = 0x37,
+        ReturnTypeSignature = 0x38,
+        SZArraySignature = 0x39,
+        ScopeDefinition = 0x3a,
+        ScopeReference = 0x3b,
+        TypeDefinition = 0x3c,
+        TypeForwarder = 0x3d,
+        TypeInstantiationSignature = 0x3e,
+        TypeReference = 0x3f,
+        TypeSpecification = 0x40,
+        TypeVariableSignature = 0x41,
     } // HandleType
 
     /// <summary>
@@ -1821,6 +1822,7 @@ namespace Internal.Metadata.NativeFormat
         TypeSpecificationHandle ToTypeSpecificationHandle(MetadataReader reader);
         ConstantInt32ArrayHandle ToConstantInt32ArrayHandle(MetadataReader reader);
         EventHandle ToEventHandle(MetadataReader reader);
+        QualifiedFieldHandle ToQualifiedFieldHandle(MetadataReader reader);
         ConstantUInt16ValueHandle ToConstantUInt16ValueHandle(MetadataReader reader);
         ConstantBooleanArrayHandle ToConstantBooleanArrayHandle(MetadataReader reader);
         GenericParameterHandle ToGenericParameterHandle(MetadataReader reader);
@@ -1955,6 +1957,7 @@ namespace Internal.Metadata.NativeFormat
         ConstantHandleArray GetConstantHandleArray(ConstantHandleArrayHandle handle);
         Method GetMethod(MethodHandle handle);
         ConstantBooleanArray GetConstantBooleanArray(ConstantBooleanArrayHandle handle);
+        QualifiedField GetQualifiedField(QualifiedFieldHandle handle);
         TypeForwarder GetTypeForwarder(TypeForwarderHandle handle);
         NamespaceDefinition GetNamespaceDefinition(NamespaceDefinitionHandle handle);
         PropertySignature GetPropertySignature(PropertySignatureHandle handle);
@@ -2694,6 +2697,50 @@ namespace Internal.Metadata.NativeFormat
     } // PropertySignatureHandle
 
     /// <summary>
+    /// IQualifiedField
+    /// </summary>
+    internal interface IQualifiedField
+    {
+        FieldHandle Field
+        {
+            get;
+        } // Field
+
+        Handle EnclosingType
+        {
+            get;
+        } // EnclosingType
+
+        QualifiedFieldHandle Handle
+        {
+            get;
+        } // Handle
+    } // IQualifiedField
+
+    /// <summary>
+    /// QualifiedField
+    /// </summary>
+    public partial struct QualifiedField : IQualifiedField
+    {
+    } // QualifiedField
+
+    /// <summary>
+    /// IQualifiedFieldHandle
+    /// </summary>
+    internal interface IQualifiedFieldHandle : IEquatable<QualifiedFieldHandle>, IEquatable<Handle>, IEquatable<Object>
+    {
+        Handle ToHandle(MetadataReader reader);
+        int GetHashCode();
+    } // IQualifiedFieldHandle
+
+    /// <summary>
+    /// QualifiedFieldHandle
+    /// </summary>
+    public partial struct QualifiedFieldHandle : IQualifiedFieldHandle
+    {
+    } // QualifiedFieldHandle
+
+    /// <summary>
     /// IQualifiedMethod
     /// </summary>
     internal interface IQualifiedMethod
@@ -2703,7 +2750,7 @@ namespace Internal.Metadata.NativeFormat
             get;
         } // Method
 
-        TypeDefinitionHandle EnclosingType
+        Handle EnclosingType
         {
             get;
         } // EnclosingType

--- a/src/Common/src/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/Common/src/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -4550,6 +4550,11 @@ namespace Internal.Metadata.NativeFormat
             return new QualifiedMethodHandle(this);
         } // ToQualifiedMethodHandle
 
+        public QualifiedFieldHandle ToQualifiedFieldHandle(MetadataReader reader)
+        {
+            return new QualifiedFieldHandle(this);
+        } // ToQualifiedFieldHandle
+
         public MethodInstantiationHandle ToMethodInstantiationHandle(MetadataReader reader)
         {
             return new MethodInstantiationHandle(this);
@@ -5093,6 +5098,15 @@ namespace Internal.Metadata.NativeFormat
             offset = _streamReader.Read(offset, out record._enclosingType);
             return record;
         } // GetQualifiedMethod
+
+        public QualifiedField GetQualifiedField(QualifiedFieldHandle handle)
+        {
+            var record = new QualifiedField() { _reader = this, _handle = handle };
+            var offset = (uint)handle.Offset;
+            offset = _streamReader.Read(offset, out record._field);
+            offset = _streamReader.Read(offset, out record._enclosingType);
+            return record;
+        } // GetQualifiedField
 
         public MethodInstantiation GetMethodInstantiation(MethodInstantiationHandle handle)
         {
@@ -5640,6 +5654,11 @@ namespace Internal.Metadata.NativeFormat
             return new Handle(handle._value);
         } // ToHandle
 
+        internal Handle ToHandle(QualifiedFieldHandle handle)
+        {
+            return new Handle(handle._value);
+        } // ToHandle
+
         internal Handle ToHandle(MethodInstantiationHandle handle)
         {
             return new Handle(handle._value);
@@ -5954,6 +5973,11 @@ namespace Internal.Metadata.NativeFormat
         {
             return new QualifiedMethodHandle(handle._value);
         } // ToQualifiedMethodHandle
+
+        internal QualifiedFieldHandle ToQualifiedFieldHandle(Handle handle)
+        {
+            return new QualifiedFieldHandle(handle._value);
+        } // ToQualifiedFieldHandle
 
         internal MethodInstantiationHandle ToMethodInstantiationHandle(Handle handle)
         {
@@ -6271,6 +6295,11 @@ namespace Internal.Metadata.NativeFormat
         } // IsNull
 
         internal bool IsNull(QualifiedMethodHandle handle)
+        {
+            return (handle._value & 0x00FFFFFF) == 0;
+        } // IsNull
+
+        internal bool IsNull(QualifiedFieldHandle handle)
         {
             return (handle._value & 0x00FFFFFF) == 0;
         } // IsNull
@@ -8448,6 +8477,129 @@ namespace Internal.Metadata.NativeFormat
     } // PropertySignatureHandle
 
     /// <summary>
+    /// QualifiedField
+    /// </summary>
+    public partial struct QualifiedField
+    {
+        internal MetadataReader _reader;
+        internal QualifiedFieldHandle _handle;
+        public QualifiedFieldHandle Handle
+        {
+            get
+            {
+                return _handle;
+            }
+        } // Handle
+
+        public FieldHandle Field
+        {
+            get
+            {
+                return _field;
+            }
+        } // Field
+
+        internal FieldHandle _field;
+        
+        /// One of: TypeDefinition, TypeSpecification
+        public Handle EnclosingType
+        {
+            get
+            {
+                return _enclosingType;
+            }
+        } // EnclosingType
+
+        internal Handle _enclosingType;
+    } // QualifiedField
+
+    /// <summary>
+    /// QualifiedFieldHandle
+    /// </summary>
+    public partial struct QualifiedFieldHandle
+    {
+        public override bool Equals(object obj)
+        {
+            if (obj is QualifiedFieldHandle)
+                return _value == ((QualifiedFieldHandle)obj)._value;
+            else if (obj is Handle)
+                return _value == ((Handle)obj)._value;
+            else
+                return false;
+        } // Equals
+
+        public bool Equals(QualifiedFieldHandle handle)
+        {
+            return _value == handle._value;
+        } // Equals
+
+        public bool Equals(Handle handle)
+        {
+            return _value == handle._value;
+        } // Equals
+
+        public override int GetHashCode()
+        {
+            return (int)_value;
+        } // GetHashCode
+
+        internal int _value;
+        internal QualifiedFieldHandle(Handle handle) : this(handle._value)
+        {
+
+        }
+
+        internal QualifiedFieldHandle(int value)
+        {
+            HandleType hType = (HandleType)(value >> 24);
+            if (!(hType == 0 || hType == HandleType.QualifiedField || hType == HandleType.Null))
+                throw new ArgumentException();
+            _value = (value & 0x00FFFFFF) | (((int)HandleType.QualifiedField) << 24);
+            _Validate();
+        }
+
+        public static implicit operator  Handle(QualifiedFieldHandle handle)
+        {
+            return new Handle(handle._value);
+        } // Handle
+
+        internal int Offset
+        {
+            get
+            {
+                return (this._value & 0x00FFFFFF);
+            }
+        } // Offset
+
+        public QualifiedField GetQualifiedField(MetadataReader reader)
+        {
+            return reader.GetQualifiedField(this);
+        } // GetQualifiedField
+
+        public bool IsNull(MetadataReader reader)
+        {
+            return reader.IsNull(this);
+        } // IsNull
+
+        public Handle ToHandle(MetadataReader reader)
+        {
+            return reader.ToHandle(this);
+        } // ToHandle
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal void _Validate()
+        {
+            if ((HandleType)((_value & 0xFF000000) >> 24) != HandleType.QualifiedField)
+                throw new ArgumentException();
+        } // _Validate
+
+        public override String ToString()
+        {
+            return String.Format("{0:X8}", _value);
+        } // ToString
+    } // QualifiedFieldHandle
+
+    /// <summary>
     /// QualifiedMethod
     /// </summary>
     public partial struct QualifiedMethod
@@ -8471,7 +8623,9 @@ namespace Internal.Metadata.NativeFormat
         } // Method
 
         internal MethodHandle _method;
-        public TypeDefinitionHandle EnclosingType
+        
+        /// One of: TypeDefinition, TypeSpecification
+        public Handle EnclosingType
         {
             get
             {
@@ -8479,7 +8633,7 @@ namespace Internal.Metadata.NativeFormat
             }
         } // EnclosingType
 
-        internal TypeDefinitionHandle _enclosingType;
+        internal Handle _enclosingType;
     } // QualifiedMethod
 
     /// <summary>

--- a/src/Common/src/Internal/Metadata/NativeFormat/Script/SchemaDef2.py
+++ b/src/Common/src/Internal/Metadata/NativeFormat/Script/SchemaDef2.py
@@ -311,8 +311,12 @@ __recordSchema = [
         ]),
     ('QualifiedMethod', None, RecordDefFlags(0), [
         ('Method', 'Method', MemberDefFlags.RecordRef),
-        ('EnclosingType', 'TypeDefinition', MemberDefFlags.RecordRef),
-    ]),
+        ('EnclosingType', ('TypeDefinition', 'TypeSpecification'), MemberDefFlags.RecordRef),
+        ]),
+    ('QualifiedField', None, RecordDefFlags(0), [
+        ('Field', 'Field', MemberDefFlags.RecordRef),
+        ('EnclosingType', ('TypeDefinition', 'TypeSpecification'), MemberDefFlags.RecordRef),
+        ]),
     ('MethodInstantiation', None, RecordDefFlags(0), [
         ('Method', MethodDefOrRef, MemberDefFlags.RecordRef),
         ('GenericTypeArguments', TypeDefOrRefOrSpec, MemberDefFlags.List | MemberDefFlags.RecordRef),

--- a/src/ILCompiler.MetadataWriter/src/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
+++ b/src/ILCompiler.MetadataWriter/src/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
@@ -495,6 +495,28 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Write
 
+        public static void Write(this NativeWriter writer, QualifiedField record)
+        {
+            if (record != null)
+                writer.WriteUnsigned((uint)record.Handle.Offset);
+            else
+                writer.WriteUnsigned(0);
+        } // Write
+
+        public static void Write(this NativeWriter writer, IEnumerable<QualifiedField> values)
+        {
+            if (values == null)
+            {
+                writer.WriteUnsigned(0);
+                return;
+            }
+            writer.WriteUnsigned((uint)values.Count());
+            foreach (QualifiedField value in values)
+            {
+                writer.Write(value);
+            }
+        } // Write
+
         public static void Write(this NativeWriter writer, MethodInstantiation record)
         {
             if (record != null)

--- a/src/ILCompiler.MetadataWriter/src/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
+++ b/src/ILCompiler.MetadataWriter/src/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
@@ -4243,6 +4243,81 @@ namespace Internal.Metadata.NativeFormat.Writer
     } // PropertySignature
 
     /// <summary>
+    /// QualifiedField
+    /// </summary>
+    public partial class QualifiedField : MetadataRecord
+    {
+        public override HandleType HandleType
+        {
+            get
+            {
+                return HandleType.QualifiedField;
+            }
+        } // HandleType
+
+        internal override void Visit(IRecordVisitor visitor)
+        {
+            Field = visitor.Visit(this, Field);
+            EnclosingType = visitor.Visit(this, EnclosingType);
+        } // Visit
+
+        public override sealed bool Equals(Object obj)
+        {
+            if (Object.ReferenceEquals(this, obj)) return true;
+            var other = obj as QualifiedField;
+            if (other == null) return false;
+            if (!Object.Equals(Field, other.Field)) return false;
+            if (!Object.Equals(EnclosingType, other.EnclosingType)) return false;
+            return true;
+        } // Equals
+
+        public override sealed int GetHashCode()
+        {
+            if (_hash != 0)
+                return _hash;
+            EnterGetHashCode();
+            int hash = -577389343;
+            hash = ((hash << 13) - (hash >> 19)) ^ (Field == null ? 0 : Field.GetHashCode());
+            hash = ((hash << 13) - (hash >> 19)) ^ (EnclosingType == null ? 0 : EnclosingType.GetHashCode());
+            LeaveGetHashCode();
+            _hash = hash;
+            return _hash;
+        } // GetHashCode
+
+        internal override void Save(NativeWriter writer)
+        {
+            writer.Write(Field);
+            Debug.Assert(EnclosingType == null ||
+                EnclosingType.HandleType == HandleType.TypeDefinition ||
+                EnclosingType.HandleType == HandleType.TypeSpecification);
+            writer.Write(EnclosingType);
+        } // Save
+
+        internal static QualifiedFieldHandle AsHandle(QualifiedField record)
+        {
+            if (record == null)
+            {
+                return new QualifiedFieldHandle(0);
+            }
+            else
+            {
+                return record.Handle;
+            }
+        } // AsHandle
+
+        internal new QualifiedFieldHandle Handle
+        {
+            get
+            {
+                return new QualifiedFieldHandle(HandleOffset);
+            }
+        } // Handle
+
+        public Field Field;
+        public MetadataRecord EnclosingType;
+    } // QualifiedField
+
+    /// <summary>
     /// QualifiedMethod
     /// </summary>
     public partial class QualifiedMethod : MetadataRecord
@@ -4287,6 +4362,9 @@ namespace Internal.Metadata.NativeFormat.Writer
         internal override void Save(NativeWriter writer)
         {
             writer.Write(Method);
+            Debug.Assert(EnclosingType == null ||
+                EnclosingType.HandleType == HandleType.TypeDefinition ||
+                EnclosingType.HandleType == HandleType.TypeSpecification);
             writer.Write(EnclosingType);
         } // Save
 
@@ -4311,7 +4389,7 @@ namespace Internal.Metadata.NativeFormat.Writer
         } // Handle
 
         public Method Method;
-        public TypeDefinition EnclosingType;
+        public MetadataRecord EnclosingType;
     } // QualifiedMethod
 
     /// <summary>


### PR DESCRIPTION
* Allow `EnclosingType` of `QualifiedMethod` be a `TypeSpecification`.
This is to allow `QualifiedMethod` to represent situations where ECMA
format uses a MemberRef.
* Introduce `QualifiedField` that mirrors what `QualifiedMethod` does,
but for fields.