### PR TITLE
A small preparatory change for TypeInfo restoration.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -67,6 +67,7 @@
     <Compile Include="System\Reflection\Runtime\General\Helpers.cs" />
     <Compile Include="System\Reflection\Runtime\General\MetadataReaderExtensions.cs" />
     <Compile Include="System\Reflection\Runtime\General\NamespaceChain.cs" />
+    <Compile Include="System\Reflection\Runtime\General\NonOverriddenApis.cs" />
     <Compile Include="System\Reflection\Runtime\General\QHandles.cs" />
     <Compile Include="System\Reflection\Runtime\General\RuntimeNamespaceInfo.cs" />
     <Compile Include="System\Reflection\Runtime\General\RuntimeTypeHandleKey.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// Why this file exists:
+//
+// Because the Reflection base types have so many overridable members, it becomes difficult to distinguish
+// members we decided not to override vs. those we forgot to override. It would be nice if C# had a construct to 
+// tell the reader (and Intellisense) that we've made an explicit decision *not* to override an inherited member, 
+// but since it doesn't, we'll make do with this instead.
+//
+// In DEBUG builds, we'll add a base-delegating override so that it's clear we made an explicit decision
+// to accept the base class's implemention. In RELEASE builds, we'll #if'd these out to avoid the extra metadata and runtime
+// cost. That way, every overridable member is accounted for (i.e. the codebase should always be kept in a state
+// where hitting "override" + SPACE never brings up additional suggestions in Intellisense.)
+//
+// To avoid introducing inadvertent inconsistencies between DEBUG and RELEASE behavior due to the fragile base class 
+// problem, only do this for public or protected members that already exist on the public api type. Since we know 
+// we'll never remove those members, we'll avoid the problem of "base" being compile-bound to something different
+// from the runtime "base."
+//
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Globalization;
+using System.Collections.Generic;
+using Internal.Reflection.Extensibility;
+
+namespace System.Reflection.Runtime.Assemblies
+{
+    internal sealed partial class RuntimeAssembly
+    {
+#if DEBUG
+        public sealed override Type GetType(string name) => base.GetType(name);
+        public sealed override bool IsDynamic => base.IsDynamic;
+        public sealed override string ToString() => base.ToString();
+#endif //DEBUG
+    }
+}
+
+namespace System.Reflection.Runtime.CustomAttributes
+{
+    internal abstract partial class RuntimeCustomAttributeData
+    {
+#if DEBUG
+        public sealed override bool Equals(object obj) => base.Equals(obj);
+        public sealed override int GetHashCode() => base.GetHashCode();
+#endif //DEBUG
+    }
+}
+
+namespace System.Reflection.Runtime.TypeInfos
+{
+    internal abstract partial class RuntimeTypeInfo
+    {
+#if DEBUG
+        public sealed override bool IsSubclassOf(Type c) => base.IsSubclassOf(c);
+#endif //DEBUG
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -50,6 +50,8 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             _legacyAsType = new RuntimeTypeTemporary(this);
         }
+         
+        public abstract override Assembly Assembly { get; }
 
         public sealed override string AssemblyQualifiedName
         {
@@ -72,6 +74,8 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             return _legacyAsType;
         }
+
+        public abstract override TypeAttributes Attributes { get; }
 
         public sealed override bool IsCOMObject
         {
@@ -345,6 +349,34 @@ namespace System.Reflection.Runtime.TypeInfos
 
             TypeInfoCachedData cachedData = this.TypeInfoCachedData;
             return cachedData.GetDeclaredMethod(name);
+        }
+
+        public sealed override IEnumerable<MethodInfo> GetDeclaredMethods(string name)
+        {
+            foreach (MethodInfo method in DeclaredMethods)
+            {
+                if (method.Name == name)
+                    yield return method;
+            }
+        }
+
+        public sealed override TypeInfo GetDeclaredNestedType(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            TypeInfo match = null;
+            foreach (TypeInfo nestedType in DeclaredNestedTypes)
+            {
+                if (nestedType.Name == name)
+                {
+                    if (match != null)
+                        throw new AmbiguousMatchException();
+
+                    match = nestedType;
+                }
+            }
+            return match;
         }
 
         public sealed override PropertyInfo GetDeclaredProperty(String name)


### PR DESCRIPTION
RuntimeTypeInfo.GetDeclaredMethods() and GetDeclaredNestedType()
were inheriting their implementations from TypeInfo.
This is fine with today's bits but as soon as we replace
TypeInfo with the one from the full framework, these
will break as the full framework TypeInfo routes everything
through the BindingFlags apis which won't be implemented
yet.

To avoid that, we'll override them with a self-sufficient
implementation to tide us over until everything's
back up and running.

This also shone light on the fact that the unspoken
convention of making sure each override/no-override
decision is made explicit in this particular codebase
has bit-rotted some. So I added some new override
declarations to fill those holes.