### PR TITLE
Couple fixes

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataTypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataTypeSystemContext.cs
@@ -41,7 +41,7 @@ namespace Internal.TypeSystem
             "Exception",
         };
 
-        private MetadataType[] _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
+        private MetadataType[] _wellKnownTypes;
 
         public MetadataTypeSystemContext()
         {
@@ -59,6 +59,8 @@ namespace Internal.TypeSystem
             // Sanity check the name table
             Debug.Assert(s_wellKnownTypeNames[(int)WellKnownType.MulticastDelegate - 1] == "MulticastDelegate");
 
+            _wellKnownTypes = new MetadataType[s_wellKnownTypeNames.Length];
+
             // Initialize all well known types - it will save us from checking the name for each loaded type
             for (int typeIndex = 0; typeIndex < _wellKnownTypes.Length; typeIndex++)
             {
@@ -70,6 +72,7 @@ namespace Internal.TypeSystem
 
         public override DefType GetWellKnownType(WellKnownType wellKnownType)
         {
+            Debug.Assert(_wellKnownTypes != null, "Forgot to call SetSystemModule?");
             return _wellKnownTypes[(int)wellKnownType - 1];
         }
     }

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -393,14 +393,14 @@ namespace Internal.TypeSystem.Ecma
 
             Object resolutionScope = GetObject(typeReference.ResolutionScope);
 
-            if (resolutionScope is EcmaModule)
+            if (resolutionScope is ModuleDesc)
             {
-                return ((EcmaModule)(resolutionScope)).GetType(_metadataReader.GetString(typeReference.Namespace), _metadataReader.GetString(typeReference.Name));
+                return ((ModuleDesc)(resolutionScope)).GetType(_metadataReader.GetString(typeReference.Namespace), _metadataReader.GetString(typeReference.Name));
             }
             else
-            if (resolutionScope is EcmaType)
+            if (resolutionScope is MetadataType)
             {
-                return ((EcmaType)(resolutionScope)).GetNestedType(_metadataReader.GetString(typeReference.Name));
+                return ((MetadataType)(resolutionScope)).GetNestedType(_metadataReader.GetString(typeReference.Name));
             }
 
             // TODO


### PR DESCRIPTION
* If user forgets to call `SetSystemModule`, make sure
`GetWellKnownType` will fail (instead of returning `null` that will
nullref sometime later).
* Allow `EcmaModule` to resolve type references in non-ECMA modules and
types.