### PR TITLE
Port Encoding changes from CoreCLR

### DIFF
--- a/src/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
@@ -21,6 +21,10 @@ namespace System.Text
     [System.Runtime.InteropServices.ComVisible(true)]
     public class ASCIIEncoding : Encoding
     {
+        // Used by Encoding.ASCII for lazy initialization
+        // The initialization code will not be run until a static member of the class is referenced
+        internal static readonly ASCIIEncoding s_default = new ASCIIEncoding(); 
+
         public ASCIIEncoding() : base(Encoding.CodePageASCII)
         {
         }

--- a/src/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -80,14 +80,6 @@ namespace System.Text
     [System.Runtime.InteropServices.ComVisible(true)]
     public abstract class Encoding : ICloneable
     {
-        private static volatile Encoding s_unicodeEncoding;
-        private static volatile Encoding s_bigEndianUnicode;
-        private static volatile Encoding s_utf7Encoding;
-        private static volatile Encoding s_utf8Encoding;
-        private static volatile Encoding s_utf32Encoding;
-        private static volatile Encoding s_asciiEncoding;
-        private static volatile Encoding s_latin1Encoding;
-
         private static EncodingCache s_encodings;
 
         // Special Case Code Pages
@@ -596,29 +588,14 @@ namespace System.Text
 
         // Returns an encoding for the ASCII character set. The returned encoding
         // will be an instance of the ASCIIEncoding class.
-        //
 
-        public static Encoding ASCII
-        {
-            get
-            {
-                if (s_asciiEncoding == null) s_asciiEncoding = new ASCIIEncoding();
-                return s_asciiEncoding;
-            }
-        }
+        public static Encoding ASCII => ASCIIEncoding.s_default;
 
         // Returns an encoding for the Latin1 character set. The returned encoding
         // will be an instance of the Latin1Encoding class.
         //
         // This is for our optimizations
-        private static Encoding Latin1
-        {
-            get
-            {
-                if (s_latin1Encoding == null) s_latin1Encoding = new Latin1Encoding();
-                return s_latin1Encoding;
-            }
-        }
+        private static Encoding Latin1 => Latin1Encoding.s_default;
 
         // Returns the number of bytes required to encode the given character
         // array.
@@ -1112,69 +1089,31 @@ namespace System.Text
         //
         // It will use little endian byte order, but will detect
         // input in big endian if it finds a byte order mark per Unicode 2.0.
-        //
 
-        public static Encoding Unicode
-        {
-            get
-            {
-                if (s_unicodeEncoding == null) s_unicodeEncoding = new UnicodeEncoding(false, true);
-                return s_unicodeEncoding;
-            }
-        }
+        public static Encoding Unicode => UnicodeEncoding.s_littleEndianDefault;
 
         // Returns an encoding for Unicode format. The returned encoding will be
         // an instance of the UnicodeEncoding class.
         //
         // It will use big endian byte order, but will detect
         // input in little endian if it finds a byte order mark per Unicode 2.0.
-        //
 
-        public static Encoding BigEndianUnicode
-        {
-            get
-            {
-                if (s_bigEndianUnicode == null) s_bigEndianUnicode = new UnicodeEncoding(true, true);
-                return s_bigEndianUnicode;
-            }
-        }
+        public static Encoding BigEndianUnicode => UnicodeEncoding.s_bigEndianDefault;
 
         // Returns an encoding for the UTF-7 format. The returned encoding will be
         // an instance of the UTF7Encoding class.
-        //
-        public static Encoding UTF7
-        {
-            get
-            {
-                if (s_utf7Encoding == null) s_utf7Encoding = new UTF7Encoding();
-                return s_utf7Encoding;
-            }
-        }
+        
+        public static Encoding UTF7 => UTF7Encoding.s_default;
 
         // Returns an encoding for the UTF-8 format. The returned encoding will be
         // an instance of the UTF8Encoding class.
-        //
 
-        public static Encoding UTF8
-        {
-            get
-            {
-                if (s_utf8Encoding == null) s_utf8Encoding = new UTF8Encoding(true);
-                return s_utf8Encoding;
-            }
-        }
+        public static Encoding UTF8 => UTF8Encoding.s_default;
 
         // Returns an encoding for the UTF-32 format. The returned encoding will be
         // an instance of the UTF32Encoding class.
-        //
-        public static Encoding UTF32
-        {
-            get
-            {
-                if (s_utf32Encoding == null) s_utf32Encoding = new UTF32Encoding(false, true);
-                return s_utf32Encoding;
-            }
-        }
+
+        public static Encoding UTF32 => UTF32Encoding.s_default;
 
         public override bool Equals(Object value)
         {

--- a/src/System.Private.CoreLib/src/System/Text/Latin1Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/Latin1Encoding.cs
@@ -18,6 +18,10 @@ namespace System.Text
     //
     internal class Latin1Encoding : EncodingNLS
     {
+        // Used by Encoding.Latin1 for lazy initialization
+        // The initialization code will not be run until a static member of the class is referenced
+        internal static readonly Latin1Encoding s_default = new Latin1Encoding();
+
         // We only use the best-fit table, of which ASCII is a superset for us.
         public Latin1Encoding() : base(Encoding.ISO_8859_1)
         {

--- a/src/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
@@ -31,9 +31,12 @@ namespace System.Text
 
             Surrogate:
             Real Unicode value = (HighSurrogate - 0xD800) * 0x400 + (LowSurrogate - 0xDC00) + 0x10000
-         */
+        */
 
-        //
+        // Used by Encoding.UTF32 for lazy initialization
+        // The initialization code will not be run until a static member of the class is referenced
+        internal static readonly UTF32Encoding s_default = new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+
         private bool _emitUTF32ByteOrderMark = false;
         private bool _isThrowException = false;
         private bool _bigEndian = false;

--- a/src/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
@@ -26,6 +26,10 @@ namespace System.Text
         // These are the characters that can be optionally directly encoded in UTF7.
         private const String optionalChars =
             "!\"#$%&*;<=>@[]^_`{|}";
+        
+        // Used by Encoding.UTF7 for lazy initialization
+        // The initialization code will not be run until a static member of the class is referenced
+        internal static readonly UTF7Encoding s_default = new UTF7Encoding();
 
         // The set of base 64 characters.
         private byte[] _base64Bytes;

--- a/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -47,9 +47,13 @@ namespace System.Text
 
             Surrogate:
             Real Unicode value = (HighSurrogate - 0xD800) * 0x400 + (LowSurrogate - 0xDC00) + 0x10000
-         */
+        */
 
         private const int UTF8_CODEPAGE = 65001;
+
+        // Used by Encoding.UTF8 for lazy initialization
+        // The initialization code will not be run until a static member of the class is referenced
+        internal static readonly UTF8Encoding s_default = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
 
         // Yes, the idea of emitting U+FEFF as a UTF-8 identifier has made it into
         // the standard.

--- a/src/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
+++ b/src/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
@@ -15,6 +15,11 @@ namespace System.Text
     [System.Runtime.InteropServices.ComVisible(true)]
     public class UnicodeEncoding : Encoding
     {
+        // Used by Encoding.BigEndianUnicode/Unicode for lazy initialization
+        // The initialization code will not be run until a static member of the class is referenced
+        internal static readonly UnicodeEncoding s_bigEndianDefault = new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
+        internal static readonly UnicodeEncoding s_littleEndianDefault = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+
         internal bool isThrowException = false;
 
         internal bool bigEndian = false;


### PR DESCRIPTION
Port of dotnet/coreclr#6890. I am not sure if the rules for running static constructors here are different than in CoreCLR, so @jkotas please feel free to notify me if I should switch to a different lazy-initialization pattern or update the comments.