### PR TITLE
Clean up some debt from the Reflection Restoration work

### DIFF
--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -124,11 +124,11 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         internal MethodInvoker GetMethodInvoker(MetadataReader reader, RuntimeTypeInfo declaringType, MethodHandle methodHandle, RuntimeTypeInfo[] genericMethodTypeArguments, MemberInfo exceptionPertainant)
         {
-            if (declaringType.InternalIsOpen)
+            if (declaringType.ContainsGenericParameters)
                 return new OpenMethodInvoker();
             for (int i = 0; i < genericMethodTypeArguments.Length; i++)
             {
-                if (genericMethodTypeArguments[i].InternalIsOpen)
+                if (genericMethodTypeArguments[i].ContainsGenericParameters)
                     return new OpenMethodInvoker();
             }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -21,11 +21,19 @@ namespace System.Reflection.Runtime.General
             return h.Equals(default(RuntimeTypeHandle));
         }
 
+        // Clones a Type[] array for the purpose of returning it from an api.
         public static Type[] CloneTypeArray(this Type[] types)
         {
-            if (types.Length == 0)
-                return Array.Empty<Type>();
-            return (Type[])(types.Clone());
+            int count = types.Length;
+            if (count == 0)
+                return Array.Empty<Type>();  // Ok not to clone empty arrays - those are immutable.
+
+            Type[] clonedTypes = new Type[count];
+            for (int i = 0; i < count; i++)
+            {
+                clonedTypes[i] = types[i];
+            }
+            return clonedTypes;
         }
 
         // TODO https://github.com/dotnet/corefx/issues/9805: This overload can and should be deleted once TypeInfo derives from Type again.

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.cs
@@ -180,7 +180,7 @@ namespace System.Reflection.Runtime.General
                 RuntimeTypeInfo outerType = reflectionDomain.TryResolveTypeReference(reader, parent.ToTypeReferenceHandle(reader), ref exception);
                 if (outerType == null)
                     return null;
-                outerTypeInfo = outerType.GetTypeInfo();   // Since we got to outerType via a metadata reference, we're assured GetTypeInfo() won't throw a MissingMetadataException.
+                outerTypeInfo = outerType;   // Since we got to outerType via a metadata reference, we're assured GetTypeInfo() won't throw a MissingMetadataException.
             }
             if (outerTypeInfo != null)
             {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -231,7 +231,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 ReflectionDomain reflectionDomain = this.ReflectionDomain;
                 for (int i = 0; i < constraints.Length; i++)
                 {
-                    constraintInfos[i] = reflectionDomain.Resolve(constraints[i].Reader, constraints[i].Handle, TypeContext).GetTypeInfo();
+                    constraintInfos[i] = reflectionDomain.Resolve(constraints[i].Reader, constraints[i].Handle, TypeContext);
                 }
                 return constraintInfos;
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -268,12 +268,6 @@ namespace System.Reflection.Runtime.TypeInfos
             return InternalGetHashCode();
         }
 
-        // TODO https://github.com/dotnet/corefx/issues/9805: This simplifies the conversion to a RuntimeTypeInfo-centric source-base. Once that's done, this can be gotten rid of.
-        public TypeInfo GetTypeInfo()
-        {
-            return this;
-        }
-
         public abstract override string FullName { get; }
 
         //
@@ -883,9 +877,6 @@ namespace System.Reflection.Runtime.TypeInfos
         internal abstract string InternalFullNameOfAssembly { get; }
 
         internal abstract string InternalGetNameIfAvailable(ref Type rootCauseForFailure);
-
-        // TODO https://github.com/dotnet/corefx/issues/9805: This was inserted to help facilitate the RuntimeType->RuntimeTypeInfo switchover. Otherwise, it's pretty useless - remove it.
-        internal bool InternalIsOpen => ContainsGenericParameters;
 
         // Left unsealed so that multidim arrays can override.
         internal virtual bool InternalIsMultiDimArray

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeName.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeName.cs
@@ -321,7 +321,7 @@ namespace System.Reflection.Runtime.TypeParsing
             Exception typeLoadException = DeclaringType.TryResolve(reflectionDomain, currentAssembly, ignoreCase, out declaringType);
             if (typeLoadException != null)
                 return typeLoadException;
-            TypeInfo nestedTypeInfo = FindDeclaredNestedType(declaringType.GetTypeInfo(), Name, ignoreCase);
+            TypeInfo nestedTypeInfo = FindDeclaredNestedType(declaringType, Name, ignoreCase);
             if (nestedTypeInfo == null)
                 return new TypeLoadException(SR.Format(SR.TypeLoad_TypeNotFound, declaringType.FullName + "+" + Name, currentAssembly.FullName));
             result = nestedTypeInfo.GetRuntimeTypeInfo<RuntimeTypeInfo>();


### PR DESCRIPTION
- Remove a couple of trivial helpers that were inserted
  to make the job easier.

- Make CloneTypeArray() allocate an actual Type[] instead
  of returning EEType$$BLAH_BLAH_BLAH$$RuntimeTypeTemporary[].
  In theory, it shouldn't matter because of type invariance,
  but since we hand this out to api callers, there's
  no point in inviting trouble.