### PR TITLE
Expose `GetMethodILDefinition` on `MethodIL`

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -140,7 +140,7 @@ namespace Internal.IL
                 var methodDefinitionIL = GetMethodIL(method.GetTypicalMethodDefinition());
                 if (methodDefinitionIL == null)
                     return null;
-                return new InstantiatedMethodIL(method, methodDefinitionIL, method.OwningType.Instantiation, method.Instantiation);
+                return new InstantiatedMethodIL(method, methodDefinitionIL);
             }
             else
             if (method is ILStubMethod)

--- a/src/Common/src/TypeSystem/IL/InstantiatedMethodIL.cs
+++ b/src/Common/src/TypeSystem/IL/InstantiatedMethodIL.cs
@@ -17,17 +17,17 @@ namespace Internal.IL
         private Instantiation _typeInstantiation;
         private Instantiation _methodInstantiation;
 
-        public InstantiatedMethodIL(MethodDesc owningMethod, MethodIL methodIL, Instantiation typeInstantiation, Instantiation methodInstantiation)
+        public InstantiatedMethodIL(MethodDesc owningMethod, MethodIL methodIL)
         {
-            Debug.Assert(!(methodIL is InstantiatedMethodIL));
+            Debug.Assert(methodIL.GetMethodILDefinition() == methodIL);
             Debug.Assert(owningMethod.HasInstantiation || owningMethod.OwningType.HasInstantiation);
             Debug.Assert(owningMethod.GetTypicalMethodDefinition() == methodIL.OwningMethod);
             
             _methodIL = methodIL;
             _method = owningMethod;
 
-            _typeInstantiation = typeInstantiation;
-            _methodInstantiation = methodInstantiation;
+            _typeInstantiation = owningMethod.OwningType.Instantiation;
+            _methodInstantiation = owningMethod.Instantiation;
         }
 
         public override MethodDesc OwningMethod
@@ -120,6 +120,11 @@ namespace Internal.IL
 
 
             return o;
+        }
+
+        public override MethodIL GetMethodILDefinition()
+        {
+            return _methodIL;
         }
     }
 }

--- a/src/Common/src/TypeSystem/IL/MethodIL.cs
+++ b/src/Common/src/TypeSystem/IL/MethodIL.cs
@@ -93,5 +93,13 @@ namespace Internal.IL
         /// Gets a list of exception regions this method body defines.
         /// </summary>
         public abstract ILExceptionRegion[] GetExceptionRegions();
+
+        /// <summary>
+        /// Gets the open (uninstantiated) version of the <see cref="MethodIL"/>.
+        /// </summary>
+        public virtual MethodIL GetMethodILDefinition()
+        {
+            return this;
+        }
     }
 }


### PR DESCRIPTION
This is a useful operation after all.

Also, simplify the constructor of `InstantiatedMethodIL`.