### PR TITLE
Merge TypeInitializationManager with CompilerTypeSystemContext

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -32,8 +32,7 @@ namespace ILCompiler
     {
         private readonly CompilerTypeSystemContext _typeSystemContext;
         private readonly CompilationOptions _options;
-        private readonly TypeInitialization _typeInitManager;
-
+        
         private NodeFactory _nodeFactory;
         private DependencyAnalyzerBase<NodeFactory> _dependencyGraph;
 
@@ -47,8 +46,6 @@ namespace ILCompiler
             _options = options;
 
             _nameMangler = new NameMangler(options.IsCppCodeGen);
-
-            _typeInitManager = new TypeInitialization();
 
             _typeSystemContext = context;
             _compilationModuleGroup = compilationGroup;
@@ -121,7 +118,7 @@ namespace ILCompiler
                 NodeFactory.CompilationUnitPrefix = NameMangler.SanitizeName(Path.GetFileNameWithoutExtension(Options.OutputFilePath));
             }
 
-            _nodeFactory = new NodeFactory(_typeSystemContext, _typeInitManager, _compilationModuleGroup, _options.IsCppCodeGen);
+            _nodeFactory = new NodeFactory(_typeSystemContext, _compilationModuleGroup, _options.IsCppCodeGen);
 
             // Choose which dependency graph implementation to use based on the amount of logging requested.
             if (_options.DgmlLog == null)
