### PR TITLE
Update how-to-build-and-run-ilcompiler-in-visual-studio-2015.md

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
@@ -18,6 +18,8 @@ If you changed `c:\corert\src\ILCompiler\repro\project.json`
 build.cmd clean
 ```
 
+_Note: The size of NuGet packages is approximately 2.75 GB, so download might take a few moments based on the speed of your internet connection. The build artifacts require additional ~1 GB, thus make sure you have at least 4 GB of free space._
+
 ## Using RyuJIT ##
 
 1. Open c:\corert\src\ILCompiler\ILCompiler.sln in VS


### PR DESCRIPTION
Added note about NuGet package download size and required space.