### PR TITLE
Fix MDArray casting

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
@@ -179,7 +179,7 @@ namespace ILCompiler
 
         static public string GetCastingHelperNameForType(TypeDesc type, bool throwing)
         {
-            if (type.IsSzArray)
+            if (type.IsArray)
                 return throwing ? "RhTypeCast_CheckCastArray" : "RhTypeCast_IsInstanceOfArray";
 
             if (type.IsInterface)

--- a/src/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -219,7 +219,8 @@ namespace System.Runtime
 
             // compare the array types structurally
 
-            if (CastCache.AreTypesAssignableInternal(pObjType->RelatedParameterType, pTargetType->RelatedParameterType,
+            if (pObjType->ParameterizedTypeShape == pTargetType->ParameterizedTypeShape &&
+                CastCache.AreTypesAssignableInternal(pObjType->RelatedParameterType, pTargetType->RelatedParameterType,
                 AssignmentVariation.AllowSizeEquivalence))
             {
                 return obj;


### PR DESCRIPTION
I went through the places in the runtime that access
`RelatedParameterType` as part of looking at issue #88. This is the only
thing I found. If there's anything else lurking, we'll find it in
testing.

Fixes #88.