### PR TITLE
Add support for ExplicitScopeAttribute to metadata generation

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -141,10 +141,12 @@ namespace ILCompiler
         private struct DummyMetadataPolicy : IMetadataPolicy
         {
             private MetadataGeneration _parent;
+            private ExplicitScopeAssemblyPolicyMixin _explicitScopeMixin;
 
             public DummyMetadataPolicy(MetadataGeneration parent)
             {
                 _parent = parent;
+                _explicitScopeMixin = new ExplicitScopeAssemblyPolicyMixin();
             }
 
             public bool GeneratesMetadata(FieldDesc fieldDef)
@@ -179,6 +181,11 @@ namespace ILCompiler
             public bool IsBlocked(MetadataType typeDef)
             {
                 return false;
+            }
+
+            public ModuleDesc GetModuleOfType(MetadataType typeDef)
+            {
+                return _explicitScopeMixin.GetModuleOfType(typeDef);
             }
         }
     }

--- a/src/ILCompiler.MetadataTransform/MetadataTransform.sln
+++ b/src/ILCompiler.MetadataTransform/MetadataTransform.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.24711.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.MetadataTransform", "src\ILCompiler.MetadataTransform.csproj", "{A965EA82-219D-48F7-AD51-BC030C16CC6F}"
 EndProject
