### PR TITLE
Fix race condition when running tests

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
@@ -25,7 +25,7 @@ build.cmd clean
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`-r:C:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll @c:\corert\bin\obj\Windows_NT.x64.Debug\ryujit.rsp`
+`-r:C:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib\System.Private.CoreLib.dll @c:\corert\bin\obj\Windows_NT.x64.Debug\ryujit.rsp`
 
   - Build & run using **F5**
     - This will run the compiler. The output is `c:\corert\src\ILCompiler\repro\obj\Debug\dnxcore50\native\repro.obj` file.

--- a/build.cmd
+++ b/build.cmd
@@ -233,7 +233,7 @@ if not exist "%__ObjDir%\cpp.rsp" set __GenRespFiles=1
 if "%__GenRespFiles%"=="1" (
     "%__DotNetCliPath%\bin\dotnet.exe" restore --quiet --source "https://dotnet.myget.org/F/dotnet-core" "%__ReproProjectDir%"
     call "!VS140COMNTOOLS!\..\..\VC\vcvarsall.bat" %__BuildArch%
-    "%__DotNetCliPath%\bin\dotnet.exe" build --native --ilcpath "%__BinDir%\.nuget\publish1" "%__ReproProjectDir%" -c %__BuildType%
+    "%__DotNetCliPath%\bin\dotnet.exe" build --native --ilcpath "%__BinDir%\packaging\publish1" "%__ReproProjectDir%" -c %__BuildType%
     copy /y "%__ReproProjectObjDir%\Debug\dnxcore50\native\dotnet-compile-native-ilc.rsp" "%__ObjDir%\ryujit.rsp"
 
     rem Workaround for https://github.com/dotnet/cli/issues/1956
@@ -244,7 +244,7 @@ if "%__GenRespFiles%"=="1" (
     if /i "%__BuildType%"=="debug" (
         set __AdditionalCompilerFlags=--cppcompilerflags /MTd
     )
-    "%__DotNetCliPath%\bin\dotnet.exe" build --native --cpp --ilcpath "%__BinDir%\.nuget\publish1" "%__ReproProjectDir%" -c %__BuildType% !__AdditionalCompilerFlags!
+    "%__DotNetCliPath%\bin\dotnet.exe" build --native --cpp --ilcpath "%__BinDir%\packaging\publish1" "%__ReproProjectDir%" -c %__BuildType% !__AdditionalCompilerFlags!
     copy /y "%__ReproProjectObjDir%\Debug\dnxcore50\native\dotnet-compile-native-ilc.rsp" "%__ObjDir%\cpp.rsp"
 )
 :AfterVsDevGenerateRespFiles

--- a/dir.props
+++ b/dir.props
@@ -101,10 +101,10 @@
     <OSPlatformConfig>$(BinDirOSGroup).$(BinDirPlatform).$(BinDirConfiguration)</OSPlatformConfig>
 
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(ProductBinDir)</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/</OutputPath>
 
     <!-- Folder where we will drop the Nuget package for the toolchain -->
-    <ProductPackageDir Condition="'$(ProductPackageDir)'==''">$(OutputPath).nuget/</ProductPackageDir>
+    <ProductPackageDir Condition="'$(ProductPackageDir)'==''">$(BaseOutputPath)$(OSPlatformConfig)/packaging/</ProductPackageDir>
     
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
     <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)\</IntermediateOutputRootPath>

--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -70,13 +70,13 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish1\jitinterface.dll">
+    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\packaging\publish1\jitinterface.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish1\objwriter.dll">
+    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\packaging\publish1\objwriter.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\.nuget\publish1\ryujit.dll">
+    <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\packaging\publish1\ryujit.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -45,7 +45,7 @@
             <ILCompilerFiles Include="ILCompiler.MetadataWriter.dll" />
             <ILCompilerFiles Include="ILCompiler.TypeSystem.dll" />
             <ILCompilerBinPlace Include="@(ILCompilerFiles)">
-                <Text><![CDATA[        <file src="$(RelativeProductBinDir)/%(Identity)" target="runtimes/any/lib/dotnet/%(Identity)" /> ]]></Text>
+                <Text><![CDATA[        <file src="$(RelativeProductBinDir)/ILCompiler/%(Identity)" target="runtimes/any/lib/dotnet/%(Identity)" /> ]]></Text>
             </ILCompilerBinPlace>
 
             <ILCompilerNativeFiles Include="jitinterface.dll" Condition="'$(OSGroup)'=='Windows_NT'" />
