### PR TITLE
Add support for single method compilation mode

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -1,0 +1,57 @@
+﻿using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// A compilation group that only contains a single method. Useful for development purposes when investigating
+    /// code generation issues.
+    /// </summary>
+    public class SingleMethodCompilationModuleGroup : CompilationModuleGroup
+    {
+        private MethodDesc _method;
+
+        public SingleMethodCompilationModuleGroup(CompilerTypeSystemContext typeSystemContext, MethodDesc method)
+            : base(typeSystemContext)
+        {
+            _method = method;
+        }
+
+        public override bool IsSingleFileCompilation
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool ContainsMethod(MethodDesc method)
+        {
+            return method == _method;
+        }
+
+        public override bool ContainsType(TypeDesc type)
+        {
+            return false;
+        }
+
+        public override bool ShouldProduceFullType(TypeDesc type)
+        {
+            return false;
+        }
+
+        public override bool ShouldShareAcrossModules(MethodDesc method)
+        {
+            return true;
+        }
+
+        public override bool ShouldShareAcrossModules(TypeDesc type)
+        {
+            return true;
+        }
+
+        public override void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        {
+            rootProvider.AddCompilationRoot(_method, "Single method mode");
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -1,4 +1,8 @@
-﻿using Internal.TypeSystem;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
 
 namespace ILCompiler
 {

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Compiler\NameMangler.cs" />
     <Compile Include="Compiler\ReadyToRun.cs" />
     <Compile Include="Compiler\SingleFileCompilationModuleGroup.cs" />
+    <Compile Include="Compiler\SingleMethodCompilationModuleGroup.cs" />
     <Compile Include="Compiler\TypeExtensions.cs" />
     <Compile Include="Compiler\TypeInitialization.cs" />
     <Compile Include="Compiler\VirtualMethodCallHelper.cs" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -31,7 +31,6 @@ namespace ILCompiler
         private string _singleMethodName;
         private IReadOnlyList<string> _singleMethodGenericArgs;
 
-
         private bool _help;
 
         private Program()
@@ -191,9 +190,8 @@ namespace ILCompiler
         {
             TypeDesc foundType = context.SystemModule.GetTypeByCustomAttributeTypeName(typeName);
             if (foundType == null)
-            {
                 throw new CommandLineException($"Type '{typeName}' not found");
-            }
+
             return foundType;
         }
 
@@ -210,9 +208,7 @@ namespace ILCompiler
             // TODO: allow specifying signature to distinguish overloads
             MethodDesc method = owningType.GetMethod(_singleMethodName, null);
             if (method == null)
-            {
                 throw new CommandLineException($"Method '{_singleMethodName}' not found in '{_singleMethodTypeName}'");
-            }
 
             if (method.HasInstantiation != (_singleMethodGenericArgs != null) ||
                 (method.HasInstantiation && (method.Instantiation.Length != _singleMethodGenericArgs.Count)))

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -27,6 +27,11 @@ namespace ILCompiler
         private string _systemModuleName = "System.Private.CoreLib";
         private bool _multiFile;
 
+        private string _singleMethodTypeName;
+        private string _singleMethodName;
+        private IReadOnlyList<string> _singleMethodGenericArgs;
+
+
         private bool _help;
 
         private Program()
@@ -88,6 +93,7 @@ namespace ILCompiler
             IReadOnlyList<string> inputFiles = Array.Empty<string>();
             IReadOnlyList<string> referenceFiles = Array.Empty<string>();
 
+            
             AssemblyName name = typeof(Program).GetTypeInfo().Assembly.GetName();
             ArgumentSyntax argSyntax = ArgumentSyntax.Parse(args, syntax =>
             {
@@ -107,6 +113,11 @@ namespace ILCompiler
                 syntax.DefineOption("verbose", ref _options.Verbose, "Enable verbose logging");
                 syntax.DefineOption("systemmodule", ref _systemModuleName, "System module name (default: System.Private.CoreLib)");
                 syntax.DefineOption("multifile", ref _multiFile, "Compile only input files (do not compile referenced assemblies)");
+
+                syntax.DefineOption("singlemethodtypename", ref _singleMethodTypeName, "Single method compilation: name of the owning type");
+                syntax.DefineOption("singlemethodname", ref _singleMethodName, "Single method compilation: name of the method");
+                syntax.DefineOptionList("singlemethodgenericarg", ref _singleMethodGenericArgs, "Single method compilation: generic arguments to the method");
+
                 syntax.DefineParameterList("in", ref inputFiles, "Input file(s) to compile");
             });
             foreach (var input in inputFiles)
@@ -149,8 +160,15 @@ namespace ILCompiler
             // Initialize compilation group
             //
 
+            // Single method mode?
+            MethodDesc singleMethod = CheckAndParseSingleMethodModeArguments(typeSystemContext);
+
             CompilationModuleGroup compilationGroup;
-            if (_multiFile)
+            if (singleMethod != null)
+            {
+                compilationGroup = new SingleMethodCompilationModuleGroup(typeSystemContext, singleMethod);
+            }
+            else if (_multiFile)
             {
                 compilationGroup = new MultiFileCompilationModuleGroup(typeSystemContext);
             }
@@ -168,6 +186,51 @@ namespace ILCompiler
             compilation.Compile();
 
             return 0;
+        }
+
+        private TypeDesc FindType(CompilerTypeSystemContext context, string typeName)
+        {
+            TypeDesc foundType = context.SystemModule.GetTypeByCustomAttributeTypeName(typeName);
+            if (foundType == null)
+            {
+                throw new CommandLineException($"Type '{typeName}' not found");
+            }
+            return foundType;
+        }
+
+        private MethodDesc CheckAndParseSingleMethodModeArguments(CompilerTypeSystemContext context)
+        {
+            if (_singleMethodName == null && _singleMethodTypeName == null && _singleMethodGenericArgs == null)
+                return null;
+
+            if (_singleMethodName == null || _singleMethodTypeName == null)
+                throw new CommandLineException("Both method name and type name are required parameters for single method mode");
+
+            TypeDesc owningType = FindType(context, _singleMethodTypeName);
+
+            // TODO: allow specifying signature to distinguish overloads
+            MethodDesc method = owningType.GetMethod(_singleMethodName, null);
+            if (method == null)
+            {
+                throw new CommandLineException($"Method '{_singleMethodName}' not found in '{_singleMethodTypeName}'");
+            }
+
+            if (method.HasInstantiation != (_singleMethodGenericArgs != null) ||
+                (method.HasInstantiation && (method.Instantiation.Length != _singleMethodGenericArgs.Count)))
+            {
+                throw new CommandLineException(
+                    $"Expected {method.Instantiation.Length} generic arguments for method '{_singleMethodName}' on type '{_singleMethodTypeName}'");
+            }
+
+            if (method.HasInstantiation)
+            {
+                List<TypeDesc> genericArguments = new List<TypeDesc>();
+                foreach (var argString in _singleMethodGenericArgs)
+                    genericArguments.Add(FindType(context, argString));
+                method = method.MakeInstantiatedMethod(genericArguments.ToArray());
+            }
+
+            return method;
         }
 
         private static int Main(string[] args)

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -93,7 +93,6 @@ namespace ILCompiler
             IReadOnlyList<string> inputFiles = Array.Empty<string>();
             IReadOnlyList<string> referenceFiles = Array.Empty<string>();
 
-            
             AssemblyName name = typeof(Program).GetTypeInfo().Assembly.GetName();
             ArgumentSyntax argSyntax = ArgumentSyntax.Parse(args, syntax =>
             {


### PR DESCRIPTION
Add a set of command line arguments that let us specify a single method
to compile. This is useful when investigating code generation issues to
help narrow down the focus and make it easier to set up breakpoints.

Fixes #1142.