### PR TITLE
Remove useless creation of a new temp name

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -623,7 +623,6 @@ namespace Internal.IL
         private void ImportLoadVar(int index, bool argument)
         {
             string name = GetVarName(index, argument);
-            string temp = NewTempName();
 
             TypeDesc type = GetVarType(index, argument);
             StackValueKind kind = GetStackValueKind(type);


### PR DESCRIPTION
Some code refactoring must have left this useless creation of a temporary local.