### PR TITLE
Change JIT-EE interface to use static methods as callbacks

### DIFF
--- a/src/ILCompiler.Compiler/src/project.json
+++ b/src/ILCompiler.Compiler/src/project.json
@@ -3,6 +3,8 @@
     "NETStandard.Library": "1.5.0-rc2-23911",
     "System.IO.MemoryMappedFiles": "4.0.0-rc2-23911",
     "System.Reflection.Metadata": "1.3.0-rc3-24102-00",
+    "System.Runtime.CompilerServices.Unsafe": "4.0.0-rc3-24102-00",
+    "System.Runtime.InteropServices": "4.1.0-rc3-24102-00",
     "Microsoft.DiaSymReader": "1.0.8-rc2-60325"
   },
   "frameworks": {

--- a/src/ILCompiler/desktop/project.json
+++ b/src/ILCompiler/desktop/project.json
@@ -3,6 +3,7 @@
     "NETStandard.Library": "1.5.0-rc2-23911",
     "System.IO.MemoryMappedFiles": "4.0.0-rc2-23911",
     "System.Reflection.Metadata": "1.3.0-rc3-24102-00",
+    "System.Runtime.CompilerServices.Unsafe": "4.0.0-rc3-24102-00",
     "Microsoft.DiaSymReader": "1.0.8-rc2-60325",
     "System.CommandLine": "0.1.0-e160323-1"
   },

--- a/src/JitInterface/src/CorInfoBase.cs
+++ b/src/JitInterface/src/CorInfoBase.cs
@@ -11,3236 +11,3068 @@ namespace Internal.JitInterface
 {
     unsafe partial class CorInfoImpl
     {
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getMethodAttribs_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _setMethodAttribs_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, CorInfoMethodRuntimeFlags attribs);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getMethodSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, CORINFO_SIG_INFO* sig, CORINFO_CLASS_STRUCT_* memberParent);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.I1)]delegate bool _getMethodInfo_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_METHOD_INFO info);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoInline _canInline_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, ref uint pRestrictions);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _reportInliningDecision_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* inlinerHnd, CORINFO_METHOD_STRUCT_* inlineeHnd, CorInfoInline inlineResult, byte* reason);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.I1)]delegate bool _canTailCall_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* declaredCalleeHnd, CORINFO_METHOD_STRUCT_* exactCalleeHnd, [MarshalAs(UnmanagedType.I1)]bool fIsTailPrefix);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _reportTailCallDecision_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, [MarshalAs(UnmanagedType.I1)]bool fIsTailPrefix, CorInfoTailCall tailCallResult, byte* reason);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getEHinfo_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, uint EHnumber, ref CORINFO_EH_CLAUSE clause);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _getMethodClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_MODULE_STRUCT_* _getMethodModule_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getMethodVTableOffset_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref uint offsetOfIndirection, ref uint offsetAfterIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoIntrinsics _getIntrinsicID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, [MarshalAs(UnmanagedType.U1)] ref bool pMustExpand);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.I1)]delegate bool _isInSIMDModule_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* classHnd);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoUnmanagedCallConv _getUnmanagedCallConv_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _pInvokeMarshalingRequired_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, CORINFO_SIG_INFO* callSiteSig);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _satisfiesMethodConstraints_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* parent, CORINFO_METHOD_STRUCT_* method);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _isCompatibleDelegate_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* objCls, CORINFO_CLASS_STRUCT_* methodParentCls, CORINFO_METHOD_STRUCT_* method, CORINFO_CLASS_STRUCT_* delegateCls, [MarshalAs(UnmanagedType.Bool)] ref bool pfIsOpenDelegate);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _isDelegateCreationAllowed_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* delegateHnd, CORINFO_METHOD_STRUCT_* calleeHnd);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoInstantiationVerification _isInstantiationOfVerifiedGeneric_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _initConstraintsForVerification_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, [MarshalAs(UnmanagedType.Bool)] ref bool pfHasCircularClassConstraints, [MarshalAs(UnmanagedType.Bool)] ref bool pfHasCircularMethodConstraint);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoCanSkipVerificationResult _canSkipMethodVerification_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftnHandle);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _methodMustBeLoadedBeforeCodeIsRun_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_METHOD_STRUCT_* _mapMethodDeclToMethodImpl_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getGSCookie_wrapper(IntPtr _this, out IntPtr exception, GSCookie* pCookieVal, GSCookie** ppCookieVal);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _resolveToken_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _findSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, uint sigTOK, CORINFO_CONTEXT_STRUCT* context, CORINFO_SIG_INFO* sig);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _findCallSiteSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, uint methTOK, CORINFO_CONTEXT_STRUCT* context, CORINFO_SIG_INFO* sig);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _getTokenTypeAsHandle_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoCanSkipVerificationResult _canSkipVerification_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _isValidToken_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, uint metaTOK);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _isValidStringRef_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, uint metaTOK);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _shouldEnforceCallvirtRestriction_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* scope);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoType _asCorInfoType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate byte* _getClassName_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate int _appendClassName_wrapper(IntPtr _this, out IntPtr exception, short** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fNamespace, [MarshalAs(UnmanagedType.Bool)]bool fFullInst, [MarshalAs(UnmanagedType.Bool)]bool fAssembly);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _isValueClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _canInlineTypeCheckWithObjectVTable_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getClassAttribs_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _isStructRequiringStackAllocRetBuf_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_MODULE_STRUCT_* _getClassModule_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_ASSEMBLY_STRUCT_* _getModuleAssembly_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* mod);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate byte* _getAssemblyName_wrapper(IntPtr _this, out IntPtr exception, CORINFO_ASSEMBLY_STRUCT_* assem);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _LongLifetimeMalloc_wrapper(IntPtr _this, out IntPtr exception, UIntPtr sz);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _LongLifetimeFree_wrapper(IntPtr _this, out IntPtr exception, void* obj);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate byte* _getClassModuleIdForStatics_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls, CORINFO_MODULE_STRUCT_** pModule, void** ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getClassSize_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getClassAlignmentRequirement_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fDoubleAlignHint);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getClassGClayout_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls, byte* gcPtrs);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getClassNumInstanceFields_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_FIELD_STRUCT_* _getFieldInClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* clsHnd, int num);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _checkMethodModifier_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* hMethod, byte* modifier, [MarshalAs(UnmanagedType.Bool)]bool fOptional);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoHelpFunc _getNewHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoHelpFunc _getNewArrHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* arrayCls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoHelpFunc _getCastingHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.I1)]bool fThrowing);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoHelpFunc _getSharedCCtorHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* clsHnd);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoHelpFunc _getSecurityPrologHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _getTypeForBox_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoHelpFunc _getBoxHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoHelpFunc _getUnBoxHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getReadyToRunHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CorInfoHelpFunc id, ref CORINFO_CONST_LOOKUP pLookup);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getReadyToRunDelegateCtorHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pTargetMethod, CORINFO_CLASS_STRUCT_* delegateType, ref CORINFO_CONST_LOOKUP pLookup);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate byte* _getHelperName_wrapper(IntPtr _this, out IntPtr exception, CorInfoHelpFunc helpFunc);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoInitClassResult _initClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, CORINFO_METHOD_STRUCT_* method, CORINFO_CONTEXT_STRUCT* context, [MarshalAs(UnmanagedType.Bool)]bool speculative);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _classMustBeLoadedBeforeCodeIsRun_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _getBuiltinClass_wrapper(IntPtr _this, out IntPtr exception, CorInfoClassId classId);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoType _getTypeForPrimitiveValueClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _canCast_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* child, CORINFO_CLASS_STRUCT_* parent);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _areTypesEquivalent_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _mergeClasses_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _getParentType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoType _getChildType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* clsHnd, ref CORINFO_CLASS_STRUCT_* clsRet);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _satisfiesClassConstraints_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _isSDArray_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getArrayRank_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getArrayInitializationData_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, uint size);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoIsAccessAllowedResult _canAccessClass_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, ref CORINFO_HELPER_DESC pAccessHelper);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate byte* _getFieldName_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* ftn, byte** moduleName);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _getFieldClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoType _getFieldType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, ref CORINFO_CLASS_STRUCT_* structType, CORINFO_CLASS_STRUCT_* memberParent);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getFieldOffset_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.I1)]delegate bool _isWriteBarrierHelperRequired_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getFieldInfo_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_ACCESS_FLAGS flags, ref CORINFO_FIELD_INFO pResult);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.I1)]delegate bool _isFieldStatic_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* fldHnd);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getBoundaries_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref uint cILOffsets, ref uint* pILOffsets, BoundaryTypes* implictBoundaries);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _setBoundaries_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, uint cMap, OffsetMapping* pMap);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getVars_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref uint cVars, ILVarInfo** vars, [MarshalAs(UnmanagedType.U1)] ref bool extendOthers);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _setVars_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, uint cVars, NativeVarInfo* vars);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _allocateArray_wrapper(IntPtr _this, out IntPtr exception, uint cBytes);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _freeArray_wrapper(IntPtr _this, out IntPtr exception, void* array);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_ARG_LIST_STRUCT_* _getArgNext_wrapper(IntPtr _this, out IntPtr exception, CORINFO_ARG_LIST_STRUCT_* args);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoTypeWithMod _getArgType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* sig, CORINFO_ARG_LIST_STRUCT_* args, ref CORINFO_CLASS_STRUCT_* vcTypeRet);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _getArgClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* sig, CORINFO_ARG_LIST_STRUCT_* args);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoType _getHFAType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* hClass);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate HRESULT _GetErrorHRESULT_wrapper(IntPtr _this, out IntPtr exception, _EXCEPTION_POINTERS* pExceptionPointers);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _GetErrorMessage_wrapper(IntPtr _this, out IntPtr exception, short* buffer, uint bufferLength);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate int _FilterException_wrapper(IntPtr _this, out IntPtr exception, _EXCEPTION_POINTERS* pExceptionPointers);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _HandleException_wrapper(IntPtr _this, out IntPtr exception, _EXCEPTION_POINTERS* pExceptionPointers);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _ThrowExceptionForJitResult_wrapper(IntPtr _this, out IntPtr exception, HRESULT result);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _ThrowExceptionForHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_HELPER_DESC throwHelper);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getEEInfo_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_EE_INFO pEEInfoOut);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.LPWStr)]delegate string _getJitTimeLogFilename_wrapper(IntPtr _this, out IntPtr exception);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate mdToken _getMethodDefFromMethod_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* hMethod);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate byte* _getMethodName_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, byte** moduleName);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getMethodHash_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate byte* _findNameOfToken_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* moduleHandle, mdToken token, byte* szFQName, UIntPtr FQNameCapacity);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.I1)]delegate bool _getSystemVAmd64PassStructInRegisterDescriptor_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* structHnd, SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* structPassInRegDescPtr);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getThreadTLSIndex_wrapper(IntPtr _this, out IntPtr exception, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getInlinedCallFrameVptr_wrapper(IntPtr _this, out IntPtr exception, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate int* _getAddrOfCaptureThreadGlobal_wrapper(IntPtr _this, out IntPtr exception, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate SIZE_T* _getAddrModuleDomainID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getHelperFtn_wrapper(IntPtr _this, out IntPtr exception, CorInfoHelpFunc ftnNum, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getFunctionEntryPoint_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult, CORINFO_ACCESS_FLAGS accessFlags);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getFunctionFixedEntryPoint_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getMethodSync_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CorInfoHelpFunc _getLazyStringLiteralHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* handle);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_MODULE_STRUCT_* _embedModuleHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* handle, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_CLASS_STRUCT_* _embedClassHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* handle, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_METHOD_STRUCT_* _embedMethodHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* handle, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_FIELD_STRUCT_* _embedFieldHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* handle, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _embedGenericHandle_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.Bool)]bool fEmbedParent, ref CORINFO_GENERICHANDLE_RESULT pResult);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getLocationOfThisType_wrapper(IntPtr _this, out IntPtr exception, out CORINFO_LOOKUP_KIND _return, CORINFO_METHOD_STRUCT_* context);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getPInvokeUnmanagedTarget_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getAddressOfPInvokeFixup_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getAddressOfPInvokeTarget_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref CORINFO_CONST_LOOKUP pLookup);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _GetCookieForPInvokeCalliSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* szMetaSig, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.I1)]delegate bool _canGetCookieForPInvokeCalliSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* szMetaSig);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_JUST_MY_CODE_HANDLE_* _getJustMyCodeHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref CORINFO_JUST_MY_CODE_HANDLE_** ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _GetProfilingHandle_wrapper(IntPtr _this, out IntPtr exception, [MarshalAs(UnmanagedType.Bool)] ref bool pbHookFunction, ref void* pProfilerHandle, [MarshalAs(UnmanagedType.Bool)] ref bool pbIndirectedHandles);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getCallInfo_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_RESOLVED_TOKEN* pConstrainedResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_CALLINFO_FLAGS flags, ref CORINFO_CALL_INFO pResult);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _canAccessFamily_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* hCaller, CORINFO_CLASS_STRUCT_* hInstanceType);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _isRIDClassDomainID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getClassDomainID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getFieldAddress_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate IntPtr _getVarArgsHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* pSig, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.I1)]delegate bool _canGetVarArgsHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* pSig);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate InfoAccessType _constructStringLiteral_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, mdToken metaTok, ref void* ppValue);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate InfoAccessType _emptyStringLiteral_wrapper(IntPtr _this, out IntPtr exception, ref void* ppValue);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getFieldThreadLocalStoreID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, ref void* ppIndirection);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _setOverride_wrapper(IntPtr _this, out IntPtr exception, IntPtr pOverride, CORINFO_METHOD_STRUCT_* currentMethod);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _addActiveDependency_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* moduleFrom, CORINFO_MODULE_STRUCT_* moduleTo);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate CORINFO_METHOD_STRUCT_* _GetDelegateCtor_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* methHnd, CORINFO_CLASS_STRUCT_* clsHnd, CORINFO_METHOD_STRUCT_* targetMethodHnd, ref DelegateCtorArgs pCtorData);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _MethodCompileComplete_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* methHnd);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getTailCallCopyArgsThunk_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* pSig, CorInfoHelperTailCallSpecialHandling flags);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _getMemoryManager_wrapper(IntPtr _this, out IntPtr exception);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _allocMem_wrapper(IntPtr _this, out IntPtr exception, uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, ref void* hotCodeBlock, ref void* coldCodeBlock, ref void* roDataBlock);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _reserveUnwindInfo_wrapper(IntPtr _this, out IntPtr exception, [MarshalAs(UnmanagedType.Bool)]bool isFunclet, [MarshalAs(UnmanagedType.Bool)]bool isColdCode, uint unwindSize);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _allocUnwindInfo_wrapper(IntPtr _this, out IntPtr exception, byte* pHotCode, byte* pColdCode, uint startOffset, uint endOffset, uint unwindSize, byte* pUnwindBlock, CorJitFuncKind funcKind);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void* _allocGCInfo_wrapper(IntPtr _this, out IntPtr exception, UIntPtr size);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _yieldExecution_wrapper(IntPtr _this, out IntPtr exception);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _setEHcount_wrapper(IntPtr _this, out IntPtr exception, uint cEH);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _setEHinfo_wrapper(IntPtr _this, out IntPtr exception, uint EHnumber, ref CORINFO_EH_CLAUSE clause);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        [return: MarshalAs(UnmanagedType.Bool)]delegate bool _logMsg_wrapper(IntPtr _this, out IntPtr exception, uint level, byte* fmt, IntPtr args);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate int _doAssert_wrapper(IntPtr _this, out IntPtr exception, byte* szFile, int iLine, byte* szExpr);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _reportFatalError_wrapper(IntPtr _this, out IntPtr exception, CorJitResult result);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate HRESULT _allocBBProfileBuffer_wrapper(IntPtr _this, out IntPtr exception, uint count, ref ProfileBuffer* profileBuffer);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate HRESULT _getBBProfileData_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftnHnd, ref uint count, ref ProfileBuffer* profileBuffer, ref uint numRuns);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _recordCallSite_wrapper(IntPtr _this, out IntPtr exception, uint instrOffset, CORINFO_SIG_INFO* callSig, CORINFO_METHOD_STRUCT_* methodHandle);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _recordRelocation_wrapper(IntPtr _this, out IntPtr exception, void* location, void* target, ushort fRelocType, ushort slotNum, int addlDelta);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate ushort _getRelocTypeHint_wrapper(IntPtr _this, out IntPtr exception, void* target);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate void _getModuleNativeEntryPointRange_wrapper(IntPtr _this, out IntPtr exception, ref void* pStart, ref void* pEnd);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getExpectedTargetArchitecture_wrapper(IntPtr _this, out IntPtr exception);
-        [UnmanagedFunctionPointerAttribute(CallingConvention.ThisCall)]
-        delegate uint _getJitFlags_wrapper(IntPtr _this, out IntPtr exception, ref CORJIT_FLAGS flags, uint sizeInBytes);
-
-        public virtual uint getMethodAttribs_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn)
-        {
-            exception = IntPtr.Zero;
-            try
-            {
-                return getMethodAttribs(ftn);
-
-            }
-            catch (Exception ex)
-            {
-                exception = AllocException(ex);
-            }
-            return (uint)0;
-        }
-
-        public virtual void setMethodAttribs_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, CorInfoMethodRuntimeFlags attribs)
-        {
-            exception = IntPtr.Zero;
-            try
-            {
-                setMethodAttribs(ftn, attribs);
-                return;
-            }
-            catch (Exception ex)
-            {
-                exception = AllocException(ex);
-            }
-        }
-
-        public virtual void getMethodSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, CORINFO_SIG_INFO* sig, CORINFO_CLASS_STRUCT_* memberParent)
-        {
-            exception = IntPtr.Zero;
-            try
-            {
-                getMethodSig(ftn, sig, memberParent);
-                return;
-            }
-            catch (Exception ex)
-            {
-                exception = AllocException(ex);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getMethodAttribs(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __setMethodAttribs(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, CorInfoMethodRuntimeFlags attribs);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getMethodSig(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, CORINFO_SIG_INFO* sig, CORINFO_CLASS_STRUCT_* memberParent);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.I1)]delegate bool __getMethodInfo(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_METHOD_INFO info);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoInline __canInline(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, ref uint pRestrictions);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __reportInliningDecision(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* inlinerHnd, CORINFO_METHOD_STRUCT_* inlineeHnd, CorInfoInline inlineResult, byte* reason);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.I1)]delegate bool __canTailCall(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* declaredCalleeHnd, CORINFO_METHOD_STRUCT_* exactCalleeHnd, [MarshalAs(UnmanagedType.I1)]bool fIsTailPrefix);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __reportTailCallDecision(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, [MarshalAs(UnmanagedType.I1)]bool fIsTailPrefix, CorInfoTailCall tailCallResult, byte* reason);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getEHinfo(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, uint EHnumber, ref CORINFO_EH_CLAUSE clause);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __getMethodClass(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_MODULE_STRUCT_* __getMethodModule(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getMethodVTableOffset(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref uint offsetOfIndirection, ref uint offsetAfterIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoIntrinsics __getIntrinsicID(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, [MarshalAs(UnmanagedType.U1)] ref bool pMustExpand);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.I1)]delegate bool __isInSIMDModule(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* classHnd);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoUnmanagedCallConv __getUnmanagedCallConv(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __pInvokeMarshalingRequired(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, CORINFO_SIG_INFO* callSiteSig);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __satisfiesMethodConstraints(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* parent, CORINFO_METHOD_STRUCT_* method);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isCompatibleDelegate(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* objCls, CORINFO_CLASS_STRUCT_* methodParentCls, CORINFO_METHOD_STRUCT_* method, CORINFO_CLASS_STRUCT_* delegateCls, [MarshalAs(UnmanagedType.Bool)] ref bool pfIsOpenDelegate);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isDelegateCreationAllowed(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* delegateHnd, CORINFO_METHOD_STRUCT_* calleeHnd);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoInstantiationVerification __isInstantiationOfVerifiedGeneric(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __initConstraintsForVerification(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, [MarshalAs(UnmanagedType.Bool)] ref bool pfHasCircularClassConstraints, [MarshalAs(UnmanagedType.Bool)] ref bool pfHasCircularMethodConstraint);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoCanSkipVerificationResult __canSkipMethodVerification(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftnHandle);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __methodMustBeLoadedBeforeCodeIsRun(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_METHOD_STRUCT_* __mapMethodDeclToMethodImpl(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getGSCookie(IntPtr _this, IntPtr* ppException, GSCookie* pCookieVal, GSCookie** ppCookieVal);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __resolveToken(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __findSig(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint sigTOK, CORINFO_CONTEXT_STRUCT* context, CORINFO_SIG_INFO* sig);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __findCallSiteSig(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint methTOK, CORINFO_CONTEXT_STRUCT* context, CORINFO_SIG_INFO* sig);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __getTokenTypeAsHandle(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoCanSkipVerificationResult __canSkipVerification(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isValidToken(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint metaTOK);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isValidStringRef(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint metaTOK);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __shouldEnforceCallvirtRestriction(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* scope);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoType __asCorInfoType(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate byte* __getClassName(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate int __appendClassName(IntPtr _this, IntPtr* ppException, short** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fNamespace, [MarshalAs(UnmanagedType.Bool)]bool fFullInst, [MarshalAs(UnmanagedType.Bool)]bool fAssembly);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isValueClass(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __canInlineTypeCheckWithObjectVTable(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getClassAttribs(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isStructRequiringStackAllocRetBuf(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_MODULE_STRUCT_* __getClassModule(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_ASSEMBLY_STRUCT_* __getModuleAssembly(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* mod);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate byte* __getAssemblyName(IntPtr _this, IntPtr* ppException, CORINFO_ASSEMBLY_STRUCT_* assem);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __LongLifetimeMalloc(IntPtr _this, IntPtr* ppException, UIntPtr sz);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __LongLifetimeFree(IntPtr _this, IntPtr* ppException, void* obj);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate byte* __getClassModuleIdForStatics(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, CORINFO_MODULE_STRUCT_** pModule, void** ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getClassSize(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getClassAlignmentRequirement(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fDoubleAlignHint);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getClassGClayout(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, byte* gcPtrs);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getClassNumInstanceFields(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_FIELD_STRUCT_* __getFieldInClass(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* clsHnd, int num);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __checkMethodModifier(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* hMethod, byte* modifier, [MarshalAs(UnmanagedType.Bool)]bool fOptional);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoHelpFunc __getNewHelper(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoHelpFunc __getNewArrHelper(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* arrayCls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoHelpFunc __getCastingHelper(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.I1)]bool fThrowing);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoHelpFunc __getSharedCCtorHelper(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* clsHnd);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoHelpFunc __getSecurityPrologHelper(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __getTypeForBox(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoHelpFunc __getBoxHelper(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoHelpFunc __getUnBoxHelper(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getReadyToRunHelper(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CorInfoHelpFunc id, ref CORINFO_CONST_LOOKUP pLookup);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getReadyToRunDelegateCtorHelper(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pTargetMethod, CORINFO_CLASS_STRUCT_* delegateType, ref CORINFO_CONST_LOOKUP pLookup);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate byte* __getHelperName(IntPtr _this, IntPtr* ppException, CorInfoHelpFunc helpFunc);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoInitClassResult __initClass(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, CORINFO_METHOD_STRUCT_* method, CORINFO_CONTEXT_STRUCT* context, [MarshalAs(UnmanagedType.Bool)]bool speculative);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __classMustBeLoadedBeforeCodeIsRun(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __getBuiltinClass(IntPtr _this, IntPtr* ppException, CorInfoClassId classId);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoType __getTypeForPrimitiveValueClass(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __canCast(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* child, CORINFO_CLASS_STRUCT_* parent);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __areTypesEquivalent(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __mergeClasses(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __getParentType(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoType __getChildType(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* clsHnd, ref CORINFO_CLASS_STRUCT_* clsRet);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __satisfiesClassConstraints(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isSDArray(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getArrayRank(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getArrayInitializationData(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, uint size);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoIsAccessAllowedResult __canAccessClass(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, ref CORINFO_HELPER_DESC pAccessHelper);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate byte* __getFieldName(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* ftn, byte** moduleName);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __getFieldClass(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoType __getFieldType(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, ref CORINFO_CLASS_STRUCT_* structType, CORINFO_CLASS_STRUCT_* memberParent);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getFieldOffset(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.I1)]delegate bool __isWriteBarrierHelperRequired(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getFieldInfo(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_ACCESS_FLAGS flags, ref CORINFO_FIELD_INFO pResult);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.I1)]delegate bool __isFieldStatic(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* fldHnd);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getBoundaries(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref uint cILOffsets, ref uint* pILOffsets, BoundaryTypes* implictBoundaries);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __setBoundaries(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, uint cMap, OffsetMapping* pMap);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getVars(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref uint cVars, ILVarInfo** vars, [MarshalAs(UnmanagedType.U1)] ref bool extendOthers);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __setVars(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, uint cVars, NativeVarInfo* vars);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __allocateArray(IntPtr _this, IntPtr* ppException, uint cBytes);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __freeArray(IntPtr _this, IntPtr* ppException, void* array);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_ARG_LIST_STRUCT_* __getArgNext(IntPtr _this, IntPtr* ppException, CORINFO_ARG_LIST_STRUCT_* args);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoTypeWithMod __getArgType(IntPtr _this, IntPtr* ppException, CORINFO_SIG_INFO* sig, CORINFO_ARG_LIST_STRUCT_* args, ref CORINFO_CLASS_STRUCT_* vcTypeRet);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __getArgClass(IntPtr _this, IntPtr* ppException, CORINFO_SIG_INFO* sig, CORINFO_ARG_LIST_STRUCT_* args);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoType __getHFAType(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* hClass);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate HRESULT __GetErrorHRESULT(IntPtr _this, IntPtr* ppException, _EXCEPTION_POINTERS* pExceptionPointers);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __GetErrorMessage(IntPtr _this, IntPtr* ppException, short* buffer, uint bufferLength);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate int __FilterException(IntPtr _this, IntPtr* ppException, _EXCEPTION_POINTERS* pExceptionPointers);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __HandleException(IntPtr _this, IntPtr* ppException, _EXCEPTION_POINTERS* pExceptionPointers);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __ThrowExceptionForJitResult(IntPtr _this, IntPtr* ppException, HRESULT result);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __ThrowExceptionForHelper(IntPtr _this, IntPtr* ppException, ref CORINFO_HELPER_DESC throwHelper);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getEEInfo(IntPtr _this, IntPtr* ppException, ref CORINFO_EE_INFO pEEInfoOut);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.LPWStr)]delegate string __getJitTimeLogFilename(IntPtr _this, IntPtr* ppException);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate mdToken __getMethodDefFromMethod(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* hMethod);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate byte* __getMethodName(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, byte** moduleName);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getMethodHash(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate byte* __findNameOfToken(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* moduleHandle, mdToken token, byte* szFQName, UIntPtr FQNameCapacity);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.I1)]delegate bool __getSystemVAmd64PassStructInRegisterDescriptor(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* structHnd, SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* structPassInRegDescPtr);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getThreadTLSIndex(IntPtr _this, IntPtr* ppException, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getInlinedCallFrameVptr(IntPtr _this, IntPtr* ppException, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate int* __getAddrOfCaptureThreadGlobal(IntPtr _this, IntPtr* ppException, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate SIZE_T* __getAddrModuleDomainID(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getHelperFtn(IntPtr _this, IntPtr* ppException, CorInfoHelpFunc ftnNum, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getFunctionEntryPoint(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult, CORINFO_ACCESS_FLAGS accessFlags);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getFunctionFixedEntryPoint(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getMethodSync(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CorInfoHelpFunc __getLazyStringLiteralHelper(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* handle);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_MODULE_STRUCT_* __embedModuleHandle(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* handle, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_CLASS_STRUCT_* __embedClassHandle(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* handle, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_METHOD_STRUCT_* __embedMethodHandle(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* handle, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_FIELD_STRUCT_* __embedFieldHandle(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* handle, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __embedGenericHandle(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.Bool)]bool fEmbedParent, ref CORINFO_GENERICHANDLE_RESULT pResult);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getLocationOfThisType(IntPtr _this, IntPtr* ppException, out CORINFO_LOOKUP_KIND _return, CORINFO_METHOD_STRUCT_* context);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getPInvokeUnmanagedTarget(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getAddressOfPInvokeFixup(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getAddressOfPInvokeTarget(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref CORINFO_CONST_LOOKUP pLookup);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __GetCookieForPInvokeCalliSig(IntPtr _this, IntPtr* ppException, CORINFO_SIG_INFO* szMetaSig, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.I1)]delegate bool __canGetCookieForPInvokeCalliSig(IntPtr _this, IntPtr* ppException, CORINFO_SIG_INFO* szMetaSig);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_JUST_MY_CODE_HANDLE_* __getJustMyCodeHandle(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref CORINFO_JUST_MY_CODE_HANDLE_** ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __GetProfilingHandle(IntPtr _this, IntPtr* ppException, [MarshalAs(UnmanagedType.Bool)] ref bool pbHookFunction, ref void* pProfilerHandle, [MarshalAs(UnmanagedType.Bool)] ref bool pbIndirectedHandles);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getCallInfo(IntPtr _this, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_RESOLVED_TOKEN* pConstrainedResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_CALLINFO_FLAGS flags, ref CORINFO_CALL_INFO pResult);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __canAccessFamily(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* hCaller, CORINFO_CLASS_STRUCT_* hInstanceType);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isRIDClassDomainID(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getClassDomainID(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getFieldAddress(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate IntPtr __getVarArgsHandle(IntPtr _this, IntPtr* ppException, CORINFO_SIG_INFO* pSig, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.I1)]delegate bool __canGetVarArgsHandle(IntPtr _this, IntPtr* ppException, CORINFO_SIG_INFO* pSig);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate InfoAccessType __constructStringLiteral(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, mdToken metaTok, ref void* ppValue);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate InfoAccessType __emptyStringLiteral(IntPtr _this, IntPtr* ppException, ref void* ppValue);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getFieldThreadLocalStoreID(IntPtr _this, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, ref void* ppIndirection);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __setOverride(IntPtr _this, IntPtr* ppException, IntPtr pOverride, CORINFO_METHOD_STRUCT_* currentMethod);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __addActiveDependency(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* moduleFrom, CORINFO_MODULE_STRUCT_* moduleTo);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate CORINFO_METHOD_STRUCT_* __GetDelegateCtor(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* methHnd, CORINFO_CLASS_STRUCT_* clsHnd, CORINFO_METHOD_STRUCT_* targetMethodHnd, ref DelegateCtorArgs pCtorData);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __MethodCompileComplete(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* methHnd);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getTailCallCopyArgsThunk(IntPtr _this, IntPtr* ppException, CORINFO_SIG_INFO* pSig, CorInfoHelperTailCallSpecialHandling flags);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __getMemoryManager(IntPtr _this, IntPtr* ppException);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __allocMem(IntPtr _this, IntPtr* ppException, uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, ref void* hotCodeBlock, ref void* coldCodeBlock, ref void* roDataBlock);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __reserveUnwindInfo(IntPtr _this, IntPtr* ppException, [MarshalAs(UnmanagedType.Bool)]bool isFunclet, [MarshalAs(UnmanagedType.Bool)]bool isColdCode, uint unwindSize);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __allocUnwindInfo(IntPtr _this, IntPtr* ppException, byte* pHotCode, byte* pColdCode, uint startOffset, uint endOffset, uint unwindSize, byte* pUnwindBlock, CorJitFuncKind funcKind);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void* __allocGCInfo(IntPtr _this, IntPtr* ppException, UIntPtr size);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __yieldExecution(IntPtr _this, IntPtr* ppException);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __setEHcount(IntPtr _this, IntPtr* ppException, uint cEH);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __setEHinfo(IntPtr _this, IntPtr* ppException, uint EHnumber, ref CORINFO_EH_CLAUSE clause);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.Bool)]delegate bool __logMsg(IntPtr _this, IntPtr* ppException, uint level, byte* fmt, IntPtr args);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate int __doAssert(IntPtr _this, IntPtr* ppException, byte* szFile, int iLine, byte* szExpr);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __reportFatalError(IntPtr _this, IntPtr* ppException, CorJitResult result);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate HRESULT __allocBBProfileBuffer(IntPtr _this, IntPtr* ppException, uint count, ref ProfileBuffer* profileBuffer);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate HRESULT __getBBProfileData(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftnHnd, ref uint count, ref ProfileBuffer* profileBuffer, ref uint numRuns);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __recordCallSite(IntPtr _this, IntPtr* ppException, uint instrOffset, CORINFO_SIG_INFO* callSig, CORINFO_METHOD_STRUCT_* methodHandle);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __recordRelocation(IntPtr _this, IntPtr* ppException, void* location, void* target, ushort fRelocType, ushort slotNum, int addlDelta);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate ushort __getRelocTypeHint(IntPtr _this, IntPtr* ppException, void* target);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate void __getModuleNativeEntryPointRange(IntPtr _this, IntPtr* ppException, ref void* pStart, ref void* pEnd);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getExpectedTargetArchitecture(IntPtr _this, IntPtr* ppException);
+        [UnmanagedFunctionPointerAttribute(CallingConvention.StdCall)]
+        delegate uint __getJitFlags(IntPtr _this, IntPtr* ppException, ref CORJIT_FLAGS flags, uint sizeInBytes);
+
+        static uint _getMethodAttribs(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn)
+        {
+            var _this = GetThis(thisHandle);
+            try
+            {
+                return _this.getMethodAttribs(ftn);
+            }
+            catch (Exception ex)
+            {
+                *ppException = _this.AllocException(ex);
+                return default(uint);
+            }
+        }
+
+        static void _setMethodAttribs(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, CorInfoMethodRuntimeFlags attribs)
+        {
+            var _this = GetThis(thisHandle);
+            try
+            {
+                _this.setMethodAttribs(ftn, attribs);
+            }
+            catch (Exception ex)
+            {
+                *ppException = _this.AllocException(ex);
+            }
+        }
+
+        static void _getMethodSig(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, CORINFO_SIG_INFO* sig, CORINFO_CLASS_STRUCT_* memberParent)
+        {
+            var _this = GetThis(thisHandle);
+            try
+            {
+                _this.getMethodSig(ftn, sig, memberParent);
+            }
+            catch (Exception ex)
+            {
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        [return: MarshalAs(UnmanagedType.I1)]public virtual bool getMethodInfo_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_METHOD_INFO info)
+        [return: MarshalAs(UnmanagedType.I1)]static bool _getMethodInfo(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_METHOD_INFO info)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getMethodInfo(ftn, ref info);
-
+                return _this.getMethodInfo(ftn, ref info);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual CorInfoInline canInline_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, ref uint pRestrictions)
+        static CorInfoInline _canInline(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, ref uint pRestrictions)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canInline(callerHnd, calleeHnd, ref pRestrictions);
-
+                return _this.canInline(callerHnd, calleeHnd, ref pRestrictions);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoInline);
             }
-            return (CorInfoInline)0;
         }
 
-        public virtual void reportInliningDecision_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* inlinerHnd, CORINFO_METHOD_STRUCT_* inlineeHnd, CorInfoInline inlineResult, byte* reason)
+        static void _reportInliningDecision(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* inlinerHnd, CORINFO_METHOD_STRUCT_* inlineeHnd, CorInfoInline inlineResult, byte* reason)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                reportInliningDecision(inlinerHnd, inlineeHnd, inlineResult, reason);
-                return;
+                _this.reportInliningDecision(inlinerHnd, inlineeHnd, inlineResult, reason);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        [return: MarshalAs(UnmanagedType.I1)]public virtual bool canTailCall_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* declaredCalleeHnd, CORINFO_METHOD_STRUCT_* exactCalleeHnd, [MarshalAs(UnmanagedType.I1)]bool fIsTailPrefix)
+        [return: MarshalAs(UnmanagedType.I1)]static bool _canTailCall(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* declaredCalleeHnd, CORINFO_METHOD_STRUCT_* exactCalleeHnd, [MarshalAs(UnmanagedType.I1)]bool fIsTailPrefix)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canTailCall(callerHnd, declaredCalleeHnd, exactCalleeHnd, fIsTailPrefix);
-
+                return _this.canTailCall(callerHnd, declaredCalleeHnd, exactCalleeHnd, fIsTailPrefix);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual void reportTailCallDecision_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, [MarshalAs(UnmanagedType.I1)]bool fIsTailPrefix, CorInfoTailCall tailCallResult, byte* reason)
+        static void _reportTailCallDecision(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, [MarshalAs(UnmanagedType.I1)]bool fIsTailPrefix, CorInfoTailCall tailCallResult, byte* reason)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                reportTailCallDecision(callerHnd, calleeHnd, fIsTailPrefix, tailCallResult, reason);
-                return;
+                _this.reportTailCallDecision(callerHnd, calleeHnd, fIsTailPrefix, tailCallResult, reason);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void getEHinfo_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, uint EHnumber, ref CORINFO_EH_CLAUSE clause)
+        static void _getEHinfo(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, uint EHnumber, ref CORINFO_EH_CLAUSE clause)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getEHinfo(ftn, EHnumber, ref clause);
-                return;
+                _this.getEHinfo(ftn, EHnumber, ref clause);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* getMethodClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method)
+        static CORINFO_CLASS_STRUCT_* _getMethodClass(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getMethodClass(method);
-
+                return _this.getMethodClass(method);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CORINFO_MODULE_STRUCT_* getMethodModule_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method)
+        static CORINFO_MODULE_STRUCT_* _getMethodModule(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getMethodModule(method);
-
+                return _this.getMethodModule(method);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_MODULE_STRUCT_*);
             }
-            return (CORINFO_MODULE_STRUCT_*)0;
         }
 
-        public virtual void getMethodVTableOffset_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref uint offsetOfIndirection, ref uint offsetAfterIndirection)
+        static void _getMethodVTableOffset(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref uint offsetOfIndirection, ref uint offsetAfterIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getMethodVTableOffset(method, ref offsetOfIndirection, ref offsetAfterIndirection);
-                return;
+                _this.getMethodVTableOffset(method, ref offsetOfIndirection, ref offsetAfterIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual CorInfoIntrinsics getIntrinsicID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, [MarshalAs(UnmanagedType.U1)] ref bool pMustExpand)
+        static CorInfoIntrinsics _getIntrinsicID(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, [MarshalAs(UnmanagedType.U1)] ref bool pMustExpand)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getIntrinsicID(method, ref pMustExpand);
-
+                return _this.getIntrinsicID(method, ref pMustExpand);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoIntrinsics);
             }
-            return (CorInfoIntrinsics)0;
         }
 
-        [return: MarshalAs(UnmanagedType.I1)]public virtual bool isInSIMDModule_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* classHnd)
+        [return: MarshalAs(UnmanagedType.I1)]static bool _isInSIMDModule(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* classHnd)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isInSIMDModule(classHnd);
-
+                return _this.isInSIMDModule(classHnd);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual CorInfoUnmanagedCallConv getUnmanagedCallConv_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method)
+        static CorInfoUnmanagedCallConv _getUnmanagedCallConv(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getUnmanagedCallConv(method);
-
+                return _this.getUnmanagedCallConv(method);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoUnmanagedCallConv);
             }
-            return (CorInfoUnmanagedCallConv)0;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool pInvokeMarshalingRequired_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, CORINFO_SIG_INFO* callSiteSig)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _pInvokeMarshalingRequired(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, CORINFO_SIG_INFO* callSiteSig)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return pInvokeMarshalingRequired(method, callSiteSig);
-
+                return _this.pInvokeMarshalingRequired(method, callSiteSig);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool satisfiesMethodConstraints_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* parent, CORINFO_METHOD_STRUCT_* method)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _satisfiesMethodConstraints(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* parent, CORINFO_METHOD_STRUCT_* method)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return satisfiesMethodConstraints(parent, method);
-
+                return _this.satisfiesMethodConstraints(parent, method);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool isCompatibleDelegate_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* objCls, CORINFO_CLASS_STRUCT_* methodParentCls, CORINFO_METHOD_STRUCT_* method, CORINFO_CLASS_STRUCT_* delegateCls, [MarshalAs(UnmanagedType.Bool)] ref bool pfIsOpenDelegate)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _isCompatibleDelegate(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* objCls, CORINFO_CLASS_STRUCT_* methodParentCls, CORINFO_METHOD_STRUCT_* method, CORINFO_CLASS_STRUCT_* delegateCls, [MarshalAs(UnmanagedType.Bool)] ref bool pfIsOpenDelegate)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isCompatibleDelegate(objCls, methodParentCls, method, delegateCls, ref pfIsOpenDelegate);
-
+                return _this.isCompatibleDelegate(objCls, methodParentCls, method, delegateCls, ref pfIsOpenDelegate);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool isDelegateCreationAllowed_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* delegateHnd, CORINFO_METHOD_STRUCT_* calleeHnd)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _isDelegateCreationAllowed(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* delegateHnd, CORINFO_METHOD_STRUCT_* calleeHnd)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isDelegateCreationAllowed(delegateHnd, calleeHnd);
-
+                return _this.isDelegateCreationAllowed(delegateHnd, calleeHnd);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual CorInfoInstantiationVerification isInstantiationOfVerifiedGeneric_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method)
+        static CorInfoInstantiationVerification _isInstantiationOfVerifiedGeneric(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isInstantiationOfVerifiedGeneric(method);
-
+                return _this.isInstantiationOfVerifiedGeneric(method);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoInstantiationVerification);
             }
-            return (CorInfoInstantiationVerification)0;
         }
 
-        public virtual void initConstraintsForVerification_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, [MarshalAs(UnmanagedType.Bool)] ref bool pfHasCircularClassConstraints, [MarshalAs(UnmanagedType.Bool)] ref bool pfHasCircularMethodConstraint)
+        static void _initConstraintsForVerification(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, [MarshalAs(UnmanagedType.Bool)] ref bool pfHasCircularClassConstraints, [MarshalAs(UnmanagedType.Bool)] ref bool pfHasCircularMethodConstraint)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                initConstraintsForVerification(method, ref pfHasCircularClassConstraints, ref pfHasCircularMethodConstraint);
-                return;
+                _this.initConstraintsForVerification(method, ref pfHasCircularClassConstraints, ref pfHasCircularMethodConstraint);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual CorInfoCanSkipVerificationResult canSkipMethodVerification_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftnHandle)
+        static CorInfoCanSkipVerificationResult _canSkipMethodVerification(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftnHandle)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canSkipMethodVerification(ftnHandle);
-
+                return _this.canSkipMethodVerification(ftnHandle);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoCanSkipVerificationResult);
             }
-            return (CorInfoCanSkipVerificationResult)0;
         }
 
-        public virtual void methodMustBeLoadedBeforeCodeIsRun_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method)
+        static void _methodMustBeLoadedBeforeCodeIsRun(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                methodMustBeLoadedBeforeCodeIsRun(method);
-                return;
+                _this.methodMustBeLoadedBeforeCodeIsRun(method);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual CORINFO_METHOD_STRUCT_* mapMethodDeclToMethodImpl_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method)
+        static CORINFO_METHOD_STRUCT_* _mapMethodDeclToMethodImpl(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return mapMethodDeclToMethodImpl(method);
-
+                return _this.mapMethodDeclToMethodImpl(method);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_METHOD_STRUCT_*);
             }
-            return (CORINFO_METHOD_STRUCT_*)0;
         }
 
-        public virtual void getGSCookie_wrapper(IntPtr _this, out IntPtr exception, GSCookie* pCookieVal, GSCookie** ppCookieVal)
+        static void _getGSCookie(IntPtr thisHandle, IntPtr* ppException, GSCookie* pCookieVal, GSCookie** ppCookieVal)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getGSCookie(pCookieVal, ppCookieVal);
-                return;
+                _this.getGSCookie(pCookieVal, ppCookieVal);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void resolveToken_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken)
+        static void _resolveToken(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                resolveToken(ref pResolvedToken);
-                return;
+                _this.resolveToken(ref pResolvedToken);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void findSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, uint sigTOK, CORINFO_CONTEXT_STRUCT* context, CORINFO_SIG_INFO* sig)
+        static void _findSig(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint sigTOK, CORINFO_CONTEXT_STRUCT* context, CORINFO_SIG_INFO* sig)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                findSig(module, sigTOK, context, sig);
-                return;
+                _this.findSig(module, sigTOK, context, sig);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void findCallSiteSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, uint methTOK, CORINFO_CONTEXT_STRUCT* context, CORINFO_SIG_INFO* sig)
+        static void _findCallSiteSig(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint methTOK, CORINFO_CONTEXT_STRUCT* context, CORINFO_SIG_INFO* sig)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                findCallSiteSig(module, methTOK, context, sig);
-                return;
+                _this.findCallSiteSig(module, methTOK, context, sig);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* getTokenTypeAsHandle_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken)
+        static CORINFO_CLASS_STRUCT_* _getTokenTypeAsHandle(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getTokenTypeAsHandle(ref pResolvedToken);
-
+                return _this.getTokenTypeAsHandle(ref pResolvedToken);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CorInfoCanSkipVerificationResult canSkipVerification_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module)
+        static CorInfoCanSkipVerificationResult _canSkipVerification(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canSkipVerification(module);
-
+                return _this.canSkipVerification(module);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoCanSkipVerificationResult);
             }
-            return (CorInfoCanSkipVerificationResult)0;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool isValidToken_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, uint metaTOK)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _isValidToken(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint metaTOK)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isValidToken(module, metaTOK);
-
+                return _this.isValidToken(module, metaTOK);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool isValidStringRef_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, uint metaTOK)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _isValidStringRef(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint metaTOK)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isValidStringRef(module, metaTOK);
-
+                return _this.isValidStringRef(module, metaTOK);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool shouldEnforceCallvirtRestriction_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* scope)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _shouldEnforceCallvirtRestriction(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* scope)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return shouldEnforceCallvirtRestriction(scope);
-
+                return _this.shouldEnforceCallvirtRestriction(scope);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual CorInfoType asCorInfoType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static CorInfoType _asCorInfoType(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return asCorInfoType(cls);
-
+                return _this.asCorInfoType(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoType);
             }
