### PR TITLE
Merge ReadyToRun header pointers on Unix platforms

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -235,6 +235,11 @@ namespace ILCompiler.DependencyAnalysis
                 else
                     return new LazilyBuiltVTableSliceNode(type);
             });
+
+            _jumpThunks = new NodeCache<Tuple<ExternSymbolNode, ISymbolNode>, SingleArgumentJumpThunk>((Tuple<ExternSymbolNode, ISymbolNode> data) =>
+            {
+                return new SingleArgumentJumpThunk(data.Item1, data.Item2);
+            });
         }
 
         private NodeCache<TypeDesc, EETypeNode> _typeSymbols;
@@ -420,6 +425,17 @@ namespace ILCompiler.DependencyAnalysis
             return _vTableNodes.GetOrAdd(type);
         }
 
+        private NodeCache<Tuple<ExternSymbolNode, ISymbolNode>, SingleArgumentJumpThunk> _jumpThunks;
+        
+        /// <summary>
+        /// Create a thunk that calls an externally defined (e.g., native) function, passing
+        /// a dependency node to the function it calls.
+        /// </summary>
+        internal SingleArgumentJumpThunk JumpThunk(ExternSymbolNode target, ISymbolNode argument)
+        {
+            return _jumpThunks.GetOrAdd(new Tuple<ExternSymbolNode, ISymbolNode>(target, argument));
+        }
+        
         private NodeCache<MethodDesc, IMethodNode> _methodEntrypoints;
         private NodeCache<MethodDesc, IMethodNode> _unboxingStubs;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
@@ -13,6 +13,18 @@ namespace ILCompiler.DependencyAnalysis
         Executable
     }
 
+    [Flags]
+    public enum SectionAttributes
+    {
+        None                    = 0x0000,
+
+        /// <summary>
+        /// On MachO, apply the S_MOD_INIT_FUNC_POINTERS section type. Data in this section is
+        /// treated as a list of function pointers that the OS loader will call on startup.
+        /// </summary>
+        MachOInitFuncPointers   = 0x0100,
+    }
+
     /// <summary>
     /// Specifies the object file section a node will be placed in; ie "text" or "data"
     /// </summary>
@@ -21,15 +33,17 @@ namespace ILCompiler.DependencyAnalysis
         public string Name { get; private set; }
         public SectionType Type { get; private set; }
         public string ComdatName { get; private set; }
+        public SectionAttributes Attributes {get; private set; }
 
-        private ObjectNodeSection(string name, SectionType attributes, string comdatName)
+        private ObjectNodeSection(string name, SectionType type, SectionAttributes attributes, string comdatName)
         {
             Name = name;
-            Type = attributes;
+            Type = type;
+            Attributes = attributes;
             ComdatName = comdatName;
         }
 
-        public ObjectNodeSection(string name, SectionType attributes) : this(name, attributes, null)
+        public ObjectNodeSection(string name, SectionType type, SectionAttributes attributes = SectionAttributes.None) : this(name, type, attributes, null)
         { }
 
         /// <summary>
@@ -49,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis
             if (IsStandardSection)
                 standardSectionPrefix = ".";
 
-            return new ObjectNodeSection(standardSectionPrefix + Name + "$" + key, Type, key);
+            return new ObjectNodeSection(standardSectionPrefix + Name + "$" + key, Type, Attributes, key);
         }
 
         public static readonly ObjectNodeSection XDataSection = new ObjectNodeSection("xdata", SectionType.ReadOnly);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -94,6 +94,11 @@ namespace ILCompiler.DependencyAnalysis
             ReadOnly = 0x0000,
             Writeable = 0x0001,
             Executable = 0x0002,
+
+            //
+            // Flags specific to particular binary formats
+            //
+            MachOInitFuncPointers = 0x0100,
         };
 
         /// <summary>
@@ -113,6 +118,13 @@ namespace ILCompiler.DependencyAnalysis
                     break;
                 case SectionType.Writeable:
                     attributes |= CustomSectionAttributes.Writeable;
