### PR TITLE
Rewamp DebugBreak handling

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -56,6 +56,11 @@ namespace Internal.IL
                 return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldarg_0, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
             }
             else
+            if (methodName == "DebugBreak" && owningType.Name == "Debug" && owningType.Namespace == "System.Diagnostics")
+            {
+                return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.break_, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
+            }
+            else
             if ((methodName == "CompareExchange" || methodName == "Exchange") && method.HasInstantiation && owningType.Name == "Interlocked" && owningType.Namespace == "System.Threading")
             {
                 // TODO: Replace with regular implementation once ref locals are available in C# (https://github.com/dotnet/roslyn/issues/118)

--- a/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
@@ -46,6 +46,10 @@ namespace ILCompiler
                     methodDesc = context.GetHelperEntryPoint("ThrowHelpers", "ThrowDivideByZeroException");
                     break;
 
+                case ReadyToRunHelper.DebugBreak:
+                    mangledName = "RhDebugBreak";
+                    break;
+
                 case ReadyToRunHelper.WriteBarrier:
                     mangledName = "RhpAssignRef";
                     break;

--- a/src/ILCompiler.Compiler/src/Compiler/ReadyToRun.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ReadyToRun.cs
@@ -75,6 +75,8 @@ namespace ILCompiler
         ThrowNullRef                = 0x25,
         ThrowDivZero                = 0x26,
 
+        DebugBreak                  = 0x2F,
+
         // Write barriers
         WriteBarrier                = 0x30,
         CheckedWriteBarrier         = 0x31,

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1883,6 +1883,7 @@ namespace Internal.JitInterface
             {
                 case CorInfoHelpFunc.CORINFO_HELP_THROW: id = ReadyToRunHelper.Throw; break;
                 case CorInfoHelpFunc.CORINFO_HELP_RETHROW: id = ReadyToRunHelper.Rethrow; break;
+                case CorInfoHelpFunc.CORINFO_HELP_USER_BREAKPOINT: id = ReadyToRunHelper.DebugBreak; break;
                 case CorInfoHelpFunc.CORINFO_HELP_OVERFLOW: id = ReadyToRunHelper.Overflow; break;
                 case CorInfoHelpFunc.CORINFO_HELP_RNGCHKFAIL: id = ReadyToRunHelper.RngChkFail; break;
                 case CorInfoHelpFunc.CORINFO_HELP_FAIL_FAST: id = ReadyToRunHelper.FailFast; break;

--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -36,6 +36,16 @@ extern "C"
 
 extern "C"
 {
+    uint32_t GetLastError()
+    {
+        return 1;
+    }
+
+    uint32_t WaitForMultipleObjectsEx(uint32_t, void*, uint32_t, uint32_t, uint32_t)
+    {
+        throw "WaitForMultipleObjectsEx";
+    }
+
     void CoCreateGuid()
     {
         throw "CoCreateGuid";

--- a/src/Native/Runtime/MiscHelpers.cpp
+++ b/src/Native/Runtime/MiscHelpers.cpp
@@ -41,6 +41,11 @@
 #include "GCMemoryHelpers.h"
 #include "GCMemoryHelpers.inl"
 
+COOP_PINVOKE_HELPER(void, RhDebugBreak, ())
+{
+    PalDebugBreak();
+}
+
 // Busy spin for the given number of iterations.
 COOP_PINVOKE_HELPER(void, RhSpinWait, (Int32 iterations))
 {

--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -809,8 +809,6 @@ REDHAWK_PALIMPORT UInt32 REDHAWK_PALAPI PalHijack(HANDLE hThread, _In_ PalHijack
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalEventEnabled(REGHANDLE regHandle, _In_ const EVENT_DESCRIPTOR* eventDescriptor);
 #endif
 
-void PalDebugBreak();
-
 REDHAWK_PALIMPORT UInt32 REDHAWK_PALAPI PalGetLogicalCpuCount();
 REDHAWK_PALIMPORT size_t REDHAWK_PALAPI PalGetLargestOnDieCacheSize(UInt32_BOOL bTrueSize);
 

--- a/src/Native/Runtime/amd64/AsmMacros.inc
+++ b/src/Native/Runtime/amd64/AsmMacros.inc
@@ -365,8 +365,6 @@ MANAGED_CALLOUT_THUNK_TRANSITION_FRAME_POINTER_OFFSET equ -8
 ;; CONSTANTS -- SYMBOLS
 ;;
 
-PALDEBUGBREAK                               equ ?PalDebugBreak@@YAXXZ
-
 ifdef FEATURE_GC_STRESS
 REDHAWKGCINTERFACE__STRESSGC                equ ?StressGc@RedhawkGCInterface@@SAXXZ
 THREAD__HIJACKFORGCSTRESS                   equ ?HijackForGcStress@Thread@@SAXPEAUPAL_LIMITED_CONTEXT@@@Z
@@ -378,7 +376,7 @@ endif ;; FEATURE_GC_STRESS
 
 EXTERN RhpGcAlloc                               : PROC
 EXTERN RhpValidateExInfoPop                     : PROC
-EXTERN PALDEBUGBREAK                            : PROC
+EXTERN RhDebugBreak                             : PROC
 EXTERN RhpWaitForSuspend2                       : PROC
 EXTERN RhpWaitForGC2                            : PROC
 EXTERN RhpReversePInvokeAttachOrTrapThread2     : PROC

--- a/src/Native/Runtime/amd64/GcProbe.asm
+++ b/src/Native/Runtime/amd64/GcProbe.asm
@@ -486,7 +486,7 @@ ifdef _DEBUG
         cmp         [RhpTrapThreads], 0
         jne         @F
 
-        call        PALDEBUGBREAK
+        call        RhDebugBreak
 @@:
 endif ;; _DEBUG
 

--- a/src/Native/Runtime/arm/AsmMacros.h
+++ b/src/Native/Runtime/arm/AsmMacros.h
@@ -221,7 +221,6 @@ $Name
 ;; CONSTANTS -- SYMBOLS
 ;;
 
-        SETALIAS PALDEBUGBREAK, ?PalDebugBreak@@YAXXZ
         SETALIAS G_LOWEST_ADDRESS, g_lowest_address
         SETALIAS G_HIGHEST_ADDRESS, g_highest_address
         SETALIAS G_EPHEMERAL_LOW, g_ephemeral_low
@@ -236,7 +235,7 @@ $Name
 ;; IMPORTS
 ;;
         EXTERN RhpGcAlloc
-        EXTERN $PALDEBUGBREAK
+        EXTERN RhDebugBreak
         EXTERN RhpWaitForSuspend2
         EXTERN RhpWaitForGC2
         EXTERN RhpReversePInvokeAttachOrTrapThread2

--- a/src/Native/Runtime/arm/GcProbe.asm
+++ b/src/Native/Runtime/arm/GcProbe.asm
@@ -553,7 +553,7 @@ DREG_SZ equ     (SIZEOF__PAL_LIMITED_CONTEXT - (OFFSETOF__PAL_LIMITED_CONTEXT__L
         ldr         r1, [r1]
         cbnz        r1, %0
 
-        bl          $PALDEBUGBREAK
+        bl          RhDebugBreak
 0
 #endif ;; _DEBUG
 

--- a/src/Native/Runtime/i386/AsmMacros.inc
+++ b/src/Native/Runtime/i386/AsmMacros.inc
@@ -154,7 +154,7 @@ OFFSETOF__Thread__m_alloc_context__alloc_limit      equ OFFSETOF__Thread__m_rgbA
 ;; CONSTANTS -- SYMBOLS
 ;;
 
-PALDEBUGBREAK                               equ ?PalDebugBreak@@YGXXZ
+RhDebugBreak                                equ @RhDebugBreak@0
 RhpGcAlloc                                  equ @RhpGcAlloc@16
 G_LOWEST_ADDRESS                            equ _g_lowest_address
 G_HIGHEST_ADDRESS                           equ _g_highest_address
@@ -176,7 +176,7 @@ endif ;; FEATURE_GC_STRESS
 ;; IMPORTS
 ;;
 EXTERN RhpGcAlloc                               : PROC
-EXTERN PALDEBUGBREAK                            : PROC
+EXTERN RhDebugBreak                             : PROC
 EXTERN RhpWaitForSuspend2                       : PROC
 EXTERN RhpWaitForGC2                            : PROC
 EXTERN RhpReversePInvokeAttachOrTrapThread2     : PROC

--- a/src/Native/Runtime/i386/GcProbe.asm
+++ b/src/Native/Runtime/i386/GcProbe.asm
@@ -112,7 +112,7 @@ ifdef _DEBUG
         and         eax, DEFAULT_PROBE_SAVE_FLAGS
         cmp         eax, DEFAULT_PROBE_SAVE_FLAGS ; make sure we have at least the flags to match what the macro pushes
         je          @F
-        call        PALDEBUGBREAK
+        call        RhDebugBreak
 @@:
 endif ;; _DEBUG
         push        edx                     ; Thread *
@@ -504,7 +504,7 @@ ifdef _DEBUG
         cmp         [RhpTrapThreads], 0
         jne         @F
 
-        call        PALDEBUGBREAK
+        call        RhDebugBreak
 @@:
 endif ;; _DEBUG
 

--- a/src/Native/Runtime/unix/PalRedhawkInline.h
+++ b/src/Native/Runtime/unix/PalRedhawkInline.h
@@ -87,3 +87,5 @@ FORCEINLINE void PalMemoryBarrier()
 {
     __sync_synchronize();
 }
+
+#define PalDebugBreak() __debugbreak()

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -1254,11 +1254,6 @@ REDHAWK_PALEXPORT Int32 PalGetModuleFileName(_Out_ const TCHAR** pModuleNameOut,
     return strlen(dl.dli_fname);
 }
 
-void PalDebugBreak()
-{
-    __debugbreak();
-}
-
 GCSystemInfo g_SystemInfo;
 
 // Initialize the g_SystemInfo
@@ -1383,36 +1378,6 @@ extern "C" UInt64 PalGetCurrentThreadIdForLogging()
 #endif
 }
 
-extern "C" UInt32_BOOL WriteFile(
-    HANDLE hFile,
-    const void* lpBuffer,
-    uint32_t nNumberOfBytesToWrite,
-    uint32_t * lpNumberOfBytesWritten,
-    void* lpOverlapped)
-{
-    // TODO: Reimplement callers using CRT
-    return UInt32_FALSE;
-}
-
-extern "C" void YieldProcessor()
-{
-}
-
-extern "C" void DebugBreak()
-{
-    PalDebugBreak();
-}
-
-extern "C" uint32_t GetLastError()
-{
-    return 1;
-}
-
-extern "C" UInt32 WaitForMultipleObjectsEx(UInt32, HANDLE *, UInt32_BOOL, UInt32, UInt32_BOOL)
-{
-    PORTABILITY_ASSERT("UNIXTODO: Implement this function");
-}
-
 // Initialize the interface implementation
 bool GCToOSInterface::Initialize()
 {
@@ -1492,8 +1457,7 @@ void GCToOSInterface::Sleep(uint32_t sleepMSec)
 //  switchCount - number of times the YieldThread was called in a loop
 void GCToOSInterface::YieldThread(uint32_t switchCount)
 {
-    // UNIXTODO: handle the switchCount
-    YieldProcessor();
+    PalSwitchToThread();
 }
 
 // Reserve virtual memory range.
@@ -1765,7 +1729,6 @@ int64_t GCToOSInterface::QueryPerformanceCounter()
     LARGE_INTEGER ts;
     if (!::QueryPerformanceCounter(&ts))
     {
-        DebugBreak();
         ASSERT_UNCONDITIONALLY("Fatal Error - cannot query performance counter.");
         abort();
     }
@@ -1781,7 +1744,6 @@ int64_t GCToOSInterface::QueryPerformanceFrequency()
     LARGE_INTEGER frequency;
     if (!::QueryPerformanceFrequency(&frequency))
     {
-        DebugBreak();
         ASSERT_UNCONDITIONALLY("Fatal Error - cannot query performance counter.");
         abort();
     }

--- a/src/Native/Runtime/windows/PalRedhawkInline.h
+++ b/src/Native/Runtime/windows/PalRedhawkInline.h
@@ -165,3 +165,5 @@ FORCEINLINE void PalYieldProcessor()
 #else
 #error Unsupported architecture
 #endif
+
+#define PalDebugBreak() __debugbreak()

--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -1284,11 +1284,6 @@ bool PalQueryProcessorTopology()
     return !fError;
 }
 
-void PalDebugBreak()
-{
-    __debugbreak();
-}
-
 #ifdef RUNTIME_SERVICES_ONLY
 // Functions called by the GC to obtain our cached values for number of logical processors and cache size.
 REDHAWK_PALEXPORT UInt32 REDHAWK_PALAPI PalGetLogicalCpuCount()

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Debug.NETNative.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Debug.NETNative.cs
@@ -65,6 +65,9 @@ namespace System.Diagnostics
         }
 
         [DebuggerHidden]
+#if CORERT
+        [Intrinsic]
+#endif
         internal static void DebugBreak()
         {
             // IMPORTANT: This call will let us detect if  debug break is broken, and also


### PR DESCRIPTION
- Expand Debug.DebugBreak as IL intrinsic
- Implement RhDebugBreak JIT helper for IL break instruction
- Switch assembly code to use RhDebugBreak to avoid C++ name mangling goo
- Change PalDebugBreak to be inline to avoid extra frames under debugger
- Cleanup some left-over cruft in Unix PAL