### PR TITLE
Fix handling of multi-dim arrays in `System.Array`

### DIFF
--- a/src/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -349,6 +349,13 @@ namespace System.Runtime
             return pEEType->ComponentSize;
         }
 
+        [RuntimeExport("RhGetBaseSize")]
+        public static unsafe uint RhGetBaseSize(EETypePtr ptrEEType)
+        {
+            EEType* pEEType = ptrEEType.ToPointer();
+            return pEEType->BaseSize;
+        }
+
         [RuntimeExport("RhGetNumInterfaces")]
         public static unsafe uint RhGetNumInterfaces(EETypePtr ptrEEType)
         {

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -114,7 +114,7 @@ namespace Internal.Runtime.Augments
         public static Array NewArray(RuntimeTypeHandle typeHandleForArrayType, int count)
         {
             // Don't make the easy mistake of passing in the element EEType rather than the "array of element" EEType.
-            Debug.Assert(typeHandleForArrayType.ToEETypePtr().IsArray);
+            Debug.Assert(typeHandleForArrayType.ToEETypePtr().IsSzArray);
             return RuntimeImports.RhNewArray(typeHandleForArrayType.ToEETypePtr(), count);
         }
 

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -24,7 +24,7 @@
     <ExcludeAssemblyInfoPartialFile>true</ExcludeAssemblyInfoPartialFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
-    <DefineConstants>CORERT;$(DefineConstants)</DefineConstants>
+    <DefineConstants>CORERT;REAL_MULTIDIM_ARRAYS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsProjectNLibrary)' == 'true'">
     <DefineConstants>ENABLE_REFLECTION_TRACE;$(DefineConstants)</DefineConstants>

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -853,7 +853,7 @@ namespace System
             if (array == null)
                 throw new ArgumentNullException("array");
 
-#if !CORERT
+#if !REAL_MULTIDIM_ARRAYS
             // NOTE: ONCE WE GET RID OF THE IFDEFS, WE SHOULD RENAME THIS METHOD.
             // Get the backing array if this is an MDArray instance
             array = array.FlattenedArray;
@@ -864,7 +864,7 @@ namespace System
             if (length > (array.Length - index))
                 throw new IndexOutOfRangeException();
 
-#if CORERT
+#if REAL_MULTIDIM_ARRAYS
             // The above checks should have covered all the reasons why Clear would fail.
             Debug.Assert(false);
 #else
