### PR TITLE
Do not convert method to a string if logging is disabled

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -231,8 +231,12 @@ namespace ILCompiler
             foreach (MethodCodeNode methodCodeNodeNeedingCode in obj)
             {
                 MethodDesc method = methodCodeNodeNeedingCode.Method;
-                string methodName = method.ToString();
-                Log.WriteLine("Compiling " + methodName);
+
+                if (Log != TextWriter.Null)
+                {
+                    string methodName = method.ToString();
+                    Log.WriteLine("Compiling " + methodName);
+                }
 
                 var methodIL = GetMethodIL(method);
                 if (methodIL == null)

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -232,7 +232,7 @@ namespace ILCompiler
             {
                 MethodDesc method = methodCodeNodeNeedingCode.Method;
 
-                if (Log != TextWriter.Null)
+                if (_options.Verbose)
                 {
                     string methodName = method.ToString();
                     Log.WriteLine("Compiling " + methodName);


### PR DESCRIPTION
We need a proper logging infrastructure as a long term fix, but this shaves off 8% of the compilation time for Hello World, so worth it on it's own...