### PR TITLE
Do not report name of param 0

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -377,6 +377,7 @@ namespace ILCompiler
                 yield return "_this";
             }
 
+            // TODO: The Params table is allowed to have holes in it. This expect all parameters to be present.
             foreach (var parameterHandle in parameters)
             {
                 Parameter p = ecmaMethod.MetadataReader.GetParameter(parameterHandle);

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -380,6 +380,11 @@ namespace ILCompiler
             foreach (var parameterHandle in parameters)
             {
                 Parameter p = ecmaMethod.MetadataReader.GetParameter(parameterHandle);
+
+                // Parameter with sequence number 0 refers to the return parameter
+                if (p.SequenceNumber == 0)
+                    continue;
+
                 yield return ecmaMethod.MetadataReader.GetString(p.Name);
             }
         }


### PR DESCRIPTION
C# compiler only emits those if the return parameter has field marshal
info and it's useless for what we're using it for.