### PR TITLE
Add flexible name formatting and use it to format ILAsm-style

### DIFF
--- a/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Provides services to convert types to strings.
+    /// </summary>
+    public abstract class TypeNameFormatter
+    {
+        public string FormatName(TypeDesc type)
+        {
+            if (type.GetType() == typeof(SignatureTypeVariable))
+                return FormatName((SignatureTypeVariable)type);
+
+            if (type.GetType() == typeof(SignatureMethodVariable))
+                return FormatName((SignatureMethodVariable)type);
+
+            switch (type.Category)
+            {
+                case TypeFlags.Array:
+                case TypeFlags.SzArray:
+                    return FormatName((ArrayType)type);
+
+                case TypeFlags.ByRef:
+                    return FormatName((ByRefType)type);
+
+                case TypeFlags.Pointer:
+                    return FormatName((PointerType)type);
+
+                case TypeFlags.GenericParameter:
+                    return FormatName((GenericParameterDesc)type);
+
+                default:
+                    if (type.GetType() == typeof(InstantiatedType))
+                        return FormatName((InstantiatedType)type);
+                    else if (type is MetadataType)
+                        return FormatName((MetadataType)type);
+                    else
+                    {
+                        Debug.Assert(type is NoMetadata.NoMetadataType);
+                        return FormatName((NoMetadata.NoMetadataType)type);
+                    }
+            }
+        }
+
+        public string FormatName(MetadataType type)
+        {
+            MetadataType containingType = type.ContainingType;
+            if (containingType != null)
+                return FormatNameForNestedType(containingType, type);
+            return FormatNameForNamespaceType(type);
+        }
+
+        public virtual string FormatName(NoMetadata.NoMetadataType type)
+        {
+            // Name formatters that can deal with NoMetadata types need to override.
+            throw new NotSupportedException();
+        }
+
+        public abstract string FormatName(ArrayType type);
+        public abstract string FormatName(ByRefType type);
+        public abstract string FormatName(PointerType type);
+        public abstract string FormatName(InstantiatedType type);
+        public abstract string FormatName(GenericParameterDesc type);
+        public abstract string FormatName(SignatureMethodVariable type);
+        public abstract string FormatName(SignatureTypeVariable type);
+
+        protected abstract string FormatNameForNestedType(MetadataType containingType, MetadataType nestedType);
+        protected abstract string FormatNameForNamespaceType(MetadataType type);
+    }
+}

