### PR TITLE
Treat UniversalCanon as a struct

### DIFF
--- a/src/Common/src/TypeSystem/Canon/CanonTypes.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.cs
@@ -207,8 +207,9 @@ namespace Internal.TypeSystem
 
             if ((mask & TypeFlags.CategoryMask) != 0)
             {
-                // Behavior for this is undefined.
-                throw new NotSupportedException();
+                // Universally canonical type is reported as a variable-sized struct.
+                // It's the closest logical thing and avoids special casing around it.
+                flags |= TypeFlags.ValueType;
             }
 
             Debug.Assert((flags & mask) != 0);


### PR DESCRIPTION
This is how UniversalCanon is reported on the .NET Native for UWP
compiler. We should align. As a nice side effect, IsDefType is now a
valid thing to call on canonical types.