### PR TITLE
Fix field layout algorithm for thread statics

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerMetadataFieldLayoutAlgorithm.cs
@@ -15,6 +15,7 @@ namespace ILCompiler
         {
             // GC statics start with a pointer to the "EEType" that signals the size and GCDesc to the GC
             layout.GcStatics.Size = context.Target.PointerSize;
+            layout.ThreadStatics.Size = context.Target.PointerSize;
         }
 
         protected override void FinalizeRuntimeSpecificStaticFieldLayout(TypeSystemContext context, ref ComputedStaticFieldLayout layout)
@@ -24,6 +25,10 @@ namespace ILCompiler
             if (layout.GcStatics.Size == context.Target.PointerSize)
             {
                 layout.GcStatics.Size = 0;
+            }
+            if (layout.ThreadStatics.Size == context.Target.PointerSize)
+            {
+                layout.ThreadStatics.Size = 0;
             }
         }
     }

--- a/src/ILCompiler.TypeSystem/tests/TestMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestMetadataFieldLayoutAlgorithm.cs
@@ -15,6 +15,7 @@ namespace TypeSystemTests
         {
             // GC statics start with a pointer to the "EEType" that signals the size and GCDesc to the GC
             layout.GcStatics.Size = context.Target.PointerSize;
+            layout.ThreadStatics.Size = context.Target.PointerSize;
         }
 
         protected override void FinalizeRuntimeSpecificStaticFieldLayout(TypeSystemContext context, ref ComputedStaticFieldLayout layout)
@@ -24,6 +25,10 @@ namespace TypeSystemTests
             if (layout.GcStatics.Size == context.Target.PointerSize)
             {
                 layout.GcStatics.Size = 0;
+            }
+            if (layout.ThreadStatics.Size == context.Target.PointerSize)
+            {
+                layout.ThreadStatics.Size = 0;
             }
         }
     }


### PR DESCRIPTION
This is not exercised yet because we lie about thread statics not being
thread static, but we will hit it at some point (I hit it when testing
GC maps for them).