### PR TITLE
Fix signature instantiation for generic method on generic types

### DIFF
--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -372,14 +372,7 @@ namespace Internal.TypeSystem
 
         public virtual MethodDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            MethodDesc method = this;
-
-            TypeDesc owningType = method.OwningType;
-            TypeDesc instantiatedOwningType = owningType.InstantiateSignature(typeInstantiation, methodInstantiation);
-            if (owningType != instantiatedOwningType)
-                method = instantiatedOwningType.Context.GetMethodForInstantiatedType(method.GetTypicalMethodDefinition(), (InstantiatedType)instantiatedOwningType);
-
-            Instantiation instantiation = method.Instantiation;
+            Instantiation instantiation = Instantiation;
             TypeDesc[] clone = null;
 
             for (int i = 0; i < instantiation.Length; i++)
@@ -400,7 +393,18 @@ namespace Internal.TypeSystem
                 }
             }
 
-            return (clone == null) ? method : method.Context.GetInstantiatedMethod(method.GetMethodDefinition(), new Instantiation(clone));
+            MethodDesc method = this;
+
+            TypeDesc owningType = method.OwningType;
+            TypeDesc instantiatedOwningType = owningType.InstantiateSignature(typeInstantiation, methodInstantiation);
+            if (owningType != instantiatedOwningType)
+            {
+                method = Context.GetMethodForInstantiatedType(method.GetTypicalMethodDefinition(), (InstantiatedType)instantiatedOwningType);
+                if (clone == null && instantiation.Length != 0)
+                    return Context.GetInstantiatedMethod(method, instantiation);
+            }
+
+            return (clone == null) ? method : Context.GetInstantiatedMethod(method.GetMethodDefinition(), new Instantiation(clone));
         }
     }
 }


### PR DESCRIPTION
If `this` is something like `Foo<!0>.Generic<Bar<!0>>` the call to
`GetTypicalMethodDefinition` would strip the method instantiation away
and we would lose a piece of the context because `method` is now
`Foo<X>.Generic`.