### PR TITLE
Pick off some low-hanging fruit off the Reflection api list.

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1654,4 +1654,10 @@
   <data name="Argument_MustHaveAttributeBaseClass" xml:space="preserve">
     <value>Type passed in must be derived from System.Attribute or System.Attribute itself.</value>
   </data>
+  <data name="InvalidFilterCriteriaException_CritString" xml:space="preserve">
+    <value>A String must be provided for the filter criteria.</value>
+  </data>
+  <data name="InvalidFilterCriteriaException_CritInt" xml:space="preserve">
+    <value>An Int32 must be provided for the filter criteria.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -168,7 +168,15 @@ namespace System.Reflection
         public static Assembly Load(AssemblyName assemblyRef) => ReflectionAugments.ReflectionCoreCallbacks.Load(assemblyRef);
         public static Assembly Load(byte[] rawAssembly) => Load(rawAssembly, rawSymbolStore: null);
         public static Assembly Load(byte[] rawAssembly, byte[] rawSymbolStore) { throw new NotImplementedException(); }
-        public static Assembly Load(string assemblyString) { throw new NotImplementedException(); }
+
+        public static Assembly Load(string assemblyString)
+        {
+            if (assemblyString == null)
+                throw new ArgumentNullException(nameof(assemblyString));
+
+            AssemblyName name = new AssemblyName(assemblyString);
+            return Load(name);
+        }
 
         public static Assembly ReflectionOnlyLoad(byte[] rawAssembly) { throw new NotImplementedException(); }
         public static Assembly ReflectionOnlyLoad(string assemblyString) { throw new NotImplementedException(); }

--- a/src/System.Private.CoreLib/src/System/Reflection/Binder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Binder.cs
@@ -11,7 +11,6 @@ namespace System.Reflection
         protected Binder() { }
         public abstract FieldInfo BindToField(BindingFlags bindingAttr, FieldInfo[] match, object value, CultureInfo culture);
         public abstract MethodBase BindToMethod(BindingFlags bindingAttr, MethodBase[] match, ref object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] names, out object state);
-        public virtual bool CanChangeType(object value, Type type, CultureInfo culture) => false;
         public abstract object ChangeType(object value, Type type, CultureInfo culture);
         public abstract void ReorderArgumentArray(ref object[] args, object state);
         public abstract MethodBase SelectMethod(BindingFlags bindingAttr, MethodBase[] match, Type[] types, ParameterModifier[] modifiers);

