### PR TITLE
Create FileStream explicitly in CppWriter

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.CppCodeGen
         {
             _compilation = compilation;
 
-            _out = new StreamWriter(File.Create(compilation.Options.OutputFilePath));
+            _out = new StreamWriter(new FileStream(compilation.Options.OutputFilePath, FileMode.Create, FileAccess.Write, FileShare.Read, 4096, false));
 
             SetWellKnownTypeSignatureName(WellKnownType.Void, "void");
             SetWellKnownTypeSignatureName(WellKnownType.Boolean, "uint8_t");


### PR DESCRIPTION
`File.Create` will open an overlapped handle which is really
unnecessary.