### PR TITLE
.NETNative CoreLib Reflection Bringup: Type and TypeInfo

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Extensibility/ExtensibleType.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Extensibility/ExtensibleType.cs
@@ -13,13 +13,5 @@ namespace Internal.Reflection.Extensibility
         protected ExtensibleType()
         {
         }
-
-        // TypeInfo/Type will undergo a lot of shakeup so we'll use this to project a 1.0-compatible viewpoint
-        // on downward types so we can manage the switchover more easily.
-
-        public override object[] GetCustomAttributes(bool inherit) { throw NotImplemented.ByDesign; }
-        public override object[] GetCustomAttributes(Type attributeType, bool inherit) { throw NotImplemented.ByDesign; }
-        public override bool IsDefined(Type attributeType, bool inherit) { throw NotImplemented.ByDesign; }
-        public override Type ReflectedType { get { throw NotImplemented.ByDesign; } }
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Extensibility/ReflectionExtensibility.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Extensibility/ReflectionExtensibility.cs
@@ -22,24 +22,24 @@ namespace Internal.Reflection.Extensibility
         {
         }
     }
-    
+
     public abstract class ExtensibleCustomAttributeData : CustomAttributeData
     {
         protected ExtensibleCustomAttributeData()
         {
         }
-        
-        public static CustomAttributeNamedArgument CreateCustomAttributeNamedArgument(System.Type attributeType, string memberName, bool isField, CustomAttributeTypedArgument typedValue) 
-        { 
+
+        public static CustomAttributeNamedArgument CreateCustomAttributeNamedArgument(System.Type attributeType, string memberName, bool isField, CustomAttributeTypedArgument typedValue)
+        {
             return new CustomAttributeNamedArgument(attributeType, memberName, isField, typedValue);
         }
-        
+
         public static CustomAttributeTypedArgument CreateCustomAttributeTypedArgument(System.Type argumentType, object value)
         {
             return new CustomAttributeTypedArgument(argumentType, value);
         }
     }
-    
+
     public abstract class ExtensibleEventInfo : EventInfo
     {
         protected ExtensibleEventInfo()
@@ -60,14 +60,14 @@ namespace Internal.Reflection.Extensibility
         {
         }
     }
-    
+
     public abstract class ExtensibleModule : Module
     {
         protected ExtensibleModule()
         {
         }
     }
-    
+
     public abstract class ExtensibleParameterInfo : ParameterInfo
     {
         protected ExtensibleParameterInfo()
@@ -125,5 +125,24 @@ namespace Internal.Reflection.Extensibility
         public override object[] GetCustomAttributes(Type attributeType, bool inherit) { throw NotImplemented.ByDesign; }
         public override bool IsDefined(Type attributeType, bool inherit) { throw NotImplemented.ByDesign; }
         public override Type ReflectedType { get { throw NotImplemented.ByDesign; } }
+
+        protected sealed override bool IsCOMObjectImpl() => IsCOMObject;
+        public new virtual bool IsCOMObject { get { throw NotImplemented.ByDesign; } }
+
+        protected sealed override bool IsPrimitiveImpl() => IsPrimitive;
+        public new virtual bool IsPrimitive { get { throw NotImplemented.ByDesign; } }
+
+        protected sealed override bool IsValueTypeImpl() => IsValueType;
+        public new virtual bool IsValueType { get { throw NotImplemented.ByDesign; } }
+
+        // There is no IsEnumImpl()
+        public new virtual bool IsEnum { get { throw NotImplemented.ByDesign; } }
+
+        protected sealed override TypeAttributes GetAttributeFlagsImpl() => Attributes;
+        public new virtual TypeAttributes Attributes { get { throw NotImplemented.ByDesign; } }
+
+        protected sealed override bool HasElementTypeImpl() => IsArray || IsByRef || IsPointer;
+
+        public sealed override Type UnderlyingSystemType => this;
     }
 }

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -169,6 +169,7 @@
     <Compile Include="System\Reflection\TypeAttributes.cs" />
     <Compile Include="System\Reflection\TypeFilter.cs" />
     <Compile Include="System\Reflection\TypeInfo.cs" />
+    <Compile Include="System\Reflection\TypeInfo.Workaround.cs" />
     <Compile Include="System\__Canon.cs" />
     <Compile Include="System\Action.cs" />
     <Compile Include="System\Activator.cs" />
@@ -546,6 +547,7 @@
     <Compile Include="System\TimeZoneInfo.cs" />
     <Compile Include="System\Tuple.cs" />
     <Compile Include="System\Type.cs" />
+    <Compile Include="System\Type.Helpers.cs" />
     <Compile Include="System\TypeUnificationKey.cs" />
     <Compile Include="System\TypeAccessException.cs" />
     <Compile Include="System\TypeCode.cs" />

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeNamedArgument.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeNamedArgument.cs
@@ -64,15 +64,14 @@ namespace System.Reflection
                 MemberInfo memberInfo = _lazyMemberInfo;
                 if (memberInfo == null)
                 {
-                    throw new NotImplementedException(); // Need to finish Type class, before this can be enabled.
-                    //if (IsField)
-                    //    memberInfo = _attributeType.GetField(MemberName, BindingFlags.Public | BindingFlags.Instance);
-                    //else
-                    //    memberInfo = _attributeType.GetProperty(MemberName, BindingFlags.Public | BindingFlags.Instance);
-                    //
-                    //if (memberInfo == null)
-                    //    throw new NotImplementedException(); // @todo: This can only come from bad metadata or missing metadata. Must find a better exception.
-                    //_lazyMemberInfo = memberInfo;
+                    if (IsField)
+                        memberInfo = _attributeType.GetField(MemberName, BindingFlags.Public | BindingFlags.Instance);
+                    else
+                        memberInfo = _attributeType.GetProperty(MemberName, BindingFlags.Public | BindingFlags.Instance);
+                    
+                    if (memberInfo == null)
+                        throw new NotImplementedException(); // @todo: This can only come from bad metadata or missing metadata. Must find a better exception.
+                    _lazyMemberInfo = memberInfo;
                 }
                 return memberInfo;
             }

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
@@ -41,7 +41,7 @@ namespace System.Reflection
 
         private static object CanonicalizeValue(object value)
         {
-            if (value.GetType().GetTypeInfo().IsEnum)
+            if (value.GetType().IsEnum)
                 return ((Enum)value).GetValue();
             return value;
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/EventInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/EventInfo.cs
@@ -34,7 +34,7 @@ namespace System.Reflection
             {
                 Type cl = EventHandlerType;
                 Type mc = typeof(MulticastDelegate);
-                return mc.GetTypeInfo().IsAssignableFrom(cl.GetTypeInfo());
+                return mc.IsAssignableFrom(cl);
             }
         }
 
@@ -48,7 +48,7 @@ namespace System.Reflection
                 for (int i = 0; i < p.Length; i++)
                 {
                     Type c = p[i].ParameterType;
-                    if (c.GetTypeInfo().IsSubclassOf(del.GetTypeInfo()))
+                    if (c.IsSubclassOf(del))
                         return c;
                 }
                 return null;

--- a/src/System.Private.CoreLib/src/System/Reflection/MemberInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MemberInfo.cs
@@ -22,10 +22,9 @@ namespace System.Reflection
                 // This check is necessary because for some reason, Type adds a new "Module" property that hides the inherited one instead 
                 // of overriding.
 
-                // @todo: Restore as soon as we finish Type.
-                //Type type = this as Type;
-                //if (type != null)
-                //    return type.Module;
+                Type type = this as Type;
+                if (type != null)
+                    return type.Module;
 
                 throw NotImplemented.ByDesign;
             }

