### PR TITLE
Avoid unnecessary allocations in BlockedRuntimeTypeNameGenerator

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/BlockedRuntimeTypeNameGenerator.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/BlockedRuntimeTypeNameGenerator.cs
@@ -29,7 +29,7 @@ namespace Internal.Reflection.Core.NonPortable
             protected override String Factory(RuntimeType key)
             {
                 uint count = s_counter++;
-                return "$BlockedFromReflection_" + count + "_" + Guid.NewGuid().ToString().Substring(0, 8);
+                return "$BlockedFromReflection_" + count.ToString() + "_" + Guid.NewGuid().ToString().Substring(0, 8);
             }
 
             private static uint s_counter;


### PR DESCRIPTION
The current implementation calls `string.Concat(object[])`, which results in an unnecessary `uint` box allocation along with an unnecessary `object[]` array allocation.

These allocations can be avoided by calling `uint.ToString()`, allowing `string.Concat(string, string, string, string)` to be used.