### PR TITLE
DateTimeFormat: Avoid intermediate char[] allocation

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.DateTimeFormat.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.DateTimeFormat.cs
@@ -1087,7 +1087,7 @@ namespace System.Globalization
                     case 'O':
                     case 's':
                     case 'u':
-                        results = new String[] { Format(dateTime, new String(new char[] { format }), dtfi) };
+                        results = new String[] { Format(dateTime, new String(format, 1), dtfi) };
                         break;
                     default:
                         throw new FormatException(SR.Format_InvalidString);


### PR DESCRIPTION
Port of https://github.com/dotnet/coreclr/pull/6863

---

An unnecessary intermediate `char[]` allocation can be avoided by calling `new string(c, 1)` instead of `new string(new char[] { c })`.

cc: @jkotas