@@ -14,6 +14,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrimaryMetadataAssembly", "tests\PrimaryMetadataAssembly\PrimaryMetadataAssembly.csproj", "{C29B7395-F925-4B0E-972D-187D2D4BFEC7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleMetadataAssembly", "tests\SampleMetadataAssembly\SampleMetadataAssembly.csproj", "{D29B7395-A925-5B0E-972D-387D2D4BFEC8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsWinrtMetadataAssembly", "tests\WindowsWinrtMetadataAssembly\WindowsWinrtMetadataAssembly.csproj", "{19D0BAA8-8762-4D64-80AF-53D7A2BBC4AE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleWinRTMetadataAssembly", "tests\SampleWinRTMetadataAssembly\SampleWinRTMetadataAssembly.csproj", "{46CDD663-FCCC-4E74-901F-3D9D5A36A0D9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +49,14 @@ Global
 		{D29B7395-A925-5B0E-972D-387D2D4BFEC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D29B7395-A925-5B0E-972D-387D2D4BFEC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D29B7395-A925-5B0E-972D-387D2D4BFEC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19D0BAA8-8762-4D64-80AF-53D7A2BBC4AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19D0BAA8-8762-4D64-80AF-53D7A2BBC4AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19D0BAA8-8762-4D64-80AF-53D7A2BBC4AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19D0BAA8-8762-4D64-80AF-53D7A2BBC4AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46CDD663-FCCC-4E74-901F-3D9D5A36A0D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46CDD663-FCCC-4E74-901F-3D9D5A36A0D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46CDD663-FCCC-4E74-901F-3D9D5A36A0D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46CDD663-FCCC-4E74-901F-3D9D5A36A0D9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ILCompiler\Metadata\EntityMap.cs" />
+    <Compile Include="ILCompiler\Metadata\ExplicitScopeAssemblyPolicyMixin.cs" />
     <Compile Include="ILCompiler\Metadata\IMetadataPolicy.cs" />
     <Compile Include="ILCompiler\Metadata\MetadataTransform.cs" />
     <Compile Include="ILCompiler\Metadata\MetadataTransformResult.cs" />

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/ExplicitScopeAssemblyPolicyMixin.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/ExplicitScopeAssemblyPolicyMixin.cs
@@ -1,0 +1,162 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Cts = Internal.TypeSystem;
+using Ecma = System.Reflection.Metadata;
+
+namespace ILCompiler.Metadata
+{
+    /// <summary>
+    /// Mixin helper class to allow easy support for ExplicitScopeAttribute for metadata transformation
+    /// 
+    /// ExplicitScopeAttribute is used to relocate where a given type appears in metadata from one 
+    /// metadata assembly to another. It must not be used to relocate into an assembly which otherwise 
+    /// exists within the compilation operation (Current implementation is not reliable in those circumstances.)
+    /// </summary>
+    public class ExplicitScopeAssemblyPolicyMixin
+    {
+        private class AssemblyNameEqualityComparer : IEqualityComparer<AssemblyName>
+        {
+            public static AssemblyNameEqualityComparer Instance { get; } = new AssemblyNameEqualityComparer();
+
+            public bool ByteArrayCompare(byte[] arr1, byte[] arr2)
+            {
+                if (arr1.Length != arr2.Length)
+                    return false;
+
+                for (int i = 0; i < arr1.Length; i++)
+                {
+                    if (arr1[i] != arr2[i])
+                        return false;
+                }
+                return true;
+            }
+
+            public bool Equals(AssemblyName x, AssemblyName y)
+            {
+                if (x.Name != y.Name)
+                    return false;
+
+                if (x.ContentType != y.ContentType)
+                    return false;
+
+                if (x.CultureName != y.CultureName)
+                    return false;
+
+                if (x.Flags != y.Flags)
+                    return false;
+                
+                if (x.Flags.HasFlag(AssemblyNameFlags.PublicKey))
+                {
+                    if (!ByteArrayCompare(x.GetPublicKey(), y.GetPublicKey()))
+                        return false;
+                }
+                else
+                {
+                    if (!ByteArrayCompare(x.GetPublicKeyToken(), y.GetPublicKeyToken()))
+                        return false;
+                }
+
+                if (x.ProcessorArchitecture != y.ProcessorArchitecture)
+                    return false;
+
+                if (!x.Version.Equals(y.Version))
+                    return false;
+
+                return true;
+            }
+
+            public int GetHashCode(AssemblyName obj)
+            {
+                return obj.Name.GetHashCode();
+            }
+        }
+
+        private class ExplicitScopeAssemblyDesc : Cts.ModuleDesc, Cts.IAssemblyDesc
+        {
+            AssemblyName _assemblyName;
+
+            public ExplicitScopeAssemblyDesc(Cts.TypeSystemContext context, AssemblyName assemblyName) : base(context)
+            {
+                _assemblyName = assemblyName;
+            }
+
+            AssemblyName Cts.IAssemblyDesc.GetName()
+            {
+                return _assemblyName;
+            }
+
+            public override Cts.MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
+            {
+                if (throwIfNotFound)
+                    throw new TypeLoadException("GetType on an ExplicitScopeAssemblyDesc is not supported");
+                return null;
+            }
+
+            public override Cts.TypeDesc GetGlobalModuleType()
+            {
+                return null;
+            }
+
+            public override IEnumerable<Cts.MetadataType> GetAllTypes()
+            {
+                return Array.Empty<Cts.MetadataType>();
+            }
+        }
+
+        private Dictionary<AssemblyName, ExplicitScopeAssemblyDesc> _dynamicallyGeneratedExplicitScopes = 
+            new Dictionary<AssemblyName, ExplicitScopeAssemblyDesc>(AssemblyNameEqualityComparer.Instance);
+
+        private Cts.ModuleDesc OverrideModuleOfTypeViaExplicitScope(Cts.MetadataType typeDef)
+        {
+            if (typeDef.HasCustomAttribute("Internal.Reflection", "ExplicitScopeAttribute"))
+            {
+                // There is no current cross type system way to represent custom attributes
+                Cts.Ecma.EcmaType ecmaType = (Cts.Ecma.EcmaType)typeDef;
+
+                var customAttributeValue = Internal.TypeSystem.Ecma.MetadataExtensions.GetDecodedCustomAttribute(
+                    ecmaType, "Internal.Reflection", "ExplicitScopeAttribute");
+
+                if (!customAttributeValue.HasValue)
+                    return null;
+
+                if (customAttributeValue.Value.FixedArguments.Length != 1)
+                    return null;
+
+                if (customAttributeValue.Value.FixedArguments[0].Type != typeDef.Context.GetWellKnownType(Cts.WellKnownType.String))
+                    return null;
+
+                string assemblyNameString = (string)customAttributeValue.Value.FixedArguments[0].Value;
+                AssemblyName assemblyName = new AssemblyName(assemblyNameString);
+
+                lock(_dynamicallyGeneratedExplicitScopes)
+                {
+                    ExplicitScopeAssemblyDesc explicitScopeAssembly;
+
+                    if (_dynamicallyGeneratedExplicitScopes.TryGetValue(assemblyName, out explicitScopeAssembly))
+                    {
+                        return explicitScopeAssembly;
+                    }
+                    explicitScopeAssembly = new ExplicitScopeAssemblyDesc(typeDef.Context, assemblyName);
+                    _dynamicallyGeneratedExplicitScopes.Add(assemblyName, explicitScopeAssembly);
+                    return explicitScopeAssembly;
+                }
+            }
+
+            return null;
+        }
+
+        public Cts.ModuleDesc GetModuleOfType(Cts.MetadataType typeDef)
+        {
+            Cts.ModuleDesc overrideModule = OverrideModuleOfTypeViaExplicitScope(typeDef);
+            if (overrideModule != null)
+                return overrideModule;
+
+            return typeDef.Module;
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/ExplicitScopeAssemblyPolicyMixin.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/ExplicitScopeAssemblyPolicyMixin.cs
@@ -76,11 +76,11 @@ namespace ILCompiler.Metadata
             }
         }
 
-        private class ExplicitScopeAssemblyDesc : Cts.ModuleDesc, Cts.IAssemblyDesc
+        private class ExplicitScopeAssembly : Cts.ModuleDesc, Cts.IAssemblyDesc
         {
             AssemblyName _assemblyName;
 
-            public ExplicitScopeAssemblyDesc(Cts.TypeSystemContext context, AssemblyName assemblyName) : base(context)
+            public ExplicitScopeAssembly(Cts.TypeSystemContext context, AssemblyName assemblyName) : base(context)
             {
                 _assemblyName = assemblyName;
             }
@@ -93,7 +93,7 @@ namespace ILCompiler.Metadata
             public override Cts.MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
             {
                 if (throwIfNotFound)
-                    throw new TypeLoadException("GetType on an ExplicitScopeAssemblyDesc is not supported");
+                    throw new TypeLoadException("GetType on an ExplicitScopeAssembly is not supported");
                 return null;
             }
 
@@ -108,8 +108,8 @@ namespace ILCompiler.Metadata
             }
         }
 
-        private Dictionary<AssemblyName, ExplicitScopeAssemblyDesc> _dynamicallyGeneratedExplicitScopes = 
-            new Dictionary<AssemblyName, ExplicitScopeAssemblyDesc>(AssemblyNameEqualityComparer.Instance);
+        private Dictionary<AssemblyName, ExplicitScopeAssembly> _dynamicallyGeneratedExplicitScopes = 
+            new Dictionary<AssemblyName, ExplicitScopeAssembly>(AssemblyNameEqualityComparer.Instance);
 
         private Cts.ModuleDesc OverrideModuleOfTypeViaExplicitScope(Cts.MetadataType typeDef)
         {
@@ -135,13 +135,13 @@ namespace ILCompiler.Metadata
 
                 lock(_dynamicallyGeneratedExplicitScopes)
                 {
-                    ExplicitScopeAssemblyDesc explicitScopeAssembly;
+                    ExplicitScopeAssembly explicitScopeAssembly;
 
                     if (_dynamicallyGeneratedExplicitScopes.TryGetValue(assemblyName, out explicitScopeAssembly))
                     {
                         return explicitScopeAssembly;
                     }
-                    explicitScopeAssembly = new ExplicitScopeAssemblyDesc(typeDef.Context, assemblyName);
+                    explicitScopeAssembly = new ExplicitScopeAssembly(typeDef.Context, assemblyName);
                     _dynamicallyGeneratedExplicitScopes.Add(assemblyName, explicitScopeAssembly);
                     return explicitScopeAssembly;
                 }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/ExplicitScopeAssemblyPolicyMixin.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/ExplicitScopeAssemblyPolicyMixin.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using Cts = Internal.TypeSystem;
 using Ecma = System.Reflection.Metadata;
@@ -15,7 +16,8 @@ namespace ILCompiler.Metadata
     /// 
     /// ExplicitScopeAttribute is used to relocate where a given type appears in metadata from one 
     /// metadata assembly to another. It must not be used to relocate into an assembly which otherwise 
-    /// exists within the compilation operation (Current implementation is not reliable in those circumstances.)
+    /// exists within the compilation operation. (Current implementation is not reliable in those
+    /// circumstances, but there is an assert that in debug builds will detect violations.)
     /// </summary>
     public class ExplicitScopeAssemblyPolicyMixin
     {
@@ -132,7 +134,7 @@ namespace ILCompiler.Metadata
 
                 string assemblyNameString = (string)customAttributeValue.Value.FixedArguments[0].Value;
                 AssemblyName assemblyName = new AssemblyName(assemblyNameString);
-
+                Debug.Assert(typeDef.Context.ResolveAssembly(assemblyName, false) == null, "ExplicitScopeAttribute must not refer to an assembly which is actually present in the type system.");
                 lock(_dynamicallyGeneratedExplicitScopes)
                 {
                     ExplicitScopeAssembly explicitScopeAssembly;

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
@@ -43,5 +43,13 @@ namespace ILCompiler.Metadata
         /// blocked types are dropped from metadata.
         /// </summary>
         bool IsBlocked(Cts.MetadataType typeDef);
+
+        /// <summary>
+        /// Return the Module that should be treated as defining the type. Typically implementations
+        /// will return typeDef.Module, but in some circumstances it may return a different value.
+        /// The ModuleDesc that is returned will be cast to IAssemblyDesc and the GetName method is
+        /// the only function that shall be used on this ModuleDesc.
+        /// </summary>
+        Cts.ModuleDesc GetModuleOfType(Cts.MetadataType typeDef);
     }
 }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/IMetadataPolicy.cs
@@ -47,8 +47,6 @@ namespace ILCompiler.Metadata
         /// <summary>
         /// Return the Module that should be treated as defining the type. Typically implementations
         /// will return typeDef.Module, but in some circumstances it may return a different value.
-        /// The ModuleDesc that is returned will be cast to IAssemblyDesc and the GetName method is
-        /// the only function that shall be used on this ModuleDesc.
         /// </summary>
         Cts.ModuleDesc GetModuleOfType(Cts.MetadataType typeDef);
     }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/MetadataTransform.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/MetadataTransform.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.Metadata
             // - change the way TypeDefs are hooked up into namespaces and scopes
             // - queue up calls to the various Initialize* methods on a threadpool
 
-            var transform = new Transform<TPolicy>(policy, modules);
+            var transform = new Transform<TPolicy>(policy);
 
             foreach (var module in modules)
             {

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -29,10 +29,6 @@ namespace ILCompiler.Metadata
 
         private void InitializeScopeDefinition(Cts.ModuleDesc module, ScopeDefinition scopeDefinition)
         {
-            // Make sure we're expected to create a scope definition here. If the assert fires, the metadata
-            // policy should have directed us to create a scope reference (or the list of inputs was incomplete).
-            Debug.Assert(_modulesToTransform.Contains(module), "Incomplete list of input modules with respect to metadata policy");
-
             var assemblyDesc = module as Cts.IAssemblyDesc;
             if (assemblyDesc != null)
             {

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -192,7 +192,7 @@ namespace ILCompiler.Metadata
             }
             else
             {
-                parentReferenceRecord.ParentNamespaceOrType = HandleNamespaceReference(containingType.Module, containingType.Namespace);
+                parentReferenceRecord.ParentNamespaceOrType = HandleNamespaceReference(_policy.GetModuleOfType(containingType), containingType.Namespace);
             }
 
             return parentReferenceRecord;
@@ -208,7 +208,7 @@ namespace ILCompiler.Metadata
             }
             else
             {
-                record.ParentNamespaceOrType = HandleNamespaceReference(entity.Module, entity.Namespace);
+                record.ParentNamespaceOrType = HandleNamespaceReference(_policy.GetModuleOfType(entity), entity.Namespace);
             }
 
             record.TypeName = HandleString(entity.Name);
@@ -225,12 +225,12 @@ namespace ILCompiler.Metadata
                 enclosingType.NestedTypes.Add(record);
 
                 var namespaceDefinition =
-                    HandleNamespaceDefinition(entity.ContainingType.Module, entity.ContainingType.Namespace);
+                    HandleNamespaceDefinition(_policy.GetModuleOfType(entity.ContainingType), entity.ContainingType.Namespace);
                 record.NamespaceDefinition = namespaceDefinition;
             }
             else
             {
-                var namespaceDefinition = HandleNamespaceDefinition(entity.Module, entity.Namespace);
+                var namespaceDefinition = HandleNamespaceDefinition(_policy.GetModuleOfType(entity), entity.Namespace);
                 record.NamespaceDefinition = namespaceDefinition;
                 namespaceDefinition.TypeDefinitions.Add(record);
             }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.cs
@@ -20,12 +20,10 @@ namespace ILCompiler.Metadata
         where TPolicy : struct, IMetadataPolicy
     {
         private TPolicy _policy;
-        private HashSet<Cts.ModuleDesc> _modulesToTransform;
 
-        public Transform(TPolicy policy, IEnumerable<Cts.ModuleDesc> modules)
+        public Transform(TPolicy policy)
         {
             _policy = policy;
-            _modulesToTransform = new HashSet<Cts.ModuleDesc>(modules);
         }
 
         private bool IsBlocked(Cts.TypeDesc type)

--- a/src/ILCompiler.MetadataTransform/tests/ExplicitScopeTests.cs
+++ b/src/ILCompiler.MetadataTransform/tests/ExplicitScopeTests.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Internal.Metadata.NativeFormat.Writer;
+using ILCompiler.Metadata;
+
+using Cts = Internal.TypeSystem;
+using NativeFormat = Internal.Metadata.NativeFormat;
+
+using Xunit;
+
+namespace MetadataTransformTests
+{
+    public class ExplicitScopeTests
+    {
+        private TestTypeSystemContext _context;
+        private Cts.Ecma.EcmaModule _systemModule;
+
+        public ExplicitScopeTests()
+        {
+            _context = new TestTypeSystemContext();
+            _systemModule = _context.CreateModuleForSimpleName("PrimaryMetadataAssembly");
+            _context.SetSystemModule(_systemModule);
+        }
+
+        public ScopeDefinition GetScopeDefinitionOfType(TypeDefinition typeDefinition)
+        {
+            Assert.NotNull(typeDefinition);
+            ScopeDefinition scope = null;
+            NamespaceDefinition currentNamespaceDefinition = typeDefinition.NamespaceDefinition;
+
+            while (scope == null)
+            {
+                Assert.NotNull(currentNamespaceDefinition);
+                scope = currentNamespaceDefinition.ParentScopeOrNamespace as ScopeDefinition;
+                currentNamespaceDefinition = currentNamespaceDefinition.ParentScopeOrNamespace as NamespaceDefinition;
+            }
+
+            return scope;
+        }
+
+        public ScopeReference GetScopeReferenceOfType(TypeReference typeReference)
+        {
+            Assert.NotNull(typeReference);
+            ScopeReference scope = null;
+            NamespaceReference currentNamespaceReference = typeReference.ParentNamespaceOrType as NamespaceReference;
+
+            while (scope == null)
+            {
+                Assert.NotNull(currentNamespaceReference);
+                scope = currentNamespaceReference.ParentScopeOrNamespace as ScopeReference;
+                currentNamespaceReference = currentNamespaceReference.ParentScopeOrNamespace as NamespaceReference;
+            }
+
+            return scope;
+        }
+
+        public void CheckTypeDefinitionForProperWinRTHome(TypeDefinition typeDefinition, string module)
+        {
+            ScopeDefinition scope = GetScopeDefinitionOfType(typeDefinition);
+            Assert.Equal(module, scope.Name.Value);
+            int windowsRuntimeFlag = ((int)System.Reflection.AssemblyContentType.WindowsRuntime << 9);
+            Assert.True((((int)scope.Flags) & windowsRuntimeFlag) == windowsRuntimeFlag);
+        }
+
+
+        public void CheckTypeReferenceForProperWinRTHome(TypeReference typeReference, string module)
+        {
+            ScopeReference scope = GetScopeReferenceOfType(typeReference);
+            Assert.Equal(module, scope.Name.Value);
+            int windowsRuntimeFlag = ((int)System.Reflection.AssemblyContentType.WindowsRuntime << 9);
+            Assert.True((((int)scope.Flags) & windowsRuntimeFlag) == windowsRuntimeFlag);
+        }
+
+        [Fact]
+        public void TestExplicitScopeAttributesForWinRTSingleFilePolicy()
+        {
+            // Test that custom attributes referring to blocked types don't show up in metadata
+
+            var sampleMetadataModule = _context.GetModuleForSimpleName("SampleMetadataAssembly");
+            var sampleWinRTMetadataModule = _context.GetModuleForSimpleName("SampleWinRTMetadataAssembly");
+            var windowsWinRTMetadataModule = _context.GetModuleForSimpleName("WindowsWinRTMetadataAssembly");
+
+            Cts.MetadataType controlType = windowsWinRTMetadataModule.GetType("Windows", "Control");
+            Cts.MetadataType derivedFromControl = sampleWinRTMetadataModule.GetType("SampleMetadataWinRT", "DerivedFromControl");
+            Cts.MetadataType derivedFromControlInCustomScope = sampleWinRTMetadataModule.GetType("SampleMetadataWinRT", "DerivedFromControlAndInCustomScope");
+
+            var policy = new SingleFileMetadataPolicy();
+
+            var transformResult = MetadataTransform.Run(policy,
+                new[] { _systemModule, sampleMetadataModule, sampleWinRTMetadataModule, windowsWinRTMetadataModule });
+
+            var controlTypeMetadata = transformResult.GetTransformedTypeDefinition(controlType);
+            var derivedFromControlMetadata = transformResult.GetTransformedTypeDefinition(derivedFromControl);
+            var derivedFromControlInCustomScopeMetadata = transformResult.GetTransformedTypeDefinition(derivedFromControlInCustomScope);
+
+            CheckTypeDefinitionForProperWinRTHome(controlTypeMetadata, "Windows");
+            ScopeDefinition scopeDefOfDerivedFromControlType = GetScopeDefinitionOfType(derivedFromControlMetadata);
+            Assert.Equal("SampleWinRTMetadataAssembly", scopeDefOfDerivedFromControlType.Name.Value);
+            CheckTypeDefinitionForProperWinRTHome(derivedFromControlInCustomScopeMetadata, "SampleMetadataWinRT");
+        }
+
+
+        [Fact]
+        public void TestExplicitScopeAttributesForWinRTMultiFilePolicy()
+        {
+            // Test that custom attributes referring to blocked types don't show up in metadata
+
+            var sampleMetadataModule = _context.GetModuleForSimpleName("SampleMetadataAssembly");
+            var sampleWinRTMetadataModule = _context.GetModuleForSimpleName("SampleWinRTMetadataAssembly");
+            var windowsWinRTMetadataModule = _context.GetModuleForSimpleName("WindowsWinRTMetadataAssembly");
+
+            Cts.MetadataType controlType = windowsWinRTMetadataModule.GetType("Windows", "Control");
+            Cts.MetadataType derivedFromControl = sampleWinRTMetadataModule.GetType("SampleMetadataWinRT", "DerivedFromControl");
+            Cts.MetadataType derivedFromControlInCustomScope = sampleWinRTMetadataModule.GetType("SampleMetadataWinRT", "DerivedFromControlAndInCustomScope");
+
+            var policy = new MultifileMetadataPolicy(sampleMetadataModule, sampleWinRTMetadataModule);
+
+            var transformResult = MetadataTransform.Run(policy,
+                new[] { _systemModule, sampleMetadataModule, sampleWinRTMetadataModule, windowsWinRTMetadataModule });
+
+            var controlTypeMetadata = transformResult.GetTransformedTypeReference(controlType);
+            var derivedFromControlMetadata = transformResult.GetTransformedTypeDefinition(derivedFromControl);
+            var derivedFromControlInCustomScopeMetadata = transformResult.GetTransformedTypeDefinition(derivedFromControlInCustomScope);
+
+            CheckTypeReferenceForProperWinRTHome(controlTypeMetadata, "Windows");
+            ScopeDefinition scopeDefOfDerivedFromControlType = GetScopeDefinitionOfType(derivedFromControlMetadata);
+            Assert.Equal("SampleWinRTMetadataAssembly", scopeDefOfDerivedFromControlType.Name.Value);
+            CheckTypeDefinitionForProperWinRTHome(derivedFromControlInCustomScopeMetadata, "SampleMetadataWinRT");
+        }
+    }
+}

--- a/src/ILCompiler.MetadataTransform/tests/ILCompiler.MetadataTransform.Tests.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/ILCompiler.MetadataTransform.Tests.csproj
@@ -39,11 +39,24 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
     </ProjectReference>
+    <ProjectReference Include="SampleWinRTMetadataAssembly\SampleWinRTMetadataAssembly.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+    <ProjectReference Include="WindowsWinrtMetadataAssembly\WindowsWinrtMetadataAssembly.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExplicitScopeTests.cs" />
     <Compile Include="MockPolicy.cs" />
     <Compile Include="MultifileMetadataPolicy.cs" />
     <Compile Include="NativeFormatExtensions.cs" />

--- a/src/ILCompiler.MetadataTransform/tests/MockPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/MockPolicy.cs
@@ -15,17 +15,20 @@ namespace MetadataTransformTests
         private Func<FieldDesc, bool> _fieldGeneratesMetadata;
 
         private Func<MetadataType, bool> _isBlockedType;
+        private Func<MetadataType, ModuleDesc> _moduleOfType;
 
         public MockPolicy(
             Func<MetadataType, bool> typeGeneratesMetadata,
             Func<MethodDesc, bool> methodGeneratesMetadata = null,
             Func<FieldDesc, bool> fieldGeneratesMetadata = null,
-            Func<MetadataType, bool> isBlockedType = null)
+            Func<MetadataType, bool> isBlockedType = null,
+            Func<MetadataType, ModuleDesc> moduleOfType = null)
         {
             _typeGeneratesMetadata = typeGeneratesMetadata;
             _methodGeneratesMetadata = methodGeneratesMetadata;
             _fieldGeneratesMetadata = fieldGeneratesMetadata;
             _isBlockedType = isBlockedType;
+            _moduleOfType = moduleOfType;
         }
 
         public bool GeneratesMetadata(MethodDesc methodDef)
@@ -52,6 +55,13 @@ namespace MetadataTransformTests
             if (_isBlockedType != null)
                 return _isBlockedType(typeDef);
             return false;
+        }
+
+        public ModuleDesc GetModuleOfType(MetadataType typeDef)
+        {
+            if (_moduleOfType != null)
+                return _moduleOfType(typeDef);
+            return typeDef.Module;
         }
     }
 }

--- a/src/ILCompiler.MetadataTransform/tests/MultifileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/MultifileMetadataPolicy.cs
@@ -17,11 +17,13 @@ namespace MetadataTransformTests
     /// </summary>
     struct MultifileMetadataPolicy : IMetadataPolicy
     {
+        ExplicitScopeAssemblyPolicyMixin _explicitScopePolicyMixin;
         HashSet<ModuleDesc> _modules;
 
         public MultifileMetadataPolicy(params ModuleDesc[] modules)
         {
             _modules = new HashSet<ModuleDesc>(modules);
+            _explicitScopePolicyMixin = new ExplicitScopeAssemblyPolicyMixin();
         }
 
         public bool GeneratesMetadata(MethodDesc methodDef)
@@ -48,6 +50,11 @@ namespace MetadataTransformTests
                 return true;
 
             return false;
+        }
+
+        public ModuleDesc GetModuleOfType(MetadataType typeDef)
+        {
+            return _explicitScopePolicyMixin.GetModuleOfType(typeDef);
         }
     }
 }

