### PR TITLE
Revisited stack management and fix for issue #1110

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -14,22 +14,26 @@ namespace Internal.IL
     //
     internal enum StackValueKind
     {
+        /// <summary>An unknow type.</summary>
         Unknown,
+        /// <summary>Any signed or unsigned integer values that can be represented as a 32-bit entity.</summary>
         Int32,
+        /// <summary>Any signed or unsigned integer values that can be represented as a 64-bit entity.</summary>
         Int64,
+        /// <summary>Underlying platform pointer type represented as an integer of the appropriate size.</summary>
         NativeInt,
+        /// <summary>Any float value.</summary>
         Float,
+        /// <summary>A managed pointer.</summary>
         ByRef,
+        /// <summary>An object reference.</summary>
         ObjRef,
+        /// <summary>A value type which is not any of the primitive one.</summary>
         ValueType
     }
 
     internal partial class ILImporter
     {
-        private static readonly StackValue[] s_emptyStack = new StackValue[0];
-        private StackValue[] _stack = s_emptyStack;
-        private int _stackTop = 0;
-
         private BasicBlock[] _basicBlocks; // Maps IL offset to basic block
 
         private BasicBlock _currentBasicBlock;
@@ -304,15 +308,6 @@ namespace Internal.IL
 
         private void ImportBasicBlock(BasicBlock basicBlock)
         {
-            _stackTop = 0;
-
-            StackValue[] entryStack = basicBlock.EntryStack;
-            if (entryStack != null)
-            {
-                for (int i = 0; i < entryStack.Length; i++)
-                    Push(entryStack[i]);
-            }
-
             _currentBasicBlock = basicBlock;
             _currentOffset = basicBlock.StartOffset;
 

--- a/src/ILCompiler.Compiler/src/CppCodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/EvaluationStack.cs
@@ -1,0 +1,509 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using ILCompiler.Compiler.CppCodeGen;
+using Internal.TypeSystem;
+
+namespace Internal.IL
+{
+    /// <summary>
+    /// Abstraction of a variable size last-in-first-out (LIFO) collection of instances of the same specified type
+    /// implemented via an array.
+    /// </summary>
+    /// <typeparam name="T">Type of elements in the stack.</typeparam>
+    internal class EvaluationStack<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the stack that is empty and has the specified initial capacity <paramref name="n"/>.
+        /// </summary>
+        /// <param name="n">Initial number of elements that the stack can contain.</param>
+        public EvaluationStack(int n)
+        {
+            Debug.Assert(n >= 0, "Count should be non-negative");
+
+            _stack = n > 0 ? new T[n] : s_emptyStack;
+            _top = 0;
+
+            Debug.Assert(n == _stack.Length, "Stack length does not match requested capacity");
+            Debug.Assert(_top == 0, "Top of stack is at bottom");
+        }
+
+        /// <summary>
+        /// Value for all stacks of length 0.
+        /// </summary>
+        private static readonly T[] s_emptyStack = new T[0];
+
+        /// <summary>
+        /// Storage for current stack.
+        /// </summary>
+        private T[] _stack;
+
+        /// <summary>
+        /// Position in <see cref="_stack"/> where next element will be pushed.
+        /// </summary>
+        private int _top;
+
+        /// <summary>
+        /// Position in stack where next element will be pushed.
+        /// </summary>
+        public int Top
+        {
+            get { return _top; }
+        }
+
+        /// <summary>
+        /// Number of elements contained in the stack.
+        /// </summary>
+        public int Length
+        {
+            get { return _top; }
+        }
+
+        /// <summary>
+        /// Push <paramref name="value"/> at the top of the stack.
+        /// </summary>
+        /// <param name="value">Element to push onto the stack.</param>
+        public void Push(T value)
+        {
+            if (_top >= _stack.Length)
+            {
+                Array.Resize(ref _stack, 2*_top + 3);
+            }
+            _stack[_top++] = value;
+        }
+
+        /// <summary>
+        /// Insert <paramref name="v"/> at position <paramref name="pos"/> in current stack, shifting all
+        /// elements after or at <paramref name="pos"/> by one.
+        /// </summary>
+        /// <param name="v">Element to insert</param>
+        /// <param name="pos">Position where to insert <paramref name="v"/></param>
+        public void InsertAt(T v, int pos)
+        {
+            Debug.Assert(pos < _top, "Invalid insertion point");
+
+            if (_top >= _stack.Length)
+            {
+                Array.Resize(ref _stack, 2*_top + 3);
+            }
+            for (int i = _top - 1; i >= pos; i--)
+            {
+                _stack[i + 1] = _stack[i];
+            }
+            _top++;
+            _stack[pos] = v;
+        }
+
+        /// <summary>
+        /// Access and set 
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public T this[int index]
+        {
+            get
+            {
+                Debug.Assert(index >= 0 && index < _top, "Index not in range");
+                return _stack[index];
+            }
+        }
+
+        /// <summary>
+        /// Return element of the top of the stack.
+        /// </summary>
+        /// <returns>Element at the top of the stack</returns>
+        public T Peek()
+        {
+            Debug.Assert(_top > 0, "Stack is not empty");
+            return _stack[_top - 1];
+        }
+
+        /// <summary>
+        /// Remove top element from stack and return it.
+        /// </summary>
+        /// <returns>Element formerly at the top of the stack</returns>
+        public T Pop()
+        {
+            Debug.Assert(_top > 0, "Stack is not empty");
+            return _stack[--_top];
+        }
+
+        /// <summary>
+        /// Remove <paramref name="n"/> elements from the stack.
+        /// </summary>
+        /// <param name="n">Number of elements to remove from the stack</param>
+        public void PopN(int n)
+        {
+            Debug.Assert(n <= _top, "Too many elements to remove");
+            _top -= n;
+        }
+
+        /// <summary>
+        /// Remove all elements from the stack.
+        /// </summary>
+        public void Clear()
+        {
+            _top = 0;
+        }
+    }
+
+    /// <summary>
+    /// Abstract representation of a stack entry
+    /// </summary>
+    internal abstract class StackEntry
+    {
+        /// <summary>
+        /// Evaluation stack kind of the entry. 
+        /// </summary>
+        public StackValueKind Kind { get; private set; }
+
+        /// <summary>
+        /// Managed type if any of the entry.
+        /// </summary>
+        public TypeDesc Type { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of StackEntry.
+        /// </summary>
+        /// <param name="kind">Kind of entry.</param>
+        /// <param name="type">Type if any of entry.</param>
+        protected StackEntry(StackValueKind kind, TypeDesc type = null)
+        {
+            Kind = kind;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Add representation of current entry in <paramref name="builder"/>.
+        /// </summary>
+        /// <param name="builder">Generation buffer used for appending new content.</param>
+        public abstract void Append(CppGenerationBuffer builder);
+
+        /// <summary>
+        /// Create a new copy of current entry.
+        /// </summary>
+        /// <returns>A new instance of the same type as the current entry.</returns>
+        public abstract StackEntry Duplicate();
+
+        /// <summary>
+        /// Overridden and sealed to force descendants to override <see cref="BuildRepresentation"/>.
+        /// </summary>
+        /// <returns>String representation of current entry</returns>
+        public override sealed string ToString()
+        {
+            StringBuilder s = new StringBuilder();
+            BuildRepresentation(s);
+            return s.ToString();
+        }
+
+        /// <summary>
+        /// Build a representation of current entry in <paramref name="s"/>.
+        /// </summary>
+        /// <param name="s">StringBuilder where representation will be saved.</param>
+        protected virtual void BuildRepresentation(StringBuilder s)
+        {
+            Debug.Assert(s != null, "StringBuilder is null.");
+            if (Type != null)
+            {
+                s.Append(Type);
+                if (Kind != StackValueKind.Unknown)
+                {
+                    s.Append('(');
+                    s.Append(Kind);
+                    s.Append(')');
+                }
+            }
+            else if (Kind != StackValueKind.Unknown)
+            {
+                if (Kind != StackValueKind.Unknown)
+                {
+                    s.Append('(');
+                    s.Append(Kind);
+                    s.Append(')');
+                }
+            }
+        }
+
+    }
+
+    /// <summary>
+    /// Abstract entry for all constant values.
+    /// </summary>
+    internal abstract class ConstantEntry : StackEntry
+    {
+        protected ConstantEntry(StackValueKind kind, TypeDesc type = null) : base(kind, type)
+        {
+        }
+
+        /// <summary>
+        /// Does current entry require a cast to be assigned to <paramref name="destType"/>?
+        /// </summary>
+        /// <param name="destType">Type of destination</param>
+        /// <returns>True if a cast is required</returns>
+        public virtual bool IsCastNecessary(TypeDesc destType)
+        {
+            return false;
+        }
+    }
+
+    internal abstract class ConstantEntry<T> : ConstantEntry where T:IConvertible
+    {
+        public T Value { get; private set; }
+
+        protected ConstantEntry(StackValueKind kind, T value, TypeDesc type = null) : base(kind, type)
+        {
+            Value = value;
+        }
+
+        public override void Append(CppGenerationBuffer _builder)
+        {
+            _builder.Append(Value.ToStringInvariant());
+        }
+
+        protected override void BuildRepresentation(StringBuilder s)
+        {
+            base.BuildRepresentation(s);
+            if (s.Length > 0)
+            {
+                s.Append(' ');
+            }
+            s.Append(Value);
+        }
+    }
+
+    internal class Int32ConstantEntry : ConstantEntry<int>
+    {
+        public Int32ConstantEntry(int value, TypeDesc type = null) : base(StackValueKind.Int32, value, type)
+        {
+        }
+
+        public override void Append(CppGenerationBuffer _builder)
+        {
+            if (Value == Int32.MinValue)
+            {
+                // Special case as if we were to print int.MinValue in decimal it would be
+                // -2147483648 but C does not understand it this way, it understands
+                // -(2147483648) and 2147483648 does not fit onto a 32-bit integer.
+                // We use an hex value instead.
+                _builder.Append("(int32_t)(0x80000000)");
+            }
+            else
+            {
+                _builder.Append(Value.ToStringInvariant());
+            }
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new Int32ConstantEntry(Value, Type);
+        }
+
+        public override bool IsCastNecessary(TypeDesc destType)
+        {
+            switch (destType.UnderlyingType.Category)
+            {
+                case TypeFlags.SByte:
+                    return Value >= sbyte.MaxValue || Value <= sbyte.MinValue;
+                case TypeFlags.Byte:
+                case TypeFlags.Boolean:
+                    return Value >= byte.MaxValue || Value < 0;
+                case TypeFlags.Int16:
+                    return Value >= short.MaxValue || Value <= short.MinValue;
+                case TypeFlags.UInt16:
+                case TypeFlags.Char:
+                    return Value >= ushort.MaxValue || Value < 0;
+                case TypeFlags.Int32:
+                    return false;
+                case TypeFlags.UInt32:
+                    return Value < 0;
+                default:
+                    return true;
+            }
+        }
+    }
+
+    internal class Int64ConstantEntry : ConstantEntry<long>
+    {
+        public Int64ConstantEntry(long value, TypeDesc type = null) : base(StackValueKind.Int64, value, type)
+        {
+        }
+
+        public override void Append(CppGenerationBuffer _builder)
+        {
+            if (Value == long.MinValue)
+            {
+                // See comment on Int32ConstantEntry.Append
+                _builder.Append("(int64_t)(INT64VAL(0x8000000000000000))");
+            }
+            else
+            {
+                _builder.Append("INT64VAL(");
+                _builder.Append(Value.ToStringInvariant());
+                _builder.Append(')');
+            }
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new Int64ConstantEntry(Value, Type);
+        }
+
+        public override bool IsCastNecessary(TypeDesc destType)
+        {
+            switch (destType.UnderlyingType.Category)
+            {
+                case TypeFlags.SByte:
+                    return Value >= sbyte.MaxValue || Value <= sbyte.MinValue;
+                case TypeFlags.Byte:
+                case TypeFlags.Boolean:
+                    return Value >= byte.MaxValue || Value < 0;
+                case TypeFlags.Int16:
+                    return Value >= short.MaxValue || Value <= short.MinValue;
+                case TypeFlags.UInt16:
+                case TypeFlags.Char:
+                    return Value >= ushort.MaxValue || Value < 0;
+                case TypeFlags.Int32:
+                    return Value >= int.MaxValue || Value <= int.MinValue;
+                case TypeFlags.UInt32:
+                    return Value >= uint.MaxValue || Value < 0;
+                case TypeFlags.Int64:
+                    return false;
+                case TypeFlags.UInt64:
+                    return Value < 0;
+                default:
+                    return true;
+            }
+        }
+    }
+
+    internal class FloatConstantEntry : ConstantEntry<double>
+    {
+        public FloatConstantEntry(double value, TypeDesc type = null) : base(StackValueKind.Float, value, type)
+        {
+        }
+
+        public override void Append(CppGenerationBuffer _builder)
+        {
+            // TODO: Handle infinity, NaN, etc.
+            if (Double.IsNaN(Value))
+            {
+                _builder.Append("nan(0)");
+                throw new NotImplementedException();
+            }
+            else if (Double.IsInfinity(Value) || Double.IsPositiveInfinity(Value) || Double.IsNegativeInfinity(Value))
+            {
+                // Negative Infinity can be encoded as 0xFFF0000000000000
+                // Positive Infinity can be encoded as 0x7FF0000000000000
+                throw new NotImplementedException();
+            }
+            else
+            {
+                _builder.Append(Value.ToStringInvariant());
+            }
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new FloatConstantEntry(Value, Type);
+        }
+    }
+
+    /// <summary>
+    /// Entry representing some expression
+    /// </summary>
+    internal class ExpressionEntry : StackEntry
+    {
+        /// <summary>
+        /// String representation of current expression
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Initializes new instance of ExpressionEntry
+        /// </summary>
+        /// <param name="kind">Kind of entry</param>
+        /// <param name="name">String representation of entry</param>
+        /// <param name="type">Type if any of entry</param>
+        public ExpressionEntry(StackValueKind kind, string name, TypeDesc type = null) : base(kind, type)
+        {
+            Name = name;
+        }
+        public override void Append(CppGenerationBuffer _builder)
+        {
+            _builder.Append(Name);
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new ExpressionEntry(Kind, Name, Type);
+        }
+
+        protected override void BuildRepresentation(StringBuilder s)
+        {
+            base.BuildRepresentation(s);
+            if (s.Length > 0)
+            {
+                s.Append(' ');
+            }
+            s.Append(Name);
+        }
+    }
+
+    /// <summary>
+    /// Entry representing some token (either of TypeDesc, MethodDesc or FieldDesc) along with its string representation
+    /// </summary>
+    internal class LdTokenEntry<T> : ExpressionEntry
+    {
+        public T LdToken { get; }
+
+        public LdTokenEntry(StackValueKind kind, string name, T token, TypeDesc type = null) : base(kind, name, type)
+        {
+            LdToken = token;
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new LdTokenEntry<T>(Kind, Name, LdToken, Type);
+        }
+
+        protected override void BuildRepresentation(StringBuilder s)
+        {
+            base.BuildRepresentation(s);
+            s.Append(' ');
+            s.Append(LdToken);
+        }
+    }
+
+    internal class InvalidEntry : StackEntry
+    {
+        /// <summary>
+        /// Entry to use to get an instance of InvalidEntry.
+        /// </summary>
+        public static InvalidEntry Entry = new InvalidEntry();
+
+        protected InvalidEntry() : base(StackValueKind.Unknown, null)
+        {
+        }
+
+        public override void Append(CppGenerationBuffer _builder)
+        {
+            _builder.Append("// FIXME: An invalid value was pushed onto the evaluation stack.");
+            Debug.Assert(false, "Invalid stack values shouldn't be appended.");
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return this;
+        }
+
+        protected override void BuildRepresentation(StringBuilder s)
+        {
+            s.Append("Invalid Entry");
+        }
+    }
+
+}

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -20,6 +20,11 @@ namespace Internal.IL
 {
     internal partial class ILImporter
     {
+        /// <summary>
+        /// Stack of values pushed onto the IL stack: locals, arguments, values, function pointer, ...
+        /// </summary>
+        private EvaluationStack<StackEntry> _stack = new EvaluationStack<StackEntry>(0);
+
         private Compilation _compilation;
         private NodeFactory _nodeFactory;
         private CppWriter _writer;
@@ -84,7 +89,7 @@ namespace Internal.IL
             public int StartOffset;
             public int EndOffset;
 
-            public StackValue[] EntryStack;
+            public EvaluationStack<StackEntry> EntryStack;
 
             public bool TryStart;
             public bool FilterStart;
@@ -105,8 +110,6 @@ namespace Internal.IL
             _methodSignature = method.Signature;
 
             _typeSystemContext = method.Context;
-
-            _msvc = (_typeSystemContext.Target.OperatingSystem == TargetOS.Windows);
 
             if (!_methodSignature.IsStatic)
                 _thisType = method.OwningType;
@@ -179,25 +182,6 @@ namespace Internal.IL
             _parameterIndexToNameMap = parameterIndexToNameMap;
         }
 
-        private struct Value
-        {
-            public Value(String name)
-            {
-                Name = name;
-                Aux = null;
-            }
-
-            public String Name;
-            public Object Aux;
-        };
-
-        private struct StackValue
-        {
-            public StackValueKind Kind;
-            public TypeDesc Type;
-            public Value Value;
-        }
-
         private StackValueKind GetStackValueKind(TypeDesc type)
         {
             switch (type.Category)
@@ -238,25 +222,6 @@ namespace Internal.IL
             }
         }
 
-        private void Push(StackValue value)
-        {
-            if (_stackTop >= _stack.Length)
-                Array.Resize(ref _stack, 2 * _stackTop + 3);
-            _stack[_stackTop++] = value;
-        }
-
-        private void Push(StackValueKind kind, Value value, TypeDesc type = null)
-        {
-            Push(new StackValue() { Kind = kind, Type = type, Value = value });
-        }
-
-        private StackValue Pop()
-        {
-            return _stack[--_stackTop];
-        }
-
-        private bool _msvc;
-
         private string GetStackValueKindCPPTypeName(StackValueKind kind, TypeDesc type = null)
         {
             switch (kind)
@@ -278,27 +243,61 @@ namespace Internal.IL
             return "_" + (_currentTemp++).ToStringInvariant();
         }
 
+      /// <summary>
+        /// Push an expression named <paramref name="name"/> of kind <paramref name="kind"/>.
+        /// </summary>
+        /// <param name="kind">Kind of entry in stack</param>
+        /// <param name="name">Variable to be pushed</param>
+        /// <param name="type">Type if any of <paramref name="name"/></param>
+        private void PushExpression(StackValueKind kind, string name, TypeDesc type = null)
+        {
+            Debug.Assert(kind != StackValueKind.Unknown, "Unknown stack kind");
+
+            _stack.Push(new ExpressionEntry(kind, name, type));
+        }
+
+        /// <summary>
+        /// Push a new temporary local of kind <paramref name="kind"/> and type <paramref name="type"/> and generate its declaration.
+        /// </summary>
+        /// <param name="kind">Kind of entry in stack</param>
+        /// <param name="type">Type if any for new entry in stack</param>
         private void PushTemp(StackValueKind kind, TypeDesc type = null)
         {
-            string temp = NewTempName();
+            Debug.Assert(kind != StackValueKind.Unknown, "Unknown stack kind");
 
-            Push(kind, new Value(temp), type);
+            PushTemp(new ExpressionEntry(kind, NewTempName(), type));
+        }
+
+        /// <summary>
+        /// Push a new entry onto evaluation stack and declare a temporary local to hold its representation.
+        /// </summary>
+        /// <param name="entry">Entry to push onto evaluation stack.</param>
+        private void PushTemp(StackEntry entry)
+        {
+            _stack.Push(entry);
 
             // Start declaration on a new line
             AppendLine();
-            Append(GetStackValueKindCPPTypeName(kind, type));
+            Append(GetStackValueKindCPPTypeName(entry.Kind, entry.Type));
             Append(" ");
-            Append(temp);
+            Append(entry);
             Append(" = ");
         }
 
-        private void AppendCastIfNecessary(TypeDesc destType, StackValueKind srcType)
+        /// <summary>
+        /// Generate a cast in case the stack type of source is not identical or compatible with destination type.
+        /// </summary>
+        /// <param name="destType">Type of destination</param>
+        /// <param name="srcEntry">Source entry from stack</param>
+        private void AppendCastIfNecessary(TypeDesc destType, StackEntry srcEntry)
         {
-            if (destType.IsValueType)
-                return;
-            Append("(");
-            Append(_writer.GetCppSignatureTypeName(destType));
-            Append(")");
+            ConstantEntry constant = srcEntry as ConstantEntry;
+            if ((constant != null) && (constant.IsCastNecessary(destType)) || !destType.IsValueType)
+            {
+                Append("(");
+                Append(_writer.GetCppSignatureTypeName(destType));
+                Append(")");
+            }
         }
 
         private void AppendCastIfNecessary(StackValueKind dstType, TypeDesc srcType)
@@ -316,19 +315,19 @@ namespace Internal.IL
             }
         }
 
-        private Value NewSpillSlot(StackValueKind kind, TypeDesc type)
+        private StackEntry NewSpillSlot(StackEntry entry)
         {
             if (_spillSlots == null)
                 _spillSlots = new List<SpillSlot>();
 
             SpillSlot spillSlot = new SpillSlot();
-            spillSlot.Kind = kind;
-            spillSlot.Type = type;
+            spillSlot.Kind = entry.Kind;
+            spillSlot.Type = entry.Type;
             spillSlot.Name = "_s" + _spillSlots.Count.ToStringInvariant();
 
             _spillSlots.Add(spillSlot);
 
-            return new Value() { Name = spillSlot.Name };
+            return new ExpressionEntry(entry.Kind, spillSlot.Name, entry.Type);
         }
 
         /// <summary>
@@ -370,6 +369,15 @@ namespace Internal.IL
         private void Append(string s)
         {
             _builder.Append(s);
+        }
+
+        /// <summary>
+        /// Append string representation of <paramref name="value"/> to <see cref="_builder"/>.
+        /// </summary>
+        /// <param name="value">Value to print.</param>
+        private void Append(StackEntry value)
+        {
+            value.Append(_builder);
         }
 
         /// <summary>
@@ -585,7 +593,7 @@ namespace Internal.IL
                                             "_" + j.ToStringInvariant() + ";");
                     }
                     AppendLine();
