### PR TITLE
Fix generated IL for the DynamicInvoke thunk

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -431,7 +431,7 @@ namespace Internal.IL.Stubs
                 {
                     Interlocked.CompareExchange(ref _helperParamIn, new DynamicInvokeParamHelperMethod(_delegateInfo.Type, 0), null);
                 }
-                return _helperParamIn;
+                return _helperParamIn.InstantiateAsOpen();
             }
         }
 
@@ -443,7 +443,7 @@ namespace Internal.IL.Stubs
                 {
                     Interlocked.CompareExchange(ref _helperParamRef, new DynamicInvokeParamHelperMethod(_delegateInfo.Type, 1), null);
                 }
-                return _helperParamRef;
+                return _helperParamRef.InstantiateAsOpen();
             }
         }
 


### PR DESCRIPTION
Since the HelperParamRef/In intrinsics are currently faked as being
member methods of the delegate itself (they have ByRef return values and
can't be expressed as a C# method we could put `[Intrinsic]` on), they
need to be instantiated as open before being called from the referenced
code. RyuJIT apparently doesn't care, but CppCodeGen is more sensitive.

(Boy I'm glad I spent time improving the IL disassembly -
troubleshooting this was a breeze.)