### PR TITLE
Cache the Rank in GetUpper/LowerBound

### DIFF
--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -2196,7 +2196,8 @@ namespace System
 #if REAL_MULTIDIM_ARRAYS
             if (!IsSzArray)
             {
-                if ((dimension >= Rank) || (dimension < 0))
+                int rank = Rank;
+                if ((uint)dimension >= rank)
                     throw new IndexOutOfRangeException();
 
                 unsafe
@@ -2204,7 +2205,7 @@ namespace System
                     fixed (int* pNumComponents = &_numComponents)
                     {
                         // Lower bounds follow after upper bounds.
-                        return *(pNumComponents + 1 + PADDING + Rank + dimension);
+                        return *(pNumComponents + 1 + PADDING + rank + dimension);
                     }
                 }
             }
@@ -2231,7 +2232,8 @@ namespace System
 #if REAL_MULTIDIM_ARRAYS
             if (!IsSzArray)
             {
-                if ((dimension >= Rank) || (dimension < 0))
+                int rank = Rank;
+                if ((uint)dimension >= rank)
                     throw new IndexOutOfRangeException();
 
                 unsafe
@@ -2240,7 +2242,7 @@ namespace System
                     {
                         // Upper bounds follow after _numComponents.
                         int hiBound = *(pNumComponents + 1 + PADDING + dimension);
-                        int loBound = *(pNumComponents + 1 + PADDING + Rank + dimension);
+                        int loBound = *(pNumComponents + 1 + PADDING + rank + dimension);
                         return hiBound + loBound - 1;
                     }
                 }


### PR DESCRIPTION
After dotnet/coreclr#4993, I decided to take a look at the corert implementation of `Array.GetLowerBound` (and others) to see if any similar optimizations could be made here.

Changes:

- `Array`
  - Port original optimizations from coreclr to `GetLowerBound`, `GetUpperBound`
  - Cache the rank in these methods as well
  - `Array.Copy`: Don't get the rank if the EETypePtrs are the same
  - Removed some branching by using a trick with uint wrapping (not sure if this is optimized by the C++ compiler)
- `MDArray`
  - Massively reduced the size of the `CheckBounds` methods (multiple `throw new ...` means mutliple throws will be in the generated IL, not sure how the AOT compiler handles this)
    - Also avoided some branching using the aforementioned trick
  - `Initialize`: When you're checking if something is negative, you're really checking if it's highest bit is set. Therefore, we can just AND everything and check if it's != 0 to check if any of the arguments are negative (again, please let me know if this is taken care of by the AOT compiler and if I should revert this)

cc @jkotas 