### PR TITLE
Use Array.Empty in a few places

### DIFF
--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -128,7 +128,7 @@ namespace System
                 // Initial array length is deliberately chosen to be 0 so that we reallocate to exactly the right size
                 // for StackFrameHelper.FormatStackTrace call. If we want to do this optimistically with one call change
                 // FormatStackTrace to accept an explicit length.
-                IntPtr[] frameIPs = new IntPtr[0];
+                IntPtr[] frameIPs = Array.Empty<IntPtr>();
                 int cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
                 if (cFrames < 0)
                 {

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -440,8 +440,7 @@ namespace System.Runtime.CompilerServices
 
                 // If any expired or removed keys exist, we won't resize.
                 bool hasExpiredEntries = false;
-                int entriesIndex;
-                for (entriesIndex = 0; entriesIndex < _entries.Length; entriesIndex++)
+                for (int entriesIndex = 0; entriesIndex < _entries.Length; entriesIndex++)
                 {
                     if (_entries[entriesIndex].hashCode == -1)
                     {
@@ -460,7 +459,7 @@ namespace System.Runtime.CompilerServices
 
                 if (!hasExpiredEntries)
                 {
-                    newSize = HashHelpers.GetPrime(_buckets.Length == 0 ? _initialCapacity + 1 : _buckets.Length * 2);
+                    newSize = HashHelpers.GetPrime(_buckets.Length * 2);
                 }
                 
                 return Resize(newSize);
@@ -479,7 +478,7 @@ namespace System.Runtime.CompilerServices
                 int newEntriesIndex = 0;
 
                 // Migrate existing entries to the new table.
-                for (entriesIndex = 0; entriesIndex < _entries.Length; entriesIndex++)
+                for (int entriesIndex = 0; entriesIndex < _entries.Length; entriesIndex++)
                 {
                     DependentHandle depHnd = _entries[entriesIndex].depHnd;
                     if (_entries[entriesIndex].hashCode != -1 && depHnd.IsAllocated && depHnd.GetPrimary() != null)

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.CompilerServices
         #region Constructors
         public ConditionalWeakTable()
         {
-            _container = new Container().Resize();
+            _container = new Container();
             _lock = new Lock();
         }
         #endregion
@@ -230,7 +230,7 @@ namespace System.Runtime.CompilerServices
         {
             lock (_lock)
             {
-                _container = new Container().Resize();
+                _container = new Container();
             }
         }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
 using System.Runtime.InteropServices;
@@ -459,7 +460,7 @@ namespace System.Runtime.CompilerServices
 
                 if (!hasExpiredEntries)
                 {
-                    newSize = System.Collections.HashHelpers.GetPrime(_buckets.Length == 0 ? _initialCapacity + 1 : _buckets.Length * 2);
+                    newSize = HashHelpers.GetPrime(_buckets.Length == 0 ? _initialCapacity + 1 : _buckets.Length * 2);
                 }
                 
                 return Resize(newSize);

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -307,9 +307,20 @@ namespace System.Runtime.CompilerServices
         {
             internal Container()
             {
-                _buckets = new int[0];
-                _entries = new Entry[0];
-                _firstFreeEntry = 0;
+                int size = HashHelpers.GetPrime(_initialCapacity + 1);
+                _buckets = new int[size];
+                for (int i = 0; i < size; i++)
+                {
+                    _buckets[i] = -1;
+                }
+                _entries = new Entry[size];
+            }
+            
+            private Container(int[] buckets, Entry[] entries, int firstFreeEntry)
+            {
+                _buckets = buckets;
+                _entries = entries;
+                _firstFreeEntry = firstFreeEntry;
             }
 
             internal bool HasCapacity
@@ -450,8 +461,12 @@ namespace System.Runtime.CompilerServices
                 {
                     newSize = System.Collections.HashHelpers.GetPrime(_buckets.Length == 0 ? _initialCapacity + 1 : _buckets.Length * 2);
                 }
-
-
+                
+                return Resize(newSize);
+            }
+            
+            internal Container Resize(int newSize)
+            {
                 // Reallocate both buckets and entries and rebuild the bucket and entries from scratch.
                 // This serves both to scrub entries with expired keys and to put the new entries in the proper bucket.
                 int[] newBuckets = new int[newSize];
@@ -480,15 +495,9 @@ namespace System.Runtime.CompilerServices
                     }
                 }
 
-
                 GC.KeepAlive(this); // ensure we don't get finalized while accessing DependentHandles.
 
-                return new Container()
-                {
-                    _buckets = newBuckets,
-                    _entries = newEntries,
-                    _firstFreeEntry = newEntriesIndex
-                };
+                return new Container(newBuckets, newEntries, newEntriesIndex);
             }
 
             internal ICollection<TKey> Keys

--- a/src/System.Private.Interop/src/Shared/List.cs
+++ b/src/System.Private.Interop/src/Shared/List.cs
@@ -19,7 +19,7 @@ namespace System.Collections.Generic.Internal
 
         public List()
         {
-            _items = new T[0];
+            _items = Array.Empty<T>();
         }
 
         // Constructs a List with a given initial capacity. The list is
@@ -52,7 +52,7 @@ namespace System.Collections.Generic.Internal
 
                 if (count == 0)
                 {
-                    _items = new T[0];
+                    _items = Array.Empty<T>();
                 }
                 else
                 {
@@ -64,7 +64,7 @@ namespace System.Collections.Generic.Internal
             else
             {
                 _size = 0;
-                _items = new T[0];
+                _items = Array.Empty<T>();
                 // This enumerable could be empty.  Let Add allocate a new array, if needed.
                 // Note it will also go to _defaultCapacity first, not 1, then 2, etc.
 
@@ -108,7 +108,7 @@ namespace System.Collections.Generic.Internal
                     }
                     else
                     {
-                        _items = new T[0];
+                        _items = Array.Empty<T>();
                     }
                 }
             }

--- a/src/System.Private.Threading/src/System/AggregateException.cs
+++ b/src/System.Private.Threading/src/System/AggregateException.cs
@@ -40,7 +40,7 @@ namespace System
         public AggregateException()
             : base(SR.AggregateException_ctor_DefaultMessage)
         {
-            m_innerExceptions = new ReadOnlyCollection<Exception>(new Exception[0]);
+            m_innerExceptions = new ReadOnlyCollection<Exception>(Array.Empty<Exception>());
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace System
         public AggregateException(string message)
             : base(message)
         {
-            m_innerExceptions = new ReadOnlyCollection<Exception>(new Exception[0]);
+            m_innerExceptions = new ReadOnlyCollection<Exception>(Array.Empty<Exception>());
         }
 
         /// <summary>

--- a/src/System.Private.Threading/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.Threading/src/System/Threading/Tasks/Task.cs
@@ -1955,7 +1955,7 @@ namespace System.Threading.Tasks
             Contract.Assert(exceptionsAvailable, "Must only be used when the task has faulted with exceptions.");
             return exceptionsAvailable ?
                 m_contingentProperties.m_exceptionsHolder.GetExceptionDispatchInfos() :
-                new ReadOnlyCollection<ExceptionDispatchInfo>(new ExceptionDispatchInfo[0]);
+                new ReadOnlyCollection<ExceptionDispatchInfo>(Array.Empty<ExceptionDispatchInfo>());
         }
 
         /// <summary>Gets the ExceptionDispatchInfo containing the OperationCanceledException for this task.</summary>
@@ -5703,7 +5703,7 @@ namespace System.Threading.Tasks
         {
             Contract.Requires(tasks != null, "Expected a non-null tasks array");
             return (tasks.Length == 0) ? // take shortcut if there are no tasks upon which to wait
-                new Task<TResult[]>(false, new TResult[0], TaskCreationOptions.None, default(CancellationToken)) :
+                new Task<TResult[]>(false, Array.Empty<TResult>(), TaskCreationOptions.None, default(CancellationToken)) :
                 new WhenAllPromise<TResult>(tasks);
         }
 


### PR DESCRIPTION
This changes a couple of files throughout the repo to use `Array.Empty<T>` in place of `new T[0]`, saving some unnecessary allocations.

Some of the classes affected:

- `List`
- `Environment`
- `Task`
- `ConditionalWeakTable`

cc @jkotas