@@ -83,7 +83,7 @@
             </ILCompilerSdkBinPlace>
 
             <ILCompilerSdkBinPlace Include="@(ILCompilerSdkFilesManaged)">
-                <Text><![CDATA[        <file src="$(RelativeProductBinDir)/%(Identity).dll" target="runtimes/$(NuPkgRid)/native/sdk/%(Identity).dll" /> ]]></Text>
+                <Text><![CDATA[        <file src="$(RelativeProductBinDir)/%(Identity)/%(Identity).dll" target="runtimes/$(NuPkgRid)/native/sdk/%(Identity).dll" /> ]]></Text>
             </ILCompilerSdkBinPlace>
             <ILCompilerSdkBinPlace Include="@(ILCompilerSdkCppCodegenFiles)">
                 <Text><![CDATA[        <file src="src/%(Identity)" target="runtimes/$(NuPkgRid)/native/inc/%(Filename)%(Extension)" /> ]]></Text>
@@ -180,7 +180,7 @@
     %(NuSpecPackageMetadata)
   </metadata>
   <files>
-      <file src="$(RelativeProductBinDir)/.nuget/%(RedirPackage).runtime.json" target="runtime.json"></file>
+      <file src="$(RelativeProductBinDir)/packaging/%(RedirPackage).runtime.json" target="runtime.json"></file>
   </files>
 </package>
 ]]>

--- a/tests/restore.cmd
+++ b/tests/restore.cmd
@@ -18,7 +18,7 @@ goto Usage
 :ArgsDone
 
 set __BuildStr=%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%
-set __NuPkgInstallDir=%CoreRT_TestRoot%\..\bin\Product\%__BuildStr%\.nuget\publish1
+set __NuPkgInstallDir=%CoreRT_TestRoot%\..\bin\Product\%__BuildStr%\packaging\publish1
 if not exist %__NuGetExeDir%\NuGet.exe ((call :Fail "No NuGet.exe found at %__NuGetExeDir%. Specify /nugetexedir option") & exit /b -1)
 
 REM ** Install packages from NuGet

--- a/tests/restore.sh
+++ b/tests/restore.sh
@@ -36,7 +36,7 @@ export CoreRT_AppDepSdkVer=1.0.6-prerelease-00003
 
 __ScriptDir=$(cd "$(dirname "$0")"; pwd -P)
 __BuildStr=${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}
-__NuPkgInstallDir=${CoreRT_TestRoot}/../bin/Product/${__BuildStr}/.nuget/publish1
+__NuPkgInstallDir=${CoreRT_TestRoot}/../bin/Product/${__BuildStr}/packaging/publish1
 
 while test $# -gt 0
     do

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -153,7 +153,6 @@ done
 __BuildStr=${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}
 __CoreRTTestBinDir=${CoreRT_TestRoot}/../bin/tests
 __LogDir=${CoreRT_TestRoot}/../bin/Logs/${__BuildStr}/tests
-__BuiltNuPkgDir=${CoreRT_TestRoot}/../bin/Product/${__BuildStr}/.nuget
 __PackageRestoreCmd=$CoreRT_TestRoot/restore.sh
 __build_os_lowcase=$(echo "${CoreRT_BuildOS}" | tr '[:upper:]' '[:lower:]')
 if [ ${__build_os_lowcase} != "osx" ]; then
@@ -161,7 +160,7 @@ if [ ${__build_os_lowcase} != "osx" ]; then
 else
     __BuildRid=osx.10.10-{CoreRT_BuildArch}
 fi
-source ${__PackageRestoreCmd} -nugetexedir ${CoreRT_TestRoot}/../packages -nupkgdir ${__BuiltNuPkgDir} -nugetopt ${CoreRT_NuGetOptions}
+source ${__PackageRestoreCmd} -nugetexedir ${CoreRT_TestRoot}/../packages -nugetopt ${CoreRT_NuGetOptions}
 
 if [ ! -d ${CoreRT_AppDepSdkDir} ]; then
     echo "AppDep SDK not installed at ${CoreRT_AppDepSdkDir}"


### PR DESCRIPTION
Fixes #974.

Changing the OutputPath also changed ProductPackageDir to something
weird, so I took this as an opportunity to stop placing packaging
related stuff into weird directories (".nuget" was a weird one too -
prefixing with a dot is how you hide directories on Unix).

runtest.sh was passing a dead parameter to restore.sh, so I fixed that
too. I didn't test on Unix. The CI will...