-                    Append("default: " + (_msvc ? "__assume(0)" : "__builtin_unreachable()") + ";");
+                    Append("default: CORERT_UNREACHABLE;");
                     Exdent();
                     AppendLine();
                     Append("}");
@@ -601,6 +609,18 @@ namespace Internal.IL
 
         private void StartImportingBasicBlock(BasicBlock basicBlock)
         {
+            _stack.Clear();
+
+            EvaluationStack<StackEntry> entryStack = basicBlock.EntryStack;
+            if (entryStack != null)
+            {
+                int n = entryStack.Length;
+                for (int i = 0; i < n; i++)
+                {
+                    _stack.Push(entryStack[i].Duplicate());
+                }
+            }
+
             Indent();
         }
 
@@ -635,7 +655,7 @@ namespace Internal.IL
 
         private void ImportStoreVar(int index, bool argument)
         {
-            var value = Pop();
+            var value = _stack.Pop();
 
             string name = GetVarName(index, argument);
 
@@ -643,8 +663,8 @@ namespace Internal.IL
             Append(name);
             Append(" = ");
             TypeDesc type = GetVarType(index, argument);
-            AppendCastIfNecessary(type, value.Kind);
-            Append(value.Value.Name);
+            AppendCastIfNecessary(type, value);
+            Append(value);
             AppendSemicolon();
         }
 
