### PR TITLE
Encoding.EncodingName: Use ordinal comparison

### DIFF
--- a/src/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -465,7 +465,7 @@ namespace System.Text
                             SR.Format(SR.MissingEncodingNameResource, this.CodePage));
                     }
 
-                    if (_encodingName.StartsWith("Globalization_cp_"))
+                    if (_encodingName.StartsWith("Globalization_cp_", StringComparison.Ordinal))
                     {
                         // On ProjectN, resource strings are stripped from retail builds and replaced by
                         // their identifier names. Since this property is meant to be a localized string,


### PR DESCRIPTION
Pass `StringComparison.Ordinal` to `StartsWith`, otherwise the comparison will be done using the current culture.