### PR TITLE
Add ICloneable to System.Private.CoreLib

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeType.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeType.cs
@@ -26,11 +26,16 @@ namespace Internal.Reflection.Core.NonPortable
     //
 
     [DebuggerDisplay("{_debugName}")]
-    public abstract class RuntimeType : ExtensibleType, IEquatable<RuntimeType>
+    public abstract class RuntimeType : ExtensibleType, IEquatable<RuntimeType>, ICloneable
     {
         protected RuntimeType()
             : base()
         {
+        }
+
+        public object Clone()
+        {
+            return this;
         }
 
         //=====================================================================================================================

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -209,6 +209,7 @@
     <Compile Include="System\Globalization\FormatProvider.TimeSpanFormat.cs" />
     <Compile Include="System\Globalization\FormatProvider.TimeSpanParse.cs" />
     <Compile Include="System\Globalization\UmAlQuraCalendar.cs" />
+    <Compile Include="System\ICloneable.cs" />
     <Compile Include="System\InvokeUtils.cs" />
     <Compile Include="System\IO\DirectoryNotFoundException.cs" />
     <Compile Include="System\IO\FileLoadException.cs" />

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -24,7 +24,7 @@ namespace System
 {
     // Note that we make a T[] (single-dimensional w/ zero as the lower bound) implement both 
     // IList<U> and IReadOnlyList<U>, where T : U dynamically.  See the SZArrayHelper class for details.
-    public abstract class Array : ICollection, IEnumerable, IList, IStructuralComparable, IStructuralEquatable
+    public abstract class Array : ICollection, IEnumerable, IList, IStructuralComparable, IStructuralEquatable, ICloneable
     {
         // This ctor exists solely to prevent C# from generating a protected .ctor that violates the surface area. I really want this to be a
         // "protected-and-internal" rather than "internal" but C# has no keyword for the former.
@@ -2668,7 +2668,7 @@ namespace System
             }
         }
 
-        private sealed class SZArrayEnumerator : IEnumerator
+        private sealed class SZArrayEnumerator : IEnumerator, ICloneable
         {
             private Array _array;
             private int _index;
@@ -2704,6 +2704,11 @@ namespace System
             public void Reset()
             {
                 _index = -1;
+            }
+
+            public object Clone()
+            {
+                return MemberwiseClone();
             }
         }
     }
@@ -2861,7 +2866,7 @@ namespace System
             throw new NotSupportedException();
         }
 
-        private sealed class ArrayEnumerator : ArrayEnumeratorBase, IEnumerator<T>
+        private sealed class ArrayEnumerator : ArrayEnumeratorBase, IEnumerator<T>, ICloneable
         {
             private T[] _array;
 
@@ -2895,6 +2900,11 @@ namespace System
             void IEnumerator.Reset()
             {
                 _index = -1;
+            }
+
+            public object Clone()
+            {
+                return MemberwiseClone();
             }
         }
     }

