### PR TITLE
Correct the virtual overload of Stream.CopyTo

### DIFF
--- a/src/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -158,7 +158,7 @@ namespace System.IO
         // Reads the bytes from the current stream and writes the bytes to
         // the destination stream until all bytes are read, starting at
         // the current position.
-        public virtual void CopyTo(Stream destination)
+        public void CopyTo(Stream destination)
         {
             int bufferSize = DefaultCopyBufferSize;
 
@@ -184,7 +184,7 @@ namespace System.IO
             CopyTo(destination, bufferSize);
         }
 
-        public void CopyTo(Stream destination, int bufferSize)
+        public virtual void CopyTo(Stream destination, int bufferSize)
         {
             ValidateCopyToArguments(destination, bufferSize);
 


### PR DESCRIPTION
Same as dotnet/coreclr#7082

/cc @jkotas, @weshaggard 