### PR TITLE
Add support for generating MethodImpl metadata in metadata transform

### DIFF
--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -302,9 +302,24 @@ namespace ILCompiler.Metadata
                 {
                     record.CustomAttributes = HandleCustomAttributes(ecmaEntity.EcmaModule, customAttributes);
                 }
-            }
 
-            // TODO: MethodImpls
+                foreach (var miHandle in ecmaRecord.GetMethodImplementations())
+                {
+                    Ecma.MetadataReader reader = ecmaEntity.EcmaModule.MetadataReader;
+
+                    Ecma.MethodImplementation miDef = reader.GetMethodImplementation(miHandle);
+
+                    Cts.MethodDesc methodBody = (Cts.MethodDesc)ecmaEntity.EcmaModule.GetObject(miDef.MethodBody);
+                    Cts.MethodDesc methodDecl = (Cts.MethodDesc)ecmaEntity.EcmaModule.GetObject(miDef.MethodDeclaration);
+                    MethodImpl methodImplRecord = new MethodImpl
+                    {
+                        MethodBody = HandleQualifiedMethod(methodBody),
+                        MethodDeclaration = HandleQualifiedMethod(methodDecl)
+                    };
+
+                    record.MethodImpls.Add(methodImplRecord);
+                }
+            }
         }
 
         private TypeAttributes GetTypeAttributes(Cts.MetadataType type)

--- a/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadata.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadata.cs
@@ -1650,4 +1650,22 @@ namespace SampleMetadataRex
     }
 }
 
+namespace SampleMetadataMethodImpl
+{
+    interface ICloneable
+    {
+        void Clone();
+        void GenericClone<T>();
+    }
+
+    class ImplementsICloneable : ICloneable
+    {
+        void ICloneable.Clone()
+        {
+        }
+        void ICloneable.GenericClone<T>()
+        {
+        }
+    }
+}
 


### PR DESCRIPTION
- implementation only for ECMA metadata as we don't have TypeSystem api surface that is general purpose enough to avoid using the ECMA metadata reader directly
- metadata transform tests for generic and non-generic scenarios