### PR TITLE
[WIP] Fix exception object passing to handler funclet

### DIFF
--- a/src/Native/Runtime/amd64/ExceptionHandling.asm
+++ b/src/Native/Runtime/amd64/ExceptionHandling.asm
@@ -383,6 +383,11 @@ endif
         movdqa  xmm15,[r8 + OFFSETOF__REGDISPLAY__Xmm + 9*10h]
 
         mov     rcx, [rsp + rsp_offsetof_arguments + 0h]            ;; rcx <- exception object
+
+ifdef CORERT
+        mov     rdx, rcx                                            ;; RyuJIT expects the exception object in rdx
+endif
+
         call    qword ptr [rsp + rsp_offsetof_arguments + 8h]       ;; call handler funclet
 ALTERNATE_ENTRY RhpCallCatchFunclet2
 

--- a/tests/src/Simple/Exceptions/Exceptions.cs
+++ b/tests/src/Simple/Exceptions/Exceptions.cs
@@ -46,6 +46,22 @@ public class BringUpTest
             Console.WriteLine("Null reference exception caught!");
         }
 
+        bool argumentExceptionCaught = false;
+        try
+        {
+            throw new ArgumentException("TheMessage", "TheParam");
+        }
+        catch (ArgumentException aex)
+        {
+            if (aex.ParamName == "TheParam")
+                Console.WriteLine("ArgumentException caught");
+            else
+                return Fail;
+            argumentExceptionCaught = true;
+        }
+        if (!argumentExceptionCaught)
+            return Fail;
+
         return Pass;
     }
 }


### PR DESCRIPTION
RyuJIT expects it to be in the second argument register.