### PR TITLE
Add IEETypeNode interface

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -47,7 +47,7 @@ namespace ILCompiler.DependencyAnalysis
     /// [Pointer Size]  | Pointer to the generic type argument of a Nullable&lt;T&gt; (optional)
     /// 
     /// </summary>
-    internal class EETypeNode : ObjectNode, ISymbolNode
+    internal sealed class EETypeNode : ObjectNode, ISymbolNode, IEETypeNode
     {
         private TypeDesc _type;
         private bool _constructed;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a symbol that is defined externally but modelled as a type in the
+    /// DependencyAnalysis infrastructure during compilation.
+    /// </summary>
+    public sealed class ExternEETypeSymbolNode : ExternSymbolNode, IEETypeNode
+    {
+        private TypeDesc _type;
+
+        public ExternEETypeSymbolNode(TypeDesc type)
+            : base("__EEType_" + NodeFactory.NameMangler.GetMangledTypeName(type))
+        {
+            _type = type;
+        }
+
+        public TypeDesc Type
+        {
+            get
+            {
+                return _type;
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternMethodSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternMethodSymbolNode.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using ILCompiler.DependencyAnalysisFramework;
-using System;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
-    /// Represents a symbol that is defined externally and statically linked to the output obj file but
-    /// modelled as a method in the DependencyAnalysis infrastructure during compilation
+    /// Represents a symbol that is defined externally but modelled as a method
+    /// in the DependencyAnalysis infrastructure during compilation
     /// </summary>
-    public class ExternMethodSymbolNode : ExternSymbolNode, IMethodNode
+    public sealed class ExternMethodSymbolNode : ExternSymbolNode, IMethodNode
     {
         private MethodDesc _method;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IEETypeNode.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// A dependency analysis node that represents a runtime type data structure.
+    /// </summary>
+    public interface IEETypeNode : ISymbolNode
+    {
+        TypeDesc Type { get; }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -55,6 +55,8 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.cs" />
     <Compile Include="Compiler\DelegateCreationInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ExternEETypeSymbolNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\IEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\SingleArgumentJumpThunk.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CppMethodCodeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeImportMethodNode.cs" />


### PR DESCRIPTION
This is similar to `IMethodNode` in the sense that it lets us preserve
information about the type associated with the symbol. Same as
`IMethodNode`, there are two classes implementing this.

I pulled the decision about which one to generate into the slow path (we
no longer need to consult the compilation group in order to pick a cache
to check).