@@ -665,12 +685,12 @@ namespace Internal.IL
 
         private void ImportDup()
         {
-            Push(_stack[_stackTop - 1]);
+            _stack.Push(_stack.Peek().Duplicate());
         }
 
         private void ImportPop()
         {
-            Pop();
+            _stack.Pop();
         }
 
         private void ImportJmp(int token)
@@ -682,14 +702,14 @@ namespace Internal.IL
         {
             TypeDesc type = (TypeDesc)_methodIL.GetObject(token);
 
-            var value = Pop();
+            var value = _stack.Pop();
             PushTemp(StackValueKind.ObjRef, type);
 
             AddTypeReference(type, false);
 
             Append(opcode == ILOpcode.isinst ? "__isinst" : "__castclass");
             Append("(");
-            Append(value.Value.Name);
+            Append(value);
             Append(", ");
             Append(_writer.GetCppTypeName(type));
             Append("::__getMethodTable())");
@@ -713,11 +733,11 @@ namespace Internal.IL
                 case "InitializeArray":
                     if (IsTypeName(method, "System.Runtime.CompilerServices", "RuntimeHelpers"))
                     {
-                        var fieldSlot = Pop();
-                        var arraySlot = Pop();
+                        var fieldSlot = (LdTokenEntry<FieldDesc>) _stack.Pop();
+                        var arraySlot = _stack.Pop();
 
-                        var fieldDesc = (TypeSystem.Ecma.EcmaField)fieldSlot.Value.Aux;
-                        var memBlock = TypeSystem.Ecma.EcmaFieldExtensions.GetFieldRvaData(fieldDesc);
+                        var fieldDesc = fieldSlot.LdToken;
+                        var memBlock = TypeSystem.Ecma.EcmaFieldExtensions.GetFieldRvaData((TypeSystem.Ecma.EcmaField)fieldDesc);
 
                         // TODO: Need to do more for arches with different endianness?
                         var preinitDataHolder = NewTempName();
@@ -753,7 +773,7 @@ namespace Internal.IL
 
                         AppendLine();
                         Append("memcpy((char*)");
-                        Append(arraySlot.Value.Name);
+                        Append(arraySlot);
                         Append(" + ARRAY_BASE, ");
                         Append(preinitDataHolder);
                         Append(", ");
@@ -767,10 +787,9 @@ namespace Internal.IL
                 case "GetValueInternal":
                     if (IsTypeName(method, "System", "RuntimeTypeHandle"))
                     {
-                        StackValue typeHandleSlot = Pop();
-                        TypeDesc typeOfEEType = (TypeDesc)typeHandleSlot.Value.Aux;
-                        Push(StackValueKind.NativeInt, new Value(
-                            String.Concat("((intptr_t)", _writer.GetCppTypeName(typeOfEEType), "::__getMethodTable())")));
+                        var typeHandleSlot = (LdTokenEntry<TypeDesc>) _stack.Pop();
+                        TypeDesc typeOfEEType = typeHandleSlot.LdToken;
+                        PushExpression(StackValueKind.NativeInt, string.Concat("((intptr_t)", _writer.GetCppTypeName(typeOfEEType), "::__getMethodTable())"));
                         return true;
                     }
                     break;
@@ -831,13 +850,7 @@ namespace Internal.IL
 
                         // WORKAROUND: the static method expects an extra arg
                         // Annoyingly, it needs to be before all the others
-                        if (_stackTop >= _stack.Length)
-                            Array.Resize(ref _stack, 2 * _stackTop + 3);
-                        for (int i = _stackTop - 1; i > _stackTop - method.Signature.Length; i--)
-                            _stack[i + 1] = _stack[i];
-                        _stackTop++;
-                        _stack[_stackTop - method.Signature.Length] =
-                            new StackValue { Kind = StackValueKind.ObjRef, Value = new Value("0") };
+                        _stack.InsertAt(new ExpressionEntry(StackValueKind.ObjRef, "0"), _stack.Top - method.Signature.Length + 1);
                     }
                     else if (owningType.IsArray)
                     {
@@ -845,7 +858,7 @@ namespace Internal.IL
                     }
                     else if (owningType.IsDelegate)
                     {
-                        delegateInfo = _compilation.GetDelegateCtor(owningType, (MethodDesc)_stack[_stackTop - 1].Value.Aux);
+                        delegateInfo = _compilation.GetDelegateCtor(owningType, ((LdTokenEntry<MethodDesc>)_stack.Peek()).LdToken);
                         method = delegateInfo.Constructor.Method;
                     }
                 }
