### PR TITLE
[WIP] An attempt to get rid of GetClosestMetadataType

### DIFF
--- a/src/Common/src/TypeSystem/Common/ArrayOfTVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayOfTVirtualMethodAlgorithm.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Virtual method algorithm for for array types which are similar to a generic type.
+    /// </summary>
+    public sealed class ArrayOfTVirtualMethodAlgorithm : VirtualMethodAlgorithm
+    {
+        private MetadataType _arrayOfTType;
+
+        public ArrayOfTVirtualMethodAlgorithm(MetadataType arrayOfTType)
+        {
+            _arrayOfTType = arrayOfTType;
+            Debug.Assert(!(arrayOfTType is InstantiatedType));
+        }
+
+        private InstantiatedType GetMatchingArrayOfT(TypeDesc type)
+        {
+            ArrayType arrayType = (ArrayType)type;
+            Debug.Assert(arrayType.IsSzArray);
+            Instantiation arrayInstantiation = new Instantiation(new TypeDesc[] { arrayType.ElementType });
+            return _arrayOfTType.Context.GetInstantiatedType(_arrayOfTType, arrayInstantiation);
+        }
+
+        private static MethodDesc Reparent(MethodDesc method, TypeDesc oldType, TypeDesc newType)
+        {
+            if (method == null)
+                return null;
+
+            if (method.OwningType == oldType)
+            {
+                return method.Context.GetReparentedMethod(newType, method);
+            }
+            else
+                return method;
+        }
+
+        private static IEnumerable<MethodDesc> Reparent(IEnumerable<MethodDesc> methods, TypeDesc oldType, TypeDesc newType)
+        {
+            foreach (var method in methods)
+                yield return Reparent(method, oldType, newType);
+        }
+
+        public override IEnumerable<MethodDesc> ComputeAllVirtualMethods(TypeDesc type)
+        {
+            var arrayOfT = GetMatchingArrayOfT(type);
+            return Reparent(arrayOfT.GetAllVirtualMethods(), arrayOfT, type);
+        }
+
+        public override IEnumerable<MethodDesc> ComputeAllVirtualSlots(TypeDesc type)
+        {
+            var arrayOfT = GetMatchingArrayOfT(type);
+            return Reparent(arrayOfT.EnumAllVirtualSlots(), arrayOfT, type);
+        }
+
+        public override MethodDesc FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType)
+        {
+            var arrayOfT = GetMatchingArrayOfT(objectType);
+
+            ReparentedMethodDesc reparentedTarget = targetMethod as ReparentedMethodDesc;
+            if (reparentedTarget != null)
+                targetMethod = reparentedTarget.ShadowMethod;
+
+            return Reparent(arrayOfT.FindVirtualFunctionTargetMethodOnObjectType(targetMethod), arrayOfT, objectType);
+        }
+
+        public override MethodDesc ResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType)
+        {
+            var arrayOfT = GetMatchingArrayOfT(currentType);
+            return Reparent(arrayOfT.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod), arrayOfT, currentType);
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/ArrayOfTVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayOfTVirtualMethodAlgorithm.cs
@@ -71,10 +71,18 @@ namespace Internal.TypeSystem
             return Reparent(arrayOfT.FindVirtualFunctionTargetMethodOnObjectType(targetMethod), arrayOfT, objectType);
         }
 
-        public override MethodDesc ResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType)
+        public override bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc resolvedMethod)
         {
             var arrayOfT = GetMatchingArrayOfT(currentType);
-            return Reparent(arrayOfT.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod), arrayOfT, currentType);
+            MethodDesc resolvedMethodOnArrayOfT;
+            if (!arrayOfT.TryResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, out resolvedMethodOnArrayOfT))
+            {
+                resolvedMethod = null;
+                return false;
+            }
+
+            resolvedMethod = Reparent(resolvedMethodOnArrayOfT, arrayOfT, currentType);
+            return true;
         }
     }
 }

--- a/src/Common/src/TypeSystem/Common/BaseTypeVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/BaseTypeVirtualMethodAlgorithm.cs
@@ -42,9 +42,10 @@ namespace Internal.TypeSystem
             return objectType.BaseType.FindVirtualFunctionTargetMethodOnObjectType(targetMethod);
         }
 
-        public override MethodDesc ResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType)
+        public override bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc resolvedMethod)
         {
-            return null;
+            resolvedMethod = null;
+            return false;
         }
     }
 }

--- a/src/Common/src/TypeSystem/Common/BaseTypeVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/BaseTypeVirtualMethodAlgorithm.cs
@@ -32,19 +32,19 @@ namespace Internal.TypeSystem
             return Array.Empty<MethodDesc>();
         }
 
-        public override IEnumerable<MethodDesc> ComputeAllVirtualSlots(TypeDesc type)
+        public override IEnumerable<ResolvedVirtualMethod> ComputeAllVirtualSlots(TypeDesc type)
         {
             return type.BaseType.EnumAllVirtualSlots();
         }
 
-        public override MethodDesc FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType)
+        public override ResolvedVirtualMethod FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType)
         {
             return objectType.BaseType.FindVirtualFunctionTargetMethodOnObjectType(targetMethod);
         }
 
-        public override bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc resolvedMethod)
+        public override bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out ResolvedVirtualMethod resolvedMethod)
         {
-            resolvedMethod = null;
+            resolvedMethod = default(ResolvedVirtualMethod);
             return false;
         }
     }

