### PR TITLE
Enable improved AggregateException message for CORERT builds only

### DIFF
--- a/src/System.Private.Threading/src/System.Private.Threading.csproj
+++ b/src/System.Private.Threading/src/System.Private.Threading.csproj
@@ -14,6 +14,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
 
+  <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
+    <DefineConstants>CORERT;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\AotPackageReference\AotPackageReference.depproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/System.Private.Threading/src/System/AggregateException.cs
+++ b/src/System.Private.Threading/src/System/AggregateException.cs
@@ -380,6 +380,7 @@ namespace System
             return new AggregateException(Message, flattenedExceptions);
         }
 
+#if CORERT
         /// <summary>Gets a message that describes the exception.</summary>
         public override string Message
         {
@@ -403,6 +404,7 @@ namespace System
                 return sb.ToString();
             }
         }
+#endif
 
         /// <summary>
         /// Creates and returns a string representation of the current <see cref="AggregateException"/>.


### PR DESCRIPTION
Temporary change. Tooling for .NET Native for UWP needs to be updated to be compatible with the improved exception message.