--- a/src/System.Private.CoreLib/src/System/Reflection/ExceptionHandlingClause.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/ExceptionHandlingClause.cs
@@ -2,19 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 namespace System.Reflection
 {
     public class ExceptionHandlingClause
     {
         protected ExceptionHandlingClause() { }
-        public virtual Type CatchType { get { throw new NotImplementedException(); } }
-        public virtual int FilterOffset { get { throw new NotImplementedException(); } }
-        public virtual ExceptionHandlingClauseOptions Flags { get { throw new NotImplementedException(); } }
-        public virtual int HandlerLength { get { throw new NotImplementedException(); } }
-        public virtual int HandlerOffset { get { throw new NotImplementedException(); } }
-        public virtual int TryLength { get { throw new NotImplementedException(); } }
-        public virtual int TryOffset { get { throw new NotImplementedException(); } }
 
-        public override string ToString() { throw new NotImplementedException(); }
+        // Desktop compat: These default implementations behave strangely because this class was originally
+        // creatable only from the native runtime, not through subclass inheritance.
+
+        public virtual Type CatchType => null;
+        public virtual int FilterOffset { get { throw new InvalidOperationException(); } }
+        public virtual ExceptionHandlingClauseOptions Flags => default(ExceptionHandlingClauseOptions);
+        public virtual int HandlerLength => 0;
+        public virtual int HandlerOffset => 0;
+        public virtual int TryLength => 0;
+        public virtual int TryOffset => 0;
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.CurrentUICulture,
+                "Flags={0}, TryOffset={1}, TryLength={2}, HandlerOffset={3}, HandlerLength={4}, CatchType={5}",
+                Flags, TryOffset, TryLength, HandlerOffset, HandlerLength, CatchType);
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/FieldInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/FieldInfo.cs
@@ -31,9 +31,9 @@ namespace System.Reflection
         public bool IsPrivate => (Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.Private;
         public bool IsPublic => (Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.Public;
 
-        public virtual bool IsSecurityCritical => false;
-        public virtual bool IsSecuritySafeCritical => false;
-        public virtual bool IsSecurityTransparent => true;
+        public virtual bool IsSecurityCritical { get { throw new NotImplementedException(); } }
+        public virtual bool IsSecuritySafeCritical { get { throw new NotImplementedException(); } }
+        public virtual bool IsSecurityTransparent { get { throw new NotImplementedException(); } }
 
         public abstract RuntimeFieldHandle FieldHandle { get; }
         public static FieldInfo GetFieldFromHandle(RuntimeFieldHandle handle) => ReflectionAugments.ReflectionCoreCallbacks.GetFieldFromHandle(handle);

--- a/src/System.Private.CoreLib/src/System/Reflection/Module.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Module.cs
@@ -122,9 +122,53 @@ namespace System.Reflection
 
         public override string ToString() => ScopeName;
 
-        public static readonly TypeFilter FilterTypeName = delegate (Type m, object filterCriteria) { throw new NotImplementedException(); };
-        public static readonly TypeFilter FilterTypeNameIgnoreCase = delegate(Type m, object filterCriteria) { throw new NotImplementedException(); };
+        public static readonly TypeFilter FilterTypeName = FilterTypeNameImpl;
+        public static readonly TypeFilter FilterTypeNameIgnoreCase = FilterTypeNameIgnoreCaseImpl;
 
         private const BindingFlags DefaultLookup = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+
+        // FilterTypeName 
+        // This method will filter the class based upon the name.  It supports
+        //    a trailing wild card.
+        private static bool FilterTypeNameImpl(Type cls, object filterCriteria)
+        {
+            // Check that the criteria object is a String object
+            if (filterCriteria == null || !(filterCriteria is string))
+                throw new InvalidFilterCriteriaException(SR.InvalidFilterCriteriaException_CritString);
+
+            string str = (string)filterCriteria;
+
+            // Check to see if this is a prefix or exact match requirement
+            if (str.Length > 0 && str[str.Length - 1] == '*')
+            {
+                str = str.Substring(0, str.Length - 1);
+                return cls.Name.StartsWith(str, StringComparison.Ordinal);
+            }
+
+            return cls.Name.Equals(str);
+        }
+
+        // FilterFieldNameIgnoreCase
+        // This method filter the Type based upon name, it ignores case.
+        private static bool FilterTypeNameIgnoreCaseImpl(Type cls, object filterCriteria)
+        {
+            // Check that the criteria object is a String object
+            if (filterCriteria == null || !(filterCriteria is string))
+                throw new InvalidFilterCriteriaException(SR.InvalidFilterCriteriaException_CritString);
+
+            string str = (string)filterCriteria;
+
+            // Check to see if this is a prefix or exact match requirement
+            if (str.Length > 0 && str[str.Length - 1] == '*')
+            {
+                str = str.Substring(0, str.Length - 1);
+                string name = cls.Name;
+                if (name.Length >= str.Length)
+                    return (string.Compare(name, 0, str, 0, str.Length, StringComparison.OrdinalIgnoreCase) == 0);
+                else
+                    return false;
+            }
+            return (string.Compare(str, cls.Name, StringComparison.OrdinalIgnoreCase) == 0);
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
@@ -50,7 +50,7 @@ namespace System.Reflection
         public virtual Type[] GetOptionalCustomModifiers() => Array.Empty<Type>();
         public virtual Type[] GetRequiredCustomModifiers() => Array.Empty<Type>();
 
-        public virtual int MetadataToken { get { throw new NotImplementedException(); } }
+        public virtual int MetadataToken => MetadataToken_ParamDef;
 
         public object GetRealObject(StreamingContext context) { throw new NotImplementedException(); }
 
@@ -62,5 +62,7 @@ namespace System.Reflection
         protected MemberInfo MemberImpl;
         protected string NameImpl;
         protected int PositionImpl;
+
+        private const int MetadataToken_ParamDef = 0x08000000;
     }
 }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CharSet.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CharSet.cs
@@ -17,9 +17,9 @@ namespace System.Runtime.InteropServices
     [System.Runtime.InteropServices.ComVisible(true)]
     public enum CharSet
     {
-        //        None = 1,        // User didn't specify how to marshal strings.
+        None = 1,        // User didn't specify how to marshal strings.
         Ansi = 2,        // Strings should be marshalled as ANSI 1 byte chars. 
         Unicode = 3,     // Strings should be marshalled as Unicode 2 byte chars.
-                         //        Auto = 4,        // Marshal Strings in the right way for the target system. 
+        Auto = 4,        // Marshal Strings in the right way for the target system. 
     }
 }

--- a/src/System.Private.CoreLib/src/System/Type.Helpers.cs
+++ b/src/System.Private.CoreLib/src/System/Type.Helpers.cs
@@ -363,6 +363,140 @@ namespace System
 
             return false;
         }
