### PR TITLE
TextInfo: Avoid intermediate allocations in ChangeCase

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.Globalization.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Globalization.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal extern static unsafe int LCMapStringEx(
                     string lpLocaleName,
                     uint dwMapFlags,
-                    string lpSrcStr,
+                    char* lpSrcStr,
                     int cchSrc,
                     void*  lpDestStr,
                     int cchDest,

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -71,13 +71,16 @@ namespace System.Globalization
 
             int tmpHash = 0;
 
-            if (Interop.mincore.LCMapStringEx(_sortHandle != IntPtr.Zero ? null : _sortName,
-                                              LCMAP_HASH | (uint)GetNativeCompareFlags(options),
-                                              source, source.Length,
-                                              &tmpHash, sizeof(int),
-                                              null, null, _sortHandle) == 0)
+            fixed (char* pSource = source)
             {
-                Environment.FailFast("LCMapStringEx failed!");
+                if (Interop.mincore.LCMapStringEx(_sortHandle != IntPtr.Zero ? null : _sortName,
+                                                  LCMAP_HASH | (uint)GetNativeCompareFlags(options),
+                                                  pSource, source.Length,
+                                                  &tmpHash, sizeof(int),
+                                                  null, null, _sortHandle) == 0)
+                {
+                    Environment.FailFast("LCMapStringEx failed!");
+                }
             }
 
             return tmpHash;

--- a/src/System.Private.CoreLib/src/System/Globalization/TextInfo.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/TextInfo.Windows.cs
@@ -47,7 +47,7 @@ namespace System.Globalization
             }
             else
             {
-                int result;
+                int ret;
 
                 // Check for Invariant to avoid A/V in LCMapStringEx
                 uint linguisticCasing = IsInvariantLocale(_textInfoName) ? 0 : LCMAP_LINGUISTIC_CASING;
@@ -55,27 +55,29 @@ namespace System.Globalization
                 //
                 //  Create the result string.
                 //
-                char[] buffer = new char[nLengthInput];
-                fixed (char* pBuffer = buffer)
+                string result = string.FastAllocateString(nLengthInput);
+
+                fixed (char* pSource = s)
+                fixed (char* pResult = result)
                 {
-                    result = Interop.mincore.LCMapStringEx(_sortHandle != IntPtr.Zero ? null : _textInfoName,
-                                                           toUpper ? LCMAP_UPPERCASE | linguisticCasing : LCMAP_LOWERCASE | linguisticCasing,
-                                                           s,
-                                                           nLengthInput,
-                                                           pBuffer,
-                                                           nLengthInput,
-                                                           null,
-                                                           null,
-                                                           _sortHandle);
+                    ret = Interop.mincore.LCMapStringEx(_sortHandle != IntPtr.Zero ? null : _textInfoName,
+                                                        toUpper ? LCMAP_UPPERCASE | linguisticCasing : LCMAP_LOWERCASE | linguisticCasing,
+                                                        pSource,
+                                                        nLengthInput,
+                                                        pResult,
+                                                        nLengthInput,
+                                                        null,
+                                                        null,
+                                                        _sortHandle);
                 }
 
-                if (0 == result)
+                if (0 == ret)
                 {
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 }
 
-                Contract.Assert(result == nLengthInput, "Expected getting the same length of the original string");
-                return new string(buffer, 0, result);
+                Contract.Assert(ret == nLengthInput, "Expected getting the same length of the original string");
+                return result;
             }
         }
 
@@ -88,7 +90,7 @@ namespace System.Globalization
 
             Interop.mincore.LCMapStringEx(_sortHandle != IntPtr.Zero ? null : _textInfoName,
                                           toUpper ? LCMAP_UPPERCASE | linguisticCasing : LCMAP_LOWERCASE | linguisticCasing,
-                                          new string(c, 1),
+                                          &c,
                                           1,
                                           &retVal,
                                           1,


### PR DESCRIPTION
Avoid unnecessary allocations in `TextInfo.ChangeCase` on Windows:

- `ChangeCase(char, bool)` allocates a temporary `string` from the source `char`. Instead, pass the address of the source `char` to avoid the intermediate string allocation.

- `ChangeCase(string, bool)` allocates a temporary `char[]` buffer, then creates a new `string` from that buffer. Instead, use `string.FastAllocateString` to avoid the intermediate buffer allocation, which aligns with the [Unix implementation in CoreCLR](https://github.com/dotnet/coreclr/blob/5cc75c3933979b788073ff065d81916680bccf5a/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs#L51).