### PR TITLE
Fix whitespace in the type system project

### DIFF
--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -19,7 +19,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\TypeSystem\CodeGen\MethodDesc.CodeGen.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\CodeGen\MethodDesc.CodeGen.cs">
       <Link>Utilities\MethodDesc.CodeGen.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\AlignmentHelper.cs">
@@ -40,127 +40,127 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
       <Link>Utilities\LockFreeReaderHashtable.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayType.cs">
       <Link>TypeSystem\Common\ArrayType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs">
       <Link>TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs">
       <Link>TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ByRefType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ByRefType.cs">
       <Link>TypeSystem\Common\ByRefType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\GenericParameterDesc.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\GenericParameterDesc.cs">
       <Link>TypeSystem\Common\GenericParameterDesc.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldForInstantiatedType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldForInstantiatedType.cs">
       <Link>TypeSystem\Common\FieldForInstantiatedType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.cs">
       <Link>TypeSystem\Common\FieldDesc.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.FieldLayout.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.FieldLayout.cs">
       <Link>TypeSystem\Common\FieldDesc.FieldLayout.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldLayoutAlgorithm.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldLayoutAlgorithm.cs">
       <Link>TypeSystem\Common\FieldLayoutAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedMethod.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedMethod.cs">
       <Link>TypeSystem\Common\InstantiatedMethod.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.cs">
       <Link>TypeSystem\Common\InstantiatedType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.Interfaces.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.Interfaces.cs">
       <Link>TypeSystem\Common\InstantiatedType.Interfaces.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.MethodImpls.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedType.MethodImpls.cs">
       <Link>TypeSystem\Common\InstantiatedType.MethodImpls.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.cs">
       <Link>TypeSystem\Common\MetadataType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.Interfaces.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.Interfaces.cs">
       <Link>TypeSystem\Common\MetadataType.Interfaces.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.MethodImpls.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataType.MethodImpls.cs">
       <Link>TypeSystem\Common\MetadataType.MethodImpls.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataFieldLayoutAlgorithm.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataFieldLayoutAlgorithm.cs">
       <Link>TypeSystem\Common\MetadataFieldLayoutAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataRuntimeInterfacesAlgorithm.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataRuntimeInterfacesAlgorithm.cs">
       <Link>TypeSystem\Common\MetadataRuntimeInterfacesAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataTypeSystemContext.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataTypeSystemContext.cs">
       <Link>TypeSystem\Common\MetadataTypeSystemContext.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodForInstantiatedType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodForInstantiatedType.cs">
       <Link>TypeSystem\Common\MethodForInstantiatedType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ParameterizedType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ParameterizedType.cs">
       <Link>TypeSystem\Common\ParameterizedType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\PointerType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\PointerType.cs">
       <Link>TypeSystem\Common\PointerType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\PropertySignature.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\PropertySignature.cs">
       <Link>TypeSystem\Common\PropertySignature.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\SignatureVariable.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\SignatureVariable.cs">
       <Link>TypeSystem\Common\SignatureVariable.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TargetDetails.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TargetDetails.cs">
       <Link>TypeSystem\Common\TargetDetails.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\ThreadSafeFlags.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\ThreadSafeFlags.cs">
       <Link>TypeSystem\Common\ThreadSafeFlags.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeCast.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeCast.cs">
       <Link>TypeSystem\Common\TypeCast.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeFlags.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeFlags.cs">
       <Link>TypeSystem\Common\TypeFlags.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeHashingAlgorithms.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeHashingAlgorithms.cs">
       <Link>TypeSystem\Common\TypeHashingAlgorithms.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemContext.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemContext.cs">
       <Link>TypeSystem\Common\TypeSystemContext.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemHelpers.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemHelpers.cs">
       <Link>TypeSystem\Common\TypeSystemHelpers.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\VirtualMethodEnumerationAlgorithm.cs">
       <Link>TypeSystem\Common\VirtualMethodEnumerationAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\WellKnownType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\WellKnownType.cs">
       <Link>TypeSystem\Common\WellKnownType.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\VirtualMethodAlgorithm.cs">
       <Link>TypeSystem\Common\VirtualMethodAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.cs">
       <Link>TypeSystem\Common\MethodDesc.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataVirtualMethodAlgorithm.cs">
       <Link>TypeSystem\Common\StandardVirtualMethodAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.cs">
       <Link>TypeSystem\Common\TypeDesc.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.Interfaces.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.Interfaces.cs">
       <Link>TypeSystem\Common\TypeDesc.Interfaces.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\DefType.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\DefType.cs">
       <Link>TypeSystem\Common\DefType.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\DefType.FieldLayout.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\DefType.FieldLayout.cs">
       <Link>TypeSystem\Common\DefType.FieldLayout.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\RuntimeInterfacesAlgorithm.cs" >
+    <Compile Include="..\..\Common\src\TypeSystem\Common\RuntimeInterfacesAlgorithm.cs">
       <Link>TypeSystem\Common\RuntimeInterfacesAlgorithm.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\CustomAttributeTypeProvider.cs">


### PR DESCRIPTION
Whenever I add a new file to the type system project, Visual Studio
insists on updating the whitespace around unrelated `Compile` items that
I manually back out every time.

Didn't investigate where the whitespace came from, but other projects
using the `Link` metadata don't seem to have it, so let's get rid of
it...