--- a/src/Common/src/TypeSystem/Common/BaseTypeVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/BaseTypeVirtualMethodAlgorithm.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Virtual method algorithm for types that don't introduce any new virtual methods.
+    /// </summary>
+    public sealed class BaseTypeVirtualMethodAlgorithm : VirtualMethodAlgorithm
+    {
+        private static BaseTypeVirtualMethodAlgorithm _singleton = new BaseTypeVirtualMethodAlgorithm();
+
+        public static VirtualMethodAlgorithm Instance
+        {
+            get
+            {
+                return _singleton;
+            }
+        }
+
+        private BaseTypeVirtualMethodAlgorithm()
+        {
+        }
+
+        public override IEnumerable<MethodDesc> ComputeAllVirtualMethods(TypeDesc type)
+        {
+            return Array.Empty<MethodDesc>();
+        }
+
+        public override IEnumerable<MethodDesc> ComputeAllVirtualSlots(TypeDesc type)
+        {
+            return type.BaseType.EnumAllVirtualSlots();
+        }
+
+        public override MethodDesc FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType)
+        {
+            return objectType.BaseType.FindVirtualFunctionTargetMethodOnObjectType(targetMethod);
+        }
+
+        public override MethodDesc ResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/ReparentedMethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/ReparentedMethodDesc.cs
@@ -1,0 +1,142 @@
+﻿namespace Internal.TypeSystem
+{
+    public class ReparentedMethodDesc : MethodDesc
+    {
+        private MethodDesc _shadowMethodDesc;
+        private TypeDesc _owningType;
+
+        public MethodDesc ShadowMethod
+        {
+            get
+            {
+                return _shadowMethodDesc;
+            }
+        }
+
+        public ReparentedMethodDesc(TypeDesc owningType, MethodDesc shadowMethodDesc)
+        {
+            _owningType = owningType;
+            _shadowMethodDesc = shadowMethodDesc;
+        }
+
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return _shadowMethodDesc.Context;
+            }
+        }
+
+        public override TypeDesc OwningType
+        {
+            get
+            {
+                return _owningType;
+            }
+        }
+
+        public override MethodSignature Signature
+        {
+            get
+            {
+                return _shadowMethodDesc.Signature;
+            }
+        }
+
+        public override bool IsVirtual
+        {
+            get
+            {
+                return _shadowMethodDesc.IsVirtual;
+            }
+        }
+
+        public override bool IsNewSlot
+        {
+            get
+            {
+                return _shadowMethodDesc.IsNewSlot;
+            }
+        }
+
+        public override bool IsFinal
+        {
+            get
+            {
+                return _shadowMethodDesc.IsFinal;
+            }
+        }
+
+        public override bool IsNoInlining
+        {
+            get
+            {
+                return _shadowMethodDesc.IsNoInlining;
+            }
+        }
+
+        public override bool IsAggressiveInlining
+        {
+            get
+            {
+                return _shadowMethodDesc.IsAggressiveInlining;
+            }
+        }
+
+        public override bool IsRuntimeImplemented
+        {
+            get
+            {
+                return _shadowMethodDesc.IsRuntimeImplemented;
+            }
+        }
+
+        public override bool IsIntrinsic
+        {
+            get
+            {
+                return _shadowMethodDesc.IsIntrinsic;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return _shadowMethodDesc.Name;
+            }
+        }
+
+        public override Instantiation Instantiation
+        {
+            get
+            {
+                return _shadowMethodDesc.Instantiation;
+            }
+        }
+
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
+        {
+            return _shadowMethodDesc.HasCustomAttribute(attributeNamespace, attributeName);
+        }
+
+        public override string ToString()
+        {
+            return _owningType.ToString() + "." + Name;
+        }
+
+        public override bool IsPInvoke
+        {
+            get
+            {
+                return _shadowMethodDesc.IsPInvoke;
+            }
+        }
+
+        public override PInvokeMetadata GetPInvokeMethodMetadata()
+        {
+            return _shadowMethodDesc.GetPInvokeMethodMetadata();
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/StandardVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/StandardVirtualMethodAlgorithm.cs
@@ -167,9 +167,9 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override MethodDesc FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType)
+        public override ResolvedVirtualMethod FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType)
         {
-            return FindVirtualFunctionTargetMethodOnObjectType(targetMethod, (MetadataType)objectType);
+            return new ResolvedVirtualMethod(FindVirtualFunctionTargetMethodOnObjectType(targetMethod, (MetadataType)objectType));
         }
 
         /// <summary>
@@ -448,10 +448,19 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc resolvedMethod)
+        public override bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out ResolvedVirtualMethod resolvedMethod)
         {
-            resolvedMethod = ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, (MetadataType)currentType);
-            return resolvedMethod != null;
+            MethodDesc method = ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, (MetadataType)currentType);
+            if (method != null)
+            {
+                resolvedMethod = new ResolvedVirtualMethod(method);
+                return true;
+            }
+            else
+            {
+                resolvedMethod = default(ResolvedVirtualMethod);
+                return false;
+            }
         }
 
         //////////////////////// INTERFACE RESOLUTION
@@ -568,9 +577,12 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override IEnumerable<MethodDesc> ComputeAllVirtualSlots(TypeDesc type)
+        public override IEnumerable<ResolvedVirtualMethod> ComputeAllVirtualSlots(TypeDesc type)
         {
-            return EnumAllVirtualSlots((MetadataType)type);
+            foreach (var method in EnumAllVirtualSlots((MetadataType)type))
+            {
+                yield return new ResolvedVirtualMethod(method);
+            }
         }
 
         // Enumerate all possible virtual slots of a type

--- a/src/Common/src/TypeSystem/Common/StandardVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/StandardVirtualMethodAlgorithm.cs
@@ -448,9 +448,10 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override MethodDesc ResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType)
+        public override bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc resolvedMethod)
         {
-            return ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, (MetadataType)currentType);
+            resolvedMethod = ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, (MetadataType)currentType);
+            return resolvedMethod != null;
         }
 
         //////////////////////// INTERFACE RESOLUTION

