### PR TITLE
Set resolvedCallvirt if virtual method can be resolved at compile time

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2011,6 +2011,7 @@ namespace Internal.JitInterface
             {
                 // Delegate targets are always treated as direct calls here. (It would be nice to clean it up...).
                 directCall = true;
+                resolvedCallVirt = !targetMethod.IsVirtual || targetMethod.IsFinal || targetMethod.OwningType.IsSealed();
             }
             else if (targetMethod.Signature.IsStatic)
             {


### PR DESCRIPTION
Found this with CoreCLR tests. The logic that special cases the
delegates expects resolvedCallVirt to be set, but we were never setting
it for this case. This pattern was copied from CoreCLR JitInterface and
it puzzles me as to how it could possibly work there.

We ended up asking for a ReadyToRun helper to resolve the virtual call
even though the method was not virtual.