@@ -942,7 +955,8 @@ namespace Internal.IL
                         MethodDesc thunkMethod = delegateInfo.Thunk.Method;
                         AddMethodReference(thunkMethod);
 
-                        _stack[_stackTop - 2].Value.Name = temp;
+                        // Update stack with new name.
+                        ((ExpressionEntry) _stack[_stack.Top - 2]).Name = temp;
 
                         var sb = new CppGenerationBuffer();
                         AppendLine();
@@ -951,7 +965,7 @@ namespace Internal.IL
                         sb.Append("::");
                         sb.Append(_writer.GetCppMethodName(thunkMethod));
 
-                        Push(StackValueKind.NativeInt, new Value(sb.ToString()), null);
+                        PushExpression(StackValueKind.NativeInt, sb.ToString());
                     }
                 }
             }
@@ -961,20 +975,23 @@ namespace Internal.IL
 
             if (callViaSlot || delegateInvoke)
             {
+                // While waiting for C# return by ref, get this reference and insert it back
+                // if it is a delegate invoke.
+                ExpressionEntry v = (ExpressionEntry) _stack[_stack.Top - (methodSignature.Length + 1)];
                 Append("(*");
                 Append(_writer.GetCppTypeName(method.OwningType));
                 Append("::");
                 Append(delegateInvoke ? "__invoke__" : "__getslot__");
                 Append(_writer.GetCppMethodName(method));
                 Append("(");
-                Append(_stack[_stackTop - (methodSignature.Length + 1)].Value.Name);
+                Append(v);
                 Append("))");
 
                 if (delegateInvoke)
                 {
-                    _stack[_stackTop - (methodSignature.Length + 1)].Value.Name =
+                    v.Name =
                         "((" + _writer.GetCppSignatureTypeName(GetWellKnownType(WellKnownType.MulticastDelegate)) + ")" +
-                            _stack[_stackTop - (methodSignature.Length + 1)].Value.Name + ")->m_firstParameter";
+                            v.Name + ")->m_firstParameter";
                 }
             }
             else if (mdArrayCreate)
