### PR TITLE
Format/style pass over System.Private.Reflection.Core.

### DIFF
--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Collections.Generic;
-using global::System.Reflection;
-using global::Internal.Metadata.NativeFormat;
-using global::System.Reflection.Runtime.General;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Internal.Metadata.NativeFormat;
+using System.Reflection.Runtime.General;
 
 namespace Internal.Reflection.Core
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.MethodInfos;
-using global::System.Reflection.Runtime.TypeParsing;
-using global::System.Reflection.Runtime.CustomAttributes;
-using global::Internal.Metadata.NativeFormat;
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.MethodInfos;
+using System.Reflection.Runtime.TypeParsing;
+using System.Reflection.Runtime.CustomAttributes;
+using Internal.Metadata.NativeFormat;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
 namespace Internal.Reflection.Core.Execution
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.IO;
-using global::System.Reflection;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::Internal.Metadata.NativeFormat;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using Internal.Metadata.NativeFormat;
 
-using OpenMethodInvoker = global::System.Reflection.Runtime.MethodInfos.OpenMethodInvoker;
+using OpenMethodInvoker = System.Reflection.Runtime.MethodInfos.OpenMethodInvoker;
 
 namespace Internal.Reflection.Core.Execution
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/FieldAccessor.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/FieldAccessor.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Collections.Generic;
-using global::Internal.Metadata.NativeFormat;
+using System;
+using System.Collections.Generic;
+using Internal.Metadata.NativeFormat;
 
 namespace Internal.Reflection.Core.Execution
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/InvokerOptions.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/InvokerOptions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
+using System;
 
 namespace Internal.Reflection.Core.Execution
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/MethodInvoker.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/MethodInvoker.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
+using System;
+using System.Reflection;
+using System.Diagnostics;
 
 namespace Internal.Reflection.Core.Execution
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ReflectionCoreExecution.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ReflectionCoreExecution.cs
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Augments;
-using global::Internal.Reflection.Core.Execution;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Augments;
+using Internal.Reflection.Core.Execution;
 
 namespace Internal.Reflection.Core.Execution
 {
@@ -22,9 +22,9 @@ namespace Internal.Reflection.Core.Execution
         {
             ExecutionDomain executionDomain = new ExecutionDomain(executionDomainSetup, executionEnvironment);
             //@todo: This check has a race window but since this is a private api targeted by the toolchain, perhaps this is not so critical.
-            if (_executionDomain != null)
+            if (s_executionDomain != null)
                 throw new InvalidOperationException(); // Multiple Initializes not allowed.
-            _executionDomain = executionDomain;
+            s_executionDomain = executionDomain;
 
             ReflectionCoreCallbacks reflectionCallbacks = new ReflectionCoreCallbacksImplementation();
             ReflectionAugments.Initialize(reflectionCallbacks);
@@ -35,7 +35,7 @@ namespace Internal.Reflection.Core.Execution
         {
             get
             {
-                return _executionDomain;
+                return s_executionDomain;
             }
         }
 
@@ -47,6 +47,6 @@ namespace Internal.Reflection.Core.Execution
             }
         }
 
