### PR TITLE
Port GC background thread creation from CoreCLR

### DIFF
--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -43,6 +43,8 @@
 
 #include "GCMemoryHelpers.h"
 
+#include "holder.h"
+
 GPTR_IMPL(EEType, g_pFreeObjectEEType);
 
 #define USE_CLR_CACHE_SIZE_BEHAVIOR
@@ -1016,12 +1018,6 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int /*max_gen*/)
 {
 }
 
-// does not acquire thread store lock
-void GCToEEInterface::AttachCurrentThread()
-{
-    ThreadStore::AttachCurrentThread(false);
-}
-
 void GCToEEInterface::SetGCSpecial(Thread * pThread)
 {
     pThread->SetGCSpecial(true);
@@ -1061,6 +1057,58 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
 #endif
 }
 
+// Context passed to the above.
+struct GCBackgroundThreadContext
+{
+    GCBackgroundThreadFunction m_pRealStartRoutine;
+    void *                     m_pRealContext;
+    Thread **                  m_pThread;
+};
+
+// Helper used to wrap the start routine of background GC threads so we can do things like initialize the
+// Redhawk thread state which requires running in the new thread's context.
+static uint32_t WINAPI BackgroundGCThreadStub(void * pContext)
+{
+    GCBackgroundThreadContext * pStartContext = (GCBackgroundThreadContext*)pContext;
+
+    // Initialize the Thread for this thread. The false being passed indicates that the thread store lock
+    // should not be acquired as part of this operation. This is necessary because this thread is created in
+    // the context of a garbage collection and the lock is already held by the GC.
+    ASSERT(GCHeap::GetGCHeap()->IsGCInProgress());
+    ThreadStore::AttachCurrentThread();
+
+    // Inform the GC which Thread* we are.
+    *pStartContext->m_pThread = GetThread();
+
+    GCBackgroundThreadFunction realStartRoutine = pStartContext->m_pRealStartRoutine;
+    void* realContext = pStartContext->m_pRealContext;
+
+    delete pStartContext;
+
+    // Run the real start procedure and capture its return code on exit.
+    return realStartRoutine(realContext);
+}
+
+bool GCToEEInterface::CreateBackgroundThread(Thread** thread, GCBackgroundThreadFunction threadStart, void* arg)
+{
+    NewHolder<GCBackgroundThreadContext> context = new (nothrow) GCBackgroundThreadContext();
+    context->m_pThread = thread;
+    context->m_pRealStartRoutine = threadStart;
+    context->m_pRealContext = arg;
+
+    if (context == NULL)
+    {
+        return false;
+    }
+
+    bool success = PalStartBackgroundGCThread(BackgroundGCThreadStub, &context);
+    if (success)
+    {
+        context.SuppressRelease();
+    }
+
+    return success;
+}
 
 // NOTE: this method is not in thread.cpp because it needs access to the layout of alloc_context for DAC to know the 
 // size, but thread.cpp doesn't generally need to include the GC environment headers for any other reason.

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -21,6 +21,8 @@ typedef struct
     CrawlFrame *   cf;
 } GCCONTEXT;
 
+// GC background thread function prototype
+typedef uint32_t (__stdcall *GCBackgroundThreadFunction)(void* param);
 
 class GCToEEInterface
 {
@@ -78,7 +80,7 @@ public:
 
     static void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);
 
-    static void AttachCurrentThread(); // does not acquire thread store lock
+    static bool CreateBackgroundThread(Thread** thread, GCBackgroundThreadFunction threadStart, void* arg);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -26720,55 +26720,11 @@ BOOL gc_heap::prepare_bgc_thread(gc_heap* gh)
 
 BOOL gc_heap::create_bgc_thread(gc_heap* gh)
 {
-    BOOL ret = FALSE;
-
     assert (background_gc_done_event.IsValid());
 
     //dprintf (2, ("Creating BGC thread"));
 
-#ifdef FEATURE_REDHAWK
-
-    // Thread creation is handled a little differently in Redhawk. We create the thread by a call to the OS
-    // (via the PAL) and it starts running immediately. We place a wrapper around the start routine to
-    // initialize the Redhawk Thread context (since that must be done from the thread itself) and also destroy
-    // it as the thread exits. We also set gh->bgc_thread from this wrapper since otherwise we'd have to
-    // search the thread store for one with the matching ID. gc->bgc_thread will be valid by the time we've
-    // finished the event wait below.
-
-    rh_bgc_thread_ctx sContext;
-    sContext.m_pRealStartRoutine = (PTHREAD_START_ROUTINE)gh->bgc_thread_stub;
-    sContext.m_pRealContext = gh;
-
-    if (!PalStartBackgroundGCThread(gh->rh_bgc_thread_stub, &sContext))
-    {
-        goto cleanup;
-    }
-
-#else // FEATURE_REDHAWK
-
-    Thread* current_bgc_thread;
-
-    gh->bgc_thread = SetupUnstartedThread(FALSE);
-    if (!(gh->bgc_thread))
-    {
-        goto cleanup;
-    }
-    
-    current_bgc_thread = gh->bgc_thread;
-    if (!current_bgc_thread->CreateNewThread (0, (DWORD (*)(void*))&(gh->bgc_thread_stub), gh))
-    {
-        goto cleanup;
-    }
-
-    current_bgc_thread->SetBackground (TRUE, FALSE);
-
-    // wait for the thread to be in its main loop, this is to detect the situation
-    // where someone triggers a GC during dll loading where the loader lock is
-    // held.
-    current_bgc_thread->StartThread();
-
-#endif // FEATURE_REDHAWK
-
+    if (GCToEEInterface::CreateBackgroundThread(&gh->bgc_thread, gh->bgc_thread_stub, gh))
     {
         dprintf (2, ("waiting for the thread to reach its main loop"));
         // In chk builds this can easily time out since
@@ -26790,19 +26746,17 @@ BOOL gc_heap::create_bgc_thread(gc_heap* gh)
         }
         //dprintf (2, ("waiting for the thread to reach its main loop Done."));
 
-        ret = TRUE;
+        return TRUE;
     }
 
 cleanup:
 