-            return (CorInfoType)0;
         }
 
-        public virtual byte* getClassName_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static byte* _getClassName(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassName(cls);
-
+                return _this.getClassName(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(byte*);
             }
-            return (byte*)0;
         }
 
-        public virtual int appendClassName_wrapper(IntPtr _this, out IntPtr exception, short** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fNamespace, [MarshalAs(UnmanagedType.Bool)]bool fFullInst, [MarshalAs(UnmanagedType.Bool)]bool fAssembly)
+        static int _appendClassName(IntPtr thisHandle, IntPtr* ppException, short** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fNamespace, [MarshalAs(UnmanagedType.Bool)]bool fFullInst, [MarshalAs(UnmanagedType.Bool)]bool fAssembly)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return appendClassName(ppBuf, ref pnBufLen, cls, fNamespace, fFullInst, fAssembly);
-
+                return _this.appendClassName(ppBuf, ref pnBufLen, cls, fNamespace, fFullInst, fAssembly);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(int);
             }
-            return (int)0;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool isValueClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _isValueClass(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isValueClass(cls);
-
+                return _this.isValueClass(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool canInlineTypeCheckWithObjectVTable_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _canInlineTypeCheckWithObjectVTable(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canInlineTypeCheckWithObjectVTable(cls);
-
+                return _this.canInlineTypeCheckWithObjectVTable(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual uint getClassAttribs_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static uint _getClassAttribs(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassAttribs(cls);
-
+                return _this.getClassAttribs(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool isStructRequiringStackAllocRetBuf_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _isStructRequiringStackAllocRetBuf(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isStructRequiringStackAllocRetBuf(cls);
-
+                return _this.isStructRequiringStackAllocRetBuf(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual CORINFO_MODULE_STRUCT_* getClassModule_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static CORINFO_MODULE_STRUCT_* _getClassModule(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassModule(cls);
-
+                return _this.getClassModule(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_MODULE_STRUCT_*);
             }
-            return (CORINFO_MODULE_STRUCT_*)0;
         }
 
-        public virtual CORINFO_ASSEMBLY_STRUCT_* getModuleAssembly_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* mod)
+        static CORINFO_ASSEMBLY_STRUCT_* _getModuleAssembly(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* mod)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getModuleAssembly(mod);
-
+                return _this.getModuleAssembly(mod);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_ASSEMBLY_STRUCT_*);
             }
-            return (CORINFO_ASSEMBLY_STRUCT_*)0;
         }
 
-        public virtual byte* getAssemblyName_wrapper(IntPtr _this, out IntPtr exception, CORINFO_ASSEMBLY_STRUCT_* assem)
+        static byte* _getAssemblyName(IntPtr thisHandle, IntPtr* ppException, CORINFO_ASSEMBLY_STRUCT_* assem)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getAssemblyName(assem);
-
+                return _this.getAssemblyName(assem);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(byte*);
             }
-            return (byte*)0;
         }
 
-        public virtual void* LongLifetimeMalloc_wrapper(IntPtr _this, out IntPtr exception, UIntPtr sz)
+        static void* _LongLifetimeMalloc(IntPtr thisHandle, IntPtr* ppException, UIntPtr sz)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return LongLifetimeMalloc(sz);
-
+                return _this.LongLifetimeMalloc(sz);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual void LongLifetimeFree_wrapper(IntPtr _this, out IntPtr exception, void* obj)
+        static void _LongLifetimeFree(IntPtr thisHandle, IntPtr* ppException, void* obj)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                LongLifetimeFree(obj);
-                return;
+                _this.LongLifetimeFree(obj);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual byte* getClassModuleIdForStatics_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls, CORINFO_MODULE_STRUCT_** pModule, void** ppIndirection)
+        static byte* _getClassModuleIdForStatics(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, CORINFO_MODULE_STRUCT_** pModule, void** ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassModuleIdForStatics(cls, pModule, ppIndirection);
-
+                return _this.getClassModuleIdForStatics(cls, pModule, ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(byte*);
             }
-            return (byte*)0;
         }
 
-        public virtual uint getClassSize_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static uint _getClassSize(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassSize(cls);
-
+                return _this.getClassSize(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual uint getClassAlignmentRequirement_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fDoubleAlignHint)
+        static uint _getClassAlignmentRequirement(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fDoubleAlignHint)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassAlignmentRequirement(cls, fDoubleAlignHint);
-
+                return _this.getClassAlignmentRequirement(cls, fDoubleAlignHint);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual uint getClassGClayout_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls, byte* gcPtrs)
+        static uint _getClassGClayout(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, byte* gcPtrs)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassGClayout(cls, gcPtrs);
-
+                return _this.getClassGClayout(cls, gcPtrs);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual uint getClassNumInstanceFields_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static uint _getClassNumInstanceFields(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassNumInstanceFields(cls);
-
+                return _this.getClassNumInstanceFields(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual CORINFO_FIELD_STRUCT_* getFieldInClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* clsHnd, int num)
+        static CORINFO_FIELD_STRUCT_* _getFieldInClass(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* clsHnd, int num)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getFieldInClass(clsHnd, num);
-
+                return _this.getFieldInClass(clsHnd, num);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_FIELD_STRUCT_*);
             }
-            return (CORINFO_FIELD_STRUCT_*)0;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool checkMethodModifier_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* hMethod, byte* modifier, [MarshalAs(UnmanagedType.Bool)]bool fOptional)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _checkMethodModifier(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* hMethod, byte* modifier, [MarshalAs(UnmanagedType.Bool)]bool fOptional)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return checkMethodModifier(hMethod, modifier, fOptional);
-
+                return _this.checkMethodModifier(hMethod, modifier, fOptional);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual CorInfoHelpFunc getNewHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle)
+        static CorInfoHelpFunc _getNewHelper(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getNewHelper(ref pResolvedToken, callerHandle);
-
+                return _this.getNewHelper(ref pResolvedToken, callerHandle);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoHelpFunc);
             }
-            return (CorInfoHelpFunc)0;
         }
 
-        public virtual CorInfoHelpFunc getNewArrHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* arrayCls)
+        static CorInfoHelpFunc _getNewArrHelper(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* arrayCls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getNewArrHelper(arrayCls);
-
+                return _this.getNewArrHelper(arrayCls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoHelpFunc);
             }
-            return (CorInfoHelpFunc)0;
         }
 
-        public virtual CorInfoHelpFunc getCastingHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.I1)]bool fThrowing)
+        static CorInfoHelpFunc _getCastingHelper(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.I1)]bool fThrowing)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getCastingHelper(ref pResolvedToken, fThrowing);
-
+                return _this.getCastingHelper(ref pResolvedToken, fThrowing);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoHelpFunc);
             }
-            return (CorInfoHelpFunc)0;
         }
 
-        public virtual CorInfoHelpFunc getSharedCCtorHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* clsHnd)
+        static CorInfoHelpFunc _getSharedCCtorHelper(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* clsHnd)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getSharedCCtorHelper(clsHnd);
-
+                return _this.getSharedCCtorHelper(clsHnd);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoHelpFunc);
             }
-            return (CorInfoHelpFunc)0;
         }
 
-        public virtual CorInfoHelpFunc getSecurityPrologHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn)
+        static CorInfoHelpFunc _getSecurityPrologHelper(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getSecurityPrologHelper(ftn);
-
+                return _this.getSecurityPrologHelper(ftn);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoHelpFunc);
             }
-            return (CorInfoHelpFunc)0;
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* getTypeForBox_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static CORINFO_CLASS_STRUCT_* _getTypeForBox(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getTypeForBox(cls);
-
+                return _this.getTypeForBox(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CorInfoHelpFunc getBoxHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static CorInfoHelpFunc _getBoxHelper(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getBoxHelper(cls);
-
+                return _this.getBoxHelper(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoHelpFunc);
             }
-            return (CorInfoHelpFunc)0;
         }
 
-        public virtual CorInfoHelpFunc getUnBoxHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static CorInfoHelpFunc _getUnBoxHelper(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getUnBoxHelper(cls);
-
+                return _this.getUnBoxHelper(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoHelpFunc);
             }
-            return (CorInfoHelpFunc)0;
         }
 
-        public virtual void getReadyToRunHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CorInfoHelpFunc id, ref CORINFO_CONST_LOOKUP pLookup)
+        static void _getReadyToRunHelper(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CorInfoHelpFunc id, ref CORINFO_CONST_LOOKUP pLookup)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getReadyToRunHelper(ref pResolvedToken, id, ref pLookup);
-                return;
+                _this.getReadyToRunHelper(ref pResolvedToken, id, ref pLookup);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void getReadyToRunDelegateCtorHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pTargetMethod, CORINFO_CLASS_STRUCT_* delegateType, ref CORINFO_CONST_LOOKUP pLookup)
+        static void _getReadyToRunDelegateCtorHelper(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pTargetMethod, CORINFO_CLASS_STRUCT_* delegateType, ref CORINFO_CONST_LOOKUP pLookup)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getReadyToRunDelegateCtorHelper(ref pTargetMethod, delegateType, ref pLookup);
-                return;
+                _this.getReadyToRunDelegateCtorHelper(ref pTargetMethod, delegateType, ref pLookup);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual byte* getHelperName_wrapper(IntPtr _this, out IntPtr exception, CorInfoHelpFunc helpFunc)
+        static byte* _getHelperName(IntPtr thisHandle, IntPtr* ppException, CorInfoHelpFunc helpFunc)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getHelperName(helpFunc);
-
+                return _this.getHelperName(helpFunc);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(byte*);
             }
-            return (byte*)0;
         }
 
-        public virtual CorInfoInitClassResult initClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, CORINFO_METHOD_STRUCT_* method, CORINFO_CONTEXT_STRUCT* context, [MarshalAs(UnmanagedType.Bool)]bool speculative)
+        static CorInfoInitClassResult _initClass(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, CORINFO_METHOD_STRUCT_* method, CORINFO_CONTEXT_STRUCT* context, [MarshalAs(UnmanagedType.Bool)]bool speculative)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return initClass(field, method, context, speculative);
-
+                return _this.initClass(field, method, context, speculative);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoInitClassResult);
             }
-            return (CorInfoInitClassResult)0;
         }
 
-        public virtual void classMustBeLoadedBeforeCodeIsRun_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static void _classMustBeLoadedBeforeCodeIsRun(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                classMustBeLoadedBeforeCodeIsRun(cls);
-                return;
+                _this.classMustBeLoadedBeforeCodeIsRun(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* getBuiltinClass_wrapper(IntPtr _this, out IntPtr exception, CorInfoClassId classId)
+        static CORINFO_CLASS_STRUCT_* _getBuiltinClass(IntPtr thisHandle, IntPtr* ppException, CorInfoClassId classId)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getBuiltinClass(classId);
-
+                return _this.getBuiltinClass(classId);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CorInfoType getTypeForPrimitiveValueClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static CorInfoType _getTypeForPrimitiveValueClass(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getTypeForPrimitiveValueClass(cls);
-
+                return _this.getTypeForPrimitiveValueClass(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoType);
             }
-            return (CorInfoType)0;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool canCast_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* child, CORINFO_CLASS_STRUCT_* parent)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _canCast(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* child, CORINFO_CLASS_STRUCT_* parent)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canCast(child, parent);
-
+                return _this.canCast(child, parent);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool areTypesEquivalent_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _areTypesEquivalent(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return areTypesEquivalent(cls1, cls2);
-
+                return _this.areTypesEquivalent(cls1, cls2);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* mergeClasses_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2)
+        static CORINFO_CLASS_STRUCT_* _mergeClasses(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return mergeClasses(cls1, cls2);
-
+                return _this.mergeClasses(cls1, cls2);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* getParentType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static CORINFO_CLASS_STRUCT_* _getParentType(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getParentType(cls);
-
+                return _this.getParentType(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CorInfoType getChildType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* clsHnd, ref CORINFO_CLASS_STRUCT_* clsRet)
+        static CorInfoType _getChildType(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* clsHnd, ref CORINFO_CLASS_STRUCT_* clsRet)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getChildType(clsHnd, ref clsRet);
-
+                return _this.getChildType(clsHnd, ref clsRet);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoType);
             }
-            return (CorInfoType)0;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool satisfiesClassConstraints_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _satisfiesClassConstraints(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return satisfiesClassConstraints(cls);
-
+                return _this.satisfiesClassConstraints(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool isSDArray_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _isSDArray(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isSDArray(cls);
-
+                return _this.isSDArray(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual uint getArrayRank_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        static uint _getArrayRank(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getArrayRank(cls);
-
+                return _this.getArrayRank(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual void* getArrayInitializationData_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, uint size)
+        static void* _getArrayInitializationData(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, uint size)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getArrayInitializationData(field, size);
-
+                return _this.getArrayInitializationData(field, size);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual CorInfoIsAccessAllowedResult canAccessClass_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, ref CORINFO_HELPER_DESC pAccessHelper)
+        static CorInfoIsAccessAllowedResult _canAccessClass(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, ref CORINFO_HELPER_DESC pAccessHelper)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canAccessClass(ref pResolvedToken, callerHandle, ref pAccessHelper);
-
+                return _this.canAccessClass(ref pResolvedToken, callerHandle, ref pAccessHelper);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoIsAccessAllowedResult);
             }
-            return (CorInfoIsAccessAllowedResult)0;
         }
 
-        public virtual byte* getFieldName_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* ftn, byte** moduleName)
+        static byte* _getFieldName(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* ftn, byte** moduleName)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getFieldName(ftn, moduleName);
-
+                return _this.getFieldName(ftn, moduleName);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(byte*);
             }
-            return (byte*)0;
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* getFieldClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field)
+        static CORINFO_CLASS_STRUCT_* _getFieldClass(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getFieldClass(field);
-
+                return _this.getFieldClass(field);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CorInfoType getFieldType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, ref CORINFO_CLASS_STRUCT_* structType, CORINFO_CLASS_STRUCT_* memberParent)
+        static CorInfoType _getFieldType(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, ref CORINFO_CLASS_STRUCT_* structType, CORINFO_CLASS_STRUCT_* memberParent)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getFieldType(field, ref structType, memberParent);
-
+                return _this.getFieldType(field, ref structType, memberParent);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoType);
             }
-            return (CorInfoType)0;
         }
 
