### PR TITLE
Add braces to avoid operator priority confusion

### DIFF
--- a/src/Native/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosamd64.inc
@@ -71,16 +71,16 @@ C_FUNC(\Name):
 
 .macro alloc_stack Size
 .att_syntax
-        lea -\Size(%rsp), %rsp
+        lea -(\Size)(%rsp), %rsp
 .intel_syntax noprefix
-        .cfi_adjust_cfa_offset \Size
+        .cfi_adjust_cfa_offset (\Size)
 .endm
 
 .macro free_stack Size
 .att_syntax
-        lea \Size(%rsp), %rsp
+        lea (\Size)(%rsp), %rsp
 .intel_syntax noprefix
-        .cfi_adjust_cfa_offset -\Size
+        .cfi_adjust_cfa_offset -(\Size)
 .endm
 
 .macro set_cfa_register Reg, Offset

--- a/src/Native/Runtime/unix/unixasmmacrosarm.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm.inc
@@ -60,13 +60,13 @@ C_FUNC(\Name):
 .endm
 
 .macro alloc_stack Size
-        sub sp, sp, \Size
-        .pad #\Size
+        sub sp, sp, (\Size)
+        .pad #(\Size)
 .endm
 
 .macro free_stack Size
-        add sp, sp, \Size
-        .pad #-\Size
+        add sp, sp, (\Size)
+        .pad #-(\Size)
 .endm
 
 .macro POP_CALLEE_SAVED_REGISTERS


### PR DESCRIPTION
This is necessary to make `alloc_stack 8 + 8` to actually allocate 16 bytes of stack...