### PR TITLE
Wean Reflection.Core off the Extensibility types.

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -33,6 +33,11 @@ namespace Internal.Reflection.Augments
             _reflectionCoreCallbacks = reflectionCoreCallbacks;
         }
 
+        public static CustomAttributeNamedArgument CreateCustomAttributeNamedArgument(Type attributeType, string memberName, bool isField, CustomAttributeTypedArgument typedValue)
+        {
+            return new CustomAttributeNamedArgument(attributeType, memberName, isField, typedValue);
+        }
+
         internal static ReflectionCoreCallbacks ReflectionCoreCallbacks
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeNormalCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeNormalCustomAttributeData.cs
@@ -13,8 +13,8 @@ using System.Reflection.Runtime.TypeInfos;
 
 using Internal.LowLevelLinq;
 using Internal.Reflection.Core;
+using Internal.Reflection.Augments;
 using Internal.Reflection.Core.Execution;
-using Internal.Reflection.Extensibility;
 using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.CustomAttributes
@@ -144,7 +144,7 @@ namespace System.Reflection.Runtime.CustomAttributes
                     Debug.Assert(!throwIfMissingMetadata);
                     return null;
                 }
-                customAttributeNamedArguments.Add(ExtensibleCustomAttributeData.CreateCustomAttributeNamedArgument(this.AttributeType, memberName, isField, typedValue));
+                customAttributeNamedArguments.Add(ReflectionAugments.CreateCustomAttributeNamedArgument(this.AttributeType, memberName, isField, typedValue));
             }
             return customAttributeNamedArguments;
         }
@@ -224,11 +224,11 @@ namespace System.Reflection.Runtime.CustomAttributes
                     CustomAttributeTypedArgument elementTypedArgument = WrapInCustomAttributeTypedArgument(elementValue, reportedElementType);
                     elementTypedArguments.Add(elementTypedArgument);
                 }
-                return ExtensibleCustomAttributeData.CreateCustomAttributeTypedArgument(argumentType, new ReadOnlyCollection<CustomAttributeTypedArgument>(elementTypedArguments));
+                return new CustomAttributeTypedArgument(argumentType, new ReadOnlyCollection<CustomAttributeTypedArgument>(elementTypedArguments));
             }
             else
             {
-                return ExtensibleCustomAttributeData.CreateCustomAttributeTypedArgument(argumentType, value);
+                return new CustomAttributeTypedArgument(argumentType, value);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -18,7 +18,6 @@ using System.Reflection.Runtime.PropertyInfos;
 
 using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
-using Internal.Reflection.Extensibility;
 
 using Internal.Metadata.NativeFormat;
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
@@ -32,17 +32,14 @@ namespace System.Reflection.Runtime.TypeInfos
             _rank = rank;
         }
 
-        public sealed override TypeAttributes Attributes
-        {
-            get
-            {
-                return TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Serializable;
-            }
-        }
-
         public sealed override int GetArrayRank()
         {
             return _rank;
+        }
+
+        protected sealed override TypeAttributes GetAttributeFlagsImpl()
+        {
+            return TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Serializable;
         }
 
         internal sealed override bool InternalIsMultiDimArray

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -44,14 +44,6 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        public sealed override TypeAttributes Attributes
-        {
-            get
-            {
-                return TypeAttributes.Class | TypeAttributes.NotPublic;
-            }
-        }
-
         public sealed override bool ContainsGenericParameters
         {
             get
@@ -123,6 +115,11 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override string ToString()
         {
             return _typeHandle.LastResortString();
+        }
+
+        protected sealed override TypeAttributes GetAttributeFlagsImpl()
+        {
+            return TypeAttributes.Class | TypeAttributes.NotPublic;
         }
 
         protected sealed override int InternalGetHashCode()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -122,14 +122,6 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        public sealed override TypeAttributes Attributes
-        {
-            get
-            {
-                return GenericTypeDefinitionTypeInfo.Attributes;
-            }
-        }
-
         public sealed override bool ContainsGenericParameters
         {
             get
@@ -204,6 +196,11 @@ namespace System.Reflection.Runtime.TypeInfos
             }
             sb.Append(']');
             return sb.ToString();
+        }
+
+        protected sealed override TypeAttributes GetAttributeFlagsImpl()
+        {
+            return GenericTypeDefinitionTypeInfo.Attributes;
         }
 
         protected sealed override int InternalGetHashCode()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -37,14 +37,6 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        public sealed override TypeAttributes Attributes
