### PR TITLE
Move CompareTo ahead of CompareOrdinal

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -586,36 +586,6 @@ namespace System
             }
         }
 
-        // Compares this String to another String (cast as object), returning an integer that
-        // indicates the relationship. This method returns a value less than 0 if this is less than value, 0
-        // if this is equal to value, or a value greater than 0 if this is greater than value.
-        //
-
-        int IComparable.CompareTo(Object value)
-        {
-            if (value == null)
-            {
-                return 1;
-            }
-
-            string other = value as string;
-
-            if (other == null)
-            {
-                throw new ArgumentException(SR.Arg_MustBeString);
-            }
-
-            return CompareTo(other); // will call the string-based overload
-        }
-
-        // Determines the sorting relation of StrB to the current instance.
-        //
-
-        public int CompareTo(String strB)
-        {
-            return string.Compare(this, strB, StringComparison.CurrentCulture);
-        }
-
         // Compares strA and strB using an ordinal (code-point) comparison.
         //
 
@@ -688,6 +658,36 @@ namespace System
             }
 
             return CompareOrdinalHelper(strA, indexA, lengthA, strB, indexB, lengthB);
+        }
+
+        // Compares this String to another String (cast as object), returning an integer that
+        // indicates the relationship. This method returns a value less than 0 if this is less than value, 0
+        // if this is equal to value, or a value greater than 0 if this is greater than value.
+        //
+
+        int IComparable.CompareTo(Object value)
+        {
+            if (value == null)
+            {
+                return 1;
+            }
+
+            string other = value as string;
+
+            if (other == null)
+            {
+                throw new ArgumentException(SR.Arg_MustBeString);
+            }
+
+            return CompareTo(other); // will call the string-based overload
+        }
+
+        // Determines the sorting relation of StrB to the current instance.
+        //
+
+        public int CompareTo(String strB)
+        {
+            return string.Compare(this, strB, StringComparison.CurrentCulture);
         }
 
         // Determines whether a specified string is a suffix of the the current instance.


### PR DESCRIPTION
I realized while working on the CoreCLR PR for #1747 that `CompareTo` is actually supposed to come after `CompareOrdinal`. Since it's best to avoid code divergence, this is a pull request that fixes up my mistake.

cc @jktoas