+
+        // FilterAttribute
+        //  This method will search for a member based upon the attribute passed in.
+        //  filterCriteria -- an Int32 representing the attribute
+        private static bool FilterAttributeImpl(MemberInfo m, object filterCriteria)
+        {
+            // Check that the criteria object is an Integer object
+            if (filterCriteria == null)
+                throw new InvalidFilterCriteriaException(SR.InvalidFilterCriteriaException_CritInt);
+
+            switch (m.MemberType)
+            {
+                case MemberTypes.Constructor:
+                case MemberTypes.Method:
+                    {
+
+                        MethodAttributes criteria = 0;
+                        try
+                        {
+                            int i = (int)filterCriteria;
+                            criteria = (MethodAttributes)i;
+                        }
+                        catch
+                        {
+                            throw new InvalidFilterCriteriaException(SR.InvalidFilterCriteriaException_CritInt);
+                        }
+
+
+                        MethodAttributes attr;
+                        if (m.MemberType == MemberTypes.Method)
+                            attr = ((MethodInfo)m).Attributes;
+                        else
+                            attr = ((ConstructorInfo)m).Attributes;
+
+                        if (((criteria & MethodAttributes.MemberAccessMask) != 0) && (attr & MethodAttributes.MemberAccessMask) != (criteria & MethodAttributes.MemberAccessMask))
+                            return false;
+                        if (((criteria & MethodAttributes.Static) != 0) && (attr & MethodAttributes.Static) == 0)
+                            return false;
+                        if (((criteria & MethodAttributes.Final) != 0) && (attr & MethodAttributes.Final) == 0)
+                            return false;
+                        if (((criteria & MethodAttributes.Virtual) != 0) && (attr & MethodAttributes.Virtual) == 0)
+                            return false;
+                        if (((criteria & MethodAttributes.Abstract) != 0) && (attr & MethodAttributes.Abstract) == 0)
+                            return false;
+                        if (((criteria & MethodAttributes.SpecialName) != 0) && (attr & MethodAttributes.SpecialName) == 0)
+                            return false;
+                        return true;
+                    }
+                case MemberTypes.Field:
+                    {
+                        FieldAttributes criteria = 0;
+                        try
+                        {
+                            int i = (int)filterCriteria;
+                            criteria = (FieldAttributes)i;
+                        }
+                        catch
+                        {
+                            throw new InvalidFilterCriteriaException(SR.InvalidFilterCriteriaException_CritInt);
+                        }
+
+                        FieldAttributes attr = ((FieldInfo)m).Attributes;
+                        if (((criteria & FieldAttributes.FieldAccessMask) != 0) && (attr & FieldAttributes.FieldAccessMask) != (criteria & FieldAttributes.FieldAccessMask))
+                            return false;
+                        if (((criteria & FieldAttributes.Static) != 0) && (attr & FieldAttributes.Static) == 0)
+                            return false;
+                        if (((criteria & FieldAttributes.InitOnly) != 0) && (attr & FieldAttributes.InitOnly) == 0)
+                            return false;
+                        if (((criteria & FieldAttributes.Literal) != 0) && (attr & FieldAttributes.Literal) == 0)
+                            return false;
+                        if (((criteria & FieldAttributes.NotSerialized) != 0) && (attr & FieldAttributes.NotSerialized) == 0)
+                            return false;
+                        if (((criteria & FieldAttributes.PinvokeImpl) != 0) && (attr & FieldAttributes.PinvokeImpl) == 0)
+                            return false;
+                        return true;
+                    }
+            }
+
+            return false;
+        }
+
+        // FilterName
+        // This method will filter based upon the name.  A partial wildcard
+        //  at the end of the string is supported.
+        //  filterCriteria -- This is the string name
+        private static bool FilterNameImpl(MemberInfo m, object filterCriteria)
+        {
+            // Check that the criteria object is a String object
+            if (filterCriteria == null || !(filterCriteria is String))
+                throw new InvalidFilterCriteriaException(SR.InvalidFilterCriteriaException_CritString);
+
+            // At the moment this fails if its done on a single line....
+            string str = ((string)filterCriteria);
+            str = str.Trim();
+
+            string name = m.Name;
+            // Get the nested class name only, as opposed to the mangled one
+            if (m.MemberType == MemberTypes.NestedType)
+                name = name.Substring(name.LastIndexOf('+') + 1);
+            // Check to see if this is a prefix or exact match requirement
+            if (str.Length > 0 && str[str.Length - 1] == '*')
+            {
+                str = str.Substring(0, str.Length - 1);
+                return (name.StartsWith(str, StringComparison.Ordinal));
+            }
+
+            return (name.Equals(str));
+        }
+
+        // FilterIgnoreCase
+        // This delegate will do a name search but does it with the
+        //  ignore case specified.
+        private static bool FilterNameIgnoreCaseImpl(MemberInfo m, object filterCriteria)
+        {
+            // Check that the criteria object is a String object
+            if (filterCriteria == null || !(filterCriteria is string))
+                throw new InvalidFilterCriteriaException(SR.InvalidFilterCriteriaException_CritString);
+
+            string str = (string)filterCriteria;
+            str = str.Trim();
+
+            string name = m.Name;
+            // Get the nested class name only, as opposed to the mangled one
+            if (m.MemberType == MemberTypes.NestedType)
+                name = name.Substring(name.LastIndexOf('+') + 1);
+            // Check to see if this is a prefix or exact match requirement
+            if (str.Length > 0 && str[str.Length - 1] == '*')
+            {
+                str = str.Substring(0, str.Length - 1);
+                return (string.Compare(name, 0, str, 0, str.Length, StringComparison.OrdinalIgnoreCase) == 0);
+            }
+
+            return (string.Compare(str, name, StringComparison.OrdinalIgnoreCase) == 0);
+        }
     }
 }
 