-        public virtual uint getFieldOffset_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field)
+        static uint _getFieldOffset(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getFieldOffset(field);
-
+                return _this.getFieldOffset(field);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        [return: MarshalAs(UnmanagedType.I1)]public virtual bool isWriteBarrierHelperRequired_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field)
+        [return: MarshalAs(UnmanagedType.I1)]static bool _isWriteBarrierHelperRequired(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isWriteBarrierHelperRequired(field);
-
+                return _this.isWriteBarrierHelperRequired(field);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual void getFieldInfo_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_ACCESS_FLAGS flags, ref CORINFO_FIELD_INFO pResult)
+        static void _getFieldInfo(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_ACCESS_FLAGS flags, ref CORINFO_FIELD_INFO pResult)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getFieldInfo(ref pResolvedToken, callerHandle, flags, ref pResult);
-                return;
+                _this.getFieldInfo(ref pResolvedToken, callerHandle, flags, ref pResult);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        [return: MarshalAs(UnmanagedType.I1)]public virtual bool isFieldStatic_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* fldHnd)
+        [return: MarshalAs(UnmanagedType.I1)]static bool _isFieldStatic(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* fldHnd)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isFieldStatic(fldHnd);
-
+                return _this.isFieldStatic(fldHnd);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual void getBoundaries_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref uint cILOffsets, ref uint* pILOffsets, BoundaryTypes* implictBoundaries)
+        static void _getBoundaries(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref uint cILOffsets, ref uint* pILOffsets, BoundaryTypes* implictBoundaries)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getBoundaries(ftn, ref cILOffsets, ref pILOffsets, implictBoundaries);
-                return;
+                _this.getBoundaries(ftn, ref cILOffsets, ref pILOffsets, implictBoundaries);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void setBoundaries_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, uint cMap, OffsetMapping* pMap)
+        static void _setBoundaries(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, uint cMap, OffsetMapping* pMap)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                setBoundaries(ftn, cMap, pMap);
-                return;
+                _this.setBoundaries(ftn, cMap, pMap);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void getVars_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref uint cVars, ILVarInfo** vars, [MarshalAs(UnmanagedType.U1)] ref bool extendOthers)
+        static void _getVars(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref uint cVars, ILVarInfo** vars, [MarshalAs(UnmanagedType.U1)] ref bool extendOthers)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getVars(ftn, ref cVars, vars, ref extendOthers);
-                return;
+                _this.getVars(ftn, ref cVars, vars, ref extendOthers);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void setVars_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, uint cVars, NativeVarInfo* vars)
+        static void _setVars(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, uint cVars, NativeVarInfo* vars)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                setVars(ftn, cVars, vars);
-                return;
+                _this.setVars(ftn, cVars, vars);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void* allocateArray_wrapper(IntPtr _this, out IntPtr exception, uint cBytes)
+        static void* _allocateArray(IntPtr thisHandle, IntPtr* ppException, uint cBytes)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return allocateArray(cBytes);
-
+                return _this.allocateArray(cBytes);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual void freeArray_wrapper(IntPtr _this, out IntPtr exception, void* array)
+        static void _freeArray(IntPtr thisHandle, IntPtr* ppException, void* array)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                freeArray(array);
-                return;
+                _this.freeArray(array);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual CORINFO_ARG_LIST_STRUCT_* getArgNext_wrapper(IntPtr _this, out IntPtr exception, CORINFO_ARG_LIST_STRUCT_* args)
+        static CORINFO_ARG_LIST_STRUCT_* _getArgNext(IntPtr thisHandle, IntPtr* ppException, CORINFO_ARG_LIST_STRUCT_* args)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getArgNext(args);
-
+                return _this.getArgNext(args);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_ARG_LIST_STRUCT_*);
             }
-            return (CORINFO_ARG_LIST_STRUCT_*)0;
         }
 
-        public virtual CorInfoTypeWithMod getArgType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* sig, CORINFO_ARG_LIST_STRUCT_* args, ref CORINFO_CLASS_STRUCT_* vcTypeRet)
+        static CorInfoTypeWithMod _getArgType(IntPtr thisHandle, IntPtr* ppException, CORINFO_SIG_INFO* sig, CORINFO_ARG_LIST_STRUCT_* args, ref CORINFO_CLASS_STRUCT_* vcTypeRet)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getArgType(sig, args, ref vcTypeRet);
-
+                return _this.getArgType(sig, args, ref vcTypeRet);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoTypeWithMod);
             }
-            return (CorInfoTypeWithMod)0;
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* getArgClass_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* sig, CORINFO_ARG_LIST_STRUCT_* args)
+        static CORINFO_CLASS_STRUCT_* _getArgClass(IntPtr thisHandle, IntPtr* ppException, CORINFO_SIG_INFO* sig, CORINFO_ARG_LIST_STRUCT_* args)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getArgClass(sig, args);
-
+                return _this.getArgClass(sig, args);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CorInfoType getHFAType_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* hClass)
+        static CorInfoType _getHFAType(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* hClass)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getHFAType(hClass);
-
+                return _this.getHFAType(hClass);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoType);
             }
-            return (CorInfoType)0;
         }
 
-        public virtual HRESULT GetErrorHRESULT_wrapper(IntPtr _this, out IntPtr exception, _EXCEPTION_POINTERS* pExceptionPointers)
+        static HRESULT _GetErrorHRESULT(IntPtr thisHandle, IntPtr* ppException, _EXCEPTION_POINTERS* pExceptionPointers)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return GetErrorHRESULT(pExceptionPointers);
-
+                return _this.GetErrorHRESULT(pExceptionPointers);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(HRESULT);
             }
-            return (HRESULT)0;
         }
 
-        public virtual uint GetErrorMessage_wrapper(IntPtr _this, out IntPtr exception, short* buffer, uint bufferLength)
+        static uint _GetErrorMessage(IntPtr thisHandle, IntPtr* ppException, short* buffer, uint bufferLength)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return GetErrorMessage(buffer, bufferLength);
-
+                return _this.GetErrorMessage(buffer, bufferLength);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual int FilterException_wrapper(IntPtr _this, out IntPtr exception, _EXCEPTION_POINTERS* pExceptionPointers)
+        static int _FilterException(IntPtr thisHandle, IntPtr* ppException, _EXCEPTION_POINTERS* pExceptionPointers)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return FilterException(pExceptionPointers);
-
+                return _this.FilterException(pExceptionPointers);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(int);
             }
-            return (int)0;
         }
 
-        public virtual void HandleException_wrapper(IntPtr _this, out IntPtr exception, _EXCEPTION_POINTERS* pExceptionPointers)
+        static void _HandleException(IntPtr thisHandle, IntPtr* ppException, _EXCEPTION_POINTERS* pExceptionPointers)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                HandleException(pExceptionPointers);
-                return;
+                _this.HandleException(pExceptionPointers);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void ThrowExceptionForJitResult_wrapper(IntPtr _this, out IntPtr exception, HRESULT result)
+        static void _ThrowExceptionForJitResult(IntPtr thisHandle, IntPtr* ppException, HRESULT result)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                ThrowExceptionForJitResult(result);
-                return;
+                _this.ThrowExceptionForJitResult(result);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void ThrowExceptionForHelper_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_HELPER_DESC throwHelper)
+        static void _ThrowExceptionForHelper(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_HELPER_DESC throwHelper)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                ThrowExceptionForHelper(ref throwHelper);
-                return;
+                _this.ThrowExceptionForHelper(ref throwHelper);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void getEEInfo_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_EE_INFO pEEInfoOut)
+        static void _getEEInfo(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_EE_INFO pEEInfoOut)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getEEInfo(ref pEEInfoOut);
-                return;
+                _this.getEEInfo(ref pEEInfoOut);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        [return: MarshalAs(UnmanagedType.LPWStr)]public virtual string getJitTimeLogFilename_wrapper(IntPtr _this, out IntPtr exception)
+        [return: MarshalAs(UnmanagedType.LPWStr)]static string _getJitTimeLogFilename(IntPtr thisHandle, IntPtr* ppException)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getJitTimeLogFilename();
-
+                return _this.getJitTimeLogFilename();
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(string);
             }
-            return null;
         }
 
-        public virtual mdToken getMethodDefFromMethod_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* hMethod)
+        static mdToken _getMethodDefFromMethod(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* hMethod)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getMethodDefFromMethod(hMethod);
-
+                return _this.getMethodDefFromMethod(hMethod);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(mdToken);
             }
-            return (mdToken)0;
         }
 
-        public virtual byte* getMethodName_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, byte** moduleName)
+        static byte* _getMethodName(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, byte** moduleName)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getMethodName(ftn, moduleName);
-
+                return _this.getMethodName(ftn, moduleName);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(byte*);
             }
-            return (byte*)0;
         }
 
-        public virtual uint getMethodHash_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn)
+        static uint _getMethodHash(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getMethodHash(ftn);
-
+                return _this.getMethodHash(ftn);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual byte* findNameOfToken_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* moduleHandle, mdToken token, byte* szFQName, UIntPtr FQNameCapacity)
+        static byte* _findNameOfToken(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* moduleHandle, mdToken token, byte* szFQName, UIntPtr FQNameCapacity)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return findNameOfToken(moduleHandle, token, szFQName, FQNameCapacity);
-
+                return _this.findNameOfToken(moduleHandle, token, szFQName, FQNameCapacity);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(byte*);
             }
-            return (byte*)0;
         }
 
-        [return: MarshalAs(UnmanagedType.I1)]public virtual bool getSystemVAmd64PassStructInRegisterDescriptor_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* structHnd, SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* structPassInRegDescPtr)
+        [return: MarshalAs(UnmanagedType.I1)]static bool _getSystemVAmd64PassStructInRegisterDescriptor(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* structHnd, SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* structPassInRegDescPtr)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getSystemVAmd64PassStructInRegisterDescriptor(structHnd, structPassInRegDescPtr);
-
+                return _this.getSystemVAmd64PassStructInRegisterDescriptor(structHnd, structPassInRegDescPtr);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual uint getThreadTLSIndex_wrapper(IntPtr _this, out IntPtr exception, ref void* ppIndirection)
+        static uint _getThreadTLSIndex(IntPtr thisHandle, IntPtr* ppException, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getThreadTLSIndex(ref ppIndirection);
-
+                return _this.getThreadTLSIndex(ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual void* getInlinedCallFrameVptr_wrapper(IntPtr _this, out IntPtr exception, ref void* ppIndirection)
+        static void* _getInlinedCallFrameVptr(IntPtr thisHandle, IntPtr* ppException, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getInlinedCallFrameVptr(ref ppIndirection);
-
+                return _this.getInlinedCallFrameVptr(ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual int* getAddrOfCaptureThreadGlobal_wrapper(IntPtr _this, out IntPtr exception, ref void* ppIndirection)
+        static int* _getAddrOfCaptureThreadGlobal(IntPtr thisHandle, IntPtr* ppException, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getAddrOfCaptureThreadGlobal(ref ppIndirection);
-
+                return _this.getAddrOfCaptureThreadGlobal(ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(int*);
             }
-            return (int*)0;
         }
 
-        public virtual SIZE_T* getAddrModuleDomainID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module)
+        static SIZE_T* _getAddrModuleDomainID(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getAddrModuleDomainID(module);
-
+                return _this.getAddrModuleDomainID(module);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(SIZE_T*);
             }
-            return (SIZE_T*)0;
         }
 
-        public virtual void* getHelperFtn_wrapper(IntPtr _this, out IntPtr exception, CorInfoHelpFunc ftnNum, ref void* ppIndirection)
+        static void* _getHelperFtn(IntPtr thisHandle, IntPtr* ppException, CorInfoHelpFunc ftnNum, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getHelperFtn(ftnNum, ref ppIndirection);
-
+                return _this.getHelperFtn(ftnNum, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual void getFunctionEntryPoint_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult, CORINFO_ACCESS_FLAGS accessFlags)
+        static void _getFunctionEntryPoint(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult, CORINFO_ACCESS_FLAGS accessFlags)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getFunctionEntryPoint(ftn, ref pResult, accessFlags);
-                return;
+                _this.getFunctionEntryPoint(ftn, ref pResult, accessFlags);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void getFunctionFixedEntryPoint_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult)
+        static void _getFunctionFixedEntryPoint(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getFunctionFixedEntryPoint(ftn, ref pResult);
-                return;
+                _this.getFunctionFixedEntryPoint(ftn, ref pResult);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void* getMethodSync_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftn, ref void* ppIndirection)
+        static void* _getMethodSync(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getMethodSync(ftn, ref ppIndirection);
-
+                return _this.getMethodSync(ftn, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual CorInfoHelpFunc getLazyStringLiteralHelper_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* handle)
+        static CorInfoHelpFunc _getLazyStringLiteralHelper(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* handle)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getLazyStringLiteralHelper(handle);
-
+                return _this.getLazyStringLiteralHelper(handle);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CorInfoHelpFunc);
             }
-            return (CorInfoHelpFunc)0;
         }
 
-        public virtual CORINFO_MODULE_STRUCT_* embedModuleHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* handle, ref void* ppIndirection)
+        static CORINFO_MODULE_STRUCT_* _embedModuleHandle(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* handle, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return embedModuleHandle(handle, ref ppIndirection);
-
+                return _this.embedModuleHandle(handle, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_MODULE_STRUCT_*);
             }
-            return (CORINFO_MODULE_STRUCT_*)0;
         }
 
-        public virtual CORINFO_CLASS_STRUCT_* embedClassHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* handle, ref void* ppIndirection)
+        static CORINFO_CLASS_STRUCT_* _embedClassHandle(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* handle, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return embedClassHandle(handle, ref ppIndirection);
-
+                return _this.embedClassHandle(handle, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_CLASS_STRUCT_*);
             }
-            return (CORINFO_CLASS_STRUCT_*)0;
         }
 
-        public virtual CORINFO_METHOD_STRUCT_* embedMethodHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* handle, ref void* ppIndirection)
+        static CORINFO_METHOD_STRUCT_* _embedMethodHandle(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* handle, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return embedMethodHandle(handle, ref ppIndirection);
-
+                return _this.embedMethodHandle(handle, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_METHOD_STRUCT_*);
             }
-            return (CORINFO_METHOD_STRUCT_*)0;
         }
 
-        public virtual CORINFO_FIELD_STRUCT_* embedFieldHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* handle, ref void* ppIndirection)
+        static CORINFO_FIELD_STRUCT_* _embedFieldHandle(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* handle, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return embedFieldHandle(handle, ref ppIndirection);
-
+                return _this.embedFieldHandle(handle, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_FIELD_STRUCT_*);
             }
-            return (CORINFO_FIELD_STRUCT_*)0;
         }
 
-        public virtual void embedGenericHandle_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.Bool)]bool fEmbedParent, ref CORINFO_GENERICHANDLE_RESULT pResult)
+        static void _embedGenericHandle(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, [MarshalAs(UnmanagedType.Bool)]bool fEmbedParent, ref CORINFO_GENERICHANDLE_RESULT pResult)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                embedGenericHandle(ref pResolvedToken, fEmbedParent, ref pResult);
-                return;
+                _this.embedGenericHandle(ref pResolvedToken, fEmbedParent, ref pResult);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void getLocationOfThisType_wrapper(IntPtr _this, out IntPtr exception, out CORINFO_LOOKUP_KIND _return, CORINFO_METHOD_STRUCT_* context)
+        static void _getLocationOfThisType(IntPtr thisHandle, IntPtr* ppException, out CORINFO_LOOKUP_KIND _return, CORINFO_METHOD_STRUCT_* context)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getLocationOfThisType(out _return, context);
-                return;
+                _this.getLocationOfThisType(out _return, context);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                _return = default(CORINFO_LOOKUP_KIND);
             }
-            _return = new CORINFO_LOOKUP_KIND();
         }
 
-        public virtual void* getPInvokeUnmanagedTarget_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection)
+        static void* _getPInvokeUnmanagedTarget(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getPInvokeUnmanagedTarget(method, ref ppIndirection);
-
+                return _this.getPInvokeUnmanagedTarget(method, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual void* getAddressOfPInvokeFixup_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection)
+        static void* _getAddressOfPInvokeFixup(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getAddressOfPInvokeFixup(method, ref ppIndirection);
-
+                return _this.getAddressOfPInvokeFixup(method, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual void getAddressOfPInvokeTarget_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref CORINFO_CONST_LOOKUP pLookup)
+        static void _getAddressOfPInvokeTarget(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref CORINFO_CONST_LOOKUP pLookup)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getAddressOfPInvokeTarget(method, ref pLookup);
-                return;
+                _this.getAddressOfPInvokeTarget(method, ref pLookup);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void* GetCookieForPInvokeCalliSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* szMetaSig, ref void* ppIndirection)
+        static void* _GetCookieForPInvokeCalliSig(IntPtr thisHandle, IntPtr* ppException, CORINFO_SIG_INFO* szMetaSig, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return GetCookieForPInvokeCalliSig(szMetaSig, ref ppIndirection);
-
+                return _this.GetCookieForPInvokeCalliSig(szMetaSig, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        [return: MarshalAs(UnmanagedType.I1)]public virtual bool canGetCookieForPInvokeCalliSig_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* szMetaSig)
+        [return: MarshalAs(UnmanagedType.I1)]static bool _canGetCookieForPInvokeCalliSig(IntPtr thisHandle, IntPtr* ppException, CORINFO_SIG_INFO* szMetaSig)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canGetCookieForPInvokeCalliSig(szMetaSig);
-
+                return _this.canGetCookieForPInvokeCalliSig(szMetaSig);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual CORINFO_JUST_MY_CODE_HANDLE_* getJustMyCodeHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* method, ref CORINFO_JUST_MY_CODE_HANDLE_** ppIndirection)
+        static CORINFO_JUST_MY_CODE_HANDLE_* _getJustMyCodeHandle(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* method, ref CORINFO_JUST_MY_CODE_HANDLE_** ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getJustMyCodeHandle(method, ref ppIndirection);
-
+                return _this.getJustMyCodeHandle(method, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_JUST_MY_CODE_HANDLE_*);
             }
-            return (CORINFO_JUST_MY_CODE_HANDLE_*)0;
         }
 
-        public virtual void GetProfilingHandle_wrapper(IntPtr _this, out IntPtr exception, [MarshalAs(UnmanagedType.Bool)] ref bool pbHookFunction, ref void* pProfilerHandle, [MarshalAs(UnmanagedType.Bool)] ref bool pbIndirectedHandles)
+        static void _GetProfilingHandle(IntPtr thisHandle, IntPtr* ppException, [MarshalAs(UnmanagedType.Bool)] ref bool pbHookFunction, ref void* pProfilerHandle, [MarshalAs(UnmanagedType.Bool)] ref bool pbIndirectedHandles)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                GetProfilingHandle(ref pbHookFunction, ref pProfilerHandle, ref pbIndirectedHandles);
-                return;
+                _this.GetProfilingHandle(ref pbHookFunction, ref pProfilerHandle, ref pbIndirectedHandles);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void getCallInfo_wrapper(IntPtr _this, out IntPtr exception, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_RESOLVED_TOKEN* pConstrainedResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_CALLINFO_FLAGS flags, ref CORINFO_CALL_INFO pResult)
+        static void _getCallInfo(IntPtr thisHandle, IntPtr* ppException, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_RESOLVED_TOKEN* pConstrainedResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_CALLINFO_FLAGS flags, ref CORINFO_CALL_INFO pResult)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getCallInfo(ref pResolvedToken, pConstrainedResolvedToken, callerHandle, flags, ref pResult);
-                return;
+                _this.getCallInfo(ref pResolvedToken, pConstrainedResolvedToken, callerHandle, flags, ref pResult);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool canAccessFamily_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* hCaller, CORINFO_CLASS_STRUCT_* hInstanceType)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _canAccessFamily(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* hCaller, CORINFO_CLASS_STRUCT_* hInstanceType)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canAccessFamily(hCaller, hInstanceType);
-
+                return _this.canAccessFamily(hCaller, hInstanceType);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool isRIDClassDomainID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _isRIDClassDomainID(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return isRIDClassDomainID(cls);
-
+                return _this.isRIDClassDomainID(cls);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual uint getClassDomainID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_CLASS_STRUCT_* cls, ref void* ppIndirection)
+        static uint _getClassDomainID(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getClassDomainID(cls, ref ppIndirection);
-
+                return _this.getClassDomainID(cls, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual void* getFieldAddress_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, ref void* ppIndirection)
+        static void* _getFieldAddress(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getFieldAddress(field, ref ppIndirection);
-
+                return _this.getFieldAddress(field, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual IntPtr getVarArgsHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* pSig, ref void* ppIndirection)
+        static IntPtr _getVarArgsHandle(IntPtr thisHandle, IntPtr* ppException, CORINFO_SIG_INFO* pSig, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getVarArgsHandle(pSig, ref ppIndirection);
-
+                return _this.getVarArgsHandle(pSig, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(IntPtr);
             }
-            return (IntPtr)0;
         }
 
-        [return: MarshalAs(UnmanagedType.I1)]public virtual bool canGetVarArgsHandle_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* pSig)
+        [return: MarshalAs(UnmanagedType.I1)]static bool _canGetVarArgsHandle(IntPtr thisHandle, IntPtr* ppException, CORINFO_SIG_INFO* pSig)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return canGetVarArgsHandle(pSig);
-
+                return _this.canGetVarArgsHandle(pSig);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual InfoAccessType constructStringLiteral_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* module, mdToken metaTok, ref void* ppValue)
+        static InfoAccessType _constructStringLiteral(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, mdToken metaTok, ref void* ppValue)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return constructStringLiteral(module, metaTok, ref ppValue);
-
+                return _this.constructStringLiteral(module, metaTok, ref ppValue);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(InfoAccessType);
             }
-            return (InfoAccessType)0;
         }
 
-        public virtual InfoAccessType emptyStringLiteral_wrapper(IntPtr _this, out IntPtr exception, ref void* ppValue)
+        static InfoAccessType _emptyStringLiteral(IntPtr thisHandle, IntPtr* ppException, ref void* ppValue)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return emptyStringLiteral(ref ppValue);
-
+                return _this.emptyStringLiteral(ref ppValue);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(InfoAccessType);
             }
-            return (InfoAccessType)0;
         }
 
-        public virtual uint getFieldThreadLocalStoreID_wrapper(IntPtr _this, out IntPtr exception, CORINFO_FIELD_STRUCT_* field, ref void* ppIndirection)
+        static uint _getFieldThreadLocalStoreID(IntPtr thisHandle, IntPtr* ppException, CORINFO_FIELD_STRUCT_* field, ref void* ppIndirection)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getFieldThreadLocalStoreID(field, ref ppIndirection);
-
+                return _this.getFieldThreadLocalStoreID(field, ref ppIndirection);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual void setOverride_wrapper(IntPtr _this, out IntPtr exception, IntPtr pOverride, CORINFO_METHOD_STRUCT_* currentMethod)
+        static void _setOverride(IntPtr thisHandle, IntPtr* ppException, IntPtr pOverride, CORINFO_METHOD_STRUCT_* currentMethod)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                setOverride(pOverride, currentMethod);
-                return;
+                _this.setOverride(pOverride, currentMethod);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void addActiveDependency_wrapper(IntPtr _this, out IntPtr exception, CORINFO_MODULE_STRUCT_* moduleFrom, CORINFO_MODULE_STRUCT_* moduleTo)
+        static void _addActiveDependency(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* moduleFrom, CORINFO_MODULE_STRUCT_* moduleTo)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                addActiveDependency(moduleFrom, moduleTo);
-                return;
+                _this.addActiveDependency(moduleFrom, moduleTo);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual CORINFO_METHOD_STRUCT_* GetDelegateCtor_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* methHnd, CORINFO_CLASS_STRUCT_* clsHnd, CORINFO_METHOD_STRUCT_* targetMethodHnd, ref DelegateCtorArgs pCtorData)
+        static CORINFO_METHOD_STRUCT_* _GetDelegateCtor(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* methHnd, CORINFO_CLASS_STRUCT_* clsHnd, CORINFO_METHOD_STRUCT_* targetMethodHnd, ref DelegateCtorArgs pCtorData)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return GetDelegateCtor(methHnd, clsHnd, targetMethodHnd, ref pCtorData);
-
+                return _this.GetDelegateCtor(methHnd, clsHnd, targetMethodHnd, ref pCtorData);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(CORINFO_METHOD_STRUCT_*);
             }
-            return (CORINFO_METHOD_STRUCT_*)0;
         }
 
-        public virtual void MethodCompileComplete_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* methHnd)
+        static void _MethodCompileComplete(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* methHnd)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                MethodCompileComplete(methHnd);
-                return;
+                _this.MethodCompileComplete(methHnd);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void* getTailCallCopyArgsThunk_wrapper(IntPtr _this, out IntPtr exception, CORINFO_SIG_INFO* pSig, CorInfoHelperTailCallSpecialHandling flags)
+        static void* _getTailCallCopyArgsThunk(IntPtr thisHandle, IntPtr* ppException, CORINFO_SIG_INFO* pSig, CorInfoHelperTailCallSpecialHandling flags)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getTailCallCopyArgsThunk(pSig, flags);
-
+                return _this.getTailCallCopyArgsThunk(pSig, flags);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual void* getMemoryManager_wrapper(IntPtr _this, out IntPtr exception)
+        static void* _getMemoryManager(IntPtr thisHandle, IntPtr* ppException)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getMemoryManager();
-
+                return _this.getMemoryManager();
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual void allocMem_wrapper(IntPtr _this, out IntPtr exception, uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, ref void* hotCodeBlock, ref void* coldCodeBlock, ref void* roDataBlock)
+        static void _allocMem(IntPtr thisHandle, IntPtr* ppException, uint hotCodeSize, uint coldCodeSize, uint roDataSize, uint xcptnsCount, CorJitAllocMemFlag flag, ref void* hotCodeBlock, ref void* coldCodeBlock, ref void* roDataBlock)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, ref hotCodeBlock, ref coldCodeBlock, ref roDataBlock);
-                return;
+                _this.allocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, ref hotCodeBlock, ref coldCodeBlock, ref roDataBlock);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void reserveUnwindInfo_wrapper(IntPtr _this, out IntPtr exception, [MarshalAs(UnmanagedType.Bool)]bool isFunclet, [MarshalAs(UnmanagedType.Bool)]bool isColdCode, uint unwindSize)
+        static void _reserveUnwindInfo(IntPtr thisHandle, IntPtr* ppException, [MarshalAs(UnmanagedType.Bool)]bool isFunclet, [MarshalAs(UnmanagedType.Bool)]bool isColdCode, uint unwindSize)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                reserveUnwindInfo(isFunclet, isColdCode, unwindSize);
-                return;
+                _this.reserveUnwindInfo(isFunclet, isColdCode, unwindSize);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void allocUnwindInfo_wrapper(IntPtr _this, out IntPtr exception, byte* pHotCode, byte* pColdCode, uint startOffset, uint endOffset, uint unwindSize, byte* pUnwindBlock, CorJitFuncKind funcKind)
+        static void _allocUnwindInfo(IntPtr thisHandle, IntPtr* ppException, byte* pHotCode, byte* pColdCode, uint startOffset, uint endOffset, uint unwindSize, byte* pUnwindBlock, CorJitFuncKind funcKind)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                allocUnwindInfo(pHotCode, pColdCode, startOffset, endOffset, unwindSize, pUnwindBlock, funcKind);
-                return;
+                _this.allocUnwindInfo(pHotCode, pColdCode, startOffset, endOffset, unwindSize, pUnwindBlock, funcKind);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void* allocGCInfo_wrapper(IntPtr _this, out IntPtr exception, UIntPtr size)
+        static void* _allocGCInfo(IntPtr thisHandle, IntPtr* ppException, UIntPtr size)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return allocGCInfo(size);
-
+                return _this.allocGCInfo(size);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(void*);
             }
-            return (void*)0;
         }
 
-        public virtual void yieldExecution_wrapper(IntPtr _this, out IntPtr exception)
+        static void _yieldExecution(IntPtr thisHandle, IntPtr* ppException)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                yieldExecution();
-                return;
+                _this.yieldExecution();
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void setEHcount_wrapper(IntPtr _this, out IntPtr exception, uint cEH)
+        static void _setEHcount(IntPtr thisHandle, IntPtr* ppException, uint cEH)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                setEHcount(cEH);
-                return;
+                _this.setEHcount(cEH);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void setEHinfo_wrapper(IntPtr _this, out IntPtr exception, uint EHnumber, ref CORINFO_EH_CLAUSE clause)
+        static void _setEHinfo(IntPtr thisHandle, IntPtr* ppException, uint EHnumber, ref CORINFO_EH_CLAUSE clause)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                setEHinfo(EHnumber, ref clause);
-                return;
+                _this.setEHinfo(EHnumber, ref clause);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        [return: MarshalAs(UnmanagedType.Bool)]public virtual bool logMsg_wrapper(IntPtr _this, out IntPtr exception, uint level, byte* fmt, IntPtr args)
+        [return: MarshalAs(UnmanagedType.Bool)]static bool _logMsg(IntPtr thisHandle, IntPtr* ppException, uint level, byte* fmt, IntPtr args)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return logMsg(level, fmt, args);
-
+                return _this.logMsg(level, fmt, args);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(bool);
             }
-            return false;
         }
 
-        public virtual int doAssert_wrapper(IntPtr _this, out IntPtr exception, byte* szFile, int iLine, byte* szExpr)
+        static int _doAssert(IntPtr thisHandle, IntPtr* ppException, byte* szFile, int iLine, byte* szExpr)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return doAssert(szFile, iLine, szExpr);
-
+                return _this.doAssert(szFile, iLine, szExpr);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(int);
             }
-            return (int)0;
         }
 
-        public virtual void reportFatalError_wrapper(IntPtr _this, out IntPtr exception, CorJitResult result)
+        static void _reportFatalError(IntPtr thisHandle, IntPtr* ppException, CorJitResult result)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                reportFatalError(result);
-                return;
+                _this.reportFatalError(result);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual HRESULT allocBBProfileBuffer_wrapper(IntPtr _this, out IntPtr exception, uint count, ref ProfileBuffer* profileBuffer)
+        static HRESULT _allocBBProfileBuffer(IntPtr thisHandle, IntPtr* ppException, uint count, ref ProfileBuffer* profileBuffer)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return allocBBProfileBuffer(count, ref profileBuffer);
-
+                return _this.allocBBProfileBuffer(count, ref profileBuffer);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(HRESULT);
             }
-            return (HRESULT)0;
         }
 
-        public virtual HRESULT getBBProfileData_wrapper(IntPtr _this, out IntPtr exception, CORINFO_METHOD_STRUCT_* ftnHnd, ref uint count, ref ProfileBuffer* profileBuffer, ref uint numRuns)
+        static HRESULT _getBBProfileData(IntPtr thisHandle, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftnHnd, ref uint count, ref ProfileBuffer* profileBuffer, ref uint numRuns)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getBBProfileData(ftnHnd, ref count, ref profileBuffer, ref numRuns);
-
+                return _this.getBBProfileData(ftnHnd, ref count, ref profileBuffer, ref numRuns);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(HRESULT);
             }
-            return (HRESULT)0;
         }
 
-        public virtual void recordCallSite_wrapper(IntPtr _this, out IntPtr exception, uint instrOffset, CORINFO_SIG_INFO* callSig, CORINFO_METHOD_STRUCT_* methodHandle)
+        static void _recordCallSite(IntPtr thisHandle, IntPtr* ppException, uint instrOffset, CORINFO_SIG_INFO* callSig, CORINFO_METHOD_STRUCT_* methodHandle)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                recordCallSite(instrOffset, callSig, methodHandle);
-                return;
+                _this.recordCallSite(instrOffset, callSig, methodHandle);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual void recordRelocation_wrapper(IntPtr _this, out IntPtr exception, void* location, void* target, ushort fRelocType, ushort slotNum, int addlDelta)
+        static void _recordRelocation(IntPtr thisHandle, IntPtr* ppException, void* location, void* target, ushort fRelocType, ushort slotNum, int addlDelta)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                recordRelocation(location, target, fRelocType, slotNum, addlDelta);
-                return;
+                _this.recordRelocation(location, target, fRelocType, slotNum, addlDelta);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual ushort getRelocTypeHint_wrapper(IntPtr _this, out IntPtr exception, void* target)
+        static ushort _getRelocTypeHint(IntPtr thisHandle, IntPtr* ppException, void* target)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getRelocTypeHint(target);
-
+                return _this.getRelocTypeHint(target);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(ushort);
             }
