### PR TITLE
Get Activator.CreateInstance working for value types

### DIFF
--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -73,6 +73,14 @@ namespace System
         // https://github.com/dotnet/corert/issues/368
         private static T CreateInstanceIntrinsic<T>()
         {
+            if (RuntimeImports.RhIsValueType(EETypePtr.EETypePtrOf<T>()))
+            {
+                // Assuming the struct has no default constructor is reasonable, given this
+                // is just a workaround. To be 100% correct, this also needs to run the default
+                // ctor if any.
+                return (T)RuntimeImports.RhNewObject(EETypePtr.EETypePtrOf<T>());
+            }
+
             throw new NotSupportedException("CreateInstance");
         }
 #else


### PR DESCRIPTION
This is really just a workaround. The next demo I'm working on bringing
up has a "new T()" where T is System.Byte, which is pretty easy to
support.