### PR TITLE
Replace numeric thread id by an opaque one

### DIFF
--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -60,4 +60,9 @@ extern "C"
     {
         throw "OutputDebugStringW";
     }
+
+    uint32_t GetCurrentThreadId()
+    {
+        throw "GetCurrentThreadId";
+    }
 }

--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -801,6 +801,8 @@ REDHAWK_PALIMPORT UInt32 REDHAWK_PALAPI PalCompatibleWaitAny(UInt32_BOOL alertab
 REDHAWK_PALIMPORT void REDHAWK_PALAPI PalAttachThread(void* thread);
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalDetachThread(void* thread);
 
+REDHAWK_PALIMPORT UInt64 PalGetCurrentThreadIdForLogging();
+
 #ifdef PLATFORM_UNIX
 REDHAWK_PALIMPORT Int32 __cdecl _stricmp(const char *string1, const char *string2);
 #endif // PLATFORM_UNIX

--- a/src/Native/Runtime/PalRedhawkFunctions.h
+++ b/src/Native/Runtime/PalRedhawkFunctions.h
@@ -86,12 +86,6 @@ inline HANDLE PalGetCurrentThread()
     return GetCurrentThread();
 }
 
-extern "C" UInt32 __stdcall GetCurrentThreadId();
-inline UInt32 PalGetCurrentThreadId()
-{
-    return GetCurrentThreadId();
-}
-
 #ifdef UNICODE
 extern "C" UInt32 __stdcall GetEnvironmentVariableW(__in_z_opt LPCWSTR, __out_z_opt LPWSTR, UInt32);
 inline UInt32 PalGetEnvironmentVariable(__in_z_opt LPCWSTR arg1, __out_z_opt LPWSTR arg2, UInt32 arg3)

--- a/src/Native/Runtime/inc/stressLog.h
+++ b/src/Native/Runtime/inc/stressLog.h
@@ -548,7 +548,7 @@ struct StressLogChunk
 //     to the corresponding field
 class ThreadStressLog {
     PTR_ThreadStressLog next;   // we keep a linked list of these
-    unsigned   threadId;        // the id for the thread using this buffer
+    EEThreadId threadId;        // the id for the thread using this buffer
     bool       isDead;          // Is this thread dead 
     StressMsg* curPtr;          // where packets are being put on the queue
     StressMsg* readPtr;         // where we are reading off the queue (used during dumping)
@@ -715,7 +715,6 @@ inline ThreadStressLog::ThreadStressLog()
     chunkListHead = chunkListTail = newChunk;
 
     next = NULL;
-    threadId = 0;
     isDead = TRUE;
     curPtr = NULL;
     readPtr = NULL;

--- a/src/Native/Runtime/stressLog.cpp
+++ b/src/Native/Runtime/stressLog.cpp
@@ -353,7 +353,7 @@ void ThreadStressLog::LogMsg ( UInt32 facility, int cArgs, const char* format, v
         msg->args[i] = data;
     }
 
-    ASSERT(IsValid() && threadId == PalGetCurrentThreadId ());
+    ASSERT(IsValid() && threadId.IsCurrentThread());
 }
 
 
@@ -361,13 +361,13 @@ void ThreadStressLog::Activate (Thread * pThread)
 {
     _ASSERTE(pThread != NULL);
     //there is no need to zero buffers because we could handle garbage contents
-    threadId = PalGetCurrentThreadId ();       
+    threadId.SetToCurrentThread();       
     isDead = FALSE;        
     curWriteChunk = chunkListTail;
     curPtr = (StressMsg *)curWriteChunk->EndPtr ();
     writeHasWrapped = FALSE;
     this->pThread = pThread;
-    ASSERT(pThread->GetPalThreadId() == threadId);
+    ASSERT(pThread->IsCurrentThread());
 }
 
 /* static */

--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -290,7 +290,8 @@ void Thread::Construct()
     // alloc_context ever needs different initialization, a matching change to the tls_CurrentThread 
     // static initialization will need to be made.
 
-    m_uPalThreadId = PalGetCurrentThreadId();
+    m_uPalThreadIdForLogging = PalGetCurrentThreadIdForLogging();
+    m_threadId.SetToCurrentThread();
 
     HANDLE curProcessPseudo = PalGetCurrentProcess();
     HANDLE curThreadPseudo  = PalGetCurrentThread();