-            return (ushort)0;
         }
 
-        public virtual void getModuleNativeEntryPointRange_wrapper(IntPtr _this, out IntPtr exception, ref void* pStart, ref void* pEnd)
+        static void _getModuleNativeEntryPointRange(IntPtr thisHandle, IntPtr* ppException, ref void* pStart, ref void* pEnd)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                getModuleNativeEntryPointRange(ref pStart, ref pEnd);
-                return;
+                _this.getModuleNativeEntryPointRange(ref pStart, ref pEnd);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
             }
         }
 
-        public virtual uint getExpectedTargetArchitecture_wrapper(IntPtr _this, out IntPtr exception)
+        static uint _getExpectedTargetArchitecture(IntPtr thisHandle, IntPtr* ppException)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getExpectedTargetArchitecture();
-
+                return _this.getExpectedTargetArchitecture();
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
-        public virtual uint getJitFlags_wrapper(IntPtr _this, out IntPtr exception, ref CORJIT_FLAGS flags, uint sizeInBytes)
+        static uint _getJitFlags(IntPtr thisHandle, IntPtr* ppException, ref CORJIT_FLAGS flags, uint sizeInBytes)
         {
-            exception = IntPtr.Zero;
+            var _this = GetThis(thisHandle);
             try
             {
-                return getJitFlags(ref flags, sizeInBytes);
-
+                return _this.getJitFlags(ref flags, sizeInBytes);
             }
             catch (Exception ex)
             {
-                exception = AllocException(ex);
+                *ppException = _this.AllocException(ex);
+                return default(uint);
             }
-            return (uint)0;
         }
 
 
