### PR TITLE
Add --waitfordebugger switch to ILC argument parser

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -92,6 +92,7 @@ namespace ILCompiler
             IReadOnlyList<string> inputFiles = Array.Empty<string>();
             IReadOnlyList<string> referenceFiles = Array.Empty<string>();
 
+            bool waitForDebugger = false;
             AssemblyName name = typeof(Program).GetTypeInfo().Assembly.GetName();
             ArgumentSyntax argSyntax = ArgumentSyntax.Parse(args, syntax =>
             {
@@ -111,6 +112,7 @@ namespace ILCompiler
                 syntax.DefineOption("verbose", ref _options.Verbose, "Enable verbose logging");
                 syntax.DefineOption("systemmodule", ref _systemModuleName, "System module name (default: System.Private.CoreLib)");
                 syntax.DefineOption("multifile", ref _multiFile, "Compile only input files (do not compile referenced assemblies)");
+                syntax.DefineOption("waitfordebugger", ref waitForDebugger, "Pause to give opportunity to attach debugger");
 
                 syntax.DefineOption("singlemethodtypename", ref _singleMethodTypeName, "Single method compilation: name of the owning type");
                 syntax.DefineOption("singlemethodname", ref _singleMethodName, "Single method compilation: name of the method");
@@ -118,6 +120,11 @@ namespace ILCompiler
 
                 syntax.DefineParameterList("in", ref inputFiles, "Input file(s) to compile");
             });
+            if (waitForDebugger)
+            {
+                Console.WriteLine("Waiting for debugger to attach. Press ENTER to continue");
+                Console.ReadLine();
+            }
             foreach (var input in inputFiles)
                 Helpers.AppendExpandedPaths(_inputFilePaths, input, true);
 


### PR DESCRIPTION
Here is the PR with the change discussed in #1531. There are two things I should note here:

1. Instead of adding the code that handles the `--waitfordebugger` switch into `Internal.CommandLine.Helpers` as @jkotas suggested, I placed it into the `ArgumentSyntax` constructor instead. I did this for two reasons: One, because doing it this way would allow me to pass `--waitfordebugger` at any location in the command-line arguments; and two, because this way it will appear in the help output for ILC.
2. I did not display the Process ID [as was done in .NET CLI](https://github.com/dotnet/cli/blob/rel/1.0.0/build_projects/Microsoft.DotNet.Cli.Build.Framework/DebugHelper.cs), because this would require adding a reference to another NuGet package. I do not know if this would be desirable or not. However, for my needs, this doesn't matter, as I can just find the `CoreRun.exe` process in the Attach to Process dialog box by its image name.