### PR TITLE
Fail compilation of generic virtual methods

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -429,6 +429,12 @@ namespace ILCompiler.DependencyAnalysis
                 MethodDesc declMethod = virtualSlots[i];
                 MethodDesc implMethod = implType.GetClosestMetadataType().FindVirtualFunctionTargetMethodOnObjectType(declMethod);
 
+                if (declMethod.HasInstantiation)
+                {
+                    // Generic virtual methods will "compile", but will fail to link. Check for it here.
+                    throw new NotImplementedException("VTable for " + _type + " has generic virtual methods.");
+                }
+
                 if (!implMethod.IsAbstract)
                     objData.EmitPointerReloc(factory.MethodEntrypoint(implMethod, implMethod.OwningType.IsValueType));
                 else


### PR DESCRIPTION
Before this change, generic virtual methods would compile, but since we
don't do any expansion, they would cause linker failures downstream.
Root causing the linker failure is not possible without debugging the
compiler.

Making the compiler error out instead.