### PR TITLE
Change PalHijack to fail silently on Unix until it is implemented

### DIFF
--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -725,6 +725,8 @@ REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalGetMaximumStackBounds(_Out_ void** ppSt
 // Return value:  number of characters in name string
 REDHAWK_PALIMPORT Int32 PalGetModuleFileName(_Out_ const TCHAR** pModuleNameOut, HANDLE moduleBase);
 
+#if _WIN32
+
 // Various intrinsic declarations needed for the PalGetCurrentTEB implementation below.
 #if defined(_X86_)
 EXTERN_C unsigned long __readfsdword(unsigned long Offset);
@@ -764,6 +766,18 @@ inline UInt8 * PalNtCurrentTeb()
 #else
 #define OFFSETOF__TEB__ThreadLocalStoragePointer 0x2c
 #endif
+
+#else // _WIN32
+
+inline UInt8 * PalNtCurrentTeb()
+{
+    // UNIXTODO: Implement PalNtCurrentTeb
+    return NULL;
+}
+
+#define OFFSETOF__TEB__ThreadLocalStoragePointer 0
+
+#endif // _WIN32
 
 //
 // Compiler intrinsic definitions. In the interest of performance the PAL doesn't provide exports of these

--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -564,7 +564,7 @@ bool Thread::Hijack()
 
     // requires THREAD_SUSPEND_RESUME / THREAD_GET_CONTEXT / THREAD_SET_CONTEXT permissions
 
-    return PalHijack(m_hPalThread, HijackCallback, this) <= 0;
+    return PalHijack(m_hPalThread, HijackCallback, this) == 0;
 }
 
 UInt32_BOOL Thread::HijackCallback(HANDLE /*hThread*/, PAL_LIMITED_CONTEXT* pThreadContext, void* pCallbackContext)

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -1110,9 +1110,10 @@ extern "C" UInt32_BOOL HeapFree(HANDLE heap, UInt32 flags, void * mem)
 
 typedef UInt32 (__stdcall *HijackCallback)(HANDLE hThread, _In_ PAL_LIMITED_CONTEXT* pThreadContext, _In_opt_ void* pCallbackContext);
 
-REDHAWK_PALEXPORT uint32_t REDHAWK_PALAPI PalHijack(HANDLE hThread, _In_ HijackCallback callback, _In_opt_ void* pCallbackContext)
+REDHAWK_PALEXPORT UInt32 REDHAWK_PALAPI PalHijack(HANDLE hThread, _In_ HijackCallback callback, _In_opt_ void* pCallbackContext)
 {
-    PORTABILITY_ASSERT("UNIXTODO: Implement this function");
+    // UNIXTODO: Implement PalHijack
+    return E_FAIL;
 }
 
 extern "C" UInt32 WaitForSingleObjectEx(HANDLE handle, UInt32 milliseconds, UInt32_BOOL alertable)


### PR DESCRIPTION
Workaround #642. This workaround won't work if there is a long running tight loop that does not allocate or P/Invoke - this situation is not common in practice.

Also included a few related portability tweaks for issues that I have run into while looking into this.