### PR TITLE
Implement Environment.Exit for Win32, UWP and Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Environment.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Environment.cs
@@ -15,5 +15,8 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetMachineName")]
         internal static unsafe extern int GetMachineName(byte *hostNameBuffer, int hostNameBufferSize);
+
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_ExitProcess")]
+        internal static extern void ExitProcess(int exitCode);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
@@ -19,5 +19,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.Kernel32, EntryPoint = "GetComputerNameW")]
         internal static unsafe extern int GetComputerName(char* nameBuffer, ref int bufferSize);
+
+        [DllImport(Libraries.Kernel32, EntryPoint = "ExitProcess")]
+        internal static extern void ExitProcess(int exitCode);
     }
 }

--- a/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
@@ -115,3 +115,8 @@ extern "C" uint64_t CoreLibNative_GetTickCount64()
 #endif // HAVE_CLOCK_MONOTONIC 
     return retval;
 }
+
+extern "C" void CoreLibNative_ExitProcess(int32_t exitCode)
+{
+    exit(exitCode);
+}

--- a/src/System.Private.CoreLib/src/System/Environment.UWP.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.UWP.cs
@@ -46,5 +46,11 @@ namespace System
                 throw new PlatformNotSupportedException();
             }
         }
+
+        public static void Exit(int exitCode)
+        {
+            // Store apps have their lifetime managed by the PLM
+            throw new PlatformNotSupportedException();
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -84,5 +84,10 @@ namespace System
                 return Encoding.UTF8.GetString(hostName, hostNameLength);
             }
         }
+
+        public static void Exit(int exitCode)
+        {
+            Interop.Sys.ExitProcess(exitCode);
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -87,6 +87,7 @@ namespace System
 
         public static void Exit(int exitCode)
         {
+            // CORERT-TODO: Shut down the runtime
             Interop.Sys.ExitProcess(exitCode);
         }
     }

--- a/src/System.Private.CoreLib/src/System/Environment.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Win32.cs
@@ -124,5 +124,10 @@ namespace System
                 return new String(buf);
             }
         }
+
+        public static void Exit(int exitCode)
+        {
+            Interop.mincore.ExitProcess(exitCode);
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Environment.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Win32.cs
@@ -127,6 +127,7 @@ namespace System
 
         public static void Exit(int exitCode)
         {
+            // CORERT-TODO: Shut down the runtime
             Interop.mincore.ExitProcess(exitCode);
         }
     }


### PR DESCRIPTION
This is exposed from the latest System.Runtime.Extensions contract.

Fixes #1130.