### PR TITLE
Add emission of custom attributes

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/CustomAttributeTypeProvider.cs
+++ b/src/Common/src/TypeSystem/Ecma/CustomAttributeTypeProvider.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Decoding;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem.Ecma
+{
+    public struct CustomAttributeTypeProvider : ICustomAttributeTypeProvider<TypeDesc>
+    {
+        private EcmaModule _module;
+
+        public CustomAttributeTypeProvider(EcmaModule module)
+        {
+            _module = module;
+        }
+
+        public TypeDesc GetPrimitiveType(PrimitiveTypeCode typeCode)
+        {
+            WellKnownType wkt;
+
+            switch (typeCode)
+            {
+                case PrimitiveTypeCode.Boolean:
+                    wkt = WellKnownType.Boolean;
+                    break;
+                case PrimitiveTypeCode.Byte:
+                    wkt = WellKnownType.Byte;
+                    break;
+                case PrimitiveTypeCode.Char:
+                    wkt = WellKnownType.Char;
+                    break;
+                case PrimitiveTypeCode.Double:
+                    wkt = WellKnownType.Double;
+                    break;
+                case PrimitiveTypeCode.Int16:
+                    wkt = WellKnownType.Int16;
+                    break;
+                case PrimitiveTypeCode.Int32:
+                    wkt = WellKnownType.Int32;
+                    break;
+                case PrimitiveTypeCode.Int64:
+                    wkt = WellKnownType.Int64;
+                    break;
+                case PrimitiveTypeCode.IntPtr:
+                    wkt = WellKnownType.IntPtr;
+                    break;
+                case PrimitiveTypeCode.Object:
+                    wkt = WellKnownType.Object;
+                    break;
+                case PrimitiveTypeCode.SByte:
+                    wkt = WellKnownType.SByte;
+                    break;
+                case PrimitiveTypeCode.Single:
+                    wkt = WellKnownType.Single;
+                    break;
+                case PrimitiveTypeCode.String:
+                    wkt = WellKnownType.String;
+                    break;
+                case PrimitiveTypeCode.UInt16:
+                    wkt = WellKnownType.UInt16;
+                    break;
+                case PrimitiveTypeCode.UInt32:
+                    wkt = WellKnownType.UInt32;
+                    break;
+                case PrimitiveTypeCode.UInt64:
+                    wkt = WellKnownType.UInt64;
+                    break;
+                case PrimitiveTypeCode.UIntPtr:
+                    wkt = WellKnownType.UIntPtr;
+                    break;
+                case PrimitiveTypeCode.Void:
+                    wkt = WellKnownType.Void;
+                    break;
+                case PrimitiveTypeCode.TypedReference:
+                    throw new NotSupportedException();
+                default:
+                    throw new BadImageFormatException();
+            }
+
+            return _module.Context.GetWellKnownType(wkt);
+        }
+
+        public TypeDesc GetSystemType()
+        {
+            MetadataType systemType = _module.Context.SystemModule.GetType("System", "Type");
+            return systemType;
+        }
+
+        public TypeDesc GetSZArrayType(TypeDesc elementType)
+        {
+            return elementType.MakeArrayType();
+        }
+
+        public TypeDesc GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, SignatureTypeHandleCode code)
+        {
+            Debug.Assert(reader == _module.MetadataReader);
+            return _module.GetType(handle);
+        }
+
+        public TypeDesc GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, SignatureTypeHandleCode code)
+        {
+            Debug.Assert(reader == _module.MetadataReader);
+            return _module.GetType(handle);
+        }
+
+        public TypeDesc GetTypeFromSpecification(MetadataReader reader, TypeSpecificationHandle handle, SignatureTypeHandleCode code)
+        {
+            Debug.Assert(reader == _module.MetadataReader);
+            return _module.GetType(handle);
+        }
+
+        public TypeDesc GetTypeFromSerializedName(string name)
+        {
+            if (name == null)
+                return null;
+
+            return _module.GetTypeByCustomAttributeTypeName(name);
+        }
+
+        public PrimitiveTypeCode GetUnderlyingEnumType(TypeDesc type)
+        {
+            switch (type.UnderlyingType.Category)
+            {
+                case TypeFlags.Byte:
+                    return PrimitiveTypeCode.Byte;
+                case TypeFlags.SByte:
+                    return PrimitiveTypeCode.SByte;
+                case TypeFlags.UInt16:
+                    return PrimitiveTypeCode.UInt16;
+                case TypeFlags.Int16:
+                    return PrimitiveTypeCode.Int16;
+                case TypeFlags.UInt32:
+                    return PrimitiveTypeCode.UInt32;
+                case TypeFlags.Int32:
+                    return PrimitiveTypeCode.Int32;
+                case TypeFlags.UInt64:
+                    return PrimitiveTypeCode.UInt64;
+                case TypeFlags.Int64:
+                    return PrimitiveTypeCode.Int64;
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
+        public bool IsSystemType(TypeDesc type)
+        {
+            var metadataType = type as MetadataType;
+            return metadataType != null
+                && metadataType.Name == "Type"
+                && metadataType.Module == _module.Context.SystemModule
+                && metadataType.Namespace == "System";
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
@@ -47,6 +47,14 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
+        public EcmaModule Module
+        {
+            get
+            {
+                return _module;
+            }
+        }
+
         public override TypeSystemContext Context
         {
             get

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
@@ -32,6 +32,7 @@
     <Compile Include="ILCompiler\Metadata\MetadataTransformResult.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Constant.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.CustomAttribute.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Event.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Field.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Method.cs" />

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.CustomAttribute.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.CustomAttribute.cs
@@ -1,0 +1,258 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+using Ecma = System.Reflection.Metadata;
+
+using Debug = System.Diagnostics.Debug;
+using NamedArgumentMemberKind = Internal.Metadata.NativeFormat.NamedArgumentMemberKind;
+
+namespace ILCompiler.Metadata
+{
+    partial class Transform<TPolicy>
+    {
+        private List<CustomAttribute> HandleCustomAttributes(Cts.Ecma.EcmaModule module, Ecma.CustomAttributeHandleCollection attributes)
+        {
+            List<CustomAttribute> customAttributes = new List<CustomAttribute>(attributes.Count);
+
+            var attributeTypeProvider = new Cts.Ecma.CustomAttributeTypeProvider(module);
+
+            foreach (var attributeHandle in attributes)
+            {
+                Ecma.MetadataReader reader = module.MetadataReader;
+                Ecma.CustomAttribute attribute = reader.GetCustomAttribute(attributeHandle);
+
+                // TODO-NICE: We can intern the attributes based on the CA constructor and blob bytes
+
+                Cts.MethodDesc constructor = module.GetMethod(attribute.Constructor);
+                var decodedValue = attribute.DecodeValue(attributeTypeProvider);
+
+                if (IsBlockedCustomAttribute(constructor, decodedValue))
+                    continue;
+
+                customAttributes.Add(HandleCustomAttribute(constructor, decodedValue));
+            }
+
+            return customAttributes;
+        }
+
+        private CustomAttribute HandleCustomAttribute(Cts.MethodDesc constructor, Ecma.Decoding.CustomAttributeValue<Cts.TypeDesc> decodedValue)
+        {
+            CustomAttribute result = new CustomAttribute
+            {
+                Constructor = HandleQualifiedMethod(constructor),
+            };
+
+            result.FixedArguments.Capacity = decodedValue.FixedArguments.Length;
+            foreach (var decodedArgument in decodedValue.FixedArguments)
+            {
+                var fixedArgument = new FixedArgument
+                {
+                    Type = HandleType(decodedArgument.Type),
+                    Value = HandleCustomAttributeConstantValue(decodedArgument.Type, decodedArgument.Value),
+                };
+                result.FixedArguments.Add(fixedArgument);
+            }
+
+            result.NamedArguments.Capacity = decodedValue.NamedArguments.Length;
+            foreach (var decodedArgument in decodedValue.NamedArguments)
+            {
+                var namedArgument = new NamedArgument
+                {
+                    Flags = decodedArgument.Kind == Ecma.CustomAttributeNamedArgumentKind.Field ?
+                        NamedArgumentMemberKind.Field : NamedArgumentMemberKind.Property,
+                    Name = HandleString(decodedArgument.Name),
+                    Value = new FixedArgument
+                    {
+                        Type = HandleType(decodedArgument.Type),
+                        Value = HandleCustomAttributeConstantValue(decodedArgument.Type, decodedArgument.Value)
+                    }
+                };
+                result.NamedArguments.Add(namedArgument);
+            }
+
+            return result;
+        }
+
+        private MetadataRecord HandleCustomAttributeConstantValue(Cts.TypeDesc type, object value)
+        {
+            switch (type.UnderlyingType.Category)
+            {
+                case Cts.TypeFlags.Boolean:
+                    return new ConstantBooleanValue { Value = (bool)value };
+                case Cts.TypeFlags.Byte:
+                    return new ConstantByteValue { Value = (byte)value };
+                case Cts.TypeFlags.Char:
+                    return new ConstantCharValue { Value = (char)value };
+                case Cts.TypeFlags.Double:
+                    return new ConstantDoubleValue { Value = (double)value };
+                case Cts.TypeFlags.Int16:
+                    return new ConstantInt16Value { Value = (short)value };
+                case Cts.TypeFlags.Int32:
+                    return new ConstantInt32Value { Value = (int)value };
+                case Cts.TypeFlags.Int64:
+                    return new ConstantInt64Value { Value = (long)value };
+                case Cts.TypeFlags.SByte:
+                    return new ConstantSByteValue { Value = (sbyte)value };
+                case Cts.TypeFlags.Single:
+                    return new ConstantSingleValue { Value = (float)value };
+                case Cts.TypeFlags.UInt16:
+                    return new ConstantUInt16Value { Value = (ushort)value };
+                case Cts.TypeFlags.UInt32:
+                    return new ConstantUInt32Value { Value = (uint)value };
+                case Cts.TypeFlags.UInt64:
+                    return new ConstantUInt64Value { Value = (ulong)value };
+            }
+
+            if (type.IsString)
+            {
+                return HandleString((string)value);
+            }
+
+            if (type.IsSzArray)
+            {
+                return HandleCustomAttributeConstantArray(
+                    (Cts.ArrayType)type,
+                    (ImmutableArray<Ecma.Decoding.CustomAttributeTypedArgument<Cts.TypeDesc>>)value);
+            }
+
+            if (value == null)
+            {
+                return new ConstantReferenceValue();
+            }
+
+            Debug.Assert(value is Cts.TypeDesc);
+            Debug.Assert(type is Cts.MetadataType
+                && ((Cts.MetadataType)type).Name == "Type"
+                && ((Cts.MetadataType)type).Namespace == "System");
+
+            return HandleType((Cts.TypeDesc)value);
+        }
+
+        private MetadataRecord HandleCustomAttributeConstantArray(
+            Cts.ArrayType type, ImmutableArray<Ecma.Decoding.CustomAttributeTypedArgument<Cts.TypeDesc>> value)
+        {
+            Cts.TypeDesc elementType = type.ElementType;
+
+            switch (elementType.UnderlyingType.Category)
+            {
+                case Cts.TypeFlags.Boolean:
+                    return new ConstantBooleanArray { Value = GetCustomAttributeConstantArrayElements<bool>(value) };
+                case Cts.TypeFlags.Byte:
+                    return new ConstantByteArray { Value = GetCustomAttributeConstantArrayElements<byte>(value) };
+                case Cts.TypeFlags.Char:
+                    return new ConstantCharArray { Value = GetCustomAttributeConstantArrayElements<char>(value) };
+                case Cts.TypeFlags.Double:
+                    return new ConstantDoubleArray { Value = GetCustomAttributeConstantArrayElements<double>(value) };
+                case Cts.TypeFlags.Int16:
+                    return new ConstantInt16Array { Value = GetCustomAttributeConstantArrayElements<short>(value) };
+                case Cts.TypeFlags.Int32:
+                    return new ConstantInt32Array { Value = GetCustomAttributeConstantArrayElements<int>(value) };
+                case Cts.TypeFlags.Int64:
+                    return new ConstantInt64Array { Value = GetCustomAttributeConstantArrayElements<long>(value) };
+                case Cts.TypeFlags.SByte:
+                    return new ConstantSByteArray { Value = GetCustomAttributeConstantArrayElements<sbyte>(value) };
+                case Cts.TypeFlags.Single:
+                    return new ConstantSingleArray { Value = GetCustomAttributeConstantArrayElements<float>(value) };
+                case Cts.TypeFlags.UInt16:
+                    return new ConstantUInt16Array { Value = GetCustomAttributeConstantArrayElements<ushort>(value) };
+                case Cts.TypeFlags.UInt32:
+                    return new ConstantUInt32Array { Value = GetCustomAttributeConstantArrayElements<uint>(value) };
+                case Cts.TypeFlags.UInt64:
+                    return new ConstantUInt64Array { Value = GetCustomAttributeConstantArrayElements<ulong>(value) };
+            }
+
+            if (elementType.IsString)
+            {
+                return new ConstantStringArray { Value = GetCustomAttributeConstantArrayElements<string>(value) };
+            }
+
+            var result = new ConstantHandleArray();
+            result.Value.Capacity = value.Length;
+            for (int i = 0; i < value.Length; i++)
+            {
+                MetadataRecord elementRecord = HandleCustomAttributeConstantValue(value[i].Type, value[i].Value);
+                if (value[i].Type.IsEnum)
+                {
+                    elementRecord = new ConstantBoxedEnumValue
+                    {
+                        Value = elementRecord,
+                        Type = HandleType(value[i].Type)
+                    };
+                }
+                result.Value.Add(elementRecord);
+            }
+
+            return result;
+        }
+
+        private bool IsBlockedCustomAttribute(Cts.MethodDesc constructor, Ecma.Decoding.CustomAttributeValue<Cts.TypeDesc> decodedValue)
+        {
+            if (IsBlocked(constructor.OwningType))
+                return true;
+
+            foreach (var fixedArgument in decodedValue.FixedArguments)
+            {
+                if (IsBlockedCustomAttributeConstantValue(fixedArgument.Type, fixedArgument.Value))
+                    return true;
+
+                if (fixedArgument.Type.IsEnum && IsBlocked(fixedArgument.Type))
+                    return true;
+            }
+
+            foreach (var namedArgument in decodedValue.NamedArguments)
+            {
+                if (IsBlockedCustomAttributeConstantValue(namedArgument.Type, namedArgument.Value))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private bool IsBlockedCustomAttributeConstantValue(Cts.TypeDesc type, object value)
+        {
+            if (type.IsSzArray)
+            {
+                var arrayType = (Cts.ArrayType)type;
+                var arrayValue = (ImmutableArray<Ecma.Decoding.CustomAttributeTypedArgument<Cts.TypeDesc>>)value;
+
+                if (arrayType.ElementType.UnderlyingType.IsPrimitive || arrayType.ElementType.IsString)
+                    return false;
+
+                foreach (var arrayElement in arrayValue)
+                {
+                    if (IsBlockedCustomAttributeConstantValue(arrayElement.Type, arrayElement.Value))
+                        return true;
+                    if (arrayElement.Type.IsEnum && IsBlocked(arrayElement.Type))
+                        return true;
+                }
+            }
+            else if (value is Cts.TypeDesc)
+            {
+                Debug.Assert(type is Cts.MetadataType
+                    && ((Cts.MetadataType)type).Name == "Type"
+                    && ((Cts.MetadataType)type).Namespace == "System");
+                return IsBlocked((Cts.TypeDesc)value);
+            }
+
+            return false;
+        }
+
+        private static TValue[] GetCustomAttributeConstantArrayElements<TValue>(ImmutableArray<Ecma.Decoding.CustomAttributeTypedArgument<Cts.TypeDesc>> value)
+        {
+            TValue[] result = new TValue[value.Length];
+            for (int i = 0; i < value.Length; i++)
+            {
+                result[i] = (TValue)value[i].Value;
+            }
+            return result;
+        }
+    }
+
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Event.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Event.cs
@@ -67,7 +67,11 @@ namespace ILCompiler.Metadata
                 });
             }
 
-            // TODO: CustomAttributes
+            Ecma.CustomAttributeHandleCollection customAttributes = eventDef.GetCustomAttributes();
+            if (customAttributes.Count > 0)
+            {
+                result.CustomAttributes = HandleCustomAttributes(module, customAttributes);
+            }
 
             return result;
         }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Field.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Field.cs
@@ -55,9 +55,14 @@ namespace ILCompiler.Metadata
                 {
                     record.DefaultValue = HandleConstant(ecmaField.Module, defaultValueHandle);
                 }
+
+                Ecma.CustomAttributeHandleCollection customAttributes = fieldDef.GetCustomAttributes();
+                if (customAttributes.Count > 0)
+                {
+                    record.CustomAttributes = HandleCustomAttributes(ecmaField.Module, customAttributes);
+                }
             }
 
-            // TODO: CustomAttributes
             // TODO: Offset
         }
 

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Method.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Method.cs
@@ -94,9 +94,19 @@ namespace ILCompiler.Metadata
                         paramRecord.DefaultValue = HandleConstant(ecmaEntity.Module, defaultValue);
                     }
 
