### PR TITLE
Check the exception before checking CorJitResult

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -164,15 +164,15 @@ namespace Internal.JitInterface
                 var result = JitCompileMethod(out exception, 
                         _jit, (IntPtr)Unsafe.AsPointer(ref _this), _unmanagedCallbacks,
                         ref methodInfo, (uint)CorJitFlag.CORJIT_FLG_CALL_GETJITFLAGS, out nativeEntry, out codeSize);
-                if (result != CorJitResult.CORJIT_OK)
-                {
-                    throw new Exception("JIT Failed");
-                }
                 if (exception != IntPtr.Zero)
                 {
                     char* szMessage = GetExceptionMessage(exception);
                     string message = szMessage != null ? new string(szMessage) : "JIT Exception";
                     throw new Exception(message);
+                }
+                if (result != CorJitResult.CORJIT_OK)
+                {
+                    throw new Exception("JIT Failed");
                 }
 
                 PublishCode();


### PR DESCRIPTION
Exception is likely to contain more useful data.

This is the root cause for the unhelpful "JIT Error" message reported in #1471.