### PR TITLE
Implement Equals/GetHashCode for CombinedDependencyListEntry

### DIFF
--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
@@ -162,11 +162,8 @@ namespace ILCompiler.DependencyAnalysisFramework
                             _conditional_dependency_store.Add(dependency.OtherReasonNode, storedDependencySet);
                         }
                         // Swap out other reason node as we're storing that as the dictionary key
-                        DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry conditionalDependencyStoreEntry = new DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry();
-                        conditionalDependencyStoreEntry.Node = dependency.Node;
-                        conditionalDependencyStoreEntry.Reason = dependency.Reason;
-                        conditionalDependencyStoreEntry.OtherReasonNode = node;
-
+                        DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry conditionalDependencyStoreEntry =
+                            new DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry(dependency.Node, node, dependency.Reason);
                         storedDependencySet.Add(conditionalDependencyStoreEntry);
                     }
                 }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
@@ -92,8 +92,8 @@ namespace ILCompiler.DependencyAnalysisFramework
 
             public bool Equals(CombinedDependencyListEntry other)
             {
-                return Object.Equals(Node, other.Node)
-                    && Object.Equals(OtherReasonNode, other.OtherReasonNode)
+                return Object.ReferenceEquals(Node, other.Node)
+                    && Object.ReferenceEquals(OtherReasonNode, other.OtherReasonNode)
                     && Object.Equals(Reason, other.Reason);
             }
         }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
@@ -46,7 +46,7 @@ namespace ILCompiler.DependencyAnalysisFramework
             }
         }
 
-        public struct CombinedDependencyListEntry
+        public struct CombinedDependencyListEntry : IEquatable<CombinedDependencyListEntry>
         {
             public CombinedDependencyListEntry(DependencyNodeCore<DependencyContextType> node,
                                                DependencyNodeCore<DependencyContextType> otherReasonNode,
@@ -67,9 +67,35 @@ namespace ILCompiler.DependencyAnalysisFramework
             }
 
             // Used by HashSet, so must have good Equals/GetHashCode
-            public DependencyNodeCore<DependencyContextType> Node;
-            public DependencyNodeCore<DependencyContextType> OtherReasonNode;
-            public string Reason;
+            public readonly DependencyNodeCore<DependencyContextType> Node;
+            public readonly DependencyNodeCore<DependencyContextType> OtherReasonNode;
+            public readonly string Reason;
+
+            public override bool Equals(object obj)
+            {
+                return obj is CombinedDependencyListEntry && Equals((CombinedDependencyListEntry)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                int hash = 23;
+                hash = hash * 31 + Node.GetHashCode();
+
+                if (OtherReasonNode != null)
+                    hash = hash * 31 + OtherReasonNode.GetHashCode();
+
+                if (Reason != null)
+                    hash = hash * 31 + Reason.GetHashCode();
+
+                return hash;
+            }
+
+            public bool Equals(CombinedDependencyListEntry other)
+            {
+                return Object.Equals(Node, other.Node)
+                    && Object.Equals(OtherReasonNode, other.OtherReasonNode)
+                    && Object.Equals(Reason, other.Reason);
+            }
         }
 
         public abstract bool InterestingForDynamicDependencyAnalysis


### PR DESCRIPTION
This was falling back to the runtime supplied implementation which has
pretty bad perf characteristics.

Also made the fields read only and implemented IEquatable for good
measure.