-                    record.Parameters.Add(paramRecord);
+                    Ecma.CustomAttributeHandleCollection paramAttributes = param.GetCustomAttributes();
+                    if (paramAttributes.Count > 0)
+                    {
+                        paramRecord.CustomAttributes = HandleCustomAttributes(ecmaEntity.Module, paramAttributes);
+                    }
 
-                    // TODO: CustomAttributes
+                    record.Parameters.Add(paramRecord);
+                }
+
+                Ecma.CustomAttributeHandleCollection attributes = methodDef.GetCustomAttributes();
+                if (attributes.Count > 0)
+                {
+                    record.CustomAttributes = HandleCustomAttributes(ecmaEntity.Module, attributes);
                 }
             }
             else
@@ -108,7 +118,6 @@ namespace ILCompiler.Metadata
             record.ImplFlags = GetMethodImplAttributes(entity);
             
             //TODO: RVA
-            //TODO: CustomAttributes
         }
 
         private MemberReference HandleMethodReference(Cts.MethodDesc method)

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Namespace.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Namespace.cs
@@ -8,6 +8,8 @@ using Internal.Metadata.NativeFormat.Writer;
 
 using Cts = Internal.TypeSystem;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace ILCompiler.Metadata
 {
     partial class Transform<TPolicy>
@@ -16,12 +18,7 @@ namespace ILCompiler.Metadata
 
         private NamespaceDefinition HandleNamespaceDefinition(Cts.ModuleDesc parentScope, string namespaceString)
         {
-            NamespaceDefinition rootNamespace = HandleScopeDefinition(parentScope).RootNamespaceDefinition;
-
-            if (String.IsNullOrEmpty(namespaceString))
-            {
-                return rootNamespace;
-            }
+            Debug.Assert(namespaceString != null);
 
             NamespaceDefinition result;
             NamespaceKey key = new NamespaceKey(parentScope, namespaceString);
@@ -30,8 +27,20 @@ namespace ILCompiler.Metadata
                 return result;
             }
 
-            NamespaceDefinition currentNamespace = rootNamespace;
+            if (namespaceString.Length == 0)
+            {
+                var rootNamespace = new NamespaceDefinition
+                {
+                    Name = null,
+                };
+                _namespaceDefs.Add(key, rootNamespace);
+                ScopeDefinition rootScope = HandleScopeDefinition(parentScope);
+                rootScope.RootNamespaceDefinition = rootNamespace;
+                return rootNamespace;
+            }
+
             string currentNamespaceName = String.Empty;
+            NamespaceDefinition currentNamespace = HandleNamespaceDefinition(parentScope, currentNamespaceName);
             foreach (var segment in namespaceString.Split('.'))
             {
                 string nextNamespaceName = currentNamespaceName;

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Parameter.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Parameter.cs
@@ -54,11 +54,15 @@ namespace ILCompiler.Metadata
 
                 result.Flags = genParamDef.Attributes;
                 result.Name = HandleString(reader.GetString(genParamDef.Name));
+
+                Ecma.CustomAttributeHandleCollection customAttributes = genParamDef.GetCustomAttributes();
+                if (customAttributes.Count > 0)
+                {
+                    result.CustomAttributes = HandleCustomAttributes(ecmaGenParam.Module, customAttributes);
+                }
             }
             else
                 throw new NotImplementedException();
-
-            // TODO: CustomAttributes
 
             return result;
         }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Property.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Property.cs