@@ -377,9 +378,14 @@ bool Thread::CatchAtSafePoint()
 
 #ifndef DACCESS_COMPILE
 
-UInt32 Thread::GetPalThreadId()
+UInt64 Thread::GetPalThreadIdForLogging()
 {
-    return m_uPalThreadId;
+    return m_uPalThreadIdForLogging;
+}
+
+bool Thread::IsCurrentThread()
+{
+    return m_threadId.IsCurrentThread();
 }
 
 void Thread::Destroy()
@@ -710,8 +716,8 @@ bool Thread::InternalHijack(PAL_LIMITED_CONTEXT * pSuspendCtx, void* HijackTarge
         }
     }
 
-    STRESS_LOG3(LF_STACKWALK, LL_INFO10000, "InternalHijack: TgtThread = %x, IP = %p, result = %d\n", 
-        GetPalThreadId(), pSuspendCtx->GetIp(), fSuccess);
+    STRESS_LOG3(LF_STACKWALK, LL_INFO10000, "InternalHijack: TgtThread = %llx, IP = %p, result = %d\n", 
+        GetPalThreadIdForLogging(), pSuspendCtx->GetIp(), fSuccess);
 
     return fSuccess;
 }

--- a/src/Native/Runtime/thread.h
+++ b/src/Native/Runtime/thread.h
@@ -81,7 +81,8 @@ struct ThreadBuffer
     PTR_VOID                m_pStackLow;
     PTR_VOID                m_pStackHigh;
     PTR_UInt8               m_pTEB;                                 // Pointer to OS TEB structure for this thread
-    UInt32                  m_uPalThreadId;                         // @TODO: likely debug-only 
+    UInt64                  m_uPalThreadIdForLogging;               // @TODO: likely debug-only 
+    EEThreadId              m_threadId;               
     PTR_VOID                m_pThreadStressLog;                     // pointer to head of thread's StressLogChunks
 #ifdef FEATURE_GC_STRESS
     UInt32                  m_uRand;                                // current per-thread random number
@@ -165,9 +166,11 @@ public:
     bool                IsInitialized();
 
     alloc_context *     GetAllocContext();  // @TODO: I would prefer to not expose this in this way
-    UInt32              GetPalThreadId();
 
 #ifndef DACCESS_COMPILE
+    UInt64              GetPalThreadIdForLogging();
+    bool                IsCurrentThread();
+
     void                GcScanRoots(void * pfnEnumCallback, void * pvCallbackData);
 #else
     typedef void GcScanRootsCallbackFunc(PTR_RtuObjectRef ppObject, void* token, UInt32 flags);

--- a/src/Native/Runtime/threadstore.cpp
+++ b/src/Native/Runtime/threadstore.cpp
@@ -317,9 +317,11 @@ DECLSPEC_THREAD ThreadBuffer tls_CurrentThread =
     INVALID_HANDLE_VALUE,               // m_hPalThread
     0,                                  // m_ppvHijackedReturnAddressLocation
     0,                                  // m_pvHijackedReturnAddress
+    0,                                  // m_pExInfoStackHead
     0,                                  // m_pStackLow
     0,                                  // m_pStackHigh
-    0,                                  // m_uPalThreadId
+    0,                                  // m_pTEB
+    0,                                  // m_uPalThreadIdForLogging
 };
 
 #ifdef CORERT

--- a/src/Native/Runtime/unix/config.h.in
+++ b/src/Native/Runtime/unix/config.h.in
@@ -49,6 +49,9 @@
 #cmakedefine01 HAS_PTHREAD_MUTEXES
 #cmakedefine01 HAVE_TTRACE
 
+#cmakedefine01 HAVE_PTHREAD_GETTHREADID_NP
+#cmakedefine01 HAVE_LWP_SELF
+
 #cmakedefine01 HAVE_STAT_TIMESPEC
 #cmakedefine01 HAVE_STAT_NSEC
 #cmakedefine01 HAVE_TM_GMTOFF

--- a/src/Native/Runtime/unix/configure.cmake
+++ b/src/Native/Runtime/unix/configure.cmake
@@ -870,6 +870,22 @@ int main(int argc, char **argv)
         return 0;
 }" UNWIND_CONTEXT_IS_UCONTEXT_T)
 
