### PR TITLE
Improve flexibility of gc static base computation

### DIFF
--- a/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
@@ -38,17 +38,13 @@ namespace Internal.TypeSystem
         /// For static fields, represents whether or not the field is held in the GC or non GC statics region
         /// Does not apply to thread static fields.
         /// </summary>
-        public virtual bool HasGCStaticBase
+        public bool HasGCStaticBase
         {
             get
             {
                 Debug.Assert(IsStatic);
 
-                TypeDesc fieldType = FieldType;
-                if (fieldType.IsValueType)
-                    return ((DefType)fieldType).ContainsGCPointers;
-                else
-                    return fieldType.IsGCPointer;
+                return Context.ComputeHasGCStaticsBase(this);
             }
         }
 

--- a/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
@@ -44,7 +44,7 @@ namespace Internal.TypeSystem
             {
                 Debug.Assert(IsStatic);
 
-                return Context.ComputeHasGCStaticsBase(this);
+                return Context.ComputeHasGCStaticBase(this);
             }
         }
 

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -690,7 +690,7 @@ namespace Internal.TypeSystem
 
         // Abstraction to allow different runtimes to have different policy about which fields are 
         // in the GC static region, and which are not
-        public virtual bool ComputeHasGCStaticsBase(FieldDesc field)
+        protected internal virtual bool ComputeHasGCStaticBase(FieldDesc field)
         {
             // Type system contexts that support this need to override this.
             throw new NotSupportedException();

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -687,5 +687,13 @@ namespace Internal.TypeSystem
             // Type system contexts that support this need to override this.
             throw new NotSupportedException();
         }
+
+        // Abstraction to allow different runtimes to have different policy about which fields are 
+        // in the GC static region, and which are not
+        public virtual bool ComputeHasGCStaticsBase(FieldDesc field)
+        {
+            // Type system contexts that support this need to override this.
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -322,7 +322,7 @@ namespace ILCompiler
             return _metadataStringDecoder;
         }
 
-        public override bool ComputeHasGCStaticsBase(FieldDesc field)
+        protected override bool ComputeHasGCStaticBase(FieldDesc field)
         {
             Debug.Assert(field.IsStatic);
 
@@ -331,7 +331,6 @@ namespace ILCompiler
                 return ((DefType)fieldType).ContainsGCPointers;
             else
                 return fieldType.IsGCPointer;
-
         }
 
         //

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -322,6 +322,18 @@ namespace ILCompiler
             return _metadataStringDecoder;
         }
 
+        public override bool ComputeHasGCStaticsBase(FieldDesc field)
+        {
+            Debug.Assert(field.IsStatic);
+
+            TypeDesc fieldType = field.FieldType;
+            if (fieldType.IsValueType)
+                return ((DefType)fieldType).ContainsGCPointers;
+            else
+                return fieldType.IsGCPointer;
+
+        }
+
         //
         // Symbols
         //

--- a/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
@@ -109,7 +109,7 @@ namespace TypeSystemTests
                 return RuntimeDeterminedCanonicalizationAlgorithm.ConvertToCanon(typeToConvert, ref kind);
         }
 
-        public override bool ComputeHasGCStaticsBase(FieldDesc field)
+        protected override bool ComputeHasGCStaticBase(FieldDesc field)
         {
             Debug.Assert(field.IsStatic);
 

--- a/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 using Internal.TypeSystem;
 using System.Reflection.PortableExecutable;
@@ -106,6 +107,18 @@ namespace TypeSystemTests
                 return StandardCanonicalizationAlgorithm.ConvertToCanon(typeToConvert, kind);
             else
                 return RuntimeDeterminedCanonicalizationAlgorithm.ConvertToCanon(typeToConvert, ref kind);
+        }
+
+        public override bool ComputeHasGCStaticsBase(FieldDesc field)
+        {
+            Debug.Assert(field.IsStatic);
+
+            TypeDesc fieldType = field.FieldType;
+            if (fieldType.IsValueType)
+                return ((DefType)fieldType).ContainsGCPointers;
+            else
+                return fieldType.IsGCPointer;
+
         }
     }
 }


### PR DESCRIPTION
- Move extension point for computing HasGCStaticBase from an override of the method on FieldDesc, to a function on the TypeSystemContext
- Will allow runtime specific determination of rules for where static variables are stored