@@ -257,7 +254,7 @@ namespace ILCompiler
 
         public bool HasLazyStaticConstructor(TypeDesc type)
         {
-            return _typeInitManager.HasLazyStaticConstructor(type);
+            return _typeSystemContext.HasLazyStaticConstructor(type);
         }
 
         public MethodDebugInformation GetDebugInfo(MethodIL methodIL)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.TypeInit.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.TypeInit.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection.Metadata;
 
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -13,12 +12,10 @@ using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler
 {
-    /// <summary>
-    /// Manages policies around static constructors (.cctors) and static data initialization.
-    /// </summary>
-    public class TypeInitialization
+    // Manages policies around static constructors (.cctors) and static data initialization.
+    partial class CompilerTypeSystemContext
     {
-        // Eventually, this class will also manage preinitialization (interpreting cctors at compile
+        // Eventually, this will also manage preinitialization (interpreting cctors at compile
         // time and converting them to blobs of preinitialized data), and the various
         // System.Runtime.CompilerServices.PreInitializedAttribute/InitDataBlobAttribute/etc. placed on
         // types and their members by toolchain components.

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -17,7 +17,7 @@ using Internal.IL;
 
 namespace ILCompiler
 {
-    public class CompilerTypeSystemContext : MetadataTypeSystemContext, IMetadataStringDecoderProvider
+    public partial class CompilerTypeSystemContext : MetadataTypeSystemContext, IMetadataStringDecoderProvider
     {
         private MetadataFieldLayoutAlgorithm _metadataFieldLayoutAlgorithm = new CompilerMetadataFieldLayoutAlgorithm();
         private MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -597,7 +597,7 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (uint)EETypeRareFlags.IsNullableFlag;
             }
 
-            if (factory.TypeInitializationManager.HasLazyStaticConstructor(_type))
+            if (factory.TypeSystemContext.HasLazyStaticConstructor(_type))
             {
                 flags |= (uint)EETypeRareFlags.HasCctorFlag;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             DependencyList dependencyList = new DependencyList();
             
-            if (factory.TypeInitializationManager.HasEagerStaticConstructor(_type))
+            if (factory.TypeSystemContext.HasEagerStaticConstructor(_type))
             {
                 dependencyList.Add(factory.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -88,7 +88,7 @@ namespace ILCompiler.DependencyAnalysis
             DependencyList dependencies = null;
 
             TypeDesc owningType = _method.OwningType;
-            if (factory.TypeInitializationManager.HasEagerStaticConstructor(owningType))
+            if (factory.TypeSystemContext.HasEagerStaticConstructor(owningType))
             {
                 if (dependencies == null)
                     dependencies = new DependencyList();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -21,13 +21,12 @@ namespace ILCompiler.DependencyAnalysis
         private bool _cppCodeGen;
         private CompilationModuleGroup _compilationModuleGroup;
 
-        public NodeFactory(CompilerTypeSystemContext context, TypeInitialization typeInitManager, CompilationModuleGroup compilationModuleGroup, bool cppCodeGen)
+        public NodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, bool cppCodeGen)
         {
             _target = context.Target;
             _context = context;
             _cppCodeGen = cppCodeGen;
             _compilationModuleGroup = compilationModuleGroup;
-            TypeInitializationManager = typeInitManager;
             CreateNodeCaches();
 
             MetadataManager = new MetadataGeneration();
@@ -49,9 +48,12 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public TypeInitialization TypeInitializationManager
+        public CompilerTypeSystemContext TypeSystemContext
         {
-            get; private set;
+            get
+            {
+                return _context;
+            }
         }
 
         public MetadataGeneration MetadataManager
@@ -247,7 +249,7 @@ namespace ILCompiler.DependencyAnalysis
             _eagerCctorIndirectionNodes = new NodeCache<MethodDesc, EmbeddedObjectNode>((MethodDesc method) =>
             {
                 Debug.Assert(method.IsStaticConstructor);
-                Debug.Assert(TypeInitializationManager.HasEagerStaticConstructor((MetadataType)method.OwningType));
+                Debug.Assert(TypeSystemContext.HasEagerStaticConstructor((MetadataType)method.OwningType));
                 return EagerCctorTable.NewNode(MethodEntrypoint(method));
             });
             

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -88,7 +88,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            if (factory.TypeInitializationManager.HasEagerStaticConstructor(_type))
+            if (factory.TypeSystemContext.HasEagerStaticConstructor(_type))
             {
                 var result = new DependencyList();
                 result.Add(factory.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");
@@ -104,7 +104,7 @@ namespace ILCompiler.DependencyAnalysis
 
             // If the type has a class constructor, its non-GC statics section is prefixed  
             // by System.Runtime.CompilerServices.StaticClassConstructionContext struct.
-            if (factory.TypeInitializationManager.HasLazyStaticConstructor(_type))
+            if (factory.TypeSystemContext.HasLazyStaticConstructor(_type))
             {
                 int alignmentRequired = Math.Max(_type.NonGCStaticFieldAlignment, GetClassConstructorContextAlignment(_type.Context.Target));
                 int classConstructorContextStorageSize = GetClassConstructorContextStorageSize(factory.Target, _type);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -73,7 +73,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.GetNonGCStaticBase:
                     {
                         MetadataType target = (MetadataType)Target;
-                        bool hasLazyStaticConstructor = factory.TypeInitializationManager.HasLazyStaticConstructor(target);
+                        bool hasLazyStaticConstructor = factory.TypeSystemContext.HasLazyStaticConstructor(target);
                         encoder.EmitLEAQ(encoder.TargetRegister.Result, factory.TypeNonGCStaticsSymbol(target), hasLazyStaticConstructor ? NonGCStaticsNode.GetClassConstructorContextStorageSize(factory.Target, target) : 0);
 
                         if (!hasLazyStaticConstructor)
@@ -108,7 +108,7 @@ namespace ILCompiler.DependencyAnalysis
                         encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromRax);
                         encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromRax);
 
-                        if (!factory.TypeInitializationManager.HasLazyStaticConstructor(target))
+                        if (!factory.TypeSystemContext.HasLazyStaticConstructor(target))
                         {
                             encoder.EmitRET();
                         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -47,7 +47,7 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             DependencyListEntry[] result;
-            if (factory.TypeInitializationManager.HasEagerStaticConstructor(_type))
+            if (factory.TypeSystemContext.HasEagerStaticConstructor(_type))
             {
                 result = new DependencyListEntry[3];
                 result[2] = new DependencyListEntry(factory.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor");

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -132,7 +132,7 @@
     <Compile Include="Compiler\SingleFileCompilationModuleGroup.cs" />
     <Compile Include="Compiler\SingleMethodCompilationModuleGroup.cs" />
     <Compile Include="Compiler\TypeExtensions.cs" />
-    <Compile Include="Compiler\TypeInitialization.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.TypeInit.cs" />
     <Compile Include="Compiler\VirtualMethodCallHelper.cs" />
     <Compile Include="Compiler\VirtualMethodEnumeration.cs" />
     <Compile Include="CppCodeGen\EvaluationStack.cs" />


### PR DESCRIPTION
There's little point in separating type initialization manager from the
type system context. It's an extra class we need to instantiate and pass
around between Compilation and NodeFactory and doesn't provide much
functionality to warrant being a separate class (we don't expect this to
be more pluggable/overridable than the type system context in general -
we might want to consider a middle man class between
MetadataTypeSystemContext and CompilerTypeSystemContext if pluggability
is desired).

Also, exposing CompilerTypeSystemContext on NodeFactory is more useful.