### PR TITLE
Get rid CastToType() helper in Reflection.Core

### DIFF
--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -82,7 +82,7 @@ namespace Internal.Reflection.Core.Execution
                 RuntimeTypeInfo result;
                 Exception typeLoadException = assemblyQualifiedTypeName.TryResolve(defaultAssembly, ignoreCase, out result);
                 if (typeLoadException == null)
-                    return result.CastToType();
+                    return result;
                 lastTypeLoadException = typeLoadException;
             }
 

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Internal.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Internal.cs
@@ -149,7 +149,7 @@ namespace Internal.Reflection.Tracing
             RuntimeTypeInfo runtimeType = type.CastToRuntimeTypeInfo();
             if (runtimeType.HasElementType)
             {
-                String elementTypeName = runtimeType.InternalRuntimeElementType.CastToType().NonQualifiedTypeName();
+                String elementTypeName = runtimeType.InternalRuntimeElementType.NonQualifiedTypeName();
                 if (elementTypeName == null)
                     return null;
                 String suffix;
@@ -185,7 +185,7 @@ namespace Internal.Reflection.Tracing
                 String sep = "";
                 foreach (RuntimeTypeInfo ga in runtimeType.InternalRuntimeGenericTypeArguments)
                 {
-                    String gaTypeName = ga.CastToType().AssemblyQualifiedTypeName();
+                    String gaTypeName = ga.AssemblyQualifiedTypeName();
                     if (gaTypeName == null)
                         return null;
                     sb.Append(sep + "[" + gaTypeName + "]");
@@ -234,10 +234,10 @@ namespace Internal.Reflection.Tracing
             RuntimeTypeInfo runtimeType = type.CastToRuntimeTypeInfo();
             if (runtimeType == null)
                 return null;
-            String nonqualifiedTypeName = runtimeType.CastToType().NonQualifiedTypeName();
+            String nonqualifiedTypeName = runtimeType.NonQualifiedTypeName();
             if (nonqualifiedTypeName == null)
                 return null;
-            String assemblyName = runtimeType.CastToType().ContainingAssemblyName();
+            String assemblyName = runtimeType.ContainingAssemblyName();
             if (assemblyName == null)
                 return assemblyName;
             return nonqualifiedTypeName + ", " + assemblyName;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
@@ -89,7 +89,7 @@ namespace System.Reflection.Runtime.Assemblies
                     IEnumerable<TypeDefinitionHandle> allTopLevelTypes = reader.GetTopLevelTypes(allNamespaceHandles);
                     IEnumerable<TypeDefinitionHandle> allTypes = reader.GetTransitiveTypes(allTopLevelTypes, publicOnly: true);
                     foreach (TypeDefinitionHandle typeDefinitionHandle in allTypes)
-                        yield return typeDefinitionHandle.ResolveTypeDefinition(reader).CastToType();
+                        yield return typeDefinitionHandle.ResolveTypeDefinition(reader);
                 }
             }
         }
@@ -204,7 +204,7 @@ namespace System.Reflection.Runtime.Assemblies
                     throw typeLoadException;
                 return null;
             }
-            return result.CastToType();
+            return result;
         }
 
         internal QScopeDefinition Scope { get; }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeNormalCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeNormalCustomAttributeData.cs
@@ -37,7 +37,7 @@ namespace System.Reflection.Runtime.CustomAttributes
                 Type lazyAttributeType = _lazyAttributeType;
                 if (lazyAttributeType == null)
                 {
-                    lazyAttributeType = _lazyAttributeType = _customAttribute.GetAttributeTypeHandle(_reader).Resolve(_reader, new TypeContext(null, null)).CastToType();
+                    lazyAttributeType = _lazyAttributeType = _customAttribute.GetAttributeTypeHandle(_reader).Resolve(_reader, new TypeContext(null, null));
                 }
                 return lazyAttributeType;
             }
@@ -191,7 +191,7 @@ namespace System.Reflection.Runtime.CustomAttributes
                 else
                     return default(CustomAttributeTypedArgument);
             }