-        private volatile static ExecutionDomain _executionDomain;
+        private volatile static ExecutionDomain s_executionDomain;
     }
 }

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/FoundationTypes.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/FoundationTypes.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
+using System;
+using System.Reflection;
 
 namespace Internal.Reflection.Core
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/ReflectionDomainSetup.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/ReflectionDomainSetup.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Reflection.Runtime.General;
+using System;
+using System.Reflection;
+using System.Reflection.Runtime.General;
 
 namespace Internal.Reflection.Core
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ITraceableTypeMember.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ITraceableTypeMember.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
+using System;
+using System.Reflection;
+using System.Diagnostics;
 
 namespace Internal.Reflection.Tracing
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Internal.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Internal.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Text;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Text;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace Internal.Reflection.Tracing
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Public.Events.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Public.Events.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using ReflectionEventSource = global::System.Reflection.Runtime.Tracing.ReflectionEventSource;
+using ReflectionEventSource = System.Reflection.Runtime.Tracing.ReflectionEventSource;
 
 namespace Internal.Reflection.Tracing
 {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Public.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Public.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Runtime.CompilerServices;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
-using ReflectionEventSource = global::System.Reflection.Runtime.Tracing.ReflectionEventSource;
+using ReflectionEventSource = System.Reflection.Runtime.Tracing.ReflectionEventSource;
 
 namespace Internal.Reflection.Tracing
 {

--- a/src/System.Private.Reflection.Core/src/System/DBNull.cs
+++ b/src/System.Private.Reflection.Core/src/System/DBNull.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System.Diagnostics;
+using System.Diagnostics;
 
 namespace System
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/AssemblyNameHelpers.StrongName.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/AssemblyNameHelpers.StrongName.cs
@@ -10,14 +10,14 @@
 **
 ==============================================================*/
 
-using global::System;
-using global::System.IO;
-using global::System.Text;
-using global::System.Collections.Generic;
-using global::Internal.Runtime.Augments;
+using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+using Internal.Runtime.Augments;
 using Buffer = System.Buffer;
 
-using SecurityException = global::System.Security.SecurityException;
+using SecurityException = System.Security.SecurityException;
 
 namespace System.Reflection.Runtime.Assemblies
 {
@@ -75,7 +75,7 @@ namespace System.Reflection.Runtime.Assemblies
 
             // The ECMA key doesn't look like a valid key so it will fail the below checks. If we were passed that
             // key, then we can skip them.
-            if (ByteArrayEquals(publicKey, EcmaKey))
+            if (ByteArrayEquals(publicKey, s_ecmaKey))
                 return true;
 
             // If a hash algorithm is specified, it must be a sensible value
@@ -130,7 +130,7 @@ namespace System.Reflection.Runtime.Assemblies
 
         private const int PUBLIC_KEY_TOKEN_LEN = 8;
 
-        private static byte[] EcmaKey =
+        private static byte[] s_ecmaKey =
         {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         };

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/AssemblyNameHelpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/AssemblyNameHelpers.cs
@@ -9,11 +9,11 @@
 **
 ==============================================================*/
 
-using global::System;
-using global::System.Globalization;
-using global::System.IO;
-using global::System.Text;
-using global::System.Collections.Generic;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
 
 namespace System.Reflection.Runtime.Assemblies
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/AssemblyNameLexer.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/AssemblyNameLexer.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.IO;
-using global::System.Text;
-using global::System.Globalization;
-using global::System.Collections.Generic;
-using global::System.Runtime.InteropServices;
+using System;
+using System.IO;
+using System.Text;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace System.Reflection.Runtime.Assemblies
 {
@@ -63,7 +63,7 @@ namespace System.Reflection.Runtime.Assemblies
                 c = _chars[_index++];
             }
 
-            for (; ;)
+            for (;;)
             {
                 if (c == 0)
                 {
@@ -133,7 +133,7 @@ namespace System.Reflection.Runtime.Assemblies
             End = 4,
         }
 
-        private char[] _chars;
+        private readonly char[] _chars;
         private int _index;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/AssemblyNameParser.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/AssemblyNameParser.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.IO;
-using global::System.Text;
-using global::System.Diagnostics;
-using global::System.Globalization;
-using global::System.Collections.Generic;
-using global::System.Runtime.InteropServices;
+using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace System.Reflection.Runtime.Assemblies
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
@@ -2,24 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.IO;
-using global::System.Text;
-using global::System.Diagnostics;
-using global::System.Reflection;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.Modules;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.TypeParsing;
-using global::System.Reflection.Runtime.CustomAttributes;
-using global::System.Collections.Generic;
+using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.Modules;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.TypeParsing;
+using System.Reflection.Runtime.CustomAttributes;
+using System.Collections.Generic;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
-using global::Internal.Metadata.NativeFormat;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
+using Internal.Metadata.NativeFormat;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
 namespace System.Reflection.Runtime.Assemblies
 {
@@ -208,9 +208,9 @@ namespace System.Reflection.Runtime.Assemblies
             return result.CastToType();
         }
 
-        internal QScopeDefinition Scope { get; private set; }
+        internal QScopeDefinition Scope { get; }
 
-        internal IEnumerable<QScopeDefinition> OverflowScopes { get; private set; }
+        internal IEnumerable<QScopeDefinition> OverflowScopes { get; }
 
         internal IEnumerable<QScopeDefinition> AllScopes
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssemblyName.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssemblyName.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.IO;
-using global::System.Text;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using global::Internal.Reflection.Augments;
+using Internal.Reflection.Augments;
 
 namespace System.Reflection.Runtime.Assemblies
 {
@@ -41,19 +41,19 @@ namespace System.Reflection.Runtime.Assemblies
         }
 
         // Simple name.
-        public String Name { get; private set; }
+        public String Name { get; }
 
         // Optional version.
-        public Version Version { get; private set; }
+        public Version Version { get; }
 
         // Optional culture name.
-        public String CultureName { get; private set; }
+        public String CultureName { get; }
 
         // Optional flags (this is actually an OR of the classic flags and the ContentType.)
-        public AssemblyNameFlags Flags { get; private set; }
+        public AssemblyNameFlags Flags { get; }
 
         // Optional public key (if Flags.PublicKey == true) or public key token.
-        public byte[] PublicKeyOrToken { get; private set; }
+        public byte[] PublicKeyOrToken { get; }
 
         // Equality - this compares every bit of data in the RuntimeAssemblyName which is acceptable for use as keys in a cache
         // where semantic duplication is permissible. This method is *not* meant to define ref->def binding rules or 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Collections.ObjectModel;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Extensibility;
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Tracing;
-using global::Internal.Metadata.NativeFormat;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Core;
+using Internal.Reflection.Extensibility;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Tracing;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.CustomAttributes
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeNormalCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeNormalCustomAttributeData.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections;
-using global::System.Collections.Generic;
-using global::System.Collections.ObjectModel;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
-using global::Internal.Metadata.NativeFormat;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.CustomAttributes
 {
@@ -235,8 +235,8 @@ namespace System.Reflection.Runtime.CustomAttributes
             }
         }
 
-        private MetadataReader _reader;
-        private CustomAttribute _customAttribute;
+        private readonly MetadataReader _reader;
+        private readonly CustomAttribute _customAttribute;
 
         private volatile Type _lazyAttributeType;
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Collections.ObjectModel;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Core;
-using global::Internal.Metadata.NativeFormat;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Core;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.CustomAttributes
 {
@@ -61,8 +61,8 @@ namespace System.Reflection.Runtime.CustomAttributes
 
         // Equals/GetHashCode no need to override (they just implement reference equality but desktop never unified these things.)
 
-        private RuntimeTypeInfo _attributeType;
-        private ReadOnlyCollection<CustomAttributeTypedArgument> _constructorArguments;
-        private ReadOnlyCollection<CustomAttributeNamedArgument> _namedArguments;
+        private readonly RuntimeTypeInfo _attributeType;
+        private readonly ReadOnlyCollection<CustomAttributeTypedArgument> _constructorArguments;
+        private readonly ReadOnlyCollection<CustomAttributeNamedArgument> _namedArguments;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DefaultDispenserPolicy.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DefaultDispenserPolicy.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
+using System;
+using System.Diagnostics;
 
 namespace System.Reflection.Runtime.Dispensers
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/Dispenser.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/Dispenser.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
+using System;
+using System.Diagnostics;
 
 namespace System.Reflection.Runtime.Dispensers
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserAlgorithm.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserAlgorithm.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
+using System;
+using System.Diagnostics;
 
 namespace System.Reflection.Runtime.Dispensers
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserFactory.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserFactory.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
-using global::System.Reflection.Runtime.TypeInfos;
+using System;
+using System.Diagnostics;
+using System.Reflection.Runtime.TypeInfos;
 
 namespace System.Reflection.Runtime.Dispensers
 {
@@ -20,7 +20,7 @@ namespace System.Reflection.Runtime.Dispensers
             where K : class, IEquatable<K>
             where V : class
         {
-            DispenserAlgorithm algorithm = _dispenserPolicy.GetAlgorithm(scenario);
+            DispenserAlgorithm algorithm = s_dispenserPolicy.GetAlgorithm(scenario);
             if (algorithm == DispenserAlgorithm.ReuseAsLongAsKeyIsAlive)
                 return new DispenserThatReusesAsLongAsKeyIsAlive<K, V>(factory);
             else
@@ -38,7 +38,7 @@ namespace System.Reflection.Runtime.Dispensers
             where K : IEquatable<K>
             where V : class
         {
-            DispenserAlgorithm algorithm = _dispenserPolicy.GetAlgorithm(scenario);
+            DispenserAlgorithm algorithm = s_dispenserPolicy.GetAlgorithm(scenario);
 
             Debug.Assert(algorithm != DispenserAlgorithm.ReuseAsLongAsKeyIsAlive,
                 "Use CreateDispenser() if you want to use this algorithm. The key must not be a valuetype.");
@@ -54,7 +54,7 @@ namespace System.Reflection.Runtime.Dispensers
         }
 
 
-        private static DispenserPolicy _dispenserPolicy = new DefaultDispenserPolicy();
+        private static readonly DispenserPolicy s_dispenserPolicy = new DefaultDispenserPolicy();
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserPolicy.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserPolicy.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
+using System;
+using System.Diagnostics;
 
 namespace System.Reflection.Runtime.Dispensers
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserScenario.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserScenario.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
+using System;
+using System.Diagnostics;
 
 namespace System.Reflection.Runtime.Dispensers
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserThatAlwaysCreates.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserThatAlwaysCreates.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
+using System;
+using System.Diagnostics;
 
 namespace System.Reflection.Runtime.Dispensers
 {
@@ -24,7 +24,7 @@ namespace System.Reflection.Runtime.Dispensers
             return _factory(key);
         }
 
-        private Func<K, V> _factory;
+        private readonly Func<K, V> _factory;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserThatAlwaysReuses.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserThatAlwaysReuses.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
-using global::System.Collections.Concurrent;
+using System;
+using System.Diagnostics;
+using System.Collections.Concurrent;
 
 namespace System.Reflection.Runtime.Dispensers
 {
@@ -37,10 +37,10 @@ namespace System.Reflection.Runtime.Dispensers
                 return _factory(key);
             }
 
-            private Func<K, V> _factory;
+            private readonly Func<K, V> _factory;
         }
 
-        private FactoryConcurrentUnifier _concurrentUnifier;
+        private readonly FactoryConcurrentUnifier _concurrentUnifier;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserThatReusesAsLongAsKeyIsAlive.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserThatReusesAsLongAsKeyIsAlive.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
-using global::System.Runtime.CompilerServices;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.Reflection.Runtime.Dispensers
 {
@@ -29,9 +29,9 @@ namespace System.Reflection.Runtime.Dispensers
             return _factory(key);
         }
 
-        private Func<K, V> _factory;
-        private ConditionalWeakTable<K, V> _conditionalWeakTable;
-        private ConditionalWeakTable<K, V>.CreateValueCallback _createValueCallback;
+        private readonly Func<K, V> _factory;
+        private readonly ConditionalWeakTable<K, V> _conditionalWeakTable;
+        private readonly ConditionalWeakTable<K, V>.CreateValueCallback _createValueCallback;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserThatReusesAsLongAsValueIsAlive.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Dispensers/DispenserThatReusesAsLongAsValueIsAlive.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
-using global::System.Collections.Concurrent;
+using System;
+using System.Diagnostics;
+using System.Collections.Concurrent;
 
 namespace System.Reflection.Runtime.Dispensers
 {
@@ -37,10 +37,10 @@ namespace System.Reflection.Runtime.Dispensers
                 return _factory(key);
             }
 
-            private Func<K, V> _factory;
+            private readonly Func<K, V> _factory;
         }
 
-        private FactoryConcurrentUnifierW _concurrentUnifier;
+        private readonly FactoryConcurrentUnifierW _concurrentUnifier;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -2,22 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Runtime.CompilerServices;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.MethodInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.MethodInfos;
+using System.Reflection.Runtime.ParameterInfos;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
+using Internal.Reflection.Tracing;
 
 namespace System.Reflection.Runtime.EventInfos
 {
@@ -126,11 +126,11 @@ namespace System.Reflection.Runtime.EventInfos
             RuntimeEventInfo other = obj as RuntimeEventInfo;
             if (other == null)
                 return false;
-            if (!(this._reader == other._reader))
+            if (!(_reader == other._reader))
                 return false;
-            if (!(this._eventHandle.Equals(other._eventHandle)))
+            if (!(_eventHandle.Equals(other._eventHandle)))
                 return false;
-            if (!(this._contextTypeInfo.Equals(other._contextTypeInfo)))
+            if (!(_contextTypeInfo.Equals(other._contextTypeInfo)))
                 return false;
             return true;
         }
@@ -262,12 +262,12 @@ namespace System.Reflection.Runtime.EventInfos
             return this;
         }
 
-        private RuntimeNamedTypeInfo _definingTypeInfo;
-        private EventHandle _eventHandle;
-        private RuntimeTypeInfo _contextTypeInfo;
+        private readonly RuntimeNamedTypeInfo _definingTypeInfo;
+        private readonly EventHandle _eventHandle;
+        private readonly RuntimeTypeInfo _contextTypeInfo;
 
-        private MetadataReader _reader;
-        private Event _event;
+        private readonly MetadataReader _reader;
+        private readonly Event _event;
 
         private String _debugName;
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/LiteralFieldAccessor.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/LiteralFieldAccessor.cs
@@ -2,21 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
-using FieldAccessException = global::System.MemberAccessException;
+using FieldAccessException = System.MemberAccessException;
 
 namespace System.Reflection.Runtime.FieldInfos
 {
@@ -37,7 +37,7 @@ namespace System.Reflection.Runtime.FieldInfos
             throw new FieldAccessException(SR.Acc_ReadOnly);
         }
 
-        private Object _value;
+        private readonly Object _value;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -2,23 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Runtime.CompilerServices;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
 namespace System.Reflection.Runtime.FieldInfos
 {
@@ -157,11 +157,11 @@ namespace System.Reflection.Runtime.FieldInfos
             RuntimeFieldInfo other = obj as RuntimeFieldInfo;
             if (other == null)
                 return false;
-            if (!(this._reader == other._reader))
+            if (!(_reader == other._reader))
                 return false;
-            if (!(this._fieldHandle.Equals(other._fieldHandle)))
+            if (!(_fieldHandle.Equals(other._fieldHandle)))
                 return false;
-            if (!(this._contextTypeInfo.Equals(other._contextTypeInfo)))
+            if (!(_contextTypeInfo.Equals(other._contextTypeInfo)))
                 return false;
             return true;
         }
@@ -250,12 +250,12 @@ namespace System.Reflection.Runtime.FieldInfos
             return this;
         }
 
-        private RuntimeNamedTypeInfo _definingTypeInfo;
-        private FieldHandle _fieldHandle;
-        private RuntimeTypeInfo _contextTypeInfo;
+        private readonly RuntimeNamedTypeInfo _definingTypeInfo;
+        private readonly FieldHandle _fieldHandle;
+        private readonly RuntimeTypeInfo _contextTypeInfo;
 
-        private MetadataReader _reader;
-        private Field _field;
+        private readonly MetadataReader _reader;
+        private readonly Field _field;
 
         private volatile FieldAccessor _lazyFieldAccessor = null;
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Assignability.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Assignability.cs
@@ -71,7 +71,7 @@ namespace System.Reflection.Runtime.General
                 if (fromTypeInfo.IsSubclassOf(toType))
                     return true;  // T[] is castable to Array or Object.
 
-                if (!toTypeInfo.IsArray) 
+                if (!toTypeInfo.IsArray)
                     return false;
 
                 int rank = fromTypeInfo.GetArrayRank();
@@ -248,7 +248,7 @@ namespace System.Reflection.Runtime.General
             }
             return true;
         }
