### PR TITLE
0 Byte Emission Fix

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -865,8 +865,8 @@ namespace ILCompiler.CppCodeGen
                 {
                     GetFormattedByteArray(byteData, divisionStartIndex, divisionStartIndex + nodeDataSections[i].SectionSize, nodeDataDecl);
                     nodeDataDecl.Append(",");
-                    divisionStartIndex += nodeDataSections[i].SectionSize;
                 }
+                divisionStartIndex += nodeDataSections[i].SectionSize;
                 nodeDataDecl.AppendLine();
                 nodeDataDecl.Exdent();
             }


### PR DESCRIPTION
Incorrect incrementing of section size was causing incorrect bytes to be
emitted.
Fix for #1793 