### PR TITLE
Make it possible to override RyuJit

### DIFF
--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -77,7 +77,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\packaging\publish1\ryujit.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/tests/restore.cmd
+++ b/tests/restore.cmd
@@ -29,6 +29,14 @@ echo.
 echo Installing CoreRT external dependencies
 %__NuGetExeDir%\NuGet.exe install -Source %__NuGetFeedUrl% -OutputDir %__NuPkgInstallDir% -Version %CoreRT_AppDepSdkVer% %CoreRT_AppDepSdkPkg% -prerelease %__NuGetOptions%
 
+rem Allow overriding RyuJit retrieved from NuGet with a locally built one.
+if exist "%LIVE_RYUJIT_PATH%" (
+    echo.
+    echo Overwriting RyuJit in "%__NuPkgInstallDir%" with "%LIVE_RYUJIT_PATH%"
+    copy /y "%LIVE_RYUJIT_PATH%" "%__NuPkgInstallDir%\"
+    echo.
+)
+
 endlocal & (
   set CoreRT_ToolchainDir=%__NuPkgInstallDir%
   set CoreRT_AppDepSdkDir=%__NuPkgInstallDir%\%CoreRT_AppDepSdkPkg%.%CoreRT_AppDepSdkVer%


### PR DESCRIPTION
This lets us override RyuJit with a locally built one. Like so:

```
set
LIVE_RYUJIT_PATH=D:\git\coreclr\bin\obj\Windows_NT.x64.Debug\src\jit\standalone\Debug\ryujit.dll
build
```