### PR TITLE
Use constant in ObjectToHandle

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -352,7 +352,7 @@ namespace Internal.JitInterface
             IntPtr handle;
             if (!_objectToHandle.TryGetValue(obj, out handle))
             {
-                handle = (IntPtr)(8 * _handleToObject.Count + handleBase);
+                handle = (IntPtr)(handleMultipler * _handleToObject.Count + handleBase);
                 _handleToObject.Add(obj);
                 _objectToHandle.Add(obj, handle);
             }


### PR DESCRIPTION
Use handleMultiplier in JitInterface ObjectToHandle instead of a literal
value to match the implementation of HandleToObject incase we ever make
the multiplier architecture specific.