### PR TITLE
Extend EETypes with information about generic composition

### DIFF
--- a/src/Native/Runtime/RuntimeInstance.cpp
+++ b/src/Native/Runtime/RuntimeInstance.cpp
@@ -796,10 +796,20 @@ COOP_PINVOKE_HELPER(EEType *, RhGetGenericInstantiation, (EEType *              
                                                           EEType ***             ppInstantiation,
                                                           GenericVarianceType ** ppVarianceInfo))
 {
+#if CORERT
+    *pArity = pEEType->get_GenericArity();
+    *ppInstantiation = pEEType->get_GenericArguments();
+    if (pEEType->HasGenericVariance())
+        *ppVarianceInfo = pEEType->get_GenericVariance();
+    else
+        *ppVarianceInfo = NULL;
+    return pEEType->get_GenericDefinition();
+#else
     return GetRuntimeInstance()->GetGenericInstantiation(pEEType,
                                                          pArity,
                                                          ppInstantiation,
                                                          ppVarianceInfo);
+#endif
 }
 
 COOP_PINVOKE_HELPER(bool, RhSetGenericInstantiation, (EEType *               pEEType,

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -13,7 +13,7 @@ class MdilModule;
 class EEType;
 class OptionalFields;
 class ModuleManager;
-
+enum GenericVarianceType : UInt8;
 
 //-------------------------------------------------------------------------------------------------
 // Array of these represents the interfaces implemented by a type
@@ -164,6 +164,8 @@ enum EETypeField
     ETF_SealedVirtualSlots,
     ETF_DynamicTemplateType,
     ETF_DynamicDispatchMap,
+    ETF_GenericDefinition,
+    ETF_GenericComposition,
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -532,6 +534,18 @@ public:
     // Determine whether a *dynamic* type has a dynamically allocated DispatchMap
     bool HasDynamicallyAllocatedDispatchMap()
         { return (get_RareFlags() & HasDynamicallyAllocatedDispatchMapFlag) != 0; }
+
+    // Retrieve the generic type definition EEType for this generic instance
+    EEType * get_GenericDefinition();
+
+    // Retrieve the number of generic arguments for this generic type instance
+    UInt32 get_GenericArity();
+
+    // Retrieve the generic arguments to this type
+    EEType** get_GenericArguments();
+
+    // Retrieve the generic variance associated with this type
+    GenericVarianceType* get_GenericVariance();
 
     // Retrieve template used to create the dynamic type
     EEType * get_DynamicTemplateType();

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -164,8 +164,10 @@ enum EETypeField
     ETF_SealedVirtualSlots,
     ETF_DynamicTemplateType,
     ETF_DynamicDispatchMap,
+#if CORERT
     ETF_GenericDefinition,
     ETF_GenericComposition,
+#endif
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -535,6 +537,7 @@ public:
     bool HasDynamicallyAllocatedDispatchMap()
         { return (get_RareFlags() & HasDynamicallyAllocatedDispatchMapFlag) != 0; }
 
+#if CORERT
     // Retrieve the generic type definition EEType for this generic instance
     EEType * get_GenericDefinition();
 
@@ -546,6 +549,7 @@ public:
 
     // Retrieve the generic variance associated with this type
     GenericVarianceType* get_GenericVariance();
+#endif
 
     // Retrieve template used to create the dynamic type
     EEType * get_DynamicTemplateType();

--- a/src/Native/Runtime/inc/eetype.inl
+++ b/src/Native/Runtime/inc/eetype.inl
@@ -469,6 +469,7 @@ inline UInt8 EEType::GetNullableValueOffset()
     return pOptFields->GetNullableValueOffset(0) + 1;
 }
 
+#if CORERT
 inline EEType * EEType::get_GenericDefinition()
 {
     ASSERT(IsGeneric());
@@ -503,6 +504,7 @@ inline GenericVarianceType* EEType::get_GenericVariance()
     // Variance info follows immediatelly after the generic arguments
     return (GenericVarianceType*)(get_GenericArguments() + get_GenericArity());
 }
+#endif
 
 inline EEType * EEType::get_DynamicTemplateType()
 {
@@ -704,6 +706,7 @@ inline EEType * EEType::GetArrayBaseType()
     if ((get_RareFlags() & HasDynamicallyAllocatedDispatchMapFlag) != 0)
         cbOffset += sizeof(UIntTarget);
 
+#if CORERT
     if (eField == ETF_GenericDefinition)
     {
         ASSERT(IsGeneric());
@@ -719,6 +722,7 @@ inline EEType * EEType::GetArrayBaseType()
     }
     if (IsGeneric())
         cbOffset += sizeof(UIntTarget);
+#endif
 
     if (eField == ETF_DynamicTemplateType)
     {

--- a/src/Native/Runtime/inc/eetype.inl
+++ b/src/Native/Runtime/inc/eetype.inl
@@ -469,6 +469,41 @@ inline UInt8 EEType::GetNullableValueOffset()
     return pOptFields->GetNullableValueOffset(0) + 1;
 }
 
+inline EEType * EEType::get_GenericDefinition()
+{
+    ASSERT(IsGeneric());
+
+    UInt32 cbOffset = GetFieldOffset(ETF_GenericDefinition);
+
+    return *(EEType**)((UInt8*)this + cbOffset);
+}
+
+inline UInt32 EEType::get_GenericArity()
+{
+    ASSERT(IsGeneric());
+
+    UInt32 cbOffset = GetFieldOffset(ETF_GenericComposition);
+
+    return **(UInt32**)((UInt8*)this + cbOffset);
+}
+
+inline EEType** EEType::get_GenericArguments()
+{
+    ASSERT(IsGeneric());
+
+    UInt32 cbOffset = GetFieldOffset(ETF_GenericComposition);
+
+    return ((*(EEType***)((UInt8*)this + cbOffset)) + 1);
+}
+
+inline GenericVarianceType* EEType::get_GenericVariance()
+{
+    ASSERT(HasGenericVariance());
+
+    // Variance info follows immediatelly after the generic arguments
+    return (GenericVarianceType*)(get_GenericArguments() + get_GenericArity());
+}
+
 inline EEType * EEType::get_DynamicTemplateType()
 {
     ASSERT(IsDynamicType());
@@ -667,6 +702,22 @@ inline EEType * EEType::GetArrayBaseType()
         return cbOffset;
     }
     if ((get_RareFlags() & HasDynamicallyAllocatedDispatchMapFlag) != 0)
+        cbOffset += sizeof(UIntTarget);
+
+    if (eField == ETF_GenericDefinition)
+    {
+        ASSERT(IsGeneric());
+        return cbOffset;
+    }
+    if (IsGeneric())
+        cbOffset += sizeof(UIntTarget);
+
+    if (eField == ETF_GenericComposition)
+    {
+        ASSERT(IsGeneric());
+        return cbOffset;
+    }
+    if (IsGeneric())
         cbOffset += sizeof(UIntTarget);
 
     if (eField == ETF_DynamicTemplateType)


### PR DESCRIPTION
In CoreRT we will not be using the `GenericInstanceDesc` mechanism from
Redhawk/Project N. Instead, generic composition (the generic type
definition, generic type arguments, arity, and variance) will be
directly available from the EEType by following two new rare fields.

The rare fields being added:
* `ETF_GenericDefinition`: pointer to the EEType of the generic type
definition
* `ETF_GenericComposition`: pointer to a variable sized stream of data
with the following grammar: ARITY | GENERIC_TYPE_ARGUMENT+ |
GENERIC_VARIANCE*. Generic variance is present only when
GenericVarianceFlag is set on the EEType.