### PR TITLE
Correct the optimization for #1283

### DIFF
--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -38,9 +38,10 @@ namespace System
 
             if (src != dst)
             {
+                RuntimeImports.RhCorElementTypeInfo dstCorElementTypeInfo = srcCorElementTypeInfo;
                 if (src.EETypePtr.RawValue != dst.EETypePtr.RawValue)
                 {
-                    RuntimeImports.RhCorElementTypeInfo dstCorElementTypeInfo = dst.ElementEEType.CorElementTypeInfo;
+                    dstCorElementTypeInfo = dst.ElementEEType.CorElementTypeInfo;
                     if (!dstCorElementTypeInfo.IsPrimitive)
                         throw new ArgumentException(SR.Arg_MustBePrimArray, "dst");
                 }

--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -38,9 +38,12 @@ namespace System
 
             if (src != dst)
             {
-                RuntimeImports.RhCorElementTypeInfo dstCorElementTypeInfo = dst.ElementEEType.CorElementTypeInfo;
-                if (!dstCorElementTypeInfo.IsPrimitive)
-                    throw new ArgumentException(SR.Arg_MustBePrimArray, "dst");
+                if (src.EETypePtr.RawValue != dst.EETypePtr.RawValue)
+                {
+                    RuntimeImports.RhCorElementTypeInfo dstCorElementTypeInfo = dst.ElementEEType.CorElementTypeInfo;
+                    if (!dstCorElementTypeInfo.IsPrimitive)
+                        throw new ArgumentException(SR.Arg_MustBePrimArray, "dst");
+                }
                 uDstLen = ((nuint)dst.Length) << dstCorElementTypeInfo.Log2OfSize;
             }
 


### PR DESCRIPTION
Apologies for the incorrect optimization before; this time I've excluded the `uDstLen` computation from the conditional block. I looked over the method a bit more carefully this time before submitting, but feel free to take another look in case you're skeptical.

cc @jkotas 