### PR TITLE
Compare with IntPtr.Zero in ResolvePInvoke

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -51,7 +51,7 @@ namespace Internal.Runtime.CompilerHelpers
 
         internal unsafe static IntPtr ResolvePInvoke(MethodFixupCell* pCell)
         {
-            if ((void*)pCell->Target != null)
+            if (pCell->Target != IntPtr.Zero)
                 return pCell->Target;
 
             return ResolvePInvokeSlow(pCell);


### PR DESCRIPTION
I originally wrote the code this way because comparing with IntPtr.Zero
was slow. #1306 should have fixed that.