### PR TITLE
Make NameMangler not depend on Compilation

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -46,7 +46,7 @@ namespace ILCompiler
         {
             _options = options;
 
-            _nameMangler = new NameMangler(this);
+            _nameMangler = new NameMangler(options.IsCppCodeGen);
 
             _typeInitManager = new TypeInitialization();
 
@@ -84,14 +84,6 @@ namespace ILCompiler
             set;
         }
 
-        internal bool IsCppCodeGen
-        {
-            get
-            {
-                return _options.IsCppCodeGen;
-            }
-        }
-
         internal CompilationOptions Options
         {
             get
@@ -116,6 +108,18 @@ namespace ILCompiler
         public void Compile()
         {
             NodeFactory.NameMangler = NameMangler;
+
+            string systemModuleName = ((IAssemblyDesc)_typeSystemContext.SystemModule).GetName().Name;
+
+            // TODO: just something to get Runtime.Base compiled
+            if (systemModuleName != "System.Private.CoreLib")
+            {
+                NodeFactory.CompilationUnitPrefix = systemModuleName.Replace(".", "_");
+            }
+            else
+            {
+                NodeFactory.CompilationUnitPrefix = NameMangler.SanitizeName(Path.GetFileNameWithoutExtension(Options.OutputFilePath));
+            }
 
             _nodeFactory = new NodeFactory(_typeSystemContext, _typeInitManager, _compilationModuleGroup, _options.IsCppCodeGen);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.DependencyAnalysis
                     throw new InvalidOperationException("MangledName called before InterfaceDispatchMap index was initialized.");
                 }
                     
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__InterfaceDispatchMap_" + _dispatchMapTableIndex;
+                return NodeFactory.CompilationUnitPrefix + "__InterfaceDispatchMap_" + _dispatchMapTableIndex;
             }
         }
         

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__embedded_metadata";
+                return NodeFactory.CompilationUnitPrefix + "__embedded_metadata";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModuleManagerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModuleManagerIndirectionNode.cs
@@ -14,7 +14,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__module_manager_indirection";
+                return NodeFactory.CompilationUnitPrefix + "__module_manager_indirection";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
@@ -48,7 +48,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__Module";
+                return NodeFactory.CompilationUnitPrefix + "__Module";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -566,26 +566,26 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         public ArrayOfEmbeddedPointersNode<GCStaticsNode> GCStaticsRegion = new ArrayOfEmbeddedPointersNode<GCStaticsNode>(
-            NameMangler.CompilationUnitPrefix + "__GCStaticRegionStart", 
-            NameMangler.CompilationUnitPrefix + "__GCStaticRegionEnd", 
+            CompilationUnitPrefix + "__GCStaticRegionStart", 
+            CompilationUnitPrefix + "__GCStaticRegionEnd", 
             null);
         public ArrayOfEmbeddedDataNode ThreadStaticsRegion = new ArrayOfEmbeddedDataNode(
-            NameMangler.CompilationUnitPrefix + "__ThreadStaticRegionStart",
-            NameMangler.CompilationUnitPrefix + "__ThreadStaticRegionEnd", 
+            CompilationUnitPrefix + "__ThreadStaticRegionStart",
+            CompilationUnitPrefix + "__ThreadStaticRegionEnd", 
             null);
         public ArrayOfEmbeddedDataNode StringTable = new ArrayOfEmbeddedDataNode(
-            NameMangler.CompilationUnitPrefix + "__StringTableStart",
-            NameMangler.CompilationUnitPrefix + "__StringTableEnd", 
+            CompilationUnitPrefix + "__StringTableStart",
+            CompilationUnitPrefix + "__StringTableEnd", 
             null);
 
         public ArrayOfEmbeddedPointersNode<IMethodNode> EagerCctorTable = new ArrayOfEmbeddedPointersNode<IMethodNode>(
-            NameMangler.CompilationUnitPrefix + "__EagerCctorStart",
-            NameMangler.CompilationUnitPrefix + "__EagerCctorEnd",
+            CompilationUnitPrefix + "__EagerCctorStart",
+            CompilationUnitPrefix + "__EagerCctorEnd",
             new EagerConstructorComparer());
 
         public ArrayOfEmbeddedPointersNode<InterfaceDispatchMapNode> DispatchMapTable = new ArrayOfEmbeddedPointersNode<InterfaceDispatchMapNode>(
-            NameMangler.CompilationUnitPrefix + "__DispatchMapTableStart",
-            NameMangler.CompilationUnitPrefix + "__DispatchMapTableEnd",
+            CompilationUnitPrefix + "__DispatchMapTableStart",
+            CompilationUnitPrefix + "__DispatchMapTableEnd",
             null);
 
         public ReadyToRunHeaderNode ReadyToRunHeader;
@@ -595,6 +595,7 @@ namespace ILCompiler.DependencyAnalysis
         internal ModuleManagerIndirectionNode ModuleManagerIndirection = new ModuleManagerIndirectionNode();
 
         public static NameMangler NameMangler;
+        public static string CompilationUnitPrefix;
 
         public void AttachToDependencyGraph(DependencyAnalysisFramework.DependencyAnalyzerBase<NodeFactory> graph)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__ReadyToRunHeader";
+                return NodeFactory.CompilationUnitPrefix + "__ReadyToRunHeader";
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
@@ -42,7 +42,7 @@ namespace ILCompiler.DependencyAnalysis
                     throw new InvalidOperationException("MangledName called before String Id was initialized.");
                 }
 
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__str_table_entry_" + _id.Value.ToStringInvariant();
+                return NodeFactory.CompilationUnitPrefix + "__str_table_entry_" + _id.Value.ToStringInvariant();
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
@@ -30,7 +30,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__str" + Offset.ToStringInvariant();
+                return NodeFactory.CompilationUnitPrefix + "__str" + Offset.ToStringInvariant();
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
@@ -33,7 +33,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return NodeFactory.NameMangler.CompilationUnitPrefix + "__type_to_metadata_map";
+                return NodeFactory.CompilationUnitPrefix + "__type_to_metadata_map";
             }
         }
 


### PR DESCRIPTION
`NameMangler`'s job is to provide stable names for types and their
members. It doesn't have a connection with the compilation process and
therefore shouldn't depend on `Compilation`. This makes it reusable and
unit testable.

I'm also taking `CompilationUnitPrefix` away from it. It doesn't have a
logical connection (except that it's related to naming and it was
convenient to put it there). I'm putting it on NodeFactory temporarily,
but there is a strong correlation between a dependency node using
`CompiationUnitPrefix` in it's name and reporting
`ShouldShareNodeAcrossModules` as false. Maybe we should use that in
`ObjectWriter` to prepend it automatically instead of hoping the node
won't mess it up and jumping through hoops (a static variable) to get to
it.