-        
+
         //
         // A[] can cast to B[] if one of the following are true:
         //
@@ -314,7 +314,7 @@ namespace System.Reflection.Runtime.General
             if (fromTypeInfo.ProvablyAGcReferenceType(foundationTypes))
                 return fromTypeInfo.CanCastTo(toTypeInfo, foundationTypes);
 
-            return false; 
+            return false;
         }
 
         //
@@ -349,7 +349,7 @@ namespace System.Reflection.Runtime.General
                 foreach (Type constraintType in t.GetGenericParameterConstraints())
                 {
                     if (constraintType.GetTypeInfo().ProvablyAGcReferenceTypeHelper(foundationTypes))
-                        return true; 
+                        return true;
                 }
                 return false;
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/BlockedRuntimeTypeNameGenerator.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/BlockedRuntimeTypeNameGenerator.cs
@@ -26,7 +26,7 @@ namespace System.Reflection.Runtime.General
 
         private sealed class BlockedRuntimeTypeNameTable : ConcurrentUnifier<RuntimeTypeHandleKey, string>
         {
-            protected override string Factory(RuntimeTypeHandleKey key)
+            protected sealed override string Factory(RuntimeTypeHandleKey key)
             {
                 uint count = s_counter++;
                 return "$BlockedFromReflection_" + count.ToString() + "_" + Guid.NewGuid().ToString().Substring(0, 8);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
@@ -2,21 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Text;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.TypeParsing;
+using System;
+using System.Text;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.TypeParsing;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Core;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Core;
 
-using global::Internal.Runtime.Augments;
+using Internal.Runtime.Augments;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.General
 {
@@ -291,7 +291,6 @@ namespace System.Reflection.Runtime.General
                         throw new BadImageFormatException();
                 }
             }
-
         }
 
         public static Object ParseConstantValue(this Handle handle, MetadataReader reader)
