### PR TITLE
Complete the timed wait for event

### DIFF
--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -65,4 +65,9 @@ extern "C"
     {
         throw "GetCurrentThreadId";
     }
+
+    uint32_t RhCompatibleReentrantWaitAny(uint32_t alertable, uint32_t timeout, uint32_t count, void* pHandles)
+    {
+        throw "RhCompatibleReentrantWaitAny";
+    }
 }

--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -1064,11 +1064,12 @@ PTR_UInt8 Thread::AllocateThreadLocalStorageForDynamicType(UInt32 uTlsTypeOffset
     return m_pDynamicTypesTlsCells[uTlsTypeOffset];
 }
 
+#ifndef PLATFORM_UNIX
 EXTERN_C REDHAWK_API UInt32 __cdecl RhCompatibleReentrantWaitAny(UInt32_BOOL alertable, UInt32 timeout, UInt32 count, HANDLE* pHandles)
 {
     return PalCompatibleWaitAny(alertable, timeout, count, pHandles, /*allowReentrantWait:*/ TRUE);
 }
-
+#endif // PLATFORM_UNIX
 
 EXTERN_C volatile UInt32 RhpTrapThreads;
 

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -127,6 +127,8 @@ typedef void* PCONTEXT;
 typedef void* PEXCEPTION_RECORD;
 typedef void* PEXCEPTION_POINTERS;
 
+#define INVALID_HANDLE_VALUE    ((HANDLE)(IntNative)-1)
+
 typedef Int32 (__stdcall *PVECTORED_EXCEPTION_HANDLER)(
     PEXCEPTION_POINTERS ExceptionInfo
     );
@@ -168,15 +170,50 @@ static pthread_key_t g_threadKey;
 extern bool PalQueryProcessorTopology();
 bool InitializeFlushProcessWriteBuffers();
 
+extern "C" void RaiseFailFastException(PEXCEPTION_RECORD arg1, PCONTEXT arg2, UInt32 arg3)
+{
+    // Abort aborts the process and causes creation of a crash dump
+    abort();
+}
+
 void TimeSpecAdd(timespec* time, uint32_t milliseconds)
 {
-    time->tv_nsec += milliseconds * tccMilliSecondsToNanoSeconds;
-    if (time->tv_nsec > tccSecondsToNanoSeconds)
+    uint64_t nsec = time->tv_nsec + (uint64_t)milliseconds * tccMilliSecondsToNanoSeconds;
+    if (nsec >= tccSecondsToNanoSeconds)
     {
-        time->tv_sec += (time->tv_nsec - tccSecondsToNanoSeconds) / tccSecondsToNanoSeconds;
-        time->tv_nsec %= tccSecondsToNanoSeconds;
+        time->tv_sec += nsec / tccSecondsToNanoSeconds;
+        nsec %= tccSecondsToNanoSeconds;
     }
+
+    time->tv_nsec = nsec;
 }
