### PR TITLE
Fix Type.GetType() not applying default assemblies to type arguments

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
@@ -33,7 +33,7 @@ namespace Internal.Runtime.Augments
 
         // Api's that are exposed in System.Runtime but are really reflection apis.
         public abstract Object ActivatorCreateInstance(Type type, Object[] args);
-        public abstract Type GetType(String typeName, bool throwOnError, bool ignoreCase);
+        public abstract Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase);
 
         public abstract IntPtr TryGetDefaultConstructorForType(RuntimeTypeHandle runtimeTypeHandle);
         public abstract IntPtr TryGetDefaultConstructorForTypeUsingLocator(object canonEquivalentEntryLocator);

--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -228,11 +228,11 @@ namespace System
 
         public static Type GetType(string typeName) => GetType(typeName, throwOnError: false, ignoreCase: false);
         public static Type GetType(string typeName, bool throwOnError) => GetType(typeName, throwOnError: throwOnError, ignoreCase: false);
-        public static Type GetType(string typeName, bool throwOnError, bool ignoreCase) => RuntimeAugments.Callbacks.GetType(typeName, throwOnError, ignoreCase);
+        public static Type GetType(string typeName, bool throwOnError, bool ignoreCase) => GetType(typeName, null, null, throwOnError: throwOnError, ignoreCase: ignoreCase);
 
         public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver) => GetType(typeName, assemblyResolver, typeResolver, throwOnError: false, ignoreCase: false);
         public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError) => GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: false);
-        public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase) { throw new NotImplementedException(); }
+        public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase) => RuntimeAugments.Callbacks.GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: ignoreCase);
 
         public virtual RuntimeTypeHandle TypeHandle { get { throw new NotSupportedException(); } }
         [Intrinsic]

--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -144,11 +144,11 @@
   <data name="Reflection_CustomReflectionObjectsNotSupported" xml:space="preserve">
     <value>The object '{0}' was created by a custom ReflectionContext and cannot be used here.</value>
   </data>
-  <data name="TypeLoad_TypeNotFoundByGetType" xml:space="preserve">
+  <data name="TypeLoad_TypeNotFound" xml:space="preserve">
     <value>The type '{0}' cannot be found.</value>
   </data>
-  <data name="TypeLoad_TypeNotFound" xml:space="preserve">
-    <value>The type '{0}' cannot be found in the metadata for '{1}'.</value>
+  <data name="TypeLoad_TypeNotFoundInAssembly" xml:space="preserve">
+    <value>The type '{0}' cannot be found in assembly '{1}'.</value>
   </data>
   <data name="TypeLoad_BadEscape" xml:space="preserve">
     <value>An invalid escape sequence was found inside a type name.</value>
@@ -257,5 +257,8 @@
   </data>
   <data name="ModuleVersionIdNotSupported" xml:space="preserve">
     <value>Module version IDs (MVIDs) cannot be retrieved on this platform.</value>
+  </data>
+  <data name="FileNotFound_ResolveAssembly" xml:space="preserve">
+    <value>Could not resolve assembly '{0}'.</value>
   </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -41,6 +41,8 @@
     <Compile Include="System\Reflection\Runtime\Assemblies\AssemblyNameLexer.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\AssemblyNameParser.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\RuntimeAssembly.cs" />
