### PR TITLE
Add helpers to compute type hashcode from native metadata

### DIFF
--- a/src/Common/src/Internal/Metadata/NativeFormat/MetadataTypeHashingAlgorithms.cs
+++ b/src/Common/src/Internal/Metadata/NativeFormat/MetadataTypeHashingAlgorithms.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using TypeAttributes = System.Reflection.TypeAttributes;
+using Debug = System.Diagnostics.Debug;
+using HashCodeBuilder = Internal.NativeFormat.TypeHashingAlgorithms.HashCodeBuilder;
+using TypeHashingAlgorithms = Internal.NativeFormat.TypeHashingAlgorithms;
+
+namespace Internal.Metadata.NativeFormat
+{
+    internal static class MetadataTypeHashingAlgorithms
+    {
+        private static void AppendNamespaceHashCode(ref HashCodeBuilder builder, NamespaceDefinitionHandle namespaceDefHandle, MetadataReader reader)
+        {
+            NamespaceDefinition namespaceDefinition = reader.GetNamespaceDefinition(namespaceDefHandle);
+
+            Handle parentHandle = namespaceDefinition.ParentScopeOrNamespace;
+            HandleType parentHandleType = parentHandle.HandleType;
+            if (parentHandleType == HandleType.NamespaceDefinition)
+            {
+                AppendNamespaceHashCode(ref builder, parentHandle.ToNamespaceDefinitionHandle(reader), reader);
+                string namespaceNamePart = reader.GetString(namespaceDefinition.Name);
+                builder.Append(namespaceNamePart);
+                builder.Append(".");
+            }
+            else
+            {
+                Debug.Assert(parentHandleType == HandleType.ScopeDefinition);
+                Debug.Assert(String.IsNullOrEmpty(reader.GetString(namespaceDefinition.Name)), "Root namespace with a name?");
+            }
+        }
+
+        private static void AppendNamespaceHashCode(ref HashCodeBuilder builder, NamespaceReferenceHandle namespaceRefHandle, MetadataReader reader)
+        {
+            NamespaceReference namespaceReference = reader.GetNamespaceReference(namespaceRefHandle);
+
+            Handle parentHandle = namespaceReference.ParentScopeOrNamespace;
+            HandleType parentHandleType = parentHandle.HandleType;
+            if (parentHandleType == HandleType.NamespaceReference)
+            {
+                AppendNamespaceHashCode(ref builder, parentHandle.ToNamespaceReferenceHandle(reader), reader);
+                string namespaceNamePart = reader.GetString(namespaceReference.Name);
+                builder.Append(namespaceNamePart);
+                builder.Append(".");
+            }
+            else
+            {
+                Debug.Assert(parentHandleType == HandleType.ScopeReference);
+                Debug.Assert(String.IsNullOrEmpty(reader.GetString(namespaceReference.Name)), "Root namespace with a name?");
+            }
+        }
+
+        public static int ComputeHashCode(this TypeDefinitionHandle typeDefHandle, MetadataReader reader)
+        {
+            HashCodeBuilder builder = new HashCodeBuilder("");
+
+            TypeDefinition typeDef = reader.GetTypeDefinition(typeDefHandle);
+            bool isNested = typeDef.Flags.IsNested();
+            if (!isNested)
+            {
+                AppendNamespaceHashCode(ref builder, typeDef.NamespaceDefinition, reader);
+            }
+
+            string typeName = reader.GetString(typeDef.Name);
+            builder.Append(typeName);
+
+            if (isNested)
+            {
+                int enclosingTypeHashCode = typeDef.EnclosingType.ComputeHashCode(reader);
+                return TypeHashingAlgorithms.ComputeNestedTypeHashCode(enclosingTypeHashCode, builder.ToHashCode());
+            }
+
+            return builder.ToHashCode();
+        }
+
+        public static int ComputeHashCode(this TypeReferenceHandle typeRefHandle, MetadataReader reader)
+        {
+            HashCodeBuilder builder = new HashCodeBuilder("");
+
+            TypeReference typeRef = reader.GetTypeReference(typeRefHandle);
+            HandleType parentHandleType = typeRef.ParentNamespaceOrType.HandleType;
+            bool isNested = parentHandleType == HandleType.TypeReference;
+            if (!isNested)
+            {
+                Debug.Assert(parentHandleType == HandleType.NamespaceReference);
+                AppendNamespaceHashCode(ref builder, typeRef.ParentNamespaceOrType.ToNamespaceReferenceHandle(reader), reader);
+            }
+
+            string typeName = reader.GetString(typeRef.TypeName);
+            builder.Append(typeName);
+
+            if (isNested)
+            {
+                int enclosingTypeHashCode = typeRef.ParentNamespaceOrType.ToTypeReferenceHandle(reader).ComputeHashCode(reader);
+                return TypeHashingAlgorithms.ComputeNestedTypeHashCode(enclosingTypeHashCode, builder.ToHashCode());
+            }
+
+            return builder.ToHashCode();
+        }
+
+        // This mask is the fastest way to check if a type is nested from its flags,
+        // but it should not be added to the BCL enum as its semantics can be misleading.
+        // Consider, for example, that (NestedFamANDAssem & NestedMask) == NestedFamORAssem.
+        // Only comparison of the masked value to 0 is meaningful, which is different from
+        // the other masks in the enum.
+        private const TypeAttributes NestedMask = (TypeAttributes)0x00000006;
+
+        private static bool IsNested(this TypeAttributes flags)
+        {
+            return (flags & NestedMask) != 0;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
+++ b/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
@@ -14,6 +14,52 @@ namespace Internal.NativeFormat
 {
     static public class TypeHashingAlgorithms
     {
+        public struct HashCodeBuilder
+        {
+            private int _hash1;
+            private int _hash2;
+            private int _numCharactersHashed;
+
+            public HashCodeBuilder(string seed)
+            {
+                _hash1 = 0x6DA3B944;
+                _hash2 = 0;
+                _numCharactersHashed = 0;
+
+                Append(seed);
+            }
+
+            public void Append(string src)
+            {
+                if (src.Length == 0)
+                    return;
+
+                int startIndex = 0;
+                if ((_numCharactersHashed & 1) == 1)
+                {
+                    _hash2 = (_hash2 + _rotl(_hash2, 5)) ^ src[0];
+                    startIndex = 1;
+                }
+
+                for (int i = startIndex; i < src.Length; i += 2)
+                {
+                    _hash1 = (_hash1 + _rotl(_hash1, 5)) ^ src[i];
+                    if ((i + 1) < src.Length)
+                        _hash2 = (_hash2 + _rotl(_hash2, 5)) ^ src[i + 1];
+                }
+
+                _numCharactersHashed += src.Length;
+            }
+
+            public int ToHashCode()
+            {
+                int hash1 = _hash1 + _rotl(_hash1, 8);
+                int hash2 = _hash2 + _rotl(_hash2, 8);
+
+                return hash1 ^ hash2;
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int _rotl(int value, int shift)
         {

--- a/src/ILCompiler.TypeSystem/tests/HashcodeTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/HashcodeTests.cs
@@ -168,5 +168,70 @@ namespace TypeSystemTests
             TypeDesc intByRefType = _context.GetByRefType(intType);
             Assert.Equal(expHashIntByRef, intByRefType.GetHashCode());
         }
+
+        [Fact]
+        public void TestHashCodeBuilder()
+        {
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xy");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xy"), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xyz");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xyz"), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xy");
+                builder.Append("");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xy"), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xy");
+                builder.Append(".");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xy."), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xyz");
+                builder.Append(".");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xyz."), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xy");
+                builder.Append("..");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xy.."), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xyz");
+                builder.Append("..");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xyz.."), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xy");
+                builder.Append(".");
+                builder.Append("Ab");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xy.Ab"), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xy");
+                builder.Append(".");
+                builder.Append("Abc");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xy.Abc"), builder.ToHashCode());
+            }
+
+            {
+                var builder = new TypeHashingAlgorithms.HashCodeBuilder("Xyz");
+                builder.Append(".");
+                builder.Append("Abc");
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("Xyz.Abc"), builder.ToHashCode());
+            }
+        }
     }
 }

