### PR TITLE
Always use PublicKeyToken in metadata transform instead of PublicKey

### DIFF
--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -103,17 +103,16 @@ namespace ILCompiler.Metadata
 
                 Debug.Assert((int)AssemblyFlags.PublicKey == (int)AssemblyNameFlags.PublicKey);
                 Debug.Assert((int)AssemblyFlags.Retargetable == (int)AssemblyNameFlags.Retargetable);
-                scopeReference.Flags = (AssemblyFlags)assemblyName.Flags;
+
+                // References use a public key token instead of full public key.
+                scopeReference.Flags = (AssemblyFlags)(assemblyName.Flags & ~AssemblyNameFlags.PublicKey);
 
                 if (assemblyName.ContentType == AssemblyContentType.WindowsRuntime)
                 {
                     scopeReference.Flags |= (AssemblyFlags)((int)AssemblyContentType.WindowsRuntime << 9);
                 }
 
-                if ((assemblyName.Flags & AssemblyNameFlags.PublicKey) != 0)
-                    scopeReference.PublicKeyOrToken = assemblyName.GetPublicKey();
-                else
-                    scopeReference.PublicKeyOrToken = assemblyName.GetPublicKeyToken();
+                scopeReference.PublicKeyOrToken = assemblyName.GetPublicKeyToken();
             }
             else
             {


### PR DESCRIPTION
While a PublicKey is a valid representation in a reference, its rarely/never desireable. PublicKeyTokens are all that are expected to be present during assembly resolution, and thus resolution algorithms ignore the extra data encoded in a PublicKey as opposed to a PublicKeyToken, and actually must perform conversion to a PublicKeyToken to function which can be costly.