### PR TITLE
Allow blitting types with Char fields

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -490,5 +490,13 @@ namespace Internal.TypeSystem.Ecma
                 return (_typeDefinition.Attributes & TypeAttributes.Sealed) != 0;
             }
         }
+
+        public override PInvokeStringFormat PInvokeStringFormat
+        {
+            get
+            {
+                return (PInvokeStringFormat)(_typeDefinition.Attributes & TypeAttributes.StringFormatMask);
+            }
+        }
     }
 }

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeMarshallingILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeMarshallingILEmitter.cs
@@ -97,7 +97,16 @@ namespace Internal.IL.Stubs
 
                     // TODO: we should also reject fields that specify custom marshalling
                     if (!IsBlittableType(fieldType))
-                        return false;
+                    {
+                        // This field can still be blittable if it's a Char and marshals as Unicode
+                        var owningType = field.OwningType as MetadataType;
+                        if (owningType == null)
+                            return false;
+
+                        if (fieldType.Category != TypeFlags.Char ||
+                            owningType.PInvokeStringFormat == PInvokeStringFormat.AnsiClass)
+                            return false;
+                    }
                 }
                 return true;
             }

--- a/src/Common/src/TypeSystem/Interop/InstantiatedType.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/InstantiatedType.Interop.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    public partial class InstantiatedType
+    {
+        public override PInvokeStringFormat PInvokeStringFormat
+        {
+            get
+            {
+                return _typeDef.PInvokeStringFormat;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Interop/MetadataType.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/MetadataType.Interop.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    public enum PInvokeStringFormat
+    {
+        /// <summary>
+        /// LPTSTR is interpreted as ANSI in this class.
+        /// </summary>
+        AnsiClass = 0x00000000,
+
+        /// <summary>
+        /// LPTSTR is interpreted as UNICODE.
+        /// </summary>
+        UnicodeClass = 0x00010000,
+
+        /// <summary>
+        /// LPTSTR is interpreted automatically.
+        /// </summary>
+        AutoClass = 0x00020000,
+    }
+
+    public partial class MetadataType
+    {
+        /// <summary>
+        /// Gets a value indicating how strings should be handled for native interop.
+        /// </summary>
+        public abstract PInvokeStringFormat PInvokeStringFormat
+        {
+            get;
+        }
+    }
+}

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -190,8 +190,14 @@
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\CachingMetadataStringDecoder.cs">
       <Link>Ecma\CachingMetadataStringDecoder.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Interop\InstantiatedType.Interop.cs">
+      <Link>TypeSystem\Interop\InstantiatedType.Interop.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Interop\MetadataType.Interop.cs">
+      <Link>TypeSystem\Interop\MetadataType.Interop.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\MethodDesc.Interop.cs">
-      <Link>MethodDesc.Interop.cs</Link>
+      <Link>TypeSystem\Interop\MethodDesc.Interop.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\System\Collections\Generic\ArrayBuilder.cs">
       <Link>Utilities\ArrayBuilder.cs</Link>


### PR DESCRIPTION
Blitting Chars is fine if the target is Unicode.

One of the test libraries in CoreCLR test suite uses DateTime.Now and it
turns out this is the only thing we need to support it. I hit this while
trying to run some delegate tests.