### PR TITLE
String literal loading special character fix

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -1908,6 +1908,9 @@ namespace Internal.IL
                     case '\t':
                         escaped.Append("\\t");
                         break;
+                    case '"':
+                        escaped.Append("'\"");
+                        break;
                     default:
                         // TODO: handle all characters < 32
                         escaped.Append(c);

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -1909,7 +1909,7 @@ namespace Internal.IL
                         escaped.Append("\\t");
                         break;
                     case '"':
-                        escaped.Append("'\"");
+                        escaped.Append("\\\"");
                         break;
                     default:
                         // TODO: handle all characters < 32


### PR DESCRIPTION
Double quotes were not getting escaped and causing CPP codegen to crash.
Fix for issue #1727.

@jkotas 