@@ -1028,7 +1045,10 @@ namespace Internal.IL
             Append(")");
 
             if (temp != null)
-                Push(retKind, new Value(temp), retType);
+            {
+                Debug.Assert(retKind != StackValueKind.Unknown, "Valid return type");
+                PushExpression(retKind, temp, retType);
+            }
             AppendSemicolon();
         }
 
@@ -1036,9 +1056,10 @@ namespace Internal.IL
         {
             int signatureLength = methodSignature.Length;
             int argumentsCount = (thisArgument != null) ? (signatureLength + 1) : signatureLength;
+            int startingIndex = _stack.Top - argumentsCount;
             for (int i = 0; i < argumentsCount; i++)
             {
-                var op = _stack[_stackTop - argumentsCount + i];
+                var op = _stack[startingIndex + i];
                 int argIndex = signatureLength - (argumentsCount - i);
                 TypeDesc argType;
                 if (argIndex == -1)
@@ -1049,12 +1070,12 @@ namespace Internal.IL
                 {
                     argType = methodSignature[argIndex];
                 }
-                AppendCastIfNecessary(argType, op.Kind);
-                Append(op.Value.Name);
+                AppendCastIfNecessary(argType, op);
+                Append(op);
                 if (i + 1 != argumentsCount)
                     Append(", ");
             }
-            _stackTop -= argumentsCount;
+            _stack.PopN(argumentsCount);
         }
 
         private void ImportCalli(int token)
@@ -1098,17 +1119,20 @@ namespace Internal.IL
                 AppendLine();
             }
 
-            var fnPtrValue = Pop();
+            var fnPtrValue = _stack.Pop();
             Append("((");
             Append(typeDefName);
             Append(")");
-            Append(fnPtrValue.Value.Name);
+            Append(fnPtrValue);
             Append(")(");
             PassCallArguments(methodSignature, thisArgument);
             Append(")");
 
             if (temp != null)
-                Push(retKind, new Value(temp), retType);
+            {
+                Debug.Assert(retKind != StackValueKind.Unknown, "Valid return type");
+                PushExpression(retKind, temp, retType);
+            }
 
             AppendSemicolon();
         }
@@ -1125,51 +1149,37 @@ namespace Internal.IL
 
             AddMethodReference(method);
 
-            PushTemp(StackValueKind.NativeInt);
+            var entry = new LdTokenEntry<MethodDesc>(StackValueKind.NativeInt, NewTempName(), method);
+            PushTemp(entry);
             Append("(intptr_t)&");
             Append(_writer.GetCppTypeName(method.OwningType));
             Append("::");
             Append(_writer.GetCppMethodName(method));
-
-            _stack[_stackTop - 1].Value.Aux = method;
 
             AppendSemicolon();
         }
 
         private void ImportLoadInt(long value, StackValueKind kind)
         {
-            string val;
             if (kind == StackValueKind.Int64)
             {
-                if (value == Int64.MinValue)
-                    val = "(int64_t)(0x8000000000000000" + (_msvc ? "i64" : "LL") + ")";
-                else
-                    val = value.ToStringInvariant() + (_msvc ? "i64" : "LL");
+                _stack.Push(new Int64ConstantEntry(value));
             }
             else
             {
-                if (value == Int32.MinValue)
-                    val = "(int32_t)(0x80000000)";
-                else
-                    val = ((int)value).ToStringInvariant();
+                Debug.Assert(value >= Int32.MinValue && value <= Int32.MaxValue, "Value too large for an Int32.");
+                _stack.Push(new Int32ConstantEntry(checked((int) value)));
             }
-
-            Push(kind, new Value(val));
         }
 
         private void ImportLoadFloat(double value)
         {
-            // TODO: Handle infinity, NaN, etc.
-            if (Double.IsNaN(value) || Double.IsInfinity(value) || Double.IsPositiveInfinity(value) || Double.IsNegativeInfinity(value))
-                throw new NotImplementedException();
-
-            string val = value.ToStringInvariant();
-            Push(StackValueKind.Float, new Value(val));
+            _stack.Push(new FloatConstantEntry(value));
         }
 
         private void ImportLoadNull()
         {
-            Push(StackValueKind.ObjRef, new Value("0"));
+            PushExpression(StackValueKind.ObjRef, "0");
         }
 
         private void ImportReturn()
@@ -1182,21 +1192,21 @@ namespace Internal.IL
             }
             else
             {
-                var value = Pop();
+                var value = _stack.Pop();
                 Append("return ");
-                AppendCastIfNecessary(returnType, value.Kind);
-                Append(value.Value.Name);
+                AppendCastIfNecessary(returnType, value);
+                Append(value);
             }
             AppendSemicolon();
         }
 
         private void ImportFallthrough(BasicBlock next)
         {
-            StackValue[] entryStack = next.EntryStack;
+            EvaluationStack<StackEntry> entryStack = next.EntryStack;
 
             if (entryStack != null)
             {
-                if (entryStack.Length != _stackTop)
+                if (entryStack.Length != _stack.Length)
                     throw new InvalidProgramException();
 
                 for (int i = 0; i < entryStack.Length; i++)
@@ -1214,25 +1224,28 @@ namespace Internal.IL
             }
             else
             {
-                entryStack = (_stackTop != 0) ? new StackValue[_stackTop] : s_emptyStack;
-
-                for (int i = 0; i < entryStack.Length; i++)
+                if (_stack.Length > 0)
                 {
-                    StackValue spilledValue = _stack[i];
-                    spilledValue.Value = NewSpillSlot(spilledValue.Kind, spilledValue.Type);
-                    entryStack[i] = spilledValue;
-                }
+                    entryStack = new EvaluationStack<StackEntry>(_stack.Length);
 
+                    for (int i = 0; i < _stack.Length; i++)
+                    {
+                        entryStack.Push(NewSpillSlot(_stack[i]));
+                    }
+                }
                 next.EntryStack = entryStack;
             }
 
