### PR TITLE
Implement delegates to virtual methods and valuetype methods

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -32,15 +32,7 @@ namespace Internal.IL
 
             if (owningType.IsDelegate)
             {
-                if (method.Name == "BeginInvoke" || method.Name == "EndInvoke")
-                {
-                    // BeginInvoke and EndInvoke are not supported on .NET Core
-                    ILEmitter emit = new ILEmitter();
-                    ILCodeStream codeStream = emit.NewCodeStream();
-                    MethodDesc notSupportedExceptionHelper = method.Context.GetHelperEntryPoint("ThrowHelpers", "ThrowPlatformNotSupportedException");
-                    codeStream.EmitCallThrowHelper(emit, notSupportedExceptionHelper);
-                    return emit.Link();
-                }
+                return DelegateMethodILEmitter.EmitIL(method);
             }
 
             return null;

--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateMethodILEmitter.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.IL;
+using Internal.IL.Stubs;
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+public static class DelegateMethodILEmitter
+{
+    public static MethodIL EmitIL(MethodDesc method)
+    {
+        Debug.Assert(method.OwningType.IsDelegate);
+        Debug.Assert(method.IsRuntimeImplemented);
+
+        if (method.Name == "BeginInvoke" || method.Name == "EndInvoke")
+        {
+            // BeginInvoke and EndInvoke are not supported on .NET Core
+            ILEmitter emit = new ILEmitter();
+            ILCodeStream codeStream = emit.NewCodeStream();
+            MethodDesc notSupportedExceptionHelper = method.Context.GetHelperEntryPoint("ThrowHelpers", "ThrowPlatformNotSupportedException");
+            codeStream.EmitCallThrowHelper(emit, notSupportedExceptionHelper);
+            return emit.Link();
+        }
+
+        if (method.Name == ".ctor")
+        {
+            TypeSystemContext context = method.Context;
+
+            ILEmitter emit = new ILEmitter();
+
+            TypeDesc delegateType = context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType;
+            MethodDesc objectCtorMethod = context.GetWellKnownType(WellKnownType.Object).GetDefaultConstructor();
+            FieldDesc functionPointerField = delegateType.GetKnownField("m_functionPointer");
+            FieldDesc firstParameterField = delegateType.GetKnownField("m_firstParameter");
+
+            ILCodeStream codeStream = emit.NewCodeStream();
+            codeStream.EmitLdArg(0);
+            codeStream.Emit(ILOpcode.call, emit.NewToken(objectCtorMethod));
+            codeStream.EmitLdArg(0);
+            codeStream.EmitLdArg(1);
+            codeStream.Emit(ILOpcode.stfld, emit.NewToken(firstParameterField));
+            codeStream.EmitLdArg(0);
+            codeStream.EmitLdArg(2);
+            codeStream.Emit(ILOpcode.stfld, emit.NewToken(functionPointerField));
+            codeStream.Emit(ILOpcode.ret);
+
+            return emit.Link();
+        }
+
+        return null;
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DelegateInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DelegateInfo.cs
@@ -18,14 +18,6 @@ namespace ILCompiler
 
             var systemDelegate = compilation.TypeSystemContext.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType;
 
-            // TODO: delegates on virtuals
-            if (target.IsVirtual && !target.IsFinal)
-                throw new NotImplementedException("Delegate to virtual");
-
-            // TODO: Delegates on valuetypes
-            if (target.OwningType.IsValueType)
-                throw new NotImplementedException("Delegate to valuetype");
-
             if (target.Signature.IsStatic)
             {
                 this.ShuffleThunk = new DelegateShuffleThunk(target);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -255,7 +255,8 @@ namespace ILCompiler.DependencyAnalysis
                     MethodDesc implMethod = VirtualFunctionResolution.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, mdType);
                     if (implMethod != null)
                     {
-                        yield return new DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.ReadyToRunHelper(ReadyToRunHelperId.InterfaceDispatch, interfaceMethod), "Interface method");
+                        yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.ReadyToRunHelper(ReadyToRunHelperId.InterfaceDispatch, interfaceMethod), "Interface method");
+                        yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.ReadyToRunHelper(ReadyToRunHelperId.ResolveVirtualFunction, interfaceMethod), "Interface method address");
                     }
                 }
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -25,6 +25,7 @@ namespace ILCompiler.DependencyAnalysis
         GetThreadStaticBase,
         DelegateCtor,
         InterfaceDispatch,
+        ResolveVirtualFunction,
     }
 
     public partial class ReadyToRunHelperNode : AssemblyStubNode
@@ -85,6 +86,8 @@ namespace ILCompiler.DependencyAnalysis
                         return "__DelegateCtor_" + NodeFactory.NameMangler.GetMangledMethodName(((DelegateInfo)_target).Target);
                     case ReadyToRunHelperId.InterfaceDispatch:
                         return "__InterfaceDispatch_" + NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target);
+                    case ReadyToRunHelperId.ResolveVirtualFunction:
+                        return "__ResolveVirtualFunction_" + NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target);
                     default:
                         throw new NotImplementedException();
                 }
