### PR TITLE
Introduce distinction between modules and assemblies

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaAssembly.Symbols.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaAssembly.Symbols.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Internal.TypeSystem.Ecma
+{
+    // Pluggable file that adds PDB handling functionality to EcmaAssembly
+    partial class EcmaAssembly
+    {
+        internal EcmaAssembly(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, PdbSymbolReader pdbReader)
+            : base(context, peReader, metadataReader, pdbReader)
+        {
+            _assemblyDefinition = metadataReader.GetAssemblyDefinition();
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaAssembly.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaAssembly.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Internal.TypeSystem.Ecma
+{
+    public sealed partial class EcmaAssembly : EcmaModule, IAssemblyDesc
+    {
+        private AssemblyName _assemblyName;
+        private AssemblyDefinition _assemblyDefinition;
+
+        public AssemblyDefinition AssemblyDefinition
+        {
+            get
+            {
+                return _assemblyDefinition;
+            }
+        }
+
+        public EcmaAssembly(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader)
+            : base(context, peReader, metadataReader)
+        {
+            _assemblyDefinition = metadataReader.GetAssemblyDefinition();
+        }
+
+        // Returns cached copy of the name. Caller has to create a clone before mutating the name.
+        public AssemblyName GetName()
+        {
+            if (_assemblyName == null)
+            {
+                MetadataReader metadataReader = this.MetadataReader;
+
+                AssemblyName an = new AssemblyName();
+                an.Name = metadataReader.GetString(_assemblyDefinition.Name);
+                an.Version = _assemblyDefinition.Version;
+                an.SetPublicKey(metadataReader.GetBlobBytes(_assemblyDefinition.PublicKey));
+
+                an.CultureName = metadataReader.GetString(_assemblyDefinition.Culture);
+                an.ContentType = GetContentTypeFromAssemblyFlags(_assemblyDefinition.Flags);
+
+                _assemblyName = an;
+            }
+
+            return _assemblyName;
+        }
+
+        public override string ToString()
+        {
+            return GetName().FullName;
+        }
+
+        public bool HasAssemblyCustomAttribute(string attributeNamespace, string attributeName)
+        {
+            return _metadataReader.GetCustomAttributeHandle(_assemblyDefinition.GetCustomAttributes(),
+                attributeNamespace, attributeName).IsNil;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.Symbols.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.Symbols.cs
@@ -15,16 +15,20 @@ namespace Internal.TypeSystem.Ecma
             get; private set;
         }
 
-        public EcmaModule(TypeSystemContext context, PEReader peReader, PdbSymbolReader pdbReader)
-            : this(context, peReader)
+        internal EcmaModule(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, PdbSymbolReader pdbReader)
+            : this(context, peReader, metadataReader)
         {
             PdbReader = pdbReader;
         }
 
-        public EcmaModule(TypeSystemContext context, MetadataReader metadataReader, PdbSymbolReader pdbReader)
-            : this(context, metadataReader)
+        public static EcmaModule Create(TypeSystemContext context, PEReader peReader, PdbSymbolReader pdbReader)
         {
-            PdbReader = pdbReader;
+            MetadataReader metadataReader = CreateMetadataReader(context, peReader);
+
+            if (metadataReader.IsAssembly)
+                return new EcmaAssembly(context, peReader, metadataReader, pdbReader);
+            else
+                return new EcmaModule(context, peReader, metadataReader, pdbReader);
         }
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -487,5 +487,11 @@ namespace Internal.TypeSystem.Ecma
             // String literals are not cached
             return _metadataReader.GetUserString(userStringHandle);
         }
+
+        public override string ToString()
+        {
+            ModuleDefinition moduleDefinition = _metadataReader.GetModuleDefinition();
+            return _metadataReader.GetString(moduleDefinition.Name);
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -13,12 +13,10 @@ using Internal.TypeSystem;
 
 namespace Internal.TypeSystem.Ecma
 {
-    public sealed partial class EcmaModule : ModuleDesc, IAssemblyDesc
+    public partial class EcmaModule : ModuleDesc
     {
         private PEReader _peReader;
-        private MetadataReader _metadataReader;
-
-        private AssemblyDefinition _assemblyDefinition;
+        protected MetadataReader _metadataReader;
 
         internal interface IEntityHandleObject
         {
@@ -164,25 +162,32 @@ namespace Internal.TypeSystem.Ecma
 
         private LockFreeReaderHashtable<EntityHandle, IEntityHandleObject> _resolvedTokens;
 
-        public EcmaModule(TypeSystemContext context, PEReader peReader)
+        internal EcmaModule(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader)
             : base(context)
         {
             _peReader = peReader;
-
-            var stringDecoderProvider = context as IMetadataStringDecoderProvider;
-
-            _metadataReader = peReader.GetMetadataReader(MetadataReaderOptions.None /* MetadataReaderOptions.ApplyWindowsRuntimeProjections */,
-                (stringDecoderProvider != null) ? stringDecoderProvider.GetMetadataStringDecoder() : null);
-
-            _assemblyDefinition = _metadataReader.GetAssemblyDefinition();
-
+            _metadataReader = metadataReader;
             _resolvedTokens = new EcmaObjectLookupHashtable(this);
         }
 
-        public EcmaModule(TypeSystemContext context, MetadataReader metadataReader)
-            : base(context)
+        public static EcmaModule Create(TypeSystemContext context, PEReader peReader)
         {
-            _metadataReader = metadataReader;
+            MetadataReader metadataReader = CreateMetadataReader(context, peReader);
+
+            if (metadataReader.IsAssembly)
+                return new EcmaAssembly(context, peReader, metadataReader);
+            else
+                return new EcmaModule(context, peReader, metadataReader);
+        }
+
+        private static MetadataReader CreateMetadataReader(TypeSystemContext context, PEReader peReader)
+        {
+            var stringDecoderProvider = context as IMetadataStringDecoderProvider;
+
+            MetadataReader metadataReader = peReader.GetMetadataReader(MetadataReaderOptions.None /* MetadataReaderOptions.ApplyWindowsRuntimeProjections */,
+                (stringDecoderProvider != null) ? stringDecoderProvider.GetMetadataStringDecoder() : null);
+
+            return metadataReader;
         }
 
         public PEReader PEReader
@@ -201,15 +206,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public AssemblyDefinition AssemblyDefinition
-        {
-            get
-            {
-                return _assemblyDefinition;
-            }
-        }
-
-        public override MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
+        public sealed override MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
         {
             var stringComparer = _metadataReader.StringComparer;
 
@@ -463,7 +460,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override IEnumerable<MetadataType> GetAllTypes()
+        public sealed override IEnumerable<MetadataType> GetAllTypes()
         {
             foreach (var typeDefinitionHandle in _metadataReader.TypeDefinitions)
             {
@@ -471,7 +468,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override TypeDesc GetGlobalModuleType()
+        public sealed override TypeDesc GetGlobalModuleType()
         {
             int typeDefinitionsCount = _metadataReader.TypeDefinitions.Count;
             if (typeDefinitionsCount == 0)
@@ -480,47 +477,15 @@ namespace Internal.TypeSystem.Ecma
             return GetType(MetadataTokens.EntityHandle(0x02000001 /* COR_GLOBAL_PARENT_TOKEN */));
         }
 
-        private static AssemblyContentType GetContentTypeFromAssemblyFlags(AssemblyFlags flags)
+        protected static AssemblyContentType GetContentTypeFromAssemblyFlags(AssemblyFlags flags)
         {
             return (AssemblyContentType)(((int)flags & 0x0E00) >> 9);
-        }
-
-        private AssemblyName _assemblyName;
-
-        // Returns cached copy of the name. Caller has to create a clone before mutating the name.
-        public AssemblyName GetName()
-        {
-            if (_assemblyName == null)
-            {
-                AssemblyName an = new AssemblyName();
-                an.Name = _metadataReader.GetString(_assemblyDefinition.Name);
-                an.Version = _assemblyDefinition.Version;
-                an.SetPublicKey(_metadataReader.GetBlobBytes(_assemblyDefinition.PublicKey));
-
-                an.CultureName = _metadataReader.GetString(_assemblyDefinition.Culture);
-                an.ContentType = GetContentTypeFromAssemblyFlags(_assemblyDefinition.Flags);
-
-                _assemblyName = an;
-            }
-
-            return _assemblyName;
         }
 
         public string GetUserString(UserStringHandle userStringHandle)
         {
             // String literals are not cached
             return _metadataReader.GetUserString(userStringHandle);
-        }
-
-        public bool HasCustomAttribute(string attributeNamespace, string attributeName)
-        {
-            return _metadataReader.GetCustomAttributeHandle(_assemblyDefinition.GetCustomAttributes(),
-                attributeNamespace, attributeName).IsNil;
-        }
-
-        public override string ToString()
-        {
-            return GetName().FullName;
         }
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -429,7 +429,7 @@ namespace Internal.TypeSystem.Ecma
 
         public override string ToString()
         {
-            return "[" + _module.GetName().Name + "]" + this.GetFullName();
+            return "[" + _module.ToString() + "]" + this.GetFullName();
         }
 
         public override ClassLayoutMetadata GetClassLayout()

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -217,7 +217,7 @@ namespace ILCompiler
                 PEReader peReader = OpenPEFile(filePath, out mappedViewAccessor);
                 pdbReader = OpenAssociatedSymbolFile(filePath);
 
-                EcmaModule module = new EcmaModule(this, peReader, pdbReader);
+                EcmaModule module = EcmaModule.Create(this, peReader, pdbReader);
 
                 MetadataReader metadataReader = module.MetadataReader;
                 string simpleName = metadataReader.GetString(metadataReader.GetAssemblyDefinition().Name);

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -120,7 +120,9 @@ namespace ILCompiler
         {
             if (type is EcmaType)
             {
-                string prependAssemblyName = SanitizeName(((EcmaType)type).EcmaModule.GetName().Name);
+                EcmaType ecmaType = (EcmaType)type;
+
+                string prependAssemblyName = SanitizeName(((EcmaAssembly)ecmaType.EcmaModule).GetName().Name);
 
                 var deduplicator = new HashSet<string>();
 
@@ -357,7 +359,7 @@ namespace ILCompiler
             {
                 if (_compilationUnitPrefix == null)
                 {
-                    string systemModuleName = ((EcmaModule)_compilation.TypeSystemContext.SystemModule).GetName().Name;
+                    string systemModuleName = ((EcmaAssembly)_compilation.TypeSystemContext.SystemModule).GetName().Name;
 
                     // TODO: just something to get Runtime.Base compiled
                     if (systemModuleName != "System.Private.CoreLib")

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -62,13 +62,13 @@ namespace ILCompiler.Metadata
 
                 scopeDefinition.PublicKey = assemblyName.GetPublicKey();
 
-                Cts.Ecma.EcmaModule ecmaModule = module as Cts.Ecma.EcmaModule;
-                if (ecmaModule != null)
+                Cts.Ecma.EcmaAssembly ecmaAssembly = module as Cts.Ecma.EcmaAssembly;
+                if (ecmaAssembly != null)
                 {
-                    Ecma.CustomAttributeHandleCollection customAttributes = ecmaModule.AssemblyDefinition.GetCustomAttributes();
+                    Ecma.CustomAttributeHandleCollection customAttributes = ecmaAssembly.AssemblyDefinition.GetCustomAttributes();
                     if (customAttributes.Count > 0)
                     {
-                        scopeDefinition.CustomAttributes = HandleCustomAttributes(ecmaModule, customAttributes);
+                        scopeDefinition.CustomAttributes = HandleCustomAttributes(ecmaAssembly, customAttributes);
                     }
                 }
             }

--- a/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
@@ -29,7 +29,7 @@ namespace MetadataTransformTests
 
         public EcmaModule CreateModuleForSimpleName(string simpleName)
         {
-            EcmaModule module = new EcmaModule(this, new PEReader(File.OpenRead(simpleName + ".dll")));
+            EcmaModule module = EcmaModule.Create(this, new PEReader(File.OpenRead(simpleName + ".dll")));
             _modules.Add(simpleName, module);
             return module;
         }

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -173,6 +173,12 @@
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\CustomAttributeTypeProvider.cs">
       <Link>Ecma\CustomAttributeTypeProvider.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaAssembly.cs">
+      <Link>Ecma\EcmaAssembly.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaAssembly.Symbols.cs">
+      <Link>Ecma\EcmaAssembly.Symbols.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaModule.Symbols.cs">
       <Link>Ecma\EcmaModule.Symbols.cs</Link>
     </Compile>

--- a/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
@@ -37,7 +37,7 @@ namespace TypeSystemTests
 
         public ModuleDesc CreateModuleForSimpleName(string simpleName)
         {
-            ModuleDesc module = new Internal.TypeSystem.Ecma.EcmaModule(this, new PEReader(File.OpenRead(simpleName + ".dll")));
+            ModuleDesc module = Internal.TypeSystem.Ecma.EcmaModule.Create(this, new PEReader(File.OpenRead(simpleName + ".dll")));
             _modules.Add(simpleName, module);
             return module;
         }


### PR DESCRIPTION
As I am looking at consolidation of the AOT metadata format, the representation of modules shows up as an interesting difference.

I'm not saying we should merge this pull request - I just wanted to see how this would look like in our type system and what might the problem points be. Doesn't seem too bad except for the part where we need to construct a name for non-assembly modules.

Feel free to say we don't want to merge this. No hard feelings :).