### PR TITLE
Initial bringup for Type.GetX() members.

### DIFF
--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -231,4 +231,13 @@
   <data name="InvalidOperation_NotGenericType" xml:space="preserve">
     <value>This operation is only valid on generic types.</value>
   </data>
+  <data name="Arg_GetMethNotFnd" xml:space="preserve">
+    <value>Property get method not found.</value>
+  </data>
+  <data name="Arg_SetMethNotFnd" xml:space="preserve">
+    <value>Property set method not found.</value>
+  </data>
+  <data name="TypeIsNotReflectable" xml:space="preserve">
+    <value>Type instance is not IReflectable.</value>
+  </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -42,6 +42,10 @@
     <Compile Include="System\Reflection\Runtime\Assemblies\AssemblyNameParser.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\RuntimeAssembly.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\RuntimeAssemblyName.cs" />
+    <Compile Include="System\Reflection\Runtime\BindingFlagSupport\InheritedPropertyInfo.cs" />
+    <Compile Include="System\Reflection\Runtime\BindingFlagSupport\LowLevelTypeExtensions.cs" />
+    <Compile Include="System\Reflection\Runtime\BindingFlagSupport\MemberEnumerator.cs" />
+    <Compile Include="System\Reflection\Runtime\BindingFlagSupport\MemberPolicies.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimeCustomAttributeData.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimeNormalCustomAttributeData.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimePseudoCustomAttributeData.cs" />
@@ -110,6 +114,7 @@
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimePointerTypeInfo.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeBlockedTypeInfo.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.cs" />
+    <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.BindingFlags.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\TypeInfoCachedData.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\TypeName.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\TypeLexer.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/InheritedPropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/InheritedPropertyInfo.cs
@@ -1,0 +1,260 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Globalization;
+using System.Collections.Generic;
+
+namespace System.Reflection.Runtime.BindingFlagSupport
+{
+    //
+    // This class exists for desktop compatibility. If one uses an api such as Type.GetProperty(string) to retrieve a member
+    // from a base class, the desktop returns a special MemberInfo object that is blocked from seeing or invoking private
+    // set or get methods on that property. That is, the type used to find the member is part of that member's object identity.
+    //
+    internal sealed class InheritedPropertyInfo : PropertyInfo
+    {
+        private readonly PropertyInfo _underlyingPropertyInfo;
+        private readonly Type _reflectedType;
+
+        internal InheritedPropertyInfo(PropertyInfo underlyingPropertyInfo, Type reflectedType)
+        {
+            // If the reflectedType is the declaring type, the caller should have used the original PropertyInfo.
+            // This assert saves us from having to check this throughout.
+            Debug.Assert(!(reflectedType.Equals(underlyingPropertyInfo.DeclaringType)), "reflectedType must be a proper base type of (and not equal to) underlyingPropertyInfo.DeclaringType.");
+
+            _underlyingPropertyInfo = underlyingPropertyInfo;
+            _reflectedType = reflectedType;
+            return;
+        }
+
+        public sealed override PropertyAttributes Attributes
+        {
+            get { return _underlyingPropertyInfo.Attributes; }
+        }
+
+        public sealed override bool CanRead
+        {
+            get { return GetMethod != null; }
+        }
+
+        public sealed override bool CanWrite
+        {
+            get { return SetMethod != null; }
+        }
+
+        public sealed override ParameterInfo[] GetIndexParameters()
+        {
+            return _underlyingPropertyInfo.GetIndexParameters();
+        }
+
+        public sealed override Type PropertyType
+        {
+            get { return _underlyingPropertyInfo.PropertyType; }
+        }
+
+        public sealed override Type DeclaringType
+        {
+            get { return _underlyingPropertyInfo.DeclaringType; }
+        }
+
+        public sealed override String Name
+        {
+            get { return _underlyingPropertyInfo.Name; }
+        }
+
+        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
+        {
+            get { return _underlyingPropertyInfo.CustomAttributes; }
+        }
+
+        public sealed override bool Equals(Object obj)
+        {
+            InheritedPropertyInfo other = obj as InheritedPropertyInfo;
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (!(_underlyingPropertyInfo.Equals(other._underlyingPropertyInfo)))
+            {
+                return false;
+            }
+
+            if (!(_reflectedType.Equals(other._reflectedType)))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public sealed override int GetHashCode()
+        {
+            int hashCode = _reflectedType.GetHashCode();
+            hashCode ^= _underlyingPropertyInfo.GetHashCode();
+            return hashCode;
+        }
+
+        public sealed override Object GetConstantValue()
+        {
+            return _underlyingPropertyInfo.GetConstantValue();
+        }
+
+        public sealed override MethodInfo GetMethod
+        {
+            get
+            {
+                MethodInfo accessor = _underlyingPropertyInfo.GetMethod;
+                return Filter(accessor);
+            }
+        }
+
+        public sealed override object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        {
+            if (GetMethod == null)
+            {
+                throw new ArgumentException(SR.Arg_GetMethNotFnd);
+            }
+
+            return _underlyingPropertyInfo.GetValue(obj, invokeAttr, binder, index, culture);
+        }
+
+        public sealed override Module Module
+        {
+            get { return _underlyingPropertyInfo.Module; }
+        }
+
+        public sealed override String ToString()
+        {
+            return _underlyingPropertyInfo.ToString();
+        }
+
+        public sealed override MethodInfo SetMethod
+        {
+            get
+            {
+                MethodInfo accessor = _underlyingPropertyInfo.SetMethod;
+                return Filter(accessor);
+            }
+        }
+
+        public sealed override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        {
+            if (SetMethod == null)
+            {
+                throw new ArgumentException(SR.Arg_SetMethNotFnd);
+            }
+
+            _underlyingPropertyInfo.SetValue(obj, value, invokeAttr, binder, index, culture);
+        }
+
+        public sealed override MemberTypes MemberType { get { return MemberTypes.Property; } }
+
+        public sealed override MethodInfo[] GetAccessors(bool nonPublic)
+        {
+            MethodInfo[] accessors = _underlyingPropertyInfo.GetAccessors(nonPublic);
+            MethodInfo[] survivors = new MethodInfo[accessors.Length];
+            int numSurvivors = 0;
+            for (int i = 0; i < accessors.Length; i++)
+            {
+                MethodInfo survivor = Filter(accessors[i]);
+                if (survivor != null)
+                {
+                    survivors[numSurvivors++] = survivor;
+                }
+            }
+            Array.Resize(ref survivors, numSurvivors);
+            return survivors;
+        }
+
+        public sealed override MethodInfo GetGetMethod(bool nonPublic)
+        {
+            MethodInfo accessor = _underlyingPropertyInfo.GetGetMethod(nonPublic);
+            return Filter(accessor);
+        }
+
+        public sealed override MethodInfo GetSetMethod(bool nonPublic)
+        {
+            MethodInfo accessor = _underlyingPropertyInfo.GetSetMethod(nonPublic);
+            return Filter(accessor);
+        }
+
+        public sealed override object[] GetCustomAttributes(bool inherit)
+        {
+            return _underlyingPropertyInfo.GetCustomAttributes(inherit);
+        }
+
+        public sealed override object[] GetCustomAttributes(Type attributeType, bool inherit)
+        {
+            return _underlyingPropertyInfo.GetCustomAttributes(attributeType, inherit);
+        }
+
+        public sealed override bool IsDefined(Type attributeType, bool inherit)
+        {
+            return _underlyingPropertyInfo.IsDefined(attributeType, inherit);
+        }
+
+        public sealed override Type ReflectedType
+        {
+            get { return _underlyingPropertyInfo.ReflectedType; }
+        }
+
+        public sealed override IList<CustomAttributeData> GetCustomAttributesData()
+        {
+            return _underlyingPropertyInfo.GetCustomAttributesData();
+        }
+
+        public sealed override Type[] GetOptionalCustomModifiers()
+        {
+            return _underlyingPropertyInfo.GetOptionalCustomModifiers();
+        }
+
+        public sealed override object GetRawConstantValue()
+        {
+            return _underlyingPropertyInfo.GetRawConstantValue();
+        }
+
+        public sealed override Type[] GetRequiredCustomModifiers()
+        {
+            return _underlyingPropertyInfo.GetRequiredCustomModifiers();
+        }
+
+        public sealed override int MetadataToken
+        {
+            get { return _underlyingPropertyInfo.MetadataToken; }
+        }
+
+#if DEBUG
+        public sealed override object GetValue(object obj, object[] index) 
+        {
+            return base.GetValue(obj, index);
+        }
+
+        public sealed override void SetValue(object obj, object value, object[] index)
+        {
+            base.SetValue(obj, value, index);
+        }
+#endif
+
+        private MethodInfo Filter(MethodInfo accessor)
+        {
+            //
+            // For desktop compat, hide inherited accessors that are marked private.
+            //  
+            //   Q: Why don't we also hide cross-assembly "internal" accessors?
+            //   A: That inconsistency is also desktop-compatible.
+            //
+            if (accessor == null || accessor.IsPrivate)
+            {
+                return null;
+            }
+
+            return accessor;
+        }
+    }
+}
+ 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/LowLevelTypeExtensions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/LowLevelTypeExtensions.cs
@@ -1,0 +1,288 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Internal.LowLevelLinq;
+
+namespace System.Reflection.Runtime.BindingFlagSupport
+{
+    /// <summary>
+    /// Extension methods offering source-code compatibility with certain instance methods of <see cref="System.Type"/> on other platforms.
+    /// </summary>
+    internal static class LowLevelTypeExtensions
+    {
+        /// <summary>
+        /// Searches for the constructors defined for the current Type, using the specified BindingFlags.
+        /// </summary>
+        /// <param name="type">Type to retrieve constructors for</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>An array of ConstructorInfo objects representing all constructors defined for the current Type that match the specified binding constraints, including the type initializer if it is defined. Returns an empty array of type ConstructorInfo if no constructors are defined for the current Type, if none of the defined constructors match the binding constraints, or if the current Type represents a type parameter in the definition of a generic type or generic method.</returns>
+        public static ConstructorInfo[] GetConstructors(Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<ConstructorInfo> constructors = type.GetMembers<ConstructorInfo>(MemberEnumerator.AnyName, bindingAttr);
+            return constructors.ToArray();
+        }
+
+        /// <summary>
+        /// Returns the EventInfo object representing the specified event, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of an event which is declared or inherited by the current Type. </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>The object representing the specified event that is declared or inherited by the current Type, if found; otherwise, null.</returns>
+        public static EventInfo GetEvent(Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<EventInfo> events = MemberEnumerator.GetMembers<EventInfo>(type, name, bindingAttr);
+            return Disambiguate(events);
+        }
+
+        /// <summary>
+        /// Searches for events that are declared or inherited by the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>An array of EventInfo objects representing all events that are declared or inherited by the current Type that match the specified binding constraints.
+        /// -or- 
+        /// An empty array of type EventInfo, if the current Type does not have events, or if none of the events match the binding constraints.</returns>
+        public static EventInfo[] GetEvents(Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<EventInfo> events = MemberEnumerator.GetMembers<EventInfo>(type, MemberEnumerator.AnyName, bindingAttr);
+            return events.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the specified field, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the data field to get. </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null.</param>
+        /// <returns>An object representing the field that matches the specified requirements, if found; otherwise, null.</returns>
+        public static FieldInfo GetField(Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<FieldInfo> fields = MemberEnumerator.GetMembers<FieldInfo>(type, name, bindingAttr);
+            return Disambiguate(fields);
+        }
+
+        /// <summary>
+        /// Searches for the fields defined for the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return an empty array. </param>
+        /// <returns>An array of FieldInfo objects representing all fields defined for the current Type that match the specified binding constraints.
+        /// -or- 
+        /// An empty array of type FieldInfo, if no fields are defined for the current Type, or if none of the defined fields match the binding constraints.</returns>
+        public static FieldInfo[] GetFields(Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            return MemberEnumerator.GetMembers<FieldInfo>(type, MemberEnumerator.AnyName, bindingAttr).ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the public members with the specified name.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name"> The string containing the name of the public members to get.  </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return an empty array. </param>
+        /// <returns>An array of MemberInfo objects representing the public members with the specified name, if found; otherwise, an empty array.</returns>
+        public static MemberInfo[] GetMember(Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            LowLevelList<MemberInfo> members = GetMembers(type, name, bindingAttr);
+            return members.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the members defined for the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return an empty array. </param>
+        /// <returns>An array of MemberInfo objects representing all members defined for the current Type that match the specified binding constraints.
+        /// -or- 
+        /// An empty array of type MemberInfo, if no members are defined for the current Type, or if none of the defined members match the binding constraints.</returns>
+        public static MemberInfo[] GetMembers(Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            LowLevelList<MemberInfo> members = GetMembers(type, MemberEnumerator.AnyName, bindingAttr);
+            return members.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the specified method, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the method to get.</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>An object representing the method that matches the specified requirements, if found; otherwise, null.</returns>
+        public static MethodInfo GetMethod(Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<MethodInfo> methods = MemberEnumerator.GetMembers<MethodInfo>(type, name, bindingAttr);
+            return Disambiguate(methods);
+        }
+
+        /// <summary>
+        /// Returns all the public methods of the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return an empty array. </param>
+        /// <returns>An array of MethodInfo objects representing all the public methods defined for the current Type
+        /// -or- 
+        /// An empty array of type MethodInfo, if no public methods are defined for the current Type.</returns>
+        public static MethodInfo[] GetMethods(Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<MethodInfo> methods = MemberEnumerator.GetMembers<MethodInfo>(type, MemberEnumerator.AnyName, bindingAttr);
+            return methods.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the specified nested type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the nested type to get. </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>An object representing the nested type that matches the specified requirements, if found; otherwise, null.</returns>
+        public static Type GetNestedType(Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<TypeInfo> nestedTypes = MemberEnumerator.GetMembers<TypeInfo>(type, name, bindingAttr);
+            TypeInfo nestedType = Disambiguate(nestedTypes);
+            return nestedType == null ? null : nestedType.AsType();
+        }
+
+        /// <summary>
+        /// Searches for the types nested in the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted -or- Zero, to return null. </param>
+        /// <returns>An array of Type objects representing all the types nested in the current Type that match the specified binding constraints (the search is not recursive), or an empty array of type Type, if no nested types are found that match the binding constraints.</returns>
+        public static Type[] GetNestedTypes(Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<TypeInfo> types = MemberEnumerator.GetMembers<TypeInfo>(type, MemberEnumerator.AnyName, bindingAttr);
+            return types.Select(t => t.AsType()).ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the properties of the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted -or- Zero, to return null. </param>
+        /// <returns>An array of PropertyInfo objects representing all properties of the current Type that match the specified binding constraints.
+        /// -or- 
+        /// An empty array of type PropertyInfo, if the current Type does not have properties, or if none of the properties match the binding constraints.</returns>
+        public static PropertyInfo[] GetProperties(this Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<PropertyInfo> properties = MemberEnumerator.GetMembers<PropertyInfo>(type, MemberEnumerator.AnyName, bindingAttr);
+            return properties.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the specified property, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the property to get. </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </returns>
+        public static PropertyInfo GetProperty(Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<PropertyInfo> properties = MemberEnumerator.GetMembers<PropertyInfo>(type, name, bindingAttr);
+            return Disambiguate(properties);
+        }
+
+        private static LowLevelList<MemberInfo> GetMembers(Type type, object nameFilterOrAnyName, BindingFlags bindingAttr)
+        {
+            LowLevelList<MemberInfo> members = new LowLevelList<MemberInfo>();
+
+            members.AddRange(MemberEnumerator.GetMembers<MethodInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<ConstructorInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<PropertyInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<EventInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<FieldInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<TypeInfo>(type, nameFilterOrAnyName, bindingAttr));
+
+            return members;
+        }
+
+        private static TypeInfo GetTypeInfoOrThrow(Type type, string parameterName = "type")
+        {
+            Debug.Assert(type != null);
+
+            TypeInfo typeInfo = type.GetTypeInfo();
+
+            if (typeInfo == null)
+            {
+                throw new ArgumentException(SR.TypeIsNotReflectable, parameterName);
+            }
+            return typeInfo;
+        }
+
+        private static T Disambiguate<T>(IEnumerable<T> members) where T : MemberInfo
+        {
+            IEnumerator<T> enumerator = members.GetEnumerator();
+            if (!enumerator.MoveNext())
+            {
+                return null;
+            }
+
+            T result = enumerator.Current;
+            if (!enumerator.MoveNext())
+            {
+                return result;
+            }
+
+            T anotherResult = enumerator.Current;
+            if (anotherResult.DeclaringType.Equals(result.DeclaringType))
+            {
+                throw new AmbiguousMatchException();
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberEnumerator.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberEnumerator.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace System.Reflection.Runtime.BindingFlagSupport
+{
+    internal static class MemberEnumerator
+    {
+        //
+        // Enumerates members, optionally filtered by a name, in the given class and its base classes (but not implemented interfaces.)
+        // Basically emulates the old Type.GetFoo(BindingFlags) api.
+        //
+        public static IEnumerable<M> GetMembers<M>(this Type type, Object nameFilterOrAnyName, BindingFlags bindingFlags) where M : MemberInfo
+        {
+            // Do all the up-front argument validation here so that the exception occurs on call rather than on the first move.
+            if (type == null)
+            {
+                throw new ArgumentNullException();
+            }
+            if (nameFilterOrAnyName == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            String optionalNameFilter;
+            if (nameFilterOrAnyName == AnyName)
+            {
+                optionalNameFilter = null;
+            }
+            else
+            {
+                optionalNameFilter = (String)nameFilterOrAnyName;
+            }
+
+            return GetMembersWorker<M>(type, optionalNameFilter, bindingFlags);
+        }
+
+        //
+        // The iterator worker for GetMember<M>()
+        //
+        private static IEnumerable<M> GetMembersWorker<M>(Type type, String optionalNameFilter, BindingFlags bindingFlags) where M : MemberInfo
+        {
+            Type reflectedType = type;
+            Type typeOfM = typeof(M);
+            Type typeOfEventInfo = typeof(EventInfo);
+
+            MemberPolicies<M> policies = MemberPolicies<M>.Default;
+            bindingFlags = policies.ModifyBindingFlags(bindingFlags);
+
+            LowLevelList<M> overridingMembers = new LowLevelList<M>();
+
+            StringComparison comparisonType = (0 != (bindingFlags & BindingFlags.IgnoreCase)) ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
+            bool inBaseClass = false;
+
+            bool nameFilterIsPrefix = false;
+            if (optionalNameFilter != null && optionalNameFilter.EndsWith("*", StringComparison.Ordinal))
+            {
+                nameFilterIsPrefix = true;
+                optionalNameFilter = optionalNameFilter.Substring(0, optionalNameFilter.Length - 1);
+            }
+
+            while (type != null)
+            {
+                TypeInfo typeInfo = type.GetTypeInfo();
+
+                foreach (M member in policies.GetDeclaredMembers(typeInfo))
+                {
+                    if (optionalNameFilter != null)
+                    {
+                        if (nameFilterIsPrefix)
+                        {
+                            if (!member.Name.StartsWith(optionalNameFilter, comparisonType))
+                            {
+                                continue;
+                            }
+                        }
+                        else if (!member.Name.Equals(optionalNameFilter, comparisonType))
+                        {
+                            continue;
+                        }
+                    }
+
+                    MethodAttributes visibility;
+                    bool isStatic;
+                    bool isVirtual;
+                    bool isNewSlot;
+                    policies.GetMemberAttributes(member, out visibility, out isStatic, out isVirtual, out isNewSlot);
+
+                    BindingFlags memberBindingFlags = (BindingFlags)0;
+                    memberBindingFlags |= (isStatic ? BindingFlags.Static : BindingFlags.Instance);
+                    memberBindingFlags |= ((visibility == MethodAttributes.Public) ? BindingFlags.Public : BindingFlags.NonPublic);
+                    if ((bindingFlags & memberBindingFlags) != memberBindingFlags)
+                    {
+                        continue;
+                    }
+
+                    bool passesVisibilityScreen = true;
+                    if (inBaseClass && visibility == MethodAttributes.Private)
+                    {
+                        passesVisibilityScreen = false;
+                    }
+
+                    bool passesStaticScreen = true;
+                    if (inBaseClass && isStatic && (0 == (bindingFlags & BindingFlags.FlattenHierarchy)))
+                    {
+                        passesStaticScreen = false;
+                    }
+
+                    //
+                    // Desktop compat: The order in which we do checks is important.
+                    //
+                    if (!passesVisibilityScreen)
+                    {
+                        continue;
+                    }
+                    if ((!passesStaticScreen) && !(typeOfM.Equals(typeOfEventInfo)))
+                    {
+                        continue;
+                    }
+
+                    bool isImplicitlyOverridden = false;
+                    if (isVirtual)
+                    {
+                        if (isNewSlot)
+                        {
+                            // A new virtual member definition.
+                            for (int i = 0; i < overridingMembers.Count; i++)
+                            {
+                                if (policies.AreNamesAndSignatureEqual(member, overridingMembers[i]))
+                                {
+                                    // This member is overridden by a more derived class.
+                                    isImplicitlyOverridden = true;
+                                    overridingMembers.RemoveAt(i);
+                                    break;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            for (int i = 0; i < overridingMembers.Count; i++)
+                            {
+                                if (policies.AreNamesAndSignatureEqual(overridingMembers[i], member))
+                                {
+                                    // This member overrides another, *and* is overridden by yet another method.
+                                    isImplicitlyOverridden = true;
+                                    break;
+                                }
+                            }
+
+                            if (!isImplicitlyOverridden)
+                            {
+                                // This member overrides another and is the most derived instance of it we've found.
+                                overridingMembers.Add(member);
+                            }
+                        }
+                    }
+
+                    if (isImplicitlyOverridden)
+                    {
+                        continue;
+                    }
+
+                    if (!passesStaticScreen)
+                    {
+                        continue;
+                    }
+
+                    if (inBaseClass)
+                    {
+                        yield return policies.GetInheritedMemberInfo(member, reflectedType);
+                    }
+                    else
+                    {
+                        yield return member;
+                    }
+                }
+
+                if (0 != (bindingFlags & BindingFlags.DeclaredOnly))
+                {
+                    break;
+                }
+
+                inBaseClass = true;
+                type = typeInfo.BaseType;
+            }
+        }
+
+        //
+        // If member is a virtual member that implicitly overrides a member in a base class, return the overridden member.
+        // Otherwise, return null.
+        //
+        // - MethodImpls ignored. (I didn't say it made sense, this is just how the desktop api we're porting behaves.)
+        // - Implemented interfaces ignores. (I didn't say it made sense, this is just how the desktop api we're porting behaves.) 
+        //
+        public static M GetImplicitlyOverriddenBaseClassMember<M>(this M member) where M : MemberInfo
+        {
+            MemberPolicies<M> policies = MemberPolicies<M>.Default;
+            MethodAttributes visibility;
+            bool isStatic;
+            bool isVirtual;
+            bool isNewSlot;
+            policies.GetMemberAttributes(member, out visibility, out isStatic, out isVirtual, out isNewSlot);
+            if (isNewSlot || !isVirtual)
+            {
+                return null;
+            }
+            String name = member.Name;
+            TypeInfo typeInfo = member.DeclaringType.GetTypeInfo();
+            for (; ;)
+            {
+                Type baseType = typeInfo.BaseType;
+                if (baseType == null)
+                {
+                    return null;
+                }
+                typeInfo = baseType.GetTypeInfo();
+                foreach (M candidate in policies.GetDeclaredMembers(typeInfo))
+                {
+                    if (candidate.Name != name)
+                    {
+                        continue;
+                    }
+                    MethodAttributes candidateVisibility;
+                    bool isCandidateStatic;
+                    bool isCandidateVirtual;
+                    bool isCandidateNewSlot;
+                    policies.GetMemberAttributes(member, out candidateVisibility, out isCandidateStatic, out isCandidateVirtual, out isCandidateNewSlot);
+                    if (!isCandidateVirtual)
+                    {
+                        continue;
+                    }
+                    if (!policies.AreNamesAndSignatureEqual(member, candidate))
+                    {
+                        continue;
+                    }
+                    return candidate;
+                }
+            }
+        }
+
+        // Uniquely allocated sentinel "string"
+        //  - can't use null as that may be an app-supplied null, which we have to throw ArgumentNullException for.
+        //  - risky to use a proper String as the FX or toolchain can unexpectedly give you back a shared string
+        //    even when you'd swear you were allocating a new one.
+        public static readonly Object AnyName = new Object();
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
@@ -1,0 +1,338 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+namespace System.Reflection.Runtime.BindingFlagSupport
+{
+    //=================================================================================================================
+    // This class encapsulates the minimum set of arcane desktop CLR policies needed to implement the Get*(BindingFlags) apis.
+    //
+    // In particular, it encapsulates behaviors such as what exactly determines the "visibility" of a property and event, and
+    // what determines whether and how they are overridden.
+    //=================================================================================================================
+    internal abstract class MemberPolicies<M> where M : MemberInfo
+    {
+        //=================================================================================================================
+        // Subclasses for specific MemberInfo types must override these:
+        //=================================================================================================================
+
+        //
+        // Returns all of the directly declared members on the given TypeInfo.
+        //
+        public abstract IEnumerable<M> GetDeclaredMembers(TypeInfo typeInfo);
+
+        //
+        // Policy to decide whether a member is considered "virtual", "virtual new" and what its member visibility is.
+        // (For "visibility", we reuse the MethodAttributes enum since Reflection lacks an element-agnostic enum for this.
+        //  Only the MemberAccessMask bits are set.)
+        //
+        public abstract void GetMemberAttributes(M member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot);
+
+        //
+        // Policy to decide whether two virtual members are signature-compatible for the purpose of implicit overriding. 
+        //
+        public abstract bool AreNamesAndSignatureEqual(M member1, M member2);
+
+        //
+        // Policy to decide how BindingFlags should be reinterpreted for a given member type.
+        // This is overridden for nested types which all match on any combination Instance | Static and are never inherited.
+        // It is also overridden for constructors which are never inherited.
+        //
+        public virtual BindingFlags ModifyBindingFlags(BindingFlags bindingFlags)
+        {
+            return bindingFlags;
+        }
+
+        //
+        // Policy to create a wrapper MemberInfo (if appropriate). This is due to the fact that MemberInfo's actually have their identity
+        // tied to the type they were queried off of and this unfortunate fact shows up in certain api behaviors.
+        //
+        public virtual M GetInheritedMemberInfo(M underlyingMemberInfo, Type reflectedType)
+        {
+            return underlyingMemberInfo;
+        }
+
+        //
+        // Helper method for determining whether two methods are signature-compatible for the purpose of implicit overriding.
+        //
+        protected static bool AreNamesAndSignaturesEqual(MethodInfo method1, MethodInfo method2)
+        {
+            if (method1.Name != method2.Name)
+            {
+                return false;
+            }
+
+            ParameterInfo[] p1 = method1.GetParameters();
+            ParameterInfo[] p2 = method2.GetParameters();
+            if (p1.Length != p2.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < p1.Length; i++)
+            {
+                Type parameterType1 = p1[i].ParameterType;
+                Type parameterType2 = p2[i].ParameterType;
+                if (!(parameterType1.Equals(parameterType2)))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        //
+        // This is a singleton class one for each MemberInfo category: Return the appropriate one. 
+        //
+        public static MemberPolicies<M> Default
+        {
+            get
+            {
+                if (_default == null)
+                {
+                    Type t = typeof(M);
+                    if (t.Equals(typeof(FieldInfo)))
+                    {
+                        _default = (MemberPolicies<M>)(Object)(new FieldPolicies());
+                    }
+                    else if (t.Equals(typeof(MethodInfo)))
+                    {
+                        _default = (MemberPolicies<M>)(Object)(new MethodPolicies());
+                    }
+                    else if (t.Equals(typeof(ConstructorInfo)))
+                    {
+                        _default = (MemberPolicies<M>)(Object)(new ConstructorPolicies());
+                    }
+                    else if (t.Equals(typeof(PropertyInfo)))
+                    {
+                        _default = (MemberPolicies<M>)(Object)(new PropertyPolicies());
+                    }
+                    else if (t.Equals(typeof(EventInfo)))
+                    {
+                        _default = (MemberPolicies<M>)(Object)(new EventPolicies());
+                    }
+                    else if (t.Equals(typeof(TypeInfo)))
+                    {
+                        _default = (MemberPolicies<M>)(Object)(new NestedTypePolicies());
+                    }
+                    else
+                    {
+                        Debug.Assert(false, "Unknown MemberInfo type.");
+                    }
+                }
+                return _default;
+            }
+        }
+
+        private static volatile MemberPolicies<M> _default;
+    }
+
+    //==========================================================================================================================
+    // Policies for fields.
+    //==========================================================================================================================
+    internal sealed class FieldPolicies : MemberPolicies<FieldInfo>
+    {
+        public sealed override IEnumerable<FieldInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredFields;
+        }
+
+        public sealed override void GetMemberAttributes(FieldInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            FieldAttributes fieldAttributes = member.Attributes;
+            visibility = (MethodAttributes)(fieldAttributes & FieldAttributes.FieldAccessMask);
+            isStatic = (0 != (fieldAttributes & FieldAttributes.Static));
+            isVirtual = false;
+            isNewSlot = false;
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(FieldInfo member1, FieldInfo member2)
+        {
+            Debug.Assert(false, "This code path should be unreachable as fields are never \"virtual\".");
+            throw new NotSupportedException();
+        }
+    }
+
+
+    //==========================================================================================================================
+    // Policies for constructors.
+    //==========================================================================================================================
+    internal sealed class ConstructorPolicies : MemberPolicies<ConstructorInfo>
+    {
+        public sealed override IEnumerable<ConstructorInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredConstructors;
+        }
+
+        public sealed override BindingFlags ModifyBindingFlags(BindingFlags bindingFlags)
+        {
+            // Constructors are not inherited.
+            return bindingFlags | BindingFlags.DeclaredOnly;
+        }
+
+        public sealed override void GetMemberAttributes(ConstructorInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            MethodAttributes methodAttributes = member.Attributes;
+            visibility = methodAttributes & MethodAttributes.MemberAccessMask;
+            isStatic = (0 != (methodAttributes & MethodAttributes.Static));
+            isVirtual = false;
+            isNewSlot = false;
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(ConstructorInfo member1, ConstructorInfo member2)
+        {
+            Debug.Assert(false, "This code path should be unreachable as constructors are never \"virtual\".");
+            throw new NotSupportedException();
+        }
+    }
+
+
+    //==========================================================================================================================
+    // Policies for methods.
+    //==========================================================================================================================
+    internal sealed class MethodPolicies : MemberPolicies<MethodInfo>
+    {
+        public sealed override IEnumerable<MethodInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredMethods;
+        }
+
+        public sealed override void GetMemberAttributes(MethodInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            MethodAttributes methodAttributes = member.Attributes;
+            visibility = methodAttributes & MethodAttributes.MemberAccessMask;
+            isStatic = (0 != (methodAttributes & MethodAttributes.Static));
+            isVirtual = (0 != (methodAttributes & MethodAttributes.Virtual));
+            isNewSlot = (0 != (methodAttributes & MethodAttributes.NewSlot));
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(MethodInfo member1, MethodInfo member2)
+        {
+            return AreNamesAndSignaturesEqual(member1, member2);
+        }
+    }
+
+    //==========================================================================================================================
+    // Policies for properties.
+    //==========================================================================================================================
+    internal sealed class PropertyPolicies : MemberPolicies<PropertyInfo>
+    {
+        public sealed override IEnumerable<PropertyInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredProperties;
+        }
+
+        public sealed override void GetMemberAttributes(PropertyInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            MethodInfo accessorMethod = GetAccessorMethod(member);
+            MethodAttributes methodAttributes = accessorMethod.Attributes;
+            visibility = methodAttributes & MethodAttributes.MemberAccessMask;
+            isStatic = (0 != (methodAttributes & MethodAttributes.Static));
+            isVirtual = (0 != (methodAttributes & MethodAttributes.Virtual));
+            isNewSlot = (0 != (methodAttributes & MethodAttributes.NewSlot));
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(PropertyInfo member1, PropertyInfo member2)
+        {
+            return AreNamesAndSignaturesEqual(GetAccessorMethod(member1), GetAccessorMethod(member2));
+        }
+
+        public sealed override PropertyInfo GetInheritedMemberInfo(PropertyInfo underlyingMemberInfo, Type reflectedType)
+        {
+            return new InheritedPropertyInfo(underlyingMemberInfo, reflectedType);
+        }
+
+        private MethodInfo GetAccessorMethod(PropertyInfo property)
+        {
+            MethodInfo accessor = property.GetMethod;
+            if (accessor == null)
+            {
+                accessor = property.SetMethod;
+            }
+
+            return accessor;
+        }
+    }
+
+    //==========================================================================================================================
+    // Policies for events.
+    //==========================================================================================================================
+    internal sealed class EventPolicies : MemberPolicies<EventInfo>
+    {
+        public sealed override IEnumerable<EventInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredEvents;
+        }
+
+        public sealed override void GetMemberAttributes(EventInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            MethodInfo accessorMethod = GetAccessorMethod(member);
+            MethodAttributes methodAttributes = accessorMethod.Attributes;
+            visibility = methodAttributes & MethodAttributes.MemberAccessMask;
+            isStatic = (0 != (methodAttributes & MethodAttributes.Static));
+            isVirtual = (0 != (methodAttributes & MethodAttributes.Virtual));
+            isNewSlot = (0 != (methodAttributes & MethodAttributes.NewSlot));
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(EventInfo member1, EventInfo member2)
+        {
+            return AreNamesAndSignaturesEqual(GetAccessorMethod(member1), GetAccessorMethod(member2));
+        }
+
+        private MethodInfo GetAccessorMethod(EventInfo e)
+        {
+            MethodInfo accessor = e.AddMethod;
+            return accessor;
+        }
+    }
+
+    //==========================================================================================================================
+    // Policies for nested types.
+    //
+    // Nested types enumerate a little differently than other members:
+    //
+    //    Base classes are never searched, regardless of BindingFlags.DeclaredOnly value.
+    //
+    //    Public|NonPublic|IgnoreCase are the only relevant BindingFlags. The apis ignore any other bits.
+    //
+    //    There is no such thing as a "static" or "instanced" nested type. For enumeration purposes,
+    //    we'll arbitrarily denote all nested types as "static."
+    //
+    //==========================================================================================================================
+    internal sealed class NestedTypePolicies : MemberPolicies<TypeInfo>
+    {
+        public sealed override IEnumerable<TypeInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredNestedTypes;
+        }
+
+        public sealed override void GetMemberAttributes(TypeInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            isStatic = true;
+            isVirtual = false;
+            isNewSlot = false;
+
+            // Since we never search base types for nested types, we don't need to map every visibility value one to one.
+            // We just need to distinguish between "public" and "everything else."
+            visibility = member.IsNestedPublic ? MethodAttributes.Public : MethodAttributes.Private;
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(TypeInfo member1, TypeInfo member2)
+        {
+            Debug.Assert(false, "This code path should be unreachable as nested types are never \"virtual\".");
+            throw new NotSupportedException();
+        }
+
+        public sealed override BindingFlags ModifyBindingFlags(BindingFlags bindingFlags)
+        {
+            bindingFlags &= BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.IgnoreCase;
+            bindingFlags |= BindingFlags.Static | BindingFlags.DeclaredOnly;
+            return bindingFlags;
+        }
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -192,7 +192,6 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override Type[] FindInterfaces(TypeFilter filter, object filterCriteria) { throw new NotImplementedException(); }
         public sealed override MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter filter, object filterCriteria) { throw new NotImplementedException(); }
         protected sealed override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
-        public sealed override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) { throw new NotImplementedException(); }
         public sealed override object[] GetCustomAttributes(bool inherit) { throw new NotImplementedException(); }
         public sealed override IList<CustomAttributeData> GetCustomAttributesData() { throw new NotImplementedException(); }
         public sealed override MemberInfo[] GetDefaultMembers() { throw new NotImplementedException(); }
@@ -200,23 +199,10 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override string[] GetEnumNames() { throw new NotImplementedException(); }
         public sealed override Type GetEnumUnderlyingType() { throw new NotImplementedException(); }
         public sealed override Array GetEnumValues() { throw new NotImplementedException(); }
-        public sealed override EventInfo GetEvent(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        public sealed override EventInfo[] GetEvents() { throw new NotImplementedException(); }
-        public sealed override EventInfo[] GetEvents(BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        public sealed override FieldInfo GetField(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        public sealed override FieldInfo[] GetFields(BindingFlags bindingAttr) { throw new NotImplementedException(); }
         public sealed override Type GetInterface(string name, bool ignoreCase) { throw new NotImplementedException(); }
         public sealed override InterfaceMapping GetInterfaceMap(Type interfaceType) { throw new NotImplementedException(); }
         public sealed override Type[] GetInterfaces() { throw new NotImplementedException(); }
-        public sealed override MemberInfo[] GetMember(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
         public sealed override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        public sealed override MemberInfo[] GetMembers(BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
-        public sealed override MethodInfo[] GetMethods(BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        public sealed override Type GetNestedType(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        public sealed override Type[] GetNestedTypes(BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        public sealed override PropertyInfo[] GetProperties(BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        protected sealed override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
         protected sealed override TypeCode GetTypeCodeImpl() { throw new NotImplementedException(); }
         public sealed override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) { throw new NotImplementedException(); }
         public sealed override bool IsDefined(Type attributeType, bool inherit) { throw new NotImplementedException(); }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -132,6 +132,7 @@ namespace System.Reflection.Runtime.TypeInfos
     internal abstract partial class RuntimeTypeInfo
     {
 #if DEBUG
+        public sealed override EventInfo[] GetEvents() => base.GetEvents();
         public sealed override bool IsSubclassOf(Type c) => base.IsSubclassOf(c);
         protected sealed override bool IsMarshalByRefImpl() => base.IsMarshalByRefImpl();
         public sealed override MemberTypes MemberType => base.MemberType;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Reflection.Runtime.BindingFlagSupport;
+
+namespace System.Reflection.Runtime.TypeInfos
+{
+    internal abstract partial class RuntimeTypeInfo
+    {
+        public sealed override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) =>  LowLevelTypeExtensions.GetConstructors(this, bindingAttr);
+
+        public sealed override EventInfo[] GetEvents(BindingFlags bindingAttr) => LowLevelTypeExtensions.GetEvents(this, bindingAttr);
+        public sealed override EventInfo GetEvent(string name, BindingFlags bindingAttr) => LowLevelTypeExtensions.GetEvent(this, name, bindingAttr);
+
+        public sealed override FieldInfo[] GetFields(BindingFlags bindingAttr) => LowLevelTypeExtensions.GetFields(this, bindingAttr);
+        public sealed override FieldInfo GetField(string name, BindingFlags bindingAttr) => LowLevelTypeExtensions.GetField(this, name, bindingAttr);
+
+        public sealed override MemberInfo[] GetMembers(BindingFlags bindingAttr) => LowLevelTypeExtensions.GetMembers(this, bindingAttr);
+        public sealed override MemberInfo[] GetMember(string name, BindingFlags bindingAttr) => LowLevelTypeExtensions.GetMember(this, name, bindingAttr);
+
+        public sealed override MethodInfo[] GetMethods(BindingFlags bindingAttr) => LowLevelTypeExtensions.GetMethods(this, bindingAttr);
+        protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        {
+            if (binder == null && callConvention == CallingConventions.Any && types == null && modifiers == null)
+                return LowLevelTypeExtensions.GetMethod(this, name, bindingAttr);
+            throw new NotImplementedException();
+        }
+
+        public sealed override Type[] GetNestedTypes(BindingFlags bindingAttr) => LowLevelTypeExtensions.GetNestedTypes(this, bindingAttr);
+        public sealed override Type GetNestedType(string name, BindingFlags bindingAttr) => LowLevelTypeExtensions.GetNestedType(this, name, bindingAttr);
+
+        public sealed override PropertyInfo[] GetProperties(BindingFlags bindingAttr) => LowLevelTypeExtensions.GetProperties(this, bindingAttr);
+        protected sealed override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+        {
+            if (binder == null && returnType == null && types == null && modifiers == null)
+                return LowLevelTypeExtensions.GetProperty(this, name, bindingAttr);
+            throw new NotImplementedException();
+        }
+    }
+}
+


### PR DESCRIPTION
These apis on System.Type are now functional.

    GetConstructors()
    GetEvents()
    GetFields()
    GetMembers()
    GetMethods()
    GetNestedTypes()
    GetProperties()

    GetConstructors(BindingFlags bindingAttr);
    GetEvents(BindingFlags bindingAttr);
    GetFields(BindingFlags bindingAttr);
    GetMembers(BindingFlags bindingAttr);
    GetMethods(BindingFlags bindingAttr);
    GetNestedTypes(BindingFlags bindingAttr);
    GetProperties(BindingFlags bindingAttr);

    GetEvent(string name);
    GetField(string name);
    GetMember(string name);
    GetMethod(string name);
    GetNestedType(string name);
    GetProperty(string name);

    GetEvent(string name, BindingFlags bindingAttr);
    GetField(string name, BindingFlags bindingAttr);
    GetMember(string name, BindingFlags bindingAttr);
    GetMethod(string name, BindingFlags bindingAttr);
    GetNestedType(string name, BindingFlags bindingAttr);
    GetProperty(string name, BindingFlags bindingAttr);

This was brought up by embedding a cut down version
of System.Reflection.TypeExtensions inside Reflection.Core.

These aren't the final implementations as there's perf
work to do, but these apis are used everywhere
(and assemblies that switch to the new contracts will
be rediverted to them whether want to be or not)
so we need to get them up and running to keep things
flowing.