--- a/src/System.Private.CoreLib/src/System/Reflection/TypeInfo.Workaround.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/TypeInfo.Workaround.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Reflection
+{
+    public abstract partial class TypeInfo : Type, IReflectableType
+    {
+        // TODO https://github.com/dotnet/corefx/issues/9805: These are inherited from Type and shouldn't need to be redeclared on TypeInfo but 
+        //   they are a well-known methods to the reducer.
+
+        public override abstract Assembly Assembly { get; }
+        public override abstract Type BaseType { get; }
+        public override Type MakeGenericType(params Type[] typeArguments) => base.MakeGenericType(typeArguments);
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Reflection/TypeInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/TypeInfo.cs
@@ -2,453 +2,75 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-/*============================================================
-**
-  Type:  TypeInfo
-**
-==============================================================*/
-
-using global::System;
-using global::System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace System.Reflection
 {
-    public abstract class TypeInfo : Type, IReflectableType
+    public abstract partial class TypeInfo : Type, IReflectableType
     {
-        protected TypeInfo()
-        {
-        }
+        protected TypeInfo() { }
 
-        public abstract Assembly Assembly { get; }
-        public abstract TypeAttributes Attributes { get; }
-        public abstract Type BaseType { get; }
-        public abstract bool ContainsGenericParameters { get; }
+        TypeInfo IReflectableType.GetTypeInfo() => this;
+        public virtual Type AsType() => this;
 
-        public virtual IEnumerable<ConstructorInfo> DeclaredConstructors
+        public virtual Type[] GenericTypeParameters => IsGenericTypeDefinition ? GetGenericArguments() : Type.EmptyTypes;
+
+        public virtual EventInfo GetDeclaredEvent(string name) => GetEvent(name, TypeInfo.DeclaredOnlyLookup);
+        public virtual FieldInfo GetDeclaredField(string name) => GetField(name, TypeInfo.DeclaredOnlyLookup);
+        public virtual MethodInfo GetDeclaredMethod(string name) => GetMethod(name, TypeInfo.DeclaredOnlyLookup);
+        public virtual TypeInfo GetDeclaredNestedType(string name) => GetNestedType(name, TypeInfo.DeclaredOnlyLookup)?.GetTypeInfo();
+        public virtual PropertyInfo GetDeclaredProperty(string name) => GetProperty(name, TypeInfo.DeclaredOnlyLookup);
+
+        public virtual IEnumerable<MethodInfo> GetDeclaredMethods(string name)
         {
-            get
+            foreach (MethodInfo method in GetMethods(TypeInfo.DeclaredOnlyLookup))
             {
-                return GetDeclaredMembersOfType<ConstructorInfo>();
+                if (method.Name == name)
+                    yield return method;
             }
         }
 
-        public virtual IEnumerable<EventInfo> DeclaredEvents
+        public virtual IEnumerable<ConstructorInfo> DeclaredConstructors => GetConstructors(TypeInfo.DeclaredOnlyLookup);
+        public virtual IEnumerable<EventInfo> DeclaredEvents => GetEvents(TypeInfo.DeclaredOnlyLookup);
+        public virtual IEnumerable<FieldInfo> DeclaredFields => GetFields(TypeInfo.DeclaredOnlyLookup);
+        public virtual IEnumerable<MemberInfo> DeclaredMembers => GetMembers(TypeInfo.DeclaredOnlyLookup);
+        public virtual IEnumerable<MethodInfo> DeclaredMethods => GetMethods(TypeInfo.DeclaredOnlyLookup);
+        public virtual IEnumerable<System.Reflection.TypeInfo> DeclaredNestedTypes
         {
             get
             {
-                return GetDeclaredMembersOfType<EventInfo>();
-            }
-        }
-
-        public virtual IEnumerable<FieldInfo> DeclaredFields
-        {
-            get
-            {
-                return GetDeclaredMembersOfType<FieldInfo>();
-            }
-        }
-
-        public virtual IEnumerable<MemberInfo> DeclaredMembers
-        {
-            get
-            {
-                throw NotImplemented.ByDesign;
-            }
-        }
-
-        public virtual IEnumerable<MethodInfo> DeclaredMethods
-        {
-            get
-            {
-                return GetDeclaredMembersOfType<MethodInfo>();
-            }
-        }
-
-        public virtual IEnumerable<TypeInfo> DeclaredNestedTypes
-        {
-            get
-            {
-                return GetDeclaredMembersOfType<TypeInfo>();
-            }
-        }
-
-        public virtual IEnumerable<PropertyInfo> DeclaredProperties
-        {
-            get
-            {
-                return GetDeclaredMembersOfType<PropertyInfo>();
-            }
-        }
-
-        private IEnumerable<T> GetDeclaredMembersOfType<T>() where T : MemberInfo
-        {
-            IEnumerable<MemberInfo> members = this.DeclaredMembers;
-            foreach (MemberInfo member in members)
-            {
-                T memberAsT = member as T;
-                if (memberAsT != null)
-                    yield return memberAsT;
-            }
-        }
-
-
-        public abstract MethodBase DeclaringMethod { get; }
-        public abstract GenericParameterAttributes GenericParameterAttributes { get; }
-
-        public virtual Type[] GenericTypeParameters
-        {
-            get
-            {
-                if (IsGenericTypeDefinition)
+                foreach (Type t in GetNestedTypes(TypeInfo.DeclaredOnlyLookup))
                 {
-                    return GenericTypeArguments;
-                }
-                else
-                {
-                    return Array.Empty<Type>();
+                    yield return t.GetTypeInfo();
                 }
             }
         }
+        public virtual IEnumerable<PropertyInfo> DeclaredProperties => GetProperties(TypeInfo.DeclaredOnlyLookup);
 
-        public abstract Guid GUID { get; }
+        public virtual IEnumerable<Type> ImplementedInterfaces => GetInterfaces();
 
-        public virtual IEnumerable<Type> ImplementedInterfaces
-        {
-            get
-            {
-                throw NotImplemented.ByDesign;
-            }
-        }
-
-
-
-        public bool IsAbstract
-        {
-            get
-            {
-                return 0 != (this.Attributes & TypeAttributes.Abstract);
-            }
-        }
-
-        public bool IsAnsiClass
-        {
-            get
-            {
-                return TypeAttributes.AnsiClass == (this.Attributes & TypeAttributes.StringFormatMask);
-            }
-        }
-
-        public bool IsAutoClass
-        {
-            get
-            {
-                return TypeAttributes.AutoClass == (this.Attributes & TypeAttributes.StringFormatMask);
-            }
-        }
-
-        public bool IsAutoLayout
-        {
-            get
-            {
-                return TypeAttributes.AutoLayout == (this.Attributes & TypeAttributes.LayoutMask);
-            }
-        }
-
-        public bool IsClass
-        {
-            get
-            {
-                return (TypeAttributes.Class == (this.Attributes & TypeAttributes.ClassSemanticsMask)) && !IsValueType;
-            }
-        }
-
-        public abstract bool IsEnum { get; }
-
-        public virtual bool IsCOMObject { get { return false; } }
-
-        public bool IsExplicitLayout
-        {
-            get
-            {
-                return TypeAttributes.ExplicitLayout == (this.Attributes & TypeAttributes.LayoutMask);
-            }
-        }
-
-        public abstract bool IsGenericType { get; }
-        public abstract bool IsGenericTypeDefinition { get; }
-
-        public bool IsImport
-        {
-            get
-            {
-                return 0 != (this.Attributes & TypeAttributes.Import);
-            }
-        }
-
-        public bool IsInterface
-        {
-            get
-            {
-                return TypeAttributes.Interface == (this.Attributes & TypeAttributes.ClassSemanticsMask);
-            }
-        }
-
-        public bool IsLayoutSequential
-        {
-            get
-            {
-                return TypeAttributes.SequentialLayout == (this.Attributes & TypeAttributes.LayoutMask);
-            }
-        }
-
-
-        public bool IsMarshalByRef { get { return false; } }
-
-
-        public bool IsNestedAssembly
-        {
-            get
-            {
-                return TypeAttributes.NestedAssembly == (this.Attributes & TypeAttributes.VisibilityMask);
-            }
-        }
-
-
-        public bool IsNestedFamANDAssem
-        {
-            get
-            {
-                return TypeAttributes.NestedFamANDAssem == (this.Attributes & TypeAttributes.VisibilityMask);
-            }
-        }
-
-
-        public bool IsNestedFamily
-        {
-            get
-            {
-                return TypeAttributes.NestedFamily == (this.Attributes & TypeAttributes.VisibilityMask);
-            }
-        }
-
-        public bool IsNestedFamORAssem
-        {
-            get
-            {
-                return TypeAttributes.NestedFamORAssem == (this.Attributes & TypeAttributes.VisibilityMask);
-            }
-        }
-
-
-        public bool IsNestedPrivate
-        {
-            get
-            {
-                return TypeAttributes.NestedPrivate == (this.Attributes & TypeAttributes.VisibilityMask);
-            }
-        }
-
-
-
-        public bool IsNestedPublic
-        {
-            get
-            {
-                return TypeAttributes.NestedPublic == (this.Attributes & TypeAttributes.VisibilityMask);
-            }
-        }
-
-
-        public bool IsNotPublic
-        {
-            get
-            {
-                return TypeAttributes.NotPublic == (this.Attributes & TypeAttributes.VisibilityMask);
-            }
-        }
-
-        public virtual bool IsPrimitive
-        {
-            get
-            {
-                throw NotImplemented.ByDesign;
-            }
-        }
-
-        public bool IsPublic
-        {
-            get
-            {
-                return TypeAttributes.Public == (this.Attributes & TypeAttributes.VisibilityMask);
-            }
-        }
-
-        public bool IsSealed
-        {
-            get
-            {
-                return 0 != (this.Attributes & TypeAttributes.Sealed);
-            }
-        }
-
-        public abstract bool IsSerializable { get; }
-
-        public bool IsSpecialName
-        {
-            get
-            {
-                return 0 != (this.Attributes & TypeAttributes.SpecialName);
-            }
-        }
-
-        public bool IsUnicodeClass
-        {
-            get
-            {
-                return TypeAttributes.UnicodeClass == (this.Attributes & TypeAttributes.StringFormatMask);
-            }
-        }
-
-        public virtual bool IsValueType
-        {
-            get
-            {
-                // Port note: The desktop version inherits an IsValueType from System.Type which calls IsSubclassOf(ValueType) - an implementation
-                // which is acknowledged to be incorrect for non-runtime types.
-                //
-                // However, since this is first time TypeInfo exposes a non-internal .ctor, no one (other than us) could have been subclassing TypeInfo.
-                // So we can safely take this opportunity to do the right thing and throw NotImplemented now.
-                throw NotImplemented.ByDesign;
-            }
-        }
-
-        public bool IsVisible
-        {
-            get
-            {
-                if (IsGenericParameter)
-                    return true;
-
-                if (HasElementType)
-                    return GetElementType().GetTypeInfo().IsVisible;
-
-                TypeInfo typeInfo = this;
-                while (typeInfo.IsNested)
-                {
-                    if (!typeInfo.IsNestedPublic)
-                        return false;
-
-                    // this should be null for non-nested types.
-                    typeInfo = typeInfo.DeclaringType.GetTypeInfo();
-                }
-
-                // Now "typeInfo" should be a top level type
-                if (!typeInfo.IsPublic)
-                    return false;
-
-                Type thisType = this.AsType();
-                if (thisType.IsConstructedGenericType)
-                {
-                    foreach (Type t in thisType.GenericTypeArguments)
-                    {
-                        if (!t.GetTypeInfo().IsVisible)
-                            return false;
-                    }
-                }
-
-                return true;
-            }
-        }
-
-        public virtual Type AsType()
-        {
-            throw NotImplemented.ByDesign;
-        }
-
-        public virtual EventInfo GetDeclaredEvent(String name)
-        {
-            return GetDeclaredMember<EventInfo>(name, DeclaredEvents);
-        }
-
-        public virtual FieldInfo GetDeclaredField(String name)
-        {
-            return GetDeclaredMember<FieldInfo>(name, DeclaredFields);
-        }
-
-        public virtual MethodInfo GetDeclaredMethod(String name)
-        {
-            return GetDeclaredMember<MethodInfo>(name, DeclaredMethods);
-        }
-
-        public virtual IEnumerable<MethodInfo> GetDeclaredMethods(String name)
-        {
-            return GetDeclaredMembers<MethodInfo>(name, DeclaredMethods);
-        }
-
-        public virtual TypeInfo GetDeclaredNestedType(String name)
-        {
-            return GetDeclaredMember<TypeInfo>(name, DeclaredNestedTypes);
-        }
-
-        public virtual PropertyInfo GetDeclaredProperty(String name)
-        {
-            return GetDeclaredMember<PropertyInfo>(name, DeclaredProperties);
-        }
-
-        private IEnumerable<T> GetDeclaredMembers<T>(String name, IEnumerable<T> members) where T : MemberInfo
-        {
-            foreach (T member in members)
-            {
-                if (member.Name == name)
-                    yield return member;
-            }
-        }
-
-        private T GetDeclaredMember<T>(String name, IEnumerable<T> members) where T : MemberInfo
-        {
-            if (name == null)
-                throw new ArgumentNullException("name");
-            IEnumerable<T> matchingMembers = GetDeclaredMembers<T>(name, members);
-            IEnumerator<T> e = matchingMembers.GetEnumerator();
-            if (!e.MoveNext())
-                return null;
-            T result = e.Current;
-            if (e.MoveNext())
-                throw new AmbiguousMatchException();
-            return result;
-        }
-
-
-        public abstract Type[] GetGenericParameterConstraints();
-
+        //a re-implementation of ISAF from Type, skipping the use of UnderlyingType
         public virtual bool IsAssignableFrom(TypeInfo typeInfo)
         {
             if (typeInfo == null)
                 return false;
 
-            if (this.Equals(typeInfo))
+            if (this == typeInfo)
                 return true;
 
-            // If c is a subclass of this class, then typeInfo can be cast to this type.
-            if (typeInfo.IsSubclassOf(this.AsType()))
+            // If c is a subclass of this class, then c can be cast to this type.
+            if (typeInfo.IsSubclassOf(this))
                 return true;
 
             if (this.IsInterface)
             {
-                foreach (Type implementedInterface in typeInfo.ImplementedInterfaces)
-                {
-                    TypeInfo resolvedImplementedInterface = implementedInterface.GetTypeInfo();
-                    if (resolvedImplementedInterface.Equals(this))
-                        return true;
-                }
-                return false;
+                return typeInfo.ImplementInterface(this);
             }
             else if (IsGenericParameter)
             {
                 Type[] constraints = GetGenericParameterConstraints();
                 for (int i = 0; i < constraints.Length; i++)
-                    if (!constraints[i].GetTypeInfo().IsAssignableFrom(typeInfo))
+                    if (!constraints[i].IsAssignableFrom(typeInfo))
                         return false;
 
                 return true;
@@ -457,32 +79,6 @@ namespace System.Reflection
             return false;
         }
 
-        public virtual bool IsSubclassOf(Type c)
-        {
-            TypeInfo resolvedC = c.GetTypeInfo();
-            TypeInfo p = this;
-            if (p.Equals(resolvedC))
-                return false;
-            while (p != null)
-            {
-                if (p.Equals(resolvedC))
-                    return true;
-                Type b = p.BaseType;
-                if (b == null)
-                    break;
-                p = b.GetTypeInfo();
-            }
-            return false;
-        }
-
-        // TODO https://github.com/dotnet/corefx/issues/9805: This is inherited from Type and shouldn't need to be redeclared on TypeInfo but 
-        //   TypeInfo.MakeGenericType is a well known method to the reducer.
-        public abstract override Type MakeGenericType(params Type[] typeArguments);
-
-        TypeInfo System.Reflection.IReflectableType.GetTypeInfo()
-        {
-            return this;
-        }
+        private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
     }
 }
-

--- a/src/System.Private.CoreLib/src/System/Type.Helpers.cs
+++ b/src/System.Private.CoreLib/src/System/Type.Helpers.cs
@@ -1,0 +1,368 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+using Internal.Reflection.Core.NonPortable;
+
+namespace System
+{
+    // This file collects the longer methods of Type to make the main Type class more readable.
+    public abstract partial class Type : MemberInfo, IReflect
+    {
+        public virtual bool ContainsGenericParameters
+        {
+            get
+            {
+                if (HasElementType)
+                    return GetRootElementType().ContainsGenericParameters;
+
+                if (IsGenericParameter)
+                    return true;
+
+                if (!IsGenericType)
+                    return false;
+
+                Type[] genericArguments = GetGenericArguments();
+                for (int i = 0; i < genericArguments.Length; i++)
+                {
+                    if (genericArguments[i].ContainsGenericParameters)
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
+        private Type GetRootElementType()
+        {
+            Type rootElementType = this;
+
+            while (rootElementType.HasElementType)
+                rootElementType = rootElementType.GetElementType();
+
+            return rootElementType;
+        }
+
+        public bool IsVisible
+        {
+            get
+            {
+                if (IsGenericParameter)
+                    return true;
+
+                if (HasElementType)
+                    return GetElementType().IsVisible;
+
+                Type type = this;
+                while (type.IsNested)
+                {
+                    if (!type.IsNestedPublic)
+                        return false;
+
+                    // this should be null for non-nested types.
+                    type = type.DeclaringType;
+                }
+
+                // Now "type" should be a top level type
+                if (!type.IsPublic)
+                    return false;
+
+                if (IsGenericType && !IsGenericTypeDefinition)
+                {
+                    foreach (Type t in GetGenericArguments())
+                    {
+                        if (!t.IsVisible)
+                            return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        public virtual Type[] FindInterfaces(TypeFilter filter, object filterCriteria)
+        {
+            if (filter == null)
+                throw new ArgumentNullException(nameof(filter));
+
+            Type[] c = GetInterfaces();
+            int cnt = 0;
+            for (int i = 0; i < c.Length; i++)
+            {
+                if (!filter(c[i], filterCriteria))
+                    c[i] = null;
+                else
+                    cnt++;
+            }
+            if (cnt == c.Length)
+                return c;
+
+            Type[] ret = new Type[cnt];
+            cnt = 0;
+            for (int i = 0; i < c.Length; i++)
+            {
+                if (c[i] != null)
+                    ret[cnt++] = c[i];
+            }
+            return ret;
+        }
+
+        public virtual MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter filter, object filterCriteria)
+        {
+            // Define the work arrays
+            MethodInfo[] m = null;
+            ConstructorInfo[] c = null;
+            FieldInfo[] f = null;
+            PropertyInfo[] p = null;
+            EventInfo[] e = null;
+            Type[] t = null;
+
+            int i = 0;
+            int cnt = 0;            // Total Matchs
+
+            // Check the methods
+            if ((memberType & MemberTypes.Method) != 0)
+            {
+                m = GetMethods(bindingAttr);
+                if (filter != null)
+                {
+                    for (i = 0; i < m.Length; i++)
+                        if (!filter(m[i], filterCriteria))
+                            m[i] = null;
+                        else
+                            cnt++;
+                }
+                else
+                {
+                    cnt += m.Length;
+                }
+            }
+
+            // Check the constructors
+            if ((memberType & MemberTypes.Constructor) != 0)
+            {
+                c = GetConstructors(bindingAttr);
+                if (filter != null)
+                {
+                    for (i = 0; i < c.Length; i++)
+                        if (!filter(c[i], filterCriteria))
+                            c[i] = null;
+                        else
+                            cnt++;
+                }
+                else
+                {
+                    cnt += c.Length;
+                }
+            }
+
+            // Check the fields
+            if ((memberType & MemberTypes.Field) != 0)
+            {
+                f = GetFields(bindingAttr);
+                if (filter != null)
+                {
+                    for (i = 0; i < f.Length; i++)
+                        if (!filter(f[i], filterCriteria))
+                            f[i] = null;
+                        else
+                            cnt++;
+                }
+                else
+                {
+                    cnt += f.Length;
+                }
+            }
+
+            // Check the Properties
+            if ((memberType & MemberTypes.Property) != 0)
+            {
+                p = GetProperties(bindingAttr);
+                if (filter != null)
+                {
+                    for (i = 0; i < p.Length; i++)
+                        if (!filter(p[i], filterCriteria))
+                            p[i] = null;
+                        else
+                            cnt++;
+                }
+                else
+                {
+                    cnt += p.Length;
+                }
+            }
+
+            // Check the Events
+            if ((memberType & MemberTypes.Event) != 0)
+            {
+                e = GetEvents(bindingAttr);
+                if (filter != null)
+                {
+                    for (i = 0; i < e.Length; i++)
+                        if (!filter(e[i], filterCriteria))
+                            e[i] = null;
+                        else
+                            cnt++;
+                }
+                else
+                {
+                    cnt += e.Length;
+                }
+            }
+
+            // Check the Types
+            if ((memberType & MemberTypes.NestedType) != 0)
+            {
+                t = GetNestedTypes(bindingAttr);
+                if (filter != null)
+                {
+                    for (i = 0; i < t.Length; i++)
+                        if (!filter(t[i], filterCriteria))
+                            t[i] = null;
+                        else
+                            cnt++;
+                }
+                else
+                {
+                    cnt += t.Length;
+                }
+            }
+
+            // Allocate the Member Info
+            MemberInfo[] ret = new MemberInfo[cnt];
+
+            // Copy the Methods
+            cnt = 0;
+            if (m != null)
+            {
+                for (i = 0; i < m.Length; i++)
+                    if (m[i] != null)
+                        ret[cnt++] = m[i];
+            }
+
+            // Copy the Constructors
+            if (c != null)
+            {
+                for (i = 0; i < c.Length; i++)
+                    if (c[i] != null)
+                        ret[cnt++] = c[i];
+            }
+
+            // Copy the Fields
+            if (f != null)
+            {
+                for (i = 0; i < f.Length; i++)
+                    if (f[i] != null)
+                        ret[cnt++] = f[i];
+            }
+
+            // Copy the Properties
+            if (p != null)
+            {
+                for (i = 0; i < p.Length; i++)
+                    if (p[i] != null)
+                        ret[cnt++] = p[i];
+            }
+
+            // Copy the Events
+            if (e != null)
+            {
+                for (i = 0; i < e.Length; i++)
+                    if (e[i] != null)
+                        ret[cnt++] = e[i];
+            }
+
+            // Copy the Types
+            if (t != null)
+            {
+                for (i = 0; i < t.Length; i++)
+                    if (t[i] != null)
+                        ret[cnt++] = t[i];
+            }
+
+            return ret;
+        }
+
+        public virtual bool IsSubclassOf(Type c)
+        {
+            Type p = this;
+            if (p == c)
+                return false;
+            while (p != null)
+            {
+                if (p == c)
+                    return true;
+                p = p.BaseType;
+            }
+            return false;
+        }
+
+        public virtual bool IsAssignableFrom(Type c)
+        {
+            if (c == null)
+                return false;
+
+            if (this == c)
+                return true;
+
+            // For backward-compatibility, we need to special case for the types
+            // whose UnderlyingSystemType are runtime implemented. 
+            Type toType = this.UnderlyingSystemType;
+            if (toType.IsRuntimeImplemented())
+                return toType.IsAssignableFrom(c);
+
+            // If c is a subclass of this class, then c can be cast to this type.
+            if (c.IsSubclassOf(this))
+                return true;
+
+            if (this.IsInterface)
+            {
+                return c.ImplementInterface(this);
+            }
+            else if (IsGenericParameter)
+            {
+                Type[] constraints = GetGenericParameterConstraints();
+                for (int i = 0; i < constraints.Length; i++)
+                    if (!constraints[i].IsAssignableFrom(c))
+                        return false;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        internal bool ImplementInterface(Type ifaceType)
+        {
+            Type t = this;
+            while (t != null)
+            {
+                Type[] interfaces = t.GetInterfaces();
+                if (interfaces != null)
+                {
+                    for (int i = 0; i < interfaces.Length; i++)
+                    {
+                        // Interfaces don't derive from other interfaces, they implement them.
+                        // So instead of IsSubclassOf, we should use ImplementInterface instead.
+                        if (interfaces[i] == ifaceType ||
+                            (interfaces[i] != null && interfaces[i].ImplementInterface(ifaceType)))
+                            return true;
+                    }
+                }
+
+                t = t.BaseType;
+            }
+
+            return false;
+        }
+    }
+}
+

--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -1,152 +1,362 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-//
-// Implements System.Type
-//
-// ======================================================================================
 
 using System;
-using System.Threading;
-using System.Runtime;
+using System.IO;
 using System.Reflection;
 using System.Globalization;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
-using System.Collections.Generic;
+
 using Internal.Runtime.Augments;
 using Internal.Reflection.Core.NonPortable;
 
 namespace System
 {
-    public abstract class Type : MemberInfo
+    public abstract partial class Type : MemberInfo, IReflect
     {
-        protected Type()
-        {
-        }
+        protected Type() { }
 
         public override MemberTypes MemberType => MemberTypes.TypeInfo;
 
-        public static readonly Object Missing = System.Reflection.Missing.Value;
-        public static readonly Type[] EmptyTypes = Array.Empty<Type>();
+        public new Type GetType() => base.GetType();
 
-        public abstract String AssemblyQualifiedName { get; }
-        public abstract String FullName { get; }
-        public abstract int GenericParameterPosition { get; }
-        public abstract Type[] GenericTypeArguments { get; }
+        public abstract string Namespace { get; }
+        public abstract string AssemblyQualifiedName { get; }
+        public abstract string FullName { get; }
+
+        public abstract Assembly Assembly { get; }
+        public abstract new Module Module { get; }
+
+        public bool IsNested => DeclaringType != null;
+        public override Type DeclaringType => null;
+        public virtual MethodBase DeclaringMethod => null;
+
+        public override Type ReflectedType => null;
+        public abstract Type UnderlyingSystemType { get; }
+
+        public bool IsArray => IsArrayImpl();
+        protected abstract bool IsArrayImpl();
+        public bool IsByRef => IsByRefImpl();
+        protected abstract bool IsByRefImpl();
+        public bool IsPointer => IsPointerImpl();
+        protected abstract bool IsPointerImpl();
+        public virtual bool IsConstructedGenericType { get { throw NotImplemented.ByDesign; } }
+        public virtual bool IsGenericParameter => false;
+        public virtual bool IsGenericType => false;
+        public virtual bool IsGenericTypeDefinition => false;
+
+        public bool HasElementType => HasElementTypeImpl();
+        protected abstract bool HasElementTypeImpl();
+        public abstract Type GetElementType();
+
+        public virtual int GetArrayRank() { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
+
+        public virtual Type GetGenericTypeDefinition() { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
+        public virtual Type[] GenericTypeArguments => IsConstructedGenericType ? GetGenericArguments() : Array.Empty<Type>();
         public virtual Type[] GetGenericArguments() { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
 
-        public bool HasElementType
+        public virtual int GenericParameterPosition { get { throw new InvalidOperationException(SR.Arg_NotGenericParameter); } }
+        public virtual GenericParameterAttributes GenericParameterAttributes { get { throw new NotSupportedException(); } }
+        public virtual Type[] GetGenericParameterConstraints()
         {
-            get
+            if (!IsGenericParameter)
+                throw new InvalidOperationException(SR.Arg_NotGenericParameter);
+            throw new InvalidOperationException();
+        }
+
+        public TypeAttributes Attributes => GetAttributeFlagsImpl();
+        protected abstract TypeAttributes GetAttributeFlagsImpl();
+
+        public bool IsAbstract => (GetAttributeFlagsImpl() & TypeAttributes.Abstract) != 0;
+        public bool IsImport => (GetAttributeFlagsImpl() & TypeAttributes.Import) != 0;
+        public bool IsSealed => (GetAttributeFlagsImpl() & TypeAttributes.Sealed) != 0;
+        public virtual bool IsSerializable => (GetAttributeFlagsImpl() & TypeAttributes.Serializable) != 0;
+        public bool IsSpecialName => (GetAttributeFlagsImpl() & TypeAttributes.SpecialName) != 0;
+
+        public bool IsClass => (GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Class && !IsValueType;
+        public bool IsInterface => (GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface;
+
+        public bool IsNestedAssembly => (GetAttributeFlagsImpl() & TypeAttributes.VisibilityMask) == TypeAttributes.NestedAssembly;
+        public bool IsNestedFamANDAssem => (GetAttributeFlagsImpl() & TypeAttributes.VisibilityMask) == TypeAttributes.NestedFamANDAssem;
+        public bool IsNestedFamily => (GetAttributeFlagsImpl() & TypeAttributes.VisibilityMask) == TypeAttributes.NestedFamily;
+        public bool IsNestedFamORAssem => (GetAttributeFlagsImpl() & TypeAttributes.VisibilityMask) == TypeAttributes.NestedFamORAssem;
+        public bool IsNestedPrivate => (GetAttributeFlagsImpl() & TypeAttributes.VisibilityMask) == TypeAttributes.NestedPrivate;
+        public bool IsNestedPublic => (GetAttributeFlagsImpl() & TypeAttributes.VisibilityMask) == TypeAttributes.NestedPublic;
+        public bool IsNotPublic => (GetAttributeFlagsImpl() & TypeAttributes.VisibilityMask) == TypeAttributes.NotPublic;
+        public bool IsPublic => (GetAttributeFlagsImpl() & TypeAttributes.VisibilityMask) == TypeAttributes.Public;
+
+        public bool IsAutoLayout => (GetAttributeFlagsImpl() & TypeAttributes.LayoutMask) == TypeAttributes.AutoLayout;
+        public bool IsExplicitLayout => (GetAttributeFlagsImpl() & TypeAttributes.LayoutMask) == TypeAttributes.ExplicitLayout;
+        public bool IsLayoutSequential => (GetAttributeFlagsImpl() & TypeAttributes.LayoutMask) == TypeAttributes.SequentialLayout;
+
+        public bool IsAnsiClass => (GetAttributeFlagsImpl() & TypeAttributes.StringFormatMask) == TypeAttributes.AnsiClass;
+        public bool IsAutoClass => (GetAttributeFlagsImpl() & TypeAttributes.StringFormatMask) == TypeAttributes.AutoClass;
+        public bool IsUnicodeClass => (GetAttributeFlagsImpl() & TypeAttributes.StringFormatMask) == TypeAttributes.UnicodeClass;
+
+        public bool IsCOMObject => IsCOMObjectImpl();
+        protected abstract bool IsCOMObjectImpl();
+        public bool IsEnum => IsSubclassOf(typeof(Enum));
+        public bool IsMarshalByRef => IsMarshalByRefImpl();
+        protected virtual bool IsMarshalByRefImpl() => typeof(MarshalByRefObject).IsAssignableFrom(this);
+        public bool IsPrimitive => IsPrimitiveImpl();
+        protected abstract bool IsPrimitiveImpl();
+        public bool IsValueType => IsValueTypeImpl();
+        protected virtual bool IsValueTypeImpl() => IsSubclassOf(typeof(ValueType));
+
+        public virtual StructLayoutAttribute StructLayoutAttribute { get { throw new NotSupportedException(); } }
+        public ConstructorInfo TypeInitializer => GetConstructorImpl(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
+
+        public ConstructorInfo GetConstructor(Type[] types) => GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, types, null);
+        public ConstructorInfo GetConstructor(BindingFlags bindingAttr, Binder binder, Type[] types, ParameterModifier[] modifiers) => GetConstructor(bindingAttr, binder, CallingConventions.Any, types, modifiers);
+        public ConstructorInfo GetConstructor(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        {
+            if (types == null)
+                throw new ArgumentNullException(nameof(types));
+            for (int i = 0; i < types.Length; i++)
             {
-                return IsArray || IsByRef || IsPointer;
+                if (types[i] == null)
+                    throw new ArgumentNullException(nameof(types));
             }
+            return GetConstructorImpl(bindingAttr, binder, callConvention, types, modifiers);
+        }
+        protected abstract ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers);
+
+        public ConstructorInfo[] GetConstructors() => GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        public abstract ConstructorInfo[] GetConstructors(BindingFlags bindingAttr);
+
+        public EventInfo GetEvent(string name) => GetEvent(name, Type.DefaultLookup);
+        public abstract EventInfo GetEvent(string name, BindingFlags bindingAttr);
+
+        public virtual EventInfo[] GetEvents() => GetEvents(Type.DefaultLookup);
+        public abstract EventInfo[] GetEvents(BindingFlags bindingAttr);
+
+        public FieldInfo GetField(string name) => GetField(name, Type.DefaultLookup);
+        public abstract FieldInfo GetField(string name, BindingFlags bindingAttr);
+
+        public FieldInfo[] GetFields() => GetFields(Type.DefaultLookup);
+        public abstract FieldInfo[] GetFields(BindingFlags bindingAttr);
+
+        public MemberInfo[] GetMember(string name) => GetMember(name, Type.DefaultLookup);
+        public virtual MemberInfo[] GetMember(string name, BindingFlags bindingAttr) => GetMember(name, MemberTypes.All, bindingAttr);
+        public virtual MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
+
+        public MemberInfo[] GetMembers() => GetMembers(Type.DefaultLookup);
+        public abstract MemberInfo[] GetMembers(BindingFlags bindingAttr);
+
+        public MethodInfo GetMethod(string name) => GetMethod(name, Type.DefaultLookup);
+        public MethodInfo GetMethod(string name, BindingFlags bindingAttr)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+            return GetMethodImpl(name, bindingAttr, null, CallingConventions.Any, null, null);
         }
 
-        public bool IsArray
+        public MethodInfo GetMethod(string name, Type[] types) => GetMethod(name, types, null);
+        public MethodInfo GetMethod(string name, Type[] types, ParameterModifier[] modifiers) => GetMethod(name, Type.DefaultLookup, null, types, modifiers);
+        public MethodInfo GetMethod(string name, BindingFlags bindingAttr, Binder binder, Type[] types, ParameterModifier[] modifiers) => GetMethod(name, bindingAttr, binder, CallingConventions.Any, types, modifiers);
+        public MethodInfo GetMethod(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
         {
-            get
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+            if (types == null)
+                throw new ArgumentNullException(nameof(types));
+            for (int i = 0; i < types.Length; i++)
             {
-                return IsArrayImpl() ;
+                if (types[i] == null)
+                    throw new ArgumentNullException(nameof(types));
             }
+            return GetMethodImpl(name, bindingAttr, binder, callConvention, types, modifiers);
         }
 
-        public bool IsByRef
+        protected abstract MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers);
+
+        public MethodInfo[] GetMethods() => GetMethods(Type.DefaultLookup);
+        public abstract MethodInfo[] GetMethods(BindingFlags bindingAttr);
+
+        public Type GetNestedType(string name) => GetNestedType(name, Type.DefaultLookup);
+        public abstract Type GetNestedType(string name, BindingFlags bindingAttr);
+
+        public Type[] GetNestedTypes() => GetNestedTypes(Type.DefaultLookup);
+        public abstract Type[] GetNestedTypes(BindingFlags bindingAttr);
+
+        public PropertyInfo GetProperty(string name) => GetProperty(name, Type.DefaultLookup);
+        public PropertyInfo GetProperty(string name, BindingFlags bindingAttr)
         {
-            get
-            {
-                return IsByRefImpl();
-            }
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+            return GetPropertyImpl(name, bindingAttr, null, null, null, null);
         }
 
-        public abstract bool IsConstructedGenericType { get; }
-        public abstract bool IsGenericParameter { get; }
-
-        public bool IsNested
+        public PropertyInfo GetProperty(string name, Type returnType)
         {
-            get
-            {
-                return DeclaringType != null;
-            }
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+            if (returnType == null)
+                throw new ArgumentNullException(nameof(returnType));
+            return GetPropertyImpl(name, Type.DefaultLookup, null, returnType, null, null);
         }
 
-        public bool IsPointer
+        public PropertyInfo GetProperty(string name, Type[] types) => GetProperty(name, null, types);
+        public PropertyInfo GetProperty(string name, Type returnType, Type[] types) => GetProperty(name, returnType, types, null);
+        public PropertyInfo GetProperty(string name, Type returnType, Type[] types, ParameterModifier[] modifiers) => GetProperty(name, Type.DefaultLookup, null, returnType, types, modifiers);
+        public PropertyInfo GetProperty(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
         {
-            get
-            {
-                return IsPointerImpl();
-            }
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+            if (types == null)
+                throw new ArgumentNullException(nameof(types));
+            return GetPropertyImpl(name, bindingAttr, binder, returnType, types, modifiers);
         }
 
-        public abstract String Namespace { get; }
+        protected abstract PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers);
 
-        public virtual RuntimeTypeHandle TypeHandle
-        {
-            get { throw new NotSupportedException(); }
-        }
+        public PropertyInfo[] GetProperties() => GetProperties(Type.DefaultLookup);
+        public abstract PropertyInfo[] GetProperties(BindingFlags bindingAttr);
 
-        public abstract int GetArrayRank();
-        public abstract Type GetElementType();
-        public abstract Type GetGenericTypeDefinition();
+        public virtual MemberInfo[] GetDefaultMembers() { throw NotImplemented.ByDesign; }
 
-        public static Type GetType(String typeName)
-        {
-            return RuntimeAugments.Callbacks.GetType(typeName, throwOnError: false, ignoreCase: false);
-        }
+        public static Type GetType(string typeName) => GetType(typeName, throwOnError: false, ignoreCase: false);
+        public static Type GetType(string typeName, bool throwOnError) => GetType(typeName, throwOnError: throwOnError, ignoreCase: false);
+        public static Type GetType(string typeName, bool throwOnError, bool ignoreCase) => RuntimeAugments.Callbacks.GetType(typeName, throwOnError, ignoreCase);
 
-        public static Type GetType(String typeName, bool throwOnError)
-        {
-            return RuntimeAugments.Callbacks.GetType(typeName, throwOnError, ignoreCase: false);
-        }
-
-        public static Type GetType(String typeName, bool throwOnError, bool ignoreCase)
-        {
-            return RuntimeAugments.Callbacks.GetType(typeName, throwOnError, ignoreCase);
-        }
-
+        public virtual RuntimeTypeHandle TypeHandle { get { throw new NotSupportedException(); } }
         [Intrinsic]
-        public static Type GetTypeFromHandle(RuntimeTypeHandle handle)
-        {
-            return ReflectionCoreNonPortable.GetTypeForRuntimeTypeHandle(handle);
-        }
-
-        public abstract Type MakeArrayType();
-        public abstract Type MakeArrayType(int rank);
-        public abstract Type MakeByRefType();
-        public abstract Type MakeGenericType(params Type[] typeArguments);
-        public abstract Type MakePointerType();
-
-        public override String ToString()
-        {
-            // FxOverRh port note: Yes, this is actually what the desktop BCL does (including the lack of localization on "Type: ").
-            // Of course, we override it in all of our runtime type implementations.
-            return "Type: " + Name;
-        }
-
-        public override bool Equals(Object o)
+        public static Type GetTypeFromHandle(RuntimeTypeHandle handle) => ReflectionCoreNonPortable.GetTypeForRuntimeTypeHandle(handle);
+        public static RuntimeTypeHandle GetTypeHandle(object o)
         {
             if (o == null)
-                return false;
+                throw new ArgumentNullException(null, SR.Arg_InvalidHandle);
+            Type type = o.GetType();
+            if (!type.IsRuntimeImplemented())
+                throw new InvalidCastException();  // For compat with full framework which casts to RuntimeType without checking.
+            return type.TypeHandle;
+        }
 
-            // Desktop calls an abstract UnderlyingSystemType which doesn't exist on System.Private.CoreLib.
+        public static Type[] GetTypeArray(object[] args)
+        {
+            if (args == null)
+                throw new ArgumentNullException(nameof(args));
+
+            Type[] cls = new Type[args.Length];
+            for (int i = 0; i < cls.Length; i++)
+            {
+                if (args[i] == null)
+                    throw new ArgumentNullException();
+                cls[i] = args[i].GetType();
+            }
+            return cls;
+        }
+
+        public static TypeCode GetTypeCode(Type type)
+        {
+            if (type == null)
+                return TypeCode.Empty;
+            return type.GetTypeCodeImpl();
+        }
+        protected virtual TypeCode GetTypeCodeImpl()
+        {
+            if (this != UnderlyingSystemType && UnderlyingSystemType != null)
+                return Type.GetTypeCode(UnderlyingSystemType);
+
+            return TypeCode.Object;
+        }
+
+        public abstract Guid GUID { get; }
+
+        public static Type GetTypeFromCLSID(Guid clsid) => GetTypeFromCLSID(clsid, null, throwOnError: false);
+        public static Type GetTypeFromCLSID(Guid clsid, bool throwOnError) => GetTypeFromCLSID(clsid, null, throwOnError: throwOnError);
+        public static Type GetTypeFromCLSID(Guid clsid, string server) => GetTypeFromCLSID(clsid, server, throwOnError: false);
+        public static Type GetTypeFromCLSID(Guid clsid, string server, bool throwOnError) { throw new NotImplementedException(); }
+
+        public static Type GetTypeFromProgID(string progID) => GetTypeFromProgID(progID, null, throwOnError: false);
+        public static Type GetTypeFromProgID(string progID, bool throwOnError) => GetTypeFromProgID(progID, null, throwOnError: throwOnError);
+        public static Type GetTypeFromProgID(string progID, string server) => GetTypeFromProgID(progID, server, throwOnError: false);
+        public static Type GetTypeFromProgID(string progID, string server, bool throwOnError) { throw new NotImplementedException(); }
+
+        public abstract Type BaseType { get; }
+        public object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args) => InvokeMember(name, invokeAttr, binder, target, args, null, null, null);
+        public object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, CultureInfo culture) => InvokeMember(name, invokeAttr, binder, target, args, null, culture, null);
+        public abstract object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters);
+
+        public Type GetInterface(string name) => GetInterface(name, ignoreCase: false);
+        public abstract Type GetInterface(string name, bool ignoreCase);
+        public abstract Type[] GetInterfaces();
+
+        public virtual InterfaceMapping GetInterfaceMap(Type interfaceType) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
+
+        public virtual bool IsInstanceOfType(object o) => o == null ? false : IsAssignableFrom(o.GetType());
+        public virtual bool IsEquivalentTo(Type other) => this == other;
+
+        public virtual bool IsEnumDefined(object value) { throw new NotImplementedException(); }
+        public virtual string GetEnumName(object value) { throw new NotImplementedException(); }
+        public virtual string[] GetEnumNames() { throw new NotImplementedException(); }
+        public virtual Type GetEnumUnderlyingType()
+        {
+            if (!IsEnum)
+                throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
+
+            FieldInfo[] fields = GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (fields == null || fields.Length != 1)
+                throw new ArgumentException(SR.Argument_InvalidEnum, "enumType");
+
+            return fields[0].FieldType;
+        }
+        public virtual Array GetEnumValues()
+        {
+            if (!IsEnum)
+                throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
+
+            // We don't support GetEnumValues in the default implementation because we cannot create an array of
+            // a non-runtime type. If there is strong need we can consider returning an object or int64 array.
             throw NotImplemented.ByDesign;
         }
 
-        public bool Equals(Type o)
-        {
-            return Equals((Object)o);
-        }
+        public virtual Type MakeArrayType() { throw new NotSupportedException(); }
+        public virtual Type MakeArrayType(int rank) { throw new NotSupportedException(); }
+        public virtual Type MakeByRefType() { throw new NotSupportedException(); }
+        public virtual Type MakeGenericType(params Type[] typeArguments) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
+        public virtual Type MakePointerType() { throw new NotSupportedException(); }
 
+        public override string ToString() => "Type: " + Name;  // Why do we add the "Type: " prefix?
+
+        public override bool Equals(object o) => o == null ? false : Equals(o as Type);
         public override int GetHashCode()
         {
-            // Desktop calls an abstract UnderlyingSystemType which doesn't exist on System.Private.CoreLib.
-            throw NotImplemented.ByDesign;
+            Type systemType = UnderlyingSystemType;
+            if (!object.ReferenceEquals(systemType, this))
+                return systemType.GetHashCode();
+            return base.GetHashCode();
         }
+        public bool Equals(Type o) => o == null ? false : object.ReferenceEquals(this.UnderlyingSystemType, o.UnderlyingSystemType);
 
-        protected abstract bool IsArrayImpl();
-        protected abstract bool IsByRefImpl();
-        protected abstract bool IsPointerImpl();
+        public static Type ReflectionOnlyGetType(string typeName, bool throwIfNotFound, bool ignoreCase) { throw new NotImplementedException(); }
+
+        public static readonly char Delimiter = '.';
+        public static readonly Type[] EmptyTypes = Array.Empty<Type>();
+        public static readonly object Missing = System.Reflection.Missing.Value;
+
+        public static readonly MemberFilter FilterAttribute = delegate (MemberInfo m, object filterCriteria) { throw new NotImplementedException(); };
+        public static readonly MemberFilter FilterName = delegate (MemberInfo m, object filterCriteria) { throw new NotImplementedException(); };
+        public static readonly MemberFilter FilterNameIgnoreCase = delegate (MemberInfo m, object filterCriteria) { throw new NotImplementedException(); };
+
+        public static Binder DefaultBinder => s_defaultBinder;
+        private static readonly Binder s_defaultBinder = new TemporaryDefaultBinder(); // Needs to be a strict singleton as we do a reference equality check against it in our Invoke() code.
+
+        private const BindingFlags DefaultLookup = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+
+        // @todo: Can probably use Common\src\Internal\Reflection\Execution\Binder.cs as is.
+        private sealed class TemporaryDefaultBinder : Binder
+        {
+            public sealed override FieldInfo BindToField(BindingFlags bindingAttr, FieldInfo[] match, object value, CultureInfo culture) { throw new NotImplementedException(); }
+            public sealed override MethodBase BindToMethod(BindingFlags bindingAttr, MethodBase[] match, ref object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] names, out object state) { throw new NotImplementedException(); }
+            public sealed override bool CanChangeType(object value, Type type, CultureInfo culture) { throw new NotImplementedException(); }
+            public sealed override object ChangeType(object value, Type type, CultureInfo culture) { throw new NotImplementedException(); }
+            public sealed override void ReorderArgumentArray(ref object[] args, object state) { throw new NotImplementedException(); }
+            public sealed override MethodBase SelectMethod(BindingFlags bindingAttr, MethodBase[] match, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
+            public sealed override PropertyInfo SelectProperty(BindingFlags bindingAttr, PropertyInfo[] match, Type returnType, Type[] indexes, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
+        }
     }
 }
-

--- a/src/System.Private.Interop/src/Shared/McgTypeHelpers.cs
+++ b/src/System.Private.Interop/src/Shared/McgTypeHelpers.cs
@@ -16,6 +16,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Runtime.InteropServices;
@@ -88,7 +89,7 @@ namespace System.Runtime.InteropServices
 #if RHTESTCL
             : Type
 #else
-            : Internal.Reflection.Extensibility.ExtensibleType
+            : Internal.Reflection.Extensibility.ExtensibleTypeInfo
 #endif
         {
             /// <summary>
@@ -112,12 +113,16 @@ namespace System.Runtime.InteropServices
 #if RHTESTCL
             public string FullName { get { return _fullTypeName; } }
 #else
+            public override Assembly Assembly { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
             public override String AssemblyQualifiedName { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
 
+            public override Type BaseType { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
             public override Type DeclaringType { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
             public override String FullName { get { return _fullTypeName; } }
             public override int GenericParameterPosition { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
             public override Type[] GenericTypeArguments { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
+
+            public override Guid GUID { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
 
             public override bool IsConstructedGenericType { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
             public override bool IsGenericParameter { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
@@ -126,14 +131,30 @@ namespace System.Runtime.InteropServices
             public override String Namespace { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
 
             public override int GetArrayRank() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
             public override Type GetElementType() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override EventInfo GetEvent(string name, BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override EventInfo[] GetEvents(BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override FieldInfo GetField(string name, BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override FieldInfo[] GetFields(BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
             public override Type GetGenericTypeDefinition() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override Type GetInterface(string name, bool ignoreCase) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override Type[] GetInterfaces() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override MemberInfo[] GetMembers(BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override MethodInfo[] GetMethods(BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override Type GetNestedType(string name, BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override Type[] GetNestedTypes(BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            public override PropertyInfo[] GetProperties(BindingFlags bindingAttr) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+
+            public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
 
             public override Type MakeArrayType() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
             public override Type MakeArrayType(int rank) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
             public override Type MakeByRefType() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
             public override Type MakeGenericType(params Type[] typeArguments) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
             public override Type MakePointerType() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+
+            public override Module Module { get { throw new System.Reflection.MissingMetadataException(_fullTypeName); } }
 
             public override String ToString()
             {
@@ -162,7 +183,10 @@ namespace System.Runtime.InteropServices
             protected override bool IsArrayImpl() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
             protected override bool IsByRefImpl() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
             protected override bool IsPointerImpl() { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
-
+            protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+            protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) { throw new System.Reflection.MissingMetadataException(_fullTypeName); }
+    
 #endif //RHTESTCL
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -188,11 +188,43 @@ namespace System.Reflection.Runtime.TypeInfos
 {
     internal abstract partial class RuntimeTypeInfo
     {
-        public sealed override object[] GetCustomAttributes(bool inherit) { throw new NotImplementedException(); }
         public sealed override object[] GetCustomAttributes(Type attributeType, bool inherit) { throw new NotImplementedException(); }
+        public sealed override Type[] FindInterfaces(TypeFilter filter, object filterCriteria) { throw new NotImplementedException(); }
+        public sealed override MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter filter, object filterCriteria) { throw new NotImplementedException(); }
+        protected sealed override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
+        public sealed override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override object[] GetCustomAttributes(bool inherit) { throw new NotImplementedException(); }
         public sealed override IList<CustomAttributeData> GetCustomAttributesData() { throw new NotImplementedException(); }
+        public sealed override MemberInfo[] GetDefaultMembers() { throw new NotImplementedException(); }
+        public sealed override string GetEnumName(object value) { throw new NotImplementedException(); }
+        public sealed override string[] GetEnumNames() { throw new NotImplementedException(); }
+        public sealed override Type GetEnumUnderlyingType() { throw new NotImplementedException(); }
+        public sealed override Array GetEnumValues() { throw new NotImplementedException(); }
+        public sealed override EventInfo GetEvent(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override EventInfo[] GetEvents() { throw new NotImplementedException(); }
+        public sealed override EventInfo[] GetEvents(BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override FieldInfo GetField(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override FieldInfo[] GetFields(BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override Type GetInterface(string name, bool ignoreCase) { throw new NotImplementedException(); }
+        public sealed override InterfaceMapping GetInterfaceMap(Type interfaceType) { throw new NotImplementedException(); }
+        public sealed override Type[] GetInterfaces() { throw new NotImplementedException(); }
+        public sealed override MemberInfo[] GetMember(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override MemberInfo[] GetMembers(BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
+        public sealed override MethodInfo[] GetMethods(BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override Type GetNestedType(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override Type[] GetNestedTypes(BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        public sealed override PropertyInfo[] GetProperties(BindingFlags bindingAttr) { throw new NotImplementedException(); }
+        protected sealed override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
+        protected sealed override TypeCode GetTypeCodeImpl() { throw new NotImplementedException(); }
+        public sealed override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) { throw new NotImplementedException(); }
         public sealed override bool IsDefined(Type attributeType, bool inherit) { throw new NotImplementedException(); }
-        public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
+        public sealed override bool IsEnumDefined(object value) { throw new NotImplementedException(); }
+        public sealed override bool IsEquivalentTo(Type other) { throw new NotImplementedException(); }
+        public sealed override bool IsInstanceOfType(object o) { throw new NotImplementedException(); }
         public sealed override int MetadataToken { get { throw new NotImplementedException(); } }
+        public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
+        public sealed override StructLayoutAttribute StructLayoutAttribute { get { throw new NotImplementedException(); } }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -133,6 +133,7 @@ namespace System.Reflection.Runtime.TypeInfos
     {
 #if DEBUG
         public sealed override bool IsSubclassOf(Type c) => base.IsSubclassOf(c);
+        protected sealed override bool IsMarshalByRefImpl() => base.IsMarshalByRefImpl();
         public sealed override MemberTypes MemberType => base.MemberType;
 #endif //DEBUG
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -452,6 +452,14 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        public sealed override bool IsAssignableFrom(Type c)
+        {
+            if (c == null)
+                return false;
+
+            return IsAssignableFrom(c.GetTypeInfo());
+        }
+
         public sealed override bool IsAssignableFrom(TypeInfo typeInfo)
         {
             RuntimeTypeInfo toTypeInfo = this;

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidatorSupport.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidatorSupport.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using Internal.Reflection.Extensibility;
 using Debug = global::System.Diagnostics.Debug;
@@ -145,11 +146,25 @@ namespace Internal.Reflection.Execution
             public override String FullName { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
             public override GenericParameterAttributes GenericParameterAttributes { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
             public override int GenericParameterPosition { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
+            public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override EventInfo GetEvent(string name, BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override EventInfo[] GetEvents(BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override FieldInfo GetField(string name, BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override FieldInfo[] GetFields(BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override Type GetInterface(string name, bool ignoreCase) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override Type[] GetInterfaces() { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override MemberInfo[] GetMembers(BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override MethodInfo[] GetMethods(BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override Type GetNestedType(string name, BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override Type[] GetNestedTypes(BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            public override PropertyInfo[] GetProperties(BindingFlags bindingAttr) { Debug.Assert(false); throw NotImplemented.ByDesign; }
             public override Guid GUID { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
+            public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) { Debug.Assert(false); throw NotImplemented.ByDesign; }
             public override bool IsEnum { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
             public override bool IsGenericParameter { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
             public override bool IsGenericTypeDefinition { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
             public override bool IsSerializable { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
+            public override Module Module { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
             public override String Namespace { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
             public override Type[] GetGenericParameterConstraints() { Debug.Assert(false); throw NotImplemented.ByDesign; }
             public sealed override Type MakeArrayType() { Debug.Assert(false); throw NotImplemented.ByDesign; }
@@ -159,6 +174,10 @@ namespace Internal.Reflection.Execution
             public sealed override Type MakePointerType() { Debug.Assert(false); throw NotImplemented.ByDesign; }
             public override Type DeclaringType { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
             public sealed override String Name { get { Debug.Assert(false); throw NotImplemented.ByDesign; } }
+
+            protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { Debug.Assert(false); throw NotImplemented.ByDesign; }
+            protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) { Debug.Assert(false); throw NotImplemented.ByDesign; }
 
             protected override bool IsArrayImpl()
             {


### PR DESCRIPTION
Restored Type/TypeInfo Reflection surface
area in Project N's S.P.Corelib.dll
to match the bringup in CoreClr
and get it suitable for a N targeting
pack for corefx to consume.

Stuff still do to:

  TypeDelegator: blocked on Type/TypeInfo.
    Actually, this probably could live in
    the System.Runtime facade, not corelib.
    No one uses it inside corelib.

  AssemblyName: Just didn't get to this -
    will do in future PR.

  operator==: They need to be done together
    (once Type/TypeInfo is done) to keep MemberInfo:==
    from recursing infinitely.

Most of the new apis throw NotImplemented,
but everything that worked in N before
still works.

Things that might look strange:

- I made McgFakeMetadataType derive from
  ExtensibleTypeInfo, as that way, I don't have to
  maintain ExtensibleType anymore.

- I implemented TypeInfo.IsAssignableFrom(Type)
  so EventInfo, et.al. could call it without
  the GetTypeInfo() call.