### PR TITLE
Set parent namespace for root namespaces

### DIFF
--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Namespace.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Namespace.cs
@@ -36,6 +36,7 @@ namespace ILCompiler.Metadata
                 _namespaceDefs.Add(key, rootNamespace);
                 ScopeDefinition rootScope = HandleScopeDefinition(parentScope);
                 rootScope.RootNamespaceDefinition = rootNamespace;
+                rootNamespace.ParentScopeOrNamespace = rootScope;
                 return rootNamespace;
             }
 


### PR DESCRIPTION
There's a two way link between a scope definition and the root
namespace. We were setting it up one way only.