### PR TITLE
Stop passing executable name on the command line

### DIFF
--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -369,7 +369,7 @@ int main(int argc, char* argv[])
     {
         // Managed apps don't see the first args argument (full path of executable) so skip it
         assert(argc > 0);
-        retval = __managed__Main(argc, argv);
+        retval = __managed__Main(argc - 1, argv + 1);
     }
     catch (const char* &e)
     {


### PR DESCRIPTION
As the comment above the line I'm changing states - the first argument
passed to C main() doesn't exist on the managed side. We need to shift
everything by one.

The logic to do that was lost at some point.