### PR TITLE
Porting various Reflection api

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -357,6 +357,11 @@ namespace Internal.Runtime.Augments
         }
 #endif
 
+        public static object GetEnumValue(Enum e)
+        {
+            return e.GetValue();
+        }
+
         public static RuntimeTypeHandle GetRelatedParameterTypeHandle(RuntimeTypeHandle parameterTypeHandle)
         {
             EETypePtr elementType = parameterTypeHandle.ToEETypePtr().ArrayElementType;

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -175,6 +175,7 @@
     <Compile Include="System\Reflection\TypeFilter.cs" />
     <Compile Include="System\Reflection\TypeInfo.cs" />
     <Compile Include="System\Reflection\TypeInfo.Workaround.cs" />
+    <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimeImplementedCustomAttributeData.cs" />
     <Compile Include="System\__Canon.cs" />
     <Compile Include="System\Action.cs" />
     <Compile Include="System\Activator.cs" />

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
@@ -4,6 +4,7 @@
 
 using System.Globalization;
 using System.Collections.Generic;
+using RuntimeImplementedCustomAttributeData = System.Reflection.Runtime.CustomAttributes.RuntimeImplementedCustomAttributeData;
 
 namespace System.Reflection
 {
@@ -11,7 +12,17 @@ namespace System.Reflection
     {
         protected CustomAttributeData() { }
 
-        public Type AttributeType => Constructor.DeclaringType;
+        public Type AttributeType
+        {
+            get
+            {
+                RuntimeImplementedCustomAttributeData runtimeImplementedCustomAttributeData = this as RuntimeImplementedCustomAttributeData;
+                if (runtimeImplementedCustomAttributeData != null)
+                    return runtimeImplementedCustomAttributeData.AttributeType;
+
+                return Constructor.DeclaringType;
+            }
+        }
 
         public virtual ConstructorInfo Constructor => null;
         public virtual IList<CustomAttributeTypedArgument> ConstructorArguments { get { throw new NullReferenceException(); } }

--- a/src/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeImplementedCustomAttributeData.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeImplementedCustomAttributeData.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Diagnostics;
+
+namespace System.Reflection.Runtime.CustomAttributes
+{
+    //
+    // If a CustomAttributeData implementation derives from this, it is a hint that it has a AttributeType implementation
+    // that's more efficient than building a ConstructorInfo and gettings its DeclaredType.
+    //
+    public abstract class RuntimeImplementedCustomAttributeData : CustomAttributeData
+    {
+        public new abstract Type AttributeType { get; }
+    }
+}
+

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
@@ -41,6 +41,23 @@ namespace System.Reflection.Runtime.CustomAttributes
             }
         }
 
+        public sealed override ConstructorInfo Constructor
+        {
+            get
+            {
+                int numArguments = _constructorArguments.Count;
+                if (numArguments == 0)
+                    return ResolveAttributeConstructor(_attributeType, Array.Empty<Type>());
+
+                Type[] expectedParameterTypes = new Type[numArguments];
+                for (int i = 0; i < numArguments; i++)
+                {
+                    expectedParameterTypes[i] = _constructorArguments[i].ArgumentType;
+                }
+                return ResolveAttributeConstructor(_attributeType, expectedParameterTypes);
+            }
+        }
+
         internal sealed override String AttributeTypeString
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -65,7 +65,6 @@ namespace System.Reflection.Runtime.FieldInfos
     {
         public sealed override RuntimeFieldHandle FieldHandle { get { throw new NotImplementedException(); } }
         public sealed override Type[] GetOptionalCustomModifiers() { throw new NotImplementedException(); }
-        public sealed override object GetRawConstantValue() { throw new NotImplementedException(); }
         public sealed override Type[] GetRequiredCustomModifiers() { throw new NotImplementedException(); }
         public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
         public sealed override bool IsSecurityCritical { get { throw new NotImplementedException(); } }
@@ -112,7 +111,6 @@ namespace System.Reflection.Runtime.ParameterInfos
     {
         public sealed override Type[] GetOptionalCustomModifiers() { throw new NotImplementedException(); }
         public sealed override Type[] GetRequiredCustomModifiers() { throw new NotImplementedException(); }
-        public sealed override object RawDefaultValue { get { throw new NotImplementedException(); } }
     }
 }
 
@@ -122,7 +120,6 @@ namespace System.Reflection.Runtime.PropertyInfos
     {
         public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
         public sealed override Type[] GetOptionalCustomModifiers() { throw new NotImplementedException(); }
-        public sealed override object GetRawConstantValue() { throw new NotImplementedException(); }
         public sealed override Type[] GetRequiredCustomModifiers() { throw new NotImplementedException(); }
     }
 }
