### PR TITLE
Emit generic type definition EETypes

### DIFF
--- a/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -60,14 +60,27 @@ namespace Internal.Runtime
         {
             UInt16 flags = (UInt16)EETypeKind.CanonicalEEType;
 
-            if (type.IsArray || type.IsPointer)
+            if (type.IsInterface)
             {
-                flags = (UInt16)EETypeKind.ParameterizedEEType;
+                flags |= (UInt16)EETypeFlags.IsInterfaceFlag;
             }
 
             if (type.IsValueType)
             {
                 flags |= (UInt16)EETypeFlags.ValueTypeFlag;
+            }
+
+            if (type.IsGenericDefinition)
+            {
+                flags |= (UInt16)EETypeKind.GenericTypeDefEEType;
+
+                // Generic type definition EETypes don't set the other flags.
+                return flags;
+            }
+
+            if (type.IsArray || type.IsPointer)
+            {
+                flags = (UInt16)EETypeKind.ParameterizedEEType;
             }
 
             if (type.HasFinalizer)
@@ -87,11 +100,6 @@ namespace Internal.Runtime
                 {
                     flags |= (UInt16)EETypeFlags.HasPointersFlag;
                 }
-            }
-
-            if (type.IsInterface)
-            {
-                flags |= (UInt16)EETypeFlags.IsInterfaceFlag;
             }
 
             if (type.HasInstantiation)

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -506,5 +506,13 @@ namespace Internal.TypeSystem
                 return (GetTypeFlags(TypeFlags.HasGenericVariance | TypeFlags.HasGenericVarianceComputed) & TypeFlags.HasGenericVariance) != 0;
             }
         }
+
+        public bool IsGenericDefinition
+        {
+            get
+            {
+                return HasInstantiation && IsTypeDefinition;
+            }
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -149,15 +149,8 @@ namespace ILCompiler.DependencyAnalysis
             objData.Alignment = 16;
             objData.DefinedSymbols.Add(this);
 
-            // Todo: Generic Type Definition EETypes
-            //       Early-out just to prevent crashing at compile time...
-            if (_type.HasInstantiation && _type.IsTypeDefinition)
-            {
-                objData.EmitZeroPointer();
-                return objData.ToObjectData();
-            }
-
-            ComputeOptionalEETypeFields(factory);
+            if (!_type.IsGenericDefinition)
+                ComputeOptionalEETypeFields(factory);
             
             OutputComponentSize(ref objData);
             OutputFlags(factory, ref objData);
@@ -175,6 +168,8 @@ namespace ILCompiler.DependencyAnalysis
 
             if (_constructed)
             {
+                Debug.Assert(!_type.IsGenericDefinition);
+
                 // Avoid consulting VTable slots until they're guaranteed complete during final data emission
                 if (!relocsOnly)
                 {
@@ -184,10 +179,13 @@ namespace ILCompiler.DependencyAnalysis
                 OutputInterfaceMap(factory, ref objData);
             }
 
-            OutputFinalizerMethod(factory, ref objData);
-            OutputOptionalFields(factory, ref objData);
-            OutputNullableTypeParameter(factory, ref objData);
-            OutputGenericInstantiationDetails(factory, ref objData);
+            if (!_type.IsGenericDefinition)
+            {
+                OutputFinalizerMethod(factory, ref objData);
+                OutputOptionalFields(factory, ref objData);
+                OutputNullableTypeParameter(factory, ref objData);
+                OutputGenericInstantiationDetails(factory, ref objData);
+            }
 
             return objData.ToObjectData();
         }
@@ -347,6 +345,12 @@ namespace ILCompiler.DependencyAnalysis
 
         private void OutputBaseSize(ref ObjectDataBuilder objData)
         {
+            if (_type.IsGenericDefinition)
+            {
+                objData.EmitInt(0);
+                return;
+            }
+
             int pointerSize = _type.Context.Target.PointerSize;
             int minimumObjectSize = pointerSize * 3;
             int objectSize;
@@ -396,6 +400,10 @@ namespace ILCompiler.DependencyAnalysis
                 var parameterType = ((ParameterizedType)_type).ParameterType;
                 relatedTypeNode = factory.NecessaryTypeSymbol(parameterType);
             }
+            else if (_type.IsGenericDefinition)
+            {
+                // Related type is not set for generic definitions
+            }
             else
             {
                 TypeDesc baseType = _type.BaseType;
@@ -430,6 +438,8 @@ namespace ILCompiler.DependencyAnalysis
                 objData.EmitShort(0);
                 return;
             }
+
+            Debug.Assert(!_type.IsGenericDefinition);
 
             int virtualSlotCount = 0;
             TypeDesc currentTypeSlice = _type.GetClosestMetadataType();


### PR DESCRIPTION
Set the expected flag and skip emitting fields that don't make sense for
generic type definitions.