--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -169,12 +169,16 @@ namespace Internal.TypeSystem
                 // TODO: this code assumes no shared generics
                 Debug.Assert(interfaceType == interfaceMethod.OwningType);
 
-                if (!constrainedType.TryResolveInterfaceMethodToVirtualMethodOnType(genInterfaceMethod, out method))
+                ResolvedVirtualMethod resolvedVirtualMethod;
+                if (!constrainedType.TryResolveInterfaceMethodToVirtualMethodOnType(genInterfaceMethod, out resolvedVirtualMethod))
                     method = null;
+                else
+                    method = resolvedVirtualMethod.Target;
             }
             else if (genInterfaceMethod.IsVirtual)
             {
-                method = constrainedType.FindVirtualFunctionTargetMethodOnObjectType(genInterfaceMethod);
+                ResolvedVirtualMethod resolvedVirtualMethod = constrainedType.FindVirtualFunctionTargetMethodOnObjectType(genInterfaceMethod);
+                method = resolvedVirtualMethod.Target;
             }
             else
             {
@@ -225,17 +229,17 @@ namespace Internal.TypeSystem
             return type.Context.GetVirtualMethodAlgorithmForType(type).ComputeAllVirtualMethods(type);
         }
 
-        public static IEnumerable<MethodDesc> EnumAllVirtualSlots(this TypeDesc type)
+        public static IEnumerable<ResolvedVirtualMethod> EnumAllVirtualSlots(this TypeDesc type)
         {
             return type.Context.GetVirtualMethodAlgorithmForType(type).ComputeAllVirtualSlots(type);
         }
 
-        public static bool TryResolveInterfaceMethodToVirtualMethodOnType(this TypeDesc type, MethodDesc interfaceMethod, out MethodDesc resolvedMethod)
+        public static bool TryResolveInterfaceMethodToVirtualMethodOnType(this TypeDesc type, MethodDesc interfaceMethod, out ResolvedVirtualMethod resolvedMethod)
         {
             return type.Context.GetVirtualMethodAlgorithmForType(type).TryResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, type, out resolvedMethod);
         }
 
-        public static MethodDesc FindVirtualFunctionTargetMethodOnObjectType(this TypeDesc type, MethodDesc targetMethod)
+        public static ResolvedVirtualMethod FindVirtualFunctionTargetMethodOnObjectType(this TypeDesc type, MethodDesc targetMethod)
         {
             return type.Context.GetVirtualMethodAlgorithmForType(type).FindVirtualFunctionTargetMethodOnObjectType(targetMethod, type);
         }

--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -169,7 +169,8 @@ namespace Internal.TypeSystem
                 // TODO: this code assumes no shared generics
                 Debug.Assert(interfaceType == interfaceMethod.OwningType);
 
-                method = constrainedType.ResolveInterfaceMethodToVirtualMethodOnType(genInterfaceMethod);
+                if (!constrainedType.TryResolveInterfaceMethodToVirtualMethodOnType(genInterfaceMethod, out method))
+                    method = null;
             }
             else if (genInterfaceMethod.IsVirtual)
             {
@@ -229,9 +230,9 @@ namespace Internal.TypeSystem
             return type.Context.GetVirtualMethodAlgorithmForType(type).ComputeAllVirtualSlots(type);
         }
 
-        public static MethodDesc ResolveInterfaceMethodToVirtualMethodOnType(this TypeDesc type, MethodDesc interfaceMethod)
+        public static bool TryResolveInterfaceMethodToVirtualMethodOnType(this TypeDesc type, MethodDesc interfaceMethod, out MethodDesc resolvedMethod)
         {
-            return type.Context.GetVirtualMethodAlgorithmForType(type).ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, type);
+            return type.Context.GetVirtualMethodAlgorithmForType(type).TryResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, type, out resolvedMethod);
         }
 
         public static MethodDesc FindVirtualFunctionTargetMethodOnObjectType(this TypeDesc type, MethodDesc targetMethod)

--- a/src/Common/src/TypeSystem/Common/VirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualMethodAlgorithm.cs
@@ -16,7 +16,7 @@ namespace Internal.TypeSystem
         /// Resolves interface method '<paramref name="interfaceMethod"/>' to a method on '<paramref name="type"/>'
         /// that implements the the method.
         /// </summary>
-        public abstract MethodDesc ResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType);
+        public abstract bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc resolvedMethod);
 
         /// <summary>
         /// Resolves a virtual method call.

--- a/src/Common/src/TypeSystem/Common/VirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualMethodAlgorithm.cs
@@ -16,12 +16,12 @@ namespace Internal.TypeSystem
         /// Resolves interface method '<paramref name="interfaceMethod"/>' to a method on '<paramref name="type"/>'
         /// that implements the the method.
         /// </summary>
-        public abstract bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc resolvedMethod);
+        public abstract bool TryResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType, out ResolvedVirtualMethod resolvedMethod);
 
         /// <summary>
         /// Resolves a virtual method call.
         /// </summary>
-        public abstract MethodDesc FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType);
+        public abstract ResolvedVirtualMethod FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType);
 
         /// <summary>
         /// Enumerates all virtual methods introduced or overriden by '<paramref name="type"/>'.
@@ -31,6 +31,24 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Enumerates all virtual slots on '<paramref name="type"/>'.
         /// </summary>
