### PR TITLE
Fix build break in .NET Native for UWP

### DIFF
--- a/src/Native/Runtime/inc/stressLog.h
+++ b/src/Native/Runtime/inc/stressLog.h
@@ -548,12 +548,12 @@ struct StressLogChunk
 //     to the corresponding field
 class ThreadStressLog {
     PTR_ThreadStressLog next;   // we keep a linked list of these
-    EEThreadId threadId;        // the id for the thread using this buffer
+    uint64_t   threadId;        // the id for the thread using this buffer
     bool       isDead;          // Is this thread dead 
-    StressMsg* curPtr;          // where packets are being put on the queue
-    StressMsg* readPtr;         // where we are reading off the queue (used during dumping)
     bool       readHasWrapped;      // set when read ptr has passed chunListTail
     bool       writeHasWrapped;     // set when write ptr has passed chunListHead
+    StressMsg* curPtr;          // where packets are being put on the queue
+    StressMsg* readPtr;         // where we are reading off the queue (used during dumping)
     PTR_StressLogChunk chunkListHead; //head of a list of stress log chunks
     PTR_StressLogChunk chunkListTail; //tail of a list of stress log chunks
     PTR_StressLogChunk curReadChunk;  //the stress log chunk we are currently reading

--- a/src/Native/Runtime/stressLog.cpp
+++ b/src/Native/Runtime/stressLog.cpp
@@ -353,7 +353,7 @@ void ThreadStressLog::LogMsg ( UInt32 facility, int cArgs, const char* format, v
         msg->args[i] = data;
     }
 
-    ASSERT(IsValid() && threadId.IsCurrentThread());
+    ASSERT(IsValid() && threadId == PalGetCurrentThreadIdForLogging());
 }
 
 
@@ -361,7 +361,7 @@ void ThreadStressLog::Activate (Thread * pThread)
 {
     _ASSERTE(pThread != NULL);
     //there is no need to zero buffers because we could handle garbage contents
-    threadId.SetToCurrentThread();       
+    threadId = PalGetCurrentThreadIdForLogging(); 
     isDead = FALSE;        
     curWriteChunk = chunkListTail;
     curPtr = (StressMsg *)curWriteChunk->EndPtr ();
@@ -542,7 +542,9 @@ void StressLog::EnumerateStressMsgs(/*STRESSMSGCALLBACK*/void* smcbWrapper, /*EN
             // Pass a copy of the args to the callback to avoid foreign code overwriting the stress log 
             // entries (this was the case for %s arguments)
             memcpy_s(argsCopy, sizeof(argsCopy), latestMsg->args, (latestMsg->numberOfArgs)*sizeof(void*));
-            if (!smcb(latestLog->threadId, deltaTime, latestMsg->facility, format, argsCopy, token))
+
+            // @TODO: CORERT: Truncating threadId to 32-bit
+            if (!smcb((UINT32)latestLog->threadId, deltaTime, latestMsg->facility, format, argsCopy, token))
                 break;
         }
 
@@ -550,7 +552,9 @@ void StressLog::EnumerateStressMsgs(/*STRESSMSGCALLBACK*/void* smcbWrapper, /*EN
         if (latestLog->CompletedDump())
         {
             latestLog->readPtr = NULL;
-            if (!etcb(latestLog->threadId, token))
+
+            // @TODO: CORERT: Truncating threadId to 32-bit
+            if (!etcb((UINT32)latestLog->threadId, token))
                 break;
         }
     }


### PR DESCRIPTION
`smcb` and `etcb` expect the thread id as uint32_t.