### PR TITLE
Move Name, Namespace and OwningType to DefType

### DIFF
--- a/src/Common/src/TypeSystem/Canon/CanonTypes.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.cs
@@ -57,9 +57,27 @@ namespace Internal.TypeSystem
     /// </summary>
     internal sealed partial class CanonType : CanonBaseType
     {
-        public const string FullName = "System.__Canon";
+        private const string _Namespace = "System";
+        private const string _Name = "__Canon";
+        public const string FullName = _Namespace + "." + _Name;
 
         private int _hashcode;
+
+        public override string Namespace
+        {
+            get
+            {
+                return _Namespace;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return _Name;
+            }
+        }
 
         public CanonType(TypeSystemContext context)
             : base(context)
@@ -130,9 +148,27 @@ namespace Internal.TypeSystem
     /// </summary>
     internal sealed partial class UniversalCanonType : CanonBaseType
     {
-        public const string FullName = "System.__UniversalCanon";
+        private const string _Namespace = "System";
+        private const string _Name = "__UniversalCanon";
+        public const string FullName = _Namespace + "." + _Name;
 
         private int _hashcode;
+
+        public override string Namespace
+        {
+            get
+            {
+                return _Namespace;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return _Name;
+            }
+        }
 
         public UniversalCanonType(TypeSystemContext context)
             : base(context)

--- a/src/Common/src/TypeSystem/Common/DefType.cs
+++ b/src/Common/src/TypeSystem/Common/DefType.cs
@@ -10,5 +10,37 @@ namespace Internal.TypeSystem
     /// </summary>
     public abstract partial class DefType : TypeDesc
     {
+        /// <summary>
+        /// Gets the namespace of the type.
+        /// </summary>
+        public virtual string Namespace
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the type as represented in the metadata.
+        /// </summary>
+        public virtual string Name
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the containing type of this type or null if the type is not nested.
+        /// </summary>
+        public virtual DefType ContainingType
+        {
+            get
+            {
+                return null;
+            }
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
+++ b/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
@@ -63,6 +63,17 @@ namespace Internal.TypeSystem
     public abstract partial class GenericParameterDesc : TypeDesc
     {
         /// <summary>
+        /// Gets the name of the generic parameter as defined in the metadata.
+        /// </summary>
+        public virtual string Name
+        {
+            get
+            {
+                return String.Concat("T", Index.ToStringInvariant());
+            }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether this is a type or method generic parameter.
         /// </summary>
         public abstract GenericParameterKind Kind { get; }

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -320,7 +320,7 @@ namespace Internal.TypeSystem
             return _typeDef.HasCustomAttribute(attributeNamespace, attributeName);
         }
 
-        public override MetadataType ContainingType
+        public override DefType ContainingType
         {
             get
             {

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -28,15 +28,9 @@ namespace Internal.TypeSystem
             }
         }
 
-        /// <summary>
-        /// Gets the name of the type as represented in the metadata.
-        /// </summary>
-        public abstract string Name { get; }
+        public abstract override string Name { get; }
 
-        /// <summary>
-        /// Gets the namespace of the type.
-        /// </summary>
-        public abstract string Namespace { get; }
+        public abstract override string Namespace { get; }
 
         /// <summary>
         /// Gets metadata that controls instance layout of this type.
@@ -93,10 +87,7 @@ namespace Internal.TypeSystem
         /// </summary>
         public abstract bool HasCustomAttribute(string attributeNamespace, string attributeName);
 
-        /// <summary>
-        /// Gets the containing type of this type or null if the type is not nested.
-        /// </summary>
-        public abstract MetadataType ContainingType { get; }
+        public abstract override DefType ContainingType { get; }
 
         /// <summary>
         /// Get all of the types nested in this type.

--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -227,9 +227,9 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Retrieves the namespace qualified name of a <see cref="MetadataType"/>.
+        /// Retrieves the namespace qualified name of a <see cref="DefType"/>.
         /// </summary>
-        public static string GetFullName(this MetadataType metadataType)
+        public static string GetFullName(this DefType metadataType)
         {
             string ns = metadataType.Namespace;
             return ns.Length > 0 ? String.Concat(ns, ".", metadataType.Name) : metadataType.Name;

--- a/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
@@ -44,44 +44,38 @@ namespace Internal.TypeSystem
                     AppendName(sb, (GenericParameterDesc)type);
                     return;
                 default:
-                    if (type.GetType() == typeof(InstantiatedType))
-                        AppendName(sb, (InstantiatedType)type);
-                    else if (type is MetadataType)
-                        AppendName(sb, (MetadataType)type);
-                    else
-                    {
-                        Debug.Assert(type is NoMetadata.NoMetadataType);
-                        AppendName(sb, (NoMetadata.NoMetadataType)type);
-                    }
+                    Debug.Assert(type.IsDefType);
+                    AppendName(sb, (DefType)type);
                     return;
             }
         }
 
-        public void AppendName(StringBuilder sb, MetadataType type)
+        public void AppendName(StringBuilder sb, DefType type)
         {
-            MetadataType containingType = type.ContainingType;
-            if (containingType != null)
-                AppendNameForNestedType(sb, type, containingType);
+            if (!type.IsTypeDefinition)
+            {
+                AppendNameForInstantiatedType(sb, type);
+            }
             else
-                AppendNameForNamespaceType(sb, type);
-        }
-
-        public virtual void AppendName(StringBuilder sb, NoMetadata.NoMetadataType type)
-        {
-            // Name formatters that can deal with NoMetadata types need to override.
-            throw new NotSupportedException();
+            {
+                DefType containingType = type.ContainingType;
+                if (containingType != null)
+                    AppendNameForNestedType(sb, type, containingType);
+                else
+                    AppendNameForNamespaceType(sb, type);
+            }
         }
 
         public abstract void AppendName(StringBuilder sb, ArrayType type);
         public abstract void AppendName(StringBuilder sb, ByRefType type);
         public abstract void AppendName(StringBuilder sb, PointerType type);
-        public abstract void AppendName(StringBuilder sb, InstantiatedType type);
         public abstract void AppendName(StringBuilder sb, GenericParameterDesc type);
         public abstract void AppendName(StringBuilder sb, SignatureMethodVariable type);
         public abstract void AppendName(StringBuilder sb, SignatureTypeVariable type);
 
-        protected abstract void AppendNameForNestedType(StringBuilder sb, MetadataType nestedType, MetadataType containingType);
-        protected abstract void AppendNameForNamespaceType(StringBuilder sb, MetadataType type);
+        protected abstract void AppendNameForNestedType(StringBuilder sb, DefType nestedType, DefType containingType);
+        protected abstract void AppendNameForNamespaceType(StringBuilder sb, DefType type);
+        protected abstract void AppendNameForInstantiatedType(StringBuilder sb, DefType type);
 
         #region Convenience methods
 
@@ -92,14 +86,7 @@ namespace Internal.TypeSystem
             return sb.ToString();
         }
 
-        public string FormatName(MetadataType type)
-        {
-            StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
-            return sb.ToString();
-        }
-
-        public string FormatName(NoMetadata.NoMetadataType type)
+        public string FormatName(DefType type)
         {
             StringBuilder sb = new StringBuilder();
             AppendName(sb, type);
@@ -130,7 +117,7 @@ namespace Internal.TypeSystem
         public string FormatName(InstantiatedType type)
         {
             StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
+            AppendNameForInstantiatedType(sb, type);
             return sb.ToString();
         }
 

--- a/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
@@ -63,6 +63,15 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
+        public override string Name
+        {
+            get
+            {
+                MetadataReader reader = _module.MetadataReader;
+                return reader.GetString(reader.GetGenericParameter(_handle).Name);
+            }
+        }
+
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = 0;

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -409,7 +409,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override MetadataType ContainingType
+        public override DefType ContainingType
         {
             get
             {
@@ -417,7 +417,7 @@ namespace Internal.TypeSystem.Ecma
                     return null;
 
                 var handle = _typeDefinition.GetDeclaringType();
-                return (MetadataType)_module.GetType(handle);
+                return (DefType)_module.GetType(handle);
             }
         }
 

--- a/src/Common/src/TypeSystem/IL/ILDisassember.cs
+++ b/src/Common/src/TypeSystem/IL/ILDisassember.cs
@@ -472,10 +472,10 @@ namespace Internal.IL
             {
                 string prefix = type.Kind == GenericParameterKind.Type ? "!" : "!!";
                 sb.Append(prefix);
-                sb.Append(type.ToString()); // TODO: should we require a Name property for this?
+                sb.Append(type.Name);
             }
 
-            public override void AppendName(StringBuilder sb, InstantiatedType type)
+            protected override void AppendNameForInstantiatedType(StringBuilder sb, DefType type)
             {
                 AppendName(sb, type.GetTypeDefinition());
                 sb.Append('<');
@@ -504,7 +504,7 @@ namespace Internal.IL
                 sb.Append(']');
             }
 
-            protected override void AppendNameForNamespaceType(StringBuilder sb, MetadataType type)
+            protected override void AppendNameForNamespaceType(StringBuilder sb, DefType type)
             {
                 switch (type.Category)
                 {
@@ -569,12 +569,11 @@ namespace Internal.IL
 
                 AppendNameForNamespaceTypeWithoutAliases(sb, type);
             }
-            public void AppendNameForNamespaceTypeWithoutAliases(StringBuilder sb, MetadataType type)
+            public void AppendNameForNamespaceTypeWithoutAliases(StringBuilder sb, DefType type)
             {
-                string ns = type.Namespace;
-
-                ModuleDesc owningModule = type.Module;
-                if (owningModule != _thisModule)
+                Debug.Assert(type is MetadataType);
+                ModuleDesc owningModule = ((MetadataType)type).Module;
+                if (owningModule != null && owningModule != _thisModule)
                 {
                     Debug.Assert(owningModule is IAssemblyDesc);
                     string owningModuleName = ((IAssemblyDesc)owningModule).GetName().Name;
@@ -583,6 +582,7 @@ namespace Internal.IL
                     sb.Append(']');
                 }
 
+                string ns = type.Namespace;
                 if (ns.Length > 0)
                 {
                     sb.Append(ns);
@@ -591,7 +591,7 @@ namespace Internal.IL
                 sb.Append(type.Name);
             }
 
-            protected override void AppendNameForNestedType(StringBuilder sb, MetadataType nestedType, MetadataType containingType)
+            protected override void AppendNameForNestedType(StringBuilder sb, DefType nestedType, DefType containingType)
             {
                 AppendName(sb, containingType);
                 sb.Append('/');

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -90,6 +90,22 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override string Name
+        {
+            get
+            {
+                return _rawCanonType.Name;
+            }
+        }
+
+        public override string Namespace
+        {
+            get
+            {
+                return String.Concat(_runtimeDeterminedDetailsType.Name, "_", _rawCanonType.Namespace);
+            }
+        }
+
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = 0;

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -133,7 +133,7 @@ namespace ILCompiler
                         string name = t.GetFullName();
 
                         // Include encapsulating type
-                        MetadataType containingType = t.ContainingType;
+                        DefType containingType = t.ContainingType;
                         while (containingType != null)
                         {
                             name = containingType.GetFullName() + "_" + name;
@@ -200,7 +200,7 @@ namespace ILCompiler
                     }
                     else
                     {
-                        mangledName = SanitizeName(((MetadataType)type).GetFullName(), true);
+                        mangledName = SanitizeName(((DefType)type).GetFullName(), true);
                     }
                     break;
             }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -166,7 +166,7 @@ namespace ILCompiler.Metadata
             // references to their definition records (we are avoiding emitting references
             // to things that have a definition within the same blob to save space).
 
-            Cts.MetadataType containingType = entity.ContainingType;
+            Cts.MetadataType containingType = (Cts.MetadataType)entity.ContainingType;
             MetadataRecord parentRecord = HandleType(containingType);
             TypeReference parentReferenceRecord = parentRecord as TypeReference;
             
@@ -218,14 +218,15 @@ namespace ILCompiler.Metadata
         {
             Debug.Assert(entity.IsTypeDefinition);
 
-            if (entity.ContainingType != null)
+            Cts.MetadataType containingType = (Cts.MetadataType)entity.ContainingType;
+            if (containingType != null)
             {
-                var enclosingType = (TypeDefinition)HandleType(entity.ContainingType);
+                var enclosingType = (TypeDefinition)HandleType(containingType);
                 record.EnclosingType = enclosingType;
                 enclosingType.NestedTypes.Add(record);
 
                 var namespaceDefinition =
-                    HandleNamespaceDefinition(_policy.GetModuleOfType(entity.ContainingType), entity.ContainingType.Namespace);
+                    HandleNamespaceDefinition(_policy.GetModuleOfType(containingType), entity.ContainingType.Namespace);
                 record.NamespaceDefinition = namespaceDefinition;
             }
             else


### PR DESCRIPTION
The motivation for this change is:
* To make the type name formatter general purpose (it can now handle
`NoMetadata` types)
* To make `NameMangler` able to mangle canon types and runtime
determined types without special casing

For situation where we have a NoMetadataType, the expectation is that
we're asking for the name for diagnostic purposes only (i.e. name
formatter wants it). In that case:
* In checked builds, the name can actually be retrieved from diagnostic
mapping tables, along with the owning type (we have a metadata TypeRef
for this).
* In the absence of diagnostic mapping tables, the name can be faked up
and the type pretended to be non-nested
("System.Runtime.NoMetadataTypes.EEType1234ABCD")

As an additional change, I'm also adding `Name` property on
`GenericParameterDesc`. We can compute a useful fallback value for this
in absence of metadata ("T" + index).