### PR TITLE
Move _fieldLayoutFlags.AddFlags out of the loop

### DIFF
--- a/src/Common/src/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/DefType.FieldLayout.cs
@@ -267,8 +267,8 @@ namespace Internal.TypeSystem
                 {
                     Debug.Assert(fieldAndOffset.Field.OwningType == this);
                     fieldAndOffset.Field.InitializeOffset(fieldAndOffset.Offset);
-                    _fieldLayoutFlags.AddFlags(FieldLayoutFlags.ComputedInstanceTypeFieldsLayout);
                 }
+                _fieldLayoutFlags.AddFlags(FieldLayoutFlags.ComputedInstanceTypeFieldsLayout);
             }
 
             _fieldLayoutFlags.AddFlags(FieldLayoutFlags.ComputedInstanceTypeLayout);


### PR DESCRIPTION
That code didn't seem right. We're publishing the flag before we're done
with the loop. Plus we're publishing it more times than needed.