### PR TITLE
Fix __debugbreak() reference for GCC-compatible compilers

### DIFF
--- a/src/Native/Runtime/unix/PalRedhawkInline.h
+++ b/src/Native/Runtime/unix/PalRedhawkInline.h
@@ -88,4 +88,4 @@ FORCEINLINE void PalMemoryBarrier()
     __sync_synchronize();
 }
 
-#define PalDebugBreak() __debugbreak()
+#define PalDebugBreak() __builtin_trap()


### PR DESCRIPTION
The equivalent compiler built-in function is `__builtin_trap()`. This change was discussed in #1593.