+
+#ifdef __APPLE__
+// Convert nanoseconds to the timespec structure
+// Parameters:
+//  nanoseconds - time in nanoseconds to convert
+//  t           - the target timespec structure
+void NanosecondsToTimespec(uint64_t nanoseconds, timespec* t)
+{
+    t->tv_sec = nanoseconds / tccSecondsToNanoSeconds;
+    t->tv_nsec = nanoseconds % tccSecondsToNanoSeconds;
+}
+#endif // __APPLE__
+
+void ReleaseCondAttr(pthread_condattr_t* condAttr)
+{
+    int st = pthread_condattr_destroy(condAttr);
+    ASSERT_MSG(st == 0, "Failed to destroy pthread_condattr_t object");
+}
+
+class PthreadCondAttrHolder : public Wrapper<pthread_condattr_t*, DoNothing, ReleaseCondAttr, nullptr>
+{
+public:
+    PthreadCondAttrHolder(pthread_condattr_t* attrs)
+    : Wrapper<pthread_condattr_t*, DoNothing, ReleaseCondAttr, nullptr>(attrs)
+    {
+    }
+};
 
 class UnixEvent
 {
@@ -184,70 +221,100 @@ class UnixEvent
     pthread_mutex_t m_mutex;
     bool m_manualReset;
     bool m_state;
-
-    void Update(bool state)
-    {
-        pthread_mutex_lock(&m_mutex);
-        m_state = state;
-        // Unblock all threads waiting for the condition variable
-        pthread_cond_broadcast(&m_condition);
-        pthread_mutex_unlock(&m_mutex);
-    }
+    bool m_isValid;
 
 public:
 
     UnixEvent(bool manualReset, bool initialState)
     : m_manualReset(manualReset),
-      m_state(initialState)
+      m_state(initialState),
+      m_isValid(false)
     {
-        int st = pthread_mutex_init(&m_mutex, NULL);
-        ASSERT(st == NULL);
-
-        pthread_condattr_t attrs;
-        st = pthread_condattr_init(&attrs);
-        ASSERT(st == NULL);
-
-#if HAVE_CLOCK_MONOTONIC
-        // Ensure that the pthread_cond_timedwait will use CLOCK_MONOTONIC
-        st = pthread_condattr_setclock(&attrs, CLOCK_MONOTONIC);
-        ASSERT(st == NULL);
-#endif // HAVE_CLOCK_MONOTONIC
-
-        st = pthread_cond_init(&m_condition, &attrs);
-        ASSERT(st == NULL);
-
-        st = pthread_condattr_destroy(&attrs);
-        ASSERT(st == NULL);
     }
 
-    ~UnixEvent()
+    bool Initialize()
     {
-        int st = pthread_mutex_destroy(&m_mutex);
-        ASSERT(st == NULL);
+        pthread_condattr_t attrs;
+        int st = pthread_condattr_init(&attrs);
+        if (st != 0)
+        {
+            ASSERT_UNCONDITIONALLY("Failed to initialize UnixEvent condition attribute");
+            return false;
+        }
 
-        st = pthread_cond_destroy(&m_condition);
-        ASSERT(st == NULL);
+        PthreadCondAttrHolder attrsHolder(&attrs);
+
+    #if HAVE_CLOCK_MONOTONIC
+        // Ensure that the pthread_cond_timedwait will use CLOCK_MONOTONIC
+        st = pthread_condattr_setclock(&attrs, CLOCK_MONOTONIC);
+        if (st != 0)
+        {
+            ASSERT_UNCONDITIONALLY("Failed to set UnixEvent condition variable wait clock");
+            return false;
+        }
+    #endif // HAVE_CLOCK_MONOTONIC
+
+        st = pthread_mutex_init(&m_mutex, NULL);
+        if (st != 0)
+        {
+            ASSERT_UNCONDITIONALLY("Failed to initialize UnixEvent mutex");
+            return false;
+        }
+
+        st = pthread_cond_init(&m_condition, &attrs);
+        if (st != 0)
+        {
+            ASSERT_UNCONDITIONALLY("Failed to initialize UnixEvent condition variable");
+
+            st = pthread_mutex_destroy(&m_mutex);
+            ASSERT_MSG(st == 0, "Failed to destroy UnixEvent mutex");
+            return false;
+        }
+
+        m_isValid = true;
+
+        return true;
+    }
+
+    bool Destroy()
+    {
+        bool success = true;
+
+        if (m_isValid)
+        {
+            int st = pthread_mutex_destroy(&m_mutex);
+            ASSERT_MSG(st == 0, "Failed to destroy UnixEvent mutex");
+            success = success && (st == 0);
+
+            st = pthread_cond_destroy(&m_condition);
+            ASSERT_MSG(st == 0, "Failed to destroy UnixEvent condition variable");
+            success = success && (st == 0);
+        }
+
+        return success;
     }
 
     uint32_t Wait(uint32_t milliseconds)
     {
         timespec endTime;
-
+#ifdef __APPLE__
+        uint64_t endMachTime;
+#endif
         if (milliseconds != INFINITE)
         {
 #if HAVE_CLOCK_MONOTONIC
             clock_gettime(CLOCK_MONOTONIC, &endTime);
             TimeSpecAdd(&endTime, milliseconds);
 #else // HAVE_CLOCK_MONOTONIC
-            // TODO: fix this. The time of day can be changed by the user and then the timeout
-            // would change. So we will need to use pthread_cond_timedwait_relative_np and
-            // update the relative time each time pthread_cond_timedwait gets waked.
-            // on OSX and other systems that don't support the monotonic clock
-            timeval now;
-            gettimeofday(&now, NULL);
-            endTime.tv_sec = now.tv_sec;
-            endTime.tv_nsec = now.tv_usec * tccMicroSecondsToNanoSeconds;
-            TimeSpecAdd(&endTime, milliseconds);
+
+#ifdef __APPLE__
+            uint64_t nanoseconds = (uint64_t)milliseconds * tccMilliSecondsToNanoSeconds;
+            NanosecondsToTimespec(nanoseconds, &endTime);
+            endMachTime =  mach_absolute_time() + nanoseconds * s_TimebaseInfo.denom / s_TimebaseInfo.numer;
+#else // __APPLE__
+#error Cannot perform reliable timed wait for pthread condition on this platform
+#endif // __APPLE__
+
 #endif // HAVE_CLOCK_MONOTONIC
         }
 
@@ -262,7 +329,32 @@ public:
             }
             else
             {
+#ifdef __APPLE__
+                // Since OSX doesn't support CLOCK_MONOTONIC, we use relative variant of the 
+                // timed wait and we need to handle spurious wakeups properly.
+                st = pthread_cond_timedwait_relative_np(&m_condition, &m_mutex, &endTime);
+                if ((st == 0) && !m_state)
+                {
+                    uint64_t machTime = mach_absolute_time();
+                    if (machTime < endMachTime)
+                    {
+                        // The wake up was spurious, recalculate the relative endTime
+                        uint64_t remainingNanoseconds = (endMachTime - machTime) * s_TimebaseInfo.numer / s_TimebaseInfo.denom;
+                        NanosecondsToTimespec(remainingNanoseconds, &endTime);
+                    }
+                    else
+                    {
+                        // Although the timed wait didn't report a timeout, time calculated from the
+                        // mach time shows we have already reached the end time. It can happen if
+                        // the wait was spuriously woken up right before the timeout.
+                        st = ETIMEDOUT;
+                    }
+                }
+#else // __APPLE__ 
                 st = pthread_cond_timedwait(&m_condition, &m_mutex, &endTime);
+#endif // __APPLE__
+                // Verify that if the wait timed out, the event was not set
+                ASSERT((st != ETIMEDOUT) || !m_state);
             }
 
             if (st != 0)
@@ -270,8 +362,14 @@ public:
                 // wait failed or timed out
                 break;
             }
