### PR TITLE
Cast to target type when unboxing

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -2199,6 +2199,9 @@ namespace Internal.IL
                     Append("*)");
                 }
 
+                Append("(");
+                Append(_writer.GetCppSignatureTypeName(type));
+                Append("*)");
                 Append("((void **)");
                 Append(obj.Value.Name);
                 Append("+1)");


### PR DESCRIPTION
Generate
```
intptr_t* _12 = (intptr_t*)((void **)_11+1);
```
instead of
```
intptr_t* _12 = ((void **)_11+1);
```