-            for (int i = 0; i < entryStack.Length; i++)
+            if (entryStack != null)
             {
-                AppendLine();
-                Append(entryStack[i].Value.Name);
-                Append(" = ");
-                Append(_stack[i].Value.Name);
-                AppendSemicolon();
+                for (int i = 0; i < entryStack.Length; i++)
+                {
+                    AppendLine();
+                    Append(entryStack[i]);
+                    Append(" = ");
+                    Append(_stack[i]);
+                    AppendSemicolon();
+                }
             }
 
             MarkBasicBlock(next);
@@ -1240,11 +1253,11 @@ namespace Internal.IL
 
         private void ImportSwitchJump(int jmpBase, int[] jmpDelta, BasicBlock fallthrough)
         {
-            var op = Pop();
+            var op = _stack.Pop();
 
             AppendLine();
             Append("switch (");
-            Append(op.Value.Name);
+            Append(op);
             Append(") {");
             Indent();
 
@@ -1280,14 +1293,14 @@ namespace Internal.IL
                 Append("if (");
                 if (opcode == ILOpcode.brfalse || opcode == ILOpcode.brtrue)
                 {
-                    var op = Pop();
-                    Append(op.Value.Name);
+                    var op = _stack.Pop();
+                    Append(op);
                     Append((opcode == ILOpcode.brtrue) ? " != 0" : " == 0");
                 }
                 else
                 {
-                    var op1 = Pop();
-                    var op2 = Pop();
+                    var op1 = _stack.Pop();
+                    var op2 = _stack.Pop();
 
                     // StackValueKind is carefully ordered to make this work (assuming the IL is valid)
                     StackValueKind kind;
@@ -1375,7 +1388,7 @@ namespace Internal.IL
                         Append(GetStackValueKindCPPTypeName(kind));
                         Append(")");
                     }
-                    Append(op2.Value.Name);
+                    Append(op2);
                     Append(" ");
                     Append(op);
                     Append(" ");
@@ -1385,7 +1398,7 @@ namespace Internal.IL
                         Append(GetStackValueKindCPPTypeName(kind));
                         Append(")");
                     }
-                    Append(op1.Value.Name);
+                    Append(op1);
                     if (inverted)
                     {
                         Append(")");
@@ -1410,8 +1423,8 @@ namespace Internal.IL
 
         private void ImportBinaryOperation(ILOpcode opcode)
         {
-            var op1 = Pop();
-            var op2 = Pop();
+            var op1 = _stack.Pop();
+            var op2 = _stack.Pop();
 
             // StackValueKind is carefully ordered to make this work (assuming the IL is valid)
             StackValueKind kind;
@@ -1470,7 +1483,7 @@ namespace Internal.IL
                 Append(GetStackValueKindCPPTypeName(kind));
                 Append(")");
             }
-            Append(op2.Value.Name);
+            Append(op2);
             Append(" ");
             Append(op);
             Append(" ");
@@ -1480,15 +1493,15 @@ namespace Internal.IL
                 Append(GetStackValueKindCPPTypeName(kind));
                 Append(")");
             }
-            Append(op1.Value.Name);
+            Append(op1);
 
             AppendSemicolon();
         }
 
         private void ImportShiftOperation(ILOpcode opcode)
         {
-            var shiftAmount = Pop();
-            var op = Pop();
+            var shiftAmount = _stack.Pop();
+            var op = _stack.Pop();
 
             PushTemp(op.Kind, op.Type);
 
@@ -1498,18 +1511,18 @@ namespace Internal.IL
                 Append(GetStackValueKindCPPTypeName(op.Kind));
                 Append(")");
             }
-            Append(op.Value.Name);
+            Append(op);
 
             Append((opcode == ILOpcode.shl) ? " << " : " >> ");
 
-            Append(shiftAmount.Value.Name);
+            Append(shiftAmount);
             AppendSemicolon();
         }
 
         private void ImportCompareOperation(ILOpcode opcode)
         {
-            var op1 = Pop();
-            var op2 = Pop();
+            var op1 = _stack.Pop();
+            var op2 = _stack.Pop();
 
             // StackValueKind is carefully ordered to make this work (assuming the IL is valid)
             StackValueKind kind;
@@ -1572,7 +1585,7 @@ namespace Internal.IL
                 Append(GetStackValueKindCPPTypeName(kind));
                 Append(")");
             }
-            Append(op2.Value.Name);
+            Append(op2);
             Append(" ");
             Append(op);
             Append(" ");
@@ -1582,7 +1595,7 @@ namespace Internal.IL
                 Append(GetStackValueKindCPPTypeName(kind));
                 Append(")");
             }
-            Append(op1.Value.Name);
+            Append(op1);
             if (inverted)
             {
                 Append(")");
@@ -1592,7 +1605,7 @@ namespace Internal.IL
 
         private void ImportConvert(WellKnownType wellKnownType, bool checkOverflow, bool unsigned)
         {
-            var op = Pop();
+            var op = _stack.Pop();
 
             TypeDesc type = GetWellKnownType(wellKnownType);
 
@@ -1600,7 +1613,7 @@ namespace Internal.IL
             Append("(");
             Append(_writer.GetCppSignatureTypeName(type));
             Append(")");
-            Append(op.Value.Name);
+            Append(op);
             AppendSemicolon();
         }
 
@@ -1610,7 +1623,7 @@ namespace Internal.IL
 
             AddFieldReference(field);
 
-            var thisPtr = isStatic ? new StackValue() : Pop();
+            var thisPtr = isStatic ? InvalidEntry.Entry : _stack.Pop();
 
             TypeDesc owningType = field.OwningType;
             TypeDesc fieldType = field.FieldType;
@@ -1637,7 +1650,7 @@ namespace Internal.IL
             else
             if (thisPtr.Kind == StackValueKind.ValueType)
             {
-                Append(thisPtr.Value.Name);
+                Append(thisPtr);
                 Append(".");
                 Append(_writer.GetCppFieldName(field));
             }
@@ -1646,7 +1659,7 @@ namespace Internal.IL
                 Append("((");
                 Append(_writer.GetCppTypeName(owningType));
                 Append("*)");
-                Append(thisPtr.Value.Name);
+                Append(thisPtr);
                 Append(")->");
                 Append(_writer.GetCppFieldName(field));
 
@@ -1663,7 +1676,7 @@ namespace Internal.IL
 
             AddFieldReference(field);
 
-            var thisPtr = isStatic ? new StackValue() : Pop();
+            var thisPtr = isStatic ? InvalidEntry.Entry: _stack.Pop();
 
             TypeDesc owningType = field.OwningType;
             TypeDesc fieldType = field.FieldType;
@@ -1700,7 +1713,7 @@ namespace Internal.IL
                 Append("((");
                 Append(_writer.GetCppTypeName(owningType));
                 Append("*)");
-                Append(thisPtr.Value.Name);
+                Append(thisPtr);
                 Append(")->");
                 Append(_writer.GetCppFieldName(field));
 
@@ -1718,8 +1731,8 @@ namespace Internal.IL
 
             AddFieldReference(field);
 
-            var value = Pop();
-            var thisPtr = isStatic ? new StackValue() : Pop();
+            var value = _stack.Pop();
+            var thisPtr = isStatic ? InvalidEntry.Entry : _stack.Pop();
 
             TypeDesc owningType = field.OwningType;
             TypeDesc fieldType = field.FieldType;
@@ -1751,7 +1764,7 @@ namespace Internal.IL
                 Append("((");
                 Append(_writer.GetCppTypeName(owningType));
                 Append("*)");
-                Append(thisPtr.Value.Name);
+                Append(thisPtr);
                 Append(")->");
                 Append(_writer.GetCppFieldName(field));
 
@@ -1765,7 +1778,7 @@ namespace Internal.IL
                 Append(_writer.GetCppSignatureTypeName(fieldType));
                 Append(")");
             }
