### PR TITLE
Split VTableSliceNode into two

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -225,7 +225,10 @@ namespace ILCompiler.DependencyAnalysis
             
             _vTableNodes = new NodeCache<TypeDesc, VTableSliceNode>((TypeDesc type ) =>
             {
-                return new VTableSliceNode(type, this);
+                if (CompilationModuleGroup.ShouldProduceFullType(type))
+                    return new EagerlyBuiltVTableSliceNode(type);
+                else
+                    return new LazilyBuiltVTableSliceNode(type);
             });
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -2,95 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.TypeSystem;
-using System;
 using System.Collections.Generic;
-using Debug = System.Diagnostics.Debug;
+
+using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysisFramework;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
     /// Represents the VTable for a type's slice. For example, System.String's VTableSliceNode includes virtual 
-    /// slots added by System.String itself, System.Object's EETypeVTableSliceNode contains the virtuals it defines.
+    /// slots added by System.String itself, System.Object's VTableSliceNode contains the virtuals it defines.
     /// </summary>
-    internal class VTableSliceNode : DependencyNodeCore<NodeFactory>
+    internal abstract class VTableSliceNode : DependencyNodeCore<NodeFactory>
     {
-        TypeDesc _type;
-        bool _shouldBuildFullVTable;
-        List<MethodDesc> _slots = new List<MethodDesc>();
+        protected TypeDesc _type;
 
-#if DEBUG
-        bool _slotsCommitted;
-#endif
-        public VTableSliceNode(TypeDesc type, NodeFactory factory)
+        public VTableSliceNode(TypeDesc type)
         {
             _type = type;
-            if (factory.CompilationModuleGroup.ShouldProduceFullType(_type))
-            {
-                _shouldBuildFullVTable = true;
-            }
         }
         
-        public IReadOnlyList<MethodDesc> Slots
+        public abstract IReadOnlyList<MethodDesc> Slots
         {
-            get
-            {
-#if DEBUG
-                _slotsCommitted = true;
-#endif
-                return _slots;
-            }
-        }
-
-        public void AddEntry(NodeFactory factory, MethodDesc virtualMethod)
-        {
-            Debug.Assert(virtualMethod.IsVirtual);
-#if DEBUG
-            Debug.Assert(!_slotsCommitted);
-#endif
-
-            if (_shouldBuildFullVTable)
-                return;
-            
-            if (!_slots.Contains(virtualMethod))
-            {
-                _slots.Add(virtualMethod);
-            }
+            get;
         }
         
         public override string GetName()
         {
             return "__vtable_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
-        }
-
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
-        {
-            List<DependencyListEntry> dependencies = new List<DependencyListEntry>();
-            if (_type.HasBaseType)
-            {
-                dependencies.Add(new DependencyListEntry(factory.VTable(_type.BaseType), "Base type VTable"));
-            }
-
-            if (_shouldBuildFullVTable)
-            {
-                Debug.Assert(_slots.Count == 0);
-
-                // When building a full VTable (such as for a type from a library), add dependencies on
-                // the virtual methods so that methods overriding them will be marked in the graph
-                // and compiled.
-                MetadataType mdType = _type.GetClosestMetadataType();
-                foreach (var method in mdType.GetMethods())
-                {
-                    if (!method.IsVirtual)
-                        continue;
-
-                    dependencies.Add(new DependencyListEntry(factory.VirtualMethodUse(method), "VTable method dependency"));
-                    _slots.Add(method);
-                }
-            }
-
-            return dependencies;
         }
 
         public override bool StaticDependenciesAreComputed
@@ -133,6 +74,108 @@ namespace ILCompiler.DependencyAnalysis
             {
                 return false;
             }
+        }
+    }
+
+    /// <summary>
+    /// Represents a VTable slice for a complete type - a type with all virtual method slots generated,
+    /// irrespective of whether they are used.
+    /// </summary>
+    internal sealed class EagerlyBuiltVTableSliceNode : VTableSliceNode
+    {
+        private MethodDesc[] _slots;
+
+        public EagerlyBuiltVTableSliceNode(TypeDesc type)
+            : base(type)
+        {
+            var slots = new ArrayBuilder<MethodDesc>();
+
+            MetadataType mdType = _type.GetClosestMetadataType();
+            foreach (var method in mdType.GetMethods())
+            {
+                if (!method.IsVirtual)
+                    continue;
+
+                slots.Add(method);
+            }
+
+            _slots = slots.ToArray();
+        }
+
+        public override IReadOnlyList<MethodDesc> Slots
+        {
+            get
+            {
+                return _slots;
+            }
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            List<DependencyListEntry> dependencies = new List<DependencyListEntry>(_slots.Length + 1);
+            if (_type.HasBaseType)
+            {
+                dependencies.Add(new DependencyListEntry(factory.VTable(_type.BaseType), "Base type VTable"));
+            }
+
+            foreach (MethodDesc method in _slots)
+            {
+                dependencies.Add(new DependencyListEntry(factory.VirtualMethodUse(method), "Full vtable dependency"));
+            }
+
+            return dependencies;
+        }
+    }
+
+    /// <summary>
+    /// Represents a VTable slice where slots are built on demand. Only the slots that are actually used
+    /// will be generated.
+    /// </summary>
+    internal sealed class LazilyBuiltVTableSliceNode : VTableSliceNode
+    {
+        private List<MethodDesc> _slots = new List<MethodDesc>();
+
+#if DEBUG
+        bool _slotsCommitted;
+#endif
+
+        public LazilyBuiltVTableSliceNode(TypeDesc type)
+            : base(type)
+        {
+        }
+
+        public override IReadOnlyList<MethodDesc> Slots
+        {
+            get
+            {
+#if DEBUG
+                _slotsCommitted = true;
+#endif
+                return _slots;
+            }
+        }
+
+        public void AddEntry(NodeFactory factory, MethodDesc virtualMethod)
+        {
+            Debug.Assert(virtualMethod.IsVirtual);
+#if DEBUG
+            Debug.Assert(!_slotsCommitted);
+#endif
+
+            if (!_slots.Contains(virtualMethod))
+            {
+                _slots.Add(virtualMethod);
+            }
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            if (_type.HasBaseType)
+            {
+                return new[] { new DependencyListEntry(factory.VTable(_type.BaseType), "Base type VTable") };
+            }
+
+            return null;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -34,7 +34,11 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override void OnMarked(NodeFactory factory)
         {
-            factory.VTable(_decl.OwningType).AddEntry(factory, _decl);
+            // If the VTable slice is getting built on demand, the fact that the virtual method is used means
+            // that the slot is used.
+            var lazyVTableSlice = factory.VTable(_decl.OwningType) as LazilyBuiltVTableSliceNode;
+            if (lazyVTableSlice != null)
+                lazyVTableSlice.AddEntry(factory, _decl);
         }
 
         public override bool HasConditionalStaticDependencies


### PR DESCRIPTION
* CompleteVTableSliceNode is the VTableSlice that is used for full types
* DemandBuiltVTableSliceNode is the one that is demand built

The _shouldBuildFullVTable if was bothering me. I believe this is a bit
easier to follow and also a tiny bit more memory efficient.