### PR TITLE
Make GetClosestMetadataType into GetClosestDefType

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -95,7 +95,7 @@ namespace ILCompiler.DependencyAnalysis
                 for (int interfaceMethodSlot = 0; interfaceMethodSlot < virtualSlots.Count; interfaceMethodSlot++)
                 {
                     MethodDesc declMethod = virtualSlots[interfaceMethodSlot];
-                    var implMethod = _type.GetClosestMetadataType().ResolveInterfaceMethodToVirtualMethodOnType(declMethod);
+                    var implMethod = _type.GetClosestDefType().ResolveInterfaceMethodToVirtualMethodOnType(declMethod);
 
                     // Interface methods first implemented by a base type in the hierarchy will return null for the implMethod (runtime interface
                     // dispatch will walk the inheritance chain).

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -90,8 +90,8 @@ namespace ILCompiler.DependencyAnalysis
         {
             var slots = new ArrayBuilder<MethodDesc>();
 
-            MetadataType mdType = _type.GetClosestMetadataType();
-            foreach (var method in mdType.GetAllVirtualMethods())
+            DefType defType = _type.GetClosestDefType();
+            foreach (var method in defType.GetAllVirtualMethods())
             {
                 slots.Add(method);
             }

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -23,7 +23,7 @@ namespace ILCompiler
             return true;
         }
 
-        static public MetadataType GetClosestMetadataType(this TypeDesc type)
+        static public DefType GetClosestDefType(this TypeDesc type)
         {
             if (type.IsSzArray && !((ArrayType)type).ElementType.IsPointer)
             {
@@ -32,11 +32,11 @@ namespace ILCompiler
             }
             else if (type.IsArray)
             {
-                return (MetadataType)type.Context.GetWellKnownType(WellKnownType.Array);
+                return type.Context.GetWellKnownType(WellKnownType.Array);
             }
 
-            Debug.Assert(type is MetadataType);
-            return (MetadataType)type;
+            Debug.Assert(type is DefType);
+            return (DefType)type;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -918,7 +918,7 @@ namespace ILCompiler.CppCodeGen
             for (int i = 0; i < virtualSlots.Count; i++)
             {
                 MethodDesc declMethod = virtualSlots[i];
-                MethodDesc implMethod = implType.GetClosestMetadataType().FindVirtualFunctionTargetMethodOnObjectType(declMethod);
+                MethodDesc implMethod = implType.GetClosestDefType().FindVirtualFunctionTargetMethodOnObjectType(declMethod);
 
                 sb.AppendLine();
                 if (implMethod.IsAbstract)

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -857,7 +857,7 @@ namespace Internal.IL
                     constrained = _constrained;
 
                     bool forceUseRuntimeLookup;
-                    MethodDesc directMethod = constrained.GetClosestMetadataType().TryResolveConstraintMethodApprox(method.OwningType, method, out forceUseRuntimeLookup);
+                    MethodDesc directMethod = constrained.GetClosestDefType().TryResolveConstraintMethodApprox(method.OwningType, method, out forceUseRuntimeLookup);
                     if (directMethod == null || forceUseRuntimeLookup)
                         throw new NotImplementedException();
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2110,7 +2110,7 @@ namespace Internal.JitInterface
                 // JIT compilation, and require a runtime lookup for the actual code pointer
                 // to call.
 
-                MethodDesc directMethod = constrainedType.GetClosestMetadataType().TryResolveConstraintMethodApprox(exactType, method, out forceUseRuntimeLookup);
+                MethodDesc directMethod = constrainedType.GetClosestDefType().TryResolveConstraintMethodApprox(exactType, method, out forceUseRuntimeLookup);
                 if (directMethod != null)
                 {
                     // Either


### PR DESCRIPTION
Making this return a `MetadataType` was too eager. We don't need a
`MetadataType` and this actually became a hindrance because Canon types
don't derive off `MetadataType` and the code in JitInterface needs to be
able to handle them.