-        Object[] _keepalive;
-
-        protected IntPtr CreateUnmanagedInstance()
+        static IntPtr GetUnmanagedCallbacks(out Object keepAlive)
         {
-            IntPtr * vtable = (IntPtr *)Marshal.AllocCoTaskMem(sizeof(IntPtr) * 163);
-            Object[] keepalive = new Object[163];
-
-            _keepalive = keepalive;
+            IntPtr * callbacks = (IntPtr *)Marshal.AllocCoTaskMem(sizeof(IntPtr) * 163);
+            Object[] delegates = new Object[163];
 
-            var d0 = new _getMethodAttribs_wrapper(getMethodAttribs_wrapper);
-            vtable[0] = Marshal.GetFunctionPointerForDelegate(d0);
-            keepalive[0] = d0;
-            var d1 = new _setMethodAttribs_wrapper(setMethodAttribs_wrapper);
-            vtable[1] = Marshal.GetFunctionPointerForDelegate(d1);
-            keepalive[1] = d1;
-            var d2 = new _getMethodSig_wrapper(getMethodSig_wrapper);
-            vtable[2] = Marshal.GetFunctionPointerForDelegate(d2);
-            keepalive[2] = d2;
-            var d3 = new _getMethodInfo_wrapper(getMethodInfo_wrapper);
-            vtable[3] = Marshal.GetFunctionPointerForDelegate(d3);
-            keepalive[3] = d3;
-            var d4 = new _canInline_wrapper(canInline_wrapper);
-            vtable[4] = Marshal.GetFunctionPointerForDelegate(d4);
-            keepalive[4] = d4;
-            var d5 = new _reportInliningDecision_wrapper(reportInliningDecision_wrapper);
-            vtable[5] = Marshal.GetFunctionPointerForDelegate(d5);
-            keepalive[5] = d5;
-            var d6 = new _canTailCall_wrapper(canTailCall_wrapper);
-            vtable[6] = Marshal.GetFunctionPointerForDelegate(d6);
-            keepalive[6] = d6;
-            var d7 = new _reportTailCallDecision_wrapper(reportTailCallDecision_wrapper);
-            vtable[7] = Marshal.GetFunctionPointerForDelegate(d7);
-            keepalive[7] = d7;
-            var d8 = new _getEHinfo_wrapper(getEHinfo_wrapper);
-            vtable[8] = Marshal.GetFunctionPointerForDelegate(d8);
-            keepalive[8] = d8;
-            var d9 = new _getMethodClass_wrapper(getMethodClass_wrapper);
-            vtable[9] = Marshal.GetFunctionPointerForDelegate(d9);
-            keepalive[9] = d9;
-            var d10 = new _getMethodModule_wrapper(getMethodModule_wrapper);
-            vtable[10] = Marshal.GetFunctionPointerForDelegate(d10);
-            keepalive[10] = d10;
-            var d11 = new _getMethodVTableOffset_wrapper(getMethodVTableOffset_wrapper);
-            vtable[11] = Marshal.GetFunctionPointerForDelegate(d11);
-            keepalive[11] = d11;
-            var d12 = new _getIntrinsicID_wrapper(getIntrinsicID_wrapper);
-            vtable[12] = Marshal.GetFunctionPointerForDelegate(d12);
-            keepalive[12] = d12;
-            var d13 = new _isInSIMDModule_wrapper(isInSIMDModule_wrapper);
-            vtable[13] = Marshal.GetFunctionPointerForDelegate(d13);
-            keepalive[13] = d13;
-            var d14 = new _getUnmanagedCallConv_wrapper(getUnmanagedCallConv_wrapper);
-            vtable[14] = Marshal.GetFunctionPointerForDelegate(d14);
-            keepalive[14] = d14;
-            var d15 = new _pInvokeMarshalingRequired_wrapper(pInvokeMarshalingRequired_wrapper);
-            vtable[15] = Marshal.GetFunctionPointerForDelegate(d15);
-            keepalive[15] = d15;
-            var d16 = new _satisfiesMethodConstraints_wrapper(satisfiesMethodConstraints_wrapper);
-            vtable[16] = Marshal.GetFunctionPointerForDelegate(d16);
-            keepalive[16] = d16;
-            var d17 = new _isCompatibleDelegate_wrapper(isCompatibleDelegate_wrapper);
-            vtable[17] = Marshal.GetFunctionPointerForDelegate(d17);
-            keepalive[17] = d17;
-            var d18 = new _isDelegateCreationAllowed_wrapper(isDelegateCreationAllowed_wrapper);
-            vtable[18] = Marshal.GetFunctionPointerForDelegate(d18);
-            keepalive[18] = d18;
-            var d19 = new _isInstantiationOfVerifiedGeneric_wrapper(isInstantiationOfVerifiedGeneric_wrapper);
-            vtable[19] = Marshal.GetFunctionPointerForDelegate(d19);
-            keepalive[19] = d19;
-            var d20 = new _initConstraintsForVerification_wrapper(initConstraintsForVerification_wrapper);
-            vtable[20] = Marshal.GetFunctionPointerForDelegate(d20);
-            keepalive[20] = d20;
-            var d21 = new _canSkipMethodVerification_wrapper(canSkipMethodVerification_wrapper);
-            vtable[21] = Marshal.GetFunctionPointerForDelegate(d21);
-            keepalive[21] = d21;
-            var d22 = new _methodMustBeLoadedBeforeCodeIsRun_wrapper(methodMustBeLoadedBeforeCodeIsRun_wrapper);
-            vtable[22] = Marshal.GetFunctionPointerForDelegate(d22);
-            keepalive[22] = d22;
-            var d23 = new _mapMethodDeclToMethodImpl_wrapper(mapMethodDeclToMethodImpl_wrapper);
-            vtable[23] = Marshal.GetFunctionPointerForDelegate(d23);
-            keepalive[23] = d23;
-            var d24 = new _getGSCookie_wrapper(getGSCookie_wrapper);
-            vtable[24] = Marshal.GetFunctionPointerForDelegate(d24);
-            keepalive[24] = d24;
-            var d25 = new _resolveToken_wrapper(resolveToken_wrapper);
-            vtable[25] = Marshal.GetFunctionPointerForDelegate(d25);
-            keepalive[25] = d25;
-            var d26 = new _findSig_wrapper(findSig_wrapper);
-            vtable[26] = Marshal.GetFunctionPointerForDelegate(d26);
-            keepalive[26] = d26;
-            var d27 = new _findCallSiteSig_wrapper(findCallSiteSig_wrapper);
-            vtable[27] = Marshal.GetFunctionPointerForDelegate(d27);
-            keepalive[27] = d27;
-            var d28 = new _getTokenTypeAsHandle_wrapper(getTokenTypeAsHandle_wrapper);
-            vtable[28] = Marshal.GetFunctionPointerForDelegate(d28);
-            keepalive[28] = d28;
-            var d29 = new _canSkipVerification_wrapper(canSkipVerification_wrapper);
-            vtable[29] = Marshal.GetFunctionPointerForDelegate(d29);
-            keepalive[29] = d29;
-            var d30 = new _isValidToken_wrapper(isValidToken_wrapper);
-            vtable[30] = Marshal.GetFunctionPointerForDelegate(d30);
-            keepalive[30] = d30;
-            var d31 = new _isValidStringRef_wrapper(isValidStringRef_wrapper);
-            vtable[31] = Marshal.GetFunctionPointerForDelegate(d31);
-            keepalive[31] = d31;
-            var d32 = new _shouldEnforceCallvirtRestriction_wrapper(shouldEnforceCallvirtRestriction_wrapper);
-            vtable[32] = Marshal.GetFunctionPointerForDelegate(d32);
-            keepalive[32] = d32;
-            var d33 = new _asCorInfoType_wrapper(asCorInfoType_wrapper);
-            vtable[33] = Marshal.GetFunctionPointerForDelegate(d33);
-            keepalive[33] = d33;
-            var d34 = new _getClassName_wrapper(getClassName_wrapper);
-            vtable[34] = Marshal.GetFunctionPointerForDelegate(d34);
-            keepalive[34] = d34;
-            var d35 = new _appendClassName_wrapper(appendClassName_wrapper);
-            vtable[35] = Marshal.GetFunctionPointerForDelegate(d35);
-            keepalive[35] = d35;
-            var d36 = new _isValueClass_wrapper(isValueClass_wrapper);
-            vtable[36] = Marshal.GetFunctionPointerForDelegate(d36);
-            keepalive[36] = d36;
-            var d37 = new _canInlineTypeCheckWithObjectVTable_wrapper(canInlineTypeCheckWithObjectVTable_wrapper);
-            vtable[37] = Marshal.GetFunctionPointerForDelegate(d37);
-            keepalive[37] = d37;
-            var d38 = new _getClassAttribs_wrapper(getClassAttribs_wrapper);
-            vtable[38] = Marshal.GetFunctionPointerForDelegate(d38);
-            keepalive[38] = d38;
-            var d39 = new _isStructRequiringStackAllocRetBuf_wrapper(isStructRequiringStackAllocRetBuf_wrapper);
-            vtable[39] = Marshal.GetFunctionPointerForDelegate(d39);
-            keepalive[39] = d39;
-            var d40 = new _getClassModule_wrapper(getClassModule_wrapper);
-            vtable[40] = Marshal.GetFunctionPointerForDelegate(d40);
-            keepalive[40] = d40;
-            var d41 = new _getModuleAssembly_wrapper(getModuleAssembly_wrapper);
-            vtable[41] = Marshal.GetFunctionPointerForDelegate(d41);
-            keepalive[41] = d41;
-            var d42 = new _getAssemblyName_wrapper(getAssemblyName_wrapper);
-            vtable[42] = Marshal.GetFunctionPointerForDelegate(d42);
-            keepalive[42] = d42;
-            var d43 = new _LongLifetimeMalloc_wrapper(LongLifetimeMalloc_wrapper);
-            vtable[43] = Marshal.GetFunctionPointerForDelegate(d43);
-            keepalive[43] = d43;
-            var d44 = new _LongLifetimeFree_wrapper(LongLifetimeFree_wrapper);
-            vtable[44] = Marshal.GetFunctionPointerForDelegate(d44);
-            keepalive[44] = d44;
-            var d45 = new _getClassModuleIdForStatics_wrapper(getClassModuleIdForStatics_wrapper);
-            vtable[45] = Marshal.GetFunctionPointerForDelegate(d45);
-            keepalive[45] = d45;
-            var d46 = new _getClassSize_wrapper(getClassSize_wrapper);
-            vtable[46] = Marshal.GetFunctionPointerForDelegate(d46);
-            keepalive[46] = d46;
-            var d47 = new _getClassAlignmentRequirement_wrapper(getClassAlignmentRequirement_wrapper);
-            vtable[47] = Marshal.GetFunctionPointerForDelegate(d47);
-            keepalive[47] = d47;
-            var d48 = new _getClassGClayout_wrapper(getClassGClayout_wrapper);
-            vtable[48] = Marshal.GetFunctionPointerForDelegate(d48);
-            keepalive[48] = d48;
-            var d49 = new _getClassNumInstanceFields_wrapper(getClassNumInstanceFields_wrapper);
-            vtable[49] = Marshal.GetFunctionPointerForDelegate(d49);
-            keepalive[49] = d49;
-            var d50 = new _getFieldInClass_wrapper(getFieldInClass_wrapper);
-            vtable[50] = Marshal.GetFunctionPointerForDelegate(d50);
-            keepalive[50] = d50;
-            var d51 = new _checkMethodModifier_wrapper(checkMethodModifier_wrapper);
-            vtable[51] = Marshal.GetFunctionPointerForDelegate(d51);
-            keepalive[51] = d51;
-            var d52 = new _getNewHelper_wrapper(getNewHelper_wrapper);
-            vtable[52] = Marshal.GetFunctionPointerForDelegate(d52);
-            keepalive[52] = d52;
-            var d53 = new _getNewArrHelper_wrapper(getNewArrHelper_wrapper);
-            vtable[53] = Marshal.GetFunctionPointerForDelegate(d53);
-            keepalive[53] = d53;
-            var d54 = new _getCastingHelper_wrapper(getCastingHelper_wrapper);
-            vtable[54] = Marshal.GetFunctionPointerForDelegate(d54);
-            keepalive[54] = d54;
-            var d55 = new _getSharedCCtorHelper_wrapper(getSharedCCtorHelper_wrapper);
-            vtable[55] = Marshal.GetFunctionPointerForDelegate(d55);
-            keepalive[55] = d55;
-            var d56 = new _getSecurityPrologHelper_wrapper(getSecurityPrologHelper_wrapper);
-            vtable[56] = Marshal.GetFunctionPointerForDelegate(d56);
-            keepalive[56] = d56;
-            var d57 = new _getTypeForBox_wrapper(getTypeForBox_wrapper);
-            vtable[57] = Marshal.GetFunctionPointerForDelegate(d57);
-            keepalive[57] = d57;
-            var d58 = new _getBoxHelper_wrapper(getBoxHelper_wrapper);
-            vtable[58] = Marshal.GetFunctionPointerForDelegate(d58);
-            keepalive[58] = d58;
-            var d59 = new _getUnBoxHelper_wrapper(getUnBoxHelper_wrapper);
-            vtable[59] = Marshal.GetFunctionPointerForDelegate(d59);
-            keepalive[59] = d59;
-            var d60 = new _getReadyToRunHelper_wrapper(getReadyToRunHelper_wrapper);
-            vtable[60] = Marshal.GetFunctionPointerForDelegate(d60);
-            keepalive[60] = d60;
-            var d61 = new _getReadyToRunDelegateCtorHelper_wrapper(getReadyToRunDelegateCtorHelper_wrapper);
-            vtable[61] = Marshal.GetFunctionPointerForDelegate(d61);
-            keepalive[61] = d61;
-            var d62 = new _getHelperName_wrapper(getHelperName_wrapper);
-            vtable[62] = Marshal.GetFunctionPointerForDelegate(d62);
-            keepalive[62] = d62;
-            var d63 = new _initClass_wrapper(initClass_wrapper);
-            vtable[63] = Marshal.GetFunctionPointerForDelegate(d63);
-            keepalive[63] = d63;
-            var d64 = new _classMustBeLoadedBeforeCodeIsRun_wrapper(classMustBeLoadedBeforeCodeIsRun_wrapper);
-            vtable[64] = Marshal.GetFunctionPointerForDelegate(d64);
-            keepalive[64] = d64;
-            var d65 = new _getBuiltinClass_wrapper(getBuiltinClass_wrapper);
-            vtable[65] = Marshal.GetFunctionPointerForDelegate(d65);
-            keepalive[65] = d65;
-            var d66 = new _getTypeForPrimitiveValueClass_wrapper(getTypeForPrimitiveValueClass_wrapper);
-            vtable[66] = Marshal.GetFunctionPointerForDelegate(d66);
-            keepalive[66] = d66;
-            var d67 = new _canCast_wrapper(canCast_wrapper);
-            vtable[67] = Marshal.GetFunctionPointerForDelegate(d67);
-            keepalive[67] = d67;
-            var d68 = new _areTypesEquivalent_wrapper(areTypesEquivalent_wrapper);
-            vtable[68] = Marshal.GetFunctionPointerForDelegate(d68);
-            keepalive[68] = d68;
-            var d69 = new _mergeClasses_wrapper(mergeClasses_wrapper);
-            vtable[69] = Marshal.GetFunctionPointerForDelegate(d69);
-            keepalive[69] = d69;
-            var d70 = new _getParentType_wrapper(getParentType_wrapper);
-            vtable[70] = Marshal.GetFunctionPointerForDelegate(d70);
-            keepalive[70] = d70;
-            var d71 = new _getChildType_wrapper(getChildType_wrapper);
-            vtable[71] = Marshal.GetFunctionPointerForDelegate(d71);
-            keepalive[71] = d71;
-            var d72 = new _satisfiesClassConstraints_wrapper(satisfiesClassConstraints_wrapper);
-            vtable[72] = Marshal.GetFunctionPointerForDelegate(d72);
-            keepalive[72] = d72;
-            var d73 = new _isSDArray_wrapper(isSDArray_wrapper);
-            vtable[73] = Marshal.GetFunctionPointerForDelegate(d73);
-            keepalive[73] = d73;
-            var d74 = new _getArrayRank_wrapper(getArrayRank_wrapper);
-            vtable[74] = Marshal.GetFunctionPointerForDelegate(d74);
-            keepalive[74] = d74;
-            var d75 = new _getArrayInitializationData_wrapper(getArrayInitializationData_wrapper);
-            vtable[75] = Marshal.GetFunctionPointerForDelegate(d75);
-            keepalive[75] = d75;
-            var d76 = new _canAccessClass_wrapper(canAccessClass_wrapper);
-            vtable[76] = Marshal.GetFunctionPointerForDelegate(d76);
-            keepalive[76] = d76;
-            var d77 = new _getFieldName_wrapper(getFieldName_wrapper);
-            vtable[77] = Marshal.GetFunctionPointerForDelegate(d77);
-            keepalive[77] = d77;
-            var d78 = new _getFieldClass_wrapper(getFieldClass_wrapper);
-            vtable[78] = Marshal.GetFunctionPointerForDelegate(d78);
-            keepalive[78] = d78;
-            var d79 = new _getFieldType_wrapper(getFieldType_wrapper);
-            vtable[79] = Marshal.GetFunctionPointerForDelegate(d79);
-            keepalive[79] = d79;
-            var d80 = new _getFieldOffset_wrapper(getFieldOffset_wrapper);
-            vtable[80] = Marshal.GetFunctionPointerForDelegate(d80);
-            keepalive[80] = d80;
-            var d81 = new _isWriteBarrierHelperRequired_wrapper(isWriteBarrierHelperRequired_wrapper);
-            vtable[81] = Marshal.GetFunctionPointerForDelegate(d81);
-            keepalive[81] = d81;
-            var d82 = new _getFieldInfo_wrapper(getFieldInfo_wrapper);
-            vtable[82] = Marshal.GetFunctionPointerForDelegate(d82);
-            keepalive[82] = d82;
-            var d83 = new _isFieldStatic_wrapper(isFieldStatic_wrapper);
-            vtable[83] = Marshal.GetFunctionPointerForDelegate(d83);
-            keepalive[83] = d83;
-            var d84 = new _getBoundaries_wrapper(getBoundaries_wrapper);
-            vtable[84] = Marshal.GetFunctionPointerForDelegate(d84);
-            keepalive[84] = d84;
-            var d85 = new _setBoundaries_wrapper(setBoundaries_wrapper);
-            vtable[85] = Marshal.GetFunctionPointerForDelegate(d85);
-            keepalive[85] = d85;
-            var d86 = new _getVars_wrapper(getVars_wrapper);
-            vtable[86] = Marshal.GetFunctionPointerForDelegate(d86);
-            keepalive[86] = d86;
-            var d87 = new _setVars_wrapper(setVars_wrapper);
-            vtable[87] = Marshal.GetFunctionPointerForDelegate(d87);
-            keepalive[87] = d87;
-            var d88 = new _allocateArray_wrapper(allocateArray_wrapper);
-            vtable[88] = Marshal.GetFunctionPointerForDelegate(d88);
-            keepalive[88] = d88;
-            var d89 = new _freeArray_wrapper(freeArray_wrapper);
-            vtable[89] = Marshal.GetFunctionPointerForDelegate(d89);
-            keepalive[89] = d89;
-            var d90 = new _getArgNext_wrapper(getArgNext_wrapper);
-            vtable[90] = Marshal.GetFunctionPointerForDelegate(d90);
-            keepalive[90] = d90;
-            var d91 = new _getArgType_wrapper(getArgType_wrapper);
-            vtable[91] = Marshal.GetFunctionPointerForDelegate(d91);
-            keepalive[91] = d91;
-            var d92 = new _getArgClass_wrapper(getArgClass_wrapper);
-            vtable[92] = Marshal.GetFunctionPointerForDelegate(d92);
-            keepalive[92] = d92;
-            var d93 = new _getHFAType_wrapper(getHFAType_wrapper);
-            vtable[93] = Marshal.GetFunctionPointerForDelegate(d93);
-            keepalive[93] = d93;
-            var d94 = new _GetErrorHRESULT_wrapper(GetErrorHRESULT_wrapper);
-            vtable[94] = Marshal.GetFunctionPointerForDelegate(d94);
-            keepalive[94] = d94;
-            var d95 = new _GetErrorMessage_wrapper(GetErrorMessage_wrapper);
-            vtable[95] = Marshal.GetFunctionPointerForDelegate(d95);
-            keepalive[95] = d95;
-            var d96 = new _FilterException_wrapper(FilterException_wrapper);
-            vtable[96] = Marshal.GetFunctionPointerForDelegate(d96);
-            keepalive[96] = d96;
-            var d97 = new _HandleException_wrapper(HandleException_wrapper);
-            vtable[97] = Marshal.GetFunctionPointerForDelegate(d97);
-            keepalive[97] = d97;
-            var d98 = new _ThrowExceptionForJitResult_wrapper(ThrowExceptionForJitResult_wrapper);
-            vtable[98] = Marshal.GetFunctionPointerForDelegate(d98);
-            keepalive[98] = d98;
-            var d99 = new _ThrowExceptionForHelper_wrapper(ThrowExceptionForHelper_wrapper);
-            vtable[99] = Marshal.GetFunctionPointerForDelegate(d99);
-            keepalive[99] = d99;
-            var d100 = new _getEEInfo_wrapper(getEEInfo_wrapper);
-            vtable[100] = Marshal.GetFunctionPointerForDelegate(d100);
-            keepalive[100] = d100;
-            var d101 = new _getJitTimeLogFilename_wrapper(getJitTimeLogFilename_wrapper);
-            vtable[101] = Marshal.GetFunctionPointerForDelegate(d101);
-            keepalive[101] = d101;
-            var d102 = new _getMethodDefFromMethod_wrapper(getMethodDefFromMethod_wrapper);
-            vtable[102] = Marshal.GetFunctionPointerForDelegate(d102);
-            keepalive[102] = d102;
-            var d103 = new _getMethodName_wrapper(getMethodName_wrapper);
-            vtable[103] = Marshal.GetFunctionPointerForDelegate(d103);
-            keepalive[103] = d103;
-            var d104 = new _getMethodHash_wrapper(getMethodHash_wrapper);
-            vtable[104] = Marshal.GetFunctionPointerForDelegate(d104);
-            keepalive[104] = d104;
-            var d105 = new _findNameOfToken_wrapper(findNameOfToken_wrapper);
-            vtable[105] = Marshal.GetFunctionPointerForDelegate(d105);
-            keepalive[105] = d105;
-            var d106 = new _getSystemVAmd64PassStructInRegisterDescriptor_wrapper(getSystemVAmd64PassStructInRegisterDescriptor_wrapper);
-            vtable[106] = Marshal.GetFunctionPointerForDelegate(d106);
-            keepalive[106] = d106;
-            var d107 = new _getThreadTLSIndex_wrapper(getThreadTLSIndex_wrapper);
-            vtable[107] = Marshal.GetFunctionPointerForDelegate(d107);
-            keepalive[107] = d107;
-            var d108 = new _getInlinedCallFrameVptr_wrapper(getInlinedCallFrameVptr_wrapper);
-            vtable[108] = Marshal.GetFunctionPointerForDelegate(d108);
-            keepalive[108] = d108;
-            var d109 = new _getAddrOfCaptureThreadGlobal_wrapper(getAddrOfCaptureThreadGlobal_wrapper);
-            vtable[109] = Marshal.GetFunctionPointerForDelegate(d109);
-            keepalive[109] = d109;
-            var d110 = new _getAddrModuleDomainID_wrapper(getAddrModuleDomainID_wrapper);
-            vtable[110] = Marshal.GetFunctionPointerForDelegate(d110);
-            keepalive[110] = d110;
-            var d111 = new _getHelperFtn_wrapper(getHelperFtn_wrapper);
-            vtable[111] = Marshal.GetFunctionPointerForDelegate(d111);
-            keepalive[111] = d111;
-            var d112 = new _getFunctionEntryPoint_wrapper(getFunctionEntryPoint_wrapper);
-            vtable[112] = Marshal.GetFunctionPointerForDelegate(d112);
-            keepalive[112] = d112;
-            var d113 = new _getFunctionFixedEntryPoint_wrapper(getFunctionFixedEntryPoint_wrapper);
-            vtable[113] = Marshal.GetFunctionPointerForDelegate(d113);
-            keepalive[113] = d113;
-            var d114 = new _getMethodSync_wrapper(getMethodSync_wrapper);
-            vtable[114] = Marshal.GetFunctionPointerForDelegate(d114);
-            keepalive[114] = d114;
-            var d115 = new _getLazyStringLiteralHelper_wrapper(getLazyStringLiteralHelper_wrapper);
-            vtable[115] = Marshal.GetFunctionPointerForDelegate(d115);
-            keepalive[115] = d115;
-            var d116 = new _embedModuleHandle_wrapper(embedModuleHandle_wrapper);
-            vtable[116] = Marshal.GetFunctionPointerForDelegate(d116);
-            keepalive[116] = d116;
-            var d117 = new _embedClassHandle_wrapper(embedClassHandle_wrapper);
-            vtable[117] = Marshal.GetFunctionPointerForDelegate(d117);
-            keepalive[117] = d117;
-            var d118 = new _embedMethodHandle_wrapper(embedMethodHandle_wrapper);
-            vtable[118] = Marshal.GetFunctionPointerForDelegate(d118);
-            keepalive[118] = d118;
-            var d119 = new _embedFieldHandle_wrapper(embedFieldHandle_wrapper);
-            vtable[119] = Marshal.GetFunctionPointerForDelegate(d119);
-            keepalive[119] = d119;
-            var d120 = new _embedGenericHandle_wrapper(embedGenericHandle_wrapper);
-            vtable[120] = Marshal.GetFunctionPointerForDelegate(d120);
-            keepalive[120] = d120;
-            var d121 = new _getLocationOfThisType_wrapper(getLocationOfThisType_wrapper);
-            vtable[121] = Marshal.GetFunctionPointerForDelegate(d121);
-            keepalive[121] = d121;
-            var d122 = new _getPInvokeUnmanagedTarget_wrapper(getPInvokeUnmanagedTarget_wrapper);
-            vtable[122] = Marshal.GetFunctionPointerForDelegate(d122);
-            keepalive[122] = d122;
-            var d123 = new _getAddressOfPInvokeFixup_wrapper(getAddressOfPInvokeFixup_wrapper);
-            vtable[123] = Marshal.GetFunctionPointerForDelegate(d123);
-            keepalive[123] = d123;
-            var d124 = new _getAddressOfPInvokeTarget_wrapper(getAddressOfPInvokeTarget_wrapper);
-            vtable[124] = Marshal.GetFunctionPointerForDelegate(d124);
-            keepalive[124] = d124;
-            var d125 = new _GetCookieForPInvokeCalliSig_wrapper(GetCookieForPInvokeCalliSig_wrapper);
-            vtable[125] = Marshal.GetFunctionPointerForDelegate(d125);
-            keepalive[125] = d125;
-            var d126 = new _canGetCookieForPInvokeCalliSig_wrapper(canGetCookieForPInvokeCalliSig_wrapper);
-            vtable[126] = Marshal.GetFunctionPointerForDelegate(d126);
-            keepalive[126] = d126;
-            var d127 = new _getJustMyCodeHandle_wrapper(getJustMyCodeHandle_wrapper);
-            vtable[127] = Marshal.GetFunctionPointerForDelegate(d127);
-            keepalive[127] = d127;
-            var d128 = new _GetProfilingHandle_wrapper(GetProfilingHandle_wrapper);
-            vtable[128] = Marshal.GetFunctionPointerForDelegate(d128);
-            keepalive[128] = d128;
-            var d129 = new _getCallInfo_wrapper(getCallInfo_wrapper);
-            vtable[129] = Marshal.GetFunctionPointerForDelegate(d129);
-            keepalive[129] = d129;
-            var d130 = new _canAccessFamily_wrapper(canAccessFamily_wrapper);
-            vtable[130] = Marshal.GetFunctionPointerForDelegate(d130);
-            keepalive[130] = d130;
-            var d131 = new _isRIDClassDomainID_wrapper(isRIDClassDomainID_wrapper);
-            vtable[131] = Marshal.GetFunctionPointerForDelegate(d131);
-            keepalive[131] = d131;
-            var d132 = new _getClassDomainID_wrapper(getClassDomainID_wrapper);
-            vtable[132] = Marshal.GetFunctionPointerForDelegate(d132);
-            keepalive[132] = d132;
-            var d133 = new _getFieldAddress_wrapper(getFieldAddress_wrapper);
-            vtable[133] = Marshal.GetFunctionPointerForDelegate(d133);
-            keepalive[133] = d133;
-            var d134 = new _getVarArgsHandle_wrapper(getVarArgsHandle_wrapper);
-            vtable[134] = Marshal.GetFunctionPointerForDelegate(d134);
-            keepalive[134] = d134;
-            var d135 = new _canGetVarArgsHandle_wrapper(canGetVarArgsHandle_wrapper);
-            vtable[135] = Marshal.GetFunctionPointerForDelegate(d135);
-            keepalive[135] = d135;
-            var d136 = new _constructStringLiteral_wrapper(constructStringLiteral_wrapper);
-            vtable[136] = Marshal.GetFunctionPointerForDelegate(d136);
-            keepalive[136] = d136;
-            var d137 = new _emptyStringLiteral_wrapper(emptyStringLiteral_wrapper);
-            vtable[137] = Marshal.GetFunctionPointerForDelegate(d137);
-            keepalive[137] = d137;
-            var d138 = new _getFieldThreadLocalStoreID_wrapper(getFieldThreadLocalStoreID_wrapper);
-            vtable[138] = Marshal.GetFunctionPointerForDelegate(d138);
-            keepalive[138] = d138;
-            var d139 = new _setOverride_wrapper(setOverride_wrapper);
-            vtable[139] = Marshal.GetFunctionPointerForDelegate(d139);
-            keepalive[139] = d139;
-            var d140 = new _addActiveDependency_wrapper(addActiveDependency_wrapper);
-            vtable[140] = Marshal.GetFunctionPointerForDelegate(d140);
-            keepalive[140] = d140;
-            var d141 = new _GetDelegateCtor_wrapper(GetDelegateCtor_wrapper);
-            vtable[141] = Marshal.GetFunctionPointerForDelegate(d141);
-            keepalive[141] = d141;
-            var d142 = new _MethodCompileComplete_wrapper(MethodCompileComplete_wrapper);
-            vtable[142] = Marshal.GetFunctionPointerForDelegate(d142);
-            keepalive[142] = d142;
-            var d143 = new _getTailCallCopyArgsThunk_wrapper(getTailCallCopyArgsThunk_wrapper);
-            vtable[143] = Marshal.GetFunctionPointerForDelegate(d143);
-            keepalive[143] = d143;
-            var d144 = new _getMemoryManager_wrapper(getMemoryManager_wrapper);
-            vtable[144] = Marshal.GetFunctionPointerForDelegate(d144);
-            keepalive[144] = d144;
-            var d145 = new _allocMem_wrapper(allocMem_wrapper);
-            vtable[145] = Marshal.GetFunctionPointerForDelegate(d145);
-            keepalive[145] = d145;
-            var d146 = new _reserveUnwindInfo_wrapper(reserveUnwindInfo_wrapper);
-            vtable[146] = Marshal.GetFunctionPointerForDelegate(d146);
-            keepalive[146] = d146;
-            var d147 = new _allocUnwindInfo_wrapper(allocUnwindInfo_wrapper);
-            vtable[147] = Marshal.GetFunctionPointerForDelegate(d147);
-            keepalive[147] = d147;
-            var d148 = new _allocGCInfo_wrapper(allocGCInfo_wrapper);
-            vtable[148] = Marshal.GetFunctionPointerForDelegate(d148);
-            keepalive[148] = d148;
-            var d149 = new _yieldExecution_wrapper(yieldExecution_wrapper);
-            vtable[149] = Marshal.GetFunctionPointerForDelegate(d149);
-            keepalive[149] = d149;
-            var d150 = new _setEHcount_wrapper(setEHcount_wrapper);
-            vtable[150] = Marshal.GetFunctionPointerForDelegate(d150);
-            keepalive[150] = d150;
-            var d151 = new _setEHinfo_wrapper(setEHinfo_wrapper);
-            vtable[151] = Marshal.GetFunctionPointerForDelegate(d151);
-            keepalive[151] = d151;
-            var d152 = new _logMsg_wrapper(logMsg_wrapper);
-            vtable[152] = Marshal.GetFunctionPointerForDelegate(d152);
-            keepalive[152] = d152;
-            var d153 = new _doAssert_wrapper(doAssert_wrapper);
-            vtable[153] = Marshal.GetFunctionPointerForDelegate(d153);
-            keepalive[153] = d153;
-            var d154 = new _reportFatalError_wrapper(reportFatalError_wrapper);
-            vtable[154] = Marshal.GetFunctionPointerForDelegate(d154);
-            keepalive[154] = d154;
-            var d155 = new _allocBBProfileBuffer_wrapper(allocBBProfileBuffer_wrapper);
-            vtable[155] = Marshal.GetFunctionPointerForDelegate(d155);
-            keepalive[155] = d155;
-            var d156 = new _getBBProfileData_wrapper(getBBProfileData_wrapper);
-            vtable[156] = Marshal.GetFunctionPointerForDelegate(d156);
-            keepalive[156] = d156;
-            var d157 = new _recordCallSite_wrapper(recordCallSite_wrapper);
-            vtable[157] = Marshal.GetFunctionPointerForDelegate(d157);
-            keepalive[157] = d157;
-            var d158 = new _recordRelocation_wrapper(recordRelocation_wrapper);
-            vtable[158] = Marshal.GetFunctionPointerForDelegate(d158);
-            keepalive[158] = d158;
-            var d159 = new _getRelocTypeHint_wrapper(getRelocTypeHint_wrapper);
-            vtable[159] = Marshal.GetFunctionPointerForDelegate(d159);
-            keepalive[159] = d159;
-            var d160 = new _getModuleNativeEntryPointRange_wrapper(getModuleNativeEntryPointRange_wrapper);
-            vtable[160] = Marshal.GetFunctionPointerForDelegate(d160);
-            keepalive[160] = d160;
-            var d161 = new _getExpectedTargetArchitecture_wrapper(getExpectedTargetArchitecture_wrapper);
-            vtable[161] = Marshal.GetFunctionPointerForDelegate(d161);
-            keepalive[161] = d161;
-            var d162 = new _getJitFlags_wrapper(getJitFlags_wrapper);
-            vtable[162] = Marshal.GetFunctionPointerForDelegate(d162);
-            keepalive[162] = d162;
+            var d0 = new __getMethodAttribs(_getMethodAttribs);
+            callbacks[0] = Marshal.GetFunctionPointerForDelegate(d0);
+            delegates[0] = d0;
+            var d1 = new __setMethodAttribs(_setMethodAttribs);
+            callbacks[1] = Marshal.GetFunctionPointerForDelegate(d1);
+            delegates[1] = d1;
+            var d2 = new __getMethodSig(_getMethodSig);
+            callbacks[2] = Marshal.GetFunctionPointerForDelegate(d2);
+            delegates[2] = d2;
+            var d3 = new __getMethodInfo(_getMethodInfo);
+            callbacks[3] = Marshal.GetFunctionPointerForDelegate(d3);
+            delegates[3] = d3;
+            var d4 = new __canInline(_canInline);
+            callbacks[4] = Marshal.GetFunctionPointerForDelegate(d4);
+            delegates[4] = d4;
+            var d5 = new __reportInliningDecision(_reportInliningDecision);
+            callbacks[5] = Marshal.GetFunctionPointerForDelegate(d5);
+            delegates[5] = d5;
+            var d6 = new __canTailCall(_canTailCall);
+            callbacks[6] = Marshal.GetFunctionPointerForDelegate(d6);
+            delegates[6] = d6;
+            var d7 = new __reportTailCallDecision(_reportTailCallDecision);
+            callbacks[7] = Marshal.GetFunctionPointerForDelegate(d7);
+            delegates[7] = d7;
+            var d8 = new __getEHinfo(_getEHinfo);
+            callbacks[8] = Marshal.GetFunctionPointerForDelegate(d8);
+            delegates[8] = d8;
+            var d9 = new __getMethodClass(_getMethodClass);
+            callbacks[9] = Marshal.GetFunctionPointerForDelegate(d9);
+            delegates[9] = d9;
+            var d10 = new __getMethodModule(_getMethodModule);
+            callbacks[10] = Marshal.GetFunctionPointerForDelegate(d10);
+            delegates[10] = d10;
+            var d11 = new __getMethodVTableOffset(_getMethodVTableOffset);
+            callbacks[11] = Marshal.GetFunctionPointerForDelegate(d11);
+            delegates[11] = d11;
+            var d12 = new __getIntrinsicID(_getIntrinsicID);
+            callbacks[12] = Marshal.GetFunctionPointerForDelegate(d12);
+            delegates[12] = d12;
+            var d13 = new __isInSIMDModule(_isInSIMDModule);
+            callbacks[13] = Marshal.GetFunctionPointerForDelegate(d13);
+            delegates[13] = d13;
+            var d14 = new __getUnmanagedCallConv(_getUnmanagedCallConv);
+            callbacks[14] = Marshal.GetFunctionPointerForDelegate(d14);
+            delegates[14] = d14;
+            var d15 = new __pInvokeMarshalingRequired(_pInvokeMarshalingRequired);
+            callbacks[15] = Marshal.GetFunctionPointerForDelegate(d15);
+            delegates[15] = d15;
+            var d16 = new __satisfiesMethodConstraints(_satisfiesMethodConstraints);
+            callbacks[16] = Marshal.GetFunctionPointerForDelegate(d16);
+            delegates[16] = d16;
+            var d17 = new __isCompatibleDelegate(_isCompatibleDelegate);
+            callbacks[17] = Marshal.GetFunctionPointerForDelegate(d17);
+            delegates[17] = d17;
+            var d18 = new __isDelegateCreationAllowed(_isDelegateCreationAllowed);
+            callbacks[18] = Marshal.GetFunctionPointerForDelegate(d18);
+            delegates[18] = d18;
+            var d19 = new __isInstantiationOfVerifiedGeneric(_isInstantiationOfVerifiedGeneric);
+            callbacks[19] = Marshal.GetFunctionPointerForDelegate(d19);
+            delegates[19] = d19;
+            var d20 = new __initConstraintsForVerification(_initConstraintsForVerification);
+            callbacks[20] = Marshal.GetFunctionPointerForDelegate(d20);
+            delegates[20] = d20;
+            var d21 = new __canSkipMethodVerification(_canSkipMethodVerification);
+            callbacks[21] = Marshal.GetFunctionPointerForDelegate(d21);
+            delegates[21] = d21;
+            var d22 = new __methodMustBeLoadedBeforeCodeIsRun(_methodMustBeLoadedBeforeCodeIsRun);
+            callbacks[22] = Marshal.GetFunctionPointerForDelegate(d22);
+            delegates[22] = d22;
+            var d23 = new __mapMethodDeclToMethodImpl(_mapMethodDeclToMethodImpl);
+            callbacks[23] = Marshal.GetFunctionPointerForDelegate(d23);
+            delegates[23] = d23;
+            var d24 = new __getGSCookie(_getGSCookie);
+            callbacks[24] = Marshal.GetFunctionPointerForDelegate(d24);
+            delegates[24] = d24;
+            var d25 = new __resolveToken(_resolveToken);
+            callbacks[25] = Marshal.GetFunctionPointerForDelegate(d25);
+            delegates[25] = d25;
+            var d26 = new __findSig(_findSig);
+            callbacks[26] = Marshal.GetFunctionPointerForDelegate(d26);
+            delegates[26] = d26;
+            var d27 = new __findCallSiteSig(_findCallSiteSig);
+            callbacks[27] = Marshal.GetFunctionPointerForDelegate(d27);
+            delegates[27] = d27;
+            var d28 = new __getTokenTypeAsHandle(_getTokenTypeAsHandle);
+            callbacks[28] = Marshal.GetFunctionPointerForDelegate(d28);
+            delegates[28] = d28;
+            var d29 = new __canSkipVerification(_canSkipVerification);
+            callbacks[29] = Marshal.GetFunctionPointerForDelegate(d29);
+            delegates[29] = d29;
+            var d30 = new __isValidToken(_isValidToken);
+            callbacks[30] = Marshal.GetFunctionPointerForDelegate(d30);
+            delegates[30] = d30;
+            var d31 = new __isValidStringRef(_isValidStringRef);
+            callbacks[31] = Marshal.GetFunctionPointerForDelegate(d31);
+            delegates[31] = d31;
+            var d32 = new __shouldEnforceCallvirtRestriction(_shouldEnforceCallvirtRestriction);
+            callbacks[32] = Marshal.GetFunctionPointerForDelegate(d32);
+            delegates[32] = d32;
+            var d33 = new __asCorInfoType(_asCorInfoType);
+            callbacks[33] = Marshal.GetFunctionPointerForDelegate(d33);
+            delegates[33] = d33;
+            var d34 = new __getClassName(_getClassName);
+            callbacks[34] = Marshal.GetFunctionPointerForDelegate(d34);
+            delegates[34] = d34;
+            var d35 = new __appendClassName(_appendClassName);
+            callbacks[35] = Marshal.GetFunctionPointerForDelegate(d35);
+            delegates[35] = d35;
+            var d36 = new __isValueClass(_isValueClass);
+            callbacks[36] = Marshal.GetFunctionPointerForDelegate(d36);
+            delegates[36] = d36;
+            var d37 = new __canInlineTypeCheckWithObjectVTable(_canInlineTypeCheckWithObjectVTable);
+            callbacks[37] = Marshal.GetFunctionPointerForDelegate(d37);
+            delegates[37] = d37;
+            var d38 = new __getClassAttribs(_getClassAttribs);
+            callbacks[38] = Marshal.GetFunctionPointerForDelegate(d38);
+            delegates[38] = d38;
+            var d39 = new __isStructRequiringStackAllocRetBuf(_isStructRequiringStackAllocRetBuf);
+            callbacks[39] = Marshal.GetFunctionPointerForDelegate(d39);
+            delegates[39] = d39;
+            var d40 = new __getClassModule(_getClassModule);
+            callbacks[40] = Marshal.GetFunctionPointerForDelegate(d40);
+            delegates[40] = d40;
+            var d41 = new __getModuleAssembly(_getModuleAssembly);
+            callbacks[41] = Marshal.GetFunctionPointerForDelegate(d41);
+            delegates[41] = d41;
+            var d42 = new __getAssemblyName(_getAssemblyName);
+            callbacks[42] = Marshal.GetFunctionPointerForDelegate(d42);
+            delegates[42] = d42;
+            var d43 = new __LongLifetimeMalloc(_LongLifetimeMalloc);
+            callbacks[43] = Marshal.GetFunctionPointerForDelegate(d43);
+            delegates[43] = d43;
+            var d44 = new __LongLifetimeFree(_LongLifetimeFree);
+            callbacks[44] = Marshal.GetFunctionPointerForDelegate(d44);
+            delegates[44] = d44;
+            var d45 = new __getClassModuleIdForStatics(_getClassModuleIdForStatics);
+            callbacks[45] = Marshal.GetFunctionPointerForDelegate(d45);
+            delegates[45] = d45;
+            var d46 = new __getClassSize(_getClassSize);
+            callbacks[46] = Marshal.GetFunctionPointerForDelegate(d46);
+            delegates[46] = d46;
+            var d47 = new __getClassAlignmentRequirement(_getClassAlignmentRequirement);
+            callbacks[47] = Marshal.GetFunctionPointerForDelegate(d47);
+            delegates[47] = d47;
+            var d48 = new __getClassGClayout(_getClassGClayout);
+            callbacks[48] = Marshal.GetFunctionPointerForDelegate(d48);
+            delegates[48] = d48;
+            var d49 = new __getClassNumInstanceFields(_getClassNumInstanceFields);
+            callbacks[49] = Marshal.GetFunctionPointerForDelegate(d49);
+            delegates[49] = d49;
+            var d50 = new __getFieldInClass(_getFieldInClass);
+            callbacks[50] = Marshal.GetFunctionPointerForDelegate(d50);
+            delegates[50] = d50;
+            var d51 = new __checkMethodModifier(_checkMethodModifier);
+            callbacks[51] = Marshal.GetFunctionPointerForDelegate(d51);
+            delegates[51] = d51;
+            var d52 = new __getNewHelper(_getNewHelper);
+            callbacks[52] = Marshal.GetFunctionPointerForDelegate(d52);
+            delegates[52] = d52;
+            var d53 = new __getNewArrHelper(_getNewArrHelper);
+            callbacks[53] = Marshal.GetFunctionPointerForDelegate(d53);
+            delegates[53] = d53;
+            var d54 = new __getCastingHelper(_getCastingHelper);
+            callbacks[54] = Marshal.GetFunctionPointerForDelegate(d54);
+            delegates[54] = d54;
+            var d55 = new __getSharedCCtorHelper(_getSharedCCtorHelper);
+            callbacks[55] = Marshal.GetFunctionPointerForDelegate(d55);
+            delegates[55] = d55;
+            var d56 = new __getSecurityPrologHelper(_getSecurityPrologHelper);
+            callbacks[56] = Marshal.GetFunctionPointerForDelegate(d56);
+            delegates[56] = d56;
+            var d57 = new __getTypeForBox(_getTypeForBox);
+            callbacks[57] = Marshal.GetFunctionPointerForDelegate(d57);
+            delegates[57] = d57;
+            var d58 = new __getBoxHelper(_getBoxHelper);
+            callbacks[58] = Marshal.GetFunctionPointerForDelegate(d58);
+            delegates[58] = d58;
+            var d59 = new __getUnBoxHelper(_getUnBoxHelper);
+            callbacks[59] = Marshal.GetFunctionPointerForDelegate(d59);
+            delegates[59] = d59;
+            var d60 = new __getReadyToRunHelper(_getReadyToRunHelper);
+            callbacks[60] = Marshal.GetFunctionPointerForDelegate(d60);
+            delegates[60] = d60;
+            var d61 = new __getReadyToRunDelegateCtorHelper(_getReadyToRunDelegateCtorHelper);
+            callbacks[61] = Marshal.GetFunctionPointerForDelegate(d61);
+            delegates[61] = d61;
+            var d62 = new __getHelperName(_getHelperName);
+            callbacks[62] = Marshal.GetFunctionPointerForDelegate(d62);
+            delegates[62] = d62;
+            var d63 = new __initClass(_initClass);
+            callbacks[63] = Marshal.GetFunctionPointerForDelegate(d63);
+            delegates[63] = d63;
+            var d64 = new __classMustBeLoadedBeforeCodeIsRun(_classMustBeLoadedBeforeCodeIsRun);
+            callbacks[64] = Marshal.GetFunctionPointerForDelegate(d64);
+            delegates[64] = d64;
+            var d65 = new __getBuiltinClass(_getBuiltinClass);
+            callbacks[65] = Marshal.GetFunctionPointerForDelegate(d65);
+            delegates[65] = d65;
+            var d66 = new __getTypeForPrimitiveValueClass(_getTypeForPrimitiveValueClass);
+            callbacks[66] = Marshal.GetFunctionPointerForDelegate(d66);
+            delegates[66] = d66;
+            var d67 = new __canCast(_canCast);
+            callbacks[67] = Marshal.GetFunctionPointerForDelegate(d67);
+            delegates[67] = d67;
+            var d68 = new __areTypesEquivalent(_areTypesEquivalent);
+            callbacks[68] = Marshal.GetFunctionPointerForDelegate(d68);
+            delegates[68] = d68;
+            var d69 = new __mergeClasses(_mergeClasses);
+            callbacks[69] = Marshal.GetFunctionPointerForDelegate(d69);
+            delegates[69] = d69;
+            var d70 = new __getParentType(_getParentType);
+            callbacks[70] = Marshal.GetFunctionPointerForDelegate(d70);
+            delegates[70] = d70;
+            var d71 = new __getChildType(_getChildType);
+            callbacks[71] = Marshal.GetFunctionPointerForDelegate(d71);
+            delegates[71] = d71;
+            var d72 = new __satisfiesClassConstraints(_satisfiesClassConstraints);
+            callbacks[72] = Marshal.GetFunctionPointerForDelegate(d72);
+            delegates[72] = d72;
+            var d73 = new __isSDArray(_isSDArray);
+            callbacks[73] = Marshal.GetFunctionPointerForDelegate(d73);
+            delegates[73] = d73;
+            var d74 = new __getArrayRank(_getArrayRank);
+            callbacks[74] = Marshal.GetFunctionPointerForDelegate(d74);
+            delegates[74] = d74;
+            var d75 = new __getArrayInitializationData(_getArrayInitializationData);
+            callbacks[75] = Marshal.GetFunctionPointerForDelegate(d75);
+            delegates[75] = d75;
+            var d76 = new __canAccessClass(_canAccessClass);
+            callbacks[76] = Marshal.GetFunctionPointerForDelegate(d76);
+            delegates[76] = d76;
+            var d77 = new __getFieldName(_getFieldName);
+            callbacks[77] = Marshal.GetFunctionPointerForDelegate(d77);
+            delegates[77] = d77;
+            var d78 = new __getFieldClass(_getFieldClass);
+            callbacks[78] = Marshal.GetFunctionPointerForDelegate(d78);
+            delegates[78] = d78;
+            var d79 = new __getFieldType(_getFieldType);
+            callbacks[79] = Marshal.GetFunctionPointerForDelegate(d79);
+            delegates[79] = d79;
+            var d80 = new __getFieldOffset(_getFieldOffset);
+            callbacks[80] = Marshal.GetFunctionPointerForDelegate(d80);
+            delegates[80] = d80;
+            var d81 = new __isWriteBarrierHelperRequired(_isWriteBarrierHelperRequired);
+            callbacks[81] = Marshal.GetFunctionPointerForDelegate(d81);
+            delegates[81] = d81;
+            var d82 = new __getFieldInfo(_getFieldInfo);
+            callbacks[82] = Marshal.GetFunctionPointerForDelegate(d82);
+            delegates[82] = d82;
+            var d83 = new __isFieldStatic(_isFieldStatic);
+            callbacks[83] = Marshal.GetFunctionPointerForDelegate(d83);
+            delegates[83] = d83;
+            var d84 = new __getBoundaries(_getBoundaries);
+            callbacks[84] = Marshal.GetFunctionPointerForDelegate(d84);
+            delegates[84] = d84;
+            var d85 = new __setBoundaries(_setBoundaries);
+            callbacks[85] = Marshal.GetFunctionPointerForDelegate(d85);
+            delegates[85] = d85;
+            var d86 = new __getVars(_getVars);
+            callbacks[86] = Marshal.GetFunctionPointerForDelegate(d86);
+            delegates[86] = d86;
+            var d87 = new __setVars(_setVars);
+            callbacks[87] = Marshal.GetFunctionPointerForDelegate(d87);
+            delegates[87] = d87;
+            var d88 = new __allocateArray(_allocateArray);
+            callbacks[88] = Marshal.GetFunctionPointerForDelegate(d88);
+            delegates[88] = d88;
+            var d89 = new __freeArray(_freeArray);
+            callbacks[89] = Marshal.GetFunctionPointerForDelegate(d89);
+            delegates[89] = d89;
+            var d90 = new __getArgNext(_getArgNext);
+            callbacks[90] = Marshal.GetFunctionPointerForDelegate(d90);
+            delegates[90] = d90;
+            var d91 = new __getArgType(_getArgType);
+            callbacks[91] = Marshal.GetFunctionPointerForDelegate(d91);
+            delegates[91] = d91;
+            var d92 = new __getArgClass(_getArgClass);
+            callbacks[92] = Marshal.GetFunctionPointerForDelegate(d92);
+            delegates[92] = d92;
+            var d93 = new __getHFAType(_getHFAType);
+            callbacks[93] = Marshal.GetFunctionPointerForDelegate(d93);
+            delegates[93] = d93;
+            var d94 = new __GetErrorHRESULT(_GetErrorHRESULT);
+            callbacks[94] = Marshal.GetFunctionPointerForDelegate(d94);
+            delegates[94] = d94;
+            var d95 = new __GetErrorMessage(_GetErrorMessage);
+            callbacks[95] = Marshal.GetFunctionPointerForDelegate(d95);
+            delegates[95] = d95;
+            var d96 = new __FilterException(_FilterException);
+            callbacks[96] = Marshal.GetFunctionPointerForDelegate(d96);
+            delegates[96] = d96;
+            var d97 = new __HandleException(_HandleException);
+            callbacks[97] = Marshal.GetFunctionPointerForDelegate(d97);
+            delegates[97] = d97;
+            var d98 = new __ThrowExceptionForJitResult(_ThrowExceptionForJitResult);
+            callbacks[98] = Marshal.GetFunctionPointerForDelegate(d98);
+            delegates[98] = d98;
+            var d99 = new __ThrowExceptionForHelper(_ThrowExceptionForHelper);
+            callbacks[99] = Marshal.GetFunctionPointerForDelegate(d99);
+            delegates[99] = d99;
+            var d100 = new __getEEInfo(_getEEInfo);
+            callbacks[100] = Marshal.GetFunctionPointerForDelegate(d100);
+            delegates[100] = d100;
+            var d101 = new __getJitTimeLogFilename(_getJitTimeLogFilename);
+            callbacks[101] = Marshal.GetFunctionPointerForDelegate(d101);
+            delegates[101] = d101;
+            var d102 = new __getMethodDefFromMethod(_getMethodDefFromMethod);
+            callbacks[102] = Marshal.GetFunctionPointerForDelegate(d102);
+            delegates[102] = d102;
+            var d103 = new __getMethodName(_getMethodName);
+            callbacks[103] = Marshal.GetFunctionPointerForDelegate(d103);
+            delegates[103] = d103;
+            var d104 = new __getMethodHash(_getMethodHash);
+            callbacks[104] = Marshal.GetFunctionPointerForDelegate(d104);
+            delegates[104] = d104;
+            var d105 = new __findNameOfToken(_findNameOfToken);
+            callbacks[105] = Marshal.GetFunctionPointerForDelegate(d105);
+            delegates[105] = d105;
+            var d106 = new __getSystemVAmd64PassStructInRegisterDescriptor(_getSystemVAmd64PassStructInRegisterDescriptor);
+            callbacks[106] = Marshal.GetFunctionPointerForDelegate(d106);
+            delegates[106] = d106;
+            var d107 = new __getThreadTLSIndex(_getThreadTLSIndex);
+            callbacks[107] = Marshal.GetFunctionPointerForDelegate(d107);
+            delegates[107] = d107;
+            var d108 = new __getInlinedCallFrameVptr(_getInlinedCallFrameVptr);
+            callbacks[108] = Marshal.GetFunctionPointerForDelegate(d108);
+            delegates[108] = d108;
+            var d109 = new __getAddrOfCaptureThreadGlobal(_getAddrOfCaptureThreadGlobal);
+            callbacks[109] = Marshal.GetFunctionPointerForDelegate(d109);
+            delegates[109] = d109;
+            var d110 = new __getAddrModuleDomainID(_getAddrModuleDomainID);
+            callbacks[110] = Marshal.GetFunctionPointerForDelegate(d110);
+            delegates[110] = d110;
+            var d111 = new __getHelperFtn(_getHelperFtn);
+            callbacks[111] = Marshal.GetFunctionPointerForDelegate(d111);
+            delegates[111] = d111;
+            var d112 = new __getFunctionEntryPoint(_getFunctionEntryPoint);
+            callbacks[112] = Marshal.GetFunctionPointerForDelegate(d112);
+            delegates[112] = d112;
+            var d113 = new __getFunctionFixedEntryPoint(_getFunctionFixedEntryPoint);
+            callbacks[113] = Marshal.GetFunctionPointerForDelegate(d113);
+            delegates[113] = d113;
+            var d114 = new __getMethodSync(_getMethodSync);
+            callbacks[114] = Marshal.GetFunctionPointerForDelegate(d114);
+            delegates[114] = d114;
+            var d115 = new __getLazyStringLiteralHelper(_getLazyStringLiteralHelper);
+            callbacks[115] = Marshal.GetFunctionPointerForDelegate(d115);
+            delegates[115] = d115;
+            var d116 = new __embedModuleHandle(_embedModuleHandle);
+            callbacks[116] = Marshal.GetFunctionPointerForDelegate(d116);
+            delegates[116] = d116;
+            var d117 = new __embedClassHandle(_embedClassHandle);
+            callbacks[117] = Marshal.GetFunctionPointerForDelegate(d117);
+            delegates[117] = d117;
+            var d118 = new __embedMethodHandle(_embedMethodHandle);
+            callbacks[118] = Marshal.GetFunctionPointerForDelegate(d118);
+            delegates[118] = d118;
+            var d119 = new __embedFieldHandle(_embedFieldHandle);
+            callbacks[119] = Marshal.GetFunctionPointerForDelegate(d119);
+            delegates[119] = d119;
+            var d120 = new __embedGenericHandle(_embedGenericHandle);
+            callbacks[120] = Marshal.GetFunctionPointerForDelegate(d120);
+            delegates[120] = d120;
+            var d121 = new __getLocationOfThisType(_getLocationOfThisType);
+            callbacks[121] = Marshal.GetFunctionPointerForDelegate(d121);
+            delegates[121] = d121;
+            var d122 = new __getPInvokeUnmanagedTarget(_getPInvokeUnmanagedTarget);
+            callbacks[122] = Marshal.GetFunctionPointerForDelegate(d122);
+            delegates[122] = d122;
+            var d123 = new __getAddressOfPInvokeFixup(_getAddressOfPInvokeFixup);
+            callbacks[123] = Marshal.GetFunctionPointerForDelegate(d123);
+            delegates[123] = d123;
+            var d124 = new __getAddressOfPInvokeTarget(_getAddressOfPInvokeTarget);
+            callbacks[124] = Marshal.GetFunctionPointerForDelegate(d124);
+            delegates[124] = d124;
+            var d125 = new __GetCookieForPInvokeCalliSig(_GetCookieForPInvokeCalliSig);
+            callbacks[125] = Marshal.GetFunctionPointerForDelegate(d125);
+            delegates[125] = d125;
+            var d126 = new __canGetCookieForPInvokeCalliSig(_canGetCookieForPInvokeCalliSig);
+            callbacks[126] = Marshal.GetFunctionPointerForDelegate(d126);
+            delegates[126] = d126;
+            var d127 = new __getJustMyCodeHandle(_getJustMyCodeHandle);
+            callbacks[127] = Marshal.GetFunctionPointerForDelegate(d127);
+            delegates[127] = d127;
+            var d128 = new __GetProfilingHandle(_GetProfilingHandle);
+            callbacks[128] = Marshal.GetFunctionPointerForDelegate(d128);
+            delegates[128] = d128;
+            var d129 = new __getCallInfo(_getCallInfo);
+            callbacks[129] = Marshal.GetFunctionPointerForDelegate(d129);
+            delegates[129] = d129;
+            var d130 = new __canAccessFamily(_canAccessFamily);
+            callbacks[130] = Marshal.GetFunctionPointerForDelegate(d130);
+            delegates[130] = d130;
+            var d131 = new __isRIDClassDomainID(_isRIDClassDomainID);
+            callbacks[131] = Marshal.GetFunctionPointerForDelegate(d131);
+            delegates[131] = d131;
+            var d132 = new __getClassDomainID(_getClassDomainID);
+            callbacks[132] = Marshal.GetFunctionPointerForDelegate(d132);
+            delegates[132] = d132;
+            var d133 = new __getFieldAddress(_getFieldAddress);
+            callbacks[133] = Marshal.GetFunctionPointerForDelegate(d133);
+            delegates[133] = d133;
+            var d134 = new __getVarArgsHandle(_getVarArgsHandle);
+            callbacks[134] = Marshal.GetFunctionPointerForDelegate(d134);
+            delegates[134] = d134;
+            var d135 = new __canGetVarArgsHandle(_canGetVarArgsHandle);
+            callbacks[135] = Marshal.GetFunctionPointerForDelegate(d135);
+            delegates[135] = d135;
+            var d136 = new __constructStringLiteral(_constructStringLiteral);
+            callbacks[136] = Marshal.GetFunctionPointerForDelegate(d136);
+            delegates[136] = d136;
+            var d137 = new __emptyStringLiteral(_emptyStringLiteral);
+            callbacks[137] = Marshal.GetFunctionPointerForDelegate(d137);
+            delegates[137] = d137;
+            var d138 = new __getFieldThreadLocalStoreID(_getFieldThreadLocalStoreID);
+            callbacks[138] = Marshal.GetFunctionPointerForDelegate(d138);
+            delegates[138] = d138;
+            var d139 = new __setOverride(_setOverride);
+            callbacks[139] = Marshal.GetFunctionPointerForDelegate(d139);
+            delegates[139] = d139;
+            var d140 = new __addActiveDependency(_addActiveDependency);
+            callbacks[140] = Marshal.GetFunctionPointerForDelegate(d140);
+            delegates[140] = d140;
+            var d141 = new __GetDelegateCtor(_GetDelegateCtor);
+            callbacks[141] = Marshal.GetFunctionPointerForDelegate(d141);
+            delegates[141] = d141;
+            var d142 = new __MethodCompileComplete(_MethodCompileComplete);
+            callbacks[142] = Marshal.GetFunctionPointerForDelegate(d142);
+            delegates[142] = d142;
+            var d143 = new __getTailCallCopyArgsThunk(_getTailCallCopyArgsThunk);
+            callbacks[143] = Marshal.GetFunctionPointerForDelegate(d143);
+            delegates[143] = d143;
+            var d144 = new __getMemoryManager(_getMemoryManager);
+            callbacks[144] = Marshal.GetFunctionPointerForDelegate(d144);
+            delegates[144] = d144;
+            var d145 = new __allocMem(_allocMem);
+            callbacks[145] = Marshal.GetFunctionPointerForDelegate(d145);
+            delegates[145] = d145;
+            var d146 = new __reserveUnwindInfo(_reserveUnwindInfo);
+            callbacks[146] = Marshal.GetFunctionPointerForDelegate(d146);
+            delegates[146] = d146;
+            var d147 = new __allocUnwindInfo(_allocUnwindInfo);
+            callbacks[147] = Marshal.GetFunctionPointerForDelegate(d147);
+            delegates[147] = d147;
+            var d148 = new __allocGCInfo(_allocGCInfo);
+            callbacks[148] = Marshal.GetFunctionPointerForDelegate(d148);
+            delegates[148] = d148;
+            var d149 = new __yieldExecution(_yieldExecution);
+            callbacks[149] = Marshal.GetFunctionPointerForDelegate(d149);
+            delegates[149] = d149;
+            var d150 = new __setEHcount(_setEHcount);
+            callbacks[150] = Marshal.GetFunctionPointerForDelegate(d150);
+            delegates[150] = d150;
+            var d151 = new __setEHinfo(_setEHinfo);
+            callbacks[151] = Marshal.GetFunctionPointerForDelegate(d151);
+            delegates[151] = d151;
+            var d152 = new __logMsg(_logMsg);
+            callbacks[152] = Marshal.GetFunctionPointerForDelegate(d152);
+            delegates[152] = d152;
+            var d153 = new __doAssert(_doAssert);
+            callbacks[153] = Marshal.GetFunctionPointerForDelegate(d153);
+            delegates[153] = d153;
+            var d154 = new __reportFatalError(_reportFatalError);
+            callbacks[154] = Marshal.GetFunctionPointerForDelegate(d154);
+            delegates[154] = d154;
+            var d155 = new __allocBBProfileBuffer(_allocBBProfileBuffer);
+            callbacks[155] = Marshal.GetFunctionPointerForDelegate(d155);
+            delegates[155] = d155;
+            var d156 = new __getBBProfileData(_getBBProfileData);
+            callbacks[156] = Marshal.GetFunctionPointerForDelegate(d156);
+            delegates[156] = d156;
+            var d157 = new __recordCallSite(_recordCallSite);
+            callbacks[157] = Marshal.GetFunctionPointerForDelegate(d157);
+            delegates[157] = d157;
+            var d158 = new __recordRelocation(_recordRelocation);
+            callbacks[158] = Marshal.GetFunctionPointerForDelegate(d158);
+            delegates[158] = d158;
+            var d159 = new __getRelocTypeHint(_getRelocTypeHint);
+            callbacks[159] = Marshal.GetFunctionPointerForDelegate(d159);
+            delegates[159] = d159;
+            var d160 = new __getModuleNativeEntryPointRange(_getModuleNativeEntryPointRange);
+            callbacks[160] = Marshal.GetFunctionPointerForDelegate(d160);
+            delegates[160] = d160;
+            var d161 = new __getExpectedTargetArchitecture(_getExpectedTargetArchitecture);
+            callbacks[161] = Marshal.GetFunctionPointerForDelegate(d161);
+            delegates[161] = d161;
+            var d162 = new __getJitFlags(_getJitFlags);
+            callbacks[162] = Marshal.GetFunctionPointerForDelegate(d162);
+            delegates[162] = d162;
 
-            IntPtr instance = Marshal.AllocCoTaskMem(sizeof(IntPtr));
-            *(IntPtr**)instance = vtable;
-            return instance;
+            keepAlive = delegates;
+            return (IntPtr)callbacks;
         }
     }
 }