@@ -517,7 +516,7 @@ namespace System.Reflection.Runtime.General
         public static String ToNamespaceName(this NamespaceDefinitionHandle namespaceDefinitionHandle, MetadataReader reader)
         {
             String ns = "";
-            for (; ;)
+            for (;;)
             {
                 NamespaceDefinition currentNamespaceDefinition = namespaceDefinitionHandle.GetNamespaceDefinition(reader);
                 String name = currentNamespaceDefinition.Name.GetStringOrNull(reader);
@@ -590,7 +589,7 @@ namespace System.Reflection.Runtime.General
         {
             LowLevelList<String> namespaceParts = new LowLevelList<String>(8);
             NamespaceReference namespaceReference;
-            for (; ;)
+            for (;;)
             {
                 namespaceReference = namespaceReferenceHandle.GetNamespaceReference(reader);
                 String namespacePart = namespaceReference.Name.GetStringOrNull(reader);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NamespaceChain.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NamespaceChain.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Text;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Text;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.General
 {
@@ -24,7 +24,7 @@ namespace System.Reflection.Runtime.General
             ConstantStringValueHandle currentNameHandle = currentNamespaceDefinition.Name;
             Handle currentNamespaceHandle = innerMostNamespaceHandle.ToHandle(reader);
             LowLevelList<String> names = new LowLevelList<String>();
-            for (; ;)
+            for (;;)
             {
                 String name = currentNameHandle.GetStringOrNull(reader);
                 names.Add(name);
@@ -74,8 +74,8 @@ namespace System.Reflection.Runtime.General
             }
         }
 
-        internal String NameSpace { get; private set; }
-        internal ScopeDefinitionHandle DefiningScope { get; private set; }
+        internal String NameSpace { get; }
+        internal ScopeDefinitionHandle DefiningScope { get; }
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QHandles.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QHandles.cs
@@ -5,11 +5,11 @@
 // Collection of "qualified handle" tuples.
 //
 
-using global::System;
-using global::System.Collections.Generic;
-using global::System.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace Internal.Reflection.Core
 {
@@ -40,9 +40,9 @@ namespace Internal.Reflection.Core
 
         public bool Equals(QScopeDefinition other)
         {
-            if (!(this._reader == other._reader))
+            if (!(_reader == other._reader))
                 return false;
-            if (!(this._handle.Equals(other._handle)))
+            if (!(_handle.Equals(other._handle)))
                 return false;
             return true;
         }
@@ -52,8 +52,8 @@ namespace Internal.Reflection.Core
             return _handle.GetHashCode();
         }
 
-        private MetadataReader _reader;
-        private ScopeDefinitionHandle _handle;
+        private readonly MetadataReader _reader;
+        private readonly ScopeDefinitionHandle _handle;
     }
 }
 
@@ -79,9 +79,9 @@ namespace System.Reflection.Runtime.General
 
         public bool Equals(QHandle other)
         {
-            if (!(this._reader == other._reader))
+            if (!(_reader == other._reader))
                 return false;
-            if (!(this._handle.Equals(other._handle)))
+            if (!(_handle.Equals(other._handle)))
                 return false;
             return true;
         }
@@ -91,8 +91,8 @@ namespace System.Reflection.Runtime.General
             return _handle.GetHashCode();
         }
 
-        private MetadataReader _reader;
-        private Handle _handle;
+        private readonly MetadataReader _reader;
+        private readonly Handle _handle;
     }
 
 
@@ -116,9 +116,9 @@ namespace System.Reflection.Runtime.General
 
         public bool Equals(QTypeDefinition other)
         {
-            if (!(this._reader == other._reader))
+            if (!(_reader == other._reader))
                 return false;
-            if (!(this._handle.Equals(other._handle)))
+            if (!(_handle.Equals(other._handle)))
                 return false;
             return true;
         }
@@ -128,8 +128,8 @@ namespace System.Reflection.Runtime.General
             return _handle.GetHashCode();
         }
 
-        private MetadataReader _reader;
-        private TypeDefinitionHandle _handle;
+        private readonly MetadataReader _reader;
+        private readonly TypeDefinitionHandle _handle;
     }
 
 
@@ -152,8 +152,8 @@ namespace System.Reflection.Runtime.General
 
         public static readonly QTypeDefRefOrSpec Null = default(QTypeDefRefOrSpec);
 
-        private MetadataReader _reader;
-        private Handle _handle;
+        private readonly MetadataReader _reader;
+        private readonly Handle _handle;
     }
 
     internal struct QGenericParameter : IEquatable<QGenericParameter>
@@ -176,9 +176,9 @@ namespace System.Reflection.Runtime.General
 
         public bool Equals(QGenericParameter other)
         {
-            if (!(this._reader == other._reader))
+            if (!(_reader == other._reader))
                 return false;
-            if (!(this._handle.Equals(other._handle)))
+            if (!(_handle.Equals(other._handle)))
                 return false;
             return true;
         }
@@ -188,7 +188,7 @@ namespace System.Reflection.Runtime.General
             return _handle.GetHashCode();
         }
 
-        private MetadataReader _reader;
-        private GenericParameterHandle _handle;
+        private readonly MetadataReader _reader;
+        private readonly GenericParameterHandle _handle;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.FieldInfos;
-using global::System.Reflection.Runtime.MethodInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.FieldInfos;
+using System.Reflection.Runtime.MethodInfos;
 
-using global::Internal.Reflection.Augments;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Augments;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.General
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ToStringUtils.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ToStringUtils.cs
@@ -2,21 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.TypeParsing;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.TypeParsing;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.General
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeContext.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeContext.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
+using System;
+using System.Diagnostics;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
 
 namespace System.Reflection.Runtime.General
 {
@@ -38,8 +38,8 @@ namespace System.Reflection.Runtime.General
             }
         }
 
