### PR TITLE
Upgrade System.Reflection.Metadata reference to v1.3

### DIFF
--- a/src/ILCompiler.Compiler/src/project.json
+++ b/src/ILCompiler.Compiler/src/project.json
@@ -1,9 +1,8 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.IO.MemoryMappedFiles": "4.0.0-rc2-23704",
-    "System.Collections.Immutable": "1.1.37",
-    "System.Reflection.Metadata": "1.1.0",
+    "NETStandard.Library": "1.0.0-rc2-23910",
+    "System.IO.MemoryMappedFiles": "4.0.0-rc2-23910",
+    "System.Reflection.Metadata": "1.3.0-rc2-23910",
     "Microsoft.DiaSymReader": "1.0.6"
   },
   "frameworks": {

--- a/src/ILCompiler.DependencyAnalysisFramework/src/project.json
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/project.json
@@ -1,8 +1,7 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.Collections.Immutable": "1.1.37",
-    "System.Xml.ReaderWriter": "4.0.0"
+    "NETStandard.Library": "1.0.0-rc2-23910",
+    "System.Collections.Immutable": "1.2.0.0-rc2-23910"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/ILCompiler.DependencyAnalysisFramework/tests/project.json
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.Collections.Immutable": "1.1.37",
+    "NETStandard.Library": "1.0.0-rc2-23910",
+    "System.Collections.Immutable": "1.2.0.0-rc2-23910",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },

--- a/src/ILCompiler.MetadataTransform/src/project.json
+++ b/src/ILCompiler.MetadataTransform/src/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.Reflection.Metadata": "1.0.22"
+    "NETStandard.Library": "1.0.0-rc2-23910",
+    "System.Reflection.Metadata": "1.3.0-rc2-23910"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/ILCompiler.MetadataTransform/tests/project.json
+++ b/src/ILCompiler.MetadataTransform/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.Reflection.Metadata": "1.0.22",
+    "NETStandard.Library": "1.0.0-rc2-23910",
+    "System.Reflection.Metadata": "1.3.0-rc2-23910",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },

