### PR TITLE
Implement parser for ECMA-335 SerString format

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -24,6 +24,15 @@ namespace Internal.TypeSystem
             return type.Context.GetArrayType(type);
         }
 
+        /// <summary>
+        /// Creates a multidimensional array type with the specified rank.
+        /// To create a vector, use the <see cref="MakeArrayType(TypeDesc)"/> overload.
+        /// </summary>
+        static public ArrayType MakeArrayType(this TypeDesc type, int rank)
+        {
+            return type.Context.GetArrayType(type, rank);
+        }
+
         static public ByRefType MakeByRefType(this TypeDesc type)
         {
             return type.Context.GetByRefType(type);

--- a/src/Common/src/TypeSystem/Common/Utilities/CustomAttributeTypeNameParser.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/CustomAttributeTypeNameParser.cs
@@ -1,0 +1,433 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using AssemblyName = System.Reflection.AssemblyName;
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    // TODO: This file is pretty much a line-by-line port of C++ code to parse CA type name strings from NUTC.
+    //       It's a stopgap solution.
+    //       This should be replaced with type name parser in System.Reflection.Metadata once it starts shipping.
+
+    public static class CustomAttributeTypeNameParser
+    {
+        /// <summary>
+        /// Parses the string '<paramref name="name"/>' and returns the type corresponding to the parsed type name.
+        /// The type name string should be in the 'SerString' format as defined by the ECMA-335 standard.
+        /// </summary>
+        public static TypeDesc GetTypeByCustomAttributeTypeName(this ModuleDesc module, string name)
+        {
+            TypeDesc loadedType;
+
+            StringBuilder genericTypeDefName = new StringBuilder(name.Length);
+
+            var ch = name.Begin();
+            var nameEnd = name.End();
+
+            for (; ch < nameEnd; ++ch)
+            {
+                // Always pass escaped characters through.
+                if (ch.Current == '\\')
+                {
+                    genericTypeDefName.Append(ch.Current);
+                    ++ch;
+                    if (ch < nameEnd)
+                    {
+                        genericTypeDefName.Append(ch.Current);
+                    }
+                    continue;
+                }
+
+                // The type def name ends if
+
+                // The start of a generic argument list
+                if (ch.Current == '[')
+                    break;
+
+                // Indication that the type is a pointer
+                if (ch.Current == '*')
+                    break;
+
+                // Indication that the type is a reference
+                if (ch.Current == '&')
+                    break;
+
+                // A comma that indicates that the rest of the name is an assembly reference
+                if (ch.Current == ',')
+                    break;
+
+                genericTypeDefName.Append(ch.Current);
+            }
+
+            ModuleDesc homeModule = module;
+            AssemblyName homeAssembly = FindAssemblyIfNamePresent(name);
+            if (homeAssembly != null)
+            {
+                homeModule = module.Context.ResolveAssembly(homeAssembly);
+            }
+            MetadataType typeDef = ResolveCustomAttributeTypeNameToTypeDesc(genericTypeDefName.ToString(), homeModule);
+
+            ArrayBuilder<TypeDesc> genericArgs = new ArrayBuilder<TypeDesc>();
+
+            // Followed by generic instantiation parameters (but check for the array case)
+            if (ch < nameEnd && ch.Current == '[' && (ch + 1) < nameEnd && (ch + 1).Current != ']' && (ch + 1).Current != ',')
+            {
+                ch++; // truncate the '['
+                var genericInstantiationEnd = ch + ReadTypeArgument(ch, nameEnd, true);  // find the end of the instantiation list
+                while (ch < genericInstantiationEnd)
+                {
+                    if (ch.Current == ',')
+                        ch++;
+
+                    int argLen = ReadTypeArgument(ch, name.End(), false);
+                    string typeArgName;
+                    if (ch.Current == '[')
+                    {
+                        // This type argument name is stringified,
+                        // we need to remove the [] from around it
+                        ch++;
+                        typeArgName = StringIterator.Substring(ch, ch + (argLen - 2));
+                        ch += argLen - 1;
+                    }
+                    else
+                    {
+                        typeArgName = StringIterator.Substring(ch, ch + argLen);
+                        ch += argLen;
+                    }
+
+                    TypeDesc argType = module.GetTypeByCustomAttributeTypeName(typeArgName);
+                    genericArgs.Add(argType);
+                }
+
+                Debug.Assert(ch == genericInstantiationEnd);
+                ch++;
+
+                loadedType = typeDef.MakeInstantiatedType(new Instantiation(genericArgs.ToArray()));
+            }
+            else
+            {
+                // Non-generic type
+                loadedType = typeDef;
+            }
+
+            // At this point the characters following may be any number of * characters to indicate pointer depth
+            while (ch < nameEnd)
+            {
+                if (ch.Current == '*')
+                {
+                    loadedType = loadedType.MakePointerType();
+                }
+                else
+                {
+                    break;
+                }
+                ch++;
+            }
+
+            // Followed by any number of "[]" or "[,*]" pairs to indicate arrays
+            int commasSeen = 0;
+            bool bracketSeen = false;
+            while (ch < nameEnd)
+            {
+                if (ch.Current == '[')
+                {
+                    ch++;
+                    commasSeen = 0;
+                    bracketSeen = true;
+                }
+                else if (ch.Current == ']')
+                {
+                    if (!bracketSeen)
+                        break;
+
+                    ch++;
+                    if (commasSeen == 0)
+                    {
+                        loadedType = loadedType.MakeArrayType();
+                    }
+                    else
+                    {
+                        loadedType = loadedType.MakeArrayType(commasSeen + 1);
+                    }
+
+                    bracketSeen = false;
+                }
+                else if (ch.Current == ',')
+                {
+                    if (!bracketSeen)
+                        break;
+                    ch++;
+                    commasSeen++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            // Followed by at most one & character to indicate a byref.
+            if (ch < nameEnd)
+            {
+                if (ch.Current == '&')
+                {
+                    loadedType = loadedType.MakeByRefType();
+                    ch++;
+                }
+            }
+
+            return loadedType;
+        }
+
+
+        private static MetadataType ResolveCustomAttributeTypeNameToTypeDesc(string name, ModuleDesc module)
+        {
+            MetadataType containingType = null;
+            StringBuilder typeName = new StringBuilder(name.Length);
+            bool escaped = false;
+            for (var c = name.Begin(); c < name.End(); c++)
+            {
+                if (c.Current == '\\' && !escaped)
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (escaped)
+                {
+                    escaped = false;
+                    typeName.Append(c.Current);
+                    continue;
+                }
+
+                if (c.Current == ',')
+                {
+                    break;
+                }
+
+                if (c.Current == '[' || c.Current == '*' || c.Current == '&')
+                {
+                    break;
+                }
+
+                if (c.Current == '+')
+                {
+                    if (containingType != null)
+                    {
+                        containingType = containingType.GetNestedType(typeName.ToString());
+                    }
+                    else
+                    {
+                        containingType = module.GetType(typeName.ToString());
+                    }
+                    typeName.Length = 0;
+                    continue;
+                }
+
+                typeName.Append(c.Current);
+            }
+
+            if (containingType != null)
+            {
+                return containingType.GetNestedType(typeName.ToString());
+            }
+
+            return module.GetType(typeName.ToString());
+        }
+
+        private static MetadataType GetType(this ModuleDesc module, string fullName)
+        {
+            string namespaceName;
+            string typeName;
+            int split = fullName.LastIndexOf('.');
+            if (split < 0)
+            {
+                namespaceName = "";
+                typeName = fullName;
+            }
+            else
+            {
+                namespaceName = fullName.Substring(0, split);
+                typeName = fullName.Substring(split + 1);
+            }
+            return module.GetType(namespaceName, typeName);
+        }
+
+        private static AssemblyName FindAssemblyIfNamePresent(string name)
+        {
+            AssemblyName result = null;
+            var endOfType = name.Begin() + ReadTypeArgument(name.Begin(), name.End(), false);
+            if (endOfType < name.End() && endOfType.Current == ',')
+            {
+                // There is an assembly name here
+                int foundCommas = 0;
+                var endOfAssemblyName = endOfType;
+                for (var ch = endOfType + 1; ch < name.End(); ch++)
+                {
+                    if (foundCommas == 3)
+                    {
+                        // We're now eating the public key token, looking for the end of the name,
+                        // or a right bracket
+                        if (ch.Current == ']' || ch.Current == ',')
+                        {
+                            endOfAssemblyName = ch - 1;
+                            break;
+                        }
+                    }
+
+                    if (ch.Current == ',')
+                    {
+                        foundCommas++;
+                    }
+                }
+                if (endOfAssemblyName == endOfType)
+                {
+                    endOfAssemblyName = name.End();
+                }
+
+                // eat the comma
+                endOfType++;
+                for (; endOfType < endOfAssemblyName; ++endOfType)
+                {
+                    // trim off spaces
+                    if (endOfType.Current != ' ')
+                        break;
+                }
+                result = new AssemblyName(StringIterator.Substring(endOfType, endOfAssemblyName));
+            }
+            return result;
+        }
+
+        private static int ReadTypeArgument(StringIterator strBegin, StringIterator strEnd, bool ignoreComma)
+        {
+            int level = 0;
+            int length = 0;
+            for (var c = strBegin; c < strEnd; c++)
+            {
+                if (c.Current == '\\')
+                {
+                    length++;
+                    if ((c + 1) < strEnd)
+                    {
+                        c++;
+                        length++;
+                    }
+                    continue;
+                }
+                if (c.Current == '[')
+                {
+                    level++;
+                }
+                else if (c.Current == ']')
+                {
+                    if (level == 0)
+                        break;
+                    level--;
+                }
+                else if (!ignoreComma && (c.Current == ','))
+                {
+                    if (level == 0)
+                        break;
+                }
+
+                length++;
+            }
+
+            return length;
+        }
+
+        #region C++ string iterator compatibility shim
+
+        private static StringIterator Begin(this string s)
+        {
+            return new StringIterator(s, 0);
+        }
+
+        private static StringIterator End(this string s)
+        {
+            return new StringIterator(s, s.Length);
+        }
+
+        struct StringIterator
+        {
+            private string _string;
+            private int _index;
+
+            public char Current
+            {
+                get
+                {
+                    return _string[_index];
+                }
+            }
+
+            public StringIterator(string s, int index)
+            {
+                Debug.Assert(index <= s.Length);
+                _string = s;
+                _index = index;
+            }
+
+            public static string Substring(StringIterator it1, StringIterator it2)
+            {
+                Debug.Assert(Object.ReferenceEquals(it1._string, it2._string));
+                return it1._string.Substring(it1._index, it2._index - it1._index);
+            }
+
+            public static StringIterator operator++(StringIterator it)
+            {
+                return new StringIterator(it._string, ++it._index);
+            }
+
+            public static bool operator <(StringIterator it1, StringIterator it2)
+            {
+                Debug.Assert(Object.ReferenceEquals(it1._string, it2._string));
+                return it1._index < it2._index;
+            }
+
+            public static bool operator >(StringIterator it1, StringIterator it2)
+            {
+                Debug.Assert(Object.ReferenceEquals(it1._string, it2._string));
+                return it1._index > it2._index;
+            }
+
+            public static StringIterator operator+(StringIterator it, int val)
+            {
+                return new StringIterator(it._string, it._index + val);
+            }
+
+            public static StringIterator operator-(StringIterator it, int val)
+            {
+                return new StringIterator(it._string, it._index - val);
+            }
+
+            public static bool operator==(StringIterator it1, StringIterator it2)
+            {
+                Debug.Assert(Object.ReferenceEquals(it1._string, it2._string));
+                return it1._index == it2._index;
+            }
+
+            public static bool operator !=(StringIterator it1, StringIterator it2)
+            {
+                Debug.Assert(Object.ReferenceEquals(it1._string, it2._string));
+                return it1._index != it2._index;
+            }
+
+            public override bool Equals(object obj)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int GetHashCode()
+            {
+                throw new NotImplementedException();
+            }
+        }
+        #endregion
+    }
+}

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -31,6 +31,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\ModuleDesc.cs">
       <Link>ModuleDesc.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\CustomAttributeTypeNameParser.cs">
+      <Link>Utilities\CustomAttributeTypeNameParser.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
       <Link>Utilities\LockFreeReaderHashtable.cs</Link>
     </Compile>

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/CoreTestAssembly.csproj
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/CoreTestAssembly.csproj
@@ -31,6 +31,7 @@
     <Compile Include="Platform.cs" />
     <Compile Include="InstanceFieldLayout.cs" />
     <Compile Include="StaticFieldLayout.cs" />
+    <Compile Include="TypeNameParsing.cs" />
     <Compile Include="VirtualFunctionOverride.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/TypeNameParsing.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/TypeNameParsing.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace TypeNameParsing
+{
+    public class Generic<T>
+    {
+        public class NestedNongeneric
+        {
+        }
+
+        public class NestedGeneric<U>
+        {
+        }
+    }
+
+    public class VeryGeneric<T, U, V>
+    {
+    }
+
+    public class Simple
+    {
+        public class Nested
+        {
+            public class NestedTwice
+            {
+            }
+        }
+    }
+
+    public struct Struct
+    {
+    }
+}

--- a/src/ILCompiler.TypeSystem/tests/TypeNameParsingTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/TypeNameParsingTests.cs
@@ -1,0 +1,226 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+
+using Xunit;
+
+namespace TypeSystemTests
+{
+    public class TypeNameParsingTests
+    {
+        TestTypeSystemContext _context;
+        ModuleDesc _testModule;
+
+        string _coreAssemblyQualifier;
+
+        MetadataType _simpleType;
+        MetadataType _nestedType;
+        MetadataType _nestedTwiceType;
+
+        MetadataType _genericType;
+        MetadataType _nestedNongenericType;
+        MetadataType _nestedGenericType;
+
+        MetadataType _veryGenericType;
+
+        MetadataType _structType;
+
+        public TypeNameParsingTests()
+        {
+            _context = new TestTypeSystemContext(TargetArchitecture.X64);
+
+            // TODO-NICE: split test types into a separate, non-core, module
+            _testModule = _context.CreateModuleForSimpleName("CoreTestAssembly");
+            _context.SetSystemModule(_testModule);
+
+            _simpleType = _testModule.GetType("TypeNameParsing", "Simple");
+            _nestedType = _simpleType.GetNestedType("Nested");
+            _nestedTwiceType = _nestedType.GetNestedType("NestedTwice");
+
+            _genericType = _testModule.GetType("TypeNameParsing", "Generic`1");
+            _nestedGenericType = _genericType.GetNestedType("NestedGeneric`1");
+            _nestedNongenericType = _genericType.GetNestedType("NestedNongeneric");
+
+            _veryGenericType = _testModule.GetType("TypeNameParsing", "VeryGeneric`3");
+
+            _structType = _testModule.GetType("TypeNameParsing", "Struct");
+
+            _coreAssemblyQualifier = ((IAssemblyDesc)_testModule).GetName().FullName;
+        }
+
+        [Fact]
+        public void TestSimpleNames()
+        {
+            {
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Simple");
+                Assert.Equal(_simpleType, result);
+            }
+
+            {
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Simple+Nested");
+                Assert.Equal(_nestedType, result);
+            }
+
+            {
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Simple+Nested+NestedTwice");
+                Assert.Equal(_nestedTwiceType, result);
+            }
+
+            {
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("System.Int32, " + _coreAssemblyQualifier);
+                Assert.Equal(_context.GetWellKnownType(WellKnownType.Int32), result);
+            }
+
+            {
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.VeryGeneric`3");
+                Assert.Equal(_veryGenericType, result);
+            }
+        }
+
+        [Fact]
+        public void TestArrayTypes()
+        {
+            {
+                TypeDesc expected = _simpleType.MakeArrayType();
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Simple[]");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _simpleType.MakeArrayType().MakeArrayType().MakeArrayType();
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Simple[][][]");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _simpleType.MakeArrayType(2).MakeArrayType(3);
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Simple[,][,,]");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _context.GetWellKnownType(WellKnownType.Int32).MakeArrayType();
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("System.Int32[], " + _coreAssemblyQualifier);
+                Assert.Equal(expected, result);
+            }
+        }
+
+        [Fact]
+        public void TestPointerTypes()
+        {
+            {
+                TypeDesc expected = _structType.MakePointerType();
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Struct*");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _structType.MakePointerType().MakePointerType();
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Struct**");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _context.GetWellKnownType(WellKnownType.Int32).MakePointerType();
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("System.Int32*, " + _coreAssemblyQualifier);
+                Assert.Equal(expected, result);
+            }
+        }
+
+        [Fact]
+        public void TestInstantiatedTypes()
+        {
+            var nullableType = (MetadataType)_context.GetWellKnownType(WellKnownType.Nullable);
+
+            {
+                TypeDesc expected = _genericType.MakeInstantiatedType(new Instantiation(new[] { _simpleType }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Generic`1[TypeNameParsing.Simple]");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _veryGenericType.MakeInstantiatedType(new Instantiation(new[]
+                {
+                    _simpleType,
+                    _genericType.MakeInstantiatedType(new Instantiation(new[] { _simpleType })),
+                    _structType
+                }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.VeryGeneric`3[TypeNameParsing.Simple,TypeNameParsing.Generic`1[TypeNameParsing.Simple],TypeNameParsing.Struct]");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _genericType.MakeInstantiatedType(new Instantiation(new[] { _context.GetWellKnownType(WellKnownType.Object) }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Generic`1[[System.Object, " + _coreAssemblyQualifier + "]]");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _veryGenericType.MakeInstantiatedType(new Instantiation(new[]
+                {
+                    _context.GetWellKnownType(WellKnownType.Object),
+                    _simpleType,
+                    _context.GetWellKnownType(WellKnownType.Int32)
+                }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName(String.Format(
+                    "TypeNameParsing.VeryGeneric`3[[System.Object, {0}],TypeNameParsing.Simple,[System.Int32, {0}]]", _coreAssemblyQualifier));
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = nullableType.MakeInstantiatedType(new Instantiation(new[] { _structType }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName(String.Format(
+                    "System.Nullable`1[TypeNameParsing.Struct], {0}", _coreAssemblyQualifier));
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = nullableType.MakeInstantiatedType(new Instantiation(new[] { _context.GetWellKnownType(WellKnownType.Int32) }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName(String.Format(
+                    "System.Nullable`1[[System.Int32, {0}]], {0}", _coreAssemblyQualifier));
+                Assert.Equal(expected, result);
+            }
+        }
+
+        [Fact]
+        public void TestMixed()
+        {
+            var nullableType = (MetadataType)_context.GetWellKnownType(WellKnownType.Nullable);
+
+            {
+                TypeDesc expected = _genericType.MakeInstantiatedType(new Instantiation(new[] { _structType.MakePointerType().MakeArrayType() }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Generic`1[TypeNameParsing.Struct*[]]");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _genericType.MakeInstantiatedType(new Instantiation(new[] { _structType.MakePointerType().MakePointerType().MakeArrayType().MakeArrayType(2) }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName("TypeNameParsing.Generic`1[TypeNameParsing.Struct**[][,]]");
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _nestedNongenericType.MakeInstantiatedType(new Instantiation(new[] {
+                    nullableType.MakeInstantiatedType(new Instantiation(new[] { _structType }))
+                }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName(String.Format(
+                    "TypeNameParsing.Generic`1+NestedNongeneric[[System.Nullable`1[TypeNameParsing.Struct], {0}]]", _coreAssemblyQualifier));
+                Assert.Equal(expected, result);
+            }
+
+            {
+                TypeDesc expected = _nestedGenericType.MakeInstantiatedType(new Instantiation(new TypeDesc[] {
+                    nullableType.MakeInstantiatedType(new Instantiation(new[] { _context.GetWellKnownType(WellKnownType.Int32) })),
+                    _nestedType.MakeArrayType()
+                }));
+                TypeDesc result = _testModule.GetTypeByCustomAttributeTypeName(String.Format(
+                    "TypeNameParsing.Generic`1+NestedGeneric`1[[System.Nullable`1[[System.Int32, {0}]], {0}],TypeNameParsing.Simple+Nested[]]", _coreAssemblyQualifier));
+                Assert.Equal(expected, result);
+            }
+        }
+    }
+}

--- a/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
+++ b/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="HashcodeTests.cs" />
     <Compile Include="InterfacesTests.cs" />
     <Compile Include="TestMetadataFieldLayoutAlgorithm.cs" />
+    <Compile Include="TypeNameParsingTests.cs" />
     <Compile Include="VirtualFunctionOverrideTests.cs" />
     <Compile Include="InstanceFieldLayoutTests.cs" />
     <Compile Include="StaticFieldLayoutTests.cs" />


### PR DESCRIPTION
This format is used to represent serialized type names in custom
attribute blobs and is a prerequisite to generating custom attribute
metadata.

This is a stopgap implementation and a line-by-line port from NUTC.

Fixes #504.