-
         }
+
+        if ((st == 0) && !m_manualReset)
+        {
+            // Clear the state for auto-reset events so that only one waiter gets released
+            m_state = false;
+        }
+
         pthread_mutex_unlock(&m_mutex);
 
         uint32_t waitStatus;
@@ -294,16 +392,36 @@ public:
 
     void Set()
     {
-        Update(true);
+        pthread_mutex_lock(&m_mutex);
+        m_state = true;
+        pthread_mutex_unlock(&m_mutex);
+
+        // Unblock all threads waiting for the condition variable
+        pthread_cond_broadcast(&m_condition);
     }
 
     void Reset()
     {
-        Update(false);
+        pthread_mutex_lock(&m_mutex);
+        m_state = false;
+        pthread_mutex_unlock(&m_mutex);
     }
 };
 
-typedef UnixHandle<UnixHandleType::Event, UnixEvent> EventUnixHandle;
+class EventUnixHandle : public UnixHandle<UnixHandleType::Event, UnixEvent>
+{
+public:
+    EventUnixHandle(UnixEvent event)
+    : UnixHandle<UnixHandleType::Event, UnixEvent>(event)
+    {
+    }
+
+    virtual bool Destroy()
+    {
+        return m_object.Destroy();
+    }
+};
+
 typedef UnixHandle<UnixHandleType::Thread, pthread_t> ThreadUnixHandle;
 
 // Destructor of the thread local object represented by the g_threadKey,
@@ -350,12 +468,6 @@ REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalInit()
 REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalHasCapability(PalCapability capability)
 {
     return (g_dwPALCapabilities & (uint32_t)capability) == (uint32_t)capability;
-}
-
-extern "C" void RaiseFailFastException(PEXCEPTION_RECORD arg1, PCONTEXT arg2, UInt32 arg3)
-{
-    // Abort aborts the process and causes creation of a crash dump
-    abort();
 }
 
 // Attach thread to PAL. 
@@ -454,16 +566,36 @@ REDHAWK_PALEXPORT UInt32_BOOL REDHAWK_PALAPI __stdcall PalSwitchToThread()
 
 extern "C" UInt32_BOOL CloseHandle(HANDLE handle)
 {
+    if ((handle == NULL) || (handle == INVALID_HANDLE_VALUE))
+    {
+        return UInt32_FALSE;
+    }
+
     UnixHandleBase* handleBase = (UnixHandleBase*)handle;
+
+    bool success = handleBase->Destroy();
 
     delete handleBase;
 
-    return UInt32_TRUE;
+    return success ? UInt32_TRUE : UInt32_FALSE;
 }
 
 REDHAWK_PALEXPORT HANDLE REDHAWK_PALAPI PalCreateEventW(_In_opt_ LPSECURITY_ATTRIBUTES pEventAttributes, UInt32_BOOL manualReset, UInt32_BOOL initialState, _In_opt_z_ const wchar_t* pName)
 {
-    return new (nothrow) EventUnixHandle(UnixEvent(manualReset, initialState));
+    UnixEvent event = UnixEvent(manualReset, initialState);
+    if (!event.Initialize())
+    {
+        return INVALID_HANDLE_VALUE;
+    }
+
+    EventUnixHandle* handle = new (nothrow) EventUnixHandle(event);
+
+    if (handle == NULL)
+    {
+        return INVALID_HANDLE_VALUE;
+    }
+
+    return handle;
 }
 
 typedef UInt32(__stdcall *BackgroundCallback)(_In_opt_ void* pCallbackContext);

--- a/src/Native/Runtime/unix/UnixHandle.h
+++ b/src/Native/Runtime/unix/UnixHandle.h
@@ -8,7 +8,6 @@
 enum class UnixHandleType
 {
     Thread,
-    Mutex,
     Event
 };
 
@@ -23,8 +22,14 @@ protected:
     }
 
 public:
+
     virtual ~UnixHandleBase()
     {
+    }
+
+    virtual bool Destroy()
+    {
+        return true;
     }
 
     UnixHandleType GetType()
@@ -36,6 +41,7 @@ public:
 template<UnixHandleType HT, typename T>
 class UnixHandle : UnixHandleBase
 {
+protected:
     T m_object;
 public:
 


### PR DESCRIPTION
The timed waiting implementation was not finished for OSX, where
we need to use relative time wait for the cond variable to achieve
reliability even when user fiddles with the system time. Also,
autoreset events were not implemented at all.
There was also an arithmetic overflow issue in the TimeSpecAdd.

This change fixes all of these and also ifdefs out the
RhCompatibleReentrantWaitAny for Unix.