### PR TITLE
Remove a misuse of GetClosestMetadataType

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -11,6 +11,18 @@ namespace ILCompiler
 {
     static class TypeExtensions
     {
+        public static bool IsSealed(this TypeDesc type)
+        {
+            var metadataType = type as MetadataType;
+            if (metadataType != null)
+            {
+                return metadataType.IsSealed;
+            }
+
+            Debug.Assert(type.IsArray, "IsSealed on a type with no virtual methods?");
+            return true;
+        }
+
         static public MetadataType GetClosestMetadataType(this TypeDesc type)
         {
             if (type.IsSzArray && !((ArrayType)type).ElementType.IsPointer)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2010,7 +2010,7 @@ namespace Internal.JitInterface
             }
             else
             {
-                if (!targetMethod.IsVirtual || targetMethod.IsFinal || targetMethod.OwningType.GetClosestMetadataType().IsSealed)
+                if (!targetMethod.IsVirtual || targetMethod.IsFinal || targetMethod.OwningType.IsSealed())
                 {
                     resolvedCallVirt = true;
                     directCall = true;


### PR DESCRIPTION
GetClosestMetadataType is a temporary solution for making generic array
interfaces work. This callsite is a misuse.