### PR TITLE
[WIP] Get rid of `AddWellKnownTypes`

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -163,7 +163,6 @@ namespace ILCompiler
 
             _nodeFactory.AttachToDependencyGraph(_dependencyGraph);
 
-            _compilationModuleGroup.AddWellKnownTypes();
             _compilationModuleGroup.AddCompilationRoots();
 
             if (!_options.IsCppCodeGen && !_options.MultiFile)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
@@ -69,16 +69,6 @@ namespace ILCompiler
             }
         }
 
-        public void AddWellKnownTypes()
-        {
-            var stringType = _typeSystemContext.GetWellKnownType(WellKnownType.String);
-
-            if (ContainsType(stringType))
-            {
-                _rootProvider.AddCompilationRoot(stringType, "String type is always generated");
-            }
-        }
-
         protected void AddCompilationRootsForRuntimeExports(EcmaModule module)
         {
             foreach (var type in module.GetAllTypes())

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructorNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructorNode.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+using ILCompiler.DependencyAnalysisFramework;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a constructor. This node does not generate <see cref="ObjectNode.ObjectData"/>. Instead, this node
+    /// maps to a regular entrypoint, but on top of that it triggers necessity of a constructed EEType of the
+    /// type being constructed.
+    /// </summary>
+    public sealed class ConstructorNode : DependencyNodeCore<NodeFactory>, IMethodNode
+    {
+        private IMethodNode _constructorNode;
+
+        public string MangledName
+        {
+            get
+            {
+                return _constructorNode.MangledName;
+            }
+        }
+
+        public MethodDesc Method
+        {
+            get
+            {
+                return _constructorNode.Method;
+            }
+        }
+
+        public int Offset
+        {
+            get
+            {
+                return _constructorNode.Offset;
+            }
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasDynamicDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool HasConditionalStaticDependencies
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public ConstructorNode(IMethodNode constructorNode)
+        {
+            // Assert that this is either an actual constructor, or a static method that returns an instance
+            // of its owning type (a "magic" constructor such as one of the String.Ctor methods).
+            Debug.Assert(constructorNode.Method.IsConstructor ||
+                (constructorNode.Method.Signature.IsStatic && constructorNode.Method.Signature.ReturnType == constructorNode.Method.OwningType));
+
+            Debug.Assert(!(constructorNode is ConstructorNode));
+
+            _constructorNode = constructorNode;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            yield return new DependencyListEntry(context.ConstructedTypeSymbol(_constructorNode.Method.OwningType), "Constructor call construction");
+            yield return new DependencyListEntry(_constructorNode, "Constructor");
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        {
+            return null;
+        }
+
+        public override string GetName()
+        {
+            return MangledName + " constructor";
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -121,6 +121,11 @@ namespace ILCompiler.DependencyAnalysis
                     return new ExternEETypeSymbolNode(type);
                 }
             });
+
+            _constructors = new NodeCache<MethodDesc, ConstructorNode>((MethodDesc constructorMethod) =>
+            {
+                return new ConstructorNode(MethodEntrypoint(constructorMethod));
+            });
             
             _nonGCStatics = new NodeCache<MetadataType, NonGCStaticsNode>((MetadataType type) =>
             {
@@ -285,6 +290,13 @@ namespace ILCompiler.DependencyAnalysis
         public IEETypeNode ConstructedTypeSymbol(TypeDesc type)
         {
             return _constructedTypeSymbols.GetOrAdd(type);
+        }
+
+        private NodeCache<MethodDesc, ConstructorNode> _constructors;
+
+        public ConstructorNode Constructor(MethodDesc constructorMethod)
+        {
+            return _constructors.GetOrAdd(constructorMethod);
         }
 
         private NodeCache<MetadataType, NonGCStaticsNode> _nonGCStatics;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -59,6 +59,14 @@ namespace ILCompiler.DependencyAnalysis
             get; private set;
         }
 
+        public CompilerTypeSystemContext TypeSystemContext
+        {
+            get
+            {
+                return _context;
+            }
+        }
+
         private struct NodeCache<TKey, TValue>
         {
             private Func<TKey, TValue> _creator;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Text;
 
+using Internal.TypeSystem;
+
 namespace ILCompiler.DependencyAnalysis
 {
     public class StringDataNode : ObjectNode, ISymbolNode
@@ -57,6 +59,16 @@ namespace ILCompiler.DependencyAnalysis
         public void SetId(int id)
         {
             _id = id;
+        }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            // Allocating string literal from the literal data requires the string EEType.
+            var list = new DependencyList() {
+                new DependencyListEntry(factory.ConstructedTypeSymbol(factory.TypeSystemContext.GetWellKnownType(WellKnownType.String)), "String literal")
+            };
+
+            return list;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.cs" />
     <Compile Include="Compiler\DelegateCreationInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ConstructorNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternEETypeSymbolNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericCompositionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IEETypeNode.cs" />

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2184,17 +2184,22 @@ namespace Internal.JitInterface
 
             if (directCall)
             {
+                IMethodNode targetNode;
+
                 if (targetMethod.IsConstructor && targetMethod.OwningType.IsString)
                 {
                     // Calling a string constructor doesn't call the actual constructor.
-                    targetMethod = targetMethod.GetStringInitializer();
+                    targetNode = _compilation.NodeFactory.Constructor(targetMethod.GetStringInitializer());
+                }
+                else
+                {
+                    targetNode = _compilation.NodeFactory.MethodEntrypoint(targetMethod);
                 }
 
                 pResult.kind = CORINFO_CALL_KIND.CORINFO_CALL;
                 pResult.codePointerOrStubLookup.constLookup.accessType = InfoAccessType.IAT_VALUE;
 
-                pResult.codePointerOrStubLookup.constLookup.addr =
-                    (void*)ObjectToHandle(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
+                pResult.codePointerOrStubLookup.constLookup.addr = (void*)ObjectToHandle(targetNode);
 
                 pResult.nullInstanceCheck = resolvedCallVirt;
             }


### PR DESCRIPTION
This method will have a tendency to become a dumping ground of
unexplained roots in the future (I just had the joy of looking through
these in the Project N dependency reducer). We should kill it before it
lays eggs.

The dependency graph should have dependencies that are traceable to the
thing that required them to become part of the graph. For the case of
`System.String` this was used as a shortcut for making string literals
work.

This will have a small perf hit, but this kind of microoptimization
should be backed by hard data quantifying how it's useful.