### PR TITLE
Get reflection over generic types working

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
@@ -80,7 +80,14 @@ namespace ILCompiler.DependencyAnalysis
                     continue;
 
                 var node = factory.ConstructedTypeSymbol(mappingEntry.Entity) as EETypeNode;
-                
+                if (!node.Marked)
+                {
+                    // Generic type definition EETypes are never constructed, but need to be
+                    // present in the mapping table.
+                    if (mappingEntry.Entity.IsTypeDefinition && mappingEntry.Entity.HasInstantiation)
+                        node = factory.NecessaryTypeSymbol(mappingEntry.Entity) as EETypeNode;
+                }
+
                 if (node.Marked)
                 {
                     // TODO: this format got very inefficient due to not being able to use RVAs

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -83,6 +83,12 @@ namespace ILCompiler
                     _modulesSeen.Add(mdType.Module);
                 }
             }
+            else if (type.HasInstantiation)
+            {
+                AddGeneratedType(type.GetTypeDefinition());
+                foreach (var argument in type.Instantiation)
+                    AddGeneratedType(argument);
+            }
 
             // TODO: track generic types, array types, etc.
         }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -563,6 +563,24 @@ namespace Internal.Runtime.Augments
             }
         }
 
+        public unsafe static RuntimeTypeHandle GetGenericInstantiation(RuntimeTypeHandle typeHandle, out RuntimeTypeHandle[] genericTypeArgumentHandles)
+        {
+            Debug.Assert(IsGenericType(typeHandle));
+
+            int arity;
+            EETypePtr* pInstantiation;
+            byte* pVarianceInfo;
+            EETypePtr eeTypeDefinition = RuntimeImports.RhGetGenericInstantiation(typeHandle.ToEETypePtr(), out arity, out pInstantiation, out pVarianceInfo);
+
+            genericTypeArgumentHandles = new RuntimeTypeHandle[arity];
+            for (int i = 0; i < arity; i++)
+            {
+                genericTypeArgumentHandles[i] = new RuntimeTypeHandle(pInstantiation[i]);
+            }
+
+            return new RuntimeTypeHandle(eeTypeDefinition);
+        }
+
         public static bool IsGenericType(RuntimeTypeHandle typeHandle)
         {
             return RuntimeImports.RhGetEETypeClassification(CreateEETypePtr(typeHandle)) == RuntimeImports.RhEETypeClassification.Generic;

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -342,6 +342,10 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhGetNullableType")]
         internal static extern EETypePtr RhGetNullableType(EETypePtr pEEType);
 
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhGetGenericInstantiation")]
+        internal static extern unsafe EETypePtr RhGetGenericInstantiation(EETypePtr pEEType, out int arity, out EETypePtr* ppInstantiation, out byte* varianceInfo);
+
         //
         // EEType Array Dissectors
         //

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -589,7 +589,8 @@ namespace Internal.Reflection.Execution
         //
         public unsafe sealed override bool TryGetConstructedGenericTypeComponents(RuntimeTypeHandle runtimeTypeHandle, out RuntimeTypeHandle genericTypeDefinitionHandle, out RuntimeTypeHandle[] genericTypeArgumentHandles)
         {
-            throw new NotImplementedException();
+            genericTypeDefinitionHandle = RuntimeAugments.GetGenericInstantiation(runtimeTypeHandle, out genericTypeArgumentHandles);
+            return true;
         }
 
         //

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -21,6 +21,9 @@ public class ReflectionTest
         if (TestTypeOf() == Fail)
             return Fail;
 
+        if (TestGenericComposition() == Fail)
+            return Fail;
+
         return Pass;
     }
 
@@ -85,5 +88,18 @@ public class ReflectionTest
         }
 
         return Pass;
+    }
+
+    private static int TestGenericComposition()
+    {
+        Console.WriteLine("Testing generic composition");
+
+        Type nullableOfIntType = typeof(int?);
+
+        string fullName = nullableOfIntType.FullName;
+        if (fullName.Contains("System.Nullable`1") && fullName.Contains("System.Int32"))
+            return Pass;
+
+        return Fail;
     }
 }


### PR DESCRIPTION
By "working" I mean let reflection find out information about the
generic composition of the type.

Two parts:
* Implement TryGetConstructedGenericTypeComponents mapping table service
as a call into an existing runtime method (this works because EEType now
contains the composition information as of last week).
* Emit metadata and mapping table entries for components of generated
generic instances.