### PR TITLE
Improve performance of String.IndexOf(char) and String.LastIndexOf(char)

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -2036,15 +2036,35 @@ namespace System
             fixed (char* pChars = &_firstChar)
             {
                 char* pCh = pChars + startIndex;
-                for (int i = 0; i < count; i++)
+
+                while (count >= 4)
+                {
+                    if (*pCh == value) goto ReturnIndex;
+                    if (*(pCh + 1) == value) goto ReturnIndex1;
+                    if (*(pCh + 2) == value) goto ReturnIndex2;
+                    if (*(pCh + 3) == value) goto ReturnIndex3;
+
+                    count -= 4;
+                    pCh += 4;
+                }
+
+                while (count > 0)
                 {
                     if (*pCh == value)
-                        return i + startIndex;
+                        goto ReturnIndex;
+
+                    count--;
                     pCh++;
                 }
-            }
 
-            return -1;
+                return -1;
+
+                ReturnIndex3: pCh++;
+                ReturnIndex2: pCh++;
+                ReturnIndex1: pCh++;
+                ReturnIndex:
+                return (int)(pCh - pChars);
+            }
         }
 
         // Returns the index of the first occurrence of any specified character in the current instance.
@@ -2249,16 +2269,36 @@ namespace System
             fixed (char* pChars = &_firstChar)
             {
                 char* pCh = pChars + startIndex;
+
                 //We search [startIndex..EndIndex]
-                for (int i = 0; i < count; i++)
+                while (count >= 4)
+                {
+                    if (*pCh == value) goto ReturnIndex;
+                    if (*(pCh - 1) == value) goto ReturnIndex1;
+                    if (*(pCh - 2) == value) goto ReturnIndex2;
+                    if (*(pCh - 3) == value) goto ReturnIndex3;
+
+                    count -= 4;
+                    pCh -= 4;
+                }
+
+                while (count > 0)
                 {
                     if (*pCh == value)
-                        return startIndex - i;
+                        goto ReturnIndex;
+
+                    count--;
                     pCh--;
                 }
-            }
 
-            return -1;
+                return -1;
+
+                ReturnIndex3: pCh--;
+                ReturnIndex2: pCh--;
+                ReturnIndex1: pCh--;
+                ReturnIndex:
+                return (int)(pCh - pChars);
+            }
         }
 
         // Returns the index of the last occurrence of any specified character in the current instance.


### PR DESCRIPTION
Before porting to CoreCLR some changes need to be made to maintain the existing performance given by the C++ implementation.

**Char not found**

           Method |      Median |     StdDev | length |
----------------- |------------ |----------- |------- |
       **ClrIndexOf** |   **2.3536 ns** |  **0.0433 ns** |      **1** |
        RtIndexOf |   2.2333 ns |  0.0466 ns |      1 |
       NewIndexOf |   2.0248 ns |  0.0391 ns |      1 |
       **ClrIndexOf** |   **9.9791 ns** |  **0.1260 ns** |     **12** |
        RtIndexOf |  11.6317 ns |  0.2680 ns |     12 |
       NewIndexOf |   5.2121 ns |  0.0663 ns |     12 |
       **ClrIndexOf** |  **35.3210 ns** |  **0.3570 ns** |     **50** |
        RtIndexOf |  46.3973 ns |  1.0294 ns |     50 |
       NewIndexOf |  33.8483 ns |  0.3785 ns |     50 |
       **ClrIndexOf** |  **60.6154 ns** |  **0.6055 ns** |    **100** |
        RtIndexOf |  79.3279 ns |  1.4144 ns |    100 |
       NewIndexOf |  48.2122 ns |  0.4125 ns |    100 |
       **ClrIndexOf** | **109.5456 ns** |  **0.7991 ns** |    **200** |
        RtIndexOf | 155.3314 ns |  3.7292 ns |    200 |
       NewIndexOf |  77.1061 ns |  0.7688 ns |    200 |
       **ClrIndexOf** | **257.6082 ns** |  **2.1920 ns** |    **500** |
        RtIndexOf | 420.8954 ns | 28.0848 ns |    500 |
       NewIndexOf | 164.0551 ns |  1.9831 ns |    500 |

**IndexOf - String of length 15 that differs at position offset**

           Method |     Median |    StdDev | offset |