-            Append(value.Value.Name);
+            Append(value);
             AppendSemicolon();
         }
 
@@ -1779,14 +1792,14 @@ namespace Internal.IL
             if (type == null)
                 type = GetWellKnownType(WellKnownType.Object);
 
-            var addr = Pop();
+            var addr = _stack.Pop();
 
             PushTemp(GetStackValueKind(type), type);
 
             Append("*(");
             Append(_writer.GetCppSignatureTypeName(type));
             Append("*)");
-            Append(addr.Value.Name);
+            Append(addr);
 
             AppendSemicolon();
         }
@@ -1801,8 +1814,8 @@ namespace Internal.IL
             if (type == null)
                 type = GetWellKnownType(WellKnownType.Object);
 
-            var value = Pop();
-            var addr = Pop();
+            var value = _stack.Pop();
+            var addr = _stack.Pop();
 
             // TODO: Write barrier as necessary!!!
 
@@ -1810,20 +1823,20 @@ namespace Internal.IL
             Append("*(");
             Append(_writer.GetCppSignatureTypeName(type));
             Append("*)");
-            Append(addr.Value.Name);
+            Append(addr);
             Append(" = ");
-            AppendCastIfNecessary(type, value.Kind);
-            Append(value.Value.Name);
+            AppendCastIfNecessary(type, value);
+            Append(value);
             AppendSemicolon();
         }
 
         private void ImportThrow()
         {
-            var obj = Pop();
+            var obj = _stack.Pop();
 
             AppendLine();
             Append("__throw_exception(");
-            Append(obj.Value.Name);
+            Append(obj);
             Append(")");
             AppendSemicolon();
         }
@@ -1868,10 +1881,10 @@ namespace Internal.IL
         {
             TypeDesc type = (TypeDesc)_methodIL.GetObject(token);
 
-            var addr = Pop();
+            var addr = _stack.Pop();
             AppendLine();
             Append("memset((void*)");
-            Append(addr.Value.Name);
+            Append(addr);
             Append(",0,sizeof(");
             Append(_writer.GetCppSignatureTypeName(type));
             Append("))");
@@ -1887,7 +1900,7 @@ namespace Internal.IL
                 if (type.IsNullable)
                     throw new NotImplementedException();
 
-                var value = Pop();
+                var value = _stack.Pop();
 
                 PushTemp(StackValueKind.ObjRef, type);
 
@@ -1902,7 +1915,10 @@ namespace Internal.IL
 
                 // TODO: Write barrier as necessary
                 AppendLine();
-                Append("*(" + typeName + " *)((void **)" + _stack[_stackTop - 1].Value.Name + "+1) = " + value.Value.Name);
+                Append("*(" + typeName + " *)((void **)");
+                Append(_stack.Peek());
+                Append(" + 1) = ");
+                Append(value);
                 AppendSemicolon();
             }
         }
@@ -1921,7 +1937,7 @@ namespace Internal.IL
         private void ImportLeave(BasicBlock target)
         {
             // Empty the stack
-            _stackTop = 0;
+            _stack.Clear();
 
             // Close the scope and open a new one so that we don't put a goto label in the middle
             // of a scope.
@@ -2009,14 +2025,14 @@ namespace Internal.IL
             TypeDesc type = (TypeDesc)_methodIL.GetObject(token);
             TypeDesc arrayType = type.Context.GetArrayType(type);
 
-            var numElements = Pop();
+            var numElements = _stack.Pop();
 
             PushTemp(StackValueKind.ObjRef, arrayType);
 
             AddTypeReference(arrayType, true);
 
             Append("__allocate_array(");
-            Append(numElements.Value.Name);
+            Append(numElements);
             Append(", ");
             Append(_writer.GetCppTypeName(arrayType));
             Append("::__getMethodTable()");
@@ -2035,15 +2051,15 @@ namespace Internal.IL
             if (elementType == null)
                 elementType = GetWellKnownType(WellKnownType.Object);
 
-            var index = Pop();
-            var arrayPtr = Pop();
+            var index = _stack.Pop();
+            var arrayPtr = _stack.Pop();
 
             // Range check
             AppendLine();
             Append("__range_check(");
-            Append(arrayPtr.Value.Name);
+            Append(arrayPtr);
             Append(",");
-            Append(index.Value.Name);
+            Append(index);
             Append(");");
 
             PushTemp(GetStackValueKind(elementType), elementType);
@@ -2051,11 +2067,11 @@ namespace Internal.IL
             Append("*(");
             Append(_writer.GetCppSignatureTypeName(elementType));
             Append("*)((char *)");
-            Append(arrayPtr.Value.Name);
+            Append(arrayPtr);
             Append(" + ARRAY_BASE + sizeof(");
             Append(_writer.GetCppSignatureTypeName(elementType));
             Append(") * ");
-            Append(index.Value.Name);
+            Append(index);
             Append(")");
 
             AppendSemicolon();
@@ -2072,16 +2088,16 @@ namespace Internal.IL
             if (elementType == null)
                 elementType = GetWellKnownType(WellKnownType.Object);
 
-            var value = Pop();
-            var index = Pop();
-            var arrayPtr = Pop();
+            var value = _stack.Pop();
+            var index = _stack.Pop();
+            var arrayPtr = _stack.Pop();
 
             // Range check
             AppendLine();
             Append("__range_check(");
-            Append(arrayPtr.Value.Name);
+            Append(arrayPtr);
             Append(",");
-            Append(index.Value.Name);
+            Append(index);
             Append(");");
 
             // TODO: Array covariance
@@ -2091,15 +2107,15 @@ namespace Internal.IL
             Append("*(");
             Append(_writer.GetCppSignatureTypeName(elementType));
             Append("*)((char *)");
-            Append(arrayPtr.Value.Name);
+            Append(arrayPtr);
             Append(" + ARRAY_BASE + sizeof(");
             Append(_writer.GetCppSignatureTypeName(elementType));
             Append(") * ");
-            Append(index.Value.Name);
+            Append(index);
             Append(") = ");
 
-            AppendCastIfNecessary(elementType, value.Kind);
-            Append(value.Value.Name);
+            AppendCastIfNecessary(elementType, value);
+            Append(value);
 
             AppendSemicolon();
         }
