### PR TITLE
Update Roslyn compiler to Microsoft.Net.Compilers 2.0.0-beta3 

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -8,12 +8,6 @@
     <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
   </PropertyGroup>
 
-  <!-- Build Tools Versions -->
-  <PropertyGroup>
-    <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>
-    <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
-  </PropertyGroup>
-
   <!--
     Switching to the .NET Core version of the BuildTools tasks seems to break numerous scenarios, such as VS intellisense and resource designer.
     Until we can get these sorted out we will continue using the .NET 4.5 version of the tasks.
@@ -151,19 +145,11 @@
     <RestorePackages>false</RestorePackages>
   </PropertyGroup>
 
-  <!--
-    Set up Roslyn predefines
-  -->
-  <PropertyGroup>
-    <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName).$(RoslynVersion)/</RoslynPackageDir>
-    <RoslynPropsFile>$(RoslynPackageDir)build/Microsoft.Net.ToolsetCompilers.props</RoslynPropsFile>
-  </PropertyGroup>
-
   <!-- Use Roslyn Compilers to build -->
   <PropertyGroup>
     <UseSharedCompilation>true</UseSharedCompilation>
   </PropertyGroup>
-      
+
   <!--
     On Unix we always use a version of Roslyn we restore from NuGet and we have to work around some known issues.
   -->
@@ -206,7 +192,7 @@
     <NoExplicitReferenceToStdLib>true</NoExplicitReferenceToStdLib>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
 
   <!-- Set up handling of build warnings -->
@@ -246,7 +232,8 @@
     <SkipTests Condition="'$(SkipTests)'=='' and ('$(OsEnvironment)'=='Windows_NT' and '$(TargetsWindows)'!='true')">true</SkipTests>
   </PropertyGroup>
 
-  <Import Project="$(RoslynPropsFile)" Condition="Exists('$(RoslynPropsFile)')" />
+  <!-- Use the latest Roslyn compilers -->
+  <Import Condition="'$(CompilerPropsAlreadyImported)'!='true' and '$(OsEnvironment)'=='Windows_NT'" Project="$(BuildToolsTaskDir)roslyn/build/Microsoft.Net.Compilers.props" />
 
   <PropertyGroup>
     <!--

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -12,7 +12,7 @@ set BUILD_TOOLS_PATH=%PACKAGES_DIR%Microsoft.DotNet.BuildTools\%BUILDTOOLS_VERSI
 set PROJECT_JSON_PATH=%TOOLRUNTIME_DIR%\%BUILDTOOLS_VERSION%
 set PROJECT_JSON_FILE=%PROJECT_JSON_PATH%\project.json
 set PROJECT_JSON_CONTENTS={ "dependencies": { "Microsoft.DotNet.BuildTools": "%BUILDTOOLS_VERSION%" }, "frameworks": { "dnxcore50": { } } }
-set BUILD_TOOLS_SEMAPHORE=%PROJECT_JSON_PATH%\init-tools.completed
+set BUILD_TOOLS_SEMAPHORE=%PROJECT_JSON_PATH%\init-tools-rev.completed
 
 :: if force option is specified then clean the tool runtime and build tools package directory to force it to get recreated
 if [%1]==[force] (
@@ -41,21 +41,21 @@ set DOTNET_ZIP_NAME=dotnet-dev-win-x64.%DOTNET_VERSION%.zip
 set DOTNET_REMOTE_PATH=https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/%DOTNET_VERSION%/%DOTNET_ZIP_NAME%
 set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> "%INIT_TOOLS_LOG%"
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; if ($AddTypeErrors.Count -eq 0) { [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%') } else { (New-Object -com shell.application).namespace('%DOTNET_PATH%').CopyHere((new-object -com shell.application).namespace('%DOTNET_LOCAL_PATH%').Items(),16) }" >> "%INIT_TOOLS_LOG%"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "$retryCount = 0; $success = $false; do { try { (New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); $success = $true; } catch { if ($retryCount -ge 6) { throw; } else { $retryCount++; Start-Sleep -Seconds (5 * $retryCount); } } } while ($success -eq $false); Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; if ($AddTypeErrors.Count -eq 0) { [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%') } else { (New-Object -com shell.application).namespace('%DOTNET_PATH%').CopyHere((new-object -com shell.application).namespace('%DOTNET_LOCAL_PATH%').Items(),16) }" >> "%INIT_TOOLS_LOG%"
 if NOT exist "%DOTNET_LOCAL_PATH%" (
   echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details.
-  goto :EOF
+  exit /b 1
 )
 
 :afterdotnetrestore
 
 if exist "%BUILD_TOOLS_PATH%" goto :afterbuildtoolsrestore
 echo Restoring BuildTools version %BUILDTOOLS_VERSION%...
-echo Running: "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
-call "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
+echo Running: "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
+call "%DOTNET_CMD%" restore "%PROJECT_JSON_FILE%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" >> "%INIT_TOOLS_LOG%"
 if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
   echo ERROR: Could not restore build tools correctly. See '%INIT_TOOLS_LOG%' for more details.
-  goto :EOF
+  exit /b 1
 )
 
 :afterbuildtoolsrestore