----------------- |----------- |---------- |------- |
       **ClrIndexOf** |  **2.1723 ns** | **0.0982 ns** |      **0** |
        RtIndexOf |  1.6250 ns | 0.0636 ns |      0 |
       NewIndexOf |  1.8871 ns | 0.0591 ns |      0 |
       **ClrIndexOf** |  **2.4480 ns** | **0.0917 ns** |      **1** |
        RtIndexOf |  2.7291 ns | 0.1096 ns |      1 |
       NewIndexOf |  2.6416 ns | 0.1344 ns |      1 |
       **ClrIndexOf** |  **3.2352 ns** | **0.0878 ns** |      **2** |
        RtIndexOf |  3.9107 ns | 0.1636 ns |      2 |
       NewIndexOf |  2.6931 ns | 0.0828 ns |      2 |
       **ClrIndexOf** |  **3.9382 ns** | **0.1211 ns** |      **3** |
        RtIndexOf |  5.0206 ns | 0.2187 ns |      3 |
       NewIndexOf |  4.0220 ns | 0.1404 ns |      3 |
       **ClrIndexOf** |  **4.6619 ns** | **0.1129 ns** |      **4** |
        RtIndexOf |  5.9470 ns | 0.2495 ns |      4 |
       NewIndexOf |  4.3271 ns | 0.0891 ns |      4 |
       **ClrIndexOf** |  **5.2063 ns** | **0.0792 ns** |      **5** |
        RtIndexOf |  5.7774 ns | 0.1005 ns |      5 |
       NewIndexOf |  3.5705 ns | 0.1941 ns |      5 |
       **ClrIndexOf** |  **6.2780 ns** | **0.1335 ns** |      **6** |
        RtIndexOf |  6.5456 ns | 0.1182 ns |      6 |
       NewIndexOf |  3.7988 ns | 0.1829 ns |      6 |
       **ClrIndexOf** |  **6.8111 ns** | **0.1668 ns** |      **7** |
        RtIndexOf |  7.7846 ns | 0.3535 ns |      7 |
       NewIndexOf |  4.0371 ns | 0.2391 ns |      7 |
       **ClrIndexOf** |  **7.3673 ns** | **0.2072 ns** |      **8** |
        RtIndexOf |  8.6105 ns | 0.3107 ns |      8 |
       NewIndexOf |  4.3943 ns | 0.2680 ns |      8 |
       **ClrIndexOf** |  **7.8907 ns** | **0.1769 ns** |      **9** |
        RtIndexOf |  9.4134 ns | 0.4834 ns |      9 |
       NewIndexOf |  4.7222 ns | 0.3327 ns |      9 |
       **ClrIndexOf** |  **8.4381 ns** | **0.1870 ns** |     **10** |
        RtIndexOf |  9.8019 ns | 0.1831 ns |     10 |
       NewIndexOf |  4.9610 ns | 0.3498 ns |     10 |
       **ClrIndexOf** |  **8.9722 ns** | **0.1447 ns** |     **11** |
        RtIndexOf | 10.6145 ns | 0.1949 ns |     11 |
       NewIndexOf |  5.2444 ns | 0.2500 ns |     11 |
       **ClrIndexOf** |  **9.5154 ns** | **0.1324 ns** |     **12** |
        RtIndexOf | 11.6821 ns | 0.3126 ns |     12 |
       NewIndexOf |  5.4905 ns | 0.4615 ns |     12 |
       **ClrIndexOf** | **10.0508 ns** | **0.2322 ns** |     **13** |
        RtIndexOf | 12.6482 ns | 0.3670 ns |     13 |
       NewIndexOf |  5.7482 ns | 0.4268 ns |     13 |
       **ClrIndexOf** | **10.5811 ns** | **0.2319 ns** |     **14** |
        RtIndexOf | 12.9956 ns | 0.2965 ns |     14 |
       NewIndexOf |  6.0515 ns | 0.1922 ns |     14 |

**LastIndexOf - Char not found**

           Method |      Median |     StdDev | length |
----------------- |------------ |----------- |------- |
   **ClrLastIndexOf** |   **2.6540 ns** |  **0.0523 ns** |      **1** |
      NewLastIndexOf |   2.0758 ns |  0.0590 ns |      1 |
   **ClrLastIndexOf** |   **8.5287 ns** |  **0.1115 ns** |     **12** |
      NewLastIndexOf |   5.3518 ns |  0.1258 ns |     12 |
   **ClrLastIndexOf** |  **32.6194 ns** |  **0.3135 ns** |     **50** |
      NewLastIndexOf |  34.5868 ns |  0.2946 ns |     50 |
   **ClrLastIndexOf** |  **52.5579 ns** |  **0.5424 ns** |    **100** |
      NewLastIndexOf |  49.3015 ns |  0.6625 ns |    100 |
   **ClrLastIndexOf** |  **91.8019 ns** |  **0.5884 ns** |    **200** |
      NewLastIndexOf |  79.3640 ns |  1.0746 ns |    200 |
   **ClrLastIndexOf** | **209.0110 ns** |  **1.6954 ns** |    **500** |
      NewLastIndexOf | 167.7079 ns |  6.4669 ns |    500 |

LastIndexOf char found has roughly the same percentages as IndexOf.
Profiling code https://gist.github.com/bbowyersmyth/791ff071a10ef901ed7a