### PR TITLE
Remove Gen0 GC heap size workaround

### DIFF
--- a/src/Native/Runtime/gcenv.h
+++ b/src/Native/Runtime/gcenv.h
@@ -174,13 +174,7 @@ public:
     int     GetGCtraceFac  ()               const { return 0; }
     int     GetGCprnLvl    ()               const { return 0; }
     bool    IsGCBreakOnOOMEnabled()         const { return false; }
-#ifdef CORERT
-    // CORERT-TODO: remove this
-    //              https://github.com/dotnet/corert/issues/913
-    int     GetGCgen0size  ()               const { return 100 * 1024 * 1024; }
-#else
     int     GetGCgen0size  ()               const { return 0; }
-#endif
     void    SetGCgen0size  (int iSize)            { UNREFERENCED_PARAMETER(iSize); }
     int     GetSegmentSize ()               const { return 0; }
     void    SetSegmentSize (int iSize)            { UNREFERENCED_PARAMETER(iSize); }


### PR DESCRIPTION
If this passes CI, we probably don't need it.