@@ -63,6 +63,29 @@ if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
 echo Initializing BuildTools ...
 echo Running: "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 call "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
+
+:: Override Roslyn with newer version. Ideally, we would pick up the compiler update via buildtools update. But new buildtools 
+:: require new CLI as well that we cannot pick up right now because of it is missing the native compilation driver.
+
+set ROSLYN_VERSION_OVERRIDE=2.0.0-beta3
+
+set ROSLYN_PACKAGE=%PACKAGES_DIR%Microsoft.Net.Compilers\%ROSLYN_VERSION_OVERRIDE%\
+
+set ROSLYN_JSON_FILE=%TOOLRUNTIME_DIR%\net45\roslyn\project.json
+set ROSLYN_JSON_CONTENTS={ "dependencies": { "Microsoft.Net.Compilers": "%ROSLYN_VERSION_OVERRIDE%" }, "frameworks": { "net46": { } } }
+echo %ROSLYN_JSON_CONTENTS% > "%ROSLYN_JSON_FILE%"
+
+set ROSLYN_SOURCE=https://api.nuget.org/v3/index.json
+
+echo Restoring Microsoft.Net.Compilers version %ROSLYN_VERSION_OVERRIDE%...
+echo Running: "%DOTNET_CMD%" restore "%ROSLYN_JSON_FILE%" --packages %PACKAGES_DIR% --source %ROSLYN_SOURCE% >> "%INIT_TOOLS_LOG%"
+call "%DOTNET_CMD%" restore "%ROSLYN_JSON_FILE%" --packages %PACKAGES_DIR% --source "%ROSLYN_SOURCE%" >> "%INIT_TOOLS_LOG%"
+if NOT exist "%ROSLYN_PACKAGE%tools\csc.exe" (
+  echo ERROR: Could not restore build tools correctly. See '%INIT_TOOLS_LOG%' for more details.
+  exit /b 1
+)
+
+Robocopy "%ROSLYN_PACKAGE%." "%TOOLRUNTIME_DIR%\net45\roslyn\." /E >> "%INIT_TOOLS_LOG%"
 
 :: Create sempahore file
 echo Done initializing tools.

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -13,6 +13,7 @@ __BUILD_TOOLS_PATH=$__PACKAGES_DIR/Microsoft.DotNet.BuildTools/$__BUILD_TOOLS_PA
 __PROJECT_JSON_PATH=$__TOOLRUNTIME_DIR/$__BUILD_TOOLS_PACKAGE_VERSION
 __PROJECT_JSON_FILE=$__PROJECT_JSON_PATH/project.json
 __PROJECT_JSON_CONTENTS="{ \"dependencies\": { \"Microsoft.DotNet.BuildTools\": \"$__BUILD_TOOLS_PACKAGE_VERSION\" }, \"frameworks\": { \"dnxcore50\": { } } }"
+__INIT_TOOLS_DONE_MARKER=$__PROJECT_JSON_PATH/done
 
 OSName=$(uname -s)
 case $OSName in
@@ -42,7 +43,7 @@ case $OSName in
         ;;
 esac
 
-if [ ! -e $__PROJECT_JSON_FILE ]; then
+if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     if [ -e $__TOOLRUNTIME_DIR ]; then rm -rf -- $__TOOLRUNTIME_DIR; fi
     echo "Running: $__scriptpath/init-tools.sh" > $__init_tools_log
     if [ ! -e $__DOTNET_PATH ]; then
@@ -55,7 +56,7 @@ if [ ! -e $__PROJECT_JSON_FILE ]; then
             mkdir -p "$__DOTNET_PATH"
             wget -q -O $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
         else
-            curl -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+            curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
         fi
         cd $__DOTNET_PATH
         tar -xf $__DOTNET_PATH/dotnet.tar
@@ -74,14 +75,39 @@ if [ ! -e $__PROJECT_JSON_FILE ]; then
 
     if [ ! -e $__BUILD_TOOLS_PATH ]; then
         echo "Restoring BuildTools version $__BUILD_TOOLS_PACKAGE_VERSION..."
-        echo "Running: $__DOTNET_CMD restore \"$__PROJECT_JSON_FILE\" --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE" >> $__init_tools_log
-        $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE >> $__init_tools_log
+        echo "Running: $__DOTNET_CMD restore \"$__PROJECT_JSON_FILE\" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE" >> $__init_tools_log
+        $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE >> $__init_tools_log
         if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."; fi
     fi
 
     echo "Initializing BuildTools..."
     echo "Running: $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR" >> $__init_tools_log
     $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR >> $__init_tools_log
