### PR TITLE
Refactor GCDesc emission

### DIFF
--- a/src/Common/src/Internal/Runtime/GCDescEncoder.cs
+++ b/src/Common/src/Internal/Runtime/GCDescEncoder.cs
@@ -74,7 +74,7 @@ namespace Internal.Runtime
                 {
                     // TODO: this optimization can be also applied to all element types that have all '1' GCPointerMap
                     //       get_GCDescSize needs to be updated appropriately when this optimization is enabled
-                    OutputStandardGCDesc(ref builder,
+                    EncodeStandardGCDesc(ref builder,
                         new GCPointerMap(new[] { 1 }, 1),
                         4 * builder.TargetPointerSize,
                         baseSize);
@@ -84,7 +84,7 @@ namespace Internal.Runtime
                     var elementDefType = (DefType)elementType;
                     if (elementDefType.ContainsGCPointers)
                     {
-                        OutputArrayGCDesc(ref builder, GCPointerMap.FromInstanceLayout(elementDefType), baseSize);
+                        EncodeArrayGCDesc(ref builder, GCPointerMap.FromInstanceLayout(elementDefType), baseSize);
                     }
                 }
             }
@@ -99,14 +99,14 @@ namespace Internal.Runtime
                     // Include syncblock
                     int objectSize = defType.InstanceByteCount + offs + builder.TargetPointerSize;
 
-                    OutputStandardGCDesc(ref builder, GCPointerMap.FromInstanceLayout(defType), objectSize, offs);
+                    EncodeStandardGCDesc(ref builder, GCPointerMap.FromInstanceLayout(defType), objectSize, offs);
                 }
             }
 
             Debug.Assert(initialBuilderPosition + GetGCDescSize(type) == builder.CountBytes);
         }
 
-        public static void OutputStandardGCDesc<T>(ref T builder, GCPointerMap map, int size, int delta)
+        public static void EncodeStandardGCDesc<T>(ref T builder, GCPointerMap map, int size, int delta)
             where T: struct, ITargetBinaryWriter
         {
             Debug.Assert(size >= map.Size);
@@ -138,7 +138,7 @@ namespace Internal.Runtime
             builder.EmitNaturalInt(numSeries);
         }
 