--- a/src/Native/jitinterface/jitinterface.cpp
+++ b/src/Native/jitinterface/jitinterface.cpp
@@ -6,8 +6,8 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#include "jitinterface.h"
 #include "dllexport.h"
+#include "jitinterface.h"
 
 enum CORINFO_RUNTIME_LOOKUP_KIND { };
 struct CORINFO_LOOKUP_KIND
@@ -29,7 +29,7 @@ CORINFO_LOOKUP_KIND JitInterfaceWrapper::getLocationOfThisType(void* context)
 {
     CorInfoException* pException = nullptr;
     CORINFO_LOOKUP_KIND _ret;
-    _pCorInfo->getLocationOfThisType(&pException, &_ret, context);
+    _callbacks->getLocationOfThisType(_thisHandle, &pException, &_ret, context);
     if (pException != nullptr)
     {
         throw pException;
@@ -82,12 +82,4 @@ static EEMemoryManager eeMemoryManager;
 void* JitInterfaceWrapper::getMemoryManager()
 {
     return &eeMemoryManager;
-}
-
-static JitInterfaceWrapper instance;
-
-DLL_EXPORT void* __stdcall GetJitInterfaceWrapper(IJitInterface *pCorInfo)
-{
-    instance._pCorInfo = pCorInfo;
-    return &instance;
 }

--- a/src/Native/jitinterface/jitinterface.h
+++ b/src/Native/jitinterface/jitinterface.h
@@ -8,1728 +8,1574 @@
 
 struct CORINFO_LOOKUP_KIND;
 
-class IJitInterface
+struct JitInterfaceCallbacks
 {
-public:
-    virtual unsigned int getMethodAttribs(CorInfoException** ppException, void* ftn) = 0;
-    virtual void setMethodAttribs(CorInfoException** ppException, void* ftn, int attribs) = 0;
-    virtual void getMethodSig(CorInfoException** ppException, void* ftn, void* sig, void* memberParent) = 0;
-    virtual bool getMethodInfo(CorInfoException** ppException, void* ftn, void* info) = 0;
-    virtual int canInline(CorInfoException** ppException, void* callerHnd, void* calleeHnd, unsigned int* pRestrictions) = 0;
-    virtual void reportInliningDecision(CorInfoException** ppException, void* inlinerHnd, void* inlineeHnd, int inlineResult, const char* reason) = 0;
-    virtual bool canTailCall(CorInfoException** ppException, void* callerHnd, void* declaredCalleeHnd, void* exactCalleeHnd, bool fIsTailPrefix) = 0;
-    virtual void reportTailCallDecision(CorInfoException** ppException, void* callerHnd, void* calleeHnd, bool fIsTailPrefix, int tailCallResult, const char* reason) = 0;
-    virtual void getEHinfo(CorInfoException** ppException, void* ftn, unsigned EHnumber, void* clause) = 0;
-    virtual void* getMethodClass(CorInfoException** ppException, void* method) = 0;
-    virtual void* getMethodModule(CorInfoException** ppException, void* method) = 0;
-    virtual void getMethodVTableOffset(CorInfoException** ppException, void* method, unsigned* offsetOfIndirection, unsigned* offsetAfterIndirection) = 0;
-    virtual int getIntrinsicID(CorInfoException** ppException, void* method, bool* pMustExpand) = 0;
-    virtual bool isInSIMDModule(CorInfoException** ppException, void* classHnd) = 0;
-    virtual int getUnmanagedCallConv(CorInfoException** ppException, void* method) = 0;
-    virtual bool pInvokeMarshalingRequired(CorInfoException** ppException, void* method, void* callSiteSig) = 0;
-    virtual bool satisfiesMethodConstraints(CorInfoException** ppException, void* parent, void* method) = 0;
-    virtual bool isCompatibleDelegate(CorInfoException** ppException, void* objCls, void* methodParentCls, void* method, void* delegateCls, int* pfIsOpenDelegate) = 0;
-    virtual bool isDelegateCreationAllowed(CorInfoException** ppException, void* delegateHnd, void* calleeHnd) = 0;
-    virtual int isInstantiationOfVerifiedGeneric(CorInfoException** ppException, void* method) = 0;
-    virtual void initConstraintsForVerification(CorInfoException** ppException, void* method, int* pfHasCircularClassConstraints, int* pfHasCircularMethodConstraint) = 0;
-    virtual int canSkipMethodVerification(CorInfoException** ppException, void* ftnHandle) = 0;
-    virtual void methodMustBeLoadedBeforeCodeIsRun(CorInfoException** ppException, void* method) = 0;
-    virtual void* mapMethodDeclToMethodImpl(CorInfoException** ppException, void* method) = 0;
-    virtual void getGSCookie(CorInfoException** ppException, void* pCookieVal, void** ppCookieVal) = 0;
-    virtual void resolveToken(CorInfoException** ppException, void* pResolvedToken) = 0;
-    virtual void findSig(CorInfoException** ppException, void* module, unsigned sigTOK, void* context, void* sig) = 0;
-    virtual void findCallSiteSig(CorInfoException** ppException, void* module, unsigned methTOK, void* context, void* sig) = 0;
-    virtual void* getTokenTypeAsHandle(CorInfoException** ppException, void* pResolvedToken) = 0;
-    virtual int canSkipVerification(CorInfoException** ppException, void* module) = 0;
-    virtual bool isValidToken(CorInfoException** ppException, void* module, unsigned metaTOK) = 0;
-    virtual bool isValidStringRef(CorInfoException** ppException, void* module, unsigned metaTOK) = 0;
-    virtual bool shouldEnforceCallvirtRestriction(CorInfoException** ppException, void* scope) = 0;
-    virtual int asCorInfoType(CorInfoException** ppException, void* cls) = 0;
-    virtual const char* getClassName(CorInfoException** ppException, void* cls) = 0;
-    virtual int appendClassName(CorInfoException** ppException, wchar_t** ppBuf, int* pnBufLen, void* cls, bool fNamespace, bool fFullInst, bool fAssembly) = 0;
-    virtual bool isValueClass(CorInfoException** ppException, void* cls) = 0;
-    virtual bool canInlineTypeCheckWithObjectVTable(CorInfoException** ppException, void* cls) = 0;
-    virtual unsigned int getClassAttribs(CorInfoException** ppException, void* cls) = 0;
-    virtual bool isStructRequiringStackAllocRetBuf(CorInfoException** ppException, void* cls) = 0;
-    virtual void* getClassModule(CorInfoException** ppException, void* cls) = 0;
-    virtual void* getModuleAssembly(CorInfoException** ppException, void* mod) = 0;
-    virtual const char* getAssemblyName(CorInfoException** ppException, void* assem) = 0;
-    virtual void* LongLifetimeMalloc(CorInfoException** ppException, size_t sz) = 0;
-    virtual void LongLifetimeFree(CorInfoException** ppException, void* obj) = 0;
-    virtual size_t getClassModuleIdForStatics(CorInfoException** ppException, void* cls, void* pModule, void** ppIndirection) = 0;
-    virtual unsigned getClassSize(CorInfoException** ppException, void* cls) = 0;
-    virtual unsigned getClassAlignmentRequirement(CorInfoException** ppException, void* cls, bool fDoubleAlignHint) = 0;
-    virtual unsigned getClassGClayout(CorInfoException** ppException, void* cls, unsigned char* gcPtrs) = 0;
-    virtual unsigned getClassNumInstanceFields(CorInfoException** ppException, void* cls) = 0;
-    virtual void* getFieldInClass(CorInfoException** ppException, void* clsHnd, int num) = 0;
-    virtual bool checkMethodModifier(CorInfoException** ppException, void* hMethod, const char* modifier, bool fOptional) = 0;
-    virtual int getNewHelper(CorInfoException** ppException, void* pResolvedToken, void* callerHandle) = 0;
-    virtual int getNewArrHelper(CorInfoException** ppException, void* arrayCls) = 0;
-    virtual int getCastingHelper(CorInfoException** ppException, void* pResolvedToken, bool fThrowing) = 0;
-    virtual int getSharedCCtorHelper(CorInfoException** ppException, void* clsHnd) = 0;
-    virtual int getSecurityPrologHelper(CorInfoException** ppException, void* ftn) = 0;
-    virtual void* getTypeForBox(CorInfoException** ppException, void* cls) = 0;
-    virtual int getBoxHelper(CorInfoException** ppException, void* cls) = 0;
-    virtual int getUnBoxHelper(CorInfoException** ppException, void* cls) = 0;
-    virtual void getReadyToRunHelper(CorInfoException** ppException, void* pResolvedToken, int id, void* pLookup) = 0;
-    virtual void getReadyToRunDelegateCtorHelper(CorInfoException** ppException, void* pTargetMethod, void* delegateType, void* pLookup) = 0;
-    virtual const char* getHelperName(CorInfoException** ppException, int helpFunc) = 0;
-    virtual int initClass(CorInfoException** ppException, void* field, void* method, void* context, bool speculative) = 0;
-    virtual void classMustBeLoadedBeforeCodeIsRun(CorInfoException** ppException, void* cls) = 0;
-    virtual void* getBuiltinClass(CorInfoException** ppException, int classId) = 0;
-    virtual int getTypeForPrimitiveValueClass(CorInfoException** ppException, void* cls) = 0;
-    virtual bool canCast(CorInfoException** ppException, void* child, void* parent) = 0;
-    virtual bool areTypesEquivalent(CorInfoException** ppException, void* cls1, void* cls2) = 0;
-    virtual void* mergeClasses(CorInfoException** ppException, void* cls1, void* cls2) = 0;
-    virtual void* getParentType(CorInfoException** ppException, void* cls) = 0;
-    virtual int getChildType(CorInfoException** ppException, void* clsHnd, void* clsRet) = 0;
-    virtual bool satisfiesClassConstraints(CorInfoException** ppException, void* cls) = 0;
-    virtual bool isSDArray(CorInfoException** ppException, void* cls) = 0;
-    virtual unsigned getArrayRank(CorInfoException** ppException, void* cls) = 0;
-    virtual void* getArrayInitializationData(CorInfoException** ppException, void* field, unsigned int size) = 0;
-    virtual int canAccessClass(CorInfoException** ppException, void* pResolvedToken, void* callerHandle, void* pAccessHelper) = 0;
-    virtual const char* getFieldName(CorInfoException** ppException, void* ftn, const char** moduleName) = 0;
-    virtual void* getFieldClass(CorInfoException** ppException, void* field) = 0;
-    virtual int getFieldType(CorInfoException** ppException, void* field, void* structType, void* memberParent) = 0;
-    virtual unsigned getFieldOffset(CorInfoException** ppException, void* field) = 0;
-    virtual bool isWriteBarrierHelperRequired(CorInfoException** ppException, void* field) = 0;
-    virtual void getFieldInfo(CorInfoException** ppException, void* pResolvedToken, void* callerHandle, int flags, void* pResult) = 0;
-    virtual bool isFieldStatic(CorInfoException** ppException, void* fldHnd) = 0;
-    virtual void getBoundaries(CorInfoException** ppException, void* ftn, unsigned int* cILOffsets, unsigned int** pILOffsets, void* implictBoundaries) = 0;
-    virtual void setBoundaries(CorInfoException** ppException, void* ftn, unsigned int cMap, void* pMap) = 0;
-    virtual void getVars(CorInfoException** ppException, void* ftn, unsigned int* cVars, void* vars, bool* extendOthers) = 0;
-    virtual void setVars(CorInfoException** ppException, void* ftn, unsigned int cVars, void* vars) = 0;
-    virtual void* allocateArray(CorInfoException** ppException, unsigned int cBytes) = 0;
-    virtual void freeArray(CorInfoException** ppException, void* array) = 0;
-    virtual void* getArgNext(CorInfoException** ppException, void* args) = 0;
-    virtual int getArgType(CorInfoException** ppException, void* sig, void* args, void* vcTypeRet) = 0;
-    virtual void* getArgClass(CorInfoException** ppException, void* sig, void* args) = 0;
-    virtual int getHFAType(CorInfoException** ppException, void* hClass) = 0;
-    virtual int GetErrorHRESULT(CorInfoException** ppException, void* pExceptionPointers) = 0;
-    virtual unsigned int GetErrorMessage(CorInfoException** ppException, wchar_t* buffer, unsigned int bufferLength) = 0;
-    virtual int FilterException(CorInfoException** ppException, void* pExceptionPointers) = 0;
-    virtual void HandleException(CorInfoException** ppException, void* pExceptionPointers) = 0;
-    virtual void ThrowExceptionForJitResult(CorInfoException** ppException, int result) = 0;
-    virtual void ThrowExceptionForHelper(CorInfoException** ppException, const void* throwHelper) = 0;
-    virtual void getEEInfo(CorInfoException** ppException, void* pEEInfoOut) = 0;
-    virtual const wchar_t* getJitTimeLogFilename(CorInfoException** ppException) = 0;
-    virtual unsigned int getMethodDefFromMethod(CorInfoException** ppException, void* hMethod) = 0;
-    virtual const char* getMethodName(CorInfoException** ppException, void* ftn, const char** moduleName) = 0;
-    virtual unsigned getMethodHash(CorInfoException** ppException, void* ftn) = 0;
-    virtual size_t findNameOfToken(CorInfoException** ppException, void* moduleHandle, unsigned int token, char* szFQName, size_t FQNameCapacity) = 0;
-    virtual bool getSystemVAmd64PassStructInRegisterDescriptor(CorInfoException** ppException, void* structHnd, void* structPassInRegDescPtr) = 0;
-    virtual unsigned int getThreadTLSIndex(CorInfoException** ppException, void** ppIndirection) = 0;
-    virtual const void* getInlinedCallFrameVptr(CorInfoException** ppException, void** ppIndirection) = 0;
-    virtual long* getAddrOfCaptureThreadGlobal(CorInfoException** ppException, void** ppIndirection) = 0;
-    virtual size_t* getAddrModuleDomainID(CorInfoException** ppException, void* module) = 0;
-    virtual void* getHelperFtn(CorInfoException** ppException, int ftnNum, void** ppIndirection) = 0;
-    virtual void getFunctionEntryPoint(CorInfoException** ppException, void* ftn, void* pResult, int accessFlags) = 0;
-    virtual void getFunctionFixedEntryPoint(CorInfoException** ppException, void* ftn, void* pResult) = 0;
-    virtual void* getMethodSync(CorInfoException** ppException, void* ftn, void** ppIndirection) = 0;
-    virtual int getLazyStringLiteralHelper(CorInfoException** ppException, void* handle) = 0;
-    virtual void* embedModuleHandle(CorInfoException** ppException, void* handle, void** ppIndirection) = 0;
-    virtual void* embedClassHandle(CorInfoException** ppException, void* handle, void** ppIndirection) = 0;
-    virtual void* embedMethodHandle(CorInfoException** ppException, void* handle, void** ppIndirection) = 0;
-    virtual void* embedFieldHandle(CorInfoException** ppException, void* handle, void** ppIndirection) = 0;
-    virtual void embedGenericHandle(CorInfoException** ppException, void* pResolvedToken, bool fEmbedParent, void* pResult) = 0;
-    virtual void getLocationOfThisType(CorInfoException** ppException, CORINFO_LOOKUP_KIND* _return, void* context) = 0;
-    virtual void* getPInvokeUnmanagedTarget(CorInfoException** ppException, void* method, void** ppIndirection) = 0;
-    virtual void* getAddressOfPInvokeFixup(CorInfoException** ppException, void* method, void** ppIndirection) = 0;
-    virtual void getAddressOfPInvokeTarget(CorInfoException** ppException, void* method, void* pLookup) = 0;
-    virtual void* GetCookieForPInvokeCalliSig(CorInfoException** ppException, void* szMetaSig, void** ppIndirection) = 0;
-    virtual bool canGetCookieForPInvokeCalliSig(CorInfoException** ppException, void* szMetaSig) = 0;
-    virtual void* getJustMyCodeHandle(CorInfoException** ppException, void* method, void** ppIndirection) = 0;
-    virtual void GetProfilingHandle(CorInfoException** ppException, int* pbHookFunction, void** pProfilerHandle, int* pbIndirectedHandles) = 0;
-    virtual void getCallInfo(CorInfoException** ppException, void* pResolvedToken, void* pConstrainedResolvedToken, void* callerHandle, int flags, void* pResult) = 0;
-    virtual bool canAccessFamily(CorInfoException** ppException, void* hCaller, void* hInstanceType) = 0;
-    virtual bool isRIDClassDomainID(CorInfoException** ppException, void* cls) = 0;
-    virtual unsigned getClassDomainID(CorInfoException** ppException, void* cls, void** ppIndirection) = 0;
-    virtual void* getFieldAddress(CorInfoException** ppException, void* field, void** ppIndirection) = 0;
-    virtual void* getVarArgsHandle(CorInfoException** ppException, void* pSig, void** ppIndirection) = 0;
-    virtual bool canGetVarArgsHandle(CorInfoException** ppException, void* pSig) = 0;
-    virtual int constructStringLiteral(CorInfoException** ppException, void* module, unsigned int metaTok, void** ppValue) = 0;
-    virtual int emptyStringLiteral(CorInfoException** ppException, void** ppValue) = 0;
-    virtual unsigned int getFieldThreadLocalStoreID(CorInfoException** ppException, void* field, void** ppIndirection) = 0;
-    virtual void setOverride(CorInfoException** ppException, void* pOverride, void* currentMethod) = 0;
-    virtual void addActiveDependency(CorInfoException** ppException, void* moduleFrom, void* moduleTo) = 0;
-    virtual void* GetDelegateCtor(CorInfoException** ppException, void* methHnd, void* clsHnd, void* targetMethodHnd, void* pCtorData) = 0;
-    virtual void MethodCompileComplete(CorInfoException** ppException, void* methHnd) = 0;
-    virtual void* getTailCallCopyArgsThunk(CorInfoException** ppException, void* pSig, int flags) = 0;
-    virtual void* getMemoryManager(CorInfoException** ppException) = 0;
-    virtual void allocMem(CorInfoException** ppException, unsigned int hotCodeSize, unsigned int coldCodeSize, unsigned int roDataSize, unsigned int xcptnsCount, int flag, void** hotCodeBlock, void** coldCodeBlock, void** roDataBlock) = 0;
-    virtual void reserveUnwindInfo(CorInfoException** ppException, bool isFunclet, bool isColdCode, unsigned int unwindSize) = 0;
-    virtual void allocUnwindInfo(CorInfoException** ppException, unsigned char* pHotCode, unsigned char* pColdCode, unsigned int startOffset, unsigned int endOffset, unsigned int unwindSize, unsigned char* pUnwindBlock, int funcKind) = 0;
-    virtual void* allocGCInfo(CorInfoException** ppException, size_t size) = 0;
-    virtual void yieldExecution(CorInfoException** ppException) = 0;
-    virtual void setEHcount(CorInfoException** ppException, unsigned cEH) = 0;
-    virtual void setEHinfo(CorInfoException** ppException, unsigned EHnumber, void* clause) = 0;
-    virtual bool logMsg(CorInfoException** ppException, unsigned level, const char* fmt, va_list args) = 0;
-    virtual int doAssert(CorInfoException** ppException, const char* szFile, int iLine, const char* szExpr) = 0;
-    virtual void reportFatalError(CorInfoException** ppException, int result) = 0;
-    virtual int allocBBProfileBuffer(CorInfoException** ppException, unsigned int count, void** profileBuffer) = 0;
-    virtual int getBBProfileData(CorInfoException** ppException, void* ftnHnd, unsigned long* count, void** profileBuffer, unsigned long* numRuns) = 0;
-    virtual void recordCallSite(CorInfoException** ppException, unsigned int instrOffset, void* callSig, void* methodHandle) = 0;
-    virtual void recordRelocation(CorInfoException** ppException, void* location, void* target, unsigned short fRelocType, unsigned short slotNum, int addlDelta) = 0;
-    virtual unsigned short getRelocTypeHint(CorInfoException** ppException, void* target) = 0;
-    virtual void getModuleNativeEntryPointRange(CorInfoException** ppException, void** pStart, void** pEnd) = 0;
-    virtual unsigned int getExpectedTargetArchitecture(CorInfoException** ppException) = 0;
-    virtual unsigned int getJitFlags(CorInfoException** ppException, void* flags, unsigned int sizeInBytes) = 0;
+    unsigned int (__stdcall * getMethodAttribs)(void * thisHandle, CorInfoException** ppException, void* ftn);
+    void (__stdcall * setMethodAttribs)(void * thisHandle, CorInfoException** ppException, void* ftn, int attribs);
+    void (__stdcall * getMethodSig)(void * thisHandle, CorInfoException** ppException, void* ftn, void* sig, void* memberParent);
+    bool (__stdcall * getMethodInfo)(void * thisHandle, CorInfoException** ppException, void* ftn, void* info);
+    int (__stdcall * canInline)(void * thisHandle, CorInfoException** ppException, void* callerHnd, void* calleeHnd, unsigned int* pRestrictions);
+    void (__stdcall * reportInliningDecision)(void * thisHandle, CorInfoException** ppException, void* inlinerHnd, void* inlineeHnd, int inlineResult, const char* reason);
+    bool (__stdcall * canTailCall)(void * thisHandle, CorInfoException** ppException, void* callerHnd, void* declaredCalleeHnd, void* exactCalleeHnd, bool fIsTailPrefix);
+    void (__stdcall * reportTailCallDecision)(void * thisHandle, CorInfoException** ppException, void* callerHnd, void* calleeHnd, bool fIsTailPrefix, int tailCallResult, const char* reason);
+    void (__stdcall * getEHinfo)(void * thisHandle, CorInfoException** ppException, void* ftn, unsigned EHnumber, void* clause);
+    void* (__stdcall * getMethodClass)(void * thisHandle, CorInfoException** ppException, void* method);
+    void* (__stdcall * getMethodModule)(void * thisHandle, CorInfoException** ppException, void* method);
+    void (__stdcall * getMethodVTableOffset)(void * thisHandle, CorInfoException** ppException, void* method, unsigned* offsetOfIndirection, unsigned* offsetAfterIndirection);
+    int (__stdcall * getIntrinsicID)(void * thisHandle, CorInfoException** ppException, void* method, bool* pMustExpand);
+    bool (__stdcall * isInSIMDModule)(void * thisHandle, CorInfoException** ppException, void* classHnd);
+    int (__stdcall * getUnmanagedCallConv)(void * thisHandle, CorInfoException** ppException, void* method);
+    bool (__stdcall * pInvokeMarshalingRequired)(void * thisHandle, CorInfoException** ppException, void* method, void* callSiteSig);
+    bool (__stdcall * satisfiesMethodConstraints)(void * thisHandle, CorInfoException** ppException, void* parent, void* method);
+    bool (__stdcall * isCompatibleDelegate)(void * thisHandle, CorInfoException** ppException, void* objCls, void* methodParentCls, void* method, void* delegateCls, int* pfIsOpenDelegate);
+    bool (__stdcall * isDelegateCreationAllowed)(void * thisHandle, CorInfoException** ppException, void* delegateHnd, void* calleeHnd);
+    int (__stdcall * isInstantiationOfVerifiedGeneric)(void * thisHandle, CorInfoException** ppException, void* method);
+    void (__stdcall * initConstraintsForVerification)(void * thisHandle, CorInfoException** ppException, void* method, int* pfHasCircularClassConstraints, int* pfHasCircularMethodConstraint);
+    int (__stdcall * canSkipMethodVerification)(void * thisHandle, CorInfoException** ppException, void* ftnHandle);
+    void (__stdcall * methodMustBeLoadedBeforeCodeIsRun)(void * thisHandle, CorInfoException** ppException, void* method);
+    void* (__stdcall * mapMethodDeclToMethodImpl)(void * thisHandle, CorInfoException** ppException, void* method);
+    void (__stdcall * getGSCookie)(void * thisHandle, CorInfoException** ppException, void* pCookieVal, void** ppCookieVal);
+    void (__stdcall * resolveToken)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken);
+    void (__stdcall * findSig)(void * thisHandle, CorInfoException** ppException, void* module, unsigned sigTOK, void* context, void* sig);
+    void (__stdcall * findCallSiteSig)(void * thisHandle, CorInfoException** ppException, void* module, unsigned methTOK, void* context, void* sig);
+    void* (__stdcall * getTokenTypeAsHandle)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken);
+    int (__stdcall * canSkipVerification)(void * thisHandle, CorInfoException** ppException, void* module);
+    bool (__stdcall * isValidToken)(void * thisHandle, CorInfoException** ppException, void* module, unsigned metaTOK);
+    bool (__stdcall * isValidStringRef)(void * thisHandle, CorInfoException** ppException, void* module, unsigned metaTOK);
+    bool (__stdcall * shouldEnforceCallvirtRestriction)(void * thisHandle, CorInfoException** ppException, void* scope);
+    int (__stdcall * asCorInfoType)(void * thisHandle, CorInfoException** ppException, void* cls);
+    const char* (__stdcall * getClassName)(void * thisHandle, CorInfoException** ppException, void* cls);
+    int (__stdcall * appendClassName)(void * thisHandle, CorInfoException** ppException, wchar_t** ppBuf, int* pnBufLen, void* cls, bool fNamespace, bool fFullInst, bool fAssembly);
+    bool (__stdcall * isValueClass)(void * thisHandle, CorInfoException** ppException, void* cls);
+    bool (__stdcall * canInlineTypeCheckWithObjectVTable)(void * thisHandle, CorInfoException** ppException, void* cls);
+    unsigned int (__stdcall * getClassAttribs)(void * thisHandle, CorInfoException** ppException, void* cls);
+    bool (__stdcall * isStructRequiringStackAllocRetBuf)(void * thisHandle, CorInfoException** ppException, void* cls);
+    void* (__stdcall * getClassModule)(void * thisHandle, CorInfoException** ppException, void* cls);
+    void* (__stdcall * getModuleAssembly)(void * thisHandle, CorInfoException** ppException, void* mod);
+    const char* (__stdcall * getAssemblyName)(void * thisHandle, CorInfoException** ppException, void* assem);
+    void* (__stdcall * LongLifetimeMalloc)(void * thisHandle, CorInfoException** ppException, size_t sz);
+    void (__stdcall * LongLifetimeFree)(void * thisHandle, CorInfoException** ppException, void* obj);
+    size_t (__stdcall * getClassModuleIdForStatics)(void * thisHandle, CorInfoException** ppException, void* cls, void* pModule, void** ppIndirection);
+    unsigned (__stdcall * getClassSize)(void * thisHandle, CorInfoException** ppException, void* cls);
+    unsigned (__stdcall * getClassAlignmentRequirement)(void * thisHandle, CorInfoException** ppException, void* cls, bool fDoubleAlignHint);
+    unsigned (__stdcall * getClassGClayout)(void * thisHandle, CorInfoException** ppException, void* cls, unsigned char* gcPtrs);
+    unsigned (__stdcall * getClassNumInstanceFields)(void * thisHandle, CorInfoException** ppException, void* cls);
+    void* (__stdcall * getFieldInClass)(void * thisHandle, CorInfoException** ppException, void* clsHnd, int num);
+    bool (__stdcall * checkMethodModifier)(void * thisHandle, CorInfoException** ppException, void* hMethod, const char* modifier, bool fOptional);
+    int (__stdcall * getNewHelper)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken, void* callerHandle);
+    int (__stdcall * getNewArrHelper)(void * thisHandle, CorInfoException** ppException, void* arrayCls);
+    int (__stdcall * getCastingHelper)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken, bool fThrowing);
+    int (__stdcall * getSharedCCtorHelper)(void * thisHandle, CorInfoException** ppException, void* clsHnd);
+    int (__stdcall * getSecurityPrologHelper)(void * thisHandle, CorInfoException** ppException, void* ftn);
+    void* (__stdcall * getTypeForBox)(void * thisHandle, CorInfoException** ppException, void* cls);
+    int (__stdcall * getBoxHelper)(void * thisHandle, CorInfoException** ppException, void* cls);
+    int (__stdcall * getUnBoxHelper)(void * thisHandle, CorInfoException** ppException, void* cls);
+    void (__stdcall * getReadyToRunHelper)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken, int id, void* pLookup);
+    void (__stdcall * getReadyToRunDelegateCtorHelper)(void * thisHandle, CorInfoException** ppException, void* pTargetMethod, void* delegateType, void* pLookup);
+    const char* (__stdcall * getHelperName)(void * thisHandle, CorInfoException** ppException, int helpFunc);
+    int (__stdcall * initClass)(void * thisHandle, CorInfoException** ppException, void* field, void* method, void* context, bool speculative);
+    void (__stdcall * classMustBeLoadedBeforeCodeIsRun)(void * thisHandle, CorInfoException** ppException, void* cls);
+    void* (__stdcall * getBuiltinClass)(void * thisHandle, CorInfoException** ppException, int classId);
+    int (__stdcall * getTypeForPrimitiveValueClass)(void * thisHandle, CorInfoException** ppException, void* cls);
+    bool (__stdcall * canCast)(void * thisHandle, CorInfoException** ppException, void* child, void* parent);
+    bool (__stdcall * areTypesEquivalent)(void * thisHandle, CorInfoException** ppException, void* cls1, void* cls2);
+    void* (__stdcall * mergeClasses)(void * thisHandle, CorInfoException** ppException, void* cls1, void* cls2);
+    void* (__stdcall * getParentType)(void * thisHandle, CorInfoException** ppException, void* cls);
+    int (__stdcall * getChildType)(void * thisHandle, CorInfoException** ppException, void* clsHnd, void* clsRet);
+    bool (__stdcall * satisfiesClassConstraints)(void * thisHandle, CorInfoException** ppException, void* cls);
+    bool (__stdcall * isSDArray)(void * thisHandle, CorInfoException** ppException, void* cls);
+    unsigned (__stdcall * getArrayRank)(void * thisHandle, CorInfoException** ppException, void* cls);
+    void* (__stdcall * getArrayInitializationData)(void * thisHandle, CorInfoException** ppException, void* field, unsigned int size);
+    int (__stdcall * canAccessClass)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken, void* callerHandle, void* pAccessHelper);
+    const char* (__stdcall * getFieldName)(void * thisHandle, CorInfoException** ppException, void* ftn, const char** moduleName);
+    void* (__stdcall * getFieldClass)(void * thisHandle, CorInfoException** ppException, void* field);
+    int (__stdcall * getFieldType)(void * thisHandle, CorInfoException** ppException, void* field, void* structType, void* memberParent);
+    unsigned (__stdcall * getFieldOffset)(void * thisHandle, CorInfoException** ppException, void* field);
+    bool (__stdcall * isWriteBarrierHelperRequired)(void * thisHandle, CorInfoException** ppException, void* field);
+    void (__stdcall * getFieldInfo)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken, void* callerHandle, int flags, void* pResult);
+    bool (__stdcall * isFieldStatic)(void * thisHandle, CorInfoException** ppException, void* fldHnd);
+    void (__stdcall * getBoundaries)(void * thisHandle, CorInfoException** ppException, void* ftn, unsigned int* cILOffsets, unsigned int** pILOffsets, void* implictBoundaries);
+    void (__stdcall * setBoundaries)(void * thisHandle, CorInfoException** ppException, void* ftn, unsigned int cMap, void* pMap);
+    void (__stdcall * getVars)(void * thisHandle, CorInfoException** ppException, void* ftn, unsigned int* cVars, void* vars, bool* extendOthers);
+    void (__stdcall * setVars)(void * thisHandle, CorInfoException** ppException, void* ftn, unsigned int cVars, void* vars);
+    void* (__stdcall * allocateArray)(void * thisHandle, CorInfoException** ppException, unsigned int cBytes);
+    void (__stdcall * freeArray)(void * thisHandle, CorInfoException** ppException, void* array);
+    void* (__stdcall * getArgNext)(void * thisHandle, CorInfoException** ppException, void* args);
+    int (__stdcall * getArgType)(void * thisHandle, CorInfoException** ppException, void* sig, void* args, void* vcTypeRet);
+    void* (__stdcall * getArgClass)(void * thisHandle, CorInfoException** ppException, void* sig, void* args);
+    int (__stdcall * getHFAType)(void * thisHandle, CorInfoException** ppException, void* hClass);
+    int (__stdcall * GetErrorHRESULT)(void * thisHandle, CorInfoException** ppException, void* pExceptionPointers);
+    unsigned int (__stdcall * GetErrorMessage)(void * thisHandle, CorInfoException** ppException, wchar_t* buffer, unsigned int bufferLength);
+    int (__stdcall * FilterException)(void * thisHandle, CorInfoException** ppException, void* pExceptionPointers);
+    void (__stdcall * HandleException)(void * thisHandle, CorInfoException** ppException, void* pExceptionPointers);
+    void (__stdcall * ThrowExceptionForJitResult)(void * thisHandle, CorInfoException** ppException, int result);
+    void (__stdcall * ThrowExceptionForHelper)(void * thisHandle, CorInfoException** ppException, const void* throwHelper);
+    void (__stdcall * getEEInfo)(void * thisHandle, CorInfoException** ppException, void* pEEInfoOut);
+    const wchar_t* (__stdcall * getJitTimeLogFilename)(void * thisHandle, CorInfoException** ppException);
+    unsigned int (__stdcall * getMethodDefFromMethod)(void * thisHandle, CorInfoException** ppException, void* hMethod);
+    const char* (__stdcall * getMethodName)(void * thisHandle, CorInfoException** ppException, void* ftn, const char** moduleName);
+    unsigned (__stdcall * getMethodHash)(void * thisHandle, CorInfoException** ppException, void* ftn);
+    size_t (__stdcall * findNameOfToken)(void * thisHandle, CorInfoException** ppException, void* moduleHandle, unsigned int token, char* szFQName, size_t FQNameCapacity);
+    bool (__stdcall * getSystemVAmd64PassStructInRegisterDescriptor)(void * thisHandle, CorInfoException** ppException, void* structHnd, void* structPassInRegDescPtr);
+    unsigned int (__stdcall * getThreadTLSIndex)(void * thisHandle, CorInfoException** ppException, void** ppIndirection);
+    const void* (__stdcall * getInlinedCallFrameVptr)(void * thisHandle, CorInfoException** ppException, void** ppIndirection);
+    long* (__stdcall * getAddrOfCaptureThreadGlobal)(void * thisHandle, CorInfoException** ppException, void** ppIndirection);
+    size_t* (__stdcall * getAddrModuleDomainID)(void * thisHandle, CorInfoException** ppException, void* module);
+    void* (__stdcall * getHelperFtn)(void * thisHandle, CorInfoException** ppException, int ftnNum, void** ppIndirection);
+    void (__stdcall * getFunctionEntryPoint)(void * thisHandle, CorInfoException** ppException, void* ftn, void* pResult, int accessFlags);
+    void (__stdcall * getFunctionFixedEntryPoint)(void * thisHandle, CorInfoException** ppException, void* ftn, void* pResult);
+    void* (__stdcall * getMethodSync)(void * thisHandle, CorInfoException** ppException, void* ftn, void** ppIndirection);
+    int (__stdcall * getLazyStringLiteralHelper)(void * thisHandle, CorInfoException** ppException, void* handle);
+    void* (__stdcall * embedModuleHandle)(void * thisHandle, CorInfoException** ppException, void* handle, void** ppIndirection);
+    void* (__stdcall * embedClassHandle)(void * thisHandle, CorInfoException** ppException, void* handle, void** ppIndirection);
+    void* (__stdcall * embedMethodHandle)(void * thisHandle, CorInfoException** ppException, void* handle, void** ppIndirection);
+    void* (__stdcall * embedFieldHandle)(void * thisHandle, CorInfoException** ppException, void* handle, void** ppIndirection);
+    void (__stdcall * embedGenericHandle)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken, bool fEmbedParent, void* pResult);
+    void (__stdcall * getLocationOfThisType)(void * thisHandle, CorInfoException** ppException, CORINFO_LOOKUP_KIND* _return, void* context);
+    void* (__stdcall * getPInvokeUnmanagedTarget)(void * thisHandle, CorInfoException** ppException, void* method, void** ppIndirection);
+    void* (__stdcall * getAddressOfPInvokeFixup)(void * thisHandle, CorInfoException** ppException, void* method, void** ppIndirection);
+    void (__stdcall * getAddressOfPInvokeTarget)(void * thisHandle, CorInfoException** ppException, void* method, void* pLookup);
+    void* (__stdcall * GetCookieForPInvokeCalliSig)(void * thisHandle, CorInfoException** ppException, void* szMetaSig, void** ppIndirection);
+    bool (__stdcall * canGetCookieForPInvokeCalliSig)(void * thisHandle, CorInfoException** ppException, void* szMetaSig);
+    void* (__stdcall * getJustMyCodeHandle)(void * thisHandle, CorInfoException** ppException, void* method, void** ppIndirection);
+    void (__stdcall * GetProfilingHandle)(void * thisHandle, CorInfoException** ppException, int* pbHookFunction, void** pProfilerHandle, int* pbIndirectedHandles);
+    void (__stdcall * getCallInfo)(void * thisHandle, CorInfoException** ppException, void* pResolvedToken, void* pConstrainedResolvedToken, void* callerHandle, int flags, void* pResult);
+    bool (__stdcall * canAccessFamily)(void * thisHandle, CorInfoException** ppException, void* hCaller, void* hInstanceType);
+    bool (__stdcall * isRIDClassDomainID)(void * thisHandle, CorInfoException** ppException, void* cls);
+    unsigned (__stdcall * getClassDomainID)(void * thisHandle, CorInfoException** ppException, void* cls, void** ppIndirection);
+    void* (__stdcall * getFieldAddress)(void * thisHandle, CorInfoException** ppException, void* field, void** ppIndirection);
+    void* (__stdcall * getVarArgsHandle)(void * thisHandle, CorInfoException** ppException, void* pSig, void** ppIndirection);
+    bool (__stdcall * canGetVarArgsHandle)(void * thisHandle, CorInfoException** ppException, void* pSig);
+    int (__stdcall * constructStringLiteral)(void * thisHandle, CorInfoException** ppException, void* module, unsigned int metaTok, void** ppValue);
+    int (__stdcall * emptyStringLiteral)(void * thisHandle, CorInfoException** ppException, void** ppValue);
+    unsigned int (__stdcall * getFieldThreadLocalStoreID)(void * thisHandle, CorInfoException** ppException, void* field, void** ppIndirection);
+    void (__stdcall * setOverride)(void * thisHandle, CorInfoException** ppException, void* pOverride, void* currentMethod);
+    void (__stdcall * addActiveDependency)(void * thisHandle, CorInfoException** ppException, void* moduleFrom, void* moduleTo);
+    void* (__stdcall * GetDelegateCtor)(void * thisHandle, CorInfoException** ppException, void* methHnd, void* clsHnd, void* targetMethodHnd, void* pCtorData);
+    void (__stdcall * MethodCompileComplete)(void * thisHandle, CorInfoException** ppException, void* methHnd);
+    void* (__stdcall * getTailCallCopyArgsThunk)(void * thisHandle, CorInfoException** ppException, void* pSig, int flags);
+    void* (__stdcall * getMemoryManager)(void * thisHandle, CorInfoException** ppException);
+    void (__stdcall * allocMem)(void * thisHandle, CorInfoException** ppException, unsigned int hotCodeSize, unsigned int coldCodeSize, unsigned int roDataSize, unsigned int xcptnsCount, int flag, void** hotCodeBlock, void** coldCodeBlock, void** roDataBlock);
+    void (__stdcall * reserveUnwindInfo)(void * thisHandle, CorInfoException** ppException, bool isFunclet, bool isColdCode, unsigned int unwindSize);
+    void (__stdcall * allocUnwindInfo)(void * thisHandle, CorInfoException** ppException, unsigned char* pHotCode, unsigned char* pColdCode, unsigned int startOffset, unsigned int endOffset, unsigned int unwindSize, unsigned char* pUnwindBlock, int funcKind);
+    void* (__stdcall * allocGCInfo)(void * thisHandle, CorInfoException** ppException, size_t size);
+    void (__stdcall * yieldExecution)(void * thisHandle, CorInfoException** ppException);
+    void (__stdcall * setEHcount)(void * thisHandle, CorInfoException** ppException, unsigned cEH);
+    void (__stdcall * setEHinfo)(void * thisHandle, CorInfoException** ppException, unsigned EHnumber, void* clause);
+    bool (__stdcall * logMsg)(void * thisHandle, CorInfoException** ppException, unsigned level, const char* fmt, va_list args);
+    int (__stdcall * doAssert)(void * thisHandle, CorInfoException** ppException, const char* szFile, int iLine, const char* szExpr);
+    void (__stdcall * reportFatalError)(void * thisHandle, CorInfoException** ppException, int result);
+    int (__stdcall * allocBBProfileBuffer)(void * thisHandle, CorInfoException** ppException, unsigned int count, void** profileBuffer);
+    int (__stdcall * getBBProfileData)(void * thisHandle, CorInfoException** ppException, void* ftnHnd, unsigned long* count, void** profileBuffer, unsigned long* numRuns);
+    void (__stdcall * recordCallSite)(void * thisHandle, CorInfoException** ppException, unsigned int instrOffset, void* callSig, void* methodHandle);
+    void (__stdcall * recordRelocation)(void * thisHandle, CorInfoException** ppException, void* location, void* target, unsigned short fRelocType, unsigned short slotNum, int addlDelta);
+    unsigned short (__stdcall * getRelocTypeHint)(void * thisHandle, CorInfoException** ppException, void* target);
+    void (__stdcall * getModuleNativeEntryPointRange)(void * thisHandle, CorInfoException** ppException, void** pStart, void** pEnd);
+    unsigned int (__stdcall * getExpectedTargetArchitecture)(void * thisHandle, CorInfoException** ppException);
+    unsigned int (__stdcall * getJitFlags)(void * thisHandle, CorInfoException** ppException, void* flags, unsigned int sizeInBytes);
 
 };
 
 class JitInterfaceWrapper
 {
+    void * _thisHandle;
+    JitInterfaceCallbacks * _callbacks;
+
 public:
+    JitInterfaceWrapper(void * thisHandle, void ** callbacks)
+        : _thisHandle(thisHandle), _callbacks((JitInterfaceCallbacks *)callbacks)
+    {
+    }
+
     virtual unsigned int getMethodAttribs(void* ftn)
     {
         CorInfoException* pException = nullptr;
-        unsigned int _ret = _pCorInfo->getMethodAttribs(&pException, ftn);
+        unsigned int _ret = _callbacks->getMethodAttribs(_thisHandle, &pException, ftn);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void setMethodAttribs(void* ftn, int attribs)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->setMethodAttribs(&pException, ftn, attribs);
+        _callbacks->setMethodAttribs(_thisHandle, &pException, ftn, attribs);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void getMethodSig(void* ftn, void* sig, void* memberParent)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getMethodSig(&pException, ftn, sig, memberParent);
+        _callbacks->getMethodSig(_thisHandle, &pException, ftn, sig, memberParent);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual bool getMethodInfo(void* ftn, void* info)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->getMethodInfo(&pException, ftn, info);
+        bool _ret = _callbacks->getMethodInfo(_thisHandle, &pException, ftn, info);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int canInline(void* callerHnd, void* calleeHnd, unsigned int* pRestrictions)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->canInline(&pException, callerHnd, calleeHnd, pRestrictions);
+        int _ret = _callbacks->canInline(_thisHandle, &pException, callerHnd, calleeHnd, pRestrictions);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void reportInliningDecision(void* inlinerHnd, void* inlineeHnd, int inlineResult, const char* reason)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->reportInliningDecision(&pException, inlinerHnd, inlineeHnd, inlineResult, reason);
+        _callbacks->reportInliningDecision(_thisHandle, &pException, inlinerHnd, inlineeHnd, inlineResult, reason);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual bool canTailCall(void* callerHnd, void* declaredCalleeHnd, void* exactCalleeHnd, bool fIsTailPrefix)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->canTailCall(&pException, callerHnd, declaredCalleeHnd, exactCalleeHnd, fIsTailPrefix);
+        bool _ret = _callbacks->canTailCall(_thisHandle, &pException, callerHnd, declaredCalleeHnd, exactCalleeHnd, fIsTailPrefix);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void reportTailCallDecision(void* callerHnd, void* calleeHnd, bool fIsTailPrefix, int tailCallResult, const char* reason)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->reportTailCallDecision(&pException, callerHnd, calleeHnd, fIsTailPrefix, tailCallResult, reason);
+        _callbacks->reportTailCallDecision(_thisHandle, &pException, callerHnd, calleeHnd, fIsTailPrefix, tailCallResult, reason);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void getEHinfo(void* ftn, unsigned EHnumber, void* clause)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getEHinfo(&pException, ftn, EHnumber, clause);
+        _callbacks->getEHinfo(_thisHandle, &pException, ftn, EHnumber, clause);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* getMethodClass(void* method)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getMethodClass(&pException, method);
+        void* _ret = _callbacks->getMethodClass(_thisHandle, &pException, method);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getMethodModule(void* method)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getMethodModule(&pException, method);
+        void* _ret = _callbacks->getMethodModule(_thisHandle, &pException, method);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void getMethodVTableOffset(void* method, unsigned* offsetOfIndirection, unsigned* offsetAfterIndirection)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getMethodVTableOffset(&pException, method, offsetOfIndirection, offsetAfterIndirection);
+        _callbacks->getMethodVTableOffset(_thisHandle, &pException, method, offsetOfIndirection, offsetAfterIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual int getIntrinsicID(void* method, bool* pMustExpand)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getIntrinsicID(&pException, method, pMustExpand);
+        int _ret = _callbacks->getIntrinsicID(_thisHandle, &pException, method, pMustExpand);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isInSIMDModule(void* classHnd)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isInSIMDModule(&pException, classHnd);
+        bool _ret = _callbacks->isInSIMDModule(_thisHandle, &pException, classHnd);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getUnmanagedCallConv(void* method)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getUnmanagedCallConv(&pException, method);
+        int _ret = _callbacks->getUnmanagedCallConv(_thisHandle, &pException, method);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool pInvokeMarshalingRequired(void* method, void* callSiteSig)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->pInvokeMarshalingRequired(&pException, method, callSiteSig);
+        bool _ret = _callbacks->pInvokeMarshalingRequired(_thisHandle, &pException, method, callSiteSig);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool satisfiesMethodConstraints(void* parent, void* method)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->satisfiesMethodConstraints(&pException, parent, method);
+        bool _ret = _callbacks->satisfiesMethodConstraints(_thisHandle, &pException, parent, method);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isCompatibleDelegate(void* objCls, void* methodParentCls, void* method, void* delegateCls, int* pfIsOpenDelegate)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isCompatibleDelegate(&pException, objCls, methodParentCls, method, delegateCls, pfIsOpenDelegate);
+        bool _ret = _callbacks->isCompatibleDelegate(_thisHandle, &pException, objCls, methodParentCls, method, delegateCls, pfIsOpenDelegate);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isDelegateCreationAllowed(void* delegateHnd, void* calleeHnd)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isDelegateCreationAllowed(&pException, delegateHnd, calleeHnd);
+        bool _ret = _callbacks->isDelegateCreationAllowed(_thisHandle, &pException, delegateHnd, calleeHnd);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int isInstantiationOfVerifiedGeneric(void* method)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->isInstantiationOfVerifiedGeneric(&pException, method);
+        int _ret = _callbacks->isInstantiationOfVerifiedGeneric(_thisHandle, &pException, method);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void initConstraintsForVerification(void* method, int* pfHasCircularClassConstraints, int* pfHasCircularMethodConstraint)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->initConstraintsForVerification(&pException, method, pfHasCircularClassConstraints, pfHasCircularMethodConstraint);
+        _callbacks->initConstraintsForVerification(_thisHandle, &pException, method, pfHasCircularClassConstraints, pfHasCircularMethodConstraint);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual int canSkipMethodVerification(void* ftnHandle)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->canSkipMethodVerification(&pException, ftnHandle);
+        int _ret = _callbacks->canSkipMethodVerification(_thisHandle, &pException, ftnHandle);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void methodMustBeLoadedBeforeCodeIsRun(void* method)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->methodMustBeLoadedBeforeCodeIsRun(&pException, method);
+        _callbacks->methodMustBeLoadedBeforeCodeIsRun(_thisHandle, &pException, method);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* mapMethodDeclToMethodImpl(void* method)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->mapMethodDeclToMethodImpl(&pException, method);
+        void* _ret = _callbacks->mapMethodDeclToMethodImpl(_thisHandle, &pException, method);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void getGSCookie(void* pCookieVal, void** ppCookieVal)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getGSCookie(&pException, pCookieVal, ppCookieVal);
+        _callbacks->getGSCookie(_thisHandle, &pException, pCookieVal, ppCookieVal);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void resolveToken(void* pResolvedToken)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->resolveToken(&pException, pResolvedToken);
+        _callbacks->resolveToken(_thisHandle, &pException, pResolvedToken);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void findSig(void* module, unsigned sigTOK, void* context, void* sig)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->findSig(&pException, module, sigTOK, context, sig);
+        _callbacks->findSig(_thisHandle, &pException, module, sigTOK, context, sig);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void findCallSiteSig(void* module, unsigned methTOK, void* context, void* sig)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->findCallSiteSig(&pException, module, methTOK, context, sig);
+        _callbacks->findCallSiteSig(_thisHandle, &pException, module, methTOK, context, sig);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* getTokenTypeAsHandle(void* pResolvedToken)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getTokenTypeAsHandle(&pException, pResolvedToken);
+        void* _ret = _callbacks->getTokenTypeAsHandle(_thisHandle, &pException, pResolvedToken);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int canSkipVerification(void* module)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->canSkipVerification(&pException, module);
+        int _ret = _callbacks->canSkipVerification(_thisHandle, &pException, module);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isValidToken(void* module, unsigned metaTOK)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isValidToken(&pException, module, metaTOK);
+        bool _ret = _callbacks->isValidToken(_thisHandle, &pException, module, metaTOK);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isValidStringRef(void* module, unsigned metaTOK)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isValidStringRef(&pException, module, metaTOK);
+        bool _ret = _callbacks->isValidStringRef(_thisHandle, &pException, module, metaTOK);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool shouldEnforceCallvirtRestriction(void* scope)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->shouldEnforceCallvirtRestriction(&pException, scope);
+        bool _ret = _callbacks->shouldEnforceCallvirtRestriction(_thisHandle, &pException, scope);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int asCorInfoType(void* cls)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->asCorInfoType(&pException, cls);
+        int _ret = _callbacks->asCorInfoType(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual const char* getClassName(void* cls)
     {
         CorInfoException* pException = nullptr;
-        const char* _ret = _pCorInfo->getClassName(&pException, cls);
+        const char* _ret = _callbacks->getClassName(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int appendClassName(wchar_t** ppBuf, int* pnBufLen, void* cls, bool fNamespace, bool fFullInst, bool fAssembly)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->appendClassName(&pException, ppBuf, pnBufLen, cls, fNamespace, fFullInst, fAssembly);
+        int _ret = _callbacks->appendClassName(_thisHandle, &pException, ppBuf, pnBufLen, cls, fNamespace, fFullInst, fAssembly);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isValueClass(void* cls)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isValueClass(&pException, cls);
+        bool _ret = _callbacks->isValueClass(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool canInlineTypeCheckWithObjectVTable(void* cls)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->canInlineTypeCheckWithObjectVTable(&pException, cls);
+        bool _ret = _callbacks->canInlineTypeCheckWithObjectVTable(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned int getClassAttribs(void* cls)
     {
         CorInfoException* pException = nullptr;
-        unsigned int _ret = _pCorInfo->getClassAttribs(&pException, cls);
+        unsigned int _ret = _callbacks->getClassAttribs(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isStructRequiringStackAllocRetBuf(void* cls)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isStructRequiringStackAllocRetBuf(&pException, cls);
+        bool _ret = _callbacks->isStructRequiringStackAllocRetBuf(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getClassModule(void* cls)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getClassModule(&pException, cls);
+        void* _ret = _callbacks->getClassModule(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getModuleAssembly(void* mod)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getModuleAssembly(&pException, mod);
+        void* _ret = _callbacks->getModuleAssembly(_thisHandle, &pException, mod);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual const char* getAssemblyName(void* assem)
     {
         CorInfoException* pException = nullptr;
-        const char* _ret = _pCorInfo->getAssemblyName(&pException, assem);
+        const char* _ret = _callbacks->getAssemblyName(_thisHandle, &pException, assem);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* LongLifetimeMalloc(size_t sz)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->LongLifetimeMalloc(&pException, sz);
+        void* _ret = _callbacks->LongLifetimeMalloc(_thisHandle, &pException, sz);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void LongLifetimeFree(void* obj)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->LongLifetimeFree(&pException, obj);
+        _callbacks->LongLifetimeFree(_thisHandle, &pException, obj);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual size_t getClassModuleIdForStatics(void* cls, void* pModule, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        size_t _ret = _pCorInfo->getClassModuleIdForStatics(&pException, cls, pModule, ppIndirection);
+        size_t _ret = _callbacks->getClassModuleIdForStatics(_thisHandle, &pException, cls, pModule, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned getClassSize(void* cls)
     {
         CorInfoException* pException = nullptr;
-        unsigned _ret = _pCorInfo->getClassSize(&pException, cls);
+        unsigned _ret = _callbacks->getClassSize(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned getClassAlignmentRequirement(void* cls, bool fDoubleAlignHint)
     {
         CorInfoException* pException = nullptr;
-        unsigned _ret = _pCorInfo->getClassAlignmentRequirement(&pException, cls, fDoubleAlignHint);
+        unsigned _ret = _callbacks->getClassAlignmentRequirement(_thisHandle, &pException, cls, fDoubleAlignHint);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned getClassGClayout(void* cls, unsigned char* gcPtrs)
     {
         CorInfoException* pException = nullptr;
-        unsigned _ret = _pCorInfo->getClassGClayout(&pException, cls, gcPtrs);
+        unsigned _ret = _callbacks->getClassGClayout(_thisHandle, &pException, cls, gcPtrs);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned getClassNumInstanceFields(void* cls)
     {
         CorInfoException* pException = nullptr;
-        unsigned _ret = _pCorInfo->getClassNumInstanceFields(&pException, cls);
+        unsigned _ret = _callbacks->getClassNumInstanceFields(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getFieldInClass(void* clsHnd, int num)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getFieldInClass(&pException, clsHnd, num);
+        void* _ret = _callbacks->getFieldInClass(_thisHandle, &pException, clsHnd, num);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool checkMethodModifier(void* hMethod, const char* modifier, bool fOptional)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->checkMethodModifier(&pException, hMethod, modifier, fOptional);
+        bool _ret = _callbacks->checkMethodModifier(_thisHandle, &pException, hMethod, modifier, fOptional);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getNewHelper(void* pResolvedToken, void* callerHandle)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getNewHelper(&pException, pResolvedToken, callerHandle);
+        int _ret = _callbacks->getNewHelper(_thisHandle, &pException, pResolvedToken, callerHandle);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getNewArrHelper(void* arrayCls)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getNewArrHelper(&pException, arrayCls);
+        int _ret = _callbacks->getNewArrHelper(_thisHandle, &pException, arrayCls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getCastingHelper(void* pResolvedToken, bool fThrowing)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getCastingHelper(&pException, pResolvedToken, fThrowing);
+        int _ret = _callbacks->getCastingHelper(_thisHandle, &pException, pResolvedToken, fThrowing);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getSharedCCtorHelper(void* clsHnd)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getSharedCCtorHelper(&pException, clsHnd);
+        int _ret = _callbacks->getSharedCCtorHelper(_thisHandle, &pException, clsHnd);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getSecurityPrologHelper(void* ftn)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getSecurityPrologHelper(&pException, ftn);
+        int _ret = _callbacks->getSecurityPrologHelper(_thisHandle, &pException, ftn);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getTypeForBox(void* cls)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getTypeForBox(&pException, cls);
+        void* _ret = _callbacks->getTypeForBox(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getBoxHelper(void* cls)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getBoxHelper(&pException, cls);
+        int _ret = _callbacks->getBoxHelper(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getUnBoxHelper(void* cls)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getUnBoxHelper(&pException, cls);
+        int _ret = _callbacks->getUnBoxHelper(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void getReadyToRunHelper(void* pResolvedToken, int id, void* pLookup)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getReadyToRunHelper(&pException, pResolvedToken, id, pLookup);
+        _callbacks->getReadyToRunHelper(_thisHandle, &pException, pResolvedToken, id, pLookup);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void getReadyToRunDelegateCtorHelper(void* pTargetMethod, void* delegateType, void* pLookup)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getReadyToRunDelegateCtorHelper(&pException, pTargetMethod, delegateType, pLookup);
+        _callbacks->getReadyToRunDelegateCtorHelper(_thisHandle, &pException, pTargetMethod, delegateType, pLookup);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual const char* getHelperName(int helpFunc)
     {
         CorInfoException* pException = nullptr;
-        const char* _ret = _pCorInfo->getHelperName(&pException, helpFunc);
+        const char* _ret = _callbacks->getHelperName(_thisHandle, &pException, helpFunc);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int initClass(void* field, void* method, void* context, bool speculative)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->initClass(&pException, field, method, context, speculative);
+        int _ret = _callbacks->initClass(_thisHandle, &pException, field, method, context, speculative);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void classMustBeLoadedBeforeCodeIsRun(void* cls)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->classMustBeLoadedBeforeCodeIsRun(&pException, cls);
+        _callbacks->classMustBeLoadedBeforeCodeIsRun(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* getBuiltinClass(int classId)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getBuiltinClass(&pException, classId);
+        void* _ret = _callbacks->getBuiltinClass(_thisHandle, &pException, classId);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getTypeForPrimitiveValueClass(void* cls)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getTypeForPrimitiveValueClass(&pException, cls);
+        int _ret = _callbacks->getTypeForPrimitiveValueClass(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool canCast(void* child, void* parent)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->canCast(&pException, child, parent);
+        bool _ret = _callbacks->canCast(_thisHandle, &pException, child, parent);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool areTypesEquivalent(void* cls1, void* cls2)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->areTypesEquivalent(&pException, cls1, cls2);
+        bool _ret = _callbacks->areTypesEquivalent(_thisHandle, &pException, cls1, cls2);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* mergeClasses(void* cls1, void* cls2)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->mergeClasses(&pException, cls1, cls2);
+        void* _ret = _callbacks->mergeClasses(_thisHandle, &pException, cls1, cls2);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getParentType(void* cls)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getParentType(&pException, cls);
+        void* _ret = _callbacks->getParentType(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getChildType(void* clsHnd, void* clsRet)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getChildType(&pException, clsHnd, clsRet);
+        int _ret = _callbacks->getChildType(_thisHandle, &pException, clsHnd, clsRet);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool satisfiesClassConstraints(void* cls)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->satisfiesClassConstraints(&pException, cls);
+        bool _ret = _callbacks->satisfiesClassConstraints(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isSDArray(void* cls)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isSDArray(&pException, cls);
+        bool _ret = _callbacks->isSDArray(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned getArrayRank(void* cls)
     {
         CorInfoException* pException = nullptr;
-        unsigned _ret = _pCorInfo->getArrayRank(&pException, cls);
+        unsigned _ret = _callbacks->getArrayRank(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getArrayInitializationData(void* field, unsigned int size)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getArrayInitializationData(&pException, field, size);
+        void* _ret = _callbacks->getArrayInitializationData(_thisHandle, &pException, field, size);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int canAccessClass(void* pResolvedToken, void* callerHandle, void* pAccessHelper)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->canAccessClass(&pException, pResolvedToken, callerHandle, pAccessHelper);
+        int _ret = _callbacks->canAccessClass(_thisHandle, &pException, pResolvedToken, callerHandle, pAccessHelper);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual const char* getFieldName(void* ftn, const char** moduleName)
     {
         CorInfoException* pException = nullptr;
-        const char* _ret = _pCorInfo->getFieldName(&pException, ftn, moduleName);
+        const char* _ret = _callbacks->getFieldName(_thisHandle, &pException, ftn, moduleName);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getFieldClass(void* field)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getFieldClass(&pException, field);
+        void* _ret = _callbacks->getFieldClass(_thisHandle, &pException, field);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getFieldType(void* field, void* structType, void* memberParent)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getFieldType(&pException, field, structType, memberParent);
+        int _ret = _callbacks->getFieldType(_thisHandle, &pException, field, structType, memberParent);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned getFieldOffset(void* field)
     {
         CorInfoException* pException = nullptr;
-        unsigned _ret = _pCorInfo->getFieldOffset(&pException, field);
+        unsigned _ret = _callbacks->getFieldOffset(_thisHandle, &pException, field);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isWriteBarrierHelperRequired(void* field)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isWriteBarrierHelperRequired(&pException, field);
+        bool _ret = _callbacks->isWriteBarrierHelperRequired(_thisHandle, &pException, field);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void getFieldInfo(void* pResolvedToken, void* callerHandle, int flags, void* pResult)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getFieldInfo(&pException, pResolvedToken, callerHandle, flags, pResult);
+        _callbacks->getFieldInfo(_thisHandle, &pException, pResolvedToken, callerHandle, flags, pResult);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual bool isFieldStatic(void* fldHnd)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isFieldStatic(&pException, fldHnd);
+        bool _ret = _callbacks->isFieldStatic(_thisHandle, &pException, fldHnd);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void getBoundaries(void* ftn, unsigned int* cILOffsets, unsigned int** pILOffsets, void* implictBoundaries)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getBoundaries(&pException, ftn, cILOffsets, pILOffsets, implictBoundaries);
+        _callbacks->getBoundaries(_thisHandle, &pException, ftn, cILOffsets, pILOffsets, implictBoundaries);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void setBoundaries(void* ftn, unsigned int cMap, void* pMap)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->setBoundaries(&pException, ftn, cMap, pMap);
+        _callbacks->setBoundaries(_thisHandle, &pException, ftn, cMap, pMap);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void getVars(void* ftn, unsigned int* cVars, void* vars, bool* extendOthers)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getVars(&pException, ftn, cVars, vars, extendOthers);
+        _callbacks->getVars(_thisHandle, &pException, ftn, cVars, vars, extendOthers);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void setVars(void* ftn, unsigned int cVars, void* vars)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->setVars(&pException, ftn, cVars, vars);
+        _callbacks->setVars(_thisHandle, &pException, ftn, cVars, vars);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* allocateArray(unsigned int cBytes)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->allocateArray(&pException, cBytes);
+        void* _ret = _callbacks->allocateArray(_thisHandle, &pException, cBytes);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void freeArray(void* array)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->freeArray(&pException, array);
+        _callbacks->freeArray(_thisHandle, &pException, array);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* getArgNext(void* args)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getArgNext(&pException, args);
+        void* _ret = _callbacks->getArgNext(_thisHandle, &pException, args);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getArgType(void* sig, void* args, void* vcTypeRet)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getArgType(&pException, sig, args, vcTypeRet);
+        int _ret = _callbacks->getArgType(_thisHandle, &pException, sig, args, vcTypeRet);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getArgClass(void* sig, void* args)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getArgClass(&pException, sig, args);
+        void* _ret = _callbacks->getArgClass(_thisHandle, &pException, sig, args);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getHFAType(void* hClass)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getHFAType(&pException, hClass);
+        int _ret = _callbacks->getHFAType(_thisHandle, &pException, hClass);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int GetErrorHRESULT(void* pExceptionPointers)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->GetErrorHRESULT(&pException, pExceptionPointers);
+        int _ret = _callbacks->GetErrorHRESULT(_thisHandle, &pException, pExceptionPointers);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned int GetErrorMessage(wchar_t* buffer, unsigned int bufferLength)
     {
         CorInfoException* pException = nullptr;
-        unsigned int _ret = _pCorInfo->GetErrorMessage(&pException, buffer, bufferLength);
+        unsigned int _ret = _callbacks->GetErrorMessage(_thisHandle, &pException, buffer, bufferLength);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int FilterException(void* pExceptionPointers);
     virtual void HandleException(void* pExceptionPointers);
     virtual void ThrowExceptionForJitResult(int result)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->ThrowExceptionForJitResult(&pException, result);
+        _callbacks->ThrowExceptionForJitResult(_thisHandle, &pException, result);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void ThrowExceptionForHelper(const void* throwHelper)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->ThrowExceptionForHelper(&pException, throwHelper);
+        _callbacks->ThrowExceptionForHelper(_thisHandle, &pException, throwHelper);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void getEEInfo(void* pEEInfoOut)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getEEInfo(&pException, pEEInfoOut);
+        _callbacks->getEEInfo(_thisHandle, &pException, pEEInfoOut);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual const wchar_t* getJitTimeLogFilename()
     {
         CorInfoException* pException = nullptr;
-        const wchar_t* _ret = _pCorInfo->getJitTimeLogFilename(&pException);
+        const wchar_t* _ret = _callbacks->getJitTimeLogFilename(_thisHandle, &pException);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned int getMethodDefFromMethod(void* hMethod)
     {
         CorInfoException* pException = nullptr;
-        unsigned int _ret = _pCorInfo->getMethodDefFromMethod(&pException, hMethod);
+        unsigned int _ret = _callbacks->getMethodDefFromMethod(_thisHandle, &pException, hMethod);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual const char* getMethodName(void* ftn, const char** moduleName)
     {
         CorInfoException* pException = nullptr;
-        const char* _ret = _pCorInfo->getMethodName(&pException, ftn, moduleName);
+        const char* _ret = _callbacks->getMethodName(_thisHandle, &pException, ftn, moduleName);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned getMethodHash(void* ftn)
     {
         CorInfoException* pException = nullptr;
-        unsigned _ret = _pCorInfo->getMethodHash(&pException, ftn);
+        unsigned _ret = _callbacks->getMethodHash(_thisHandle, &pException, ftn);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual size_t findNameOfToken(void* moduleHandle, unsigned int token, char* szFQName, size_t FQNameCapacity)
     {
         CorInfoException* pException = nullptr;
-        size_t _ret = _pCorInfo->findNameOfToken(&pException, moduleHandle, token, szFQName, FQNameCapacity);
+        size_t _ret = _callbacks->findNameOfToken(_thisHandle, &pException, moduleHandle, token, szFQName, FQNameCapacity);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool getSystemVAmd64PassStructInRegisterDescriptor(void* structHnd, void* structPassInRegDescPtr)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->getSystemVAmd64PassStructInRegisterDescriptor(&pException, structHnd, structPassInRegDescPtr);
+        bool _ret = _callbacks->getSystemVAmd64PassStructInRegisterDescriptor(_thisHandle, &pException, structHnd, structPassInRegDescPtr);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned int getThreadTLSIndex(void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        unsigned int _ret = _pCorInfo->getThreadTLSIndex(&pException, ppIndirection);
+        unsigned int _ret = _callbacks->getThreadTLSIndex(_thisHandle, &pException, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual const void* getInlinedCallFrameVptr(void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        const void* _ret = _pCorInfo->getInlinedCallFrameVptr(&pException, ppIndirection);
+        const void* _ret = _callbacks->getInlinedCallFrameVptr(_thisHandle, &pException, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual long* getAddrOfCaptureThreadGlobal(void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        long* _ret = _pCorInfo->getAddrOfCaptureThreadGlobal(&pException, ppIndirection);
+        long* _ret = _callbacks->getAddrOfCaptureThreadGlobal(_thisHandle, &pException, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual size_t* getAddrModuleDomainID(void* module)
     {
         CorInfoException* pException = nullptr;
-        size_t* _ret = _pCorInfo->getAddrModuleDomainID(&pException, module);
+        size_t* _ret = _callbacks->getAddrModuleDomainID(_thisHandle, &pException, module);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getHelperFtn(int ftnNum, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getHelperFtn(&pException, ftnNum, ppIndirection);
+        void* _ret = _callbacks->getHelperFtn(_thisHandle, &pException, ftnNum, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void getFunctionEntryPoint(void* ftn, void* pResult, int accessFlags)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getFunctionEntryPoint(&pException, ftn, pResult, accessFlags);
+        _callbacks->getFunctionEntryPoint(_thisHandle, &pException, ftn, pResult, accessFlags);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void getFunctionFixedEntryPoint(void* ftn, void* pResult)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getFunctionFixedEntryPoint(&pException, ftn, pResult);
+        _callbacks->getFunctionFixedEntryPoint(_thisHandle, &pException, ftn, pResult);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* getMethodSync(void* ftn, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getMethodSync(&pException, ftn, ppIndirection);
+        void* _ret = _callbacks->getMethodSync(_thisHandle, &pException, ftn, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int getLazyStringLiteralHelper(void* handle)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getLazyStringLiteralHelper(&pException, handle);
+        int _ret = _callbacks->getLazyStringLiteralHelper(_thisHandle, &pException, handle);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* embedModuleHandle(void* handle, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->embedModuleHandle(&pException, handle, ppIndirection);
+        void* _ret = _callbacks->embedModuleHandle(_thisHandle, &pException, handle, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* embedClassHandle(void* handle, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->embedClassHandle(&pException, handle, ppIndirection);
+        void* _ret = _callbacks->embedClassHandle(_thisHandle, &pException, handle, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* embedMethodHandle(void* handle, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->embedMethodHandle(&pException, handle, ppIndirection);
+        void* _ret = _callbacks->embedMethodHandle(_thisHandle, &pException, handle, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* embedFieldHandle(void* handle, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->embedFieldHandle(&pException, handle, ppIndirection);
+        void* _ret = _callbacks->embedFieldHandle(_thisHandle, &pException, handle, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void embedGenericHandle(void* pResolvedToken, bool fEmbedParent, void* pResult)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->embedGenericHandle(&pException, pResolvedToken, fEmbedParent, pResult);
+        _callbacks->embedGenericHandle(_thisHandle, &pException, pResolvedToken, fEmbedParent, pResult);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual CORINFO_LOOKUP_KIND getLocationOfThisType(void* context);
     virtual void* getPInvokeUnmanagedTarget(void* method, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getPInvokeUnmanagedTarget(&pException, method, ppIndirection);
+        void* _ret = _callbacks->getPInvokeUnmanagedTarget(_thisHandle, &pException, method, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getAddressOfPInvokeFixup(void* method, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getAddressOfPInvokeFixup(&pException, method, ppIndirection);
+        void* _ret = _callbacks->getAddressOfPInvokeFixup(_thisHandle, &pException, method, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void getAddressOfPInvokeTarget(void* method, void* pLookup)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getAddressOfPInvokeTarget(&pException, method, pLookup);
+        _callbacks->getAddressOfPInvokeTarget(_thisHandle, &pException, method, pLookup);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* GetCookieForPInvokeCalliSig(void* szMetaSig, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->GetCookieForPInvokeCalliSig(&pException, szMetaSig, ppIndirection);
+        void* _ret = _callbacks->GetCookieForPInvokeCalliSig(_thisHandle, &pException, szMetaSig, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool canGetCookieForPInvokeCalliSig(void* szMetaSig)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->canGetCookieForPInvokeCalliSig(&pException, szMetaSig);
+        bool _ret = _callbacks->canGetCookieForPInvokeCalliSig(_thisHandle, &pException, szMetaSig);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getJustMyCodeHandle(void* method, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getJustMyCodeHandle(&pException, method, ppIndirection);
+        void* _ret = _callbacks->getJustMyCodeHandle(_thisHandle, &pException, method, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void GetProfilingHandle(int* pbHookFunction, void** pProfilerHandle, int* pbIndirectedHandles)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->GetProfilingHandle(&pException, pbHookFunction, pProfilerHandle, pbIndirectedHandles);
+        _callbacks->GetProfilingHandle(_thisHandle, &pException, pbHookFunction, pProfilerHandle, pbIndirectedHandles);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void getCallInfo(void* pResolvedToken, void* pConstrainedResolvedToken, void* callerHandle, int flags, void* pResult)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->getCallInfo(&pException, pResolvedToken, pConstrainedResolvedToken, callerHandle, flags, pResult);
+        _callbacks->getCallInfo(_thisHandle, &pException, pResolvedToken, pConstrainedResolvedToken, callerHandle, flags, pResult);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual bool canAccessFamily(void* hCaller, void* hInstanceType)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->canAccessFamily(&pException, hCaller, hInstanceType);
+        bool _ret = _callbacks->canAccessFamily(_thisHandle, &pException, hCaller, hInstanceType);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool isRIDClassDomainID(void* cls)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->isRIDClassDomainID(&pException, cls);
+        bool _ret = _callbacks->isRIDClassDomainID(_thisHandle, &pException, cls);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned getClassDomainID(void* cls, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        unsigned _ret = _pCorInfo->getClassDomainID(&pException, cls, ppIndirection);
+        unsigned _ret = _callbacks->getClassDomainID(_thisHandle, &pException, cls, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getFieldAddress(void* field, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getFieldAddress(&pException, field, ppIndirection);
+        void* _ret = _callbacks->getFieldAddress(_thisHandle, &pException, field, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getVarArgsHandle(void* pSig, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getVarArgsHandle(&pException, pSig, ppIndirection);
+        void* _ret = _callbacks->getVarArgsHandle(_thisHandle, &pException, pSig, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual bool canGetVarArgsHandle(void* pSig)
     {
         CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->canGetVarArgsHandle(&pException, pSig);
+        bool _ret = _callbacks->canGetVarArgsHandle(_thisHandle, &pException, pSig);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int constructStringLiteral(void* module, unsigned int metaTok, void** ppValue)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->constructStringLiteral(&pException, module, metaTok, ppValue);
+        int _ret = _callbacks->constructStringLiteral(_thisHandle, &pException, module, metaTok, ppValue);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual int emptyStringLiteral(void** ppValue)
     {
         CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->emptyStringLiteral(&pException, ppValue);
+        int _ret = _callbacks->emptyStringLiteral(_thisHandle, &pException, ppValue);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual unsigned int getFieldThreadLocalStoreID(void* field, void** ppIndirection)
     {
         CorInfoException* pException = nullptr;
-        unsigned int _ret = _pCorInfo->getFieldThreadLocalStoreID(&pException, field, ppIndirection);
+        unsigned int _ret = _callbacks->getFieldThreadLocalStoreID(_thisHandle, &pException, field, ppIndirection);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void setOverride(void* pOverride, void* currentMethod)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->setOverride(&pException, pOverride, currentMethod);
+        _callbacks->setOverride(_thisHandle, &pException, pOverride, currentMethod);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void addActiveDependency(void* moduleFrom, void* moduleTo)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->addActiveDependency(&pException, moduleFrom, moduleTo);
+        _callbacks->addActiveDependency(_thisHandle, &pException, moduleFrom, moduleTo);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* GetDelegateCtor(void* methHnd, void* clsHnd, void* targetMethodHnd, void* pCtorData)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->GetDelegateCtor(&pException, methHnd, clsHnd, targetMethodHnd, pCtorData);
+        void* _ret = _callbacks->GetDelegateCtor(_thisHandle, &pException, methHnd, clsHnd, targetMethodHnd, pCtorData);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void MethodCompileComplete(void* methHnd)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->MethodCompileComplete(&pException, methHnd);
+        _callbacks->MethodCompileComplete(_thisHandle, &pException, methHnd);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* getTailCallCopyArgsThunk(void* pSig, int flags)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->getTailCallCopyArgsThunk(&pException, pSig, flags);
+        void* _ret = _callbacks->getTailCallCopyArgsThunk(_thisHandle, &pException, pSig, flags);
         if (pException != nullptr)
-        {
             throw pException;
-        }
         return _ret;
     }
+
     virtual void* getMemoryManager();
     virtual void allocMem(unsigned int hotCodeSize, unsigned int coldCodeSize, unsigned int roDataSize, unsigned int xcptnsCount, int flag, void** hotCodeBlock, void** coldCodeBlock, void** roDataBlock)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->allocMem(&pException, hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, coldCodeBlock, roDataBlock);
+        _callbacks->allocMem(_thisHandle, &pException, hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock, coldCodeBlock, roDataBlock);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void reserveUnwindInfo(bool isFunclet, bool isColdCode, unsigned int unwindSize)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->reserveUnwindInfo(&pException, isFunclet, isColdCode, unwindSize);
+        _callbacks->reserveUnwindInfo(_thisHandle, &pException, isFunclet, isColdCode, unwindSize);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void allocUnwindInfo(unsigned char* pHotCode, unsigned char* pColdCode, unsigned int startOffset, unsigned int endOffset, unsigned int unwindSize, unsigned char* pUnwindBlock, int funcKind)
     {
         CorInfoException* pException = nullptr;
-        _pCorInfo->allocUnwindInfo(&pException, pHotCode, pColdCode, startOffset, endOffset, unwindSize, pUnwindBlock, funcKind);
+        _callbacks->allocUnwindInfo(_thisHandle, &pException, pHotCode, pColdCode, startOffset, endOffset, unwindSize, pUnwindBlock, funcKind);
         if (pException != nullptr)
-        {
             throw pException;
-        }
     }
+
     virtual void* allocGCInfo(size_t size)
     {
         CorInfoException* pException = nullptr;
-        void* _ret = _pCorInfo->allocGCInfo(&pException, size);
+        void* _ret = _callbacks->allocGCInfo(_thisHandle, &pException, size);
         if (pException != nullptr)
-        {
             throw pException;
-        }
-        return _ret;
-    }
-    virtual void yieldExecution()
-    {
-        CorInfoException* pException = nullptr;
-        _pCorInfo->yieldExecution(&pException);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-    }
-    virtual void setEHcount(unsigned cEH)
-    {
-        CorInfoException* pException = nullptr;
-        _pCorInfo->setEHcount(&pException, cEH);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-    }
-    virtual void setEHinfo(unsigned EHnumber, void* clause)
-    {
-        CorInfoException* pException = nullptr;
-        _pCorInfo->setEHinfo(&pException, EHnumber, clause);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-    }
-    virtual bool logMsg(unsigned level, const char* fmt, va_list args)
-    {
-        CorInfoException* pException = nullptr;
-        bool _ret = _pCorInfo->logMsg(&pException, level, fmt, args);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-        return _ret;
-    }
-    virtual int doAssert(const char* szFile, int iLine, const char* szExpr)
-    {
-        CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->doAssert(&pException, szFile, iLine, szExpr);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-        return _ret;
-    }
-    virtual void reportFatalError(int result)
-    {
-        CorInfoException* pException = nullptr;
-        _pCorInfo->reportFatalError(&pException, result);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-    }
-    virtual int allocBBProfileBuffer(unsigned int count, void** profileBuffer)
-    {
-        CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->allocBBProfileBuffer(&pException, count, profileBuffer);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-        return _ret;
-    }
-    virtual int getBBProfileData(void* ftnHnd, unsigned long* count, void** profileBuffer, unsigned long* numRuns)
-    {
-        CorInfoException* pException = nullptr;
-        int _ret = _pCorInfo->getBBProfileData(&pException, ftnHnd, count, profileBuffer, numRuns);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-        return _ret;
-    }
-    virtual void recordCallSite(unsigned int instrOffset, void* callSig, void* methodHandle)
-    {
-        CorInfoException* pException = nullptr;
-        _pCorInfo->recordCallSite(&pException, instrOffset, callSig, methodHandle);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-    }
-    virtual void recordRelocation(void* location, void* target, unsigned short fRelocType, unsigned short slotNum, int addlDelta)
-    {
-        CorInfoException* pException = nullptr;
-        _pCorInfo->recordRelocation(&pException, location, target, fRelocType, slotNum, addlDelta);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-    }
-    virtual unsigned short getRelocTypeHint(void* target)
-    {
-        CorInfoException* pException = nullptr;
-        unsigned short _ret = _pCorInfo->getRelocTypeHint(&pException, target);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-        return _ret;
-    }
-    virtual void getModuleNativeEntryPointRange(void** pStart, void** pEnd)
-    {
-        CorInfoException* pException = nullptr;
-        _pCorInfo->getModuleNativeEntryPointRange(&pException, pStart, pEnd);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-    }
-    virtual unsigned int getExpectedTargetArchitecture()
-    {
-        CorInfoException* pException = nullptr;
-        unsigned int _ret = _pCorInfo->getExpectedTargetArchitecture(&pException);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
-        return _ret;
-    }
-    virtual unsigned int getJitFlags(void* flags, unsigned int sizeInBytes)
-    {
-        CorInfoException* pException = nullptr;
-        unsigned int _ret = _pCorInfo->getJitFlags(&pException, flags, sizeInBytes);
-        if (pException != nullptr)
-        {
-            throw pException;
-        }
         return _ret;
     }
 
-    IJitInterface *_pCorInfo;
+    virtual void yieldExecution()
+    {
+        CorInfoException* pException = nullptr;
+        _callbacks->yieldExecution(_thisHandle, &pException);
+        if (pException != nullptr)
+            throw pException;
+    }
+
+    virtual void setEHcount(unsigned cEH)
+    {
+        CorInfoException* pException = nullptr;
+        _callbacks->setEHcount(_thisHandle, &pException, cEH);
+        if (pException != nullptr)
+            throw pException;
+    }
+
+    virtual void setEHinfo(unsigned EHnumber, void* clause)
+    {
+        CorInfoException* pException = nullptr;
+        _callbacks->setEHinfo(_thisHandle, &pException, EHnumber, clause);
+        if (pException != nullptr)
+            throw pException;
+    }
+
+    virtual bool logMsg(unsigned level, const char* fmt, va_list args)
+    {
+        CorInfoException* pException = nullptr;
+        bool _ret = _callbacks->logMsg(_thisHandle, &pException, level, fmt, args);
+        if (pException != nullptr)
+            throw pException;
+        return _ret;
+    }
+
+    virtual int doAssert(const char* szFile, int iLine, const char* szExpr)
+    {
+        CorInfoException* pException = nullptr;
+        int _ret = _callbacks->doAssert(_thisHandle, &pException, szFile, iLine, szExpr);
+        if (pException != nullptr)
+            throw pException;
+        return _ret;
+    }
+
+    virtual void reportFatalError(int result)
+    {
+        CorInfoException* pException = nullptr;
+        _callbacks->reportFatalError(_thisHandle, &pException, result);
+        if (pException != nullptr)
+            throw pException;
+    }
+
+    virtual int allocBBProfileBuffer(unsigned int count, void** profileBuffer)
+    {
+        CorInfoException* pException = nullptr;
+        int _ret = _callbacks->allocBBProfileBuffer(_thisHandle, &pException, count, profileBuffer);
+        if (pException != nullptr)
+            throw pException;
+        return _ret;
+    }
+
+    virtual int getBBProfileData(void* ftnHnd, unsigned long* count, void** profileBuffer, unsigned long* numRuns)
+    {
+        CorInfoException* pException = nullptr;
+        int _ret = _callbacks->getBBProfileData(_thisHandle, &pException, ftnHnd, count, profileBuffer, numRuns);
+        if (pException != nullptr)
+            throw pException;
+        return _ret;
+    }
+
+    virtual void recordCallSite(unsigned int instrOffset, void* callSig, void* methodHandle)
+    {
+        CorInfoException* pException = nullptr;
+        _callbacks->recordCallSite(_thisHandle, &pException, instrOffset, callSig, methodHandle);
+        if (pException != nullptr)
+            throw pException;
+    }
+
+    virtual void recordRelocation(void* location, void* target, unsigned short fRelocType, unsigned short slotNum, int addlDelta)
+    {
+        CorInfoException* pException = nullptr;
+        _callbacks->recordRelocation(_thisHandle, &pException, location, target, fRelocType, slotNum, addlDelta);
+        if (pException != nullptr)
+            throw pException;
+    }
+
+    virtual unsigned short getRelocTypeHint(void* target)
+    {
+        CorInfoException* pException = nullptr;
+        unsigned short _ret = _callbacks->getRelocTypeHint(_thisHandle, &pException, target);
+        if (pException != nullptr)
+            throw pException;
+        return _ret;
+    }
+
+    virtual void getModuleNativeEntryPointRange(void** pStart, void** pEnd)
+    {
+        CorInfoException* pException = nullptr;
+        _callbacks->getModuleNativeEntryPointRange(_thisHandle, &pException, pStart, pEnd);
+        if (pException != nullptr)
+            throw pException;
+    }
+
+    virtual unsigned int getExpectedTargetArchitecture()
+    {
+        CorInfoException* pException = nullptr;
+        unsigned int _ret = _callbacks->getExpectedTargetArchitecture(_thisHandle, &pException);
+        if (pException != nullptr)
+            throw pException;
+        return _ret;
+    }
+
+    virtual unsigned int getJitFlags(void* flags, unsigned int sizeInBytes)
+    {
+        CorInfoException* pException = nullptr;
+        unsigned int _ret = _callbacks->getJitFlags(_thisHandle, &pException, flags, sizeInBytes);
+        if (pException != nullptr)
+            throw pException;
+        return _ret;
+    }
+
 };

--- a/src/Native/jitinterface/jitwrapper.cpp
+++ b/src/Native/jitinterface/jitwrapper.cpp
@@ -2,8 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#include "corinfoexception.h"
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdint.h>
+
 #include "dllexport.h"
+#include "jitinterface.h"
 
 typedef struct _GUID {
     unsigned int Data1;
@@ -40,10 +44,11 @@ public:
     virtual void getVersionIdentifier(GUID* versionIdentifier) = 0;
 };
 
-DLL_EXPORT int JitWrapper(
+DLL_EXPORT int JitCompileMethod(
     CorInfoException **ppException,
-    Jit* pJit,
-    void* compHnd,
+    Jit * pJit, 
+    void * thisHandle, 
+    void ** callbacks,
     void* methodInfo,
     unsigned flags,
     void* entryAddress,
@@ -58,7 +63,8 @@ DLL_EXPORT int JitWrapper(
 
     try
     {
-        return pJit->compileMethod(compHnd, methodInfo, flags, entryAddress, nativeSizeOfCode);
+        JitInterfaceWrapper jitInterfaceWrapper(thisHandle, callbacks);
+        return pJit->compileMethod(&jitInterfaceWrapper, methodInfo, flags, entryAddress, nativeSizeOfCode);
     }
     catch (CorInfoException *pException)
     {

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -97,6 +97,7 @@
         <dependency id="System.Collections.Immutable" version="1.2.0-rc2-23911" />
         <dependency id="System.IO.MemoryMappedFiles" version="4.0.0-rc2-23911" />
         <dependency id="System.Reflection.Metadata" version="1.3.0-rc3-24102-00" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.0.0-rc3-24102-00" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.0" />
         <dependency id="Microsoft.DiaSymReader" version="1.0.8-rc2-60325" />
         <dependency id="System.CommandLine" version="0.1.0-e160323-1" />


### PR DESCRIPTION
This makes the callbacks compatible with `[NativeCallable]`. The callbacks are not marked with `[NativeCallable]` yet because of it does not work on full framework, but everything else is setup for it. It should allow us to do self-hosting without depending on delegate marshalling. And the [NativeCallable] callbacks will be faster as well.