### PR TITLE
Fix virtual function (non-interface) method impl simple case

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -106,7 +106,11 @@ namespace Internal.TypeSystem
                 if (!IsInGroup(newDefiningMethod) &&
                     DefiningMethod != newDefiningMethod)
                 {
+                    // When we set the defining method, ensure that the old defining method isn't removed from the group
+                    MethodDesc oldDefiningMethod = DefiningMethod;
                     DefiningMethod = newDefiningMethod;
+                    AddToGroup(oldDefiningMethod);
+
                     // TODO! Add assertion that DefiningMethod is a slot defining method
                 }
             }
@@ -128,6 +132,7 @@ namespace Internal.TypeSystem
                         if (_members[i] == null)
                         {
                             _members[i] = method;
+                            break;
                         }
                     }
                 }

--- a/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
@@ -112,7 +112,6 @@ namespace TypeSystemTests
         }
 
         [Fact]
-        [ActiveIssue(1302)]
         public void TestExplicitOverride()
         {
             //


### PR DESCRIPTION
- SetDefiningMethod and AddToGroup on UnificationGroup produced invalid results
- Likely does not fix all issues, but should make nearly all C#/VB code that uses MethodImpls work correctly