### PR TITLE
Assert VTables are complete before slots are used

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -160,14 +160,24 @@ namespace ILCompiler.DependencyAnalysis
             OutputFlags(factory, ref objData);
             OutputBaseSize(ref objData);
             OutputRelatedType(factory, ref objData);
-            OutputVirtualSlotAndInterfaceCount(factory, ref objData);
+
+            // Avoid consulting VTable slots until they're guaranteed complete during final data emission
+            if (!relocsOnly)
+            {
+                OutputVirtualSlotAndInterfaceCount(factory, ref objData);
+            }
 
             objData.EmitInt(_type.GetHashCode());
             objData.EmitPointerReloc(factory.ModuleManagerIndirection);
 
             if (_constructed)
             {
-                OutputVirtualSlots(factory, ref objData, _type, _type);
+                // Avoid consulting VTable slots until they're guaranteed complete during final data emission
+                if (!relocsOnly)
+                {
+                    OutputVirtualSlots(factory, ref objData, _type, _type);
+                }
+
                 OutputInterfaceMap(factory, ref objData);
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -76,15 +76,19 @@ namespace ILCompiler.DependencyAnalysis
             
             // End the run of dispatch cells
             objData.EmitZeroPointer();
-            
-            int interfaceMethodSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, _targetMethod);
-            if (factory.Target.PointerSize == 8)
+
+            // Avoid consulting VTable slots until they're guaranteed complete during final data emission
+            if (!relocsOnly)
             {
-                objData.EmitLong(interfaceMethodSlot);
-            }
-            else
-            {
-                throw new NotImplementedException();
+                int interfaceMethodSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, _targetMethod);
+                if (factory.Target.PointerSize == 8)
+                {
+                    objData.EmitLong(interfaceMethodSlot);
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
             }
 
             return objData.ToObjectData();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -20,6 +20,9 @@ namespace ILCompiler.DependencyAnalysis
         bool _shouldBuildFullVTable;
         List<MethodDesc> _slots = new List<MethodDesc>();
 
+#if DEBUG
+        bool _slotsCommitted;
+#endif
         public VTableSliceNode(TypeDesc type, NodeFactory factory)
         {
             _type = type;
@@ -33,6 +36,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
+#if DEBUG
+                _slotsCommitted = true;
+#endif
                 return _slots;
             }
         }
@@ -40,6 +46,9 @@ namespace ILCompiler.DependencyAnalysis
         public void AddEntry(NodeFactory factory, MethodDesc virtualMethod)
         {
             Debug.Assert(virtualMethod.IsVirtual);
+#if DEBUG
+            Debug.Assert(!_slotsCommitted);
+#endif
 
             if (_shouldBuildFullVTable)
                 return;


### PR DESCRIPTION
Add an assert in VTableSliceNode to ensure no VTable entries are added
to a slice after the Slots property is read.  Clean up a few places in
the dependency analysis where slots were read before they were
guaranteed to be complete.