-        private RuntimeTypeInfo[] _genericTypeArguments;
-        private RuntimeTypeInfo[] _genericMethodArguments;
+        private readonly RuntimeTypeInfo[] _genericTypeArguments;
+        private readonly RuntimeTypeInfo[] _genericMethodArguments;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.TypeParsing;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.TypeParsing;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.General
 {
@@ -24,7 +24,7 @@ namespace System.Reflection.Runtime.General
         //
         // Main routine to resolve a typeDef/Ref/Spec.
         //
-        internal static RuntimeTypeInfo Resolve(this Handle typeDefRefOrSpec, MetadataReader reader,TypeContext typeContext)
+        internal static RuntimeTypeInfo Resolve(this Handle typeDefRefOrSpec, MetadataReader reader, TypeContext typeContext)
         {
             Exception exception = null;
             RuntimeTypeInfo runtimeType = typeDefRefOrSpec.TryResolve(reader, typeContext, ref exception);
@@ -151,9 +151,9 @@ namespace System.Reflection.Runtime.General
         //
         private static RuntimeTypeInfo TryResolveTypeReference(this TypeReferenceHandle typeReferenceHandle, MetadataReader reader, ref Exception exception)
         {
-           RuntimeTypeHandle resolvedRuntimeTypeHandle;
-           if (ReflectionCoreExecution.ExecutionEnvironment.TryGetNamedTypeForTypeReference(reader, typeReferenceHandle, out resolvedRuntimeTypeHandle))
-               return resolvedRuntimeTypeHandle.GetTypeForRuntimeTypeHandle();
+            RuntimeTypeHandle resolvedRuntimeTypeHandle;
+            if (ReflectionCoreExecution.ExecutionEnvironment.TryGetNamedTypeForTypeReference(reader, typeReferenceHandle, out resolvedRuntimeTypeHandle))
+                return resolvedRuntimeTypeHandle.GetTypeForRuntimeTypeHandle();
 
             TypeReference typeReference = typeReferenceHandle.GetTypeReference(reader);
             String name = typeReference.TypeName.GetString(reader);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/OpenMethodInvoker.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/OpenMethodInvoker.cs
@@ -2,16 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {
@@ -56,13 +56,13 @@ namespace System.Reflection.Runtime.MethodInfos
             RuntimeConstructedGenericMethodInfo other = obj as RuntimeConstructedGenericMethodInfo;
             if (other == null)
                 return false;
-            if (!this._genericMethodDefinition.Equals(other._genericMethodDefinition))
+            if (!_genericMethodDefinition.Equals(other._genericMethodDefinition))
                 return false;
-            if (this._genericTypeArguments.Length != other._genericTypeArguments.Length)
+            if (_genericTypeArguments.Length != other._genericTypeArguments.Length)
                 return false;
             for (int i = 0; i < _genericTypeArguments.Length; i++)
             {
-                if (!this._genericTypeArguments[i].Equals(other._genericTypeArguments[i]))
+                if (!_genericTypeArguments[i].Equals(other._genericTypeArguments[i]))
                     return false;
             }
             return true;
@@ -162,8 +162,8 @@ namespace System.Reflection.Runtime.MethodInfos
             return _genericMethodDefinition.GetRuntimeParametersAndReturn(this);
         }
 
-        private RuntimeNamedMethodInfo _genericMethodDefinition;
-        private RuntimeTypeInfo[] _genericTypeArguments;
+        private readonly RuntimeNamedMethodInfo _genericMethodDefinition;
+        private readonly RuntimeTypeInfo[] _genericTypeArguments;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
 namespace System.Reflection.Runtime.MethodInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodCommon.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Text;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System;
+using System.Text;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {
@@ -268,11 +268,11 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public bool Equals(RuntimeMethodCommon other)
         {
-            if (!(this._reader == other._reader))
+            if (!(_reader == other._reader))
                 return false;
-            if (!(this._methodHandle.Equals(other._methodHandle)))
+            if (!(_methodHandle.Equals(other._methodHandle)))
                 return false;
-            if (!(this._contextTypeInfo.Equals(other._contextTypeInfo)))
+            if (!(_contextTypeInfo.Equals(other._contextTypeInfo)))
                 return false;
             return true;
         }
@@ -290,12 +290,12 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
-        private RuntimeNamedTypeInfo _definingTypeInfo;
-        private MethodHandle _methodHandle;
-        private RuntimeTypeInfo _contextTypeInfo;
+        private readonly RuntimeNamedTypeInfo _definingTypeInfo;
+        private readonly MethodHandle _methodHandle;
+        private readonly RuntimeTypeInfo _contextTypeInfo;
 
-        private MetadataReader _reader;
+        private readonly MetadataReader _reader;
 
-        private Method _method;
+        private readonly Method _method;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Runtime.CompilerServices;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
+using Internal.Reflection.Tracing;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {
@@ -268,7 +268,7 @@ namespace System.Reflection.Runtime.MethodInfos
         private Delegate CreateDelegate(Type delegateType, Object target, bool allowClosedInstanceDelegates)
         {
             if (delegateType == null)
-                throw new ArgumentNullException("delegateType");
+                throw new ArgumentNullException(nameof(delegateType));
 
             ExecutionEnvironment executionEnvironment = ReflectionCoreExecution.ExecutionEnvironment;
             RuntimeTypeHandle delegateTypeHandle = delegateType.TypeHandle;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {
@@ -109,7 +109,7 @@ namespace System.Reflection.Runtime.MethodInfos
 #endif
 
             if (typeArguments == null)
-                throw new ArgumentNullException("typeArguments");
+                throw new ArgumentNullException(nameof(typeArguments));
             if (GenericTypeParameters.Length == 0)
                 throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericMethodDefinition, this));
             RuntimeTypeInfo[] genericTypeArguments = new RuntimeTypeInfo[typeArguments.Length];
@@ -156,7 +156,7 @@ namespace System.Reflection.Runtime.MethodInfos
             RuntimeNamedMethodInfo other = obj as RuntimeNamedMethodInfo;
             if (other == null)
                 return false;
-            return this._common.Equals(other._common);
+            return _common.Equals(other._common);
         }
 
         public sealed override int GetHashCode()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {
@@ -134,7 +134,7 @@ namespace System.Reflection.Runtime.MethodInfos
             RuntimePlainConstructorInfo other = obj as RuntimePlainConstructorInfo;
             if (other == null)
                 return false;
-            return this._common.Equals(other._common);
+            return _common.Equals(other._common);
         }
 
         public sealed override int GetHashCode()
@@ -159,8 +159,8 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
-                if (this._common.DefiningTypeInfo.IsAbstract)
-                    throw new MemberAccessException(SR.Format(SR.Acc_CreateAbstEx, this._common.DefiningTypeInfo.FullName));
+                if (_common.DefiningTypeInfo.IsAbstract)
+                    throw new MemberAccessException(SR.Format(SR.Acc_CreateAbstEx, _common.DefiningTypeInfo.FullName));
 
                 if (this.IsStatic)
                     throw new MemberAccessException(SR.Acc_NotClassInit);
@@ -169,7 +169,7 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
-        private RuntimeMethodCommon _common;
+        private readonly RuntimeMethodCommon _common;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {
@@ -92,16 +92,16 @@ namespace System.Reflection.Runtime.MethodInfos
             RuntimeSyntheticConstructorInfo other = obj as RuntimeSyntheticConstructorInfo;
             if (other == null)
                 return false;
-            if (this._syntheticMethodId != other._syntheticMethodId)
+            if (_syntheticMethodId != other._syntheticMethodId)
                 return false;
-            if (!(this._declaringType.Equals(other._declaringType)))
+            if (!(_declaringType.Equals(other._declaringType)))
                 return false;
             return true;
         }
 
         public sealed override int GetHashCode()
         {
-            return this._declaringType.GetHashCode();
+            return _declaringType.GetHashCode();
         }
 
         public sealed override String ToString()
@@ -144,10 +144,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         private volatile RuntimeParameterInfo[] _lazyRuntimeParametersAndReturn;
 
-        private SyntheticMethodId _syntheticMethodId;
-        private RuntimeTypeInfo _declaringType;
-        private RuntimeTypeInfo[] _runtimeParameterTypesAndReturn;
-        private InvokerOptions _options;
-        private Func<Object, Object[], Object> _invoker;
+        private readonly SyntheticMethodId _syntheticMethodId;
+        private readonly RuntimeTypeInfo _declaringType;
+        private readonly RuntimeTypeInfo[] _runtimeParameterTypesAndReturn;
+        private readonly InvokerOptions _options;
+        private readonly Func<Object, Object[], Object> _invoker;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {
@@ -60,9 +60,9 @@ namespace System.Reflection.Runtime.MethodInfos
             RuntimeSyntheticMethodInfo other = obj as RuntimeSyntheticMethodInfo;
             if (other == null)
                 return false;
-            if (this._syntheticMethodId != other._syntheticMethodId)
+            if (_syntheticMethodId != other._syntheticMethodId)
                 return false;
-            if (!(this._declaringType.Equals(other._declaringType)))
+            if (!(_declaringType.Equals(other._declaringType)))
                 return false;
             return true;
         }
@@ -74,7 +74,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override int GetHashCode()
         {
-            return this._declaringType.GetHashCode();
+            return _declaringType.GetHashCode();
         }
 
         public sealed override bool IsGenericMethod
@@ -175,11 +175,11 @@ namespace System.Reflection.Runtime.MethodInfos
 
         private volatile RuntimeParameterInfo[] _lazyRuntimeParametersAndReturn;
 
-        private String _name;
-        private SyntheticMethodId _syntheticMethodId;
-        private RuntimeTypeInfo _declaringType;
-        private RuntimeTypeInfo[] _runtimeParameterTypesAndReturn;
-        private InvokerOptions _options;
-        private Func<Object, Object[], Object> _invoker;
+        private readonly String _name;
+        private readonly SyntheticMethodId _syntheticMethodId;
+        private readonly RuntimeTypeInfo _declaringType;
+        private readonly RuntimeTypeInfo[] _runtimeParameterTypesAndReturn;
+        private readonly InvokerOptions _options;
+        private readonly Func<Object, Object[], Object> _invoker;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/SyntheticMethodId.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/SyntheticMethodId.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.ParameterInfos;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.MethodInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Reflection.Runtime.Assemblies;
+using System.Collections.Generic;
 
-using global::Internal.Reflection.Extensibility;
+using Internal.Reflection.Extensibility;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.Modules
 {
@@ -65,7 +65,7 @@ namespace System.Reflection.Runtime.Modules
             RuntimeModule other = o as RuntimeModule;
             if (other == null)
                 return false;
-            return this._assembly.Equals(other._assembly);
+            return _assembly.Equals(other._assembly);
         }
 
         public sealed override int GetHashCode()
@@ -83,7 +83,7 @@ namespace System.Reflection.Runtime.Modules
             return "<Unknown>";
         }
 
-        private Assembly _assembly;
+        private readonly Assembly _assembly;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeFatMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeFatMethodParameterInfo.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {
@@ -98,9 +98,9 @@ namespace System.Reflection.Runtime.ParameterInfos
             }
         }
 
-        private MethodHandle _methodHandle;
-        private ParameterHandle _parameterHandle;
-        private Parameter _parameter;
+        private readonly MethodHandle _methodHandle;
+        private readonly ParameterHandle _parameterHandle;
+        private readonly Parameter _parameter;
         private volatile Tuple<bool, Object> _lazyDefaultValueInfo;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
 
-using global::Internal.Reflection.Core;
+using Internal.Reflection.Core;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {
@@ -44,10 +44,10 @@ namespace System.Reflection.Runtime.ParameterInfos
             }
         }
 
-        protected MetadataReader Reader { get; private set; }
+        protected MetadataReader Reader { get; }
 
 
-        private Handle _typeHandle;
-        private TypeContext _typeContext;
+        private readonly Handle _typeHandle;
+        private readonly TypeContext _typeContext;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using global::System.Reflection.Runtime.CustomAttributes;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {
@@ -37,9 +37,9 @@ namespace System.Reflection.Runtime.ParameterInfos
             RuntimeParameterInfo other = obj as RuntimeParameterInfo;
             if (other == null)
                 return false;
-            if (this._position != other._position)
+            if (_position != other._position)
                 return false;
-            if (!(this._member.Equals(other._member)))
+            if (!(_member.Equals(other._member)))
                 return false;
             return true;
         }
@@ -79,8 +79,8 @@ namespace System.Reflection.Runtime.ParameterInfos
         // "ParameterType.ToString()".
         internal abstract String ParameterTypeString { get; }
 
-        private MemberInfo _member;
-        private int _position;
+        private readonly MemberInfo _member;
+        private readonly int _position;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimePropertyIndexParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimePropertyIndexParameterInfo.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.PropertyInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.PropertyInfos;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {
@@ -80,7 +80,7 @@ namespace System.Reflection.Runtime.ParameterInfos
             }
         }
 
