### PR TITLE
Add ulimit -n 2048 workaround in scripts for mac build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -190,6 +190,7 @@ case $OSName in
         __BuildOS=OSX
         __ToolNugetRuntimeId=osx.10.10-x64
         __TestNugetRuntimeId=osx.10.10-x64
+        ulimit -n 2048
         ;;
 
     FreeBSD)


### PR DESCRIPTION
@MichalStrehovsky @schellap PTAL. Turns out this is what was causing mac build issues during the dotnet restore step inside build.proj. 