### PR TITLE
Seal Equals and GetHashCode on DependencyNode

### DIFF
--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNode.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNode.cs
@@ -46,5 +46,15 @@ namespace ILCompiler.DependencyAnalysisFramework
         {
             return GetName();
         }
+
+        public sealed override bool Equals(object obj)
+        {
+            return Object.ReferenceEquals(this, obj);
+        }
+
+        public sealed override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
Dependency nodes always use referential equality. Trying to provide
other semantics would break the dependency analysis engine, so let's
forbid that.