@@ -131,14 +128,8 @@ namespace System.Reflection.Runtime.TypeInfos
 {
     internal abstract partial class RuntimeTypeInfo
     {
-        public sealed override string GetEnumName(object value) { throw new NotImplementedException(); }
-        public sealed override string[] GetEnumNames() { throw new NotImplementedException(); }
-        public sealed override Type GetEnumUnderlyingType() { throw new NotImplementedException(); }
-        public sealed override Array GetEnumValues() { throw new NotImplementedException(); }
         public sealed override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) { throw new NotImplementedException(); }
         public sealed override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) { throw new NotImplementedException(); }
-        public sealed override bool IsEnumDefined(object value) { throw new NotImplementedException(); }
-        public sealed override bool IsEquivalentTo(Type other) { throw new NotImplementedException(); }
         public sealed override Type ReflectedType { get { throw new NotImplementedException(); } }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -12,6 +12,7 @@ using System.Reflection.Runtime.TypeInfos;
 
 using IRuntimeImplementedType = Internal.Reflection.Core.NonPortable.IRuntimeImplementedType;
 using Internal.LowLevelLinq;
+using Internal.Runtime.Augments;
 using Internal.Reflection.Core.Execution;
 
 namespace System.Reflection.Runtime.General
@@ -86,6 +87,14 @@ namespace System.Reflection.Runtime.General
             if (accessor.IsPublic)
                 return accessor;
             return null;
+        }
+
+        public static object ToRawValue(this object defaultValueOrLiteral)
+        {
+            Enum e = defaultValueOrLiteral as Enum;
+            if (e != null)
+                return RuntimeAugments.GetEnumValue(e);
+            return defaultValueOrLiteral;
         }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
@@ -156,6 +156,18 @@ namespace System.Reflection.Runtime.General
             }
         }
 
+        // If a typedef/ref/spec handle has one or more custom modifiers wrapped around it, unwrap it. All we care about is the actual type.
+        public static Handle WithoutCustomModifiers(this Handle h, MetadataReader reader)
+        {
+            HandleType handleType;
+            while ((handleType = h.HandleType) == HandleType.ModifiedType)
+            {
+                h = h.ToModifiedTypeHandle(reader).GetModifiedType(reader).Type;
+            }
+            Debug.Assert(handleType == HandleType.TypeDefinition || handleType == HandleType.TypeReference || handleType == HandleType.TypeSpecification);
+            return h;
+        }
+
         public static MethodSignature ParseMethodSignature(this Handle handle, MetadataReader reader)
         {
             return handle.ToMethodSignatureHandle(reader).GetMethodSignature(reader);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -138,6 +138,7 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override MemberTypes MemberType => base.MemberType;
         public sealed override bool IsInstanceOfType(object o) => base.IsInstanceOfType(o);
         public sealed override bool IsSerializable => base.IsSerializable;
+        public sealed override bool IsEquivalentTo(Type other) => base.IsEquivalentTo(other); // Note: If we enable COM type equivalence, this is no longer the correct implementation.
 #endif //DEBUG
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
@@ -83,12 +83,35 @@ namespace System.Reflection.Runtime.EventInfos
     }
 }
 
