### PR TITLE
[Don't Merge]Compile multi-module basic tests on Ubuntu

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
@@ -62,5 +62,10 @@ namespace ILCompiler.DependencyAnalysis
         {
             return ((ISymbolNode)this).MangledName;
         }
+
+        public override bool ShouldShareNodeAcrossModules(NodeFactory factory)
+        {
+            return true;
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -641,7 +641,7 @@ namespace ILCompiler.DependencyAnalysis
                     ObjectNode.ObjectData nodeContents = node.GetData(factory);
 
                     ObjectNodeSection section = node.Section;
-                    if (node.ShouldShareNodeAcrossModules(factory) && factory.Target.OperatingSystem == TargetOS.Windows)
+                    if (node.ShouldShareNodeAcrossModules(factory) && (factory.Target.OperatingSystem == TargetOS.Windows || factory.Target.OperatingSystem == TargetOS.Linux))
                     {
                         Debug.Assert(node is ISymbolNode);
                         section = section.GetSharedSection(((ISymbolNode)node).MangledName);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -93,6 +93,10 @@ namespace ILCompiler.DependencyAnalysis
             MetadataType mdType = _type.GetClosestMetadataType();
             foreach (var method in mdType.GetAllVirtualMethods())
             {
+                if (method.HasInstantiation)
+                {
+                    continue;
+                }
                 slots.Add(method);
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
@@ -141,7 +141,7 @@ namespace ILCompiler
             foreach (MethodDesc method in type.GetMethods())
             {
                 // Skip methods with no IL and uninstantiated generic methods
-                if (method.IsIntrinsic || method.IsAbstract || method.ContainsGenericVariables)
+                if (method.IsAbstract || method.ContainsGenericVariables)
                     continue;
                 
                 if (method.GetMethodDefinition() is EcmaMethod && ((EcmaMethod)method.GetMethodDefinition()).ImplAttributes.HasFlag(System.Reflection.MethodImplAttributes.InternalCall))

--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -421,3 +421,56 @@ COOP_PINVOKE_HELPER(bool, RhpETWShouldWalkCom, ())
     ASSERT_UNCONDITIONALLY("NYI");
     return false;
 }
+
+#if !defined(_WIN32)
+//
+// Mincore APIs for threading
+//
+COOP_PINVOKE_HELPER(void *, VirtualQuery, (void * lpAddress, void ** lpBuffer, void * dwLength))
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+    return nullptr;
+}
+
+COOP_PINVOKE_HELPER(void *, CreateSemaphoreExW, (void * lpSemaphoreAttributes, Int32 lInitialCount, Int32 lMaximumCount, Object * lpName, UInt32 dwFlags, UInt32 dwDesiredAccess))
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+    return nullptr;
+}
+
+COOP_PINVOKE_HELPER(bool, ReleaseSemaphore, (void * hSemaphore, Int32 lReleaseCount, Int32 * lpPreviousCount))
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+    return false;
+}
+
+COOP_PINVOKE_HELPER(UInt32, ReleaseMutex, (void * hMutex))
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+    return false;
+}
+
+COOP_PINVOKE_HELPER(void *, OpenSemaphoreW, (UInt32 dwDesiredAccess, bool bInheritHandle, Object * lpName))
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+    return nullptr;
+}
+
+COOP_PINVOKE_HELPER(void *, OpenMutexW, (UInt32 dwDesiredAccess, bool bInheritHandle, Object * lpName))
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+    return nullptr;
+}
+
+COOP_PINVOKE_HELPER(void *, OpenEventW, (UInt32 dwDesiredAccess, Int32 bInheritHandle, Object * lpName))
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+    return nullptr;
+}
+
+COOP_PINVOKE_HELPER(void *, CreateMutexExW, (void * lpMutexAttributes, Object * lpName, UInt32 dwFlags, UInt32 dwDesiredAccess))
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+    return nullptr;
+}
+#endif // !_WIN32


### PR DESCRIPTION
Provide stubs for p/invokes missing on non-Windows platforms that are
included in library compilation.
Allow types with GVMs to compile in SDK code by not rooting any GVMs. If
they're actually needed by anything, compilation will still fail.
Root intrinsic methods in multi-module libraries. Now we fall back to generating an IL body for methods without any code,
include intrinsic methods as roots in compilation of library code.