### PR TITLE
Fix EEType::BaseSize computation for value types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -355,6 +355,9 @@ namespace ILCompiler.DependencyAnalysis
             {
                 objectSize = pointerSize +
                     ((MetadataType)_type).InstanceByteCount; // +pointerSize for SyncBlock
+
+                if (_type.IsValueType)
+                    objectSize += pointerSize; // + EETypePtr field inherited from System.Object
             }
             else if (_type is ArrayType)
             {


### PR DESCRIPTION
BaseSize should report the boxed size of the type instance for value
types.

InstanceByteCount returns the number of bytes that would be reported by
the sizeof() operator. This doesn't include the one inherited field from
System.Object. That field is present when the type is boxed and needs to
be accounted for.