### PR TITLE
Use ToStringInvariant where appropriate.

### DIFF
--- a/src/Common/src/TypeSystem/Common/SignatureVariable.cs
+++ b/src/Common/src/TypeSystem/Common/SignatureVariable.cs
@@ -74,7 +74,7 @@ namespace Internal.TypeSystem
 
         public override string ToString()
         {
-            return "!" + Index.ToString();
+            return "!" + Index.ToStringInvariant();
         }
     }
 
@@ -112,7 +112,7 @@ namespace Internal.TypeSystem
 
         public override string ToString()
         {
-            return "!!" + Index.ToString();
+            return "!!" + Index.ToStringInvariant();
         }
     }
 }

--- a/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
+++ b/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
@@ -81,7 +81,7 @@ namespace Internal.NativeFormat
             }
             else
             {
-                hashCode = ComputeNameHashCode("System.MDArrayRank" + rank.ToString() + "`1");
+                hashCode = ComputeNameHashCode("System.MDArrayRank" + rank.ToStringInvariant() + "`1");
             }
 
             hashCode = (hashCode + _rotl(hashCode, 13)) ^ elementTypeHashCode;

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -353,6 +353,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\TypeSystemContext.RuntimeDetermined.cs">
       <Link>TypeSystem\RuntimeDetermined\TypeSystemContext.RuntimeDetermined.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\System\FormattingHelpers.cs">
+      <Link>Common\System\FormattingHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
- Type hashcodes shouldn't be dependent on current culture
- ToString behavior in type system shouldn't be dependent on current culture