--- a/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/Platform.cs
+++ b/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/Platform.cs
@@ -140,3 +140,19 @@ namespace System.Runtime.CompilerServices
     }
 }
 
+namespace Internal.Reflection
+{
+    public sealed class ExplicitScopeAttribute : System.Attribute
+    {
+        public ExplicitScopeAttribute(string explicitScope)
+        { }
+    }
+}
+
+namespace Windows
+{
+    [Internal.Reflection.ExplicitScope("Windows, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime")]
+    public class Control
+    {
+    }
+}

--- a/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/Platform.cs
+++ b/src/ILCompiler.MetadataTransform/tests/PrimaryMetadataAssembly/Platform.cs
@@ -148,11 +148,3 @@ namespace Internal.Reflection
         { }
     }
 }
-
-namespace Windows
-{
-    [Internal.Reflection.ExplicitScope("Windows, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime")]
-    public class Control
-    {
-    }
-}

--- a/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadata.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadata.cs
@@ -1650,3 +1650,16 @@ namespace SampleMetadataRex
     }
 }
 
+namespace SampleMetadataWinRT
+{
+    // This class should appear to be in a regular managed module
+    public class DerivedFromControl : Windows.Control
+    { }
+
+    // This class should appear to be in a winmd called SampleMetadataWinRT
+    [global::Internal.Reflection.ExplicitScope("SampleMetadataWinRT, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime")]
+    public class DerivedFromControlAndInCustomScope : Windows.Control
+    {
+    }
+}
+

