### PR TITLE
Implement PalGetModuleFileName for Unix

### DIFF
--- a/src/Native/Runtime/EHHelpers.cpp
+++ b/src/Native/Runtime/EHHelpers.cpp
@@ -118,7 +118,7 @@ COOP_PINVOKE_HELPER(void, RhpSetThreadDoNotTriggerGC, ())
     pThisThread->SetDoNotTriggerGc();
 }
 
-COOP_PINVOKE_HELPER(Int32, RhGetModuleFileName, (HANDLE moduleHandle, _Out_ wchar_t** pModuleNameOut))
+COOP_PINVOKE_HELPER(Int32, RhGetModuleFileName, (HANDLE moduleHandle, _Out_ const TCHAR** pModuleNameOut))
 {
     return PalGetModuleFileName(pModuleNameOut, moduleHandle);
 }

--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -50,6 +50,12 @@ typedef void *              LPOVERLAPPED;
 #define WINBASEAPI          __declspec(dllimport)
 #endif //!GCENV_INCLUDED
 
+#ifdef PLATFORM_UNIX
+#define DIRECTORY_SEPARATOR_CHAR '/'
+#else // PLATFORM_UNIX
+#define DIRECTORY_SEPARATOR_CHAR '\\'
+#endif // PLATFORM_UNIX
+
 typedef union _LARGE_INTEGER {
     struct {
 #if BIGENDIAN
@@ -708,7 +714,7 @@ REDHAWK_PALIMPORT UInt32 REDHAWK_PALAPI PalReadFileContents(_In_z_ const TCHAR *
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalGetMaximumStackBounds(_Out_ void** ppStackLowOut, _Out_ void** ppStackHighOut);
 
 // Return value:  number of characters in name string
-REDHAWK_PALIMPORT Int32 PalGetModuleFileName(_Out_ wchar_t** pModuleNameOut, HANDLE moduleBase);
+REDHAWK_PALIMPORT Int32 PalGetModuleFileName(_Out_ const TCHAR** pModuleNameOut, HANDLE moduleBase);
 
 // Various intrinsic declarations needed for the PalGetCurrentTEB implementation below.
 #if defined(_X86_)

--- a/src/Native/Runtime/RhConfig.cpp
+++ b/src/Native/Runtime/RhConfig.cpp
@@ -221,50 +221,45 @@ void RhConfig::ReadConfigIni()
 //returns the path to the runtime configuration ini
 _Ret_maybenull_z_ TCHAR* RhConfig::GetConfigPath()
 {
-    TCHAR* exePathBuff;
+    const TCHAR* exePathBuff;
 
     //get the path to rhconfig.ini, this file is expected to live along side the app 
     //to build the path get the process executable module full path strip off the file name and 
     //append rhconfig.ini
-#ifdef PLATFORM_UNIX
-    // UNIXTODO: Implement RhConfig::GetConfigPath!
-    Int32 pathLen = 0; exePathBuff = NULL;
-#else
     Int32 pathLen = PalGetModuleFileName(&exePathBuff, NULL);
-#endif
 
     if (pathLen <= 0)
     {
         return NULL;
     }
-    UInt32 iLastBackslash = 0;
+    UInt32 iLastDirSeparator = 0;
 
     for (UInt32 iPath = pathLen - 1; iPath > 0; iPath--)
     {
-        if (exePathBuff[iPath] == '\\')
+        if (exePathBuff[iPath] == DIRECTORY_SEPARATOR_CHAR)
         {
-            iLastBackslash = iPath;
+            iLastDirSeparator = iPath;
             break;
         }
     }
 
-    if (iLastBackslash == 0)
+    if (iLastDirSeparator == 0)
     {
         return NULL;
     }
 
-    TCHAR* configPath = new (nothrow) TCHAR[iLastBackslash + 1 + wcslen(CONFIG_INI_FILENAME) + 1];
+    TCHAR* configPath = new (nothrow) TCHAR[iLastDirSeparator + 1 + wcslen(CONFIG_INI_FILENAME) + 1];
     if (configPath != NULL)
     {
         //copy the path base and file name
-        for (UInt32 i = 0; i <= iLastBackslash; i++)
+        for (UInt32 i = 0; i <= iLastDirSeparator; i++)
         {
             configPath[i] = exePathBuff[i];
         }
 
         for (UInt32 i = 0; i <= wcslen(CONFIG_INI_FILENAME); i++)
         {
-            configPath[i + iLastBackslash + 1] = CONFIG_INI_FILENAME[i];
+            configPath[i + iLastDirSeparator + 1] = CONFIG_INI_FILENAME[i];
         }
     }
 

--- a/src/Native/Runtime/windows/PalRedhawkCommon.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkCommon.cpp
@@ -378,7 +378,7 @@ typedef struct _TEB {
 //NOTE:  This implementation exists because calling GetModuleFileName is not wack compliant.  if we later decide
 //       that the framework package containing mrt100_app no longer needs to be wack compliant, this should be 
 //       removed and the windows implementation of GetModuleFileName should be substitued on windows.
-REDHAWK_PALEXPORT Int32 PalGetModuleFileName(_Out_ wchar_t** pModuleNameOut, HANDLE moduleBase)
+REDHAWK_PALEXPORT Int32 PalGetModuleFileName(_Out_ const TCHAR** pModuleNameOut, HANDLE moduleBase)
 {
     TEB* pTEB = NtCurrentTeb();
     LIST_ENTRY* pStartLink = &(pTEB->ProcessEnvironmentBlock->Ldr->InMemoryOrderModuleList);

--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -190,7 +190,7 @@ extern "C" UInt64 PalGetCurrentThreadIdForLogging()
     }                                                   \
     WHILE_0;
 
-extern "C" int __stdcall PalGetModuleFileName(_Out_ wchar_t** pModuleNameOut, HANDLE moduleBase);
+extern "C" int __stdcall PalGetModuleFileName(_Out_ const TCHAR** pModuleNameOut, HANDLE moduleBase);
 
 HRESULT STDMETHODCALLTYPE AllocateThunksFromTemplate(
     _In_ HANDLE hTemplateModule,
@@ -204,7 +204,7 @@ HRESULT STDMETHODCALLTYPE AllocateThunksFromTemplate(
     bool success = false;
     HANDLE hMap = NULL, hFile = INVALID_HANDLE_VALUE;
 
-    WCHAR * wszModuleFileName = NULL;
+    const WCHAR * wszModuleFileName = NULL;
     if (PalGetModuleFileName(&wszModuleFileName, hTemplateModule) == 0 || wszModuleFileName == NULL)
         return E_FAIL;
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -675,9 +675,15 @@ namespace Internal.Runtime.Augments
         /// <param name="moduleBase">Module base address</param>
         public static unsafe String TryGetFullPathToApplicationModule(IntPtr moduleBase)
         {
+#if PLATFORM_UNIX
+            byte* pModuleNameUtf8;
+            int numUtf8Chars = RuntimeImports.RhGetModuleFileName(moduleBase, out pModuleNameUtf8);
+            String modulePath = System.Text.Encoding.UTF8.GetString(pModuleNameUtf8, numUtf8Chars);
+#else // PLATFORM_UNIX
             char* pModuleName;
             int numChars = RuntimeImports.RhGetModuleFileName(moduleBase, out pModuleName);
             String modulePath = new String(pModuleName, 0, numChars);
+#endif // PLATFORM_UNIX
             return modulePath;
         }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -531,7 +531,11 @@ namespace System.Runtime
         //
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetModuleFileName")]
+#if PLATFORM_UNIX
+        internal static extern unsafe int RhGetModuleFileName(IntPtr moduleHandle, out byte* moduleName);
+#else
         internal static extern unsafe int RhGetModuleFileName(IntPtr moduleHandle, out char* moduleName);
+#endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetExceptionsForCurrentThread")]


### PR DESCRIPTION
This change implements PalGetModuleFileName for Unix. Since the module name
passed to us is a utf-8 string, I have modified the signature of the function
to use TCHAR and then modified managed RhGetModuleFileName interop signature
to use byte* for Unix instead of char*. And I have also modified the caller
of this function, the TryGetFullPathToApplicationModule, to perform
conversion of that to .NET string.
I have also modified the RhConfig::GetConfigPath so that it works on Unix too now that 
it can extract the module path.