### PR TITLE
Add support for canonicalization of types\methods that contain

### DIFF
--- a/src/Common/src/TypeSystem/Canon/StandardCanonicalizationAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Canon/StandardCanonicalizationAlgorithm.cs
@@ -68,6 +68,10 @@ namespace Internal.TypeSystem
                 {
                     return context.UniversalCanonType;
                 }
+                else if (typeToConvert.IsSignatureVariable)
+                {
+                    return typeToConvert;
+                }
                 else if (typeToConvert.IsDefType)
                 {
                     if (!typeToConvert.IsValueType)

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedCanonicalizationAlgorithm.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedCanonicalizationAlgorithm.cs
@@ -84,6 +84,10 @@ namespace Internal.TypeSystem
                     kind = CanonicalFormKind.Universal;
                     return context.UniversalCanonType;
                 }
+                else if (typeToConvert.IsSignatureVariable)
+                {
+                    return typeToConvert;
+                }
                 else if (typeToConvert.IsDefType)
                 {
                     if (!typeToConvert.IsValueType)

--- a/src/ILCompiler.TypeSystem/tests/CanonicalizationTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/CanonicalizationTests.cs
@@ -107,6 +107,16 @@ namespace TypeSystemTests
             Assert.Same(
                 referenceOverGenericStructOverReference.ConvertToCanonForm(CanonicalFormKind.Universal),
                 referenceOverReference.ConvertToCanonForm(CanonicalFormKind.Universal));
+
+            // Canon of a type instantiated over a signature variable is the same type when just canonicalizing as specific,
+            // but the universal canon form when performing universal canonicalization.
+            var genericStructOverSignatureVariable = _genericStructType.MakeInstantiatedType(_context.GetSignatureVariable(0, false));
+            Assert.Same(
+                genericStructOverSignatureVariable,
+                genericStructOverSignatureVariable.ConvertToCanonForm(CanonicalFormKind.Specific));
+            Assert.NotSame(
+                genericStructOverSignatureVariable,
+                genericStructOverSignatureVariable.ConvertToCanonForm(CanonicalFormKind.Universal));
         }
 
         [Theory]


### PR DESCRIPTION
SignatureVariables
- Specific canonicalization will pass the type through
- Universal canonicalization will convert to UniversalCanon