--- a/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadata.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadata.cs
@@ -1650,16 +1650,4 @@ namespace SampleMetadataRex
     }
 }
 
-namespace SampleMetadataWinRT
-{
-    // This class should appear to be in a regular managed module
-    public class DerivedFromControl : Windows.Control
-    { }
-
-    // This class should appear to be in a winmd called SampleMetadataWinRT
-    [global::Internal.Reflection.ExplicitScope("SampleMetadataWinRT, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime")]
-    public class DerivedFromControlAndInCustomScope : Windows.Control
-    {
-    }
-}
 

--- a/src/ILCompiler.MetadataTransform/tests/SampleWinRTMetadataAssembly/SampleWinRTMetadata.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SampleWinRTMetadataAssembly/SampleWinRTMetadata.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable 414
+#pragma warning disable 67
+#pragma warning disable 3009
+#pragma warning disable 3016
+#pragma warning disable 3001
+#pragma warning disable 3015
+#pragma warning disable 169
+#pragma warning disable 649
+
+namespace SampleMetadataWinRT
+{
+    // This class should appear to be in a regular managed module
+    public class DerivedFromControl : Windows.Control
+    { }
+
+    // This class should appear to be in a winmd called SampleMetadataWinRT
+    [global::Internal.Reflection.ExplicitScope("SampleMetadataWinRT, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime")]
+    public class DerivedFromControlAndInCustomScope : Windows.Control
+    {
+    }
+}
+