-        private RuntimeParameterInfo _backingParameter;
+        private readonly RuntimeParameterInfo _backingParameter;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeSyntheticParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeSyntheticParameterInfo.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {
@@ -83,7 +83,7 @@ namespace System.Reflection.Runtime.ParameterInfos
             }
         }
 
-        private RuntimeTypeInfo _parameterType;
+        private readonly RuntimeTypeInfo _parameterType;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeThinMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeThinMethodParameterInfo.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
 
-using global::Internal.Reflection.Core;
+using Internal.Reflection.Core;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -2,25 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Text;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Runtime.CompilerServices;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.MethodInfos;
-using global::System.Reflection.Runtime.ParameterInfos;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System;
+using System.Text;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.MethodInfos;
+using System.Reflection.Runtime.ParameterInfos;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.PropertyInfos
 {
@@ -118,11 +118,11 @@ namespace System.Reflection.Runtime.PropertyInfos
             RuntimePropertyInfo other = obj as RuntimePropertyInfo;
             if (other == null)
                 return false;
-            if (!(this._reader == other._reader))
+            if (!(_reader == other._reader))
                 return false;
-            if (!(this._propertyHandle.Equals(other._propertyHandle)))
+            if (!(_propertyHandle.Equals(other._propertyHandle)))
                 return false;
-            if (!(this._contextTypeInfo.Equals(other._contextTypeInfo)))
+            if (!(_contextTypeInfo.Equals(other._contextTypeInfo)))
                 return false;
             return true;
         }
@@ -379,12 +379,12 @@ namespace System.Reflection.Runtime.PropertyInfos
             return this;
         }
 
-        private RuntimeNamedTypeInfo _definingTypeInfo;
-        private PropertyHandle _propertyHandle;
-        private RuntimeTypeInfo _contextTypeInfo;
+        private readonly RuntimeNamedTypeInfo _definingTypeInfo;
+        private readonly PropertyHandle _propertyHandle;
+        private readonly RuntimeTypeInfo _contextTypeInfo;
 
-        private MetadataReader _reader;
-        private Property _property;
+        private readonly MetadataReader _reader;
+        private readonly Property _property;
 
         private volatile MethodInvoker _lazyGetterInvoker = null;
         private volatile MethodInvoker _lazySetterInvoker = null;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.MethodInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.MethodInfos;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 using TargetException = System.ArgumentException;
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Tracing;
-using global::Internal.Reflection.Core.Execution;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Tracing;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.TypeInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeByRefTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeByRefTypeInfo.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
 
 namespace System.Reflection.Runtime.TypeInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Text;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Collections.Concurrent;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
+using System;
+using System.Text;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
 
 using Internal.Reflection.Tracing;
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 using Internal.Reflection.Core.Execution;
 
 namespace System.Reflection.Runtime.TypeInfos

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.MethodInfos;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.MethodInfos;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.TypeInfos
 {
@@ -131,6 +131,10 @@ namespace System.Reflection.Runtime.TypeInfos
             return GenericParameterHandle.GetHashCode();
         }
 
+        protected GenericParameterHandle GenericParameterHandle { get; }
+
+        protected MetadataReader Reader { get; }
+
         internal sealed override string InternalFullNameOfAssembly
         {
             get
@@ -154,9 +158,6 @@ namespace System.Reflection.Runtime.TypeInfos
                 return default(RuntimeTypeHandle);
             }
         }
-
-        internal GenericParameterHandle GenericParameterHandle { get; }
-        internal MetadataReader Reader { get; }
 
         //
         // Returns the base type as a typeDef, Ref, or Spec. Default behavior is to QTypeDefRefOrSpec.Null, which causes BaseType to return null.

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfoForMethods.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfoForMethods.cs
@@ -22,7 +22,7 @@ namespace System.Reflection.Runtime.TypeInfos
         private RuntimeGenericParameterTypeInfoForMethods(MetadataReader reader, GenericParameterHandle genericParameterHandle, RuntimeNamedMethodInfo declaringRuntimeNamedMethodInfo)
            : base(reader, genericParameterHandle)
         {
-            DeclaringRuntimeNamedMethodInfo = declaringRuntimeNamedMethodInfo;
+            _declaringRuntimeNamedMethodInfo = declaringRuntimeNamedMethodInfo;
         }
 
         public sealed override MethodBase DeclaringMethod
@@ -33,7 +33,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_DeclaringMethod(this);
 #endif
-                return DeclaringRuntimeNamedMethodInfo;
+                return _declaringRuntimeNamedMethodInfo;
             }
         }
 
@@ -61,7 +61,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return new UnificationKey(DeclaringRuntimeNamedMethodInfo, Reader, GenericParameterHandle);
+                return new UnificationKey(_declaringRuntimeNamedMethodInfo, Reader, GenericParameterHandle);
             }
         }
 
@@ -69,7 +69,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return DeclaringRuntimeNamedMethodInfo.DeclaringType;
+                return _declaringRuntimeNamedMethodInfo.DeclaringType;
             }
         }
 
@@ -78,11 +78,11 @@ namespace System.Reflection.Runtime.TypeInfos
             get
             {
                 TypeContext typeContext = this.DeclaringType.CastToRuntimeTypeInfo().TypeContext;
-                return new TypeContext(typeContext.GenericTypeArguments, DeclaringRuntimeNamedMethodInfo.RuntimeGenericArgumentsOrParameters);
+                return new TypeContext(typeContext.GenericTypeArguments, _declaringRuntimeNamedMethodInfo.RuntimeGenericArgumentsOrParameters);
             }
         }
 