-            return WrapInCustomAttributeTypedArgument(value, argumentType.CastToType());
+            return WrapInCustomAttributeTypedArgument(value, argumentType);
         }
 
         //

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
@@ -37,7 +37,7 @@ namespace System.Reflection.Runtime.CustomAttributes
         {
             get
             {
-                return _attributeType.CastToType();
+                return _attributeType;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -143,7 +143,7 @@ namespace System.Reflection.Runtime.EventInfos
         {
             get
             {
-                return _event.Type.Resolve(_reader, _contextTypeInfo.TypeContext).CastToType();
+                return _event.Type.Resolve(_reader, _contextTypeInfo.TypeContext);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -98,7 +98,7 @@ namespace System.Reflection.Runtime.FieldInfos
         {
             get
             {
-                return this.FieldRuntimeType.CastToType();
+                return this.FieldRuntimeType;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -70,12 +70,5 @@ namespace System.Reflection.Runtime.General
             Debug.Assert(type is RuntimeTypeInfo);
             return (RuntimeTypeInfo)type;
         }
-
-        // TODO https://github.com/dotnet/corefx/issues/9805: Once TypeInfo derives from Type, this helper becomes a NOP and will go away entirely.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Type CastToType(this TypeInfo typeInfo)
-        {
-            return typeInfo;
-        }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
@@ -198,7 +198,7 @@ namespace System.Reflection.Runtime.General
             ConstantBoxedEnumValue record = handle.GetConstantBoxedEnumValue(reader);
 
             Exception exception = null;
-            Type enumType = record.Type.TryResolve(reader, new TypeContext(null, null), ref exception).CastToType();
+            Type enumType = record.Type.TryResolve(reader, new TypeContext(null, null), ref exception);
             if (enumType == null)
             {
                 value = null;
@@ -351,7 +351,7 @@ namespace System.Reflection.Runtime.General
                 case HandleType.TypeSpecification:
                     {
                         Exception exception = null;
-                        Type type = handle.TryResolve(reader, new TypeContext(null, null), ref exception).CastToType();
+                        Type type = handle.TryResolve(reader, new TypeContext(null, null), ref exception);
                         value = type;
                         return (value == null) ? exception : null;
                     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -96,7 +96,7 @@ namespace System.Reflection.Runtime.MethodInfos
                     ReflectionTrace.MethodBase_DeclaringType(this);
 #endif
 
-                return this.RuntimeDeclaringType.CastToType();
+                return this.RuntimeDeclaringType;
             }
         }
 
@@ -211,7 +211,7 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
-                return this.RuntimeDeclaringType.CastToType();
+                return this.RuntimeDeclaringType;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -86,7 +86,7 @@ namespace System.Reflection.Runtime.MethodInfos
                     ReflectionTrace.MethodBase_DeclaringType(this);
 #endif
 
-                return _common.DeclaringType.CastToType();
+                return _common.DeclaringType;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
@@ -59,7 +59,7 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
-                return _declaringType.CastToType();
+                return _declaringType;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
@@ -32,7 +32,7 @@ namespace System.Reflection.Runtime.ParameterInfos
         {
             get
             {
-                return _typeHandle.Resolve(this.Reader, _typeContext).CastToType();
+                return _typeHandle.Resolve(this.Reader, _typeContext);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeSyntheticParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeSyntheticParameterInfo.cs
@@ -71,7 +71,7 @@ namespace System.Reflection.Runtime.ParameterInfos
         {
             get
             {
-                return _parameterType.CastToType();
+                return _parameterType;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -235,7 +235,7 @@ namespace System.Reflection.Runtime.PropertyInfos
 
                 TypeContext typeContext = _contextTypeInfo.TypeContext;
                 Handle typeHandle = _property.Signature.GetPropertySignature(_reader).Type;
-                return typeHandle.Resolve(_reader, typeContext).CastToType();
+                return typeHandle.Resolve(_reader, typeContext);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -278,7 +278,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 {
                     declaringType = enclosingTypeDefHandle.ResolveTypeDefinition(_reader);
                 }
-                return declaringType.CastToType();
+                return declaringType;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -77,7 +77,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return ReflectionCoreExecution.ExecutionEnvironment.IsCOMObject(this.CastToType());
+                return ReflectionCoreExecution.ExecutionEnvironment.IsCOMObject(this);
             }
         }
 
@@ -99,7 +99,7 @@ namespace System.Reflection.Runtime.TypeInfos
                         return Type.GetTypeFromHandle(baseTypeHandle);
                 }
 
-                Type baseType = BaseTypeWithoutTheGenericParameterQuirk.CastToType();
+                Type baseType = BaseTypeWithoutTheGenericParameterQuirk;
                 if (baseType != null && baseType.IsGenericParameter)
                 {
                     // Desktop quirk: a generic parameter whose constraint is another generic parameter reports its BaseType as System.Object
@@ -430,12 +430,12 @@ namespace System.Reflection.Runtime.TypeInfos
                 if (!done)
                 {
                     TypeContext typeContext = this.TypeContext;
-                    Type baseType = this.BaseTypeWithoutTheGenericParameterQuirk.CastToType();
+                    Type baseType = this.BaseTypeWithoutTheGenericParameterQuirk;
                     if (baseType != null)
                         result.AddRange(baseType.GetTypeInfo().ImplementedInterfaces);
                     foreach (QTypeDefRefOrSpec directlyImplementedInterface in this.TypeRefDefOrSpecsForDirectlyImplementedInterfaces)
                     {
-                        Type ifc = directlyImplementedInterface.Handle.Resolve(directlyImplementedInterface.Reader, typeContext).CastToType();
+                        Type ifc = directlyImplementedInterface.Handle.Resolve(directlyImplementedInterface.Reader, typeContext);
                         if (result.Contains(ifc))
                             continue;
                         result.Add(ifc);
@@ -464,7 +464,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             RuntimeTypeInfo toTypeInfo = this;
 
-            if (typeInfo == null || !typeInfo.CastToType().IsRuntimeImplemented())
+            if (typeInfo == null || !typeInfo.IsRuntimeImplemented())
                 return false;  // Desktop compat: If typeInfo is null, or implemented by a different Reflection implementation, return "false."
 
             RuntimeTypeInfo fromTypeInfo = typeInfo.CastToRuntimeTypeInfo();
@@ -595,7 +595,7 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override Type GetElementType()
         {
-            return InternalRuntimeElementType.CastToType();
+            return InternalRuntimeElementType;
         }
 
         //


### PR DESCRIPTION
This was a helper function meant to ease
the transition over to unified Type/TypeInfo's.
Now it's purpose has been served.