### PR TITLE
Emit metadata mapping for all unconstructed EETypes

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
@@ -79,13 +79,13 @@ namespace ILCompiler.DependencyAnalysis
                 if (!factory.CompilationModuleGroup.ContainsType(mappingEntry.Entity))
                     continue;
 
+                // We are looking for any EEType - constructed or not, it has to be in the mapping
+                // table so that we can map it to metadata.
                 var node = factory.ConstructedTypeSymbol(mappingEntry.Entity) as EETypeNode;
                 if (!node.Marked)
                 {
-                    // Generic type definition EETypes are never constructed, but need to be
-                    // present in the mapping table.
-                    if (mappingEntry.Entity.IsGenericDefinition)
-                        node = factory.NecessaryTypeSymbol(mappingEntry.Entity) as EETypeNode;
+                    // This might have been a typeof() expression.
+                    node = factory.NecessaryTypeSymbol(mappingEntry.Entity) as EETypeNode;
                 }
 
                 if (node.Marked)

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -81,6 +81,12 @@ public class ReflectionTest
             return Fail;
         }
 
+        // This type only has a limited EEType (without a vtable) because it's not constructed.
+        if (typeof(UnallocatedType).FullName != "UnallocatedType")
+        {
+            return Fail;
+        }
+
         if (typeof(int) != typeof(int))
         {
             Console.WriteLine("Bad compare");
@@ -103,3 +109,5 @@ public class ReflectionTest
         return Fail;
     }
 }
+
+class UnallocatedType { }


### PR DESCRIPTION
Restricting this to generic definitions is incorrect. We need this for typeof() to work.

Fixes #1474.