### PR TITLE
Don't emit _ecvt_s

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -400,6 +400,10 @@ namespace ILCompiler.CppCodeGen
 
             try
             {
+                // TODO: hacky special-case
+                if (method.Name == "_ecvt_s")
+                    throw new NotImplementedException();
+
                 var ilImporter = new ILImporter(_compilation, this, method, methodIL);
 
                 CompilerTypeSystemContext typeSystemContext = _compilation.TypeSystemContext;


### PR DESCRIPTION
`_ecvt_s` is already defined in the C headers we include, but with a
slightly different signature. I wanted to group this hack together with
the other `TODO: hacky special-case`, but not emitting the declaration
doesn't fix this either because the signature is incompatible. This will
do the job.