-        {
-            get
-            {
-                return TypeAttributes.Public;
-            }
-        }
-
         public sealed override bool ContainsGenericParameters
         {
             get
@@ -124,6 +116,11 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override string ToString()
         {
             return Name;
+        }
+
+        protected sealed override TypeAttributes GetAttributeFlagsImpl()
+        {
+            return TypeAttributes.Public;
         }
 
         protected sealed override int InternalGetHashCode()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
@@ -61,18 +61,6 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        //
-        // Left unsealed because this implemention is correct for ByRefs and Pointers but not Arrays.
-        //
-        public override TypeAttributes Attributes
-        {
-            get
-            {
-                Debug.Assert(IsByRef || IsPointer);
-                return TypeAttributes.AnsiClass;
-            }
-        }
-
         public sealed override bool ContainsGenericParameters
         {
             get
@@ -111,6 +99,20 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override string ToString()
         {
             return _key.ElementType.ToString() + Suffix;
+        }
+
+        //
+        // Left unsealed because this implemention is correct for ByRefs and Pointers but not Arrays.
+        //
+        protected override TypeAttributes GetAttributeFlagsImpl()
+        {
+            Debug.Assert(IsByRef || IsPointer);
+            return TypeAttributes.AnsiClass;
+        }
+
+        protected sealed override bool HasElementTypeImpl()
+        {
+            return true;
         }
 
         protected sealed override int InternalGetHashCode()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -51,15 +51,6 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        public sealed override TypeAttributes Attributes
-        {
-            get
-            {
-                TypeAttributes attr = _typeDefinition.Flags;
-                return attr;
-            }
-        }
-
         public sealed override bool ContainsGenericParameters
         {
             get
@@ -239,6 +230,12 @@ namespace System.Reflection.Runtime.TypeInfos
             {
                 return sb.Append(']').ToString();
             }
+        }
+
+        protected sealed override TypeAttributes GetAttributeFlagsImpl()
+        {
+            TypeAttributes attr = _typeDefinition.Flags;
+            return attr;
         }
 
         protected sealed override int InternalGetHashCode()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
@@ -39,14 +39,6 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        public sealed override TypeAttributes Attributes
-        {
-            get
-            {
-                throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(this);
-            }
-        }
-
         public sealed override bool ContainsGenericParameters
         {
             get
@@ -114,6 +106,11 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override string ToString()
         {
             return _typeHandle.LastResortString();
+        }
+
+        protected sealed override TypeAttributes GetAttributeFlagsImpl()
+        {
+            throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(this);
         }
 
         protected sealed override int InternalGetHashCode()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -16,7 +16,6 @@ using System.Reflection.Runtime.EventInfos;
 using Internal.LowLevelLinq;
 using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
-using Internal.Reflection.Extensibility;
 using Internal.Reflection.Tracing;
 
 using Internal.Metadata.NativeFormat;
@@ -41,12 +40,12 @@ namespace System.Reflection.Runtime.TypeInfos
     //     shows up as build error.
     //
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimeTypeInfo : ExtensibleTypeInfo, ITraceableTypeMember, ICloneable, IRuntimeImplementedType
+    internal abstract partial class RuntimeTypeInfo : TypeInfo, ITraceableTypeMember, ICloneable, IRuntimeImplementedType
     {
         protected RuntimeTypeInfo()
         {
         }
-         
+
         public abstract override Assembly Assembly { get; }
 
         public sealed override string AssemblyQualifiedName
@@ -69,16 +68,6 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override Type AsType()
         {
             return this;
-        }
-
-        public abstract override TypeAttributes Attributes { get; }
-
-        public sealed override bool IsCOMObject
-        {
-            get
-            {
-                return ReflectionCoreExecution.ExecutionEnvironment.IsCOMObject(this);
-            }
         }
 
         public sealed override Type BaseType
@@ -504,14 +493,6 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        public sealed override bool IsEnum
-        {
-            get
-            {
-                return 0 != (Classification & TypeClassification.IsEnum);
-            }
-        }
-
         //
         // Left unsealed as generic parameter types must override.
         //
@@ -542,27 +523,11 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        public sealed override bool IsPrimitive
-        {
-            get
-            {
-                return 0 != (Classification & TypeClassification.IsPrimitive);
-            }
-        }
-
         public sealed override bool IsSerializable
         {
             get
             {
                 return 0 != (this.Attributes & TypeAttributes.Serializable);
-            }
-        }
-
-        public sealed override bool IsValueType
-        {
-            get
-            {
-                return 0 != (Classification & TypeClassification.IsValueType);
             }
         }
 
@@ -741,6 +706,24 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        public sealed override Type UnderlyingSystemType
+        {
+            get
+            {
+                return this;
+            }
+        }
+
+        protected abstract override TypeAttributes GetAttributeFlagsImpl();
+
+        //
+        // Left unsealed so that RuntimeHasElementTypeInfo can override.
+        //
+        protected override bool HasElementTypeImpl()
+        {
+            return false;
+        }
+
         protected abstract int InternalGetHashCode();
 
         //
@@ -765,6 +748,21 @@ namespace System.Reflection.Runtime.TypeInfos
         protected override bool IsPointerImpl()
         {
             return false;
+        }
+
+        protected sealed override bool IsCOMObjectImpl()
+        {
+            return ReflectionCoreExecution.ExecutionEnvironment.IsCOMObject(this);
+        }
+
+        protected sealed override bool IsPrimitiveImpl()
+        {
+            return 0 != (Classification & TypeClassification.IsPrimitive);
+        }
+
+        protected sealed override bool IsValueTypeImpl()
+        {
+            return 0 != (Classification & TypeClassification.IsValueType);
         }
 
         String ITraceableTypeMember.MemberName


### PR DESCRIPTION
I'll leave the interop and constraint validator work
to their respective owners. It's low-pri work and
I don't want to keep guessing the correct behavior
there.