### PR TITLE
Improve String.Equals loop body performance

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -701,19 +701,19 @@ namespace System
 
                 while (length >= 12)
                 {
-                    if (*(long*)a != *(long*)b) return false;
-                    if (*(long*)(a + 4) != *(long*)(b + 4)) return false;
-                    if (*(long*)(a + 8) != *(long*)(b + 8)) return false;
+                    if (*(long*)a != *(long*)b) goto ReturnFalse;
+                    if (*(long*)(a + 4) != *(long*)(b + 4)) goto ReturnFalse;
+                    if (*(long*)(a + 8) != *(long*)(b + 8)) goto ReturnFalse;
                     length -= 12; a += 12; b += 12;
                 }
 #else
                 while (length >= 10)
                 {
-                    if (*(int*)a != *(int*)b) return false;
-                    if (*(int*)(a + 2) != *(int*)(b + 2)) return false;
-                    if (*(int*)(a + 4) != *(int*)(b + 4)) return false;
-                    if (*(int*)(a + 6) != *(int*)(b + 6)) return false;
-                    if (*(int*)(a + 8) != *(int*)(b + 8)) return false;
+                    if (*(int*)a != *(int*)b) goto ReturnFalse;
+                    if (*(int*)(a + 2) != *(int*)(b + 2)) goto ReturnFalse;
+                    if (*(int*)(a + 4) != *(int*)(b + 4)) goto ReturnFalse;
+                    if (*(int*)(a + 6) != *(int*)(b + 6)) goto ReturnFalse;
+                    if (*(int*)(a + 8) != *(int*)(b + 8)) goto ReturnFalse;
                     length -= 10; a += 10; b += 10;
                 }
 #endif
@@ -724,11 +724,14 @@ namespace System
                 // the zero terminator.
                 while (length > 0)
                 {
-                    if (*(int*)a != *(int*)b) break;
+                    if (*(int*)a != *(int*)b) goto ReturnFalse;
                     length -= 2; a += 2; b += 2;
                 }
 
-                return (length <= 0);
+                return true;
+
+                ReturnFalse:
+                return false;
             }
         }
 
@@ -967,13 +970,10 @@ namespace System
                 return true;
             }
 
-            if ((Object)a == null || (Object)b == null)
+            if ((Object)a == null || (Object)b == null || a.Length != b.Length)
             {
                 return false;
             }
-
-            if (a.Length != b.Length)
-                return false;
 
             return OrdinalCompareEqualLengthStrings(a, b);
         }
@@ -1022,9 +1022,7 @@ namespace System
         {
             if (Object.ReferenceEquals(a, b))
                 return true;
-            if (a == null || b == null)
-                return false;
-            if (a.Length != b.Length)
+            if (a == null || b == null || a.Length != b.Length)
                 return false;
             return OrdinalCompareEqualLengthStrings(a, b);
         }
@@ -1033,9 +1031,7 @@ namespace System
         {
             if (Object.ReferenceEquals(a, b))
                 return false;
-            if (a == null || b == null)
-                return true;
-            if (a.Length != b.Length)
+            if (a == null || b == null || a.Length != b.Length)
                 return true;
             return !OrdinalCompareEqualLengthStrings(a, b);
         }


### PR DESCRIPTION
Apply the same loop exit optimization to `Equals` as what was applied to `StartsWith(char)`. Up to a x2 improvement in equal strings.
Also collapses the length not equals check into the existing null branch to remove a duplicate branch body.

Benchmark code https://gist.github.com/bbowyersmyth/da8a3b6d6a65cbb47902