### PR TITLE
Fix Array.Reverse incorrectly validating index

### DIFF
--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -1703,9 +1703,10 @@ namespace System
         {
             if (array == null)
                 throw new ArgumentNullException("array");
-            if (index < 0 || length < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "length"), SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (array.Length - index < length)
+            int lowerBound = array.GetLowerBound(0);
+            if (index < lowerBound || length < 0)
+                throw new ArgumentOutOfRangeException((index < lowerBound ? "index" : "length"), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (array.Length - (index - lowerBound) < length)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             if (array.Rank != 1)
                 throw new RankException(SR.Rank_MultiDimNotSupported);


### PR DESCRIPTION
We need to actually check GetLowerBound

This could be a breaking change, but very unlikely as mscorlib validates the index correctly.

/cc @jamesqo @jkotas