+namespace System.Reflection.Runtime.FieldInfos
+{
+    internal sealed partial class RuntimeFieldInfo
+    {
+        public sealed override object GetRawConstantValue()
+        {
+            if (!IsLiteral)
+                throw new InvalidOperationException();
+
+            object value = GetValue(null);
+            return value.ToRawValue();
+        }
+    }
+}
+
 namespace System.Reflection.Runtime.MethodInfos
 {
     internal abstract partial class RuntimeMethodInfo
     {
         public sealed override MethodImplAttributes GetMethodImplementationFlags() => MethodImplementationFlags;
         public sealed override ICustomAttributeProvider ReturnTypeCustomAttributes => ReturnParameter;
+    }
+}
+
+namespace System.Reflection.Runtime.ParameterInfos
+{
+    internal abstract partial class RuntimeParameterInfo
+    {
+        public sealed override object RawDefaultValue => DefaultValue.ToRawValue();
     }
 }
 
@@ -115,6 +138,8 @@ namespace System.Reflection.Runtime.PropertyInfos
                 accessors[index++] = setter;
             return accessors;
         }
+
+        public sealed override object GetRawConstantValue() => GetConstantValue().ToRawValue();
     }
 }
 
@@ -133,6 +158,12 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override bool IsGenericType => IsConstructedGenericType || IsGenericTypeDefinition;
         public sealed override Type[] GetInterfaces() => ImplementedInterfaces.ToArray();
+
+        public sealed override string GetEnumName(object value) => Enum.GetName(this, value);
+        public sealed override string[] GetEnumNames() => Enum.GetNames(this);
+        public sealed override Type GetEnumUnderlyingType() => Enum.GetUnderlyingType(this);
+        public sealed override Array GetEnumValues() => Enum.GetValues(this);
+        public sealed override bool IsEnumDefined(object value) => Enum.IsDefined(this, value);
 
         public sealed override Type GetInterface(string name, bool ignoreCase)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -125,7 +125,7 @@ namespace System.Reflection.Runtime.TypeInfos
     //-----------------------------------------------------------------------------------------------------------
     internal sealed partial class RuntimeNamedTypeInfo : RuntimeTypeInfo
     {
-        internal static RuntimeTypeInfo GetRuntimeNamedTypeInfo(MetadataReader metadataReader, TypeDefinitionHandle typeDefHandle, RuntimeTypeHandle precomputedTypeHandle)
+        internal static RuntimeNamedTypeInfo GetRuntimeNamedTypeInfo(MetadataReader metadataReader, TypeDefinitionHandle typeDefHandle, RuntimeTypeHandle precomputedTypeHandle)
         {
             RuntimeTypeHandle typeHandle = precomputedTypeHandle;
             if (typeHandle.IsNull())


### PR DESCRIPTION
Fix https://github.com/dotnet/corert/issues/1759  (CustomAttributeData.Constructor)

  This property now works. Also added a bypass so we don't have to
  execute it just to get the AttributeType.

Fix https://github.com/dotnet/corert/issues/1763  (IsEquivalentTo(Type))

  (Since we don't have type equivalence yet, match the CoreClr behavior of
  comparing the types using operator==)

Fix https://github.com/dotnet/corert/issues/1754  (Enum apis on RuntimeTypeInfo)

  At some point, we may want to have Enum thunk to Type rather than vice-versa
  so that those apis work for user-extended types and we can more easily cache
  results if desired. That's not happening anytime soon, though, and there's
  no point in having the apis non-functional in the meantime.

Fix https://github.com/dotnet/corert/issues/1753  (RawDefaultValue)

  While instantiating an enum just to unwrap it is not exactly in the
  spirit of the api, it should suffice unless someday we add ReflectionOnly
  loading or Emit. In that case, we'll have to tear up a some foundations
  to get it right in those scenarios. But we don't need to undertake
  that dev cost now.