### PR TITLE
Remove SetHashCode from the public surface area of MethodDesc

### DIFF
--- a/src/Common/src/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedMethod.cs
@@ -25,6 +25,15 @@ namespace Internal.TypeSystem
             _instantiation = instantiation;
         }
 
+        // This constructor is a performance optimization - it allows supplying the hash code if it has already
+        // been computed prior to the allocation of this type. The supplied hash code still has to match the
+        // hash code this type would compute on it's own (and we assert to enforce that).
+        internal InstantiatedMethod(MethodDesc methodDef, Instantiation instantiation, int hashcode)
+            : this(methodDef, instantiation)
+        {
+            SetHashCode(hashcode);
+        }
+
         protected override int ComputeHashCode()
         {
             return TypeHashingAlgorithms.ComputeMethodHashCode(OwningType.GetHashCode(), Instantiation.ComputeGenericInstanceHashCode(TypeHashingAlgorithms.ComputeNameHashCode(Name)));

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -198,6 +198,8 @@ namespace Internal.TypeSystem
         private int _hashcode;
 
         /// <summary>
+        /// Allows a performance optimization that skips the potentially expensive
+        /// construction of a hash code if a hash code has already been computed elsewhere.
         /// Use to allow objects to have their hashcode computed
         /// independently of the allocation of a MethodDesc object
         /// For instance, compute the hashcode when looking up the object,
@@ -205,7 +207,7 @@ namespace Internal.TypeSystem
         /// The hashcode specified MUST exactly match the algorithm implemented
         /// on this type normally.
         /// </summary>
-        public void SetHashCode(int hashcode)
+        protected void SetHashCode(int hashcode)
         {
             _hashcode = hashcode;
             Debug.Assert(hashcode == ComputeHashCode());

--- a/src/Common/src/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -19,6 +19,15 @@ namespace Internal.TypeSystem
             _instantiatedType = instantiatedType;
         }
 
+        // This constructor is a performance optimization - it allows supplying the hash code if it has already
+        // been computed prior to the allocation of this type. The supplied hash code still has to match the
+        // hash code this type would compute on it's own (and we assert to enforce that).
+        internal MethodForInstantiatedType(MethodDesc typicalMethodDef, InstantiatedType instantiatedType, int hashcode)
+            : this(typicalMethodDef, instantiatedType)
+        {
+            SetHashCode(hashcode);
+        }
+
         public override TypeSystemContext Context
         {
             get

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -404,9 +404,7 @@ namespace Internal.TypeSystem
 
                 protected override InstantiatedMethod CreateValueFromKey(InstantiatedMethodKey key)
                 {
-                    InstantiatedMethod returnValue = new InstantiatedMethod(key.MethodDef, key.Instantiation);
-                    returnValue.SetHashCode(key._hashcode);
-                    return returnValue;
+                    return new InstantiatedMethod(key.MethodDef, key.Instantiation, key._hashcode);
                 }
             }
         }
@@ -479,9 +477,7 @@ namespace Internal.TypeSystem
 
                 protected override MethodForInstantiatedType CreateValueFromKey(MethodForInstantiatedTypeKey key)
                 {
-                    MethodForInstantiatedType returnValue = new MethodForInstantiatedType(key.TypicalMethodDef, key.InstantiatedType);
-                    returnValue.SetHashCode(key._hashcode);
-                    return returnValue;
+                    return new MethodForInstantiatedType(key.TypicalMethodDef, key.InstantiatedType, key._hashcode);
                 }
             }
         }


### PR DESCRIPTION
This is an awkward method to expose from the public surface area. Make
it protected.