@@ -76,7 +76,11 @@ namespace ILCompiler.Metadata
                 result.DefaultValue = HandleConstant(module, defaultValue);
             }
 
-            // TODO: CustomAttributes
+            Ecma.CustomAttributeHandleCollection customAttributes = propDef.GetCustomAttributes();
+            if (customAttributes.Count > 0)
+            {
+                result.CustomAttributes = HandleCustomAttributes(module, customAttributes);
+            }
 
             return result;
         }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Internal.Metadata.NativeFormat.Writer;
 
 using Cts = Internal.TypeSystem;
+using Ecma = System.Reflection.Metadata;
 
 using Debug = System.Diagnostics.Debug;
 using AssemblyFlags = Internal.Metadata.NativeFormat.AssemblyFlags;
@@ -61,18 +62,20 @@ namespace ILCompiler.Metadata
 
                 scopeDefinition.PublicKey = assemblyName.GetPublicKey();
 
-                // TODO: CustomAttributes
+                Cts.Ecma.EcmaModule ecmaModule = module as Cts.Ecma.EcmaModule;
+                if (ecmaModule != null)
+                {
+                    Ecma.CustomAttributeHandleCollection customAttributes = ecmaModule.AssemblyDefinition.GetCustomAttributes();
+                    if (customAttributes.Count > 0)
+                    {
+                        scopeDefinition.CustomAttributes = HandleCustomAttributes(ecmaModule, customAttributes);
+                    }
+                }
             }
             else
             {
                 throw new NotSupportedException("Multi-module assemblies");
             }