+    <Compile Include="System\Reflection\Runtime\Assemblies\RuntimeAssembly.GetTypeCore.CaseInsensitive.cs" />
+    <Compile Include="System\Reflection\Runtime\Assemblies\RuntimeAssembly.GetTypeCore.CaseSensitive.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\RuntimeAssemblyName.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\DefaultBinder.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\DefaultBinder.LimitedBinder.cs" />
@@ -120,6 +122,7 @@
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.BindingFlags.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\TypeInfoCachedData.cs" />
+    <Compile Include="System\Reflection\Runtime\TypeParsing\GetTypeOptions.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\TypeName.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\TypeLexer.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\TypeParser.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.GetTypeCore.CaseInsensitive.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.GetTypeCore.CaseInsensitive.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+
+using Internal.Reflection.Core;
+using Internal.Metadata.NativeFormat;
+
+namespace System.Reflection.Runtime.Assemblies
+{
+    //
+    // The runtime's implementation of an Assembly. 
+    //
+    internal partial class RuntimeAssembly
+    {
+        private RuntimeTypeInfo GetTypeCoreCaseInsensitive(string fullName)
+        {
+            LowLevelDictionary<string, QHandle> dict = CaseInsensitiveTypeDictionary;
+            QHandle qualifiedHandle;
+            if (!dict.TryGetValue(fullName.ToLower(), out qualifiedHandle))
+            {
+                return null;
+            }
+
+            MetadataReader reader = qualifiedHandle.Reader;
+            Handle typeDefOrForwarderHandle = qualifiedHandle.Handle;
+
+            HandleType handleType = typeDefOrForwarderHandle.HandleType;
+            switch (handleType)
+            {
+                case HandleType.TypeDefinition:
+                    {
+                        TypeDefinitionHandle typeDefinitionHandle = typeDefOrForwarderHandle.ToTypeDefinitionHandle(reader);
+                        return typeDefinitionHandle.ResolveTypeDefinition(reader);
+                    }
+                case HandleType.TypeForwarder:
+                    {
+                        TypeForwarder typeForwarder = typeDefOrForwarderHandle.ToTypeForwarderHandle(reader).GetTypeForwarder(reader);
+                        ScopeReferenceHandle destinationScope = typeForwarder.Scope;
+                        RuntimeAssemblyName destinationAssemblyName = destinationScope.ToRuntimeAssemblyName(reader);
+                        RuntimeAssembly destinationAssembly = RuntimeAssembly.GetRuntimeAssemblyIfExists(destinationAssemblyName);
+                        if (destinationAssembly == null)
+                            return null;
+                        return destinationAssembly.GetTypeCoreCaseInsensitive(fullName);
+                    }
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        private LowLevelDictionary<string, QHandle> CaseInsensitiveTypeDictionary
+        {
+            get
+            {
+                return _lazyCaseInsensitiveTypeDictionary ?? (_lazyCaseInsensitiveTypeDictionary = CreateCaseInsensitiveTypeDictionary());
+            }
+        }
+
+        private LowLevelDictionary<string, QHandle> CreateCaseInsensitiveTypeDictionary()
+        {
+            //
+            // Collect all of the *non-nested* types and type-forwards. 
+            //
+            //   The keys are full typenames in lower-cased form.
+            //   The value is a tuple containing either a TypeDefinitionHandle or TypeForwarderHandle and the associated Reader
+            //      for that handle.
+            //
+            // We do not store nested types here. The container type is resolved and chosen first, then the nested type chosen from 
+            // that. If we chose the wrong container type and fail the match as a result, that's too bad. (The desktop CLR has the
+            // same issue.)
+            //
+
+            LowLevelDictionary<string, QHandle> dict = new LowLevelDictionary<string, QHandle>();
+
+            foreach (QScopeDefinition scope in AllScopes)
+            {
+                MetadataReader reader = scope.Reader;
+                ScopeDefinition scopeDefinition = scope.ScopeDefinition;
+                IEnumerable<NamespaceDefinitionHandle> topLevelNamespaceHandles = new NamespaceDefinitionHandle[] { scopeDefinition.RootNamespaceDefinition };
+                IEnumerable<NamespaceDefinitionHandle> allNamespaceHandles = reader.GetTransitiveNamespaces(topLevelNamespaceHandles);
+                foreach (NamespaceDefinitionHandle namespaceHandle in allNamespaceHandles)
+                {
+                    string ns = namespaceHandle.ToNamespaceName(reader);
+                    if (ns.Length != 0)
+                        ns = ns + ".";
+                    ns = ns.ToLower();
+
+                    NamespaceDefinition namespaceDefinition = namespaceHandle.GetNamespaceDefinition(reader);
+                    foreach (TypeDefinitionHandle typeDefinitionHandle in namespaceDefinition.TypeDefinitions)
+                    {
+                        string fullName = ns + typeDefinitionHandle.GetTypeDefinition(reader).Name.GetString(reader).ToLower();
+                        QHandle existingValue;
+                        if (!dict.TryGetValue(fullName, out existingValue))
+                        {
+                            dict.Add(fullName, new QHandle(reader, typeDefinitionHandle));
+                        }
+                    }
+
+                    foreach (TypeForwarderHandle typeForwarderHandle in namespaceDefinition.TypeForwarders)
+                    {
+                        string fullName = ns + typeForwarderHandle.GetTypeForwarder(reader).Name.GetString(reader).ToLower();
+                        QHandle existingValue;
+                        if (!dict.TryGetValue(fullName, out existingValue))
+                        {
+                            dict.Add(fullName, new QHandle(reader, typeForwarderHandle));
+                        }
+                    }
+                }
+            }
+
+            return dict;
+        }
+
+        private volatile LowLevelDictionary<string, QHandle> _lazyCaseInsensitiveTypeDictionary;
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.GetTypeCore.CaseSensitive.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.GetTypeCore.CaseSensitive.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.TypeInfos;
+
+using Internal.Reflection.Core;
+using Internal.Metadata.NativeFormat;
+
+namespace System.Reflection.Runtime.Assemblies
+{
+    //
+    // The runtime's implementation of an Assembly. 
+    //
+    internal partial class RuntimeAssembly
+    {
+        private RuntimeTypeInfo GetTypeCoreCaseSensitive(string fullName)
+        {
+            return this.CaseSensitiveTypeTable.GetOrAdd(fullName);
+        }
+
+        private RuntimeTypeInfo UncachedGetTypeCoreCaseSensitive(string fullName)
+        {
+            string[] parts = fullName.Split('.');
+            int numNamespaceParts = parts.Length - 1;
+            string[] namespaceParts = new string[numNamespaceParts];
+            for (int i = 0; i < numNamespaceParts; i++)
+                namespaceParts[numNamespaceParts - i - 1] = parts[i];
+            string name = parts[numNamespaceParts];
+
+            foreach (QScopeDefinition scopeDefinition in AllScopes)
+            {
+                MetadataReader reader = scopeDefinition.Reader;
+                ScopeDefinitionHandle scopeDefinitionHandle = scopeDefinition.Handle;
+
+                NamespaceDefinition namespaceDefinition;
+                if (!TryResolveNamespaceDefinitionCaseSensitive(reader, namespaceParts, scopeDefinitionHandle, out namespaceDefinition))
+                    continue;
+
+                // We've successfully drilled down the namespace chain. Now look for a top-level type matching the type name.
+                IEnumerable<TypeDefinitionHandle> candidateTypes = namespaceDefinition.TypeDefinitions;
+                foreach (TypeDefinitionHandle candidateType in candidateTypes)
+                {
+                    TypeDefinition typeDefinition = candidateType.GetTypeDefinition(reader);
+                    if (typeDefinition.Name.StringEquals(name, reader))
+                        return candidateType.ResolveTypeDefinition(reader);
+                }
+
+                // No match found in this assembly - see if there's a matching type forwarder.
+                IEnumerable<TypeForwarderHandle> candidateTypeForwarders = namespaceDefinition.TypeForwarders;
+                foreach (TypeForwarderHandle typeForwarderHandle in candidateTypeForwarders)
+                {
+                    TypeForwarder typeForwarder = typeForwarderHandle.GetTypeForwarder(reader);
+                    if (typeForwarder.Name.StringEquals(name, reader))
+                    {
+                        RuntimeAssemblyName redirectedAssemblyName = typeForwarder.Scope.ToRuntimeAssemblyName(reader);
+                        RuntimeAssembly redirectedAssembly = RuntimeAssembly.GetRuntimeAssemblyIfExists(redirectedAssemblyName);
+                        if (redirectedAssemblyName == null)
+                            return null;
+                        return redirectedAssembly.GetTypeCoreCaseSensitive(fullName);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private bool TryResolveNamespaceDefinitionCaseSensitive(MetadataReader reader, string[] namespaceParts, ScopeDefinitionHandle scopeDefinitionHandle, out NamespaceDefinition namespaceDefinition)
+        {
+            namespaceDefinition = scopeDefinitionHandle.GetScopeDefinition(reader).RootNamespaceDefinition.GetNamespaceDefinition(reader);
+            IEnumerable<NamespaceDefinitionHandle> candidates = namespaceDefinition.NamespaceDefinitions;
+            int idx = namespaceParts.Length;
+            while (idx-- != 0)
+            {
+                // Each iteration finds a match for one segment of the namespace chain.
+                String expected = namespaceParts[idx];
+                bool foundMatch = false;
+                foreach (NamespaceDefinitionHandle candidate in candidates)
+                {
+                    namespaceDefinition = candidate.GetNamespaceDefinition(reader);
+                    if (namespaceDefinition.Name.StringOrNullEquals(expected, reader))
+                    {
+                        // Found a match for this segment of the namespace chain. Move on to the next level.
+                        foundMatch = true;
+                        candidates = namespaceDefinition.NamespaceDefinitions;
+                        break;
+                    }
+                }
+
+                if (!foundMatch)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private CaseSensitiveTypeCache CaseSensitiveTypeTable
+        {
+            get
+            {
+                return _lazyCaseSensitiveTypeTable ?? (_lazyCaseSensitiveTypeTable = new CaseSensitiveTypeCache(this));
+            }
+        }
+
+        private volatile CaseSensitiveTypeCache _lazyCaseSensitiveTypeTable;
+
+        private sealed class CaseSensitiveTypeCache : ConcurrentUnifier<string, RuntimeTypeInfo>
+        {
+            public CaseSensitiveTypeCache(RuntimeAssembly runtimeAssembly)
+            {
+                _runtimeAssembly = runtimeAssembly;
+            }
+
+            protected sealed override RuntimeTypeInfo Factory(string key)
+            {
+                return _runtimeAssembly.UncachedGetTypeCoreCaseSensitive(key);
+            }
+
+            private readonly RuntimeAssembly _runtimeAssembly;
+        }
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection.Runtime.Assemblies;
-using System.Reflection.Runtime.TypeParsing;
 
 using Internal.LowLevelLinq;
 using Internal.Reflection.Core;
@@ -597,9 +596,9 @@ namespace System.Reflection.Runtime.General
             }
         }
 
-        public static AssemblyQualifiedTypeName ToAssemblyQualifiedTypeName(this NamespaceReferenceHandle namespaceReferenceHandle, String typeName, MetadataReader reader)
+        public static string ToFullyQualifiedTypeName(this NamespaceReferenceHandle namespaceReferenceHandle, string typeName, MetadataReader reader)
         {
-            LowLevelList<String> namespaceParts = new LowLevelList<String>(8);
+            StringBuilder fullName = new StringBuilder();
             NamespaceReference namespaceReference;
             for (;;)
             {
@@ -607,13 +606,12 @@ namespace System.Reflection.Runtime.General
                 String namespacePart = namespaceReference.Name.GetStringOrNull(reader);
                 if (namespacePart == null)
                     break;
-                namespaceParts.Add(namespacePart);
+                fullName.Append(namespacePart);
+                fullName.Append('.');
                 namespaceReferenceHandle = namespaceReference.ParentScopeOrNamespace.ToExpectedNamespaceReferenceHandle(reader);
             }
-
-            ScopeReferenceHandle scopeReferenceHandle = namespaceReference.ParentScopeOrNamespace.ToExpectedScopeReferenceHandle(reader);
-            RuntimeAssemblyName assemblyName = scopeReferenceHandle.ToRuntimeAssemblyName(reader);
-            return new AssemblyQualifiedTypeName(new NamespaceTypeName(namespaceParts.ToArray(), typeName), assemblyName);
+            fullName.Append(typeName);
+            return fullName.ToString();
         }
 
         public static RuntimeAssemblyName ToRuntimeAssemblyName(this ScopeDefinitionHandle scopeDefinitionHandle, MetadataReader reader)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Text;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
@@ -190,11 +191,20 @@ namespace System.Reflection.Runtime.General
             // If we got here, the typeReference was to a non-nested type. 
             if (parentType == HandleType.NamespaceReference)
             {
-                AssemblyQualifiedTypeName assemblyQualifiedTypeName = parent.ToNamespaceReferenceHandle(reader).ToAssemblyQualifiedTypeName(name, reader);
-                RuntimeTypeInfo runtimeType;
-                exception = assemblyQualifiedTypeName.TryResolve(null, /*ignoreCase: */false, out runtimeType);
+                NamespaceReferenceHandle namespaceReferenceHandle = parent.ToNamespaceReferenceHandle(reader);
+                string fullName = namespaceReferenceHandle.ToFullyQualifiedTypeName(name, reader);
+                ScopeReferenceHandle scopeReferenceHandle = namespaceReferenceHandle.GetNamespaceReference(reader).ParentScopeOrNamespace.ToExpectedScopeReferenceHandle(reader);
+                RuntimeAssemblyName assemblyName = scopeReferenceHandle.ToRuntimeAssemblyName(reader);
+                RuntimeAssembly runtimeAssembly;
+                exception = RuntimeAssembly.TryGetRuntimeAssembly(assemblyName, out runtimeAssembly);
                 if (exception != null)
                     return null;
+                RuntimeTypeInfo runtimeType = runtimeAssembly.GetTypeCore(fullName, ignoreCase: false);
+                if (runtimeType == null)
+                {
+                    exception = Helpers.CreateTypeLoadException(fullName, assemblyName.FullName);
+                    return null;
+                }
                 return runtimeType;
             }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -167,7 +167,7 @@ namespace System.Reflection.Runtime.TypeInfos
                     ReflectionTrace.TypeInfo_Namespace(this);
 #endif
 
-                return EscapeIdentifier(NamespaceChain.NameSpace);
+                return NamespaceChain.NameSpace.EscapeTypeNameIdentifier();
             }
         }
 
@@ -347,7 +347,7 @@ namespace System.Reflection.Runtime.TypeInfos
             ConstantStringValueHandle nameHandle = _typeDefinition.Name;
             string name = nameHandle.GetString(_reader);
 
-            return EscapeIdentifier(name);
+            return name.EscapeTypeNameIdentifier();
         }
 
         internal sealed override RuntimeTypeHandle InternalTypeHandleIfAvailable
@@ -498,27 +498,6 @@ namespace System.Reflection.Runtime.TypeInfos
             {
                 return new Tuple<Guid>(Guid.NewGuid());
             }
-        }
-
-        private static readonly char[] s_charsToEscape = new char[] { '\\', '[', ']', '+', '*', '&', ',' };
-        // Escape identifiers as described in "Specifying Fully Qualified Type Names" on msdn.
-        // Current link is http://msdn.microsoft.com/en-us/library/yfsftwz6(v=vs.110).aspx
-        private static string EscapeIdentifier(string identifier)
-        {
-            // Some characters in a type name need to be escaped
-            if (identifier != null && identifier.IndexOfAny(s_charsToEscape) != -1)
-            {
-                StringBuilder sbEscapedName = new StringBuilder(identifier);
-                sbEscapedName.Replace("\\", "\\\\");
-                sbEscapedName.Replace("+", "\\+");
-                sbEscapedName.Replace("[", "\\[");
-                sbEscapedName.Replace("]", "\\]");
-                sbEscapedName.Replace("*", "\\*");
-                sbEscapedName.Replace("&", "\\&");
-                sbEscapedName.Replace(",", "\\,");
-                identifier = sbEscapedName.ToString();
-            }
-            return identifier;
         }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/GetTypeOptions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/GetTypeOptions.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Diagnostics;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.Assemblies;
+
+namespace System.Reflection.Runtime.TypeParsing
+{
+    /// <summary>
+    /// Return the assembly matching the refName if one exists. If a matching assembly doesn't exist, return null. Throw for all other errors.
+    /// </summary>
+    internal delegate Assembly CoreAssemblyResolver(RuntimeAssemblyName refName);
+
+    /// <summary>
+    /// Look for a type matching the name inside the provided assembly. If "containingAssemblyIfAny" is null, look in a set of default assemblies. For example, if
+    /// this resolver is for the Type.GetType() api, the default assemblies are the assembly that invoked Type.GetType() and mscorlib in that order.
+    /// If this resolver is for Assembly.GetType(), the default is that assembly. Third-party resolvers can do whatever they want. If no type exists for that name,
+    /// return null. Throw for all other errors. The name will be for a top-level named type only. No nested types. No constructed types.
+    /// </summary>
+    /// 
+    /// </remarks>
+    /// This delegate "should" take an "ignoreCase" parameter too, but pragmatically, every resolver we create is a closure for other reasons so
+    /// it's more convenient to let "ignoreCase" be just another variable that's captured in that closure.
+    /// <remarks>
+    internal delegate Type CoreTypeResolver(Assembly containingAssemblyIfAny, string name);
+
+    // 
+    // Captures the various options passed to the Type.GetType() family of apis.
+    // 
+    internal sealed class GetTypeOptions
+    {
+        public GetTypeOptions(CoreAssemblyResolver coreAssemblyResolver, CoreTypeResolver coreTypeResolver, bool throwOnError, bool ignoreCase)
+        {
+            Debug.Assert(coreAssemblyResolver != null);
+            Debug.Assert(coreTypeResolver != null);
+
+            _coreAssemblyResolver = coreAssemblyResolver;
+            _coreTypeResolver = coreTypeResolver;
+            ThrowOnError = throwOnError;
+            IgnoreCase = ignoreCase;
+        }
+
+        public Assembly CoreResolveAssembly(RuntimeAssemblyName name)
+        {
+            Assembly assembly = _coreAssemblyResolver(name);
+            if (assembly == null && ThrowOnError)
+                throw new FileNotFoundException(SR.Format(SR.FileNotFound_AssemblyNotFound, name.FullName));
+            return assembly;
+        }
+
+        public Type CoreResolveType(Assembly containingAssemblyIfAny, string name)
+        {
+            Type type = _coreTypeResolver(containingAssemblyIfAny, name);
+            if (type == null && ThrowOnError)
+                throw Helpers.CreateTypeLoadException(name.EscapeTypeNameIdentifier(), containingAssemblyIfAny);
+            return type;
+        }
+
+        public bool ThrowOnError { get; }
+        public bool IgnoreCase { get; }
+
+        private readonly CoreAssemblyResolver _coreAssemblyResolver;
+        private readonly CoreTypeResolver _coreTypeResolver;
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeLexer.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeLexer.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.Assemblies;
 
 namespace System.Reflection.Runtime.TypeParsing
@@ -92,7 +93,7 @@ namespace System.Reflection.Runtime.TypeParsing
                     c = _chars[src];
                     if (c != NUL)
                         src++;
-                    if (c == NUL || CharToToken(c) == TokenType.Other)
+                    if (!c.NeedsEscapingInTypeName())
                     {
                         // If we got here, a backslash was used to escape a character that is not legal to escape inside a type name.
                         //

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
@@ -69,19 +69,28 @@ namespace Internal.Reflection.Execution
         // This entry is targeted by the ILTransformer to implement Type.GetType()'s ability to detect the calling assembly and use it as
         // a default assembly name.
         //
-        public static Type GetType(String typeName, String callingAssemblyName, bool throwOnError, bool ignoreCase)
+        public static Type GetType(string typeName, string callingAssemblyName, bool throwOnError, bool ignoreCase)
+        {
+            return ExtensibleGetType(typeName, callingAssemblyName, null, null, throwOnError: throwOnError, ignoreCase: ignoreCase);
+        }
+
+        //
+        // This entry is targeted by the ILTransformer to implement Type.GetType()'s ability to detect the calling assembly and use it as
+        // a default assembly name.
+        //
+        public static Type ExtensibleGetType(string typeName, string callingAssemblyName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase)
         {
             LowLevelListWithIList<String> defaultAssemblies = new LowLevelListWithIList<String>();
             defaultAssemblies.Add(callingAssemblyName);
             defaultAssemblies.AddRange(DefaultAssemblyNamesForGetType);
-            return ReflectionCoreExecution.ExecutionDomain.GetType(typeName, throwOnError, ignoreCase, defaultAssemblies);
+            return ReflectionCoreExecution.ExecutionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, defaultAssemblies);
         }
 
         internal static ExecutionEnvironmentImplementation ExecutionEnvironment { get; private set; }
 
         //@todo: Is there a better way than hard-coding?
         internal const String DefaultAssemblyNameForGetType = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
-        internal static IEnumerable<String> DefaultAssemblyNamesForGetType;
+        internal static IList<string> DefaultAssemblyNamesForGetType;
     }
 }
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -110,9 +110,9 @@ namespace Internal.Reflection.Execution
             return newObject;
         }
 
-        public sealed override Type GetType(String typeName, bool throwOnError, bool ignoreCase)
+        public sealed override Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase)
         {
-            return _executionDomain.GetType(typeName, throwOnError, ignoreCase, ReflectionExecution.DefaultAssemblyNamesForGetType);
+            return _executionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, ReflectionExecution.DefaultAssemblyNamesForGetType);
         }
 
         public sealed override bool IsReflectionBlocked(RuntimeTypeHandle typeHandle)


### PR DESCRIPTION
(https://github.com/dotnet/corert/issues/1787)

- Fixed the bug that was causing

   Type.GetType("Foo`1[[System.Int32]], MyAssembly")

  to be interpreted as

   Type.GetType("Foo`1[[System.Int32, MyAssembly]], MyAssembly")


  Generic type arguments without assembly names are supposed to be
  treated the same way as the top level type (i.e. probe the caller's
  assembly, then mscorlib.)

  This also fixes a similar problem with Assembly.GetType()
  (unqualified types are supposed to be probed for in the Assembly
  you called GetType() on, no matter where they appear in the
  type-string.)

- Since I was replumbing the TypeName code anyway, I brought up the
  Type.GetType() overloads that accept user-created assembly and
  type resolvers (no sense in redesigning this code twice.)
  The old Type.GetType() overloads now call that api with null
  passed for both resolvers.

  (https://github.com/dotnet/corert/issues/1788)


- General notes:

  - RuntimeAssembly.GetTypeCore() now does the basic lookup
    (non-nested, non-constructed types only.) The TypeName Resolve()
    methods perform all the advanced type construction.

  - The TypeName code is now agnostic wrt to the provenance
    of the Type and Assembly objects.

  - The TypeName code is now parameterized wrt to assembly
    and basic type name resolution.