--- a/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Text;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -13,65 +14,147 @@ namespace Internal.TypeSystem
     /// </summary>
     public abstract class TypeNameFormatter
     {
-        public string FormatName(TypeDesc type)
+        public void AppendName(StringBuilder sb, TypeDesc type)
         {
             if (type.GetType() == typeof(SignatureTypeVariable))
-                return FormatName((SignatureTypeVariable)type);
+            {
+                AppendName(sb, (SignatureTypeVariable)type);
+                return;
+            }
 
             if (type.GetType() == typeof(SignatureMethodVariable))
-                return FormatName((SignatureMethodVariable)type);
+            {
+                AppendName(sb, (SignatureMethodVariable)type);
+                return;
+            }
 
             switch (type.Category)
             {
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
-                    return FormatName((ArrayType)type);
-
+                    AppendName(sb, (ArrayType)type);
+                    return;
                 case TypeFlags.ByRef:
-                    return FormatName((ByRefType)type);
-
+                    AppendName(sb, (ByRefType)type);
+                    return;
                 case TypeFlags.Pointer:
-                    return FormatName((PointerType)type);
-
+                    AppendName(sb, (PointerType)type);
+                    return;
                 case TypeFlags.GenericParameter:
-                    return FormatName((GenericParameterDesc)type);
-
+                    AppendName(sb, (GenericParameterDesc)type);
+                    return;
                 default:
                     if (type.GetType() == typeof(InstantiatedType))
-                        return FormatName((InstantiatedType)type);
+                        AppendName(sb, (InstantiatedType)type);
                     else if (type is MetadataType)
-                        return FormatName((MetadataType)type);
+                        AppendName(sb, (MetadataType)type);
                     else
                     {
                         Debug.Assert(type is NoMetadata.NoMetadataType);
-                        return FormatName((NoMetadata.NoMetadataType)type);
+                        AppendName(sb, (NoMetadata.NoMetadataType)type);
                     }
+                    return;
             }
         }
 
-        public string FormatName(MetadataType type)
+        public void AppendName(StringBuilder sb, MetadataType type)
         {
             MetadataType containingType = type.ContainingType;
             if (containingType != null)
-                return FormatNameForNestedType(containingType, type);
-            return FormatNameForNamespaceType(type);
+                AppendNameForNestedType(sb, type, containingType);
+            else
+                AppendNameForNamespaceType(sb, type);
         }
 
-        public virtual string FormatName(NoMetadata.NoMetadataType type)
+        public virtual void AppendName(StringBuilder sb, NoMetadata.NoMetadataType type)
         {
             // Name formatters that can deal with NoMetadata types need to override.
             throw new NotSupportedException();
         }
 
-        public abstract string FormatName(ArrayType type);
-        public abstract string FormatName(ByRefType type);
-        public abstract string FormatName(PointerType type);
-        public abstract string FormatName(InstantiatedType type);
-        public abstract string FormatName(GenericParameterDesc type);
-        public abstract string FormatName(SignatureMethodVariable type);
-        public abstract string FormatName(SignatureTypeVariable type);
+        public abstract void AppendName(StringBuilder sb, ArrayType type);
+        public abstract void AppendName(StringBuilder sb, ByRefType type);
+        public abstract void AppendName(StringBuilder sb, PointerType type);
+        public abstract void AppendName(StringBuilder sb, InstantiatedType type);
+        public abstract void AppendName(StringBuilder sb, GenericParameterDesc type);
+        public abstract void AppendName(StringBuilder sb, SignatureMethodVariable type);
+        public abstract void AppendName(StringBuilder sb, SignatureTypeVariable type);
 
-        protected abstract string FormatNameForNestedType(MetadataType containingType, MetadataType nestedType);
-        protected abstract string FormatNameForNamespaceType(MetadataType type);
+        protected abstract void AppendNameForNestedType(StringBuilder sb, MetadataType nestedType, MetadataType containingType);
+        protected abstract void AppendNameForNamespaceType(StringBuilder sb, MetadataType type);
+
+        #region Convenience methods
+
+        public string FormatName(TypeDesc type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(MetadataType type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(NoMetadata.NoMetadataType type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(ArrayType type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(ByRefType type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(PointerType type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(InstantiatedType type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(GenericParameterDesc type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(SignatureMethodVariable type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        public string FormatName(SignatureTypeVariable type)
+        {
+            StringBuilder sb = new StringBuilder();
+            AppendName(sb, type);
+            return sb.ToString();
+        }
+
+        #endregion
     }
 }

--- a/src/Common/src/TypeSystem/IL/ILDisassember.cs
+++ b/src/Common/src/TypeSystem/IL/ILDisassember.cs
@@ -3,51 +3,216 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Text;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace Internal.IL
 {
-    public static class ILDisassember
+    public struct ILDisassember
     {
-        private static byte ReadILByte(byte[] _ilBytes, ref int _currentOffset)
+        private byte[] _ilBytes;
+        private MethodIL _methodIL;
+        private ILTypeNameFormatter _typeNameFormatter;
+        private int _currentOffset;
+
+        public ILDisassember(MethodIL methodIL)
+        {
+            _methodIL = methodIL;
+            _ilBytes = methodIL.GetILBytes();
+            _currentOffset = 0;
+            _typeNameFormatter = null;
+        }
+
+        #region Type/member/signature name formatting
+        private ILTypeNameFormatter TypeNameFormatter
+        {
+            get
+            {
+                if (_typeNameFormatter == null)
+                {
+                    // Find the owning module so that the type name formatter can remove
+                    // redundant assembly name qualifiers in type names.
+                    TypeDesc owningTypeDefinition = _methodIL.OwningMethod.OwningType;
+                    ModuleDesc owningModule = owningTypeDefinition is MetadataType ?
+                        ((MetadataType)owningTypeDefinition).Module : null;
+
+                    _typeNameFormatter = new ILTypeNameFormatter(owningModule);
+                }
+                return _typeNameFormatter;
+            }
+        }
+
+        public string FormatType(TypeDesc type)
+        {
+            // Types referenced from the IL show as instantiated over generic parameter.
+            // E.g. "initobj !0" becomes "initobj !T"
+            TypeDesc typeInContext = type.InstantiateSignature(
+                _methodIL.OwningMethod.OwningType.Instantiation, _methodIL.OwningMethod.Instantiation);
+            if (typeInContext.HasInstantiation)
+                return this.TypeNameFormatter.FormatNameWithValueClassPrefix(typeInContext);
+            return this.TypeNameFormatter.FormatName(typeInContext);
+        }
+
+        private string FormatOwningType(TypeDesc type)
+        {
+            // Special case primitive types: we don't want to use short names here
+            if (type.IsPrimitive || type.IsString || type.IsObject)
+            {
+                MetadataType mdType = (MetadataType)type;
+                return String.Concat(mdType.Namespace, ".", mdType.Name);
+            }
+            return FormatType(type);
+        }
+
+        private string FormatMethodSignature(MethodDesc method)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            MethodSignature signature = method.Signature;
+
+            FormatSignaturePrefix(signature, sb);
+            sb.Append(' ');
+            sb.Append(FormatOwningType(method.OwningType));
+            sb.Append("::");
+            sb.Append(method.Name);
+            sb.Append('(');
+            FormatSignatureArgumentList(signature, sb);
+            sb.Append(')');
+
+            return sb.ToString();
+        }
+
+        private string FormatMethodSignature(MethodSignature signature)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            FormatSignaturePrefix(signature, sb);
+            sb.Append('(');
+            FormatSignatureArgumentList(signature, sb);
+            sb.Append(')');
+
+            return sb.ToString();
+        }
+
+        private void FormatSignaturePrefix(MethodSignature signature, StringBuilder sb)
+        {
+            if (!signature.IsStatic)
+                sb.Append("instance ");
+
+            sb.Append(this.TypeNameFormatter.FormatNameWithValueClassPrefix(signature.ReturnType));
+        }
+
+        private void FormatSignatureArgumentList(MethodSignature signature, StringBuilder sb)
+        {
+            for (int i = 0; i < signature.Length; i++)
+            {
+                if (i != 0)
+                    sb.Append(", ");
+
+                sb.Append(this.TypeNameFormatter.FormatNameWithValueClassPrefix(signature[i]));
+            }
+        }
+
+        private string FormatFieldSignature(FieldDesc field)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append(this.TypeNameFormatter.FormatNameWithValueClassPrefix(field.FieldType));
+            sb.Append(' ');
+            sb.Append(FormatOwningType(field.OwningType));
+            sb.Append("::");
+            sb.Append(field.Name);
+
+            return sb.ToString();
+        }
+
+        private string FormatStringLiteral(string s)
+        {
+            StringBuilder sb = new StringBuilder(s.Length + 2);
+
+            sb.Append('"');
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                if (s[i] == '\\')
+                    sb.Append("\\\\");
+                else if (s[i] == '\t')
+                    sb.Append("\\t");
+                else if (s[i] == '"')
+                    sb.Append("\\\"");
+                else if (s[i] == '\n')
+                    sb.Append("\\n");
+                else
+                    sb.Append(s[i]);
+            }
+            sb.Append('"');
+
+            return sb.ToString();
+        }
+
+        private string FormatToken(int token)
+        {
+            object obj = _methodIL.GetObject(token);
+            if (obj is MethodDesc)
+                return FormatMethodSignature((MethodDesc)obj);
+            else if (obj is FieldDesc)
+                return FormatFieldSignature((FieldDesc)obj);
+            else if (obj is MethodSignature)
+                return FormatMethodSignature((MethodSignature)obj);
+            else if (obj is TypeDesc)
+                return FormatType((TypeDesc)obj);
+            else
+            {
+                Debug.Assert(obj is string, "NYI: " + obj.GetType());
+                return FormatStringLiteral((string)obj);
+            }
+        }
+        #endregion
+
+        #region Instruction decoding
+        private byte ReadILByte()
         {
             return _ilBytes[_currentOffset++];
         }
 
-        private static UInt16 ReadILUInt16(byte[] _ilBytes, ref int _currentOffset)
+        private UInt16 ReadILUInt16()
         {
             UInt16 val = (UInt16)(_ilBytes[_currentOffset] + (_ilBytes[_currentOffset + 1] << 8));
             _currentOffset += 2;
             return val;
         }
 
-        private static UInt32 ReadILUInt32(byte[] _ilBytes, ref int _currentOffset)
+        private UInt32 ReadILUInt32()
         {
             UInt32 val = (UInt32)(_ilBytes[_currentOffset] + (_ilBytes[_currentOffset + 1] << 8) + (_ilBytes[_currentOffset + 2] << 16) + (_ilBytes[_currentOffset + 3] << 24));
             _currentOffset += 4;
             return val;
         }
 
-        private static int ReadILToken(byte[] _ilBytes, ref int _currentOffset)
+        private int ReadILToken()
         {
-            return (int)ReadILUInt32(_ilBytes, ref _currentOffset);
+            return (int)ReadILUInt32();
         }
 
-        private static ulong ReadILUInt64(byte[] _ilBytes, ref int _currentOffset)
+        private ulong ReadILUInt64()
         {
-            ulong value = ReadILUInt32(_ilBytes, ref _currentOffset);
-            value |= (((ulong)ReadILUInt32(_ilBytes, ref _currentOffset)) << 32);
+            ulong value = ReadILUInt32();
+            value |= (((ulong)ReadILUInt32()) << 32);
             return value;
         }
 
-        private static unsafe float ReadILFloat(byte[] _ilBytes, ref int _currentOffset)
+        private unsafe float ReadILFloat()
         {
-            uint value = ReadILUInt32(_ilBytes, ref _currentOffset);
+            uint value = ReadILUInt32();
             return *(float*)(&value);
         }
 
-        private static unsafe double ReadILDouble(byte[] _ilBytes, ref int _currentOffset)
+        private unsafe double ReadILDouble()
         {
-            ulong value = ReadILUInt64(_ilBytes, ref _currentOffset);
+            ulong value = ReadILUInt64();
             return *(double*)(&value);
         }
 
@@ -56,20 +221,35 @@ namespace Internal.IL
             return "IL_" + offset.ToString("X4");
         }
 
-        public static string Disassemble(Func<int, string> tokenResolver, byte[] instructionStream, ref int offset)
+        public bool HasNextInstruction
         {
-            string opCodeName = "";
+            get
+            {
+                return _currentOffset < _ilBytes.Length;
+            }
+        }
+
+        public int CodeSize
+        {
+            get
+            {
+                return _ilBytes.Length;
+            }
+        }
+
+        public string GetNextInstruction()
+        {
+            string opCodeName = FormatOffset(_currentOffset) + ": ";
 
         again:
 
-            ILOpcode opCode = (ILOpcode)ReadILByte(instructionStream, ref offset);
+            ILOpcode opCode = (ILOpcode)ReadILByte();
             if (opCode == ILOpcode.prefix1)
             {
-                opCode = (ILOpcode)(0x100 + ReadILByte(instructionStream, ref offset));
+                opCode = (ILOpcode)(0x100 + ReadILByte());
             }
 
-            opCodeName += opCode.ToString();
-            opCodeName = opCodeName.Replace("_", ".");
+            opCodeName += opCode.ToString().Replace("_", ".");
 
             switch (opCode)
             {
@@ -80,10 +260,10 @@ namespace Internal.IL
                 case ILOpcode.ldloca_s:
                 case ILOpcode.stloc_s:
                 case ILOpcode.ldc_i4_s:
-                    return opCodeName + " " + ReadILByte(instructionStream, ref offset);
+                    return opCodeName + " " + ReadILByte();
 
                 case ILOpcode.unaligned:
-                    opCodeName += " " + ReadILByte(instructionStream, ref offset) + " ";
+                    opCodeName += " " + ReadILByte() + " ";
                     goto again;
 
                 case ILOpcode.ldarg:
@@ -92,19 +272,19 @@ namespace Internal.IL
                 case ILOpcode.ldloc:
                 case ILOpcode.ldloca:
                 case ILOpcode.stloc:
-                    return opCodeName + " " + ReadILUInt16(instructionStream, ref offset);
+                    return opCodeName + " " + ReadILUInt16();
 
                 case ILOpcode.ldc_i4:
-                    return opCodeName + " " + ReadILUInt32(instructionStream, ref offset);
+                    return opCodeName + " " + ReadILUInt32();
 
                 case ILOpcode.ldc_r4:
-                    return opCodeName + " " + ReadILFloat(instructionStream, ref offset);
+                    return opCodeName + " " + ReadILFloat();
 
                 case ILOpcode.ldc_i8:
-                    return opCodeName + " " + ReadILUInt64(instructionStream, ref offset);
+                    return opCodeName + " " + ReadILUInt64();
 
                 case ILOpcode.ldc_r8:
-                    return opCodeName + " " + ReadILDouble(instructionStream, ref offset);
+                    return opCodeName + " " + ReadILDouble();
 
                 case ILOpcode.jmp:
                 case ILOpcode.call:
@@ -138,7 +318,7 @@ namespace Internal.IL
                 case ILOpcode.initobj:
                 case ILOpcode.constrained:
                 case ILOpcode.sizeof_:
-                    return opCodeName + " " + tokenResolver(ReadILToken(instructionStream, ref offset));
+                    return opCodeName + " " + FormatToken(ReadILToken());
 
                 case ILOpcode.br_s:
                 case ILOpcode.leave_s:
@@ -154,7 +334,7 @@ namespace Internal.IL
                 case ILOpcode.bgt_un_s:
                 case ILOpcode.ble_un_s:
                 case ILOpcode.blt_un_s:
-                    return opCodeName + " " + FormatOffset((sbyte)ReadILByte(instructionStream, ref offset) + offset);
+                    return opCodeName + " " + FormatOffset((sbyte)ReadILByte() + _currentOffset);
 
                 case ILOpcode.br:
                 case ILOpcode.leave:
@@ -170,18 +350,18 @@ namespace Internal.IL
                 case ILOpcode.bgt_un:
                 case ILOpcode.ble_un:
                 case ILOpcode.blt_un:
-                    return opCodeName + " " + FormatOffset((int)ReadILUInt32(instructionStream, ref offset) + offset);
+                    return opCodeName + " " + FormatOffset((int)ReadILUInt32() + _currentOffset);
 
                 case ILOpcode.switch_:
                     {
                         opCodeName = "switch (";
-                        uint count = ReadILUInt32(instructionStream, ref offset);
-                        int jmpBase = offset + (int)(4 * count);
+                        uint count = ReadILUInt32();
+                        int jmpBase = _currentOffset + (int)(4 * count);
                         for (uint i = 0; i < count; i++)
                         {
                             if (i != 0)
                                 opCodeName += ", ";
-                            int delta = (int)ReadILUInt32(instructionStream, ref offset);
+                            int delta = (int)ReadILUInt32();
                             opCodeName += FormatOffset(jmpBase + delta);
                         }
                         opCodeName += ")";
@@ -192,5 +372,129 @@ namespace Internal.IL
                     return opCodeName;
             }
         }
+        #endregion
+
+        #region Helpers
+        private class ILTypeNameFormatter : TypeNameFormatter
+        {
+            private ModuleDesc _thisModule;
+
+            public ILTypeNameFormatter(ModuleDesc thisModule)
+            {
+                _thisModule = thisModule;
+            }
+
+            public string FormatNameWithValueClassPrefix(TypeDesc type)
+            {
+                if (!type.IsSignatureVariable
+                    && type.IsDefType
+                    && !type.IsPrimitive
+                    && !type.IsObject
+                    && !type.IsString)
+                {
+                    string prefix = type.IsValueType ? "valuetype " : "class ";
+                    return String.Concat(prefix, FormatName(type));
+                }
+
+                return FormatName(type);
+            }
+
+            public override string FormatName(PointerType type)
+                => String.Concat(FormatNameWithValueClassPrefix(type.ParameterType), "*");
+
+            public override string FormatName(SignatureMethodVariable type)
+                => String.Concat("!!", type.Index.ToStringInvariant());
+
+            public override string FormatName(SignatureTypeVariable type)
+                => String.Concat("!", type.Index.ToStringInvariant());
+
+            public override string FormatName(GenericParameterDesc type)
+            {
+                if (type.Kind == GenericParameterKind.Type)
+                    return "!" + type.ToString(); // TODO: should we require a Name property for this?
+                return "!!" + type.ToString();
+            }
+
+            public override string FormatName(InstantiatedType type)
+            {
+                StringBuilder sb = new StringBuilder();
+
+                sb.Append(FormatName(type.GetTypeDefinition()));
+                sb.Append('<');
+
+                foreach (var arg in type.Instantiation)
+                    sb.Append(FormatNameWithValueClassPrefix(arg));
+
+                sb.Append('>');
+
+                return sb.ToString();
+            }
+
+            public override string FormatName(ByRefType type)
+                => String.Concat(FormatNameWithValueClassPrefix(type.ParameterType), "&");
+
+            public override string FormatName(ArrayType type)
+                => String.Concat(FormatNameWithValueClassPrefix(type.ElementType), "[", new String(',', type.Rank - 1), "]");
+
+            protected override string FormatNameForNamespaceType(MetadataType type)
+            {
+                switch (type.Category)
+                {
+                    case TypeFlags.Void:
+                        return "void";
+                    case TypeFlags.Boolean:
+                        return "bool";
+                    case TypeFlags.Char:
+                        return "char";
+                    case TypeFlags.SByte:
+                        return "int8";
+                    case TypeFlags.Byte:
+                        return "uint8";
+                    case TypeFlags.Int16:
+                        return "int16";
+                    case TypeFlags.UInt16:
+                        return "uint16";
+                    case TypeFlags.Int32:
+                        return "int32";
+                    case TypeFlags.UInt32:
+                        return "uint32";
+                    case TypeFlags.Int64:
+                        return "int64";
+                    case TypeFlags.UInt64:
+                        return "uint64";
+                    case TypeFlags.IntPtr:
+                        return "native int";
+                    case TypeFlags.UIntPtr:
+                        return "native uint";
+                    case TypeFlags.Single:
+                        return "float32";
+                    case TypeFlags.Double:
+                        return "float64";
+                }
+
+                if (type.IsString)
+                    return "string";
+                if (type.IsObject)
+                    return "object";
+
+                string ns = type.Namespace;
+
+                ModuleDesc owningModule = type.Module;
+                if (owningModule != _thisModule)
+                {
+                    Debug.Assert(owningModule is IAssemblyDesc);
+                    string owningModuleName = ((IAssemblyDesc)owningModule).GetName().Name;
+                    return ns.Length > 0 ?
+                        String.Concat("[", owningModuleName, "]", ns, ".", type.Name) :
+                        String.Concat("[", owningModuleName, "]", type.Name);
+                }
+
+                return ns.Length > 0 ? String.Concat(ns, ".", type.Name) : type.Name;
+            }
+
+            protected override string FormatNameForNestedType(MetadataType containingType, MetadataType nestedType)
+                => String.Concat(FormatName(containingType), "/", nestedType.Name);
+        }
+        #endregion
     }
 }

--- a/src/Common/src/TypeSystem/IL/ILDisassember.cs
+++ b/src/Common/src/TypeSystem/IL/ILDisassember.cs
@@ -75,6 +75,21 @@ namespace Internal.IL
             AppendOwningType(sb, method.OwningType);
             sb.Append("::");
             sb.Append(method.Name);
+
+            if (method.HasInstantiation)
+            {
+                sb.Append('<');
+
+                for (int i = 0; i < method.Instantiation.Length; i++)
+                {
+                    if (i != 0)
+                        sb.Append(", ");
+                    _typeNameFormatter.AppendNameWithValueClassPrefix(sb, method.Instantiation[i]);
+                }
+
+                sb.Append('>');
+            }
+
             sb.Append('(');
             AppendSignatureArgumentList(sb, signature);
             sb.Append(')');

--- a/src/Common/src/TypeSystem/IL/MethodILDebugView.cs
+++ b/src/Common/src/TypeSystem/IL/MethodILDebugView.cs
@@ -50,7 +50,7 @@ namespace Internal.IL
                             sb.AppendLine(",");
                             sb.Append(' ', 4);
                         }
-                        sb.Append(disasm.FormatType(locals[i].Type));
+                        disasm.AppendType(sb, locals[i].Type);
                         sb.Append(" ");
                         if (locals[i].IsPinned)
                             sb.Append("pinned ");

--- a/src/Common/src/TypeSystem/IL/MethodILDebugView.cs
+++ b/src/Common/src/TypeSystem/IL/MethodILDebugView.cs
@@ -6,6 +6,8 @@ using Internal.TypeSystem;
 using System;
 using System.Text;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace Internal.IL
 {
     internal sealed class MethodILDebugView
@@ -21,12 +23,12 @@ namespace Internal.IL
         {
             get
             {
-                byte[] ilBytes = _methodIL.GetILBytes() ?? Array.Empty<byte>();
+                ILDisassember disasm = new ILDisassember(_methodIL);
 
                 StringBuilder sb = new StringBuilder();
 
                 sb.Append("// Code size: ");
-                sb.Append(ilBytes.Length);
+                sb.Append(disasm.CodeSize);
                 sb.AppendLine();
                 sb.Append(".maxstack ");
                 sb.Append(_methodIL.MaxStack);
@@ -48,7 +50,7 @@ namespace Internal.IL
                             sb.AppendLine(",");
                             sb.Append(' ', 4);
                         }
-                        sb.Append(locals[i].Type.ToString());
+                        sb.Append(disasm.FormatType(locals[i].Type));
                         sb.Append(" ");
                         if (locals[i].IsPinned)
                             sb.Append("pinned ");
@@ -59,15 +61,9 @@ namespace Internal.IL
                 }
                 sb.AppendLine();
 
-                int offset = 0;
-
-                Func<int, string> resolver = token => _methodIL.GetObject(token).ToString();
-
-                while (offset < ilBytes.Length)
+                while (disasm.HasNextInstruction)
                 {
-                    sb.Append(ILDisassember.FormatOffset(offset));
-                    sb.Append(": ");
-                    sb.AppendLine(ILDisassember.Disassemble(resolver, ilBytes, ref offset));
+                    sb.AppendLine(disasm.GetNextInstruction());
                 }
 
                 return sb.ToString();

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -194,6 +194,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemHelpers.cs">
       <Link>TypeSystem\Common\TypeSystemHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\TypeNameFormatter.cs">
+      <Link>Utilities\TypeNameFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\VirtualMethodEnumerationAlgorithm.cs">
       <Link>TypeSystem\Common\VirtualMethodEnumerationAlgorithm.cs</Link>
     </Compile>

--- a/src/ILCompiler.TypeSystem/tests/ILDisassemblerTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/ILDisassemblerTests.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.IL;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using Xunit;
+
+namespace TypeSystemTests
+{
+    public class ILDisassemblerTests
+    {
+        private TestTypeSystemContext _context;
+        private ModuleDesc _testModule;
+
+        public ILDisassemblerTests()
+        {
+            _context = new TestTypeSystemContext(TargetArchitecture.X64);
+            var systemModule = _context.CreateModuleForSimpleName("CoreTestAssembly");
+            _context.SetSystemModule(systemModule);
+
+            _testModule = _context.GetModuleForSimpleName("ILTestAssembly");
+        }
+
+        [Fact]
+        public void TestGenericNameFormatting()
+        {
+            MetadataType testClass = _testModule.GetType("ILDisassembler", "TestGenericClass`1");
+            EcmaMethod testMethod = (EcmaMethod)testClass.GetMethod("TestMethod", null);
+            EcmaMethodIL methodIL = EcmaMethodIL.Create(testMethod);
+
+            Dictionary<int, string> interestingLines = new Dictionary<int, string>
+            {
+                { 4, "IL_0003:  ldstr       \"Hello \\\"World\\\"!\\n\"" },
+                { 9, "IL_000D:  call        instance void class ILDisassembler.TestGenericClass`1<!TClassParam>::VoidGenericMethod<string, valuetype ILDisassembler.TestStruct>(!!0, int32, native int, class ILDisassembler.TestClass&)" },
+                { 14, "IL_0017:  initobj     !TClassParam" },
+                { 16, "IL_001E:  call        !!0 class ILDisassembler.TestGenericClass`1<!TClassParam>::MethodParamGenericMethod<class ILDisassembler.TestClass>(class ILDisassembler.TestGenericClass`1<!!0>, class ILDisassembler.TestGenericClass`1/Nested<!0>, valuetype ILDisassembler.TestStruct*[], !0)" },
+                { 24, "IL_0030:  call        !!0 class ILDisassembler.TestGenericClass`1<!TClassParam>::MethodParamGenericMethod<!0>(class ILDisassembler.TestGenericClass`1<!!0>, class ILDisassembler.TestGenericClass`1/Nested<!0>, valuetype ILDisassembler.TestStruct*[], !0)" },
+                { 26, "IL_0036:  ldtoken     !TClassParam" },
+                { 28, "IL_003C:  ldtoken     valuetype [CoreTestAssembly]System.Nullable`1<int32>" },
+                { 31, "IL_0043:  ldc.r8      3.14" },
+                { 32, "IL_004C:  ldc.r4      1.68" },
+                { 34, "IL_0053:  call        instance valuetype ILDisassembler.TestStruct class ILDisassembler.TestGenericClass`1<!TClassParam>::NonGenericMethod(float64, float32, int16)" },
+                { 37, "IL_005A:  ldflda      !0 class ILDisassembler.TestGenericClass`1<!TClassParam>::somefield" },
+                { 41, "IL_0067:  stfld       class ILDisassembler.TestClass class ILDisassembler.TestGenericClass`1<!TClassParam>::otherfield" },
+                { 44, "IL_006E:  stfld       class ILDisassembler.TestGenericClass`1<class ILDisassembler.TestGenericClass`1<class ILDisassembler.TestClass>> class ILDisassembler.TestGenericClass`1<!TClassParam>::genericfield" },
+                { 47, "IL_0075:  stfld       !0[] class ILDisassembler.TestGenericClass`1<!TClassParam>::arrayfield" },
+                { 48, "IL_007A:  call        void ILDisassembler.TestClass::NonGenericMethod()" },
+                { 49, "IL_007F:  ldsflda     valuetype ILDisassembler.TestStruct ILDisassembler.TestClass::somefield" },
+                { 50, "IL_0084:  initobj     ILDisassembler.TestStruct" }
+            };
+
+            ILDisassember disasm = new ILDisassember(methodIL);
+
+            int numLines = 1;
+            while (disasm.HasNextInstruction)
+            {
+                string line = disasm.GetNextInstruction();
+                string expectedLine;
+                if (interestingLines.TryGetValue(numLines, out expectedLine))
+                {
+                    Assert.Equal(expectedLine, line);
+                }
+                numLines++;
+            }
+
+            Assert.Equal(52, numLines);
+        }
+    }
+}

--- a/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILDisassembler.il
+++ b/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILDisassembler.il
@@ -1,0 +1,177 @@
+// While this is all expressible in C#, we need a deterministic IL to test the disassembler, hence
+// this is in IL.
+
+.class private sequential ansi sealed beforefieldinit ILDisassembler.TestStruct
+       extends [CoreTestAssembly]System.ValueType
+{
+  .pack 0
+  .size 1
+} // end of class ILDisassembler.TestStruct
+
+.class private auto ansi beforefieldinit ILDisassembler.TestClass
+       extends [CoreTestAssembly]System.Object
+{
+  .field public static valuetype ILDisassembler.TestStruct somefield
+  .method public hidebysig static void  NonGenericMethod() cil managed
+  {
+    // Code size       1 (0x1)
+    .maxstack  8
+    ret
+  } // end of method TestClass::NonGenericMethod
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    ldarg.0
+    call       instance void [CoreTestAssembly]System.Object::.ctor()
+    ret
+  } // end of method TestClass::.ctor
+
+} // end of class ILDisassembler.TestClass
+
+.class private auto ansi beforefieldinit ILDisassembler.TestGenericClass`1<TClassParam>
+       extends [CoreTestAssembly]System.Object
+{
+  .class auto ansi nested public beforefieldinit Nested<TClassParam>
+         extends [CoreTestAssembly]System.Object
+  {
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      ldarg.0
+      call       instance void [CoreTestAssembly]System.Object::.ctor()
+      ret
+    } // end of method Nested::.ctor
+
+  } // end of class Nested
+
+  .field private !TClassParam somefield
+  .field private class ILDisassembler.TestClass otherfield
+  .field private class ILDisassembler.TestGenericClass`1<class ILDisassembler.TestGenericClass`1<class ILDisassembler.TestClass>> genericfield
+  .field private !TClassParam[] arrayfield
+  .method public hidebysig instance void 
+          VoidGenericMethod<TMethodParam1,MethodParam2>(!!TMethodParam1 p,
+                                                        int32 x,
+                                                        native int y,
+                                                        class ILDisassembler.TestClass& z) cil managed
+  {
+    // Code size       1 (0x1)
+    .maxstack  8
+    ret
+  } // end of method TestGenericClass`1::VoidGenericMethod
+
+  .method public hidebysig static !!TMethodParam 
+          MethodParamGenericMethod<TMethodParam>(class ILDisassembler.TestGenericClass`1<!!TMethodParam> x,
+                                                 class ILDisassembler.TestGenericClass`1/Nested<!TClassParam> y,
+                                                 valuetype ILDisassembler.TestStruct*[] z,
+                                                 !TClassParam w) cil managed
+  {
+    // Code size       10 (0xa)
+    .maxstack  1
+    .locals init ([0] !!TMethodParam V_0)
+    ldloca.s   V_0
+    initobj    !!TMethodParam
+    ldloc.0
+    ret
+  } // end of method TestGenericClass`1::MethodParamGenericMethod
+
+  .method public hidebysig instance valuetype ILDisassembler.TestStruct 
+          NonGenericMethod(float64 x,
+                           float32 y,
+                           int16 z) cil managed
+  {
+    // Code size       10 (0xa)
+    .maxstack  1
+    .locals init ([0] valuetype ILDisassembler.TestStruct V_0)
+    ldloca.s   V_0
+    initobj    ILDisassembler.TestStruct
+    ldloc.0
+    ret
+  } // end of method TestGenericClass`1::NonGenericMethod
+
+  .method public hidebysig instance void 
+          TestMethod() cil managed
+  {
+    // Code size       162 (0xa2)
+    .maxstack  5
+    .locals init ([0] class ILDisassembler.TestClass t,
+             [1] !TClassParam V_1)
+    ldnull
+    stloc.0
+    ldarg.0
+    ldstr      "Hello \"World\"!\n"
+    ldc.i4.0
+    ldc.i4.0
+    conv.i
+    ldloca.s   t
+    call       instance void class ILDisassembler.TestGenericClass`1<!TClassParam>::VoidGenericMethod<string,valuetype ILDisassembler.TestStruct>(!!0,
+                                                                                                                                                 int32,
+                                                                                                                                                 native int,
+                                                                                                                                                 class ILDisassembler.TestClass&)
+    ldnull
+    ldnull
+    ldnull
+    ldloca.s   V_1
+    initobj    !TClassParam
+    ldloc.1
+    call       !!0 class ILDisassembler.TestGenericClass`1<!TClassParam>::MethodParamGenericMethod<class ILDisassembler.TestClass>(class ILDisassembler.TestGenericClass`1<!!0>,
+                                                                                                                                  class ILDisassembler.TestGenericClass`1/Nested<!0>,
+                                                                                                                                  valuetype ILDisassembler.TestStruct*[],
+                                                                                                                                  !0)
+    pop
+    ldnull
+    ldnull
+    ldnull
+    ldloca.s   V_1
+    initobj    !TClassParam
+    ldloc.1
+    call       !!0 class ILDisassembler.TestGenericClass`1<!TClassParam>::MethodParamGenericMethod<!0>(class ILDisassembler.TestGenericClass`1<!!0>,
+                                                                                                      class ILDisassembler.TestGenericClass`1/Nested<!0>,
+                                                                                                      valuetype ILDisassembler.TestStruct*[],
+                                                                                                      !0)
+    pop
+    ldtoken    !TClassParam
+    pop
+    ldtoken    valuetype [CoreTestAssembly]System.Nullable`1<int32>
+    pop
+    ldarg.0
+    ldc.r8     3.1400000000000001
+    ldc.r4     1.6799999
+    ldc.i4.s   42
+    call       instance valuetype ILDisassembler.TestStruct class ILDisassembler.TestGenericClass`1<!TClassParam>::NonGenericMethod(float64,
+                                                                                                                                   float32,
+                                                                                                                                   int16)
+    pop
+    ldarg.0
+    ldflda     !0 class ILDisassembler.TestGenericClass`1<!TClassParam>::somefield
+    initobj    !TClassParam
+    ldarg.0
+    ldnull
+    stfld      class ILDisassembler.TestClass class ILDisassembler.TestGenericClass`1<!TClassParam>::otherfield
+    ldarg.0
+    ldnull
+    stfld      class ILDisassembler.TestGenericClass`1<class ILDisassembler.TestGenericClass`1<class ILDisassembler.TestClass>> class ILDisassembler.TestGenericClass`1<!TClassParam>::genericfield
+    ldarg.0
+    ldnull
+    stfld      !0[] class ILDisassembler.TestGenericClass`1<!TClassParam>::arrayfield
+    call       void ILDisassembler.TestClass::NonGenericMethod()
+    ldsflda    valuetype ILDisassembler.TestStruct ILDisassembler.TestClass::somefield
+    initobj    ILDisassembler.TestStruct
+    ret
+  } // end of method TestGenericClass`1::TestMethod
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    ldarg.0
+    call       instance void [CoreTestAssembly]System.Object::.ctor()
+    ret
+  } // end of method TestGenericClass`1::.ctor
+
+} // end of class ILDisassembler.TestGenericClass`1

--- a/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILDisassembler.il
+++ b/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILDisassembler.il
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 // While this is all expressible in C#, we need a deterministic IL to test the disassembler, hence
 // this is in IL.
 

--- a/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILTestAssembly.ilproj
+++ b/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILTestAssembly.ilproj
@@ -17,7 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Main has to be the first file. Do not put anything before Main.il -->
     <Compile Include="Main.il" />
+
+    <Compile Include="ILDisassembler.il" />
     <Compile Include="StaticFieldLayout.il" />
     <Compile Include="VirtualFunctionOverride.il" />
   </ItemGroup>

--- a/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
+++ b/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="GenericTypeAndMethodTests.cs" />
     <Compile Include="CastingTests.cs" />
     <Compile Include="HashcodeTests.cs" />
+    <Compile Include="ILDisassemblerTests.cs" />
     <Compile Include="InterfacesTests.cs" />
     <Compile Include="RuntimeDeterminedTypesTests.cs" />
     <Compile Include="SyntheticVirtualOverrideTests.cs" />


### PR DESCRIPTION
* Base class for flexible name formatting. I have one other use for it in mind, and with this, we can probably reconsider our "ToString" formatting story in general.
* Flexible name formatting for ILAsm syntax.
* Revamp `ILDisassembler`

Moves us closer to fixing #1192 and #1276.