### PR TITLE
Protect from arrays with ElementType.ElementSize >= 64k

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -335,7 +335,14 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (_type.IsArray)
             {
-                objData.EmitShort((short)((ArrayType)_type).ElementType.GetElementSize());
+                int elementSize = ((ArrayType)_type).ElementType.GetElementSize();
+                if (elementSize >= 64 * 1024)
+                {
+                    // TODO: Array of type 'X' cannot be created because base value type is too large.
+                    throw new TypeLoadException();
+                }
+
+                objData.EmitShort((short)elementSize);
             }
             else if (_type.IsString)
             {


### PR DESCRIPTION
This can't be encoded in the EEType (and in the array GCDescs, for that
matter).

I'm removing checked arithmetic from the GCDesc encoder because that
code runs before ComponentSize emission, but it's not the right place to
check for this, because this also applies to value types with no GC
pointers.