### PR TITLE
Make ILDisassembler usable on bodies instatiated over canon types

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILDisassember.cs
+++ b/src/Common/src/TypeSystem/IL/ILDisassember.cs
@@ -571,8 +571,7 @@ namespace Internal.IL
             }
             public void AppendNameForNamespaceTypeWithoutAliases(StringBuilder sb, DefType type)
             {
-                Debug.Assert(type is MetadataType);
-                ModuleDesc owningModule = ((MetadataType)type).Module;
+                ModuleDesc owningModule = (type as MetadataType)?.Module;
                 if (owningModule != null && owningModule != _thisModule)
                 {
                     Debug.Assert(owningModule is IAssemblyDesc);


### PR DESCRIPTION
Hard cast to `MetadataType` is unnecessary. Treat DefTypes not deriving
from MetadataType as not having a home assembly.