--- a/src/System.Private.CoreLib/src/System/CharEnumerator.cs
+++ b/src/System.Private.CoreLib/src/System/CharEnumerator.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 
 namespace System
 {
-    internal sealed class CharEnumerator : IEnumerator, IEnumerator<char>, IDisposable
+    internal sealed class CharEnumerator : IEnumerator, IEnumerator<char>, IDisposable, ICloneable
     {
         private String _str;
         private int _index;
@@ -29,9 +29,10 @@ namespace System
             _index = -1;
         }
 
-        //public Object Clone() {
-        //    return MemberwiseClone();
-        //}
+        public object Clone()
+        {
+            return MemberwiseClone();
+        }
 
         public bool MoveNext()
         {

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -18,7 +18,7 @@ namespace System
     // sequential layout directive so that Bartok matches it.
     [StructLayout(LayoutKind.Sequential)]
     [DebuggerDisplay("Target method(s) = {GetTargetMethodsDescriptionForDebugger()}")]
-    public abstract class Delegate
+    public abstract class Delegate : ICloneable
     {
         // This ctor exists solely to prevent C# from generating a protected .ctor that violates the surface area. I really want this to be a
         // "protected-and-internal" rather than "internal" but C# has no keyword for the former.
@@ -673,6 +673,11 @@ namespace System
                 // Closed instance delegates place a value in m_firstParameter, and we've ruled out all other types of delegates
                 return m_firstParameter;
             }
+        }
+
+        public virtual object Clone()
+        {
+            return MemberwiseClone();
         }
 
         internal bool IsOpenStatic

--- a/src/System.Private.CoreLib/src/System/Globalization/Calendar.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/Calendar.cs
@@ -31,7 +31,7 @@ namespace System.Globalization
 
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    public abstract class Calendar
+    public abstract class Calendar : ICloneable
     {
         // Number of 100ns (10E-7 second) ticks per time unit
         internal const long TicksPerMillisecond = 10000;
@@ -133,11 +133,11 @@ namespace System.Globalization
         //
         //  Clone
         //
-        //  Is the implementation of IColnable.
+        //  Is the implementation of ICloneable.
         //
         ////////////////////////////////////////////////////////////////////////
         [System.Runtime.InteropServices.ComVisible(false)]
-        internal virtual Object Clone()
+        public virtual object Clone()
         {
             object o = MemberwiseClone();
             ((Calendar)o).SetReadOnlyState(false);

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -39,7 +39,7 @@ using Internal.Runtime.Augments;
 
 namespace System.Globalization
 {
-    public partial class CultureInfo : IFormatProvider
+    public partial class CultureInfo : IFormatProvider, ICloneable
     {
         //--------------------------------------------------------------------//
         //                        Internal Information                        //

--- a/src/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -55,7 +55,7 @@ namespace System.Globalization
 
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class DateTimeFormatInfo : IFormatProvider
+    public sealed class DateTimeFormatInfo : IFormatProvider, ICloneable
     {
         // cache for the invariant culture.
         // invariantInfo is constant irrespective of your current culture.

--- a/src/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -41,7 +41,7 @@ namespace System.Globalization
     //
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    sealed public class NumberFormatInfo : IFormatProvider
+    sealed public class NumberFormatInfo : IFormatProvider, ICloneable
     {
         // invariantInfo is constant irrespective of your current culture.
         private static volatile NumberFormatInfo s_invariantInfo;

--- a/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -23,7 +23,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Globalization
 {
-    public partial class TextInfo
+    public partial class TextInfo : ICloneable
     {
         ////--------------------------------------------------------------------//
         ////                        Internal Information                        //
@@ -138,10 +138,10 @@ namespace System.Globalization
         ////
         ////  Clone
         ////
-        ////  Is the implementation of IColnable.
+        ////  Is the implementation of ICloneable.
         ////
         //////////////////////////////////////////////////////////////////////////
-        internal virtual Object Clone()
+        public virtual object Clone()
         {
             object o = MemberwiseClone();
             ((TextInfo)o).SetReadOnlyState(false);

--- a/src/System.Private.CoreLib/src/System/ICloneable.cs
+++ b/src/System.Private.CoreLib/src/System/ICloneable.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    /// <summary>Defines an interface indicating that an object may be cloned.</summary>
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public interface ICloneable
+    {
+        object Clone();
+    }
+}

--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -84,7 +84,7 @@ namespace System
     [ComVisible(true)]
     [StructLayout(LayoutKind.Sequential)]
     [System.Runtime.CompilerServices.EagerStaticClassConstructionAttribute]
-    public sealed class String : IComparable, IEnumerable, IEnumerable<char>, IComparable<String>, IEquatable<String>, IConvertible
+    public sealed class String : IComparable, IEnumerable, IEnumerable<char>, IComparable<String>, IEquatable<String>, IConvertible, ICloneable
     {
 #if BIT64
         private const int POINTER_SIZE = 8;
@@ -328,6 +328,11 @@ namespace System
                 return String.Empty;
             else
                 throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NegativeCount);
+        }
+
+        public object Clone()
+        {
+            return this;
         }
 
         private const int TrimHead = 0;

--- a/src/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -78,7 +78,7 @@ namespace System.Text
     //
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    public abstract class Encoding // : ICloneable
+    public abstract class Encoding : ICloneable
     {
         private static volatile Encoding s_unicodeEncoding;
         private static volatile Encoding s_bigEndianUnicode;

--- a/src/System.Private.CoreLib/src/System/Version.cs
+++ b/src/System.Private.CoreLib/src/System/Version.cs
@@ -15,7 +15,7 @@ namespace System
     // specified component.
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class Version : IComparable, IComparable<Version>, IEquatable<Version>
+    public sealed class Version : IComparable, IComparable<Version>, IEquatable<Version>, ICloneable
     {
         // AssemblyName depends on the order staying the same
         private int _Major;
@@ -82,6 +82,11 @@ namespace System
             _Minor = v.Minor;
             _Build = v.Build;
             _Revision = v.Revision;
+        }
+
+        public object Clone()
+        {
+            return new Version(_Major, _Minor, _Build, _Revision);
         }
 
         // Properties for setting and getting version numbers

--- a/src/System.Private.Reflection/src/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.Reflection/src/System/Reflection/AssemblyName.cs
@@ -15,7 +15,7 @@ using global::Internal.Reflection.Augments;
 
 namespace System.Reflection
 {
-    public sealed class AssemblyName
+    public sealed class AssemblyName : ICloneable
     {
         private String _Name;                  // Name
         private byte[] _PublicKey;
@@ -36,6 +36,18 @@ namespace System.Reflection
             if (assemblyName == null)
                 throw new ArgumentNullException("assemblyName");
             ReflectionAugments.ReflectionCoreCallbacks.InitializeAssemblyName(this, assemblyName);
+        }
+
+        public object Clone()
+        {
+            var n = new AssemblyName();
+            n._Name = _Name;
+            n._PublicKey = (byte[])_PublicKey?.Clone();
+            n._PublicKeyToken = (byte[])_PublicKeyToken?.Clone();
+            n._CultureName = _CultureName;
+            n._Version = (Version)_Version?.Clone();
+            n._Flags = _Flags;
+            return n;
         }
 
         public ProcessorArchitecture ProcessorArchitecture


### PR DESCRIPTION
I went through all of the types from desktop/coreclr that implement ICloneable and ensured that the same types in corert also implemented the interface, which is being exposed in the System.Runtime contract in https://github.com/dotnet/corefx/pull/9970.

cc: @jkotas, @danmosemsft