--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -352,9 +352,9 @@ namespace System
         public static readonly Type[] EmptyTypes = Array.Empty<Type>();
         public static readonly object Missing = System.Reflection.Missing.Value;
 
-        public static readonly MemberFilter FilterAttribute = delegate (MemberInfo m, object filterCriteria) { throw new NotImplementedException(); };
-        public static readonly MemberFilter FilterName = delegate (MemberInfo m, object filterCriteria) { throw new NotImplementedException(); };
-        public static readonly MemberFilter FilterNameIgnoreCase = delegate (MemberInfo m, object filterCriteria) { throw new NotImplementedException(); };
+        public static readonly MemberFilter FilterAttribute = FilterAttributeImpl;
+        public static readonly MemberFilter FilterName = FilterNameImpl;
+        public static readonly MemberFilter FilterNameIgnoreCase = FilterNameIgnoreCaseImpl;
 
         public static Binder DefaultBinder => _GetDefaultBinder();
         private static volatile Binder s_defaultBinder;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
@@ -207,6 +207,14 @@ namespace System.Reflection.Runtime.Assemblies
             return result;
         }
 
+        public sealed override bool ReflectionOnly
+        {
+            get
+            {
+                return false; // ReflectionOnly loading not supported.
+            }
+        }
+
         internal QScopeDefinition Scope { get; }
 
         internal IEnumerable<QScopeDefinition> OverflowScopes { get; }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -23,16 +23,13 @@ namespace System.Reflection.Runtime.Assemblies
         public sealed override string CodeBase { get { throw new NotImplementedException(); } }
         public sealed override object CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes) { throw new NotImplementedException(); }
         public sealed override MethodInfo EntryPoint { get { throw new NotImplementedException(); } }
-        public sealed override Stream GetManifestResourceStream(Type type, string name) { throw new NotImplementedException(); }
         public sealed override Module GetModule(string name) { throw new NotImplementedException(); }
-        public sealed override AssemblyName GetName(bool copiedName) { throw new NotImplementedException(); }
         public sealed override void GetObjectData(SerializationInfo info, StreamingContext context) { throw new NotImplementedException(); }
         public sealed override AssemblyName[] GetReferencedAssemblies() { throw new NotImplementedException(); }
         public sealed override Assembly GetSatelliteAssembly(CultureInfo culture) { throw new NotImplementedException(); }
         public sealed override Assembly GetSatelliteAssembly(CultureInfo culture, Version version) { throw new NotImplementedException(); }
         public sealed override string ImageRuntimeVersion { get { throw new NotImplementedException(); } }
         public sealed override string Location { get { throw new NotImplementedException(); } }