-
-            scopeDefinition.RootNamespaceDefinition = new NamespaceDefinition
-            {
-                Name = null,
-                ParentScopeOrNamespace = scopeDefinition,
-            };
         }
 
         private EntityMap<Cts.ModuleDesc, ScopeReference> _scopeRefs

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -298,7 +298,11 @@ namespace ILCompiler.Metadata
                         record.Properties.Add(prop);
                 }
 
-                // TODO: CustomAttributes
+                Ecma.CustomAttributeHandleCollection customAttributes = ecmaRecord.GetCustomAttributes();
+                if (customAttributes.Count > 0)
+                {
+                    record.CustomAttributes = HandleCustomAttributes(ecmaEntity.EcmaModule, customAttributes);
+                }
             }
 
             // TODO: MethodImpls

--- a/src/ILCompiler.MetadataTransform/tests/MultifileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/MultifileMetadataPolicy.cs
@@ -44,6 +44,9 @@ namespace MetadataTransformTests
             if (typeDef.Name == "ICastable")
                 return true;
 
+            if (typeDef.HasCustomAttribute("System.Runtime.CompilerServices", "__BlockReflectionAttribute"))
+                return true;
+
             return false;
         }
     }

--- a/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/BlockedMetadata.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/BlockedMetadata.cs
@@ -1,0 +1,111 @@
+﻿// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable 169 // Field 'x' is never used
+
+namespace System.Runtime.CompilerServices
+{
+    [__BlockReflection]
+    public class __BlockReflectionAttribute : Attribute
+    {
+    }
+}
+
+namespace BlockedMetadata
+{
+    [__BlockReflection]
+    public class BlockedType
+    {
+    }
+
+    public class AllowedType
+    {
+    }
+
+    [__BlockReflection]
+    public class BlockedGenericType<T>
+    {
+    }
+
+    public class AllowedGenericType<T>
+    {
+    }
+
+    [__BlockReflection]
+    public enum BlockedEnum
+    {
+        One,
+        Two,
+    }
+
+    public enum AllowedEnum
+    {
+        One,
+        Two,
+    }
+
+    public class AttributeHolder
+    {
+        [My(typeof(AllowedType))]
+        int AllowedNongeneric;
+
+        [My(typeof(BlockedType))]
+        int BlockedNongeneric;
+
+        [My(typeof(AllowedGenericType<AllowedType>))]
+        int AllowedGeneric;
+
+        [My(typeof(BlockedGenericType<AllowedType>))]
+        int BlockedGeneric;
+
+        [My(typeof(AllowedGenericType<BlockedType>))]
+        int BlockedGenericInstantiation;
+
+        [My(typeof(AllowedGenericType<BlockedType[]>))]
+        int BlockedArrayGenericInstantiation;
+
+        [My(AllowedEnum.One)]
+        int AllowedEnumType;
+
+        [My(BlockedEnum.One)]
+        int BlockedEnumType;
+
+        [Blocked]
+        int BlockedAttribute;
+
+        [My(new object[] { typeof(AllowedType) })]
+        int AllowedTypeArray;
+
+        [My(new object[] { typeof(BlockedType)})]
+        int BlockedTypeArray;
+
+        [My(new object[] { AllowedEnum.One })]
+        int AllowedEnumArray;
+
+        [My(new object[] { BlockedEnum.One})]
+        int BlockedEnumArray;
+    }
+
+    public class MyAttribute : Attribute
+    {
+        public MyAttribute(Type type)
+        {
+        }
+
+        public MyAttribute(object[] o)
+        {
+        }
+
+        public MyAttribute(object o)
+        {
+        }
+    }
+
+    [__BlockReflection]
+    public class BlockedAttribute : Attribute
+    {
+    }
+}

--- a/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadataAssembly.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadataAssembly.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="BlockedMetadata.cs" />
     <Compile Include="SampleMetadata.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
@@ -30,6 +30,9 @@ namespace MetadataTransformTests
             if (typeDef.Name == "ICastable")
                 return true;
 
+            if (typeDef.HasCustomAttribute("System.Runtime.CompilerServices", "__BlockReflectionAttribute"))
+                return true;
+
             return false;
         }
     }

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -154,6 +154,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\RuntimeInterfacesAlgorithm.cs" >
       <Link>TypeSystem\Common\RuntimeInterfacesAlgorithm.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\CustomAttributeTypeProvider.cs">
+      <Link>Ecma\CustomAttributeTypeProvider.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.cs">
       <Link>Ecma\EcmaField.cs</Link>
     </Compile>


### PR DESCRIPTION
This includes:
* An implementation of ICustomAttributeTypeProvider from S.R.Metadata
* Generation of CustomAttribute records
* Calls to generate custom attributes for HasCustomAttribute metadata records

This also includes a test to test the tricky part of making
custom attributes disappear from metadata if they refer to types
that are blocked from reflection.