### PR TITLE
Buffer.BlockCopy optimization for arrays of same type

### DIFF
--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -36,7 +36,7 @@ namespace System
             if (!srcCorElementTypeInfo.IsPrimitive)
                 throw new ArgumentException(SR.Arg_MustBePrimArray, "src");
 
-            if (src != dst && src.EETypePtr != dst.EETypePtr)
+            if (src != dst && src.EETypePtr.RawValue != dst.EETypePtr.RawValue)
             {
                 RuntimeImports.RhCorElementTypeInfo dstCorElementTypeInfo = dst.ElementEEType.CorElementTypeInfo;
                 if (!dstCorElementTypeInfo.IsPrimitive)

--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -36,7 +36,7 @@ namespace System
             if (!srcCorElementTypeInfo.IsPrimitive)
                 throw new ArgumentException(SR.Arg_MustBePrimArray, "src");
 
-            if (src != dst)
+            if (src != dst && src.EETypePtr != dst.EETypePtr)
             {
                 RuntimeImports.RhCorElementTypeInfo dstCorElementTypeInfo = dst.ElementEEType.CorElementTypeInfo;
                 if (!dstCorElementTypeInfo.IsPrimitive)


### PR DESCRIPTION
Basically a port of dotnet/coreclr#4807 to corert.

Not sure if there's a way to apply the byte array-related optimizations from there as well here (so we can skip the first primitive typecheck as well, if either `src` or `dst` is a byte array) (how would you 'load' the byte array EETypePtr statically so you could compare it like `src.EETypePtr == s_byteArrayTypePtr`?).

cc @jkotas 