### PR TITLE
Add TypeFlags for signature variables

### DIFF
--- a/src/Common/src/TypeSystem/Common/SignatureVariable.cs
+++ b/src/Common/src/TypeSystem/Common/SignatureVariable.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+
 using Internal.NativeFormat;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem
 {
@@ -61,10 +64,17 @@ namespace Internal.TypeSystem
 
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
-            // We might be able to compute the type flags for some masks, but for some this will always throw (e.g.
-            // Category and GenericVariance should always throw). If you hit an exception, it means you need a
-            // special case for IsSignatureVariable.
-            throw new NotImplementedException();
+            TypeFlags flags = 0;
+
+            if ((mask & TypeFlags.CategoryMask) != 0)
+            {
+                flags |= TypeFlags.SignatureTypeVariable;
+            }
+
+            // Not all masks are valid to ask on signature variables. If you hit this assert, you might
+            // need to special case, or you have a bug.
+            Debug.Assert((flags & mask) != 0);
+            return flags;
         }
 
         public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
@@ -99,10 +109,17 @@ namespace Internal.TypeSystem
 
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
-            // We might be able to compute the type flags for some masks, but for some this will always throw (e.g.
-            // Category and GenericVariance should always throw). If you hit an exception, it means you need a
-            // special case for IsSignatureVariable.
-            throw new NotImplementedException();
+            TypeFlags flags = 0;
+
+            if ((mask & TypeFlags.CategoryMask) != 0)
+            {
+                flags |= TypeFlags.SignatureMethodVariable;
+            }
+
+            // Not all masks are valid to ask on signature variables. If you hit this assert, you might
+            // need to special case, or you have a bug.
+            Debug.Assert((flags & mask) != 0);
+            return flags;
         }
 
         public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)

--- a/src/Common/src/TypeSystem/Common/TypeFlags.cs
+++ b/src/Common/src/TypeSystem/Common/TypeFlags.cs
@@ -43,7 +43,9 @@ namespace Internal.TypeSystem
         ByRef           = 0x19,
         Pointer         = 0x1A,
 
-        GenericParameter = 0x1C,
+        GenericParameter        = 0x1C,
+        SignatureTypeVariable   = 0x1D,
+        SignatureMethodVariable = 0x1E,
 
         ContainsGenericVariables         = 0x100,
         ContainsGenericVariablesComputed = 0x200,