+
+    # Override Roslyn with newer version. Ideally, we would pick up the compiler update via buildtools update. But new buildtools 
+    # require new CLI as well that we cannot pick up right now because of it is missing the native compilation driver.
+
+    __ROSLYN_VERSION_OVERRIDE=2.0.0-beta3
+
+    __ROSLYN_JSON_FILE=$__TOOLRUNTIME_DIR/roslyn.project.json
+    __ROSLYN_JSON_CONTENTS="{ \"dependencies\": { \"Microsoft.Net.Compilers.netcore\": \"$__ROSLYN_VERSION_OVERRIDE\" }, \"frameworks\": { \"netcoreapp1.0\": { } } }"
+    echo $__ROSLYN_JSON_CONTENTS > "$__ROSLYN_JSON_FILE"
+
+    __ROSLYN_SOURCE=https://api.nuget.org/v3/index.json
+
+    echo "Restoring Microsoft.Net.Compilers version $__ROSLYN_VERSION_OVERRIDE..."
+    echo "Running: $__DOTNET_CMD restore \"$__ROSLYN_JSON_FILE\" --no-cache --packages $__PACKAGES_DIR --source $__ROSLYN_SOURCE" >> $__init_tools_log
+    $__DOTNET_CMD restore "$__ROSLYN_JSON_FILE" --no-cache --packages $__PACKAGES_DIR --source $__ROSLYN_SOURCE >> $__init_tools_log
+    if [ ! -e "$__PACKAGES_DIR/Microsoft.Net.Compilers.netcore/$__ROSLYN_VERSION_OVERRIDE/runtimes/any/native" ]; then echo "ERROR: Could not restore Microsoft.Net.Compilers correctly. See '$__init_tools_log' for more details."; fi
+
+    cp "$__PACKAGES_DIR/Microsoft.Net.Compilers.netcore/$__ROSLYN_VERSION_OVERRIDE/runtimes/any/native/csc.exe" $__TOOLRUNTIME_DIR
+    cp "$__PACKAGES_DIR/Microsoft.CodeAnalysis.Common/$__ROSLYN_VERSION_OVERRIDE/lib/netstandard1.3/Microsoft.CodeAnalysis.dll" $__TOOLRUNTIME_DIR
+    cp "$__PACKAGES_DIR/Microsoft.CodeAnalysis.CSharp/$__ROSLYN_VERSION_OVERRIDE/lib/netstandard1.3/Microsoft.CodeAnalysis.CSharp.dll" $__TOOLRUNTIME_DIR
+    cp "$__PACKAGES_DIR/Microsoft.CodeAnalysis.VisualBasic/$__ROSLYN_VERSION_OVERRIDE/lib/netstandard1.3/Microsoft.CodeAnalysis.VisualBasic.dll" $__TOOLRUNTIME_DIR
+    cp "$__PACKAGES_DIR/System.Reflection.Metadata/1.3.0/lib/netstandard1.1/System.Reflection.Metadata.dll" $__TOOLRUNTIME_DIR
+    cp "$__PACKAGES_DIR/System.Collections.Immutable/1.2.0/lib/netstandard1.0/System.Collections.Immutable.dll" $__TOOLRUNTIME_DIR
+
+    touch $__INIT_TOOLS_DONE_MARKER
     echo "Done initializing tools."
 else
     echo "Tools are already initialized"

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -327,6 +327,7 @@
     <Compile Include="System\Runtime\CompilerServices\EagerOrderedStaticConstructorAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\TypeForwardedFromAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\TypeForwardedToAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\Unsafe.cs" />
     <Compile Include="System\Runtime\CompilerServices\UnsafeValueTypeAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\NetNativeToolsVersionAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\FakeElementAttribute.cs" />

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    //
+    // Subsetted clone of System.Runtime.CompilerServices.Unsafe for internal runtime use.
+    // Keep in sync with https://github.com/dotnet/corefx/tree/master/src/System.Runtime.CompilerServices.Unsafe.
+    // 
+
+    /// <summary>
+    /// Contains generic, low-level functionality for manipulating pointers.
+    /// </summary>
+    public static class Unsafe
+    {
+#if CORERT
+        /// <summary>
+        /// Reinterprets the given reference as a reference to a value of type <typeparamref name="TTo"/>.
+        /// </summary>
+        [Intrinsic]
+        public static extern ref TTo As<TFrom, TTo>(ref TFrom source);
+        // ldarg.0
+        // ret
+#endif
+    }
+}


### PR DESCRIPTION
Ideally, we would pick up the compiler update via buildtools update. But new buildtools require new CLI as well that we cannot pick up right now because of it is missing the native compilation driver. So I have ended up patching the buildtools with the updated compiler for now.

The change also contains start of Unsafe utility class. For now, it has just one unimplemented byref returning method to verify that we are really using C# 7.