### PR TITLE
Remove contracts from the startup path

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/LowLevelUTF8Encoding.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/LowLevelUTF8Encoding.cs
@@ -5,9 +5,10 @@
 #define FASTLOOP
 
 using System;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Text;
+
+using Debug = Internal.Runtime.CompilerHelpers.StartupDebug;
 
 namespace Internal.Runtime.CompilerHelpers
 {
@@ -51,8 +52,8 @@ namespace Internal.Runtime.CompilerHelpers
         // kept the same as much as possible
         internal unsafe static int GetCharCount(byte* bytes, int count)
         {
-            Contract.Assert(count >= 0);
-            Contract.Assert(bytes != null);
+            Debug.Assert(count >= 0);
+            Debug.Assert(bytes != null);
 
             // Initialize stuff
             byte* pSrc = bytes;
@@ -99,7 +100,7 @@ namespace Internal.Runtime.CompilerHelpers
 
                 if ((ch & FinalByte) == 0)
                 {
-                    Contract.Assert((ch & (SupplimentarySeq | ThreeByteSeq)) != 0);
+                    Debug.Assert((ch & (SupplimentarySeq | ThreeByteSeq)) != 0);
 
                     if ((ch & SupplimentarySeq) != 0)
                     {
@@ -432,7 +433,7 @@ namespace Internal.Runtime.CompilerHelpers
 
             // Shouldn't have anything in fallback buffer for GetCharCount
             // (don't have to check m_throwOnOverflow for count)
-            Contract.Assert(fallback == null);
+            Debug.Assert(fallback == null);
 
             return charCount;
         }
@@ -450,10 +451,10 @@ namespace Internal.Runtime.CompilerHelpers
         internal unsafe static int GetChars(byte* bytes, int byteCount,
                                         char* chars, int charCount)
         {
-            Contract.Assert(chars != null);
-            Contract.Assert(byteCount >= 0);
-            Contract.Assert(charCount >= 0);
-            Contract.Assert(bytes != null);
+            Debug.Assert(chars != null);
+            Debug.Assert(byteCount >= 0);
+            Debug.Assert(charCount >= 0);
+            Debug.Assert(bytes != null);
 
             byte* pSrc = bytes;
             char* pTarget = chars;
@@ -500,7 +501,7 @@ namespace Internal.Runtime.CompilerHelpers
                 if ((ch & FinalByte) == 0)
                 {
                     // Not at last byte yet
-                    Contract.Assert((ch & (SupplimentarySeq | ThreeByteSeq)) != 0);
+                    Debug.Assert((ch & (SupplimentarySeq | ThreeByteSeq)) != 0);
 
                     if ((ch & SupplimentarySeq) != 0)
                     {
@@ -649,7 +650,7 @@ namespace Internal.Runtime.CompilerHelpers
 
                     // Throw that we don't have enough room (pSrc could be < chars if we had started to process
                     // a 4 byte sequence alredy)
-                    Contract.Assert(pSrc >= bytes || pTarget == chars);
+                    Debug.Assert(pSrc >= bytes || pTarget == chars);
                     if (pTarget == chars)
                     {
                         // Overflow, buffer too short.
@@ -924,7 +925,7 @@ namespace Internal.Runtime.CompilerHelpers
                 }
 #endif // FASTLOOP
 
-                Contract.Assert(pTarget <= pAllocatedBufferEnd);
+                Debug.Assert(pTarget <= pAllocatedBufferEnd);
 
                 // no pending bits at this point
                 ch = 0;
@@ -945,7 +946,7 @@ namespace Internal.Runtime.CompilerHelpers
 
             // Shouldn't have anything in fallback buffer for GetChars
             // (don't have to check m_throwOnOverflow for chars)
-            Contract.Assert(fallback == null);
+            Debug.Assert(fallback == null);
 
             return PtrDiff(pTarget, chars);
         }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using Internal.NativeFormat;
-using System.Diagnostics.Contracts;
-using System.Runtime.InteropServices;
-using System.Text;
 using System;
 using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
 
-using Debug = System.Diagnostics.Debug;
+using Internal.NativeFormat;
+
+using Debug = Internal.Runtime.CompilerHelpers.StartupDebug;
 
 namespace Internal.Runtime.CompilerHelpers
 {
@@ -121,7 +121,7 @@ namespace Internal.Runtime.CompilerHelpers
             IntPtr stringSection = GetModuleSection(moduleManager, ReadyToRunSectionType.StringTable, out length);
             if (stringSection != IntPtr.Zero)
             {
-                Contract.Assert(length % IntPtr.Size == 0);
+                Debug.Assert(length % IntPtr.Size == 0);
                 InitializeStringTable(stringSection, length);
             }
 
@@ -129,7 +129,7 @@ namespace Internal.Runtime.CompilerHelpers
             IntPtr staticsSection = GetModuleSection(moduleManager, ReadyToRunSectionType.GCStaticRegion, out length);
             if (staticsSection != IntPtr.Zero)
             {
-                Contract.Assert(length % IntPtr.Size == 0);
+                Debug.Assert(length % IntPtr.Size == 0);
                 InitializeStatics(staticsSection, length);
             }
         }
@@ -142,7 +142,7 @@ namespace Internal.Runtime.CompilerHelpers
             IntPtr eagerClassConstructorSection = GetModuleSection(moduleManager, ReadyToRunSectionType.EagerCctor, out length);
             if (eagerClassConstructorSection != IntPtr.Zero)
             {
-                Contract.Assert(length % IntPtr.Size == 0);
+                Debug.Assert(length % IntPtr.Size == 0);
                 RunEagerClassConstructors(eagerClassConstructorSection, length);
             }
         }
@@ -155,13 +155,13 @@ namespace Internal.Runtime.CompilerHelpers
                 byte* bytes = (byte*)*tab;
                 int len = (int)NativePrimitiveDecoder.DecodeUnsigned(ref bytes);
                 int count = LowLevelUTF8Encoding.GetCharCount(bytes, len);
-                Contract.Assert(count >= 0);
+                Debug.Assert(count >= 0);
 
                 string newStr = RuntimeImports.RhNewArrayAsString(EETypePtr.EETypePtrOf<string>(), count);
                 fixed (char* dest = newStr)
                 {
                     int newCount = LowLevelUTF8Encoding.GetChars(bytes, len, dest, count);
-                    Contract.Assert(newCount == count);
+                    Debug.Assert(newCount == count);
                 }
                 GCHandle handle = GCHandle.Alloc(newStr);
                 *tab = (IntPtr)handle;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupDebug.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupDebug.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    /// <summary>
+    /// <see cref="System.Diagnostics.Debug"/> replacement for the startup path.
+    /// It's not safe to use the full-blown Debug class during startup because big chunks
+    /// of the managed execution environment are not initialized yet.
+    /// </summary>
+    static class StartupDebug
+    {
+        [Conditional("DEBUG")]
+        public static void Assert(bool condition)
+        {
+            if (!condition)
+                unsafe { *(int*)0 = 0; }
+        }
+
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -62,6 +62,7 @@
     </Compile>
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\LowLevelUTF8Encoding.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\StartupCodeHelpers.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\StartupDebug.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\InteropHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\LdTokenHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\MathHelpers.cs" />


### PR DESCRIPTION
Seems like the reason for using `Contract.Assert` instead of
`Debug.Assert` in the startup path was that `Debug.Assert` won't work
because it's not low level enough (needs `String.Empty` to work).
`Contract.Assert` is still problematic when the condition is not met.

The right solution is to actually define a lower level Assert.