### PR TITLE
Patch repro project response files

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
@@ -25,7 +25,7 @@ build.cmd clean
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`-r:C:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib\System.Private.CoreLib.dll @c:\corert\bin\obj\Windows_NT.x64.Debug\ryujit.rsp`
+`@c:\corert\bin\obj\Windows_NT.x64.Debug\ryujit.rsp`
 
   - Build & run using **F5**
     - This will run the compiler. The output is `c:\corert\src\ILCompiler\repro\obj\Debug\dnxcore50\native\repro.obj` file.
@@ -48,7 +48,7 @@ build.cmd clean
   - Set "desktop" project in solution explorer as your startup project
 
   - Set startup command line to:
-`-r:C:\corert\bin\Product\Windows_NT.x64.Debug\System.Private.CoreLib.dll @c:\corert\bin\obj\Windows_NT.x64.Debug\cpp.rsp`
+`@c:\corert\bin\obj\Windows_NT.x64.Debug\cpp.rsp`
 
     - `-nolinenumbers` command line option can be used to suppress generation of line number mappings in C++ files - useful for debugging
 


### PR DESCRIPTION
This replaces references to assemblies under publish1\sdk to point to
the live built ones.

Fixes #941.