+check_cxx_source_compiles("
+#include <pthread_np.h>
+
+int main(int argc, char **argv)
+{
+    return (int)pthread_getthreadid_np();
+}" HAVE_PTHREAD_GETTHREADID_NP)
+
+check_cxx_source_compiles("
+#include <lwp.h>
+
+int main(int argc, char **argv)
+{
+    return (int)_lwp_self();
+}" HAVE_LWP_SELF)
+
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   if(NOT HAVE_LIBUUID_H)
     unset(HAVE_LIBUUID_H CACHE)

--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -158,6 +158,11 @@ extern "C" bool PalDetachThread(void* thread)
 }
 #endif // RUNTIME_SERVICES_ONLY
 
+extern "C" UInt64 PalGetCurrentThreadIdForLogging()
+{
+    return GetCurrentThreadId();
+}
+
 #define SUPPRESS_WARNING_4127   \
     __pragma(warning(push))     \
     __pragma(warning(disable:4127)) /* conditional expression is constant*/
@@ -1348,7 +1353,7 @@ void GCToOSInterface::Shutdown()
 // current platform. It is indended for logging purposes only.
 // Return:
 //  Numeric id of the current thread or 0 if the 
-uint32_t GCToOSInterface::GetCurrentThreadIdForLogging()
+uint64_t GCToOSInterface::GetCurrentThreadIdForLogging()
 {
     return ::GetCurrentThreadId();
 }

--- a/src/Native/gc/env/gcenv.os.h
+++ b/src/Native/gc/env/gcenv.os.h
@@ -181,7 +181,7 @@ public:
     // current platform. It is indended for logging purposes only.
     // Return:
     //  Numeric id of the current thread or 0 if the 
-    static uint32_t GetCurrentThreadIdForLogging();
+    static uint64_t GetCurrentThreadIdForLogging();
 
     // Get id of the current process
     // Return:

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -399,7 +399,7 @@ void log_va_msg(const char *fmt, va_list args)
 
     pBuffer[0] = '\n';
     int buffer_start = 1;
-    int pid_len = sprintf_s (&pBuffer[buffer_start], BUFFERSIZE - buffer_start, "[%5d]", GCToOSInterface::GetCurrentThreadIdForLogging());
+    int pid_len = sprintf_s (&pBuffer[buffer_start], BUFFERSIZE - buffer_start, "[%5lld]", GCToOSInterface::GetCurrentThreadIdForLogging());
     buffer_start += pid_len;
     memset(&pBuffer[buffer_start], '-', BUFFERSIZE - buffer_start);
     int msg_len = _vsnprintf(&pBuffer[buffer_start], BUFFERSIZE - buffer_start, fmt, args );
@@ -26762,7 +26762,7 @@ uint32_t gc_heap::bgc_thread_function()
     Thread* current_thread = GetThread();
     BOOL cooperative_mode = TRUE;
     bgc_thread_id.SetToCurrentThread();
-    dprintf (1, ("bgc_thread_id is set to %Ix", GCToOSInterface::GetCurrentThreadIdForLogging()));
+    dprintf (1, ("bgc_thread_id is set to %llx", GCToOSInterface::GetCurrentThreadIdForLogging()));
     //this also indicates that the thread is ready.
     background_gc_create_event.Set();
     while (1)

--- a/src/Native/gc/sample/gcenv.windows.cpp
+++ b/src/Native/gc/sample/gcenv.windows.cpp
@@ -52,7 +52,7 @@ void GCToOSInterface::Shutdown()
 // current platform. It is indended for logging purposes only.
 // Return:
 //  Numeric id of the current thread or 0 if the 
-uint32_t GCToOSInterface::GetCurrentThreadIdForLogging()
+uint64_t GCToOSInterface::GetCurrentThreadIdForLogging()
 {
     return ::GetCurrentThreadId();
 }


### PR DESCRIPTION
This change replaces usages of the uint thread id by EEThreadId at
places where we use it for thread matching. It also adds new
PAL function PalGetThreadIdForLogging that returns a numeric thread
id for logging purposes if the target platform supports it.
The reason for this change is that in pthreads, thread id is an
opaque struct and numeric id existence is platform specific.
Finally, I have changed the return value of the 
GCToOSInterface::GetPalThreadIdForLogging to uint64_t so
that we can get and log the full id e.g. on OSX.