### PR TITLE
ASP.NET 5 -> Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ CoreRT is a [.NET Foundation](http://www.dotnetfoundation.org/projects) project.
 There are many .NET related projects on GitHub.
 - The [.NET home repo](https://github.com/Microsoft/dotnet) links to 100s of .NET projects, from Microsoft and the community.
 - The [.NET Core repo](https://github.com/dotnet/core) links to .NET Core related projects from Microsoft.
-- The [ASP.NET home repo](https://github.com/aspnet/home) is the best place to start learning about [ASP.NET 5](http://www.asp.net).
+- The [ASP.NET home repo](https://github.com/aspnet/home) is the best place to start learning about [ASP.NET Core](http://www.asp.net).
 - dotnet.github.io is a good place to discover .NET Foundation projects.


### PR DESCRIPTION
ASP.NET 5 should now be called ASP.NET Core...

cc @jkotas