### PR TITLE
Implement EETypePtr.ConstructedEETypePtrOf

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -62,7 +62,7 @@ namespace Internal.IL
                 return InterlockedIntrinsic.EmitIL(method);
             }
             else
-            if (methodName == "EETypePtrOf" && owningType.Name == "EETypePtr" && owningType.Namespace == "System")
+            if ((methodName == "EETypePtrOf" || methodName == "ConstructedEETypePtrOf") && owningType.Name == "EETypePtr" && owningType.Namespace == "System")
             {
                 return EETypePtrOfIntrinsic.EmitIL(method);
             }

--- a/src/Common/src/TypeSystem/IL/Stubs/EETypePtrOfIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/EETypePtrOfIntrinsic.cs
@@ -17,7 +17,11 @@ namespace Internal.IL.Stubs
     {
         public static MethodIL EmitIL(MethodDesc target)
         {
-            Debug.Assert(target.Name == "EETypePtrOf");
+            // Note: The expanded method body can't fully capture the semantic of ConstructedEETypePtrOf.
+            //       Codegen backend either needs to not use this body and provide its own expansion, or have
+            //       some special casing to capture the difference elsewhere.
+
+            Debug.Assert(target.Name == "EETypePtrOf" || target.Name == "ConstructedEETypePtrOf");
             Debug.Assert(target.Signature.Length == 0
                 && target.Signature.ReturnType == target.OwningType);
             Debug.Assert(target.Instantiation.Length == 1);

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
@@ -71,6 +71,11 @@ namespace ILCompiler
 
         public void AddWellKnownTypes()
         {
+            // NOTE: this method is going away once RyuJit can generate proper code for EETypePtr.ConstructedEETypePtr.
+            //       https://github.com/dotnet/corert/issues/1314
+            //       DO NOT ADD NEW CODE TO THIS METHOD. There should be no such thing as "well known always rooted types".
+            //       Everything should fall out from the dependency graph.
+
             var stringType = _typeSystemContext.GetWellKnownType(WellKnownType.String);
 
             if (ContainsType(stringType))

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -793,6 +793,19 @@ namespace Internal.IL
                         return true;
                     }
                     break;
+                case "ConstructedEETypePtrOf":
+                    if (IsTypeName(method, "System", "EETypePtr"))
+                    {
+                        TypeDesc typeOfEEType = method.Instantiation[0];
+
+                        // Marking the type as constructed is the side effect we care for here.
+                        AddTypeReference(typeOfEEType, true);
+
+                        // We marked the type as constructed, but since we didn't attempt to expand the intrinsic, return false
+                        // so that we process the IL body of the instrinsic.
+                        return false;
+                    }
+                    break;
                 default:
                     break;
             }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.cs
@@ -157,7 +157,7 @@ namespace Internal.Runtime.CompilerHelpers
                 int count = LowLevelUTF8Encoding.GetCharCount(bytes, len);
                 Debug.Assert(count >= 0);
 
-                string newStr = RuntimeImports.RhNewArrayAsString(EETypePtr.EETypePtrOf<string>(), count);
+                string newStr = RuntimeImports.RhNewArrayAsString(EETypePtr.ConstructedEETypePtrOf<string>(), count);
                 fixed (char* dest = newStr)
                 {
                     int newCount = LowLevelUTF8Encoding.GetChars(bytes, len, dest, count);

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -254,6 +254,11 @@ namespace System
             }
         }
 
+        /// <summary>
+        /// Retrieves <see cref="EETypePtr"/> for a type. This can potentially be an EEType that has the VTable
+        /// and GCDesc optimized away. If the EEType pointer is getting used as part of an allocation, use
+        /// <see cref="ConstructedEETypePtrOf{T}"/>.
+        /// </summary>
 #if CORERT
         [Intrinsic]
 #endif
@@ -263,6 +268,30 @@ namespace System
             // This can be achieved by optimizing away the reflection part of this implementation
             // by optimizing typeof(!!0).TypeHandle into "ldtoken !!0", or by
             // completely replacing the body of this method.
+
+            // Compilers are allowed to optimize away some of the components of the emitted EEType
+            // (e.g. the GCDesc and VTable may not be present).
+
+            return typeof(T).TypeHandle.ToEETypePtr();
+        }
+
+        /// <summary>
+        /// Retrieves <see cref="EETypePtr"/> for a type that is safe to be passed to RhNewObj and similar APIs.
+        /// If the EEType is not used as part of allocation, use <see cref="EETypePtrOf{T}"/>.
+        /// </summary>
+#if CORERT
+        [Intrinsic]
+#endif
+        internal static EETypePtr ConstructedEETypePtrOf<T>()
+        {
+            // Compilers are required to provide a low level implementation of this method.
+            // This can be achieved by optimizing away the reflection part of this implementation
+            // by optimizing typeof(!!0).TypeHandle into "ldtoken !!0", or by
+            // completely replacing the body of this method.
+
+            // Compilers are required to track EEType pointers obtained through this method as if they
+            // were constructed (i.e. their VTable and GCDesc has to be present).
+
             return typeof(T).TypeHandle.ToEETypePtr();
         }
     }

--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -1632,7 +1632,7 @@ namespace System
                 // We allocate one extra char as an interop convenience so that our strings are null-
                 // terminated, however, we don't pass the extra +1 to the array allocation because the base
                 // size of this object includes the _firstChar field.
-                string newStr = RuntimeImports.RhNewArrayAsString(EETypePtr.EETypePtrOf<string>(), length);
+                string newStr = RuntimeImports.RhNewArrayAsString(EETypePtr.ConstructedEETypePtrOf<string>(), length);
                 Debug.Assert(newStr._stringLength == length);
                 return newStr;
             }


### PR DESCRIPTION
Make it possible for the class library to declare the intent with which
`EETypePtrOf` intrinsic is being used.

I'm implementing it for CppCodeGen only for now.

RyuJIT will need to learn to recognize this intrinsic and pass
`CorInfoTokenKind.CORINFO_TOKENKIND_NewObj` to `embedGenericHandle` when
it's used. Tracked by #1314.