### PR TITLE
[Gardening] Random fixes to the type system

### DIFF
--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -6,10 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
-using Debug = System.Diagnostics.Debug;
-
 namespace Internal.TypeSystem
 {
+    /// <summary>
+    /// Represents an array type - either a multidimensional array, or a vector
+    /// (a one-dimensional array with a zero lower bound).
+    /// </summary>
     public sealed partial class ArrayType : ParameterizedType
     {
         private int _rank; // -1 for regular single dimensional arrays, > 0 for multidimensional arrays
@@ -33,6 +35,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets the type of the element of this array.
+        /// </summary>
         public TypeDesc ElementType
         {
             get
@@ -43,6 +48,9 @@ namespace Internal.TypeSystem
 
         internal MethodDesc[] _methods;
 
+        /// <summary>
+        /// Gets a value indicating whether this type is a vector.
+        /// </summary>
         public new bool IsSzArray
         {
             get
@@ -51,6 +59,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets the rank of this array. Note this returns "1" for both vectors, and
+        /// for general arrays of rank 1. Use <see cref="IsSzArray"/> to disambiguate.
+        /// </summary>
         public int Rank
         {
             get
@@ -108,6 +120,7 @@ namespace Internal.TypeSystem
             return instantiatedElementType.Context.GetArrayType(instantiatedElementType, _rank);
         }
 
+        // TODO: this is a pretty weird semantic...
         public override TypeDesc GetTypeDefinition()
         {
             TypeDesc result = this;
@@ -149,6 +162,11 @@ namespace Internal.TypeSystem
         Ctor
     }
 
+    /// <summary>
+    /// Represents one of the methods on array types. While array types are not typical
+    /// classes backed by metadata, they do have methods that can be referenced from the IL
+    /// and the type system needs to provide a way to represent them.
+    /// </summary>
     public partial class ArrayMethod : MethodDesc
     {
         private ArrayType _owningType;
@@ -261,21 +279,9 @@ namespace Internal.TypeSystem
             }
         }
 
-        // Strips method instantiation. E.g C<int>.m<string> -> C<int>.m<U>
-        public override MethodDesc GetMethodDefinition()
-        {
-            return this;
-        }
-
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
         {
             return false;
-        }
-
-        // Strips both type and method instantiation. E.g C<int>.m<string> -> C<T>.m<U>
-        public override MethodDesc GetTypicalMethodDefinition()
-        {
-            return this;
         }
 
         public override MethodDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)

--- a/src/Common/src/TypeSystem/Common/ByRefType.cs
+++ b/src/Common/src/TypeSystem/Common/ByRefType.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Internal.TypeSystem
 {
+    /// <summary>
+    /// Represents a managed pointer type.
+    /// </summary>
     public sealed partial class ByRefType : ParameterizedType
     {
         internal ByRefType(TypeDesc parameter)
@@ -24,6 +25,7 @@ namespace Internal.TypeSystem
             return instantiatedParameterType.MakeByRefType();
         }
 
+        // TODO: this is a pretty weird semantic...
         public override TypeDesc GetTypeDefinition()
         {
             TypeDesc result = this;

--- a/src/Common/src/TypeSystem/Common/DefType.cs
+++ b/src/Common/src/TypeSystem/Common/DefType.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Internal.TypeSystem
 {
     /// <summary>
     /// Type that is logically equivalent to a type which is defined by a TypeDef
-    /// record in an ECMA 335 metadata stream.
+    /// record in an ECMA 335 metadata stream - a class, an interface, or a value type.
     /// </summary>
     public abstract partial class DefType : TypeDesc
     {

--- a/src/Common/src/TypeSystem/Common/Instantiation.cs
+++ b/src/Common/src/TypeSystem/Common/Instantiation.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Represents a generic instantiation - a collection of generic parameters
+    /// or arguments of a generic type or a generic method.
+    /// </summary>
+    public struct Instantiation
+    {
+        private TypeDesc[] _genericParameters;
+
+        public Instantiation(params TypeDesc[] genericParameters)
+        {
+            _genericParameters = genericParameters;
+        }
+
+        [IndexerName("GenericParameters")]
+        public TypeDesc this[int index]
+        {
+            get
+            {
+                return _genericParameters[index];
+            }
+        }
+
+        public int Length
+        {
+            get
+            {
+                return _genericParameters.Length;
+            }
+        }
+
+        public bool IsNull
+        {
+            get
+            {
+                return _genericParameters == null;
+            }
+        }
+
+        /// <summary>
+        /// Combines the given generic definition's hash code with the hashes
+        /// of the generic parameters in this instantiation
+        /// </summary>
+        public int ComputeGenericInstanceHashCode(int genericDefinitionHashCode)
+        {
+            return NativeFormat.TypeHashingAlgorithms.ComputeGenericInstanceHashCode(genericDefinitionHashCode, _genericParameters);
+        }
+
+        public static readonly Instantiation Empty = new Instantiation(TypeDesc.EmptyTypes);
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_genericParameters);
+        }
+
+        /// <summary>
+        /// Enumerator for iterating over the types in an instantiation
+        /// </summary>
+        public struct Enumerator
+        {
+            private TypeDesc[] _collection;
+            private int _currentIndex;
+
+            public Enumerator(TypeDesc[] collection)
+            {
+                _collection = collection;
+                _currentIndex = -1;
+            }
+
+            public TypeDesc Current
+            {
+                get
+                {
+                    return _collection[_currentIndex];
+                }
+            }
+
+            public bool MoveNext()
+            {
+                _currentIndex++;
+                if (_currentIndex >= _collection.Length)
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -8,6 +8,7 @@ namespace Internal.TypeSystem
 {
     /// <summary>
     /// Type with metadata available that is equivalent to a TypeDef record in an ECMA 335 metadata stream.
+    /// A class, an interface, or a value type.
     /// </summary>
     public abstract partial class MetadataType : DefType
     {
@@ -103,7 +104,8 @@ namespace Internal.TypeSystem
         public abstract IEnumerable<MetadataType> GetNestedTypes();
 
         /// <summary>
-        /// Get a specific type nested in this type.
+        /// Get a specific type nested in this type. Returns null if the type
+        /// doesn't exist.
         /// </summary>
         public abstract MetadataType GetNestedType(string name);
     }

--- a/src/Common/src/TypeSystem/Common/PointerType.cs
+++ b/src/Common/src/TypeSystem/Common/PointerType.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Internal.TypeSystem
 {
+    /// <summary>
+    /// Represents an unmanaged pointer type.
+    /// </summary>
     public sealed partial class PointerType : ParameterizedType
     {
         internal PointerType(TypeDesc parameterType)

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -9,90 +9,9 @@ using System.Runtime.CompilerServices;
 
 namespace Internal.TypeSystem
 {
-    public struct Instantiation
-    {
-        private TypeDesc[] _genericParameters;
-
-        public Instantiation(params TypeDesc[] genericParameters)
-        {
-            _genericParameters = genericParameters;
-        }
-
-        [System.Runtime.CompilerServices.IndexerName("GenericParameters")]
-        public TypeDesc this[int index]
-        {
-            get
-            {
-                return _genericParameters[index];
-            }
-        }
-
-        public int Length
-        {
-            get
-            {
-                return _genericParameters.Length;
-            }
-        }
-
-        public bool IsNull
-        {
-            get
-            {
-                return _genericParameters == null;
-            }
-        }
-
-        /// <summary>
-        /// Combines the given generic definition's hash code with the hashes
-        /// of the generic parameters in this instantiation
-        /// </summary>
-        public int ComputeGenericInstanceHashCode(int genericDefinitionHashCode)
-        {
-            return Internal.NativeFormat.TypeHashingAlgorithms.ComputeGenericInstanceHashCode(genericDefinitionHashCode, _genericParameters);
-        }
-
-        public static readonly Instantiation Empty = new Instantiation(TypeDesc.EmptyTypes);
-
-        public Enumerator GetEnumerator()
-        {
-            return new Enumerator(_genericParameters);
-        }
-
-        /// <summary>
-        /// Enumerator for iterating over the types in an instantiation
-        /// </summary>
-        public struct Enumerator
-        {
-            private TypeDesc[] _collection;
-            private int _currentIndex;
-
-            public Enumerator(TypeDesc[] collection)
-            {
-                _collection = collection;
-                _currentIndex = -1;
-            }
-
-            public TypeDesc Current
-            {
-                get
-                {
-                    return _collection[_currentIndex];
-                }
-            }
-
-            public bool MoveNext()
-            {
-                _currentIndex++;
-                if (_currentIndex >= _collection.Length)
-                {
-                    return false;
-                }
-                return true;
-            }
-        }
-    }
-
+    /// <summary>
+    /// Represents the fundamental base type of all types within the type system.
+    /// </summary>
     public abstract partial class TypeDesc
     {
         public static readonly TypeDesc[] EmptyTypes = new TypeDesc[0];
@@ -127,11 +46,19 @@ namespace Internal.TypeSystem
         // The most frequently used type properties are cached here to avoid excesive virtual calls
         private TypeFlags _typeFlags;
 
+        /// <summary>
+        /// Gets the type system context this type belongs to.
+        /// </summary>
         public abstract TypeSystemContext Context
         {
             get;
         }
 
+        /// <summary>
+        /// Gets the generic instantiation information of this type.
+        /// For generic definitions, retrieves the generic parameters of the type.
+        /// For generic instantiation, retrieves the generic arguments of the type.
+        /// </summary>
         public virtual Instantiation Instantiation
         {
             get
@@ -140,6 +67,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this type has a generic instantiation.
+        /// This will be true for generic type instantiations and generic definitions.
+        /// </summary>
         public bool HasInstantiation
         {
             get
@@ -148,7 +79,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public void SetWellKnownType(WellKnownType wellKnownType)
+        internal void SetWellKnownType(WellKnownType wellKnownType)
         {
             TypeFlags flags;
 
@@ -224,6 +155,10 @@ namespace Internal.TypeSystem
             return InitializeTypeFlags(mask);
         }
 
+        /// <summary>
+        /// Retrieves the category of the type. This is one of the possible values of
+        /// <see cref="TypeFlags"/> less than <see cref="TypeFlags.CategoryMask"/>.
+        /// </summary>
         public TypeFlags Category
         {
             get
@@ -232,6 +167,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this type is an interface type.
+        /// </summary>
         public bool IsInterface
         {
             get
@@ -240,6 +178,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this type is a value type (not a reference type).
+        /// </summary>
         public bool IsValueType
         {
             get
@@ -248,6 +189,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is one of the primitive types (boolean, char, void,
+        /// a floating point, or an integer type).
+        /// </summary>
         public bool IsPrimitive
         {
             get
@@ -256,6 +201,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is an enum type.
+        /// Access <see cref="UnderlyingType"/> to retrieve the underlying integral type.
+        /// </summary>
         public bool IsEnum
         {
             get
@@ -264,6 +213,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is a delegate type.
+        /// </summary>
         public bool IsDelegate
         {
             get
@@ -273,6 +225,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is System.Void type.
+        /// </summary>
         public bool IsVoid
         {
             get
@@ -281,6 +236,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is System.String type.
+        /// </summary>
         public bool IsString
         {
             get
@@ -289,6 +247,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is System.Object type.
+        /// </summary>
         public bool IsObject
         {
             get
@@ -297,6 +258,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is a generic definition, or
+        /// an instance of System.Nullable`1.
+        /// </summary>
         public bool IsNullable
         {
             get
@@ -305,6 +270,11 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is an array type (<see cref="ArrayType"/>).
+        /// Note this will return true for both multidimensional array types and vector types.
+        /// Use <see cref="IsSzArray"/> to check for vector types.
+        /// </summary>
         public bool IsArray
         {
             get
@@ -313,6 +283,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is a vector type. A vector is a single-dimensional
+        /// array with a zero lower bound. To check for arrays in general, use <see cref="IsArray"/>.
+        /// </summary>
         public bool IsSzArray
         {
             get
@@ -321,6 +295,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is a managed pointer type (<see cref="ByRefType"/>).
+        /// </summary>
         public bool IsByRef
         {
             get
@@ -329,6 +306,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is an unmanaged pointer type (<see cref="PointerType"/>).
+        /// </summary>
         public bool IsPointer
         {
             get
@@ -337,6 +317,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is a generic parameter (<see cref="GenericParameterDesc"/>).
+        /// </summary>
         public bool IsGenericParameter
         {
             get
@@ -345,6 +328,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is a class, an interface, a value type, or a
+        /// generic instance of one of them.
+        /// </summary>
         public bool IsDefType
         {
             get
@@ -377,6 +364,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets the type from which this type derives from, or null if there's no such type.
+        /// </summary>
         public virtual DefType BaseType
         {
             get
@@ -385,6 +375,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this type has a base type.
+        /// </summary>
         public bool HasBaseType
         {
             get
@@ -393,7 +386,11 @@ namespace Internal.TypeSystem
             }
         }
 
-        public virtual TypeDesc UnderlyingType // For enums
+        /// <summary>
+        /// If this is an enum type, gets the underlying integral type of the enum type.
+        /// For all other types, returns 'this'.
+        /// </summary>
+        public virtual TypeDesc UnderlyingType
         {
             get
             {
@@ -411,6 +408,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this type has a class constructor method.
+        /// Use <see cref="GetStaticConstructor"/> to retrieve it.
+        /// </summary>
         public virtual bool HasStaticConstructor
         {
             get
@@ -419,11 +420,21 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets all methods on this type defined within the type's metadata.
+        /// This will not include methods injected by the type system context.
+        /// </summary>
         public virtual IEnumerable<MethodDesc> GetMethods()
         {
             return MethodDesc.EmptyMethods;
         }
 
+        /// <summary>
+        /// Gets a named method on the type. This method only looks at methods defined
+        /// in type's metadata. The <paramref name="signature"/> parameter can be null.
+        /// If signature is not specified and there are multiple matches, the first one
+        /// is returned. Returns null if method not found.
+        /// </summary>
         // TODO: Substitutions, generics, modopts, ...
         public virtual MethodDesc GetMethod(string name, MethodSignature signature)
         {
@@ -438,17 +449,28 @@ namespace Internal.TypeSystem
             return null;
         }
 
+        /// <summary>
+        /// Retrieves the class constructor method of this type.
+        /// </summary>
+        /// <returns></returns>
         public virtual MethodDesc GetStaticConstructor()
         {
             return null;
         }
 
+        /// <summary>
+        /// Gets all fields on the type as defined in the metadata.
+        /// </summary>
         public virtual IEnumerable<FieldDesc> GetFields()
         {
             return FieldDesc.EmptyFields;
         }
 
+        /// <summary>
+        /// Gets a named field on the type. Returns null if the field wasn't found.
+        /// </summary>
         // TODO: Substitutions, generics, modopts, ...
+        // TODO: field signature
         public virtual FieldDesc GetField(string name)
         {
             foreach (var field in GetFields())
@@ -464,12 +486,19 @@ namespace Internal.TypeSystem
             return this;
         }
 
-        // Strips instantiation. E.g C<int> -> C<T>
+        /// <summary>
+        /// Gets the definition of the type. If this is a generic type instance,
+        /// this method strips the instantiation (E.g C&lt;int&gt; -> C&lt;T&gt;)
+        /// </summary>
         public virtual TypeDesc GetTypeDefinition()
         {
             return this;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this is a type definition. Returns false
+        /// if this is an instantiated generic type.
+        /// </summary>
         public bool IsTypeDefinition
         {
             get
@@ -486,6 +515,10 @@ namespace Internal.TypeSystem
             return GetTypeDefinition() == otherType.GetTypeDefinition();
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this type has a finalizer method.
+        /// Use <see cref="GetFinalizer"/> to retrieve the method.
+        /// </summary>
         public virtual bool HasFinalizer
         {
             get
@@ -494,6 +527,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets the finalizer method (an override of the System.Object::Finalize method)
+        /// if this type has one. Returns null if the type doesn't define one.
+        /// </summary>
         public virtual MethodDesc GetFinalizer()
         {
             return null;
@@ -511,6 +548,9 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this type is an uninstantiated definition of a generic type.
+        /// </summary>
         public bool IsGenericDefinition
         {
             get

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -32,6 +32,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\IAssemblyDesc.cs">
       <Link>TypeSystem\Common\IAssemblyDesc.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\Instantiation.cs">
+      <Link>TypeSystem\Common\Instantiation.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataVirtualMethodEnumerationAlgorithm.cs">
       <Link>TypeSystem\Common\MetadataVirtualMethodEnumerationAlgorithm.cs</Link>
     </Compile>


### PR DESCRIPTION
Mostly, adding comments for things that are unlikely to change.

Also:
* Move Instantiation to a separate file. We generally keep helper
structs together with classes that use them, but this one is used by
generic methods too and doesn't feel like something intrinsic to
TypeDesc.
* Delete useless overrides on ArrayMethod. Base implementation is
identical.
* Add a comment about weird overrides of GetTypeDefinition. Their
purpose puzzles me - we should either document it, or delete them. I
don't think anything relies on the sematic.