### PR TITLE
Implement a caching version of virtual method enumeration algorithm

### DIFF
--- a/src/Common/src/TypeSystem/Common/CachingVirtualMethodEnumerationAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/CachingVirtualMethodEnumerationAlgorithm.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Provides an implementation of <see cref="VirtualMethodEnumerationAlgorithm"/> that is
+    /// based on the metadata, as reported by the type through the <see cref="TypeDesc.GetMethods"/> method.
+    /// The algorithm operates simliarly to <see cref="MetadataVirtualMethodEnumerationAlgorithm"/>, but
+    /// maintains a cache of the results.
+    /// </summary>
+    public sealed class CachingVirtualMethodEnumerationAlgorithm : VirtualMethodEnumerationAlgorithm
+    {
+        private class VirtualMethodListHashTable : LockFreeReaderHashtable<TypeDesc, Tuple<TypeDesc, MethodDesc[]>>
+        {
+            protected override int GetKeyHashCode(TypeDesc key)
+            {
+                return key.GetHashCode();
+            }
+            protected override int GetValueHashCode(Tuple<TypeDesc, MethodDesc[]> value)
+            {
+                return value.Item1.GetHashCode();
+            }
+            protected override bool CompareKeyToValue(TypeDesc key, Tuple<TypeDesc, MethodDesc[]> value)
+            {
+                return key == value.Item1;
+            }
+            protected override bool CompareValueToValue(Tuple<TypeDesc, MethodDesc[]> value1, Tuple<TypeDesc, MethodDesc[]> value2)
+            {
+                return value1.Item1 == value2.Item1;
+            }
+            protected override Tuple<TypeDesc, MethodDesc[]> CreateValueFromKey(TypeDesc key)
+            {
+                ArrayBuilder<MethodDesc> virtualMethods = new ArrayBuilder<MethodDesc>();
+
+                foreach (var method in key.GetMethods())
+                {
+                    if (method.IsVirtual)
+                    {
+                        virtualMethods.Add(method);
+                    }
+                }
+
+                return new Tuple<TypeDesc, MethodDesc[]>(key, virtualMethods.ToArray());
+            }
+        }
+        private VirtualMethodListHashTable _virtualMethodLists = new VirtualMethodListHashTable();
+
+        public override IEnumerable<MethodDesc> ComputeAllVirtualMethods(TypeDesc type)
+        {
+            InstantiatedType instantiatedType = type as InstantiatedType;
+
+            if (instantiatedType != null)
+            {
+                return ComputeAllVirtualMethodsForInstantiatedType(instantiatedType);
+            }
+            else
+            {
+                return _virtualMethodLists.GetOrCreateValue(type).Item2;
+            }
+        }
+
+        private IEnumerable<MethodDesc> ComputeAllVirtualMethodsForInstantiatedType(InstantiatedType instantiatedType)
+        {
+            foreach (var typicalMethod in _virtualMethodLists.GetOrCreateValue(instantiatedType.GetTypeDefinition()).Item2)
+            {
+                yield return instantiatedType.Context.GetMethodForInstantiatedType(typicalMethod, instantiatedType);
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -23,7 +23,7 @@ namespace ILCompiler
         private MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
         private MetadataVirtualMethodAlgorithm _virtualMethodAlgorithm = new MetadataVirtualMethodAlgorithm();
-        private MetadataVirtualMethodEnumerationAlgorithm _virtualMethodEnumAlgorithm = new MetadataVirtualMethodEnumerationAlgorithm();
+        private CachingVirtualMethodEnumerationAlgorithm _virtualMethodEnumAlgorithm = new CachingVirtualMethodEnumerationAlgorithm();
         private DelegateVirtualMethodEnumerationAlgorithm _delegateVirtualMethodEnumAlgorithm = new DelegateVirtualMethodEnumerationAlgorithm();
 
         private MetadataStringDecoder _metadataStringDecoder;

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -71,6 +71,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\AlignmentHelper.cs">
       <Link>Utilities\AlignmentHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\CachingVirtualMethodEnumerationAlgorithm.cs">
+      <Link>TypeSystem\Common\CachingVirtualMethodEnumerationAlgorithm.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\CastingHelper.cs">
       <Link>TypeSystem\Common\CastingHelper.cs</Link>
     </Compile>

--- a/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
+++ b/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="InstanceFieldLayoutTests.cs" />
     <Compile Include="StaticFieldLayoutTests.cs" />
     <Compile Include="TestTypeSystemContext.cs" />
+    <Compile Include="VirtualMethodEnumerationAlgorithmTests.cs" />
     <Compile Include="WellKnownTypeTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ILCompiler.TypeSystem/tests/VirtualMethodEnumerationAlgorithmTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/VirtualMethodEnumerationAlgorithmTests.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Internal.TypeSystem;
+
+using Xunit;
+
+
+namespace TypeSystemTests
+{
+    public class VirtualMethodEnumerationAlgorithmTests
+    {
+        TestTypeSystemContext _context;
+        ModuleDesc _testModule;
+        MetadataType _testType;
+
+        public VirtualMethodEnumerationAlgorithmTests()
+        {
+            _context = new TestTypeSystemContext(TargetArchitecture.Unknown);
+            var systemModule = _context.CreateModuleForSimpleName("CoreTestAssembly");
+            _context.SetSystemModule(systemModule);
+
+            _testModule = systemModule;
+
+            _testType = _testModule.GetType("VirtualFunctionOverride", "SimpleGeneric`1")
+                .MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Object));
+        }
+
+        [Fact]
+        public void TestMetadataEnumerationAlgorithm()
+        {
+            var algo = new MetadataVirtualMethodEnumerationAlgorithm();
+
+            DefType objectType = _context.GetWellKnownType(WellKnownType.Object);
+            var objectMethods = algo.ComputeAllVirtualMethods(objectType).ToArray();
+            Assert.Equal(4, objectMethods.Length);
+            Assert.Superset(new HashSet<string> { "Equals", "GetHashCode", "ToString", "Finalize" },
+                new HashSet<string>(objectMethods.Select(m => m.Name)));
+
+            var testTypeMethods = algo.ComputeAllVirtualMethods(_testType).ToArray();
+            Assert.Equal(1, testTypeMethods.Length);
+            Assert.Equal("ToString", testTypeMethods[0].Name);
+            Assert.Equal(_testType, testTypeMethods[0].OwningType);
+        }
+
+        [Fact]
+        public void TestCachingEnumerationAlgorithm()
+        {
+            var algo = new CachingVirtualMethodEnumerationAlgorithm();
+
+            DefType objectType = _context.GetWellKnownType(WellKnownType.Object);
+            var objectMethods = algo.ComputeAllVirtualMethods(objectType).ToArray();
+            Assert.Equal(4, objectMethods.Length);
+            Assert.Superset(new HashSet<string> { "Equals", "GetHashCode", "ToString", "Finalize" },
+                new HashSet<string>(objectMethods.Select(m => m.Name)));
+
+            var testTypeMethods = algo.ComputeAllVirtualMethods(_testType).ToArray();
+            Assert.Equal(1, testTypeMethods.Length);
+            Assert.Equal("ToString", testTypeMethods[0].Name);
+            Assert.Equal(_testType, testTypeMethods[0].OwningType);
+        }
+    }
+}


### PR DESCRIPTION
When compiling hello world, computing virtual method overrides shows up as pretty hot. Turns out the slowdown is mostly caused by the enumeration being slow. I'm introducing a caching version of the algorithm.

This drops hello world compilation time from ~3.4 seconds to ~3.2 seconds (!).

Some notes:
* Caching only the methods on definitions, not on instantiated types.
* I'm not adding cache invalidation. Since I'm not caching methods on generic instantiations, this shouldn't explode too much.
* We might get further benefit if we change `IEnumerable<MethodDesc>` to `MethodDesc[]` in the method signature, but I'm not sure we would want to do that.