### PR TITLE
Drop xunit.netcore.extensions from test projects

### DIFF
--- a/src/ILCompiler.DependencyAnalysisFramework/tests/project.json
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/project.json
@@ -2,8 +2,7 @@
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23910",
     "System.Collections.Immutable": "1.2.0.0-rc2-23910",
-    "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/ILCompiler.MetadataTransform/tests/project.json
+++ b/src/ILCompiler.MetadataTransform/tests/project.json
@@ -2,8 +2,7 @@
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23910",
     "System.Reflection.Metadata": "1.3.0-rc2-23910",
-    "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "dnxcore50": { 

--- a/src/ILCompiler.TypeSystem/tests/project.json
+++ b/src/ILCompiler.TypeSystem/tests/project.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23910", 
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "System.Reflection.Metadata": "1.3.0-rc2-23910"
   },
   "frameworks": {

--- a/src/System.Private.Reflection.Metadata/tests/project.json
+++ b/src/System.Private.Reflection.Metadata/tests/project.json
@@ -1,8 +1,7 @@
 {
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23910",
-    "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "dnxcore50": { 


### PR DESCRIPTION
Seems like the only value we were getting out of it was this warning as
part of the build:

```
Found conflicts between different versions of the same dependent
assembly that could not be resolved.
```

I can live without that.