### PR TITLE
Throw TypeLoadException if method has no body

### DIFF
--- a/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
+++ b/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
@@ -50,9 +50,21 @@ namespace Internal.TypeSystem
 
         /// <summary>
         /// Gets a value specifying whether the implementation of this method
-        /// is provided by the runtime.
+        /// is provided by the runtime (i.e., through generated IL).
         /// </summary>
         public virtual bool IsRuntimeImplemented
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value specifying whether the implementation of this method is
+        /// provided externally by calling out into the runtime.
+        /// </summary>
+        public virtual bool IsInternalCall
         {
             get
             {
@@ -95,6 +107,14 @@ namespace Internal.TypeSystem
                 return _methodDef.IsRuntimeImplemented;
             }
         }
+
+        public override bool IsInternalCall
+        {
+            get
+            {
+                return _methodDef.IsInternalCall;
+            }
+        }
     }
 
     // Additional members of MethodForInstantiatedType related to code generation.
@@ -129,6 +149,14 @@ namespace Internal.TypeSystem
             get
             {
                 return _typicalMethodDef.IsRuntimeImplemented;
+            }
+        }
+
+        public override bool IsInternalCall
+        {
+            get
+            {
+                return _typicalMethodDef.IsInternalCall;
             }
         }
     }

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -27,7 +27,8 @@ namespace Internal.TypeSystem.Ecma
             public const int RuntimeImplemented     = 0x0080;
 
             public const int AttributeMetadataCache = 0x0100;
-            public const int Intrinsic            = 0x0200;
+            public const int Intrinsic              = 0x0200;
+            public const int InternalCall           = 0x0400;
         };
 
         private EcmaType _type;
@@ -149,6 +150,9 @@ namespace Internal.TypeSystem.Ecma
                 if ((methodImplAttributes & MethodImplAttributes.Runtime) != 0)
                     flags |= MethodFlags.RuntimeImplemented;
 
+                if ((methodImplAttributes & MethodImplAttributes.InternalCall) != 0)
+                    flags |= MethodFlags.InternalCall;
+
                 flags |= MethodFlags.BasicMetadataCache;
             }
 
@@ -253,6 +257,14 @@ namespace Internal.TypeSystem.Ecma
             get
             {
                 return (GetMethodFlags(MethodFlags.AttributeMetadataCache | MethodFlags.Intrinsic) & MethodFlags.Intrinsic) != 0;
+            }
+        }
+
+        public override bool IsInternalCall
+        {
+            get
+            {
+                return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.InternalCall) & MethodFlags.InternalCall) != 0;
             }
         }
 

--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -117,8 +117,7 @@ namespace Internal.IL
                 if (methodIL != null)
                     return methodIL;
                 
-                if (!((EcmaMethod)method).ImplAttributes.HasFlag(System.Reflection.MethodImplAttributes.InternalCall) && 
-                    !method.IsRuntimeImplemented)
+                if (!method.IsInternalCall && !method.IsRuntimeImplemented)
                 {
                     return MissingMethodBodyILEmitter.EmitIL(method);
                 }

--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -113,7 +113,17 @@ namespace Internal.IL
                         return result;
                 }
 
-                return EcmaMethodIL.Create((EcmaMethod)method);
+                MethodIL methodIL = EcmaMethodIL.Create((EcmaMethod)method);
+                if (methodIL != null)
+                    return methodIL;
+                
+                if (!((EcmaMethod)method).ImplAttributes.HasFlag(System.Reflection.MethodImplAttributes.InternalCall) && 
+                    !method.IsRuntimeImplemented)
+                {
+                    return MissingMethodBodyILEmitter.EmitIL(method);
+                }
+
+                return null;
             }
             else
             if (method is MethodForInstantiatedType)

--- a/src/ILCompiler.Compiler/src/IL/Stubs/MissingMethodBodyILEmitter.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/MissingMethodBodyILEmitter.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Internal.IL;
+using Internal.IL.Stubs;
+using Internal.TypeSystem;
+
+namespace Internal.IL.Stubs
+{
+    public static class MissingMethodBodyILEmitter
+    {
+        public static MethodIL EmitIL(MethodDesc method)
+        {
+            ILEmitter emit = new ILEmitter();
+            ILCodeStream codeStream = emit.NewCodeStream();
+            MethodDesc notSupportedExceptionHelper = method.Context.GetHelperEntryPoint("ThrowHelpers", "ThrowTypeLoadException");
+            codeStream.EmitCallThrowHelper(emit, notSupportedExceptionHelper);
+            return emit.Link();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/IL/Stubs/MissingMethodBodyILEmitter.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/MissingMethodBodyILEmitter.cs
@@ -15,8 +15,8 @@ namespace Internal.IL.Stubs
         {
             ILEmitter emit = new ILEmitter();
             ILCodeStream codeStream = emit.NewCodeStream();
-            MethodDesc notSupportedExceptionHelper = method.Context.GetHelperEntryPoint("ThrowHelpers", "ThrowTypeLoadException");
-            codeStream.EmitCallThrowHelper(emit, notSupportedExceptionHelper);
+            MethodDesc typeLoadExceptionHelper = method.Context.GetHelperEntryPoint("ThrowHelpers", "ThrowTypeLoadException");
+            codeStream.EmitCallThrowHelper(emit, typeLoadExceptionHelper);
             return emit.Link();
         }
     }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -125,6 +125,7 @@
     <Compile Include="CppCodeGen\EvaluationStack.cs" />
     <Compile Include="CppCodeGen\CppGenerationBuffer.cs" />
     <Compile Include="CppCodeGen\CppWriter.cs" />
+    <Compile Include="IL\Stubs\MissingMethodBodyILEmitter.cs" />
     <Compile Include="IL\Stubs\StartupCode\StartupCodeMainMethod.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -40,5 +40,10 @@ namespace Internal.Runtime.CompilerHelpers
         {
             throw new PlatformNotSupportedException();
         }
+
+        private static void ThrowTypeLoadException()
+        {
+            throw new TypeLoadException();
+        }
     }
 }


### PR DESCRIPTION
The ILProvider returns no IL for a method if it has no body which causes
asserts in the compiler when unexpected (ie, not runtime implemented or
an internal call).  If the ILProvider fails to find an implementation
for the method, throw a TypeLoadException.