### PR TITLE
Monitor.GetLock: No dynamic type checks if IsLock == true

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -37,7 +37,7 @@ namespace System.Threading
                 throw new ArgumentNullException("obj");
 
             if (Lock.IsLock(obj))
-                return (Lock)obj;
+                return RuntimeHelpers.UncheckedCast<Lock>(obj);
 
             return GetLockFromTable(obj);
         }


### PR DESCRIPTION
`Monitor.GetLock` uses `Lock.IsLock` to determine whether a given object is a `Lock`. The `Lock.IsLock` function is [optimized](https://github.com/dotnet/corert/blob/4376c55dd018d8b7b9fed82449728711231ba266/src/System.Private.CoreLib/src/System/Threading/Lock.cs#L25-L26) to avoid "the overhead of the full casting logic in the runtime," yet we still perform a typecheck when we cast to `Lock` since the compiler doesn't know that `obj` must be an instance of `Lock` at that point.

This change changes it to use `RuntimeHelpers.UncheckedCast` instead of a regular cast to avoid the overhead of dynamic typechecking.

Public methods this affects (if `obj` is a `Lock`):

- `Enter`
- `TryEnter`
- `Exit`
- `IsEntered`

cc @jkotas 