--- a/src/ILCompiler.MetadataWriter/src/project.json
+++ b/src/ILCompiler.MetadataWriter/src/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
+    "NETStandard.Library": "1.0.0-rc2-23910"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/ILCompiler.TypeSystem/src/project.json
+++ b/src/ILCompiler.TypeSystem/src/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.Reflection.Metadata": "1.0.22"
+    "NETStandard.Library": "1.0.0-rc2-23910",
+    "System.Reflection.Metadata": "1.3.0-rc2-23910"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/ILCompiler.TypeSystem/tests/project.json
+++ b/src/ILCompiler.TypeSystem/tests/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704", 
+    "NETStandard.Library": "1.0.0-rc2-23910", 
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
-    "System.Reflection.Metadata": "1.0.22"
+    "System.Reflection.Metadata": "1.3.0-rc2-23910"
   },
   "frameworks": {
     "dnxcore50": { 

--- a/src/ILCompiler/desktop/App.config
+++ b/src/ILCompiler/desktop/App.config
@@ -9,6 +9,12 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
       </dependentAssembly>

--- a/src/ILCompiler/desktop/project.json
+++ b/src/ILCompiler/desktop/project.json
@@ -1,12 +1,10 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.IO.MemoryMappedFiles": "4.0.0-rc2-23704",
-    "System.Collections.Immutable": "1.2.0-rc2-23704",
-    "System.Reflection.Metadata": "1.2.0-rc2-23704",
+    "NETStandard.Library": "1.0.0-rc2-23910",
+    "System.IO.MemoryMappedFiles": "4.0.0-rc2-23910",
+    "System.Reflection.Metadata": "1.3.0-rc2-23910",
     "Microsoft.DiaSymReader": "1.0.6",
     "System.CommandLine": "0.1.0-d111815-3",
-    "System.IO.FileSystem": "4.0.1-rc2-23704"
   },
   "frameworks": {
     "net46": {

--- a/src/ILCompiler/repro/project.json
+++ b/src/ILCompiler/repro/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23819"
+        "NETStandard.Library": "1.0.0-rc2-23910"
     },
 
     "frameworks": {

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.IO.MemoryMappedFiles": "4.0.0-rc2-23704",
-    "System.Reflection.Metadata": "1.1.0",
+    "NETStandard.Library": "1.0.0-rc2-23910",
+    "System.IO.MemoryMappedFiles": "4.0.0-rc2-23910",
+    "System.Reflection.Metadata": "1.3.0-rc2-23910",
     "System.CommandLine": "0.1.0-e160208-1",
     "Microsoft.DotNet.RyuJit": "1.0.5-prerelease-00001",
     "Microsoft.DotNet.ObjectWriter": "1.0.9-prerelease-00001"

--- a/src/System.Private.Reflection.Metadata/tests/project.json
+++ b/src/System.Private.Reflection.Metadata/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
+    "NETStandard.Library": "1.0.0-rc2-23910",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },

--- a/src/System.Private.Reflection.Metadata/tests/project.json
+++ b/src/System.Private.Reflection.Metadata/tests/project.json
@@ -5,7 +5,6 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {
-    "net46": {},
     "dnxcore50": { 
         "imports": "portable-net451+win8"
     }

--- a/src/packaging/buildtools/test-runtime/project.json
+++ b/src/packaging/buildtools/test-runtime/project.json
@@ -1,8 +1,8 @@
 {
     "dependencies": {
-      "NETStandard.Library": "1.0.0-rc2-23704",
-      "Microsoft.NETCore.TestHost": "1.0.0-rc2-23704",
-      "Microsoft.NETCore.Console": "1.0.0-rc2-23704",
+      "NETStandard.Library": "1.0.0-rc2-23910",
+      "Microsoft.NETCore.TestHost": "1.0.0-rc2-23910",
+      "Microsoft.NETCore.Console": "1.0.0-rc2-23910",
       "System.IO.Compression": "4.1.0-rc2-23713",
       "coveralls.io": "1.4",
       "OpenCover": "4.6.166",

--- a/src/packaging/buildtools/tool-runtime/project.json
+++ b/src/packaging/buildtools/tool-runtime/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
+    "NETStandard.Library": "1.0.0-rc2-23910",
     "Microsoft.NETCore.TestHost": "1.0.0-beta-23328",
     "Microsoft.Cci": "4.0.0-beta-23328",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0-beta-23328",

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -98,10 +98,10 @@
                 <Dependencies><![CDATA[
         <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.9-prerelease-00001" />
         <dependency id="Microsoft.DotNet.RyuJit" version="1.0.5-prerelease-00001" />
-        <dependency id="NETStandard.Library" version="1.0.0-rc2-23704" />
-        <dependency id="System.Collections.Immutable" version="1.1.37" />
-        <dependency id="System.IO.MemoryMappedFiles" version="4.0.0-rc2-23616" />
-        <dependency id="System.Reflection.Metadata" version="1.1.0" />
+        <dependency id="NETStandard.Library" version="1.0.0-rc2-23910" />
+        <dependency id="System.Collections.Immutable" version="1.2.0-rc2-23910" />
+        <dependency id="System.IO.MemoryMappedFiles" version="4.0.0-rc2-23910" />
+        <dependency id="System.Reflection.Metadata" version="1.3.0-rc2-23910" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.0" />
         <dependency id="Microsoft.DiaSymReader" version="1.0.6" />
         <dependency id="System.CommandLine" version="0.1.0-e160208-1" />
@@ -228,7 +228,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23704",
+        "NETStandard.Library": "1.0.0-rc2-23910",
         "Microsoft.NETCore.TestHost": "1.0.0-beta-23504",
         "toolchain.$(NuPkgRid).$(RuntimeSdkPackageName)": "$(RuntimeSdkVersion)",
     },


### PR DESCRIPTION
This will let us use the custom attribute decoder that is getting newly added to S.R.M.

I had to also upgrade the NETStandard.Library reference across the board. Hopefully I didn't break anything.