--- a/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
@@ -16,18 +16,6 @@ namespace Internal.TypeSystem
     {
         public void AppendName(StringBuilder sb, TypeDesc type)
         {
-            if (type.GetType() == typeof(SignatureTypeVariable))
-            {
-                AppendName(sb, (SignatureTypeVariable)type);
-                return;
-            }
-
-            if (type.GetType() == typeof(SignatureMethodVariable))
-            {
-                AppendName(sb, (SignatureMethodVariable)type);
-                return;
-            }
-
             switch (type.Category)
             {
                 case TypeFlags.Array:
@@ -42,6 +30,12 @@ namespace Internal.TypeSystem
                     return;
                 case TypeFlags.GenericParameter:
                     AppendName(sb, (GenericParameterDesc)type);
+                    return;
+                case TypeFlags.SignatureTypeVariable:
+                    AppendName(sb, (SignatureTypeVariable)type);
+                    return;
+                case TypeFlags.SignatureMethodVariable:
+                    AppendName(sb, (SignatureMethodVariable)type);
                     return;
                 default:
                     Debug.Assert(type.IsDefType);

--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -222,7 +222,7 @@ namespace Internal.IL.Stubs
             ILLocalVariable delegateToCallLocal = emitter.NewLocal(SystemDelegateType);
 
             ILLocalVariable returnValueLocal = 0;
-            if (Signature.ReturnType.IsSignatureVariable || !Signature.ReturnType.IsVoid)
+            if (!Signature.ReturnType.IsVoid)
             {
                 returnValueLocal = emitter.NewLocal(Signature.ReturnType);
             }
@@ -543,7 +543,7 @@ namespace Internal.IL.Stubs
 
             callSiteSetupStream.Emit(ILOpcode.calli, emitter.NewToken(targetMethodSig));
 
-            if (!delegateSignature.ReturnType.IsSignatureVariable && delegateSignature.ReturnType.IsVoid)
+            if (delegateSignature.ReturnType.IsVoid)
             {
                 callSiteSetupStream.Emit(ILOpcode.ldnull);
             }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.Metadata
         private Action<Cts.ArrayType, TypeSpecification> _initArray;
         private Action<Cts.ByRefType, TypeSpecification> _initByRef;
         private Action<Cts.PointerType, TypeSpecification> _initPointer;
-        private Action<Cts.InstantiatedType, TypeSpecification> _initTypeInst;
+        private Action<Cts.TypeDesc, TypeSpecification> _initTypeInst;
         private Action<Cts.SignatureTypeVariable, TypeSpecification> _initTypeVar;
         private Action<Cts.SignatureMethodVariable, TypeSpecification> _initMethodVar;
 
@@ -39,54 +39,53 @@ namespace ILCompiler.Metadata
                 return rec;
             }
 
-            if (type.IsSzArray)
+            switch (type.Category)
             {
-                var arrayType = (Cts.ArrayType)type;
-                rec = _types.Create(arrayType, _initSzArray ?? (_initSzArray = InitializeSzArray));
-            }
-            else if (type.IsArray)
-            {
-                var arrayType = (Cts.ArrayType)type;
-                rec = _types.Create(arrayType, _initArray ?? (_initArray = InitializeArray));
-            }
-            else if (type.IsByRef)
-            {
-                var byRefType = (Cts.ByRefType)type;
-                rec = _types.Create(byRefType, _initByRef ?? (_initByRef = InitializeByRef));
-            }
-            else if (type.IsPointer)
-            {
-                var pointerType = (Cts.PointerType)type;
-                rec = _types.Create(pointerType, _initPointer ?? (_initPointer = InitializePointer));
-            }
-            else if (type is Cts.SignatureTypeVariable)
-            {
-                var variable = (Cts.SignatureTypeVariable)type;
-                rec = _types.Create(variable, _initTypeVar ?? (_initTypeVar = InitializeTypeVariable));
-            }
-            else if (type is Cts.SignatureMethodVariable)
-            {
-                var variable = (Cts.SignatureMethodVariable)type;
-                rec = _types.Create(variable, _initMethodVar ?? (_initMethodVar = InitializeMethodVariable));
-            }
-            else if (type is Cts.InstantiatedType)
-            {
-                var instType = (Cts.InstantiatedType)type;
-                rec = _types.Create(instType, _initTypeInst ?? (_initTypeInst = InitializeTypeInstance));
-            }
-            else
-            {
-                var metadataType = (Cts.MetadataType)type;
-                if (_policy.GeneratesMetadata(metadataType))
-                {
-                    rec = _types.Create(metadataType, _initTypeDef ?? (_initTypeDef = InitializeTypeDef));
-                }
-                else
-                {
-                    rec = _types.Create(metadataType, _initTypeRef ?? (_initTypeRef = InitializeTypeRef));
-                }
-            }
+                case Cts.TypeFlags.SzArray:
+                    rec = _types.Create((Cts.ArrayType)type, _initSzArray ?? (_initSzArray = InitializeSzArray));
+                    break;
+                case Cts.TypeFlags.Array:
+                    rec = _types.Create((Cts.ArrayType)type, _initArray ?? (_initArray = InitializeArray));
+                    break;
+                case Cts.TypeFlags.ByRef:
+                    rec = _types.Create((Cts.ByRefType)type, _initByRef ?? (_initByRef = InitializeByRef));
+                    break;
+                case Cts.TypeFlags.Pointer:
+                    rec = _types.Create((Cts.PointerType)type, _initPointer ?? (_initPointer = InitializePointer));
+                    break;
+                case Cts.TypeFlags.SignatureTypeVariable:
+                    rec = _types.Create((Cts.SignatureTypeVariable)type, _initTypeVar ?? (_initTypeVar = InitializeTypeVariable));
+                    break;
+                case Cts.TypeFlags.SignatureMethodVariable:
+                    rec = _types.Create((Cts.SignatureMethodVariable)type, _initMethodVar ?? (_initMethodVar = InitializeMethodVariable));
+                    break;
+                default:
+                    {
+                        Debug.Assert(type.IsDefType);
 
+                        if (!type.IsTypeDefinition)
+                        {
+                            // Instantiated generic type
+                            rec = _types.Create(type, _initTypeInst ?? (_initTypeInst = InitializeTypeInstance));
+                        }
+                        else
+                        {
+                            // Type definition
+                            var metadataType = (Cts.MetadataType)type;
+                            if (_policy.GeneratesMetadata(metadataType))
+                            {
+                                rec = _types.Create(metadataType, _initTypeDef ?? (_initTypeDef = InitializeTypeDef));
+                            }
+                            else
+                            {
+                                rec = _types.Create(metadataType, _initTypeRef ?? (_initTypeRef = InitializeTypeRef));
+                            }
+                        }
+                    }
+                    break;
+            }
+            
+ 
             Debug.Assert(rec is TypeDefinition || rec is TypeReference || rec is TypeSpecification);
 
             return rec;
@@ -143,7 +142,7 @@ namespace ILCompiler.Metadata
             };
         }
 
-        private void InitializeTypeInstance(Cts.InstantiatedType entity, TypeSpecification record)
+        private void InitializeTypeInstance(Cts.TypeDesc entity, TypeSpecification record)
         {
             var sig = new TypeInstantiationSignature
             {


### PR DESCRIPTION
This makes signature variables easier to handle in various double
dispatch scenarios.