### PR TITLE
Fix issues with instantiated generics

### DIFF
--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -159,7 +159,22 @@ namespace Internal.TypeSystem
             MethodDesc typicalFinalizer = _typeDef.GetFinalizer();
             if (typicalFinalizer == null)
                 return null;
-            return _typeDef.Context.GetMethodForInstantiatedType(typicalFinalizer, this);
+
+            MetadataType typeInHierarchy = this;
+            while (typicalFinalizer.OwningType.GetTypeDefinition() != typeInHierarchy.GetTypeDefinition())
+            {
+                typeInHierarchy = (MetadataType)typeInHierarchy.BaseType;
+            }
+
+            if (typeInHierarchy == typicalFinalizer.OwningType)
+            {
+                return typicalFinalizer;
+            }
+            else
+            {
+                Debug.Assert(typeInHierarchy is InstantiatedType);
+                return _typeDef.Context.GetMethodForInstantiatedType(typicalFinalizer.GetTypicalMethodDefinition(), (InstantiatedType)typeInHierarchy);
+            }
         }
 
         public override IEnumerable<FieldDesc> GetFields()

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -161,6 +161,12 @@ namespace Internal.TypeSystem
                 return null;
 
             MetadataType typeInHierarchy = this;
+
+            // Note, we go back to the type definition/typical method definition in this code.
+            // If the finalizer is implemented on a base type that is also a generic, then the 
+            // typicalFinalizer in that case is a MethodForInstantiatedType for an instantiated type 
+            // which is instantiated over the open type variables of the derived type.
+
             while (typicalFinalizer.OwningType.GetTypeDefinition() != typeInHierarchy.GetTypeDefinition())
             {
                 typeInHierarchy = typeInHierarchy.MetadataBaseType;

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -163,7 +163,7 @@ namespace Internal.TypeSystem
             MetadataType typeInHierarchy = this;
             while (typicalFinalizer.OwningType.GetTypeDefinition() != typeInHierarchy.GetTypeDefinition())
             {
-                typeInHierarchy = (MetadataType)typeInHierarchy.BaseType;
+                typeInHierarchy = typeInHierarchy.MetadataBaseType;
             }
 
             if (typeInHierarchy == typicalFinalizer.OwningType)

--- a/src/Common/src/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -101,6 +101,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool IsFinal
+        {
+            get
+            {
+                return _typicalMethodDef.IsFinal;
+            }
+        }
+
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
         {
             return _typicalMethodDef.HasCustomAttribute(attributeNamespace, attributeName);

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/GenericTypes.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/GenericTypes.cs
@@ -8,23 +8,30 @@ namespace GenericTypes
     /// Generic class to be used for testing.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class GenericClass<T>
+    public abstract class GenericClass<T>
     {
         /// <summary>
         /// Purpose is to manipulate a method involving a generic parameter in its return type.
         /// </summary>
-        public virtual T Foo()
-        {
-            return default(T);
-        }
+        public abstract T Foo();
         /// <summary>
         /// Purpose is to manipulate a method involving a generic parameter in its parameter list.
         /// </summary>
         public void Bar(T a)
         {
         }
+
+        ~GenericClass()
+        { }
     }
 
+    public class DerivedGenericClass<T> : GenericClass<T>
+    {
+        public override sealed T Foo()
+        {
+            return default(T);
+        }
+    }
     /// <summary>
     /// Generic class with multiple parameters to be used for testing.
     /// </summary>

--- a/src/ILCompiler.TypeSystem/tests/GenericTypeAndMethodTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/GenericTypeAndMethodTests.cs
@@ -68,6 +68,46 @@ namespace TypeSystemTests
             Assert.Same(newType, t);
         }
 
+        [Fact]
+        public void TestMethodAttributes()
+        {
+            MetadataType tGen = _testModule.GetType("GenericTypes", "GenericClass`1");
+            MetadataType tDerivedGen = _testModule.GetType("GenericTypes", "DerivedGenericClass`1");
+            InstantiatedType genOfInt = tGen.MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Int32));
+            InstantiatedType derivedGenOfInt = tDerivedGen.MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Int32));
+            MethodDesc fooInstantiatedMethod = genOfInt.GetMethods().First(m => m.Name == "Foo");
+            MethodDesc barInstantiatedMethod = genOfInt.GetMethods().First(m => m.Name == "Bar");
+            MethodDesc fooDerivedInstantiatedMethod = derivedGenOfInt.GetMethods().First(m => m.Name == "Foo");
+
+            Assert.False(barInstantiatedMethod.IsVirtual);
+            Assert.False(barInstantiatedMethod.IsNewSlot);
+            Assert.False(barInstantiatedMethod.IsFinal);
+            Assert.False(barInstantiatedMethod.IsAbstract);
+
+            Assert.True(fooInstantiatedMethod.IsVirtual);
+            Assert.True(fooInstantiatedMethod.IsNewSlot);
+            Assert.False(fooInstantiatedMethod.IsFinal);
+            Assert.True(fooInstantiatedMethod.IsAbstract);
+
+            Assert.True(fooDerivedInstantiatedMethod.IsVirtual);
+            Assert.False(fooDerivedInstantiatedMethod.IsNewSlot);
+            Assert.True(fooDerivedInstantiatedMethod.IsFinal);
+            Assert.False(fooDerivedInstantiatedMethod.IsAbstract);
+        }
+
+        [Fact]
+        public void TestFinalize()
+        {
+            MetadataType tGen = _testModule.GetType("GenericTypes", "GenericClass`1");
+            MetadataType tDerivedGen = _testModule.GetType("GenericTypes", "DerivedGenericClass`1");
+            InstantiatedType genOfInt = tGen.MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Int32));
+            InstantiatedType derivedGenOfInt = tDerivedGen.MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Int32));
+            MethodDesc finalizeInstantiatedMethod = genOfInt.GetMethods().First(m => m.Name == "Finalize");
+
+            Assert.Equal(finalizeInstantiatedMethod, genOfInt.GetFinalizer());
+            Assert.Equal(finalizeInstantiatedMethod, derivedGenOfInt.GetFinalizer());
+        }
+
         /// <summary>
         /// Testing lookup up of a method in an instantiated type.
         /// </summary>


### PR DESCRIPTION
- IsFinal property not correctly implemented for MethodForInstantiatedType
- GetFinalizer does not work if the type does not implement the finalizer directly, but instead inherits it from the parent type