-        public sealed override bool ReflectionOnly { get { throw new NotImplementedException(); } }
     }
 }
 
@@ -58,7 +55,6 @@ namespace System.Reflection.Runtime.EventInfos
     internal sealed partial class RuntimeEventInfo
     {
         public sealed override MethodInfo[] GetOtherMethods(bool nonPublic) { throw new NotImplementedException(); }
-        public sealed override bool IsMulticast { get { throw new NotImplementedException(); } }
         public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
     }
 }
@@ -72,6 +68,9 @@ namespace System.Reflection.Runtime.FieldInfos
         public sealed override object GetRawConstantValue() { throw new NotImplementedException(); }
         public sealed override Type[] GetRequiredCustomModifiers() { throw new NotImplementedException(); }
         public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
+        public sealed override bool IsSecurityCritical { get { throw new NotImplementedException(); } }
+        public sealed override bool IsSecuritySafeCritical { get { throw new NotImplementedException(); } }
+        public sealed override bool IsSecurityTransparent { get { throw new NotImplementedException(); } }
     }
 }
 
@@ -82,7 +81,6 @@ namespace System.Reflection.Runtime.MethodInfos
         public sealed override MethodBody GetMethodBody() { throw new NotImplementedException(); }
         public sealed override RuntimeMethodHandle MethodHandle { get { throw new NotImplementedException(); } }
         public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
-        public sealed override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new NotImplementedException(); } }
     }
 }
 
