### PR TITLE
Delete weird GetTypeDefinition overrides

### DIFF
--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -120,18 +120,6 @@ namespace Internal.TypeSystem
             return instantiatedElementType.Context.GetArrayType(instantiatedElementType, _rank);
         }
 
-        // TODO: this is a pretty weird semantic...
-        public override TypeDesc GetTypeDefinition()
-        {
-            TypeDesc result = this;
-
-            TypeDesc elementDef = this.ElementType.GetTypeDefinition();
-            if (elementDef != this.ElementType)
-                result = elementDef.Context.GetArrayType(elementDef);
-
-            return result;
-        }
-
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = _rank == -1 ? TypeFlags.SzArray : TypeFlags.Array;

--- a/src/Common/src/TypeSystem/Common/ByRefType.cs
+++ b/src/Common/src/TypeSystem/Common/ByRefType.cs
@@ -25,18 +25,6 @@ namespace Internal.TypeSystem
             return instantiatedParameterType.MakeByRefType();
         }
 
-        // TODO: this is a pretty weird semantic...
-        public override TypeDesc GetTypeDefinition()
-        {
-            TypeDesc result = this;
-
-            TypeDesc parameterDef = this.ParameterType.GetTypeDefinition();
-            if (parameterDef != this.ParameterType)
-                result = parameterDef.MakeByRefType();
-
-            return result;
-        }
-
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = TypeFlags.ByRef;

--- a/src/Common/src/TypeSystem/Common/PointerType.cs
+++ b/src/Common/src/TypeSystem/Common/PointerType.cs
@@ -25,17 +25,6 @@ namespace Internal.TypeSystem
             return instantiatedParameterType.Context.GetPointerType(instantiatedParameterType);
         }
 
-        public override TypeDesc GetTypeDefinition()
-        {
-            TypeDesc result = this;
-
-            TypeDesc parameterDef = this.ParameterType.GetTypeDefinition();
-            if (parameterDef != this.ParameterType)
-                result = parameterDef.Context.GetPointerType(parameterDef);
-
-            return result;
-        }
-
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = TypeFlags.Pointer;


### PR DESCRIPTION
Returning `this` (which is what the base implementation does) is as good
as the implementation I'm deleting. This operation is only meaningful
for generic type instances, but we expose the method on `TypeDesc` for
perf reasons.

The less code - the fewer bugs. Bonus points for finding the bug in the
code I'm deleting.