@@ -2107,15 +2123,15 @@ namespace Internal.IL
         private void ImportAddressOfElement(int token)
         {
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
-            var index = Pop();
-            var arrayPtr = Pop();
+            var index = _stack.Pop();
+            var arrayPtr = _stack.Pop();
 
             // Range check
             AppendLine();
             Append("__range_check(");
-            Append(arrayPtr.Value.Name);
+            Append(arrayPtr);
             Append(",");
-            Append(index.Value.Name);
+            Append(index);
             Append(");");
 
             TypeDesc byRef = elementType.MakeByRefType();
@@ -2126,11 +2142,11 @@ namespace Internal.IL
             Append("(");
             Append(_writer.GetCppSignatureTypeName(elementType));
             Append("*)((char *)");
-            Append(arrayPtr.Value.Name);
+            Append(arrayPtr);
             Append(" + ARRAY_BASE + sizeof(");
             Append(_writer.GetCppSignatureTypeName(elementType));
             Append(") * ");
-            Append(index.Value.Name);
+            Append(index);
             Append(")");
 
             AppendSemicolon();
@@ -2138,12 +2154,12 @@ namespace Internal.IL
 
         private void ImportLoadLength()
         {
-            var arrayPtr = Pop();
+            var arrayPtr = _stack.Pop();
 
             PushTemp(StackValueKind.NativeInt);
 
             Append("*((intptr_t *)");
-            Append(arrayPtr.Value.Name);
+            Append(arrayPtr);
             Append("+ 1)");
 
             AppendSemicolon();
@@ -2151,7 +2167,7 @@ namespace Internal.IL
 
         private void ImportUnaryOperation(ILOpcode opCode)
         {
-            var argument = Pop();
+            var argument = _stack.Pop();
 
             if (argument.Kind == StackValueKind.Float)
                 throw new NotImplementedException();
@@ -2159,7 +2175,7 @@ namespace Internal.IL
             PushTemp(argument.Kind, argument.Type);
 
             Append((opCode == ILOpcode.neg) ? "~" : "!");
-            Append(argument.Value.Name);
+            Append(argument);
 
             AppendSemicolon();
         }
@@ -2173,7 +2189,7 @@ namespace Internal.IL
         {
             var type = ResolveTypeToken(token);
 
-            var obj = Pop();
+            var obj = _stack.Pop();
 
             if (opCode == ILOpcode.unbox)
             {
@@ -2202,13 +2218,13 @@ namespace Internal.IL
                 Append(_writer.GetCppSignatureTypeName(type));
                 Append("*)");
                 Append("((void **)");
-                Append(obj.Value.Name);
+                Append(obj);
                 Append("+1)");
             }
             else
             {
                 // TODO: Cast
-                Append(obj.Value.Name);
+                Append(obj);
             }
 
             AppendSemicolon();
@@ -2234,6 +2250,7 @@ namespace Internal.IL
             var ldtokenValue = _methodIL.GetObject(token);
             WellKnownType ldtokenKind;
             string name;
+            StackEntry value;
             if (ldtokenValue is TypeDesc)
             {
                 ldtokenKind = WellKnownType.RuntimeTypeHandle;
@@ -2249,11 +2266,13 @@ namespace Internal.IL
                     "((intptr_t)",
                     _writer.GetCppTypeName((TypeDesc)ldtokenValue),
                     "::__getMethodTable())");
+
+                value = new LdTokenEntry<TypeDesc>(StackValueKind.ValueType, name, (TypeDesc)ldtokenValue, GetWellKnownType(ldtokenKind));
             }
             else if (ldtokenValue is FieldDesc)
             {
                 ldtokenKind = WellKnownType.RuntimeFieldHandle;
-                name = null;
+                value = new LdTokenEntry<FieldDesc>(StackValueKind.ValueType, null, (FieldDesc) ldtokenValue, GetWellKnownType(ldtokenKind));
             }
             else if (ldtokenValue is MethodDesc)
             {
@@ -2262,22 +2281,12 @@ namespace Internal.IL
             else
                 throw new InvalidOperationException();
 
-            var value = new StackValue
-            {
-                Kind = StackValueKind.ValueType,
-                Value = new Value
-                {
-                    Aux = ldtokenValue,
-                    Name = name
-                },
-                Type = GetWellKnownType(ldtokenKind),
-            };
-            Push(value);
+            _stack.Push(value);
         }
 
         private void ImportLocalAlloc()
         {
-            StackValue count = Pop();
+            StackEntry count = _stack.Pop();
 
             // TODO: this is machine dependent and might not result in a HW stack overflow exception
             // TODO: might not have enough alignment guarantees for the allocated buffer
@@ -2287,7 +2296,7 @@ namespace Internal.IL
             Append("void* ");
             Append(bufferName);
             Append(" = alloca(");
-            Append(count.Value.Name);
+            Append(count);
             Append(")");
             AppendSemicolon();
 
@@ -2297,12 +2306,12 @@ namespace Internal.IL
                 Append("memset(");
                 Append(bufferName);
                 Append(", 0, ");
-                Append(count.Value.Name);
+                Append(count);
                 Append(")");
                 AppendSemicolon();
             }
 
-            Push(StackValueKind.NativeInt, new Value(bufferName));
+            PushExpression(StackValueKind.NativeInt, bufferName);
         }
 
         private void ImportEndFilter()
@@ -2332,7 +2341,7 @@ namespace Internal.IL
             // TODO: Remove
             _writer.GetCppSignatureTypeName(type);
 
-            Push(StackValueKind.Int32, new Value("sizeof(" + _writer.GetCppTypeName(type) + ")"));
+            PushExpression(StackValueKind.Int32, "sizeof(" + _writer.GetCppTypeName(type) + ")");
         }
 
         private void ImportRefAnyType()

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Compiler\TypeInitialization.cs" />
     <Compile Include="Compiler\VirtualMethodCallHelper.cs" />
     <Compile Include="Compiler\VirtualMethodEnumeration.cs" />
+    <Compile Include="CppCodeGen\EvaluationStack.cs" />
     <Compile Include="CppCodeGen\CppGenerationBuffer.cs" />
     <Compile Include="CppCodeGen\CppWriter.cs" />
     <Compile Include="IL\Stubs\StartupCode\StartupCodeMainMethod.cs" />

--- a/src/Native/Bootstrap/common.h
+++ b/src/Native/Bootstrap/common.h
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <math.h>
 
 #include <new>
 
@@ -111,6 +112,18 @@ inline bool IS_ALIGNED(T* val, UIntNative alignment)
 #pragma warning(disable:4102) // unreferenced label
 #pragma warning(disable:4244) // possible loss of data
 #pragma warning(disable:4717) // recursive on all control paths
+#endif
+
+#ifdef _MSC_VER
+#define INT64VAL(x) (x##i64)
+#else
+#define INT64VAL(x) (x##LL)
+#endif
+
+#ifdef _MSC_VER
+#define CORERT_UNREACHABLE  __assume(0)
+#else
+#define CORERT_UNREACHABLE  __builtin_unreachable()
 #endif
 
 #endif // __COMMON_H


### PR DESCRIPTION
I've followed the suggestion I made for #1110 to change the evaluation stack. This is not final but before I continue I'd like feedback if this goes in the right direction.

So far what is not implemented is that now the stack contains object, not structs, so it means allocation and no optimization have been made to cache the allocation of stack entries.

As part of this, I've also removed the check against MSVC in the C++ code generation and added some macros to take into account the differences.

I'm using Debug.Assert for internal sanity checks, but I saw some incoming commits using the Code Contract facilities which goes against the discussion we had on issue #320.

The new type VariableEntry is still too generic and could be split at least in two, one for just holding a variable/expression and one that also stores the ```Aux``` field.