### PR TITLE
GCDesc fixes

### DIFF
--- a/src/Common/src/TypeSystem/Common/Utilities/GCPointerMap.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/GCPointerMap.cs
@@ -62,6 +62,22 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Returns true if the map is all pointers
+        /// </summary>
+        public bool IsAllGCPointers
+        {
+            get
+            {
+                for (int i = 0; i < _numCells; i++)
+                {
+                    if (!this[i])
+                        return false;
+                }
+                return true;
+            }
+        }
+
         public bool this[int index]
         {
             get

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -84,7 +84,8 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.Alignment = 16;
             dataBuilder.DefinedSymbols.Add(this);
 
-            int totalSize = _gcMap.Size * _target.PointerSize;
+            // +2 for SyncBlock and EETypePtr field
+            int totalSize = (_gcMap.Size + 2) * _target.PointerSize;
 
             // We only need to check for containsPointers because ThreadStatics are always allocated
             // on the GC heap (no matter what "HasGCStaticBase" says).


### PR DESCRIPTION
- Fix base size in GCStaticEETypeNode GCDesc
- Optimized GCDesc encoding for arrays of structs that are all GC pointers