### PR TITLE
Update CLI to 1.0.0-beta-002228

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -100,9 +100,9 @@ install_dotnet_cli()
         fi
         
         local __build_arch_lowercase=$(echo "${__BuildArch}" | tr '[:upper:]' '[:lower:]')
-        local __cli_tarball=dotnet-dev-${__build_os_lowercase}-${__build_arch_lowercase}.1.0.0-beta-002209.tar.gz
+        local __cli_tarball=dotnet-dev-${__build_os_lowercase}-${__build_arch_lowercase}.1.0.0-beta-002228.tar.gz
         local __cli_tarball_path=${__tools_dir}/${__cli_tarball}
-        download_file ${__cli_tarball_path} "https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/1.0.0-beta-002209/${__cli_tarball}"
+        download_file ${__cli_tarball_path} "https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/1.0.0-beta-002228/${__cli_tarball}"
         tar -xzf ${__cli_tarball_path} -C ${__cli_dir}
         export DOTNET_HOME=${__cli_dir}
         #

--- a/src/scripts/install-cli.ps1
+++ b/src/scripts/install-cli.ps1
@@ -14,8 +14,8 @@ $ProgressPreference="SilentlyContinue"
 
 $Feed="https://dotnetcli.blob.core.windows.net/dotnet"
 $Channel="beta"
-$DotNetFileName="dotnet-dev-win-" + $TargetPlatform + ".1.0.0-beta-002209.zip"
-$DotNetUrl="$Feed/$Channel/Binaries/1.0.0-beta-002209"
+$DotNetFileName="dotnet-dev-win-" + $TargetPlatform + ".1.0.0-beta-002228.zip"
+$DotNetUrl="$Feed/$Channel/Binaries/1.0.0-beta-002228"
 
 function say($str)
 {


### PR DESCRIPTION
Windows' CLI blob seems to have been removed and can no longer be
restored during build. Roll forwards to the latest blob version.