### PR TITLE
Update ILCompiler to netstandard1.3

### DIFF
--- a/src/ILCompiler.Compiler/src/project.json
+++ b/src/ILCompiler.Compiler/src/project.json
@@ -6,7 +6,7 @@
     "Microsoft.DiaSymReader": "1.0.6"
   },
   "frameworks": {
-    "dnxcore50": {
+    "netstandard1.3": {
       "imports": "portable-net452"
     }
   }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/project.json
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/project.json
@@ -4,6 +4,6 @@
     "System.Collections.Immutable": "1.2.0-rc2-23911"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netstandard1.3": { }
   }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/tests/project.json
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/project.json
@@ -5,7 +5,7 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
+    "netstandard1.3": {
       "imports": "portable-net45+win8"
     }
   }

--- a/src/ILCompiler.MetadataTransform/src/project.json
+++ b/src/ILCompiler.MetadataTransform/src/project.json
@@ -4,6 +4,6 @@
     "System.Reflection.Metadata": "1.3.0-rc2-23911"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netstandard1.3": { }
   }
 }

--- a/src/ILCompiler.MetadataTransform/tests/project.json
+++ b/src/ILCompiler.MetadataTransform/tests/project.json
@@ -5,8 +5,8 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": { 
-        "imports": "portable-net451+win8"
+    "netstandard1.3": {
+      "imports": "portable-net451+win8"
     }
   }
 }

--- a/src/ILCompiler.MetadataWriter/src/project.json
+++ b/src/ILCompiler.MetadataWriter/src/project.json
@@ -3,6 +3,6 @@
     "NETStandard.Library": "1.5.0-rc2-23911"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netstandard1.3": { }
   }
 }

--- a/src/ILCompiler.TypeSystem/src/project.json
+++ b/src/ILCompiler.TypeSystem/src/project.json
@@ -4,6 +4,6 @@
     "System.Reflection.Metadata": "1.3.0-rc2-23911"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netstandard1.3": { }
   }
 }

--- a/src/ILCompiler.TypeSystem/tests/project.json
+++ b/src/ILCompiler.TypeSystem/tests/project.json
@@ -5,8 +5,8 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": { 
-       "imports": "portable-net451+win8"
+    "netstandard1.3": {
+      "imports": "portable-net451+win8"
     }
   },
 }

--- a/src/ILCompiler/src/project.json
+++ b/src/ILCompiler/src/project.json
@@ -8,7 +8,7 @@
     "Microsoft.DotNet.ObjectWriter": "1.0.11-prerelease-00001"
   },
   "frameworks": {
-    "dnxcore50": {
+    "netstandard1.3": {
       "imports": "portable-net451+win8"
     }
   }

--- a/src/System.Private.Reflection.Metadata/tests/project.json
+++ b/src/System.Private.Reflection.Metadata/tests/project.json
@@ -4,8 +4,8 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": { 
-        "imports": "portable-net451+win8"
+    "netstandard1.3": {
+      "imports": "portable-net451+win8"
     }
   }
 }


### PR DESCRIPTION
Fixes #1144. Unsupported version of System.Linq was getting picked up for desktop project.