@@ -890,7 +890,7 @@ namespace System
         {
             get
             {
-#if CORERT
+#if REAL_MULTIDIM_ARRAYS
                 int boundsSize = (int)this.EETypePtr.BaseSize - SZARRAY_BASE_SIZE;
                 if (boundsSize > 0)
                 {
@@ -2186,7 +2186,7 @@ namespace System
 
         public int GetLowerBound(int dimension)
         {
-#if CORERT
+#if REAL_MULTIDIM_ARRAYS
             if (!this.EETypePtr.IsSzArray)
             {
                 if ((dimension >= Rank) || (dimension < 0))
@@ -2226,7 +2226,7 @@ namespace System
 
         public int GetUpperBound(int dimension)
         {
-#if CORERT
+#if REAL_MULTIDIM_ARRAYS
             if (!this.EETypePtr.IsSzArray)
             {
                 if ((dimension >= Rank) || (dimension < 0))
@@ -2285,7 +2285,7 @@ namespace System
 
         public unsafe Object GetValue(int index)
         {
-#if CORERT
+#if REAL_MULTIDIM_ARRAYS
             if (!this.EETypePtr.IsSzArray)
 #else
             if (this is MDArray)
@@ -2331,7 +2331,7 @@ namespace System
 
         public unsafe void SetValue(Object value, int index)
         {
-#if CORERT
+#if REAL_MULTIDIM_ARRAYS
             if (!this.EETypePtr.IsSzArray)
 #else
             if (this is MDArray)

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -853,15 +853,24 @@ namespace System
             if (array == null)
                 throw new ArgumentNullException("array");
 
+#if !CORERT
+            // NOTE: ONCE WE GET RID OF THE IFDEFS, WE SHOULD RENAME THIS METHOD.
+            // Get the backing array if this is an MDArray instance
             array = array.FlattenedArray;
+#endif
 
             if (index < 0 || index > array.Length || length < 0 || length > array.Length)
                 throw new IndexOutOfRangeException();
             if (length > (array.Length - index))
                 throw new IndexOutOfRangeException();
 
+#if CORERT
+            // The above checks should have covered all the reasons why Clear would fail.
+            Debug.Assert(false);
+#else
             bool success = RuntimeImports.TryArrayClear(array, index, length);
             Debug.Assert(success);
+#endif
         }
 
         // We impose limits on maximum array lenght in each dimension to allow efficient 

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -61,7 +61,11 @@ namespace System
         {
             get
             {
+#if REAL_MULTIDIM_ARRAYS
                 return this.EETypePtr.BaseSize == SZARRAY_BASE_SIZE;
+#else
+                return !(this is MDArray);
+#endif
             }
         }
 
@@ -2281,11 +2285,7 @@ namespace System
 
         public unsafe Object GetValue(int index)
         {
-#if REAL_MULTIDIM_ARRAYS
             if (!IsSzArray)
-#else
-            if (this is MDArray)
-#endif
                 throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
 
             EETypePtr pElementEEType = ElementEEType;
@@ -2327,11 +2327,7 @@ namespace System
 
         public unsafe void SetValue(Object value, int index)
         {
-#if REAL_MULTIDIM_ARRAYS
             if (!IsSzArray)
-#else
-            if (this is MDArray)
-#endif
                 throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
 
             if (index < 0 || index >= Length)

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -112,6 +112,14 @@ namespace System
             }
         }
 
+        internal bool IsSzArray
+        {
+            get
+            {
+                return IsArray && BaseSize == Array.SZARRAY_BASE_SIZE;
+            }
+        }
+
         internal bool IsPointer
         {
             get
@@ -182,12 +190,14 @@ namespace System
                     return new EETypePtr(default(IntPtr));
 
                 EETypePtr baseEEType = RuntimeImports.RhGetNonArrayBaseType(this);
+#if !CORERT
                 if (baseEEType == typeof(MDArrayRank2).TypeHandle.ToEETypePtr() ||
                     baseEEType == typeof(MDArrayRank3).TypeHandle.ToEETypePtr() ||
                     baseEEType == typeof(MDArrayRank4).TypeHandle.ToEETypePtr())
                 {
                     return typeof(Array).TypeHandle.ToEETypePtr();
                 }
+#endif
 
                 return baseEEType;
             }
@@ -198,6 +208,14 @@ namespace System
             get
             {
                 return RuntimeImports.RhGetComponentSize(this);
+            }
+        }
+
+        internal uint BaseSize
+        {
+            get
+            {
+                return RuntimeImports.RhGetBaseSize(this);
             }
         }
 

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -190,7 +190,7 @@ namespace System
                     return new EETypePtr(default(IntPtr));
 
                 EETypePtr baseEEType = RuntimeImports.RhGetNonArrayBaseType(this);
-#if !CORERT
+#if !REAL_MULTIDIM_ARRAYS
                 if (baseEEType == typeof(MDArrayRank2).TypeHandle.ToEETypePtr() ||
                     baseEEType == typeof(MDArrayRank3).TypeHandle.ToEETypePtr() ||
                     baseEEType == typeof(MDArrayRank4).TypeHandle.ToEETypePtr())

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -358,6 +358,10 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhGetComponentSize")]
         internal static extern ushort RhGetComponentSize(EETypePtr pEEType);
 
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhGetBaseSize")]
+        internal static extern uint RhGetBaseSize(EETypePtr pEEType);
+
         //
         // EEType Parent Hierarchy
         //


### PR DESCRIPTION
On CoreRT we diverged from Project N by treating multi-dim arrays same
as CLR. BCL needs to be fixed to reflect that.

Things that still need fixing:
* Various Copy details
* Enumerator
* SetValue(params)/GetValue(params)

I'll do those in a later pull request - the more code this has, the harder it is to review it. I'll keep #1103 open.