### PR TITLE
Optimize string.Replace for the same string

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -2782,6 +2782,8 @@ namespace System
                 // Api behavior: if newValue is null, instances of oldValue are to be removed.
                 if (newValue == null)
                     newValue = String.Empty;
+                else if (object.ReferenceEquals(oldValue, newValue))
+                    return this;
 
                 int numOccurrences = 0;
                 int[] replacementIndices = new int[this.Length];


### PR DESCRIPTION
Does a check if the two strings passed in reference-equal each other, and if so, returns the current string. Note that this is an O(1) operation, since we're just doing a pointer comparison, and not looking at the actual contents of the string.

cc @jkotas