--- a/src/System.Private.Reflection.Metadata/tests/HashCodeTests.cs
+++ b/src/System.Private.Reflection.Metadata/tests/HashCodeTests.cs
@@ -1,0 +1,202 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Need to use "extern alias", because both the writer and reader define types with same names.
+extern alias writer;
+
+using System.IO;
+using System.Linq;
+
+using Xunit;
+
+using Reader = Internal.Metadata.NativeFormat;
+using Writer = writer.Internal.Metadata.NativeFormat.Writer;
+
+using TypeAttributes = System.Reflection.TypeAttributes;
+using MetadataTypeHashingAlgorithms = Internal.Metadata.NativeFormat.MetadataTypeHashingAlgorithms;
+using TypeHashingAlgorithms = Internal.NativeFormat.TypeHashingAlgorithms;
+
+namespace System.Private.Reflection.Metadata.Tests
+{
+    public class HashCodeTests
+    {
+        private static Writer.ScopeDefinition BuildSimpleTestDefinitionData()
+        {
+            // Scope for System.Runtime, 4.0.0.0
+            var systemRuntimeScope = new Writer.ScopeDefinition
+            {
+                Name = (Writer.ConstantStringValue)"System.Runtime",
+                MajorVersion = 4,
+            };
+
+            // Root namespace (".")
+            var rootNamespaceDefinition = new Writer.NamespaceDefinition
+            {
+                ParentScopeOrNamespace = systemRuntimeScope,
+            };
+            systemRuntimeScope.RootNamespaceDefinition = rootNamespaceDefinition;
+
+            // The <Module> type
+            var moduleTypeDefinition = new Writer.TypeDefinition
+            {
+                Flags = TypeAttributes.Abstract | TypeAttributes.Public,
+                Name = (Writer.ConstantStringValue)"<Module>",
+                NamespaceDefinition = rootNamespaceDefinition,
+            };
+            rootNamespaceDefinition.TypeDefinitions.Add(moduleTypeDefinition);
+
+            // System namespace
+            var systemNamespaceDefinition = new Writer.NamespaceDefinition
+            {
+                Name = (Writer.ConstantStringValue)"System",
+                ParentScopeOrNamespace = rootNamespaceDefinition,
+            };
+            rootNamespaceDefinition.NamespaceDefinitions.Add(systemNamespaceDefinition);
+
+            // System.Object type
+            var objectType = new Writer.TypeDefinition
+            {
+                Flags = TypeAttributes.Public | TypeAttributes.SequentialLayout,
+                Name = (Writer.ConstantStringValue)"Object",
+                NamespaceDefinition = systemNamespaceDefinition
+            };
+            systemNamespaceDefinition.TypeDefinitions.Add(objectType);
+
+            // System.Object+Nested type
+            var nestedType = new Writer.TypeDefinition
+            {
+                Flags = TypeAttributes.SequentialLayout | TypeAttributes.NestedPublic,
+                Name = (Writer.ConstantStringValue)"Nested",
+                NamespaceDefinition = null,
+                EnclosingType = objectType
+            };
+            objectType.NestedTypes.Add(nestedType);
+
+            // System.Object+Nested+ReallyNested type
+            var reallyNestedType = new Writer.TypeDefinition
+            {
+                Flags = TypeAttributes.SequentialLayout | TypeAttributes.NestedPublic,
+                Name = (Writer.ConstantStringValue)"ReallyNested",
+                NamespaceDefinition = null,
+                EnclosingType = nestedType
+            };
+            nestedType.NestedTypes.Add(reallyNestedType);
+
+            return systemRuntimeScope;
+        }
+
+        [Fact]
+        public unsafe void TestDefinitionHashCodes()
+        {
+            var wr = new Writer.MetadataWriter();
+            wr.ScopeDefinitions.Add(BuildSimpleTestDefinitionData());
+            var ms = new MemoryStream();
+            wr.Write(ms);
+
+            fixed (byte* pBuffer = ms.ToArray())
+            {
+                var rd = new Reader.MetadataReader((IntPtr)pBuffer, (int)ms.Length);
+
+                Reader.ScopeDefinitionHandle scopeHandle = rd.ScopeDefinitions.Single();
+                Reader.ScopeDefinition systemRuntimeScope = scopeHandle.GetScopeDefinition(rd);
+
+                // Validate root type hash code
+                Reader.NamespaceDefinition rootNamespace = systemRuntimeScope.RootNamespaceDefinition.GetNamespaceDefinition(rd);
+                Reader.TypeDefinitionHandle moduleTypeHandle = rootNamespace.TypeDefinitions.Single();
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("<Module>"), MetadataTypeHashingAlgorithms.ComputeHashCode(moduleTypeHandle, rd));
+
+                // Validate namespace type hashcode
+                Reader.NamespaceDefinition systemNamespace = rootNamespace.NamespaceDefinitions.Single().GetNamespaceDefinition(rd);
+                Reader.TypeDefinitionHandle objectTypeHandle = systemNamespace.TypeDefinitions.Single();
+                int objectHashCode = TypeHashingAlgorithms.ComputeNameHashCode("System.Object");
+                Assert.Equal(objectHashCode, MetadataTypeHashingAlgorithms.ComputeHashCode(objectTypeHandle, rd));
+
+                // Validate nested type hashcode
+                Reader.TypeDefinitionHandle nestedTypeHandle = objectTypeHandle.GetTypeDefinition(rd).NestedTypes.Single();
+                int nestedHashCode = TypeHashingAlgorithms.ComputeNestedTypeHashCode(objectHashCode, TypeHashingAlgorithms.ComputeNameHashCode("Nested"));
+                Assert.Equal(nestedHashCode, MetadataTypeHashingAlgorithms.ComputeHashCode(nestedTypeHandle, rd));
+
+                // Validate really nested type hashcode
+                Reader.TypeDefinitionHandle reallyNestedTypeHandle = nestedTypeHandle.GetTypeDefinition(rd).NestedTypes.Single();
+                int reallyNestedHashCode = TypeHashingAlgorithms.ComputeNestedTypeHashCode(nestedHashCode, TypeHashingAlgorithms.ComputeNameHashCode("ReallyNested"));
+                Assert.Equal(reallyNestedHashCode, MetadataTypeHashingAlgorithms.ComputeHashCode(reallyNestedTypeHandle, rd));
+            }
+        }
+
+        [Fact]
+        public unsafe void TestReferenceHashCodes()
+        {
+            var wr = new Writer.MetadataWriter();
+
+            var systemRuntimeScopeRecord = new Writer.ScopeReference
+            {
+                Name = (Writer.ConstantStringValue)"System.Runtime",
+                MajorVersion = 4,
+            };
+
+            var rootNamespaceRecord = new Writer.NamespaceReference
+            {
+                Name = null,
+                ParentScopeOrNamespace = systemRuntimeScopeRecord,
+            };
+
+            var fooTypeRecord = new Writer.TypeReference
+            {
+                ParentNamespaceOrType = rootNamespaceRecord,
+                TypeName = (Writer.ConstantStringValue)"Foo",
+            };
+
+            var nestedTypeRecord = new Writer.TypeReference
+            {
+                ParentNamespaceOrType = fooTypeRecord,
+                TypeName = (Writer.ConstantStringValue)"Nested",
+            };
+
+            var reallyNestedTypeRecord = new Writer.TypeReference
+            {
+                ParentNamespaceOrType = nestedTypeRecord,
+                TypeName = (Writer.ConstantStringValue)"ReallyNested",
+            };
+
+            var systemNamespaceRecord = new Writer.NamespaceReference
+            {
+                Name = (Writer.ConstantStringValue)"System",
+                ParentScopeOrNamespace = rootNamespaceRecord,
+            };
+
+            var objectTypeRecord = new Writer.TypeReference
+            {
+                ParentNamespaceOrType = systemNamespaceRecord,
+                TypeName = (Writer.ConstantStringValue)"Object",
+            };
+
+            wr.AdditionalRootRecords.Add(objectTypeRecord);
+            wr.AdditionalRootRecords.Add(fooTypeRecord);
+            wr.AdditionalRootRecords.Add(nestedTypeRecord);
+            wr.AdditionalRootRecords.Add(reallyNestedTypeRecord);
+            var ms = new MemoryStream();
+            wr.Write(ms);
+
+            fixed (byte* pBuffer = ms.ToArray())
+            {
+                var rd = new Reader.MetadataReader((IntPtr)pBuffer, (int)ms.Length);
+
+                var fooTypeHandle = new Reader.TypeReferenceHandle(wr.GetRecordHandle(fooTypeRecord));
+                var fooTypeHashCode = TypeHashingAlgorithms.ComputeNameHashCode("Foo");
+                Assert.Equal(fooTypeHashCode, MetadataTypeHashingAlgorithms.ComputeHashCode(fooTypeHandle, rd));
+
+                var objectTypeHandle = new Reader.TypeReferenceHandle(wr.GetRecordHandle(objectTypeRecord));
+                Assert.Equal(TypeHashingAlgorithms.ComputeNameHashCode("System.Object"), MetadataTypeHashingAlgorithms.ComputeHashCode(objectTypeHandle, rd));
+
+                var nestedTypeHandle = new Reader.TypeReferenceHandle(wr.GetRecordHandle(nestedTypeRecord));
+                var nestedTypeHashCode = TypeHashingAlgorithms.ComputeNestedTypeHashCode(fooTypeHashCode, TypeHashingAlgorithms.ComputeNameHashCode("Nested"));
+                Assert.Equal(nestedTypeHashCode , MetadataTypeHashingAlgorithms.ComputeHashCode(nestedTypeHandle, rd));
+
+                var reallyNestedTypeHandle = new Reader.TypeReferenceHandle(wr.GetRecordHandle(reallyNestedTypeRecord));
+                var reallyNestedTypeHashCode = TypeHashingAlgorithms.ComputeNestedTypeHashCode(nestedTypeHashCode, TypeHashingAlgorithms.ComputeNameHashCode("ReallyNested"));
+                Assert.Equal(reallyNestedTypeHashCode, MetadataTypeHashingAlgorithms.ComputeHashCode(reallyNestedTypeHandle, rd));
+            }
+        }
+    }
+}

--- a/src/System.Private.Reflection.Metadata/tests/System.Private.Reflection.Metadata.Tests.csproj
+++ b/src/System.Private.Reflection.Metadata/tests/System.Private.Reflection.Metadata.Tests.csproj
@@ -40,6 +40,16 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Common\src\Internal\Metadata\NativeFormat\MetadataTypeHashingAlgorithms.cs">
+      <Link>MetadataTypeHashingAlgorithms.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\System\FormattingHelpers.cs">
+      <Link>FormattingHelpers.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeHashingAlgorithms.cs">
+      <Link>TypeHashingAlgorithms.cs</Link>
+    </Compile>
+    <Compile Include="HashCodeTests.cs" />
     <Compile Include="RoundTripTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
We will be converting the type reflection mapping table (the one that
converts between EETypes and type metadata handles) to a hashtable.

In order to do that, we need to be able to compute the type hash code
from metadata. In this commit:

* I'm making it possible to compute the type hash code without
allocating and formatting the complete type name (to cut down on
allocations)
* I'm adding a helper to compute hash codes from `TypeReferenceHandle`
and `TypeDefinitionHandle`
* A bunch of unit tests for both.