-        internal RuntimeNamedMethodInfo DeclaringRuntimeNamedMethodInfo { get; }
+        private readonly RuntimeNamedMethodInfo _declaringRuntimeNamedMethodInfo;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfoForTypes.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfoForTypes.cs
@@ -20,7 +20,7 @@ namespace System.Reflection.Runtime.TypeInfos
         private RuntimeGenericParameterTypeInfoForTypes(MetadataReader reader, GenericParameterHandle genericParameterHandle, RuntimeTypeInfo declaringRuntimeNamedTypeInfo)
            : base(reader, genericParameterHandle)
         {
-            DeclaringRuntimeNamedTypeInfo = declaringRuntimeNamedTypeInfo;
+            _declaringRuntimeNamedTypeInfo = declaringRuntimeNamedTypeInfo;
         }
 
         public sealed override MethodBase DeclaringMethod
@@ -39,7 +39,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return DeclaringRuntimeNamedTypeInfo.AsType();
+                return _declaringRuntimeNamedTypeInfo.AsType();
             }
         }
 
@@ -47,11 +47,11 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return DeclaringRuntimeNamedTypeInfo.TypeContext;
+                return _declaringRuntimeNamedTypeInfo.TypeContext;
             }
         }
 
-        internal RuntimeTypeInfo DeclaringRuntimeNamedTypeInfo { get; }
+        private readonly RuntimeTypeInfo _declaringRuntimeNamedTypeInfo;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Collections.Concurrent;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
 namespace System.Reflection.Runtime.TypeInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -2,23 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Text;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Collections.Concurrent;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System;
+using System.Text;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Core.Execution;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Reflection.Tracing;
+using Internal.Reflection.Tracing;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.TypeInfos
 {
@@ -151,7 +151,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 // uses the GUID as a dictionary key to look up types.) It will not be the same GUID on multiple runs of the app but so far, there's
                 // no evidence that's needed.
                 //
-                return _namedTypeToGuidTable.GetOrAdd(this).Item1;
+                return s_namedTypeToGuidTable.GetOrAdd(this).Item1;
             }
         }
 
@@ -441,7 +441,7 @@ namespace System.Reflection.Runtime.TypeInfos
 
         private volatile NamespaceChain _lazyNamespaceChain;
 
-        private static NamedTypeToGuidTable _namedTypeToGuidTable = new NamedTypeToGuidTable();
+        private static readonly NamedTypeToGuidTable s_namedTypeToGuidTable = new NamedTypeToGuidTable();
         private sealed class NamedTypeToGuidTable : ConcurrentUnifier<RuntimeNamedTypeInfo, Tuple<Guid>>
         {
             protected sealed override Tuple<Guid> Factory(RuntimeNamedTypeInfo key)
@@ -450,13 +450,13 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        private static char[] charsToEscape = new char[] { '\\', '[', ']', '+', '*', '&', ',' };
+        private static readonly char[] s_charsToEscape = new char[] { '\\', '[', ']', '+', '*', '&', ',' };
         // Escape identifiers as described in "Specifying Fully Qualified Type Names" on msdn.
         // Current link is http://msdn.microsoft.com/en-us/library/yfsftwz6(v=vs.110).aspx
         private static string EscapeIdentifier(string identifier)
         {
             // Some characters in a type name need to be escaped
-            if (identifier != null && identifier.IndexOfAny(charsToEscape) != -1)
+            if (identifier != null && identifier.IndexOfAny(s_charsToEscape) != -1)
             {
                 StringBuilder sbEscapedName = new StringBuilder(identifier);
                 sbEscapedName.Replace("\\", "\\\\");

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
-using global::System.Reflection.Runtime.CustomAttributes;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.CustomAttributes;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Tracing;
-using global::Internal.Reflection.Core.Execution;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Tracing;
+using Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.TypeInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimePointerTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimePointerTypeInfo.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
 
 namespace System.Reflection.Runtime.TypeInfos
 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -2,24 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Runtime.CompilerServices;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.MethodInfos;
-using global::System.Reflection.Runtime.FieldInfos;
-using global::System.Reflection.Runtime.PropertyInfos;
-using global::System.Reflection.Runtime.EventInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.MethodInfos;
+using System.Reflection.Runtime.FieldInfos;
+using System.Reflection.Runtime.PropertyInfos;
+using System.Reflection.Runtime.EventInfos;
 
-using global::Internal.LowLevelLinq;
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
-using global::Internal.Reflection.Extensibility;
-using global::Internal.Reflection.Tracing;
+using Internal.LowLevelLinq;
+using Internal.Reflection.Core;
+using Internal.Reflection.Core.Execution;
+using Internal.Reflection.Extensibility;
+using Internal.Reflection.Tracing;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 using IRuntimeImplementedType = Internal.Reflection.Core.NonPortable.IRuntimeImplementedType;
 using RuntimeType = Internal.Reflection.Core.NonPortable.RuntimeType;
@@ -313,7 +313,7 @@ namespace System.Reflection.Runtime.TypeInfos
 #endif
 
             if (name == null)
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
 
             TypeInfoCachedData cachedData = this.TypeInfoCachedData;
             return cachedData.GetDeclaredEvent(name);
@@ -327,7 +327,7 @@ namespace System.Reflection.Runtime.TypeInfos
 #endif
 
             if (name == null)
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
 
             TypeInfoCachedData cachedData = this.TypeInfoCachedData;
             return cachedData.GetDeclaredField(name);
@@ -341,7 +341,7 @@ namespace System.Reflection.Runtime.TypeInfos
 #endif
 
             if (name == null)
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
 
             TypeInfoCachedData cachedData = this.TypeInfoCachedData;
             return cachedData.GetDeclaredMethod(name);
@@ -355,7 +355,7 @@ namespace System.Reflection.Runtime.TypeInfos
 #endif
 
             if (name == null)
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
 
             TypeInfoCachedData cachedData = this.TypeInfoCachedData;
             return cachedData.GetDeclaredProperty(name);
@@ -1004,7 +1004,7 @@ namespace System.Reflection.Runtime.TypeInfos
                     debugName = this.GetTraceString();  // If tracing on, call this.GetTraceString() which only gives you useful strings when metadata is available but doesn't pollute the ETW trace.
                 else
 #endif
-                    debugName = this.ToString();
+                debugName = this.ToString();
                 if (debugName == null)
                     debugName = "";
                 _debugName = debugName;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/TypeInfoCachedData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/TypeInfoCachedData.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.Dispensers;
-using global::System.Reflection.Runtime.FieldInfos;
-using global::System.Reflection.Runtime.EventInfos;
-using global::System.Reflection.Runtime.MethodInfos;
-using global::System.Reflection.Runtime.PropertyInfos;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.Dispensers;
+using System.Reflection.Runtime.FieldInfos;
+using System.Reflection.Runtime.EventInfos;
+using System.Reflection.Runtime.MethodInfos;
+using System.Reflection.Runtime.PropertyInfos;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.TypeInfos
 {
@@ -57,7 +57,7 @@ namespace System.Reflection.Runtime.TypeInfos
         }
 
 
-        private Dispenser<String, RuntimeMethodInfo> _methodLookupDispenser;
+        private readonly Dispenser<String, RuntimeMethodInfo> _methodLookupDispenser;
 
         private RuntimeMethodInfo LookupDeclaredMethodByName(String name)
         {
@@ -71,7 +71,7 @@ namespace System.Reflection.Runtime.TypeInfos
             return result;
         }
 
-        private Dispenser<String, RuntimeFieldInfo> _fieldLookupDispenser;
+        private readonly Dispenser<String, RuntimeFieldInfo> _fieldLookupDispenser;
 
         private RuntimeFieldInfo LookupDeclaredFieldByName(String name)
         {
@@ -85,7 +85,7 @@ namespace System.Reflection.Runtime.TypeInfos
             return result;
         }
 
-        private Dispenser<String, RuntimePropertyInfo> _propertyLookupDispenser;
+        private readonly Dispenser<String, RuntimePropertyInfo> _propertyLookupDispenser;
 
         private RuntimePropertyInfo LookupDeclaredPropertyByName(String name)
         {
@@ -100,7 +100,7 @@ namespace System.Reflection.Runtime.TypeInfos
         }
 
 
-        private Dispenser<String, RuntimeEventInfo> _eventLookupDispenser;
+        private readonly Dispenser<String, RuntimeEventInfo> _eventLookupDispenser;
 
         private RuntimeEventInfo LookupDeclaredEventByName(String name)
         {
@@ -114,6 +114,6 @@ namespace System.Reflection.Runtime.TypeInfos
             return result;
         }
 
-        private RuntimeTypeInfo _runtimeTypeInfo;
+        private readonly RuntimeTypeInfo _runtimeTypeInfo;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeLexer.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeLexer.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
-using global::System.Collections;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.Assemblies;
+using System;
+using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection.Runtime.Assemblies;
 
 namespace System.Reflection.Runtime.TypeParsing
 {
@@ -80,7 +80,7 @@ namespace System.Reflection.Runtime.TypeParsing
             int src = _index;
             char[] buffer = new char[_chars.Length];
             int dst = 0;
-            for (; ;)
+            for (;;)
             {
                 char c = _chars[src];
                 TokenType token = CharToToken(c);
@@ -129,7 +129,7 @@ namespace System.Reflection.Runtime.TypeParsing
             int src = _index;
             char[] buffer = new char[_chars.Length];
             int dst = 0;
-            for (; ;)
+            for (;;)
             {
                 char c = _chars[src];
                 if (c == NUL)
@@ -154,7 +154,7 @@ namespace System.Reflection.Runtime.TypeParsing
             int src = _index;
             char[] buffer = new char[_chars.Length];
             int dst = 0;
-            for (; ;)
+            for (;;)
             {
                 char c = _chars[src];
                 if (c == NUL)
@@ -220,7 +220,7 @@ namespace System.Reflection.Runtime.TypeParsing
 
 
         private int _index;
-        private char[] _chars;
+        private readonly char[] _chars;
         private const char NUL = (char)0;
 
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeName.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeName.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
-using global::System.Collections;
-using global::System.Reflection;
-using global::System.Collections.Generic;
+using System;
+using System.Diagnostics;
+using System.Collections;
+using System.Reflection;
+using System.Collections.Generic;
 
-using global::System.Reflection.Runtime.General;
-using global::System.Reflection.Runtime.TypeInfos;
-using global::System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+using System.Reflection.Runtime.Assemblies;
 
-using global::Internal.Metadata.NativeFormat;
+using Internal.Metadata.NativeFormat;
 
-using global::Internal.Reflection.Core;
+using Internal.Reflection.Core;
 
 using ReflectionCoreNonPortable = Internal.Reflection.Core.NonPortable.ReflectionCoreNonPortable;
 
@@ -48,8 +48,8 @@ namespace System.Reflection.Runtime.TypeParsing
             AssemblyName = assemblyName;
         }
 
-        public NonQualifiedTypeName TypeName { get; private set; }
-        public RuntimeAssemblyName AssemblyName { get; private set; }  // This can return null if the type name was not actually qualified.
+        public NonQualifiedTypeName TypeName { get; }
+        public RuntimeAssemblyName AssemblyName { get; }  // This can return null if the type name was not actually qualified.
 
         public sealed override String ToString()
         {
@@ -291,8 +291,8 @@ namespace System.Reflection.Runtime.TypeParsing
             return dict;
         }
 
-        private String _name;
-        private String[] _namespaceParts;
+        private readonly String _name;
+        private readonly String[] _namespaceParts;
     }
 
     //
@@ -306,8 +306,8 @@ namespace System.Reflection.Runtime.TypeParsing
             DeclaringType = declaringType;
         }
 
-        public String Name { get; private set; }
-        public NamedTypeName DeclaringType { get; private set; }
+        public String Name { get; }
+        public NamedTypeName DeclaringType { get; }
 
         public sealed override String ToString()
         {
@@ -366,7 +366,7 @@ namespace System.Reflection.Runtime.TypeParsing
             ElementTypeName = elementTypeName;
         }
 
-        public TypeName ElementTypeName { get; private set; }
+        public TypeName ElementTypeName { get; }
     }
 
     //
@@ -423,7 +423,7 @@ namespace System.Reflection.Runtime.TypeParsing
             return null;
         }
 
-        private int _rank;
+        private readonly int _rank;
     }
 
     //
@@ -491,8 +491,8 @@ namespace System.Reflection.Runtime.TypeParsing
             GenericArguments = genericArguments;
         }
 