--- a/src/ILCompiler.MetadataTransform/tests/SampleWinRTMetadataAssembly/SampleWinRTMetadataAssembly.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/SampleWinRTMetadataAssembly/SampleWinRTMetadataAssembly.csproj
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AssemblyName>SampleWinRTMetadataAssembly</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <ProjectGuid>{46CDD663-FCCC-4E74-901F-3D9D5A36A0D9}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PrimaryMetadataAssembly\PrimaryMetadataAssembly.csproj" />
+    <ProjectReference Include="..\SampleMetadataAssembly\SampleMetadataAssembly.csproj" />
+    <ProjectReference Include="..\WindowsWinrtMetadataAssembly\WindowsWinrtMetadataAssembly.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="SampleWinRTMetadata.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/ILCompiler.MetadataTransform/tests/SimpleTests.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SimpleTests.cs
@@ -7,7 +7,6 @@ using Internal.Metadata.NativeFormat.Writer;
 using ILCompiler.Metadata;
 
 using Cts = Internal.TypeSystem;
-using NativeFormat = Internal.Metadata.NativeFormat;
 
 using Xunit;
 
@@ -35,7 +34,7 @@ namespace MetadataTransformTests
             
             Assert.Equal(
                 _systemModule.GetAllTypes().Count(x => !policy.IsBlocked(x)),
-                transformResult.Scopes.First().GetAllTypes().Count());
+                transformResult.Scopes.Single().GetAllTypes().Count());
         }
 
         [Fact]
