### PR TITLE
Enable Project N reflection stack

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
+++ b/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
@@ -103,7 +103,7 @@ namespace Internal.JitInterface
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_StringGetChar, "get_Chars", "System", "String");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_StringLength, "get_Length", "System", "String");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_InitializeArray, "InitializeArray", "System.Runtime.CompilerServices", "RuntimeHelpers");
-            table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetTypeFromHandle, "GetTypeFromHandle", "System", "Type");
+            //table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetTypeFromHandle, "GetTypeFromHandle", "System", "Type"); // RuntimeTypeHandle has to be RuntimeType
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_RTH_GetValueInternal, "GetValueInternal", "System", "RuntimeTypeHandle");
             // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_TypeEQ, "op_Equality", "System", "Type"); // not in .NET Core
             // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_TypeNEQ, "op_Inequality", "System", "Type"); // not in .NET Core

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -227,7 +227,7 @@ namespace Internal.Runtime.Augments
 
         public static RuntimeTypeHandle CreateRuntimeTypeHandle(IntPtr ldTokenResult)
         {
-#if CORERT // CORERT-TODO: RuntimeTypeHandle
+#if CLR_RUNTIMETYPEHANDLE // CORERT-TODO: RuntimeTypeHandle
             throw new NotImplementedException();
 #else
             return new RuntimeTypeHandle(new EETypePtr(ldTokenResult));

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LdTokenHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LdTokenHelpers.cs
@@ -15,7 +15,11 @@ namespace Internal.Runtime.CompilerHelpers
     {
         private static RuntimeTypeHandle GetRuntimeTypeHandle(IntPtr pEEType)
         {
+#if CLR_RUNTIMETYPEHANDLE
             return new RuntimeTypeHandle(ReflectionCoreNonPortable.GetRuntimeTypeForEEType(new EETypePtr(pEEType)));
+#else
+            return new RuntimeTypeHandle(new EETypePtr(pEEType));
+#endif
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -84,6 +84,8 @@
   <ItemGroup Condition="'$(IsProjectNLibrary)' == 'true'">
     <Compile Include="Internal\Runtime\Augments\ReflectionTraceCallbacks.cs" />
     <Compile Include="Internal\Runtime\Augments\ReflectionTraceConnector.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="Internal\Reflection\Core\NonPortable\BlockedRuntimeTypeNameGenerator.cs" />
     <Compile Include="Internal\Reflection\Core\NonPortable\ConstructedGenericTypeKey.cs" />
     <Compile Include="Internal\Reflection\Core\NonPortable\RawRuntimeTypeHandleKey.cs" />
@@ -107,17 +109,19 @@
     <Compile Include="Internal\Reflection\Core\NonPortable\ReflectionCoreNonPortable.cs" />
     <Compile Include="Internal\Reflection\MetadataTransformedAttribute.cs" />
     <Compile Include="Internal\Reflection\ExplicitScopeAttribute.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsProjectNLibrary)' == 'true'">
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.cs" />
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Public.Events.cs" />
     <Compile Include="Internal\Reflection\Tracing\ReflectionTrace.Internal.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">
+  <!--ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs" >
       <Link>TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs</Link>
     </Compile>
     <Compile Include="Internal\Reflection\CoreRT\RuntimeType.cs" />
     <Compile Include="Internal\Reflection\CoreRT\ReflectionCoreNonPortable.cs" />
-  </ItemGroup>
+  </ItemGroup-->
 
   <ItemGroup>
     <Compile Include="Internal\Reflection\Extensibility\ExtensibleType.cs" />

--- a/src/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
@@ -17,7 +17,7 @@ namespace System
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct RuntimeTypeHandle
     {
-#if CORERT
+#if CLR_RUNTIMETYPEHANDLE
         internal RuntimeTypeHandle(RuntimeType type)
         {
             _type = type;
@@ -61,7 +61,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(RuntimeTypeHandle handle)
         {
-#if CORERT
+#if CLR_RUNTIMETYPEHANDLE
             return Object.ReferenceEquals(_type, handle._type);
 #else
             if (_value == handle._value)
@@ -109,7 +109,7 @@ namespace System
 
         internal EETypePtr ToEETypePtr()
         {
-#if CORERT
+#if CLR_RUNTIMETYPEHANDLE
             return _type.ToEETypePtr();
 #else
             return new EETypePtr(_value);
@@ -128,7 +128,7 @@ namespace System
         {
             get
             {
-#if CORERT
+#if CLR_RUNTIMETYPEHANDLE
                 return _type == null;
 #else
                 return _value == new IntPtr(0);
@@ -171,7 +171,7 @@ namespace System
         {
             get
             {
-#if CORERT
+#if CLR_RUNTIMETYPEHANDLE
                 return ToEETypePtr().RawValue;
 #else
                 return _value;
@@ -179,7 +179,7 @@ namespace System
             }
         }
 
-#if CORERT
+#if CLR_RUNTIMETYPEHANDLE
         internal RuntimeType RuntimeType
         {
             get
@@ -189,7 +189,7 @@ namespace System
         }
 #endif
 
-#if CORERT
+#if CLR_RUNTIMETYPEHANDLE
         private RuntimeType _type;
 #else
         private IntPtr _value;

--- a/tests/src/Simple/Reflection/Reflection.cmd
+++ b/tests/src/Simple/Reflection/Reflection.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+"%1\%2"
+set ErrorCode=%ERRORLEVEL%
+IF "%ErrorCode%"=="100" (
+    echo %~n0: pass
+    EXIT /b 0
+) ELSE (
+    echo %~n0: fail
+    EXIT /b 1
+)
+endlocal

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+public class ReflectionTest
+{
+    const int Pass = 100;
+    const int Fail = -1;
+
+    public static int Main()
+    {
+        if (TestNames() == Fail)
+            return Fail;
+
+        if (TestUnification() == Fail)
+            return Fail;
+
+        if (TestTypeOf() == Fail)
+            return Fail;
+
+        return Pass;
+    }
+
+    private static int TestNames()
+    {
+        string hello = "Hello";
+
+        Type stringType = hello.GetType();
+
+        if (stringType.FullName != "System.String")
+        {
+            Console.WriteLine("Bad name");
+            return Fail;
+        }
+
+        return Pass;
+    }
+
+    private static int TestUnification()
+    {
+        Console.WriteLine("Testing unification");
+
+        // ReflectionTest type doesn't have an EEType and is metadata only.
+        Type programType = Type.GetType("ReflectionTest, Reflection");
+        TypeInfo programTypeInfo = programType.GetTypeInfo();
+
+        Type programBaseType = programTypeInfo.BaseType;
+
+        Type objectType = (new Object()).GetType();
+
+        if (!objectType.Equals(programBaseType))
+        {
+            Console.WriteLine("Unification failed");
+            return Fail;
+        }
+
+        return Pass;
+    }
+
+    private static int TestTypeOf()
+    {
+        Console.WriteLine("Testing typeof()");
+
+        Type intType = typeof(int);
+
+        if (intType.FullName != "System.Int32")
+        {
+            Console.WriteLine("Bad name");
+            return Fail;
+        }
+
+        if (12.GetType() != typeof(int))
+        {
+            Console.WriteLine("Bad compare");
+            return Fail;
+        }
+
+        if (typeof(int) != typeof(int))
+        {
+            Console.WriteLine("Bad compare");
+            return Fail;
+        }
+
+        return Pass;
+    }
+}

--- a/tests/src/Simple/Reflection/Reflection.sh
+++ b/tests/src/Simple/Reflection/Reflection.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+$1/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/Reflection/no_cpp
+++ b/tests/src/Simple/Reflection/no_cpp
@@ -1,0 +1,1 @@
+Skip this test for cpp codegen mode

--- a/tests/src/Simple/Reflection/project.json
+++ b/tests/src/Simple/Reflection/project.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23819"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    },
+
+    "runtimes": {
+        "win7-x64": { },
+        "osx.10.10-x64": { },
+        "ubuntu.14.04-x64": { }
+    }
+}


### PR DESCRIPTION
Turns out the only JIT assumption about RuntimeTypeHandle having a single field of type RuntimeType that was biting us was the intrinsic expansion of GetTypeFromHandle. Not reporting the intrinsic to the JIT seems to work well enough.

I scanned the rest of the JIT code base but I couldn't find other places where this would be a problem.

Not reporting GetTypeFromHandle means we don't get optimizations around equality comparison, but we can likely live with that for a year or so...