### PR TITLE
EncodingTable: Remove unnecessary use of unsafe

### DIFF
--- a/src/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -28,7 +28,7 @@ namespace System.Text
             }
         }
 
-        unsafe private static int InternalGetCodePageFromName(string name)
+        private static int InternalGetCodePageFromName(string name)
         {
             int left = 0;
             int right = s_encodingNameIndices.Length - 2;
@@ -97,7 +97,7 @@ namespace System.Text
             return s1.Length - length;
         }
 
-        unsafe internal static string GetWebNameFromCodePage(int codePage)
+        internal static string GetWebNameFromCodePage(int codePage)
         {
             return CodePageToWebNameCache.Instance.GetOrAdd(codePage);
         }
@@ -112,7 +112,7 @@ namespace System.Text
             }
         }
 
-        unsafe internal static string GetEnglishNameFromCodePage(int codePage)
+        internal static string GetEnglishNameFromCodePage(int codePage)
         {
             return CodePageToEnglishNameCache.Instance.GetOrAdd(codePage);
         }
@@ -127,7 +127,7 @@ namespace System.Text
             }
         }
 
-        unsafe private static string GetNameFromCodePage(int codePage, string names, int[] indices)
+        private static string GetNameFromCodePage(int codePage, string names, int[] indices)
         {
             string name;
 
@@ -141,10 +141,7 @@ namespace System.Text
                 {
                     Contract.Assert(i < indices.Length - 1);
 
-                    fixed (char* pChar = names)
-                    {
-                        name = new String(pChar, indices[i], indices[i + 1] - indices[i]);
-                    }
+                    name = names.Substring(indices[i], indices[i + 1] - indices[i]);
 
                     return name;
                 }


### PR DESCRIPTION
`string.Substring` can be used to get the substring, instead of string's unsafe constructor. Also removed the unsafe modifiers that weren't needed.

Related: https://github.com/dotnet/corefx/pull/11304

cc: @stephentoub @tarekgh @jkotas 