### PR TITLE
Fix NullReferenceException in VTable computation

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -395,22 +395,22 @@ namespace Internal.TypeSystem
             // have seperated themselves from the group
 
             // Start with removing methods that seperated themselves from the group via name/sig matches
-            MethodDescHashtable seperatedMethods = null;
+            MethodDescHashtable separatedMethods = null;
 
             foreach (MethodDesc memberMethod in unificationGroup)
             {
                 MethodDesc nameSigMatchMemberMethod = FindMatchingVirtualMethodOnTypeByNameAndSigWithSlotCheck(memberMethod, currentType);
                 if (nameSigMatchMemberMethod != null)
                 {
-                    if (seperatedMethods == null)
-                        seperatedMethods = new MethodDescHashtable();
-                    seperatedMethods.AddOrGetExisting(memberMethod);
+                    if (separatedMethods == null)
+                        separatedMethods = new MethodDescHashtable();
+                    separatedMethods.AddOrGetExisting(memberMethod);
                 }
             }
 
-            if (seperatedMethods != null)
+            if (separatedMethods != null)
             {
-                foreach (MethodDesc seperatedMethod in MethodDescHashtable.Enumerator.Get(seperatedMethods))
+                foreach (MethodDesc seperatedMethod in MethodDescHashtable.Enumerator.Get(separatedMethods))
                 {
                     unificationGroup.RemoveFromGroup(seperatedMethod);
                 }
@@ -425,7 +425,10 @@ namespace Internal.TypeSystem
                 if (unificationGroup.IsInGroup(declSlot) && !unificationGroup.IsInGroupOrIsDefiningSlot(implSlot))
                 {
                     unificationGroup.RemoveFromGroup(declSlot);
-                    seperatedMethods.AddOrGetExisting(declSlot);
+
+                    if (separatedMethods == null)
+                        separatedMethods = new MethodDescHashtable();
+                    separatedMethods.AddOrGetExisting(declSlot);
                     continue;
                 }
                 if (!unificationGroup.IsInGroupOrIsDefiningSlot(declSlot) && unificationGroup.IsInGroupOrIsDefiningSlot(implSlot))
@@ -439,14 +442,14 @@ namespace Internal.TypeSystem
 
                     // Add all members from the decl's unification group except for ones that have been seperated by name/sig matches
                     // or previously processed methodimpls. NOTE: This implies that method impls are order dependent.
-                    if (!seperatedMethods.Contains(addDeclGroup.DefiningMethod))
+                    if (separatedMethods == null || !separatedMethods.Contains(addDeclGroup.DefiningMethod))
                     {
                         unificationGroup.AddToGroup(addDeclGroup.DefiningMethod);
                     }
 
                     foreach (MethodDesc addDeclGroupMemberMethod in addDeclGroup)
                     {
-                        if (!seperatedMethods.Contains(addDeclGroupMemberMethod))
+                        if (separatedMethods == null || !separatedMethods.Contains(addDeclGroupMemberMethod))
                         {
                             unificationGroup.AddToGroup(addDeclGroupMemberMethod);
                         }

--- a/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILTestAssembly.ilproj
+++ b/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILTestAssembly.ilproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 

--- a/src/ILCompiler.TypeSystem/tests/ILTestAssembly/VirtualFunctionOverride.il
+++ b/src/ILCompiler.TypeSystem/tests/ILTestAssembly/VirtualFunctionOverride.il
@@ -13,3 +13,37 @@
     ret
   }
 }
+
+.class private auto ansi beforefieldinit VirtualFunctionOverride.MyBase
+       extends [CoreTestAssembly]System.Object
+{
+  .method public hidebysig newslot specialname virtual 
+          instance int32  get_foo() cil managed
+  {
+    ldc.i4 42
+    ret
+  }
+
+  .property instance int32 foo()
+  {
+    .get instance int32 VirtualFunctionOverride.MyBase::get_foo()
+  }
+}
+
+.class private auto ansi beforefieldinit VirtualFunctionOverride.MyDerived2
+       extends VirtualFunctionOverride.MyBase
+{
+  .method public hidebysig newslot specialname virtual 
+          instance int32  get_foo() cil managed
+  {
+    .override VirtualFunctionOverride.MyBase::get_foo
+    
+    ldc.i4 42
+    ret
+  }
+
+  .property instance int32 foo()
+  {
+    .get instance int32 VirtualFunctionOverride.MyDerived2::get_foo()
+  }
+}

--- a/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
@@ -129,5 +129,20 @@ namespace TypeSystemTests
 
             Assert.Equal(myGetHashCodeMethod, foundOverride);
         }
+
+        [Fact]
+        public void TestFindBaseUnificationGroup()
+        {
+            var algo = new MetadataVirtualMethodAlgorithm();
+            var ilModule = _context.GetModuleForSimpleName("ILTestAssembly");
+            MetadataType myDerived2Type = ilModule.GetType("VirtualFunctionOverride", "MyDerived2");
+            Assert.NotNull(myDerived2Type);
+            MethodDesc method = myDerived2Type.GetMethod("get_foo", null);
+            Assert.NotNull(method);
+
+            MethodDesc virtualMethod = algo.FindVirtualFunctionTargetMethodOnObjectType(method, myDerived2Type);
+            Assert.NotNull(virtualMethod);
+            Assert.Equal(method, virtualMethod);
+        }
     }
 }


### PR DESCRIPTION
Fix NullReferenceException in
MetadataVirtualMethodAlgorithm.FindBaseUnificationGroup where the
separateMethods variable is constructed on demand and later assumed to
have an instance when it's possible it won't.