### PR TITLE
Detect cases when type system objects from multiple contexts are used…

### DIFF
--- a/src/Common/src/TypeSystem/Common/FieldDesc.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.cs
@@ -21,6 +21,8 @@ namespace Internal.TypeSystem
 
         public override bool Equals(Object o)
         {
+            // Its only valid to compare two FieldDescs in the same context
+            Debug.Assert(Object.ReferenceEquals(o, null) || !(o is FieldDesc) || Object.ReferenceEquals(((FieldDesc)o).Context, this.Context));
             return Object.ReferenceEquals(this, o);
         }
 

--- a/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -24,11 +24,13 @@ namespace Internal.TypeSystem
 
             protected override bool CompareKeyToValue(MethodDesc key, MethodDesc value)
             {
+                Debug.Assert(key.Context == value.Context);
                 return Object.ReferenceEquals(key, value);
             }
 
             protected override bool CompareValueToValue(MethodDesc value1, MethodDesc value2)
             {
+                Debug.Assert(value1.Context == value2.Context);
                 return Object.ReferenceEquals(value1, value2);
             }
 

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -229,6 +229,8 @@ namespace Internal.TypeSystem
 
         public override bool Equals(Object o)
         {
+            // Its only valid to compare two MethodDescs in the same context
+            Debug.Assert(Object.ReferenceEquals(o, null) || !(o is MethodDesc) || Object.ReferenceEquals(((MethodDesc)o).Context, this.Context));
             return Object.ReferenceEquals(this, o);
         }
 

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -103,8 +103,26 @@ namespace Internal.TypeSystem
 
         public override bool Equals(Object o)
         {
+            // Its only valid to compare two TypeDescs in the same context
+            Debug.Assert(o == null || !(o is TypeDesc) || Object.ReferenceEquals(((TypeDesc)o).Context, this.Context));
             return Object.ReferenceEquals(this, o);
         }
+
+#if DEBUG
+        public static bool operator ==(TypeDesc left, TypeDesc right)
+        {
+            // Its only valid to compare two TypeDescs in the same context
+            Debug.Assert(Object.ReferenceEquals(left, null) || Object.ReferenceEquals(right, null) || Object.ReferenceEquals(left.Context, right.Context));
+            return Object.ReferenceEquals(left, right);
+        }
+
+        public static bool operator !=(TypeDesc left, TypeDesc right)
+        {
+            // Its only valid to compare two TypeDescs in the same context
+            Debug.Assert(Object.ReferenceEquals(left, null) || Object.ReferenceEquals(right, null) || Object.ReferenceEquals(left.Context, right.Context));
+            return !Object.ReferenceEquals(left, right);
+        }
+#endif
 
         // The most frequently used type properties are cached here to avoid excesive virtual calls
         private TypeFlags _typeFlags;


### PR DESCRIPTION
… in combination. This is done via asserts around comparison operators which should be sufficient.