@@ -103,6 +106,12 @@ namespace ILCompiler.DependencyAnalysis
             {
                 DependencyList dependencyList = new DependencyList();
                 dependencyList.Add(context.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Interface Method Call");
+                return dependencyList;
+            }
+            else if (_id == ReadyToRunHelperId.ResolveVirtualFunction)
+            {
+                DependencyList dependencyList = new DependencyList();
+                dependencyList.Add(context.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Address Load");
                 return dependencyList;
             }
             else

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -40,6 +40,9 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs">
       <Link>Common\MetadataBlob.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateMethodILEmitter.cs">
+      <Link>IL\Stubs\DelegateMethodILEmitter.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\EETypePtrOfIntrinsic.cs">
       <Link>IL\Stubs\EETypePtrOfIntrinsic.cs</Link>
     </Compile>

--- a/tests/src/Simple/Delegates/Delegates.cmd
+++ b/tests/src/Simple/Delegates/Delegates.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+"%1\%2"
+set ErrorCode=%ERRORLEVEL%
+IF "%ErrorCode%"=="100" (
+    echo %~n0: pass
+    EXIT /b 0
+) ELSE (
+    echo %~n0: fail
+    EXIT /b 1
+)
+endlocal

--- a/tests/src/Simple/Delegates/Delegates.cs
+++ b/tests/src/Simple/Delegates/Delegates.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+public class BringUpTests
+{
+    const int Pass = 100;
+    const int Fail = -1;
+
+    public static int Main()
+    {
+        int result = Pass;
+
+        if (!TestValueTypeDelegates())
+        {
+            Console.WriteLine("Failed");
+            result = Fail;
+        }
+
+        if (!TestVirtualDelegates())
+        {
+            Console.WriteLine("Failed");
+            result = Fail;
+        }
+
+        if (!TestInterfaceDelegates())
+        {
+            Console.WriteLine("Failed");
+            result = Fail;
+        }
+
+        return result;
+    }
+
+    public static bool TestValueTypeDelegates()
+    {
+        Console.Write("Testing delegates to value types...");
+
+        {
+            TestValueType t = new TestValueType { X = 123 };
+            Func<string, string> d = t.GiveX;
+            string result = d("MyPrefix");
+            if (result != "MyPrefix123")
+                return false;
+        }
+
+        {
+            object t = new TestValueType { X = 456 };
+            Func<string> d = t.ToString;
+            string result = d();
+            if (result != "456")
+                return false;
+        }
+
+        {
+            Func<int, TestValueType> d = TestValueType.MakeValueType;
+            TestValueType result = d(789);
+            if (result.X != 789)
+                return false;
+        }
+
+        Console.WriteLine("OK");
+        return true;
+    }
+
+    public static bool TestVirtualDelegates()
+    {
+        Console.Write("Testing delegates to virtual methods...");
+
+        {
+            Mid t = new Mid();
+            if (t.GetBaseDo()() != "Base")
+                return false;
+
+            if (t.GetDerivedDo()() != "Mid")
+                return false;
+        }
+
+        {
+            Mid t = new Derived();
+            if (t.GetBaseDo()() != "Base")
+                return false;
+
+            if (t.GetDerivedDo()() != "Derived")
+                return false;
+        }
+
+        Console.WriteLine("OK");
+        return true;
+    }
+
+    public static bool TestInterfaceDelegates()
+    {
+        Console.Write("Testing delegates to interface methods...");
+
+        {
+            IFoo t = new ClassWithIFoo("Class");
+            Func<int, string> d = t.DoFoo;
+            if (d(987) != "Class987")
+                return false;
+        }
+
+        {
+            IFoo t = new StructWithIFoo("Struct");
+            Func<int, string> d = t.DoFoo;
+            if (d(654) != "Struct654")
+                return false;
+        }
+
+        Console.WriteLine("OK");
+        return true;
+    }
+
+    struct TestValueType
+    {
+        public int X;
+
+        public string GiveX(string prefix)
+        {
+            return prefix + X.ToString();
+        }
+
+        public static TestValueType MakeValueType(int value)
+        {
+            return new TestValueType { X = value };
+        }
+
+        public override string ToString()
+        {
+            return X.ToString();
+        }
+    }
+
+    class Base
+    {
+        public virtual string Do()
+        {
+            return "Base";
+        }
+    }
+
+    class Mid : Base
+    {
+        public override string Do()
+        {
+            return "Mid";
+        }
+
+        public Func<string> GetBaseDo()
+        {
+            return base.Do;
+        }
+
+        public Func<string> GetDerivedDo()
+        {
+            return Do;
+        }
+    }
+
+    class Derived : Mid
+    {
+        public override string Do()
+        {
+            return "Derived";
+        }
+    }
+
+    interface IFoo
+    {
+        string DoFoo(int x);
+    }
+
+    class ClassWithIFoo : IFoo
+    {
+        string _prefix;
+
+        public ClassWithIFoo(string prefix)
+        {
+            _prefix = prefix;
+        }
+
+        public string DoFoo(int x)
+        {
+            return _prefix + x.ToString();
+        }
+    }
+
+    struct StructWithIFoo : IFoo
+    {
+        string _prefix;
+
+        public StructWithIFoo(string prefix)
+        {
+            _prefix = prefix;
+        }
+
+        public string DoFoo(int x)
+        {
+            return _prefix + x.ToString();
+        }
+    }
+}

--- a/tests/src/Simple/Delegates/Delegates.sh
+++ b/tests/src/Simple/Delegates/Delegates.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+$1/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/Delegates/no_cpp
+++ b/tests/src/Simple/Delegates/no_cpp
@@ -1,0 +1,1 @@
+Skip this test for cpp codegen mode

--- a/tests/src/Simple/Delegates/project.json
+++ b/tests/src/Simple/Delegates/project.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23819"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    },
+
+    "runtimes": {
+        "win7-x64": { },
+        "osx.10.10-x64": { },
+        "ubuntu.14.04-x64": { }
+    }
+}


### PR DESCRIPTION
Delegates to virtual methods need to go through the ready to run helpers.

Delegates to value type instance methods need to go through an unboxing stub.

Fixes #373.
Fixes #369.
