### PR TITLE
Fix repro project RSP file generation

### DIFF
--- a/src/ILCompiler/repro/project.json
+++ b/src/ILCompiler/repro/project.json
@@ -10,5 +10,11 @@
 
     "frameworks": {
         "dnxcore50": { }
+    },
+
+    "runtimes": {
+        "win7-x64": { },
+        "osx.10.10-x64": { },
+        "ubuntu.14.04-x64": { }
     }
 }


### PR DESCRIPTION
Latest version of dotnet CLI gets deeply offended by the lack of
"runtimes" section