### PR TITLE
Fix build on NetBSD - stop redefining SIZE_T_MAX

### DIFF
--- a/src/Native/gc/env/gcenv.base.h
+++ b/src/Native/gc/env/gcenv.base.h
@@ -24,8 +24,12 @@
 #endif // __clang__
 #endif // !_MSC_VER
 
+#ifndef SIZE_T_MAX
 #define SIZE_T_MAX ((size_t)-1)
+#endif
+#ifndef SSIZE_T_MAX
 #define SSIZE_T_MAX ((ptrdiff_t)(SIZE_T_MAX / 2))
+#endif
 
 #ifndef _INC_WINDOWS
 // -----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
```
/tmp/pkgsrc-tmp/wip/corert-git/work/corert/src/Native/Bootstrap/../gc/env/gcenv.base.h:27:9:
error: 'SIZE_T_MAX' macro redefined [-Werror,-Wmacro-redefined]
        ^
/usr/include/machine/limits.h:72:9: note: previous definition is here
        ^
1 error generated.
```