+                    break;
+            }
+
+            switch (section.Attributes)
+            {
+                case SectionAttributes.MachOInitFuncPointers:
+                    attributes |= CustomSectionAttributes.MachOInitFuncPointers;
                     break;
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SingleArgumentJumpThunk.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SingleArgumentJumpThunk.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Provides a mechanism to call a generated method with a pointer to another generated
+    /// node as a parameter.
+    /// </summary>
+    public partial class SingleArgumentJumpThunk : AssemblyStubNode
+    {
+        ExternSymbolNode _target;
+        ISymbolNode _argument;
+
+        public SingleArgumentJumpThunk(ExternSymbolNode target, ISymbolNode argument)
+        {
+            _target = target;
+            _argument = argument;
+        }
+
+        public override string MangledName
+        {
+            get
+            {
+                return "jumpthunk_1_" + _target.MangledName + "__" + _argument.MangledName;
+            }
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64SingleArgumentJumpThunk.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64SingleArgumentJumpThunk.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using ILCompiler.DependencyAnalysis.X64;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public partial class SingleArgumentJumpThunk : AssemblyStubNode
+    {
+        protected override void EmitCode(NodeFactory factory, ref X64Emitter encoder, bool relocsOnly)
+        {
+            encoder.EmitLEAQ(encoder.TargetRegister.Arg0, _argument);
+            encoder.EmitJMP(_target);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -55,8 +55,10 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.cs" />
     <Compile Include="Compiler\DelegateCreationInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\SingleArgumentJumpThunk.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CppMethodCodeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeImportMethodNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64SingleArgumentJumpThunk.cs" />
     <Compile Include="Compiler\DependencyAnalysis\VTableSliceNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EETypeOptionalFieldsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EmbeddedObjectNode.cs" />

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -5,7 +5,7 @@
     "System.Reflection.Metadata": "1.3.0-rc2-23910",
     "System.CommandLine": "0.1.0-e160208-1",
     "Microsoft.DotNet.RyuJit": "1.0.7-prerelease-00001",
-    "Microsoft.DotNet.ObjectWriter": "1.0.9-prerelease-00001"
+    "Microsoft.DotNet.ObjectWriter": "1.0.11-prerelease-00001"
   },
   "frameworks": {
     "dnxcore50": {

--- a/src/Native/Bootstrap/vector.h
+++ b/src/Native/Bootstrap/vector.h
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace NoStl
+{
+    //
+    // Simple vector that avoids using the STL but provides a familiar interface
+    //
+    template <class T>
+    class vector
+    {
+    public:
+        vector()
+            : m_data(0), m_capacity(0), m_count(0)
+        {
+        }
+
+        T &operator[](unsigned int i)
+        {
+            assert(i < m_count);
+            assert(m_data);
+            
+            return m_data[i];
+        }
+        
+        void push_back(const T &val)
+        {
+            if (!m_data || m_count >= m_capacity)
+                resize();
+        
+            if (m_data)
+                m_data[m_count++] = val;
+        }
+        
+        T &at(unsigned int i)
+        {
+            assert(m_data);
+            assert(i < m_count);
+            
+            return m_data[i];
+        }
+        
+        unsigned int size() const
+        {
+            assert(m_count == 0 || m_data);
+            return m_count;
+        }
+        
+        unsigned int capacity() const
+        {
+            return m_capacity;
+        }
+        
+        void clear()
+        {
+            if (m_data)
+                delete [] m_data;
+            
+            m_data = 0;
+            m_capacity = 0;
+            m_count = 0;
+        }
+
+        ~vector()
+        {
+            delete[] m_data;
+        }
+
+        vector(vector<T>& other) : m_count(0), m_capacity(0), m_data(0)
+        {
+            copy(other);
+        }
+
+        vector<T>& operator= (vector<T>& other)
+        {
+            // Avoid self-assignment
+            if (this != &other)
+            {
+                clear();
+                copy(other);
+            }
+
+            return this;
+        }
+
+    private:
+        void resize(unsigned int capacity = 0)
+        {
+            if (capacity == 0)
+            {
+                if (m_capacity)
+                {
+                    capacity = m_capacity << 1;
+                }
+                else
+                {
+                    capacity = 0x10;
+                }
+            }
+            
+            if (capacity > m_capacity)
+            {
+                T *buffer = new T[capacity];
+                memcpy(buffer, m_data, sizeof(T)*m_count);
+                
+                delete [] m_data;
+                m_data = buffer;
+                
+                m_capacity = capacity;
+            }
+        }
+
+        void copy(vector<T>& other)
+        {
+            resize(other.m_capacity);
+            for (int i = 0; i < other.size(); ++i)
+            {
+                push_back(other[i]);
+            }
+            assert(size() == other.size());
+        }
+        
+    private:
+        T *m_data;
+        unsigned int m_capacity;
+        unsigned int m_count;
+    };
+}

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -75,6 +75,8 @@
             <ILCompilerSdkFilesManaged Include="System.Private.StackTraceGenerator" />
             <ILCompilerSdkFilesManaged Include="System.Private.Threading" />
 
+            <ILCompilerSdkContentFiles Include="scripts/linkerscript" />
+
             <ILCompilerSdkBinPlace Include="@(ILCompilerSdkFiles)">
                 <Text><![CDATA[        <file src="$(RelativeProductBinDir)/lib/$(LibPrefix)%(Identity).$(StaticLibExt)" target="runtimes/$(NuPkgRid)/native/sdk/$(LibPrefix)%(Identity).$(StaticLibExt)" /> ]]></Text>
             </ILCompilerSdkBinPlace>
@@ -88,7 +90,10 @@
             <ILCompilerSdkBinPlace Include="@(ILCompilerSdkCppCodegenFiles)">
                 <Text><![CDATA[        <file src="src/%(Identity)" target="runtimes/$(NuPkgRid)/native/inc/%(Filename)%(Extension)" /> ]]></Text>
             </ILCompilerSdkBinPlace>
-            
+            <ILCompilerSdkBinPlace Include="@(ILCompilerSdkContentFiles)">
+                <Text><![CDATA[        <file src="src/%(Identity)" target="runtimes/$(NuPkgRid)/native/sdk/%(Filename)%(Extension)" /> ]]></Text>
+            </ILCompilerSdkBinPlace>
+
             <!-- ILCompiler nuspec file -->
             <NuSpecFile Include="$(ToolchainPackageName)">
                 <Stage>1</Stage>
@@ -98,7 +103,7 @@
                 <Files>@(ILCompilerBinPlace -> '%(Text)', '')</Files>
                 <!-- TODO: Obtain this from project.lock.json -->
                 <Dependencies><![CDATA[
-        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.9-prerelease-00001" />
+        <dependency id="Microsoft.DotNet.ObjectWriter" version="1.0.11-prerelease-00001" />
         <dependency id="Microsoft.DotNet.RyuJit" version="1.0.7-prerelease-00001" />
         <dependency id="NETStandard.Library" version="1.0.0-rc2-23910" />
         <dependency id="System.Collections.Immutable" version="1.2.0-rc2-23910" />

--- a/src/scripts/linkerscript
+++ b/src/scripts/linkerscript
@@ -1,0 +1,15 @@
+/*
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MIT license.
+See the LICENSE file in the project root for more information.
+*/
+
+SECTIONS
+{
+    .data : ALIGN(8)
+    {
+        *(.modules$A)
+        KEEP(*(.modules$I))
+        *(.modules$Z)
+    }
+}


### PR DESCRIPTION
Add a linker script which controls how sections are merged to group
together module header indirection cells. This allows the ReadyToRun
headers to be collated and iterated at start up. The updated CLI looks
for a file named "linkerscript" in the CoreRT SDK folder and passes it
to the linker on Unix platforms if so.

Remove work-around for Unix from ModulesSectionNode that was inserting
symbols for __modules_a and __modules_z which are now consumed from
those defined in main.cpp and linked in from libbootstrapper.a