@@ -90,14 +88,12 @@ namespace System.Reflection.Runtime.Modules
 {
     internal sealed partial class RuntimeModule
     {
-        public sealed override Type[] FindTypes(TypeFilter filter, object filterCriteria) { throw new NotImplementedException(); }
         public sealed override FieldInfo GetField(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
         public sealed override FieldInfo[] GetFields(BindingFlags bindingFlags) { throw new NotImplementedException(); }
         protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
         public sealed override MethodInfo[] GetMethods(BindingFlags bindingFlags) { throw new NotImplementedException(); }
         public sealed override void GetObjectData(SerializationInfo info, StreamingContext context) { throw new NotImplementedException(); }
         public sealed override void GetPEKind(out PortableExecutableKinds peKind, out ImageFileMachine machine) { throw new NotImplementedException(); }
-        public sealed override Type[] GetTypes() { throw new NotImplementedException(); }
         public sealed override bool IsResource() { throw new NotImplementedException(); }
         public sealed override int MDStreamVersion { get { throw new NotImplementedException(); } }
         public sealed override FieldInfo ResolveField(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new NotImplementedException(); }
@@ -135,8 +131,6 @@ namespace System.Reflection.Runtime.TypeInfos
 {
     internal abstract partial class RuntimeTypeInfo
     {
-        public sealed override Type[] FindInterfaces(TypeFilter filter, object filterCriteria) { throw new NotImplementedException(); }
-        public sealed override MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter filter, object filterCriteria) { throw new NotImplementedException(); }
         public sealed override string GetEnumName(object value) { throw new NotImplementedException(); }
         public sealed override string[] GetEnumNames() { throw new NotImplementedException(); }
         public sealed override Type GetEnumUnderlyingType() { throw new NotImplementedException(); }
@@ -148,6 +142,5 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override bool IsEnumDefined(object value) { throw new NotImplementedException(); }
         public sealed override bool IsEquivalentTo(Type other) { throw new NotImplementedException(); }
         public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
-        public sealed override StructLayoutAttribute StructLayoutAttribute { get { throw new NotImplementedException(); } }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -67,6 +67,7 @@ namespace System.Reflection.Runtime.EventInfos
     {
 #if DEBUG
         public sealed override MemberTypes MemberType => base.MemberType;
+        public sealed override bool IsMulticast => base.IsMulticast;
 #endif //DEBUG
     }
 }
@@ -77,10 +78,6 @@ namespace System.Reflection.Runtime.FieldInfos
     {
 #if DEBUG
         public sealed override MemberTypes MemberType => base.MemberType;
-
-        public sealed override bool IsSecurityCritical => base.IsSecurityCritical;
-        public sealed override bool IsSecuritySafeCritical => base.IsSecuritySafeCritical;
-        public sealed override bool IsSecurityTransparent => base.IsSecurityTransparent;
 #endif //DEBUG
     }
 }
@@ -100,6 +97,7 @@ namespace System.Reflection.Runtime.Modules
     internal sealed partial class RuntimeModule
     {
 #if DEBUG
+        public sealed override Type[] FindTypes(TypeFilter filter, object filterCriteria) => base.FindTypes(filter, filterCriteria);
         public sealed override Type GetType(string className) => base.GetType(className);
         public sealed override Type GetType(string className, bool ignoreCase) => base.GetType(className, ignoreCase);
 #endif //DEBUG
@@ -132,6 +130,8 @@ namespace System.Reflection.Runtime.TypeInfos
     internal abstract partial class RuntimeTypeInfo
     {
 #if DEBUG
+        public sealed override Type[] FindInterfaces(TypeFilter filter, object filterCriteria) => base.FindInterfaces(filter, filterCriteria);
+        public sealed override MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter filter, object filterCriteria) => base.FindMembers(memberType, bindingAttr, filter, filterCriteria);
         public sealed override EventInfo[] GetEvents() => base.GetEvents();
         public sealed override bool IsSubclassOf(Type c) => base.IsSubclassOf(c);
         protected sealed override bool IsMarshalByRefImpl() => base.IsMarshalByRefImpl();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -84,6 +84,12 @@ namespace System.Reflection.Runtime.Modules
             return _assembly.GetType(name, throwOnError, ignoreCase);
         }
 
+        public sealed override Type[] GetTypes()
+        {
+            Debug.Assert(this.Equals(_assembly.ManifestModule)); // We only support single-module assemblies so we have to be the manifest module.
+            return _assembly.GetTypes();
+        }
+
         public sealed override Guid ModuleVersionId
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -17,6 +17,10 @@ using Internal.Reflection.Core.Execution;
 
 using Internal.Metadata.NativeFormat;
 
+using CharSet = System.Runtime.InteropServices.CharSet;
+using LayoutKind = System.Runtime.InteropServices.LayoutKind;
+using StructLayoutAttribute = System.Runtime.InteropServices.StructLayoutAttribute;
+
 namespace System.Reflection.Runtime.TypeInfos
 {
     //
@@ -109,6 +113,19 @@ namespace System.Reflection.Runtime.TypeInfos
                     ReflectionTrace.TypeInfo_Namespace(this);
 #endif
                 return null;  // Reflection-blocked framework types report themselves as existing in the "root" namespace.
+            }
+        }
+
+        public sealed override StructLayoutAttribute StructLayoutAttribute
+        {
+            get
+            {
+                return new StructLayoutAttribute(LayoutKind.Auto)
+                {
+                    CharSet = CharSet.Ansi,
+                    Pack = 8,
+                    Size = 0,
+                };
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -15,6 +15,8 @@ using Internal.Reflection.Tracing;
 using Internal.Metadata.NativeFormat;
 using Internal.Reflection.Core.Execution;
 
+using StructLayoutAttribute = System.Runtime.InteropServices.StructLayoutAttribute;
+
 namespace System.Reflection.Runtime.TypeInfos
 {
     //
@@ -160,6 +162,14 @@ namespace System.Reflection.Runtime.TypeInfos
                     ReflectionTrace.TypeInfo_Namespace(this);
 #endif
                 return GenericTypeDefinitionTypeInfo.Namespace;
+            }
+        }
+
+        public sealed override StructLayoutAttribute StructLayoutAttribute
+        {
+            get
+            {
+                return GenericTypeDefinitionTypeInfo.StructLayoutAttribute;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -6,6 +6,7 @@ using System;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.MethodInfos;
 using System.Reflection.Runtime.CustomAttributes;
@@ -110,6 +111,14 @@ namespace System.Reflection.Runtime.TypeInfos
                     ReflectionTrace.TypeInfo_Namespace(this);
 #endif
                 return DeclaringType.Namespace;
+            }
+        }
+
+        public sealed override StructLayoutAttribute StructLayoutAttribute
+        {
+            get
+            {
+                return null;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
 
@@ -93,6 +94,14 @@ namespace System.Reflection.Runtime.TypeInfos
                     ReflectionTrace.TypeInfo_Namespace(this);
 #endif
                 return _key.ElementType.Namespace;
+            }
+        }
+
+        public sealed override StructLayoutAttribute StructLayoutAttribute
+        {
+            get
+            {
+                return null;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
@@ -17,6 +17,8 @@ using Internal.Reflection.Core.Execution;
 
 using Internal.Metadata.NativeFormat;
 
+using StructLayoutAttribute = System.Runtime.InteropServices.StructLayoutAttribute;
+
 namespace System.Reflection.Runtime.TypeInfos
 {
     //
@@ -99,6 +101,14 @@ namespace System.Reflection.Runtime.TypeInfos
                 if (ReflectionTrace.Enabled)
                     ReflectionTrace.TypeInfo_Namespace(this);
 #endif
+                throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(this);
+            }
+        }
+
+        public sealed override StructLayoutAttribute StructLayoutAttribute
+        {
+            get
+            {
                 throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(this);
             }
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
@@ -20,6 +20,9 @@ namespace System.Reflection.Runtime.TypeInfos
             if (callConvention != CallingConventions.Any)
                 throw new NotImplementedException();
 
+            if (!OnlySearchRelatedBitsSet(bindingAttr))  // We don't yet have proper handling for BindingFlags not related to search so throw rather return a wrong result.
+                throw new NotImplementedException();
+
             if (binder == null)
                 binder = Type._GetDefaultBinder();
             ConstructorInfo[] candidates = GetConstructors(bindingAttr);
@@ -52,6 +55,9 @@ namespace System.Reflection.Runtime.TypeInfos
             }
             else
             {
+                if (!OnlySearchRelatedBitsSet(bindingAttr))  // We don't yet have proper handling for BindingFlags not related to search so throw rather return a wrong result.
+                    throw new NotImplementedException();
+
                 // Group #2: This group of api takes a set of parameter types and an optional binder. 
                 if (callConvention != CallingConventions.Any)
                     throw new NotImplementedException();
@@ -71,6 +77,9 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             Debug.Assert(name != null);
 
+            if (!OnlySearchRelatedBitsSet(bindingAttr))  // We don't yet have proper handling for BindingFlags not related to search so throw rather return a wrong result.
+                throw new NotImplementedException();
+
             // GetPropertyImpl() is a funnel for two groups of api. We can distinguish by comparing "types" to null.
             if (types == null && returnType == null)
             {
@@ -81,12 +90,21 @@ namespace System.Reflection.Runtime.TypeInfos
             }
             else
             {
+                if (!OnlySearchRelatedBitsSet(bindingAttr))  // We don't yet have proper handling for BindingFlags not related to search so throw rather return a wrong result.
+                    throw new NotImplementedException();
+
                 // Group #2: This group of api takes a set of parameter types, a return type (both cannot be null) and an optional binder. 
                 if (binder == null)
                     binder = Type._GetDefaultBinder();
                 PropertyInfo[] candidates = LowLevelTypeExtensions.GetProperties(this, name, bindingAttr);
                 return binder.SelectProperty(bindingAttr, candidates, returnType, types, modifiers);
             }
+        }
+
+        private static bool OnlySearchRelatedBitsSet(BindingFlags bindingFlags)
+        {
+            const BindingFlags SearchRelatedBits = BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
+            return (bindingFlags & ~SearchRelatedBits) == 0;
         }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -22,6 +22,8 @@ using Internal.Metadata.NativeFormat;
 
 using IRuntimeImplementedType = Internal.Reflection.Core.NonPortable.IRuntimeImplementedType;
 
+using StructLayoutAttribute = System.Runtime.InteropServices.StructLayoutAttribute;
+
 namespace System.Reflection.Runtime.TypeInfos
 {
     //
@@ -689,6 +691,8 @@ namespace System.Reflection.Runtime.TypeInfos
                 return name;
             }
         }
+
+        public abstract override StructLayoutAttribute StructLayoutAttribute { get; }
 
         public abstract override string ToString();
 


### PR DESCRIPTION
This commit finishes off an assorted set of Reflection api.
They were chosen by going down the list of "NotImplemented"
throws and asking:

-  Is this a brain-dead one-liner? (or close to it?)

or

-  Is this something we can copy-paste directly from
   CoreClr with no other work?

If so, it went on this list. Main purpose is to winnow
down the list of todo items so we can focus more clearly
on the harder stuff.

Also, along the way, I put back a couple of things
back on the NYI list until we can fully implement or
decide what their behavior should be on N.

Also, removed the CanChangeType public member from Binder -
this is not part of the surface area and has already been
removed from CoreClr.