### PR TITLE
Throw meaningful exception if type doesn't derive from System.Object

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -335,6 +335,12 @@ namespace Internal.TypeSystem.Ecma
             if (decl != null)
             {
                 MethodDesc impl = this.FindVirtualFunctionTargetMethodOnObjectType(decl);
+                if (impl == null)
+                {
+                    // TODO: invalid input: the type doesn't derive from our System.Object
+                    throw new TypeLoadException(this.GetFullName());
+                }
+
                 if (impl.OwningType != objectType)
                 {
                     return impl;


### PR DESCRIPTION
If we can't find an implementation of the Finalize method in the
hierarchy, the type hierarchy starts with something weird.

Marking as TODO because we still need to standardize on what exception
types to throw and how to throw them.

Related to #1226.