-    if (!ret)
+    if (gh->bgc_thread)
     {
-        if (gh->bgc_thread)
-        {
-            gh->bgc_thread = 0;
-        }
+        gh->bgc_thread = 0;
     }
-    return ret;
+
+    return FALSE;
 }
 
 BOOL gc_heap::create_bgc_threads_support (int number_of_heaps)

--- a/src/Native/gc/gcee.cpp
+++ b/src/Native/gc/gcee.cpp
@@ -827,29 +827,6 @@ void GCHeap::DescrGenerationsToProfiler (gen_walk_fn fn, void *context)
 }
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
-#if defined(BACKGROUND_GC) && defined(FEATURE_REDHAWK)
-
-// Helper used to wrap the start routine of background GC threads so we can do things like initialize the
-// Redhawk thread state which requires running in the new thread's context.
-uint32_t WINAPI gc_heap::rh_bgc_thread_stub(void * pContext)
-{
-    rh_bgc_thread_ctx * pStartContext = (rh_bgc_thread_ctx*)pContext;
-
-    // Initialize the Thread for this thread. The false being passed indicates that the thread store lock
-    // should not be acquired as part of this operation. This is necessary because this thread is created in
-    // the context of a garbage collection and the lock is already held by the GC.
-    ASSERT(GCHeap::GetGCHeap()->IsGCInProgress());
-    GCToEEInterface::AttachCurrentThread();
-
-    // Inform the GC which Thread* we are.
-    pStartContext->m_pRealContext->bgc_thread = GetThread();
-
-    // Run the real start procedure and capture its return code on exit.
-    return pStartContext->m_pRealStartRoutine(pStartContext->m_pRealContext);
-}
-
-#endif // BACKGROUND_GC && FEATURE_REDHAWK
-
 #ifdef FEATURE_BASICFREEZE
 segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)
 {

--- a/src/Native/gc/gcpriv.h
+++ b/src/Native/gc/gcpriv.h
@@ -2736,19 +2736,6 @@ protected:
     static
     uint32_t __stdcall bgc_thread_stub (void* arg);
 
-#ifdef FEATURE_REDHAWK
-    // Helper used to wrap the start routine of background GC threads so we can do things like initialize the
-    // Redhawk thread state which requires running in the new thread's context.
-    static uint32_t WINAPI rh_bgc_thread_stub(void * pContext);
-
-    // Context passed to the above.
-    struct rh_bgc_thread_ctx
-    {
-        PTHREAD_START_ROUTINE   m_pRealStartRoutine;
-        gc_heap *               m_pRealContext;
-    };
-#endif //FEATURE_REDHAWK
-
 #endif //BACKGROUND_GC
  
 public:

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -191,12 +191,6 @@ bool GCToEEInterface::CatchAtSafePoint(Thread * pThread)
     return pThread->CatchAtSafePoint();
 }
 
-// does not acquire thread store lock
-void GCToEEInterface::AttachCurrentThread()
-{
-    ThreadStore::AttachCurrentThread();
-}
-
 void GCToEEInterface::GcEnumAllocContexts (enum_alloc_context_func* fn, void* param)
 {
     Thread * pThread = NULL;
@@ -218,6 +212,12 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int /*max_gen*/)
 {
 }
 
+bool GCToEEInterface::CreateBackgroundThread(Thread** thread, GCBackgroundThreadFunction threadStart, void* arg)
+{
+    // TODO: Implement for background GC
+    return false;
+}
+
 void FinalizerThread::EnableFinalization()
 {
     // Signal to finalizer thread that there are objects to finalize
@@ -226,12 +226,6 @@ void FinalizerThread::EnableFinalization()
 
 bool FinalizerThread::HaveExtraWorkForFinalizer()
 {
-    return false;
-}
-
-bool REDHAWK_PALAPI PalStartBackgroundGCThread(BackgroundCallback callback, void* pCallbackContext)
-{
-    // TODO: Implement for background GC
     return false;
 }
 


### PR DESCRIPTION
Port the GC background thread creation from CoreCLR and implement
the new GCToOSInterface::CreateBackgroundThread.