### PR TITLE
Check in easy changes from WIP

### DIFF
--- a/src/Common/src/TypeSystem/Canon/CanonTypes.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.cs
@@ -100,6 +100,11 @@ namespace Internal.TypeSystem
                 flags |= TypeFlags.Class;
             }
 
+            if ((mask & TypeFlags.HasGenericVarianceComputed) != 0)
+            {
+                flags |= TypeFlags.HasGenericVarianceComputed;
+            }
+
             Debug.Assert((flags & mask) != 0);
             return flags;
         }

--- a/src/Common/src/TypeSystem/RuntimeDetermined/DefType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/DefType.RuntimeDetermined.cs
@@ -10,6 +10,9 @@ namespace Internal.TypeSystem
         {
             get
             {
+                if (IsGenericDefinition)
+                    return false;
+
                 foreach (TypeDesc type in Instantiation)
                 {
                     if (type.IsRuntimeDeterminedSubtype)

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -99,6 +99,11 @@ namespace Internal.TypeSystem
                 flags |= _rawCanonType.GetTypeFlags(mask);
             }
 
+            if ((mask & TypeFlags.HasGenericVarianceComputed) != 0)
+            {
+                flags |= _rawCanonType.GetTypeFlags(mask);
+            }
+
             // Might need to define the behavior if we ever hit this.
             Debug.Assert((flags & mask) != 0);
             return flags;


### PR DESCRIPTION
* Do not ask generic parameters if they're runtime determined 
* Get variance information off of Canon/RuntimeDetermined types