### PR TITLE
Minor fixes in EETypeBuilderHelpers

### DIFF
--- a/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -94,9 +94,8 @@ namespace Internal.Runtime
             }
             else if (type.IsArray)
             {
-                ArrayType arrayType = type as ArrayType;
-                if ((arrayType.ElementType.IsValueType && ((DefType)arrayType.ElementType).ContainsGCPointers) ||
-                    !arrayType.ElementType.IsValueType)
+                var elementType = ((ArrayType)type).ElementType;
+                if ((elementType.IsValueType && ((DefType)elementType).ContainsGCPointers) || elementType.IsGCPointer)
                 {
                     flags |= (UInt16)EETypeFlags.HasPointersFlag;
                 }
@@ -106,7 +105,7 @@ namespace Internal.Runtime
             {
                 flags |= (UInt16)EETypeFlags.IsGenericFlag;
 
-                if (type.GetTypeDefinition().HasVariance)
+                if (type.HasVariance)
                 {
                     flags |= (UInt16)EETypeFlags.GenericVarianceFlag;
                 }


### PR DESCRIPTION
* `!arrayType.ElementType.IsValueType` doesn't mean the type has GC
pointers (unmanaged pointers don't, for example)
* `HasVariance` check was unnecessarily going to the definition. This is
not wrong, just unnecessary and confusing.