### PR TITLE
Generate method bodies for Delegate.Begin/EndInvoke

### DIFF
--- a/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
+++ b/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
@@ -47,6 +47,18 @@ namespace Internal.TypeSystem
                 return false;
             }
         }
+
+        /// <summary>
+        /// Gets a value specifying whether the implementation of this method
+        /// is provided by the runtime.
+        /// </summary>
+        public virtual bool IsRuntimeImplemented
+        {
+            get
+            {
+                return false;
+            }
+        }
     }
 
     // Additional members of InstantiatedMethod related to code generation.
@@ -75,6 +87,14 @@ namespace Internal.TypeSystem
                 return _methodDef.IsAggressiveInlining;
             }
         }
+
+        public override bool IsRuntimeImplemented
+        {
+            get
+            {
+                return _methodDef.IsRuntimeImplemented;
+            }
+        }
     }
 
     // Additional members of MethodForInstantiatedType related to code generation.
@@ -101,6 +121,14 @@ namespace Internal.TypeSystem
             get
             {
                 return _typicalMethodDef.IsAggressiveInlining;
+            }
+        }
+
+        public override bool IsRuntimeImplemented
+        {
+            get
+            {
+                return _typicalMethodDef.IsRuntimeImplemented;
             }
         }
     }

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -24,6 +24,7 @@ namespace Internal.TypeSystem.Ecma
             public const int Final                  = 0x0010;
             public const int NoInlining             = 0x0020;
             public const int AggressiveInlining     = 0x0040;
+            public const int RuntimeImplemented     = 0x0080;
 
             public const int AttributeMetadataCache = 0x0100;
             public const int Intrinsic            = 0x0200;
@@ -145,6 +146,9 @@ namespace Internal.TypeSystem.Ecma
                 if ((methodImplAttributes & MethodImplAttributes.AggressiveInlining) != 0)
                     flags |= MethodFlags.AggressiveInlining;
 
+                if ((methodImplAttributes & MethodImplAttributes.Runtime) != 0)
+                    flags |= MethodFlags.RuntimeImplemented;
+
                 flags |= MethodFlags.BasicMetadataCache;
             }
 
@@ -233,6 +237,14 @@ namespace Internal.TypeSystem.Ecma
             get
             {
                 return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.AggressiveInlining) & MethodFlags.AggressiveInlining) != 0;
+            }
+        }
+
+        public override bool IsRuntimeImplemented
+        {
+            get
+            {
+                return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.RuntimeImplemented) & MethodFlags.RuntimeImplemented) != 0;
             }
         }
 

--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -21,6 +21,31 @@ namespace Internal.IL
         {
         }
 
+        private MethodIL TryGetRuntimeImplementedMethodIL(MethodDesc method)
+        {
+            // Provides method bodies for runtime implemented methods. It can return null for
+            // methods that are treated specially by the codegen.
+
+            Debug.Assert(method.IsRuntimeImplemented);
+
+            TypeDesc owningType = method.OwningType;
+
+            if (owningType.IsDelegate)
+            {
+                if (method.Name == "BeginInvoke" || method.Name == "EndInvoke")
+                {
+                    // BeginInvoke and EndInvoke are not supported on .NET Core
+                    ILEmitter emit = new ILEmitter();
+                    ILCodeStream codeStream = emit.NewCodeStream();
+                    MethodDesc notSupportedExceptionHelper = method.Context.GetHelperEntryPoint("ThrowHelpers", "ThrowPlatformNotSupportedException");
+                    codeStream.EmitCallThrowHelper(emit, notSupportedExceptionHelper);
+                    return emit.Link();
+                }
+            }
+
+            return null;
+        }
+
         private MethodIL TryGetIntrinsicMethodIL(MethodDesc method)
         {
             // Provides method bodies for intrinsics recognized by the compiler.
@@ -87,6 +112,13 @@ namespace Internal.IL
                     if (pregenerated == null)
                         return PInvokeMarshallingILEmitter.EmitIL(method);
                     method = pregenerated;
+                }
+
+                if (method.IsRuntimeImplemented)
+                {
+                    MethodIL result = TryGetRuntimeImplementedMethodIL(method);
+                    if (result != null)
+                        return result;
                 }
 
                 return EcmaMethodIL.Create((EcmaMethod)method);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -13,7 +13,7 @@ namespace Internal.Runtime.CompilerHelpers
     {
         private static void ThrowOverflowException()
         {
-            throw new IndexOutOfRangeException();
+            throw new OverflowException();
         }
 
         private static void ThrowIndexOutOfRangeException()
@@ -23,12 +23,12 @@ namespace Internal.Runtime.CompilerHelpers
 
         private static void ThrowNullReferenceException()
         {
-            throw new IndexOutOfRangeException();
+            throw new NullReferenceException();
         }
 
         private static void ThrowDivideByZeroException()
         {
-            throw new IndexOutOfRangeException();
+            throw new DivideByZeroException();
         }
 
         private static void ThrowArrayTypeMismatchException()

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -35,5 +35,10 @@ namespace Internal.Runtime.CompilerHelpers
         {
             throw new ArrayTypeMismatchException();
         }
+
+        private static void ThrowPlatformNotSupportedException()
+        {
+            throw new PlatformNotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
I'm going with the NotSupportedException that CoreCLR throws. Project N throws PlatformNotSupportedException. I'm not sure which one is better (Platform?), but we should standardize on one.

I'll file a bug in the respective product once we decide on the direction.