@@ -64,9 +63,7 @@ namespace MetadataTransformTests
         [Fact]
         public void TestStandaloneSignatureGeneration()
         {
-            var policy = new SingleFileMetadataPolicy();
-
-            var transformResult = MetadataTransform.Run(policy, new[] { _systemModule });
+            var transformResult = MetadataTransform.Run(new SingleFileMetadataPolicy(), new[] { _systemModule });
 
             var stringRecord = transformResult.GetTransformedTypeDefinition(
                 (Cts.MetadataType)_context.GetWellKnownType(Cts.WellKnownType.String));
@@ -89,7 +86,6 @@ namespace MetadataTransformTests
         public void TestSampleMetadataGeneration()
         {
             var policy = new SingleFileMetadataPolicy();
-
             var sampleMetadataModule = _context.GetModuleForSimpleName("SampleMetadataAssembly");
             var transformResult = MetadataTransform.Run(policy,
                 new[] { _systemModule, sampleMetadataModule });
@@ -115,7 +111,7 @@ namespace MetadataTransformTests
 
             Assert.Equal(1, transformResult.Scopes.Count);
 
-            var sampleScope = transformResult.Scopes.First();
+            var sampleScope = transformResult.Scopes.Single();
             Assert.Equal(sampleMetadataModule.GetAllTypes().Count(t => !policy.IsBlocked(t)), sampleScope.GetAllTypes().Count());
 
             var objectType = (Cts.MetadataType)_context.GetWellKnownType(Cts.WellKnownType.Object);
@@ -185,7 +181,6 @@ namespace MetadataTransformTests
             Cts.MetadataType attributeHolder = sampleMetadataModule.GetType("BlockedMetadata", "AttributeHolder");
 
             var policy = new SingleFileMetadataPolicy();
-
             var transformResult = MetadataTransform.Run(policy,
                 new[] { _systemModule, sampleMetadataModule });
 

--- a/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Reflection;
 using ILCompiler.Metadata;
 using Internal.TypeSystem;
 
@@ -10,6 +11,13 @@ namespace MetadataTransformTests
 {
     struct SingleFileMetadataPolicy : IMetadataPolicy
     {
+        ExplicitScopeAssemblyPolicyMixin _explicitScopePolicyMixin;
+
+        public void Init()
+        {
+            _explicitScopePolicyMixin = new ExplicitScopeAssemblyPolicyMixin();
+        }
+
         public bool GeneratesMetadata(MethodDesc methodDef)
         {
             return true;
@@ -34,6 +42,11 @@ namespace MetadataTransformTests
                 return true;
 
             return false;
+        }
+
+        public ModuleDesc GetModuleOfType(MetadataType typeDef)
+        {
+            return _explicitScopePolicyMixin.GetModuleOfType(typeDef);
         }
     }
 }

--- a/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
@@ -11,7 +11,8 @@ namespace MetadataTransformTests
 {
     struct SingleFileMetadataPolicy : IMetadataPolicy
     {
-        ExplicitScopeAssemblyPolicyMixin _explicitScopePolicyMixin;
+        private static object s_lazyInitThreadSafetyLock = new object();
+        private ExplicitScopeAssemblyPolicyMixin _explicitScopePolicyMixin;
 
         public bool GeneratesMetadata(MethodDesc methodDef)
         {
@@ -42,7 +43,13 @@ namespace MetadataTransformTests
         public ModuleDesc GetModuleOfType(MetadataType typeDef)
         {
             if (_explicitScopePolicyMixin == null)
-                _explicitScopePolicyMixin = new ExplicitScopeAssemblyPolicyMixin();
+            {
+                lock (s_lazyInitThreadSafetyLock)
+                {
+                    if (_explicitScopePolicyMixin == null)
+                        _explicitScopePolicyMixin = new ExplicitScopeAssemblyPolicyMixin();
+                }
+            }
 
             return _explicitScopePolicyMixin.GetModuleOfType(typeDef);
         }

--- a/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SingleFileMetadataPolicy.cs
@@ -13,11 +13,6 @@ namespace MetadataTransformTests
     {
         ExplicitScopeAssemblyPolicyMixin _explicitScopePolicyMixin;
 
-        public void Init()
-        {
-            _explicitScopePolicyMixin = new ExplicitScopeAssemblyPolicyMixin();
-        }
-
         public bool GeneratesMetadata(MethodDesc methodDef)
         {
             return true;
@@ -46,6 +41,9 @@ namespace MetadataTransformTests
 
         public ModuleDesc GetModuleOfType(MetadataType typeDef)
         {
+            if (_explicitScopePolicyMixin == null)
+                _explicitScopePolicyMixin = new ExplicitScopeAssemblyPolicyMixin();
+
             return _explicitScopePolicyMixin.GetModuleOfType(typeDef);
         }
     }

--- a/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.MetadataTransform/tests/TestTypeSystemContext.cs
@@ -18,25 +18,40 @@ namespace MetadataTransformTests
     {
         Dictionary<string, EcmaModule> _modules = new Dictionary<string, EcmaModule>(StringComparer.OrdinalIgnoreCase);
 
-        public EcmaModule GetModuleForSimpleName(string simpleName)
+        public EcmaModule GetModuleForSimpleName(string simpleName, bool throwIfNotFound = true)
         {
-            EcmaModule existingModule;
-            if (_modules.TryGetValue(simpleName, out existingModule))
-                return existingModule;
+            EcmaModule module;
+            if (!_modules.TryGetValue(simpleName, out module))
+            {
+                module = CreateModuleForSimpleName(simpleName);
+            }
 
-            return CreateModuleForSimpleName(simpleName);
+            if (module == null && throwIfNotFound)
+            {
+                throw new FileNotFoundException(simpleName + ".dll");
+            }
+            return module;
         }
 
         public EcmaModule CreateModuleForSimpleName(string simpleName)
         {
-            EcmaModule module = EcmaModule.Create(this, new PEReader(File.OpenRead(simpleName + ".dll")));
+            EcmaModule module = null;
+            try
+            {
+                module = EcmaModule.Create(this, new PEReader(File.OpenRead(simpleName + ".dll")));
+            }
+            catch (FileNotFoundException)
+            {
+                // FileNotFound is treated as being unable to load the module
+            }
+
             _modules.Add(simpleName, module);
             return module;
         }
 
         public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name, bool throwIfNotFound)
         {
-            return GetModuleForSimpleName(name.Name);
+            return GetModuleForSimpleName(name.Name, throwIfNotFound);
         }
     }
 }

--- a/src/ILCompiler.MetadataTransform/tests/WindowsWinrtMetadataAssembly/WindowsWinrtMetadata.cs
+++ b/src/ILCompiler.MetadataTransform/tests/WindowsWinrtMetadataAssembly/WindowsWinrtMetadata.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable 414
+#pragma warning disable 67
+#pragma warning disable 3009
+#pragma warning disable 3016
+#pragma warning disable 3001
+#pragma warning disable 3015
+#pragma warning disable 169
+#pragma warning disable 649
+
+namespace Windows
+{
+    [Internal.Reflection.ExplicitScope("Windows, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime")]
+    public class Control
+    {
+    }
+}

--- a/src/ILCompiler.MetadataTransform/tests/WindowsWinrtMetadataAssembly/WindowsWinrtMetadataAssembly.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/WindowsWinrtMetadataAssembly/WindowsWinrtMetadataAssembly.csproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AssemblyName>WindowsWinrtMetadataAssembly</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <ProjectGuid>{19D0BAA8-8762-4D64-80AF-53D7A2BBC4AE}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PrimaryMetadataAssembly\PrimaryMetadataAssembly.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="WindowsWinrtMetadata.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
- Add new IMetadataPolicy member to control the defining module of a type
- Added mixin implementation that works for ExplicitScopeAttribute
- Added WinRT explicit scope defined types in both the primary metadata assembly and same metadata assembly
- Added single file and multi file tests to ensure that both definition and reference to these relocated types is correct