### PR TITLE
Some readability edits to build instructions

### DIFF
--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -1,22 +1,19 @@
 The following pre-requisites need to be installed for building the repo:
 
-# Common Pre-requisites
-
-1. CMake is used for the build system and needs to be installed and present on the path. You can download it from [here](http://www.cmake.org/download/).
-
 # Windows (Windows 7+)
 
-Install [Visual Studio 2015](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), including Visual C++ support.
+1. Install [Visual Studio 2015](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), including Visual C++ support.
+2. Install [CMake](http://www.cmake.org/download/). We use CMake 3.3.2 but any later version should work.
+3. (Windows 7 only) Install PowerShell 3.0. It's part of [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Windows 8 or later comes with the right version inbox.
 
-PowerShell 3.0 or later is required to run the build scripts. On Windows 7, you need to install [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Later versions of Windows come with the right version of PowerShell inbox.
-PowerShell also needs to be available from the PATH environment variable. Typically it should be %SYSTEMROOT%\System32\WindowsPowerShell\v1.0\.
+PowerShell also needs to be available from the PATH environment variable (it's the default). Typically it should be %SYSTEMROOT%\System32\WindowsPowerShell\v1.0\.
 
 # Ubuntu (14.04)
 
 Install basic dependency packages:
 
 ```
-sudo apt-get install llvm-3.5 clang-3.5 lldb-3.6 lldb-3.6-dev libunwind8 libunwind8-dev liblttng-ust liblttng-ust-dev uuid uuid-dev
+sudo apt-get install cmake llvm-3.5 clang-3.5 lldb-3.6 lldb-3.6-dev libunwind8 libunwind8-dev liblttng-ust liblttng-ust-dev uuid uuid-dev
 ```
 
 
@@ -31,14 +28,11 @@ sudo apt-get update
 Next, install the **mono-complete** and **referenceassemblies-pcl** packages using the commands below:
 
 ```
-sudo apt-get install mono-complete
-sudo apt-get install referenceassemblies-pcl
+sudo apt-get install mono-complete referenceassemblies-pcl
 ```
 
 # Mac OSX (10.10+)
 
-Install [Command Line Tools for XCode 6.3.1](https://developer.apple.com/xcode/download/) or higher. 
-
-Next, install [Mono](http://www.mono-project.com/docs/getting-started/install/mac/)
-
-Download CMake from https://cmake.org/download/ and launch `/Applications/CMake.app/Contents/MacOS/CMake` GUI. Goto "OSX App Menu -> Tools -> Install For Command Line Use" and follow the steps.
+1. Install [Command Line Tools for XCode 6.3.1](https://developer.apple.com/xcode/download/) or higher. 
+2. Install [Mono](http://www.mono-project.com/docs/getting-started/install/mac/)
+3. Install [CMake](https://cmake.org/download/). Launch `/Applications/CMake.app/Contents/MacOS/CMake` GUI. Goto "OSX App Menu -> Tools -> Install For Command Line Use" and follow the steps.


### PR DESCRIPTION
I was following the Linux ones and of course I missed the `cmake` dependency. Getting rid of the "Common prerequisites" section and inlining it everywhere based on the usability test done on myself.