-        public abstract IEnumerable<MethodDesc> ComputeAllVirtualSlots(TypeDesc type);
+        public abstract IEnumerable<ResolvedVirtualMethod> ComputeAllVirtualSlots(TypeDesc type);
+    }
+
+
+    public struct ResolvedVirtualMethod
+    {
+        public readonly TypeDesc OwningType;
+        public readonly MethodDesc Target;
+
+        public ResolvedVirtualMethod(TypeDesc owningType, MethodDesc target)
+        {
+            OwningType = owningType;
+            Target = target;
+        }
+
+        public ResolvedVirtualMethod(MethodDesc target)
+            : this(target.OwningType, target)
+        {
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/VirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/VirtualMethodAlgorithm.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Pluggable virtual method computation algorithm.
+    /// </summary>
+    public abstract class VirtualMethodAlgorithm
+    {
+        /// <summary>
+        /// Resolves interface method '<paramref name="interfaceMethod"/>' to a method on '<paramref name="type"/>'
+        /// that implements the the method.
+        /// </summary>
+        public abstract MethodDesc ResolveInterfaceMethodToVirtualMethodOnType(MethodDesc interfaceMethod, TypeDesc currentType);
+
+        /// <summary>
+        /// Resolves a virtual method call.
+        /// </summary>
+        public abstract MethodDesc FindVirtualFunctionTargetMethodOnObjectType(MethodDesc targetMethod, TypeDesc objectType);
+
+        /// <summary>
+        /// Enumerates all virtual methods introduced or overriden by '<paramref name="type"/>'.
+        /// </summary>
+        public abstract IEnumerable<MethodDesc> ComputeAllVirtualMethods(TypeDesc type);
+
+        /// <summary>
+        /// Enumerates all virtual slots on '<paramref name="type"/>'.
+        /// </summary>
+        public abstract IEnumerable<MethodDesc> ComputeAllVirtualSlots(TypeDesc type);
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -320,10 +320,10 @@ namespace Internal.TypeSystem.Ecma
 
             if (decl != null)
             {
-                MethodDesc impl = this.FindVirtualFunctionTargetMethodOnObjectType(decl);
+                ResolvedVirtualMethod impl = this.FindVirtualFunctionTargetMethodOnObjectType(decl);
                 if (impl.OwningType != objectType)
                 {
-                    return impl;
+                    return impl.Target;
                 }
 
                 return null;

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -320,7 +320,7 @@ namespace Internal.TypeSystem.Ecma
 
             if (decl != null)
             {
-                MethodDesc impl = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(decl, this);
+                MethodDesc impl = this.FindVirtualFunctionTargetMethodOnObjectType(decl);
                 if (impl.OwningType != objectType)
                 {
                     return impl;

--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -142,6 +142,10 @@ namespace Internal.IL
                 return ArrayMethodILEmitter.EmitIL((ArrayMethod)method);
             }
             else
+            if (method is ReparentedMethodDesc)
+            {
+                return CreateMethodIL(((ReparentedMethodDesc)method).ShadowMethod);
+            }
             {
                 return null;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -24,6 +24,8 @@ namespace ILCompiler
         private MetadataFieldLayoutAlgorithm _metadataFieldLayoutAlgorithm = new CompilerMetadataFieldLayoutAlgorithm();
         private MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
+        private StandardVirtualMethodAlgorithm _metadataVirtualMethodAlgorithm = new StandardVirtualMethodAlgorithm();
+        private ArrayOfTVirtualMethodAlgorithm _arrayOfTVirtualMethodAlgorithm;
 
         private MetadataStringDecoder _metadataStringDecoder;
 
@@ -250,6 +252,20 @@ namespace ILCompiler
         protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForDefType(DefType type)
         {
             return _metadataRuntimeInterfacesAlgorithm;
+        }
+
+        protected override VirtualMethodAlgorithm GetVirtualMethodAlgorithmForDefType(DefType type)
+        {
+            return _metadataVirtualMethodAlgorithm;
+        }
+
+        protected override VirtualMethodAlgorithm GetVirtualMethodAlgorithmForNonPointerArrayType(ArrayType type)
+        {
+            if (_arrayOfTVirtualMethodAlgorithm == null)
+            {
+                _arrayOfTVirtualMethodAlgorithm = new ArrayOfTVirtualMethodAlgorithm(SystemModule.GetKnownType("System", "Array`1"));
+            }
+            return _arrayOfTVirtualMethodAlgorithm;
         }
 
         public MetadataStringDecoder GetMetadataStringDecoder()

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -247,8 +247,8 @@ namespace ILCompiler.DependencyAnalysis
 
                 foreach (MethodDesc interfaceMethod in interfaceType.GetAllVirtualMethods())
                 {
-                    MethodDesc implMethod = _type.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod);
-                    if (implMethod != null)
+                    MethodDesc implMethod;
+                    if (_type.TryResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, out implMethod))
                     {
                         yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.ReadyToRunHelper(ReadyToRunHelperId.InterfaceDispatch, interfaceMethod), "Interface method");
                         yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.ReadyToRunHelper(ReadyToRunHelperId.ResolveVirtualFunction, interfaceMethod), "Interface method address");

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -77,7 +77,7 @@ namespace ILCompiler.DependencyAnalysis
             // End the run of dispatch cells
             objData.EmitZeroPointer();
             
-            int interfaceMethodSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, _targetMethod);
+            int interfaceMethodSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, new ResolvedVirtualMethod(_targetMethod));
             if (factory.Target.PointerSize == 8)
             {
                 objData.EmitLong(interfaceMethodSlot);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -102,7 +102,7 @@ namespace ILCompiler.DependencyAnalysis
                 for (int j = 0; j < virtualSlots.Count; j++)
                 {
                     MethodDesc declMethod = virtualSlots[j];
-                    var implMethod = VirtualFunctionResolution.ResolveInterfaceMethodToVirtualMethodOnType(declMethod, _type.GetClosestMetadataType());
+                    var implMethod = _type.ResolveInterfaceMethodToVirtualMethodOnType(declMethod);
 
                     // Interface methods first implemented by a base type in the hierarchy will return null for the implMethod (runtime interface
                     // dispatch will walk the inheritance chain).

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -97,16 +97,16 @@ namespace ILCompiler.DependencyAnalysis
                 var interfaceType = _type.RuntimeInterfaces[i];
                 Debug.Assert(interfaceType.IsInterface);
 
-                IReadOnlyList<MethodDesc> virtualSlots = factory.VTable(interfaceType).Slots;
+                IReadOnlyList<ResolvedVirtualMethod> virtualSlots = factory.VTable(interfaceType).Slots;
                 
                 for (int j = 0; j < virtualSlots.Count; j++)
                 {
-                    MethodDesc declMethod = virtualSlots[j];
-                    MethodDesc implMethod;
+                    ResolvedVirtualMethod declMethod = virtualSlots[j];
+                    ResolvedVirtualMethod implMethod;
 
                     // Interface methods first implemented by a base type in the hierarchy will return false (runtime interface
                     // dispatch will walk the inheritance chain).
-                    if (_type.TryResolveInterfaceMethodToVirtualMethodOnType(declMethod, out implMethod))
+                    if (_type.TryResolveInterfaceMethodToVirtualMethodOnType(declMethod.Target, out implMethod))
                     {
                         var entry = new DispatchMapEntry();
                         entry.InterfaceIndex = checked((short)i);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -102,11 +102,11 @@ namespace ILCompiler.DependencyAnalysis
                 for (int j = 0; j < virtualSlots.Count; j++)
                 {
                     MethodDesc declMethod = virtualSlots[j];
-                    var implMethod = _type.ResolveInterfaceMethodToVirtualMethodOnType(declMethod);
+                    MethodDesc implMethod;
 
-                    // Interface methods first implemented by a base type in the hierarchy will return null for the implMethod (runtime interface
+                    // Interface methods first implemented by a base type in the hierarchy will return false (runtime interface
                     // dispatch will walk the inheritance chain).
-                    if (implMethod != null)
+                    if (_type.TryResolveInterfaceMethodToVirtualMethodOnType(declMethod, out implMethod))
                     {
                         var entry = new DispatchMapEntry();
                         entry.InterfaceIndex = checked((short)i);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -167,7 +167,7 @@ namespace ILCompiler.DependencyAnalysis
                 return new JumpStubNode(node);
             });
 
-            _virtMethods = new NodeCache<MethodDesc, VirtualMethodUseNode>((MethodDesc method) =>
+            _virtMethods = new NodeCache<ResolvedVirtualMethod, VirtualMethodUseNode>((ResolvedVirtualMethod method) =>
             {
                 return new VirtualMethodUseNode(method);
             });
@@ -506,9 +506,9 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        private NodeCache<MethodDesc, VirtualMethodUseNode> _virtMethods;
+        private NodeCache<ResolvedVirtualMethod, VirtualMethodUseNode> _virtMethods;
 
-        public DependencyNode VirtualMethodUse(MethodDesc decl)
+        public DependencyNode VirtualMethodUse(ResolvedVirtualMethod decl)
         {
             return _virtMethods.GetOrAdd(decl);
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -104,20 +104,20 @@ namespace ILCompiler.DependencyAnalysis
             if (_id == ReadyToRunHelperId.VirtualCall)
             {
                 DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(context.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Call");
+                dependencyList.Add(context.VirtualMethodUse(new ResolvedVirtualMethod((MethodDesc)_target)), "ReadyToRun Virtual Method Call");
                 dependencyList.Add(context.VTable(((MethodDesc)_target).OwningType), "ReadyToRun Virtual Method Call Target VTable");
                 return dependencyList;
             }
             else if (_id == ReadyToRunHelperId.InterfaceDispatch)
             {
                 DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(context.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Interface Method Call");
+                dependencyList.Add(context.VirtualMethodUse(new ResolvedVirtualMethod((MethodDesc)_target)), "ReadyToRun Interface Method Call");
                 return dependencyList;
             }
             else if (_id == ReadyToRunHelperId.ResolveVirtualFunction)
             {
                 DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(context.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Address Load");
+                dependencyList.Add(context.VirtualMethodUse(new ResolvedVirtualMethod((MethodDesc)_target)), "ReadyToRun Virtual Method Address Load");
                 return dependencyList;
             }
             else

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.DependencyAnalysis
                         AddrMode loadFromThisPtr = new AddrMode(encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int64);
                         encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromThisPtr);
                     
-                        int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, (MethodDesc)Target);
+                        int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, new ResolvedVirtualMethod((MethodDesc)Target));
                         Debug.Assert(slot != -1);
                         AddrMode jmpAddrMode = new AddrMode(encoder.TargetRegister.Result, null, EETypeNode.GetVTableOffset(factory.Target.PointerSize) + (slot * factory.Target.PointerSize), 0, AddrModeSize.Int64);
                         encoder.EmitJmpToAddrMode(ref jmpAddrMode);
@@ -167,7 +167,7 @@ namespace ILCompiler.DependencyAnalysis
                             AddrMode loadFromThisPtr = new AddrMode(encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int64);
                             encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromThisPtr);
 
-                            int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod);
+                            int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, new ResolvedVirtualMethod(targetMethod));
                             Debug.Assert(slot != -1);
                             AddrMode loadFromSlot = new AddrMode(encoder.TargetRegister.Result, null, EETypeNode.GetVTableOffset(factory.Target.PointerSize) + (slot * factory.Target.PointerSize), 0, AddrModeSize.Int64);
                             encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromSlot);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -70,12 +70,8 @@ namespace ILCompiler.DependencyAnalysis
                 // When building a full VTable (such as for a type from a library), add dependencies on
                 // the virtual methods so that methods overriding them will be marked in the graph
                 // and compiled.
-                MetadataType mdType = _type.GetClosestMetadataType();
-                foreach (var method in mdType.GetMethods())
+                foreach (var method in _type.GetAllVirtualMethods())
                 {
-                    if (!method.IsVirtual)
-                        continue;
-
                     dependencies.Add(new DependencyListEntry(context.VirtualMethodUse(method), "VTable method dependency"));
                     _slots.Add(method);
                 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         TypeDesc _type;
         bool _shouldBuildFullVTable;
-        List<MethodDesc> _slots = new List<MethodDesc>();
+        List<ResolvedVirtualMethod> _slots = new List<ResolvedVirtualMethod>();
 
         public VTableSliceNode(TypeDesc type, NodeFactory context)
         {
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
         
-        public IReadOnlyList<MethodDesc> Slots
+        public IReadOnlyList<ResolvedVirtualMethod> Slots
         {
             get
             {
@@ -37,9 +37,9 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public void AddEntry(NodeFactory context, MethodDesc virtualMethod)
+        public void AddEntry(NodeFactory context, ResolvedVirtualMethod virtualMethod)
         {
-            Debug.Assert(virtualMethod.IsVirtual);
+            Debug.Assert(virtualMethod.Target.IsVirtual);
 
             if (_shouldBuildFullVTable)
                 return;
@@ -72,8 +72,9 @@ namespace ILCompiler.DependencyAnalysis
                 // and compiled.
                 foreach (var method in _type.GetAllVirtualMethods())
                 {
-                    dependencies.Add(new DependencyListEntry(context.VirtualMethodUse(method), "VTable method dependency"));
-                    _slots.Add(method);
+                    ResolvedVirtualMethod resolvedMethod = new ResolvedVirtualMethod(_type, method);
+                    dependencies.Add(new DependencyListEntry(context.VirtualMethodUse(resolvedMethod), "VTable method dependency"));
+                    _slots.Add(resolvedMethod);
                 }
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -20,9 +20,9 @@ namespace ILCompiler.DependencyAnalysis
     // vtables are properly constructed
     internal class VirtualMethodUseNode : DependencyNodeCore<NodeFactory>
     {
-        private MethodDesc _decl;
+        private ResolvedVirtualMethod _decl;
 
-        public VirtualMethodUseNode(MethodDesc decl)
+        public VirtualMethodUseNode(ResolvedVirtualMethod decl)
         {
             _decl = decl;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -22,21 +22,5 @@ namespace ILCompiler
             Debug.Assert(type.IsArray, "IsSealed on a type with no virtual methods?");
             return true;
         }
-
-        static public MetadataType GetClosestMetadataType(this TypeDesc type)
-        {
-            if (type.IsSzArray && !((ArrayType)type).ElementType.IsPointer)
-            {
-                MetadataType arrayType = type.Context.SystemModule.GetKnownType("System", "Array`1");
-                return arrayType.MakeInstantiatedType(new Instantiation(new TypeDesc[] { ((ArrayType)type).ElementType }));
-            }
-            else if (type.IsArray)
-            {
-                return (MetadataType)type.Context.GetWellKnownType(WellKnownType.Array);
-            }
-
-            Debug.Assert(type is MetadataType);
-            return (MetadataType)type;
-        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
@@ -12,7 +12,7 @@ namespace ILCompiler
         /// Given a virtual method decl, return its VTable slot if the method is used on its containing type.
         /// Return -1 if the virtual method is not used.
         /// </summary>
-        public static int GetVirtualMethodSlot(NodeFactory factory, MethodDesc method)
+        public static int GetVirtualMethodSlot(NodeFactory factory, ResolvedVirtualMethod method)
         {
             // TODO: More efficient lookup of the slot
             TypeDesc owningType = method.OwningType;
@@ -21,16 +21,16 @@ namespace ILCompiler
 
             while (baseType != null)
             {
-                IReadOnlyList<MethodDesc> baseVirtualSlots = factory.VTable(baseType).Slots;
+                IReadOnlyList<ResolvedVirtualMethod> baseVirtualSlots = factory.VTable(baseType).Slots;
                 baseSlots += baseVirtualSlots.Count;
                 baseType = baseType.BaseType;
             }
 
-            IReadOnlyList<MethodDesc> virtualSlots = factory.VTable(owningType).Slots;
+            IReadOnlyList<ResolvedVirtualMethod> virtualSlots = factory.VTable(owningType).Slots;
             int methodSlot = -1;
             for (int slot = 0; slot < virtualSlots.Count; slot++)
             {
-                if (virtualSlots[slot] == method)
+                if (virtualSlots[slot].Target == method.Target)
                 {
                     methodSlot = slot;
                     break;

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -914,7 +914,7 @@ namespace ILCompiler.CppCodeGen
             for (int i = 0; i < virtualSlots.Count; i++)
             {
                 MethodDesc declMethod = virtualSlots[i];
-                MethodDesc implMethod = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(declMethod, implType.GetClosestMetadataType());
+                MethodDesc implMethod = implType.FindVirtualFunctionTargetMethodOnObjectType(declMethod);
 
                 sb.AppendLine();
                 if (implMethod.IsAbstract)

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -651,13 +651,13 @@ namespace ILCompiler.CppCodeGen
                     sb.Append("static MethodTable * __getMethodTable();");
                 }
 
-                IReadOnlyList<MethodDesc> virtualSlots = _compilation.NodeFactory.VTable(t).Slots;
+                IReadOnlyList<ResolvedVirtualMethod> virtualSlots = _compilation.NodeFactory.VTable(t).Slots;
                 
                 int baseSlots = 0;
                 var baseType = t.BaseType;
                 while (baseType != null)
                 {
-                    IReadOnlyList<MethodDesc> baseVirtualSlots = _compilation.NodeFactory.VTable(baseType).Slots;
+                    IReadOnlyList<ResolvedVirtualMethod> baseVirtualSlots = _compilation.NodeFactory.VTable(baseType).Slots;
                     if (baseVirtualSlots != null)
                         baseSlots += baseVirtualSlots.Count;
                     baseType = baseType.BaseType;
@@ -665,7 +665,7 @@ namespace ILCompiler.CppCodeGen
 
                 for (int slot = 0; slot < virtualSlots.Count; slot++)
                 {
-                    MethodDesc virtualMethod = virtualSlots[slot];
+                    MethodDesc virtualMethod = virtualSlots[slot].Target;
                     sb.AppendLine();
                     sb.Append(GetCodeForVirtualMethod(virtualMethod, baseSlots + slot));
                 }
@@ -910,21 +910,21 @@ namespace ILCompiler.CppCodeGen
             if (baseType != null)
                 AppendVirtualSlots(sb, implType, baseType);
 
-            IReadOnlyList<MethodDesc> virtualSlots = _compilation.NodeFactory.VTable(declType).Slots;
+            IReadOnlyList<ResolvedVirtualMethod> virtualSlots = _compilation.NodeFactory.VTable(declType).Slots;
             for (int i = 0; i < virtualSlots.Count; i++)
             {
-                MethodDesc declMethod = virtualSlots[i];
-                MethodDesc implMethod = implType.FindVirtualFunctionTargetMethodOnObjectType(declMethod);
+                MethodDesc declMethod = virtualSlots[i].Target;
+                ResolvedVirtualMethod implMethod = implType.FindVirtualFunctionTargetMethodOnObjectType(declMethod);
 
                 sb.AppendLine();
-                if (implMethod.IsAbstract)
+                if (implMethod.Target.IsAbstract)
                 {
                     sb.Append("NULL,");
                 }
                 else
                 {
                     sb.Append("(void*)&");
-                    sb.Append(GetCppMethodDeclarationName(implMethod.OwningType, GetCppMethodName(implMethod)));
+                    sb.Append(GetCppMethodDeclarationName(implMethod.OwningType, GetCppMethodName(implMethod.Target)));
                     sb.Append(",");
                 }
             }
@@ -939,7 +939,7 @@ namespace ILCompiler.CppCodeGen
             TypeDesc t = type;
             while (t != null)
             {
-                IReadOnlyList<MethodDesc> virtualSlots = _compilation.NodeFactory.VTable(t).Slots;
+                IReadOnlyList<ResolvedVirtualMethod> virtualSlots = _compilation.NodeFactory.VTable(t).Slots;
                 totalSlots += virtualSlots.Count;
                 t = t.BaseType;
             }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -805,7 +805,7 @@ namespace Internal.IL
                     constrained = _constrained;
 
                     bool forceUseRuntimeLookup;
-                    MethodDesc directMethod = constrained.GetClosestMetadataType().TryResolveConstraintMethodApprox(method.OwningType, method, out forceUseRuntimeLookup);
+                    MethodDesc directMethod = constrained.TryResolveConstraintMethodApprox(method.OwningType, method, out forceUseRuntimeLookup);
                     if (directMethod == null || forceUseRuntimeLookup)
                         throw new NotImplementedException();
 

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -875,7 +875,7 @@ namespace Internal.IL
                     if (method.OwningType.IsInterface)
                         throw new NotImplementedException();
 
-                    _dependencies.Add(_nodeFactory.VirtualMethodUse(method));
+                    _dependencies.Add(_nodeFactory.VirtualMethodUse(new ResolvedVirtualMethod(method)));
 
                     callViaSlot = true;
                 }

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -25,11 +25,20 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\AlignmentHelper.cs">
       <Link>Utilities\AlignmentHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayOfTVirtualMethodAlgorithm.cs">
+      <Link>TypeSystem\Common\ArrayOfTVirtualMethodAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\BaseTypeVirtualMethodAlgorithm.cs">
+      <Link>TypeSystem\Common\BaseTypeVirtualMethodAlgorithm.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\IAssemblyDesc.cs">
       <Link>IAssemblyDesc.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\ModuleDesc.cs">
       <Link>ModuleDesc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ReparentedMethodDesc.cs">
+      <Link>TypeSystem\Common\ReparentedMethodDesc.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\CustomAttributeTypeNameParser.cs">
       <Link>Utilities\CustomAttributeTypeNameParser.cs</Link>
@@ -133,11 +142,14 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\WellKnownType.cs" >
       <Link>TypeSystem\Common\WellKnownType.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\VirtualMethodAlgorithm.cs">
+      <Link>TypeSystem\Common\VirtualMethodAlgorithm.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.cs" >
       <Link>TypeSystem\Common\MethodDesc.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\VirtualFunctionResolution.cs" >
-      <Link>TypeSystem\Common\VirtualFunctionResolution.cs</Link>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\StandardVirtualMethodAlgorithm.cs">
+      <Link>TypeSystem\Common\StandardVirtualMethodAlgorithm.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.cs" >
       <Link>TypeSystem\Common\TypeDesc.cs</Link>

--- a/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
@@ -23,6 +23,9 @@ namespace TypeSystemTests
         MetadataFieldLayoutAlgorithm _metadataFieldLayout = new TestMetadataFieldLayoutAlgorithm();
         MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
         ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
+        private StandardVirtualMethodAlgorithm _metadataVirtualMethodAlgorithm = new StandardVirtualMethodAlgorithm();
+        private ArrayOfTVirtualMethodAlgorithm _arrayOfTVirtualMethodAlgorithm;
+
 
         public TestTypeSystemContext(TargetArchitecture arch)
             : base(new TargetDetails(arch, TargetOS.Unknown))
@@ -67,6 +70,20 @@ namespace TypeSystemTests
         protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForDefType(DefType type)
         {
             return _metadataRuntimeInterfacesAlgorithm;
+        }
+
+        protected override VirtualMethodAlgorithm GetVirtualMethodAlgorithmForDefType(DefType type)
+        {
+            return _metadataVirtualMethodAlgorithm;
+        }
+
+        protected override VirtualMethodAlgorithm GetVirtualMethodAlgorithmForNonPointerArrayType(ArrayType type)
+        {
+            if (_arrayOfTVirtualMethodAlgorithm == null)
+            {
+                _arrayOfTVirtualMethodAlgorithm = new ArrayOfTVirtualMethodAlgorithm(SystemModule.GetType("System", "Array`1"));
+            }
+            return _arrayOfTVirtualMethodAlgorithm;
         }
     }
 }

--- a/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
@@ -62,7 +62,9 @@ namespace TypeSystemTests
             }
             Assert.NotNull(expectedVirtualMethod);
 
-            Assert.Equal(expectedVirtualMethod, objectType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod));
+            MethodDesc resolvedVirtualMethod;
+            Assert.True(objectType.TryResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, out resolvedVirtualMethod));
+            Assert.Equal(expectedVirtualMethod, resolvedVirtualMethod);
         }
 
         [Fact]

--- a/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
@@ -62,7 +62,7 @@ namespace TypeSystemTests
             }
             Assert.NotNull(expectedVirtualMethod);
 
-            Assert.Equal(expectedVirtualMethod, VirtualFunctionResolution.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, objectType));
+            Assert.Equal(expectedVirtualMethod, objectType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod));
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace TypeSystemTests
             InstantiatedType testInstance = openTestType.MakeInstantiatedType(new Instantiation(new TypeDesc[] { objectType }));
             MethodDesc targetOnInstance = testInstance.GetMethod("ToString", toStringSig);
 
-            MethodDesc targetMethod = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(objectToString, testInstance);
+            MethodDesc targetMethod = testInstance.FindVirtualFunctionTargetMethodOnObjectType(objectToString);
             Assert.Equal(targetOnInstance, targetMethod);        
         }
 
@@ -90,12 +90,12 @@ namespace TypeSystemTests
 
             MethodDesc baseNongenericOverload = baseInstance.GetMethod("MyMethod", new MethodSignature(MethodSignatureFlags.None, 0, _voidType, new TypeDesc[] { _stringType }));
             MethodDesc derivedNongenericOverload = derivedInstance.GetMethod("MyMethod", new MethodSignature(MethodSignatureFlags.None, 0, _voidType, new TypeDesc[] { _stringType }));
-            MethodDesc nongenericTargetOverload = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(baseNongenericOverload, derivedInstance);
+            MethodDesc nongenericTargetOverload = derivedInstance.FindVirtualFunctionTargetMethodOnObjectType(baseNongenericOverload);
             Assert.Equal(derivedNongenericOverload, nongenericTargetOverload);
 
             MethodDesc baseGenericOverload = baseInstance.GetMethod("MyMethod", new MethodSignature(MethodSignatureFlags.None, 0, _voidType, new TypeDesc[] { _context.GetSignatureVariable(0, false) }));
             MethodDesc derivedGenericOverload = derivedInstance.GetMethod("MyMethod", new MethodSignature(MethodSignatureFlags.None, 0, _voidType, new TypeDesc[] { _context.GetSignatureVariable(0, false) }));
-            MethodDesc genericTargetOverload = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(baseGenericOverload, derivedInstance);
+            MethodDesc genericTargetOverload = derivedInstance.FindVirtualFunctionTargetMethodOnObjectType(baseGenericOverload);
             Assert.Equal(derivedGenericOverload, genericTargetOverload);
         }
 
@@ -106,7 +106,7 @@ namespace TypeSystemTests
             DefType objectType = _testModule.Context.GetWellKnownType(WellKnownType.Object);
             MethodDesc finalizeMethod = objectType.GetMethod("Finalize", new MethodSignature(MethodSignatureFlags.None, 0, _voidType, new TypeDesc[] { }));
 
-            MethodDesc actualFinalizer = VirtualFunctionResolution.FindVirtualFunctionTargetMethodOnObjectType(finalizeMethod, classWithFinalizer);
+            MethodDesc actualFinalizer = classWithFinalizer.FindVirtualFunctionTargetMethodOnObjectType(finalizeMethod);
             Assert.NotNull(actualFinalizer);
             Assert.NotEqual(actualFinalizer, finalizeMethod);
         }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1954,7 +1954,7 @@ namespace Internal.JitInterface
                 // JIT compilation, and require a runtime lookup for the actual code pointer
                 // to call.
 
-                MethodDesc directMethod = constrainedType.GetClosestMetadataType().TryResolveConstraintMethodApprox(exactType, method, out forceUseRuntimeLookup);
+                MethodDesc directMethod = constrainedType.TryResolveConstraintMethodApprox(exactType, method, out forceUseRuntimeLookup);
                 if (directMethod != null)
                 {
                     // Either


### PR DESCRIPTION
I'm starting to feel like getting rid of GetClosestMetadataType is not feasible.

Things looked good until I found out (the hard way) that there are a bunch of places that use `.OwningType` on the various virtual methods and make decision based on that. Since the owning type is still ArrayOfT, things didn't work out so great.

That's when I came up with the monster that is `ReparentedMethodDesc`. How much do y'all hate it?