### PR TITLE
Comments to remind developers not to break VS debugger dependencies

### DIFF
--- a/src/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -309,6 +309,10 @@ namespace System.Collections.Generic
 
     internal class ArraySortHelper<TKey, TValue>
     {
+        // The following field is required for interop with the VS Debugger
+        // Prior to making any changes to this field, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
         private static volatile ArraySortHelper<TKey, TValue> s_defaultArraySortHelper;
 
         public static ArraySortHelper<TKey, TValue> Default

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -107,6 +107,11 @@ namespace System.Globalization
         // All of the following will be created on demand.
         //
 
+        // The following three fields are required for interop with the VS Debugger
+        // Prior to making any changes to these fields, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
+
         //The Invariant culture;
         private static volatile CultureInfo s_InvariantCultureInfo;
 

--- a/src/System.Private.CoreLib/src/System/Intptr.cs
+++ b/src/System.Private.CoreLib/src/System/Intptr.cs
@@ -24,6 +24,10 @@ namespace System
 
     public struct IntPtr
     {
+        // The following field is required for interop with the VS Debugger
+        // Prior to making any changes to this field, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
         unsafe private void* _value; // The compiler treats void* closest to uint hence explicit casts are required to preserve int behavior
 
         [Intrinsic]

--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -101,6 +101,10 @@ namespace System
 #if !CORERT
         [Bound]
 #endif
+        // The following two fields are required for interop with the VS Debugger
+        // Prior to making any changes to these fields, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
         private int _stringLength;
         private char _firstChar;
 

--- a/src/System.Private.CoreLib/src/System/Text/StringBuilderCache.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilderCache.cs
@@ -40,6 +40,10 @@ namespace System.Text
     {
         private const int MAX_BUILDER_SIZE = 260;
 
+        // The following field is required for interop with the VS Debugger
+        // Prior to making any changes to this field, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
         [ThreadStatic]
         private static StringBuilder t_cachedInstance;
 


### PR DESCRIPTION
In the previous change, we already have baked in the build system changes. This change is simply adding a bunch of boilerplate comments right next to the fields we care about to remind developers not to change them.