-        public NamedTypeName GenericType { get; private set; }
-        public IEnumerable<TypeName> GenericArguments { get; private set; }
+        public NamedTypeName GenericType { get; }
+        public IEnumerable<TypeName> GenericArguments { get; }
 
         public sealed override String ToString()
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeParser.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeParser.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Diagnostics;
-using global::System.Collections;
-using global::System.Collections.Generic;
-using global::System.Reflection.Runtime.Assemblies;
+using System;
+using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection.Runtime.Assemblies;
 
 namespace System.Reflection.Runtime.TypeParsing
 {
@@ -69,7 +69,7 @@ namespace System.Reflection.Runtime.TypeParsing
             NonQualifiedTypeName typeName = ParseNamedOrConstructedGenericTypeName();
 
             // Iterate through any "has-element" qualifiers ([], &, *).
-            for (; ;)
+            for (;;)
             {
                 TokenType token = _lexer.Peek;
                 if (token == TokenType.End)
@@ -130,7 +130,7 @@ namespace System.Reflection.Runtime.TypeParsing
             {
                 _lexer.Skip();
                 LowLevelListWithIList<TypeName> genericTypeArguments = new LowLevelListWithIList<TypeName>();
-                for (; ;)
+                for (;;)
                 {
                     TypeName genericTypeArgument = ParseGenericTypeArgument();
                     genericTypeArguments.Add(genericTypeArgument);
@@ -204,8 +204,7 @@ namespace System.Reflection.Runtime.TypeParsing
                 throw new ArgumentException();
         }
 
-
-        private TypeLexer _lexer;
+        private readonly TypeLexer _lexer;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Types/RuntimeTypeTemporary.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Types/RuntimeTypeTemporary.cs
@@ -41,7 +41,7 @@ namespace System.Reflection.Runtime.Types
                 return true;
 
             // TODO https://github.com/dotnet/corefx/issues/9805: This makes Equals() act as if Type and TypeInfo are already the same instance. This extra check will go away once they actually are the same instance.
-            if (obj is RuntimeTypeInfo && object.ReferenceEquals(this, ((RuntimeTypeInfo)obj).AsType())) 
+            if (obj is RuntimeTypeInfo && object.ReferenceEquals(this, ((RuntimeTypeInfo)obj).AsType()))
                 return true;
 
             return false;


### PR DESCRIPTION
Take advantage of C# 6.0 and bring things closer
to our OSS coding guidelines:

- Run a CodeFormatter pass.

- Remove the "global::" qualifiers on the usings
  (a relic from days where we nested them inside the
  namespace blocks)

- Add "readonly" to fields where possible.

- Make properties read-only whenever possible.

- Use nameof() rather than string literal for exceptions.

- Do a pass for unsealed internal types or unsealed
  overridden members (unless accompanied by a comment
  explaining exactly what I expect to override.)