### PR TITLE
Add handling of NaN, +Inf and -Inf in C++ code generation

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -1128,6 +1128,7 @@ namespace ILCompiler.CppCodeGen
             ExpandTypes();
 
             Out.WriteLine("#include \"common.h\"");
+            Out.WriteLine("#include \"CppCodeGen.h\"");
             Out.WriteLine();
 
             Out.Write("/* Forward type definitions */");

--- a/src/ILCompiler.Compiler/src/CppCodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/EvaluationStack.cs
@@ -388,22 +388,29 @@ namespace Internal.IL
 
         public override void Append(CppGenerationBuffer _builder)
         {
-            // TODO: Handle infinity, NaN, etc.
+            long val = BitConverter.DoubleToInt64Bits(Value);
+            _builder.Append("__uint64_to_double(0x");
+            _builder.Append(val.ToStringInvariant("x8"));
+            _builder.Append(')');
+            // Let's print the actual value as comment.
+            _builder.Append("/* ");
             if (Double.IsNaN(Value))
             {
-                _builder.Append("nan(0)");
-                throw new NotImplementedException();
+                _builder.Append("NaN");
             }
-            else if (Double.IsInfinity(Value) || Double.IsPositiveInfinity(Value) || Double.IsNegativeInfinity(Value))
+            else if (Double.IsPositiveInfinity(Value))
             {
-                // Negative Infinity can be encoded as 0xFFF0000000000000
-                // Positive Infinity can be encoded as 0x7FF0000000000000
-                throw new NotImplementedException();
+                _builder.Append("+Inf");
+            }
+            else if (Double.IsNegativeInfinity(Value))
+            {
+                _builder.Append("-Inf");
             }
             else
             {
                 _builder.Append(Value.ToStringInvariant());
             }
+            _builder.Append(" */");
         }
 
         public override StackEntry Duplicate()

--- a/src/Native/Bootstrap/CppCodeGen.h
+++ b/src/Native/Bootstrap/CppCodeGen.h
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// CppCodeGen.h : Facilities for the C++ code generation backend
+
+#ifndef __CPP_CODE_GEN_H
+#define __CPP_CODE_GEN_H
+
+#define _CRT_SECURE_NO_WARNINGS
+
+#ifdef _MSC_VER
+// Warnings disabled for generated cpp code
+#pragma warning(disable:4200) // zero-sized array
+#pragma warning(disable:4102) // unreferenced label
+#pragma warning(disable:4244) // possible loss of data
+#pragma warning(disable:4717) // recursive on all control paths
+#endif
+
+#ifdef _MSC_VER
+#define INT64VAL(x) (x##i64)
+#else
+#define INT64VAL(x) (x##LL)
+#endif
+
+#ifdef _MSC_VER
+#define CORERT_UNREACHABLE  __assume(0)
+#else
+#define CORERT_UNREACHABLE  __builtin_unreachable()
+#endif
+
+// Use the bit representation of uint64_t `v` as the bit representation of a double.
+inline double __uint64_to_double(uint64_t v)
+{
+    union
+    {
+        uint64_t u64;
+        double d;
+    } val;
+    val.u64 = v;
+    return val.d;
+}
+
+#endif // __CPP_CODE_GEN_H

--- a/src/Native/Bootstrap/common.h
+++ b/src/Native/Bootstrap/common.h
@@ -28,10 +28,6 @@
 #include <pthread.h>
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(disable:4200) // zero-sized array
-#endif
-
 using namespace std;
 
 class MethodTable;
@@ -106,24 +102,5 @@ inline bool IS_ALIGNED(T* val, UIntNative alignment)
 #define AlignBaseSize(s) ((s < RAW_MIN_OBJECT_SIZE) ? RAW_MIN_OBJECT_SIZE : ((s + (sizeof(void*)-1) & ~(sizeof(void*)-1))))
 
 #define ARRAY_BASE (2*sizeof(void*))
-
-#ifdef _MSC_VER
-// Warnings disabled for auto-generated cpp code
-#pragma warning(disable:4102) // unreferenced label
-#pragma warning(disable:4244) // possible loss of data
-#pragma warning(disable:4717) // recursive on all control paths
-#endif
-
-#ifdef _MSC_VER
-#define INT64VAL(x) (x##i64)
-#else
-#define INT64VAL(x) (x##LL)
-#endif
-
-#ifdef _MSC_VER
-#define CORERT_UNREACHABLE  __assume(0)
-#else
-#define CORERT_UNREACHABLE  __builtin_unreachable()
-#endif
 
 #endif // __COMMON_H

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -51,6 +51,7 @@
 
             <!-- ILCompiler.SDK Cpp Codegen support files -->
             <ILCompilerSdkCppCodegenFiles Include="Native/Bootstrap/common.h" />
+            <ILCompilerSdkCppCodegenFiles Include="Native/Bootstrap/CppCodeGen.h" />
 
             <ILCompilerSdkFilesManaged Include="System.Private.CoreLib" />
             <ILCompilerSdkFilesManaged Include="System.Private.DeveloperExperience.Console" />


### PR DESCRIPTION
Added the generation for Nan, +Inf and -Inf.

Currently it always generates the hex representation of a double (actual value is commented for understandability) which is decoded via the helper function __uint64_to_double. 

I've also moved some C++ code generation specific code from common.h to the new CppCodeGen.h header file. Let me know if I have been overzealous here.