### PR TITLE
Improve consistency of type hierarchy checks

### DIFF
--- a/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -88,7 +88,7 @@ namespace Internal.Runtime
                 flags |= (UInt16)EETypeFlags.HasFinalizerFlag;
             }
 
-            if (type is MetadataType && ((MetadataType)type).ContainsPointers)
+            if (type.IsDefType && ((DefType)type).ContainsPointers)
             {
                 flags |= (UInt16)EETypeFlags.HasPointersFlag;
             }
@@ -153,7 +153,7 @@ namespace Internal.Runtime
                     return true;
                 }
             }
-            else if (type is DefType && ((DefType)type).InstanceByteAlignment > 4)
+            else if (type.IsDefType && ((DefType)type).InstanceByteAlignment > 4)
             {
                 return true;
             }

--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -232,13 +232,13 @@ namespace Internal.TypeSystem
                     if (fieldType.IsPrimitive)
                         continue;
 
-                    if (((MetadataType)fieldType).ContainsPointers)
+                    if (((DefType)fieldType).ContainsPointers)
                     {
                         someFieldContainsPointers = true;
                         break;
                     }
                 }
-                else if (fieldType.IsDefType || fieldType.IsArray || fieldType.IsByRef)
+                else if (fieldType.IsObjRef || fieldType.IsByRef)
                 {
                     someFieldContainsPointers = true;
                     break;

--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -123,7 +123,7 @@ namespace Internal.TypeSystem
 
             // Verify that no ByRef types present in this type's fields
             foreach (var field in type.GetFields())
-                if (field.FieldType is ByRefType)
+                if (field.FieldType.IsByRef)
                     throw new TypeLoadException();
 
             // If the type has layout, read its packing and size info
@@ -238,7 +238,7 @@ namespace Internal.TypeSystem
                         break;
                     }
                 }
-                else if (fieldType is DefType || fieldType is ArrayType || fieldType.IsByRef)
+                else if (fieldType.IsDefType || fieldType.IsArray || fieldType.IsByRef)
                 {
                     someFieldContainsPointers = true;
                     break;
@@ -401,11 +401,11 @@ namespace Internal.TypeSystem
         {
             SizeAndAlignment result;
 
-            if (fieldType is MetadataType)
+            if (fieldType.IsDefType)
             {
                 if (fieldType.IsValueType)
                 {
-                    MetadataType metadataType = (MetadataType)fieldType;
+                    DefType metadataType = (DefType)fieldType;
                     result.Size = metadataType.InstanceFieldSize;
                     result.Alignment = metadataType.InstanceFieldAlignment;
                 }
@@ -415,7 +415,7 @@ namespace Internal.TypeSystem
                     result.Alignment = fieldType.Context.Target.PointerSize;
                 }
             }
-            else if (fieldType is ByRefType || fieldType is ArrayType)
+            else if (fieldType.IsByRef || fieldType.IsArray)
             {
                 // This could use InstanceFieldSize/Alignment (and those results should match what's here)
                 // but, its more efficient to just assume pointer size instead of fulling processing
@@ -423,7 +423,7 @@ namespace Internal.TypeSystem
                 result.Size = fieldType.Context.Target.PointerSize;
                 result.Alignment = fieldType.Context.Target.PointerSize;
             }
-            else if (fieldType is PointerType)
+            else if (fieldType.IsPointer)
             {
                 result.Size = fieldType.Context.Target.PointerSize;
                 result.Alignment = fieldType.Context.Target.PointerSize;

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -353,6 +353,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether locations of this type refer to the GC heap.
+        /// </summary>
         public bool IsObjRef
         {
             get

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -645,11 +645,11 @@ namespace Internal.TypeSystem
         /// </summary>
         public RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForType(TypeDesc type)
         {
-            if (type is DefType)
+            if (type.IsDefType)
             {
                 return GetRuntimeInterfacesAlgorithmForDefType((DefType)type);
             }
-            else if (type is ArrayType)
+            else if (type.IsArray)
             {
                 ArrayType arrType = (ArrayType)type;
                 if (arrType.IsSzArray && !arrType.ElementType.IsPointer)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -355,22 +355,22 @@ namespace ILCompiler.DependencyAnalysis
             int minimumObjectSize = pointerSize * 3;
             int objectSize;
 
-            if (_type is MetadataType)
+            if (_type.IsDefType)
             {
                 objectSize = pointerSize +
-                    ((MetadataType)_type).InstanceByteCount; // +pointerSize for SyncBlock
+                    ((DefType)_type).InstanceByteCount; // +pointerSize for SyncBlock
 
                 if (_type.IsValueType)
                     objectSize += pointerSize; // + EETypePtr field inherited from System.Object
             }
-            else if (_type is ArrayType)
+            else if (_type.IsArray)
             {
                 objectSize = 3 * pointerSize; // SyncBlock + EETypePtr + Length
                 if (!_type.IsSzArray)
                     objectSize +=
                         2 * _type.Context.GetWellKnownType(WellKnownType.Int32).GetElementSize() * ((ArrayType)_type).Rank;
             }
-            else if (_type is PointerType)
+            else if (_type.IsPointer)
             {
                 // Object size 0 is a sentinel value in the runtime for parameterized types that means "Pointer Type"
                 objData.EmitInt(0);
@@ -568,7 +568,7 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (uint)EETypeRareFlags.RequiresAlign8Flag;
             }
 
-            if (_type is DefType && ((DefType)_type).IsHFA())
+            if (_type.IsDefType && ((DefType)_type).IsHFA())
             {
                 flags |= (uint)EETypeRareFlags.IsHFAFlag;
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -902,12 +902,12 @@ namespace Internal.JitInterface
                 var fieldType = field.FieldType;
                 if (fieldType.IsValueType)
                 {
-                    if (!((MetadataType)fieldType).ContainsPointers)
+                    if (!((DefType)fieldType).ContainsPointers)
                         continue;
 
                     gcType = CorInfoGCType.TYPE_GC_OTHER;
                 }
-                else if ((fieldType.IsDefType) || (fieldType.IsArray))
+                else if (fieldType.IsObjRef)
                 {
                     gcType = CorInfoGCType.TYPE_GC_REF;
                 }
@@ -950,7 +950,7 @@ namespace Internal.JitInterface
         {
             uint result = 0;
 
-            MetadataType type = (MetadataType)HandleToObject(cls);
+            DefType type = (DefType)HandleToObject(cls);
 
             Debug.Assert(type.IsValueType);
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -907,7 +907,7 @@ namespace Internal.JitInterface
 
                     gcType = CorInfoGCType.TYPE_GC_OTHER;
                 }
-                else if ((fieldType is DefType) || (fieldType is ArrayType))
+                else if ((fieldType.IsDefType) || (fieldType.IsArray))
                 {
                     gcType = CorInfoGCType.TYPE_GC_REF;
                 }
@@ -1050,7 +1050,7 @@ namespace Internal.JitInterface
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_NEW:
                     {
                         var type = HandleToObject(pResolvedToken.hClass);
-                        Debug.Assert(type is DefType);
+                        Debug.Assert(type.IsDefType);
 
                         pLookup.addr = (void*)ObjectToHandle(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.NewHelper, type));
                     }


### PR DESCRIPTION
Use IsXXX properties in lieu of "is XXX" checks.

Also, downgrade "is MetadataType" to "IsDefType" where it makes sense.