-        private static void OutputArrayGCDesc<T>(ref T builder, GCPointerMap map, int size)
+        private static void EncodeArrayGCDesc<T>(ref T builder, GCPointerMap map, int size)
             where T : struct, ITargetBinaryWriter
         {
             int numSeries = 0;

--- a/src/Common/src/Internal/Runtime/ITargetBinaryWriter.cs
+++ b/src/Common/src/Internal/Runtime/ITargetBinaryWriter.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.Runtime
+{
+    /// <summary>
+    /// Abstraction to emit byte streams of data in a format expected by the target platform.
+    /// </summary>
+    public interface ITargetBinaryWriter
+    {
+        /// <summary>
+        /// Gets the number of bytes written.
+        /// </summary>
+        int CountBytes { get; }
+
+        /// <summary>
+        /// Gets the size, in bytes, of a pointer on the target architecture.
+        /// </summary>
+        int TargetPointerSize { get; }
+
+        /// <summary>
+        /// Emits an integer that has a natural size on the target platform (e.g. 64 bits on 64 bit platforms).
+        /// </summary>
+        void EmitNaturalInt(int emit);
+
+        /// <summary>
+        /// Emits an integer that has half of the natural size on the target platform (e.g. 32 bits on 64 bit platforms).
+        /// </summary>
+        void EmitHalfNaturalInt(short emit);
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -307,6 +307,28 @@ namespace ILCompiler.DependencyAnalysis
             return 16 + 2 * pointerSize;
         }
 
+        private int GCDescSize
+        {
+            get
+            {
+                if (!_constructed || _type.IsGenericDefinition)
+                    return 0;
+
+                return GCDescEncoder.GetGCDescSize(_type);
+            }
+        }
+
+        private void OutputGCDesc(ref ObjectDataBuilder builder)
+        {
+            if (!_constructed || _type.IsGenericDefinition)
+            {
+                Debug.Assert(GCDescSize == 0);
+                return;
+            }
+
+            GCDescEncoder.EncodeGCDesc(ref builder, _type);
+        }
+
         private void OutputComponentSize(ref ObjectDataBuilder objData)
         {
             if (_type.IsArray)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -26,6 +26,8 @@ namespace ILCompiler.DependencyAnalysis
     ///                 | HasOptionalFields, IsInterface, IsGeneric. Top 5 bits are used for enum CorElementType to
     ///                 | record whether it's back by an Int32, Int16 etc
     ///                 |
+    /// Uint32          | Base size.
+    ///                 |
     /// [Pointer Size]  | Related type. Base type for regular types. Element type for arrays / pointer types.
     ///                 |
     /// UInt16          | Number of VTable slots (X)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -3,40 +3,29 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Text;
 
+using Internal.Runtime;
 using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler.DependencyAnalysis
 {
+    /// <summary>
+    /// Represents a subset of <see cref="EETypeNode"/> that is used to describe GC static field regions for
+    /// types. It only fills out enough pieces of the EEType structure so that the GC can operate on it. Runtime should
+    /// never see these.
+    /// </summary>
     internal class GCStaticEETypeNode : ObjectNode, ISymbolNode
     {
-        private int[] _runLengths; // First is offset to first gc field, second is length of gc static run, third is length of non-gc data, etc
-        private int _targetPointerSize;
+        private GCPointerMap _gcMap;
         private TargetDetails _target;
 
-        public GCStaticEETypeNode(bool[] gcDesc, NodeFactory factory)
+        public GCStaticEETypeNode(TargetDetails target, GCPointerMap gcMap)
         {
-            List<int> runLengths = new List<int>();
-            bool encodingGCPointers = false;
-            int currentPointerCount = 0;
-            foreach (bool pointerIsGC in gcDesc)
-            {
-                if (encodingGCPointers == pointerIsGC)
-                {
-                    currentPointerCount++;
-                }
-                else
-                {
-                    runLengths.Add(currentPointerCount * factory.Target.PointerSize);
-                    encodingGCPointers = pointerIsGC;
-                }
-            }
-            runLengths.Add(currentPointerCount);
-            _runLengths = runLengths.ToArray();
-            _targetPointerSize = factory.Target.PointerSize;
-            _target = factory.Target;
+            _gcMap = gcMap;
+            _target = target;
         }
 
         public override string GetName()
@@ -68,16 +57,8 @@ namespace ILCompiler.DependencyAnalysis
             get
             {
                 StringBuilder nameBuilder = new StringBuilder();
-                nameBuilder.Append(NodeFactory.NameMangler.CompilationUnitPrefix + "__GCStaticEEType_");
-                int totalSize = 0;
-                foreach (int run in _runLengths)
-                {
-                    nameBuilder.Append(run.ToStringInvariant());
-                    nameBuilder.Append("_");
-                    totalSize += run;
-                }
-                nameBuilder.Append(totalSize.ToStringInvariant());
-                nameBuilder.Append("_");
+                nameBuilder.Append("__GCStaticEEType_");
+                nameBuilder.Append(_gcMap.ToString());
 
                 return nameBuilder.ToString();
             }
@@ -87,23 +68,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                if (NumSeries > 0)
-                {
-                    return _targetPointerSize * ((NumSeries * 2) + 1);
-                }
-                else
-                {
-                    return 0;
-                }
+                return ((_gcMap.NumSeries * 2) + 1) * _target.PointerSize;
             }
         }
 
-        private int NumSeries
+        public override bool ShouldShareNodeAcrossModules(NodeFactory factory)
         {
-            get
-            {
-                return (_runLengths.Length - 1) / 2;
-            }
+            return true;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
@@ -112,45 +83,21 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.Alignment = 16;
             dataBuilder.DefinedSymbols.Add(this);
 
-            bool hasPointers = NumSeries > 0;
-            if (hasPointers)
-            {
-                for (int i = ((_runLengths.Length / 2) * 2) - 1; i >= 0; i--)
-                {
-                    if (_targetPointerSize == 4)
-                    {
-                        dataBuilder.EmitInt(_runLengths[i]);
-                    }
-                    else
-                    {
-                        dataBuilder.EmitLong(_runLengths[i]);
-                    }
-                }
-                if (_targetPointerSize == 4)
-                {
-                    dataBuilder.EmitInt(NumSeries);
-                }
-                else
-                {
-                    dataBuilder.EmitLong(NumSeries);
-                }
-            }
+            int totalSize = _gcMap.Size * _target.PointerSize;
 
-            int totalSize = 0;
-            foreach (int run in _runLengths)
-            {
-                totalSize += run * _targetPointerSize;
-            }
+            GCDescEncoder.EncodeStandardGCDesc(ref dataBuilder, _gcMap, totalSize, 0);
+
+            Debug.Assert(dataBuilder.CountBytes == ((ISymbolNode)this).Offset);
 
             dataBuilder.EmitShort(0); // ComponentSize is always 0
 
-            if (hasPointers)
-                dataBuilder.EmitShort(0x20); // TypeFlags.HasPointers
-            else
-                dataBuilder.EmitShort(0x00);
+            dataBuilder.EmitShort((short)EETypeFlags.HasPointersFlag);
 
-            totalSize = Math.Max(totalSize, _targetPointerSize * 3); // minimum GC eetype size is 3 pointers
+            totalSize = Math.Max(totalSize, _target.PointerSize * 3); // minimum GC eetype size is 3 pointers
             dataBuilder.EmitInt(totalSize);
+
+            // This is just so that EEType::Validate doesn't blow up at runtime
+            dataBuilder.EmitPointerReloc(this); // Related type: itself
 
             return dataBuilder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -2,13 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Internal.TypeSystem;
-using ILCompiler.DependencyAnalysisFramework;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -36,16 +30,8 @@ namespace ILCompiler.DependencyAnalysis
 
         private ISymbolNode GetGCStaticEETypeNode(NodeFactory factory)
         {
-            // TODO Replace with better gcDesc computation algorithm when we add gc handling to the type system
-            bool[] gcDesc = new bool[_type.GCStaticFieldSize / factory.Target.PointerSize + 1];
-
             GCPointerMap map = GCPointerMap.FromStaticLayout(_type);
-            for (int i = 0; i < map.Size; i++)
-            {
-                gcDesc[i] = map[i];
-            }
-
-            return factory.GCStaticEEType(gcDesc);
+            return factory.GCStaticEEType(map);
         }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -136,10 +136,10 @@ namespace ILCompiler.DependencyAnalysis
                 return new ThreadStaticsNode(type, this);
             });
 
-            _GCStaticEETypes = new NodeCache<bool[], GCStaticEETypeNode>((bool[] gcdesc) =>
+            _GCStaticEETypes = new NodeCache<GCPointerMap, GCStaticEETypeNode>((GCPointerMap gcMap) =>
             {
-                return new GCStaticEETypeNode(gcdesc, this);
-            }, new BoolArrayEqualityComparer());
+                return new GCStaticEETypeNode(Target, gcMap);
+            });
 
             _readOnlyDataBlobs = new NodeCache<Tuple<string, byte[], int>, BlobNode>((Tuple<string, byte[], int> key) =>
             {
@@ -330,36 +330,6 @@ namespace ILCompiler.DependencyAnalysis
             return _interfaceDispatchCells.GetOrAdd(method);
         }
 
-        private class BoolArrayEqualityComparer : IEqualityComparer<bool[]>
-        {
-            bool IEqualityComparer<bool[]>.Equals(bool[] x, bool[] y)
-            {
-                if (x.Length != y.Length)
-                    return false;
-
-                for (int i = 0; i < x.Length; i++)
-                {
-                    if (x[i] != y[i])
-                        return false;
-                }
-
-                return true;
-            }
-
-            int IEqualityComparer<bool[]>.GetHashCode(bool[] obj)
-            {
-                // TODO get better combining function for bools
-                int hash = 0x5d83481;
-                foreach (bool b in obj)
-                {
-                    int bAsInt = b ? 1 : 0;
-                    hash = (hash << 4) ^ hash ^ bAsInt;
-                }
-
-                return hash;
-            }
-        }
-
         private class BlobTupleEqualityComparer : IEqualityComparer<Tuple<string, byte[], int>>
         {
             bool IEqualityComparer<Tuple<string, byte[], int>>.Equals(Tuple<string, byte[], int> x, Tuple<string, byte[], int> y)
@@ -373,11 +343,11 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        private NodeCache<bool[], GCStaticEETypeNode> _GCStaticEETypes;
+        private NodeCache<GCPointerMap, GCStaticEETypeNode> _GCStaticEETypes;
 
-        public ISymbolNode GCStaticEEType(bool[] gcdesc)
+        public ISymbolNode GCStaticEEType(GCPointerMap gcMap)
         {
-            return _GCStaticEETypes.GetOrAdd(gcdesc);
+            return _GCStaticEETypes.GetOrAdd(gcMap);
         }
 
         private NodeCache<Tuple<string, byte[], int>, BlobNode> _readOnlyDataBlobs;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -10,7 +10,7 @@ using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public struct ObjectDataBuilder
+    public struct ObjectDataBuilder : Internal.Runtime.ITargetBinaryWriter
     {
         public ObjectDataBuilder(NodeFactory factory)
         {
@@ -39,6 +39,14 @@ namespace ILCompiler.DependencyAnalysis
             get
             {
                 return _data.Count;
+            }
+        }
+
+        public int TargetPointerSize
+        {
+            get
+            {
+                return _target.PointerSize;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -40,17 +40,8 @@ namespace ILCompiler.DependencyAnalysis
 
         private ISymbolNode GetGCStaticEETypeNode(NodeFactory factory)
         {
-            // TODO Replace with better gcDesc computation algorithm when we add gc handling to the type system
-            // TODO This logic should be shared with GCStaticsNode.
-            bool[] gcDesc = new bool[_type.ThreadStaticFieldSize / factory.Target.PointerSize + 1];
-
             GCPointerMap map = GCPointerMap.FromThreadStaticLayout(_type);
-            for (int i = 0; i < map.Size; i++)
-            {
-                gcDesc[i] = map[i];
-            }
-
-            return factory.GCStaticEEType(gcDesc);
+            return factory.GCStaticEEType(map);
         }
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -38,6 +38,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Common\src\Internal\Runtime\GCDescEncoder.cs">
+      <Link>Common\GCDescBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Internal\Runtime\ITargetBinaryWriter.cs">
+      <Link>Common\IBinaryWriter.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs">
       <Link>Common\MetadataBlob.cs</Link>
     </Compile>
@@ -56,7 +62,6 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.cs" />
     <Compile Include="Compiler\DelegateCreationInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\EETypeNode.GCDesc.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternEETypeSymbolNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericCompositionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IEETypeNode.cs" />

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -39,10 +39,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\Internal\Runtime\GCDescEncoder.cs">
-      <Link>Common\GCDescBuilder.cs</Link>
+      <Link>Common\GCDescEncoder.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\Internal\Runtime\ITargetBinaryWriter.cs">
-      <Link>Common\IBinaryWriter.cs</Link>
+      <Link>Common\ITargetBinaryWriter.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs">
       <Link>Common\MetadataBlob.cs</Link>


### PR DESCRIPTION
* Pull out GCDescEncoder into a separate struct so that it can be shared by GCStaticEETypeNode.
* Get GCStaticEETypeNode into using it.

Fixes #1239.