### PR TITLE
Make Environment.GetCommandLineArgs working

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -1236,7 +1236,7 @@ namespace ILCompiler.CppCodeGen
                 sb.AppendLine();
                 sb.Append("int ret = ");
                 sb.Append(GetCppMethodDeclarationName(entrypoint.OwningType, GetCppMethodName(entrypoint)));
-                sb.Append("(argc-1, (intptr_t)(argv+1));");
+                sb.Append("(argc, (intptr_t)argv);");
 
                 sb.AppendEmptyLine();
                 sb.AppendLine();

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -64,8 +64,7 @@ namespace Internal.IL.Stubs.StartupCode
             // Call program Main
             if (_mainMethod.Signature.Length > 0)
             {
-                TypeDesc environ = Context.SystemModule.GetKnownType("System", "Environment");
-                codeStream.Emit(ILOpcode.call, emitter.NewToken(environ.GetKnownMethod("GetCommandLineArgs", null)));
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(startup.GetKnownMethod("GetMainMethodArguments", null)));
             }
             codeStream.Emit(ILOpcode.call, emitter.NewToken(_mainMethod));
             if (_mainMethod.Signature.ReturnType.IsVoid)

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -359,9 +359,7 @@ int main(int argc, char* argv[])
     int retval;
     try
     {
-        // Managed apps don't see the first args argument (full path of executable) so skip it
-        assert(argc > 0);
-        retval = __managed__Main(argc - 1, argv + 1);
+        retval = __managed__Main(argc, argv);
     }
     catch (const char* &e)
     {

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
@@ -66,6 +66,19 @@ namespace Internal.Runtime.CompilerHelpers
             Environment.SetCommandLineArgs(args);
         }
 
+        private static string[] GetMainMethodArguments()
+        {
+            // GetCommandLineArgs includes the executable name, Main() arguments do not.
+            string[] args = Environment.GetCommandLineArgs();
+
+            Debug.Assert(args.Length > 0);
+
+            string[] mainArgs = new string[args.Length - 1];
+            Array.Copy(args, 1, mainArgs, 0, mainArgs.Length);
+
+            return mainArgs;
+        }
+
         private static unsafe IntPtr[] CreateModuleManagers(IntPtr moduleHeaders, int count)
         {
             // Count the number of modules so we can allocate an array to hold the ModuleManager objects.

--- a/tests/src/Simple/Hello/Hello.cmd
+++ b/tests/src/Simple/Hello/Hello.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 set ErrorCode=100
-for /f "usebackq delims=;" %%F in (`"%1\%2"`) do (
+for /f "usebackq delims=;" %%F in (`"%1\%2" world`) do (
     if "%%F"=="Hello world" set ErrorCode=0
 )
 IF "%ErrorCode%"=="0" (

--- a/tests/src/Simple/Hello/Hello.cs
+++ b/tests/src/Simple/Hello/Hello.cs
@@ -12,7 +12,13 @@ namespace Hello
     {
         private static void Main(string[] args)
         {
-            Console.WriteLine("Hello world");
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Usage: hello name");
+                return;
+            }
+
+            Console.WriteLine("Hello " + args[0]);
         }
     }
 }

--- a/tests/src/Simple/Hello/Hello.sh
+++ b/tests/src/Simple/Hello/Hello.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 dir=$1
 file=$2
-cmp=`$dir/$file | tr '\r' ';'`
+cmp=`$dir/$file world | tr '\r' ';'`
 if [[ $cmp = "Hello world;" ]]; then
     echo pass
     exit 0


### PR DESCRIPTION
My fix in #1127 fixed arguments to `Main` but broke
`Environment.GetCommandLine`. Make sure both work this time...