### PR TITLE
Reduce memory allocations for walking method parameters.

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInheritanceRules.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInheritanceRules.cs
@@ -234,7 +234,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                 MethodInfo methodParent = new MethodCustomAttributeSearcher().GetParent(method);
                 if (methodParent == null)
                     return null;
-                return methodParent.GetParameters()[e.Position];
+                return methodParent.GetParametersNoCopy()[e.Position];
             }
 
             public static readonly ParameterCustomAttributeSearcher Default = new ParameterCustomAttributeSearcher();

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
@@ -44,7 +44,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                 if ((ctor.Attributes & (MethodAttributes.Static | MethodAttributes.MemberAccessMask)) != (MethodAttributes.Public))
                     continue;
 
-                ParameterInfo[] parameters = ctor.GetParameters();
+                ParameterInfo[] parameters = ctor.GetParametersNoCopy();
                 if (parameters.Length != constructorArguments.Count)
                     continue;
                 int i;

--- a/src/System.Private.CoreLib/src/System/Reflection/EventInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/EventInfo.cs
@@ -45,7 +45,7 @@ namespace System.Reflection
             get
             {
                 MethodInfo m = GetAddMethod(true);
-                ParameterInfo[] p = m.GetParameters();
+                ParameterInfo[] p = m.GetParametersNoCopy();
                 Type del = typeof(Delegate);
                 for (int i = 0; i < p.Length; i++)
                 {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/DefaultBinder.LimitedBinder.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/DefaultBinder.LimitedBinder.cs
@@ -62,7 +62,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
     
                 for (i = 0; i < candidates.Length; i++)
                 {
-                    ParameterInfo[] par = candidates[i].GetParameters();
+                    ParameterInfo[] par = candidates[i].GetParametersNoCopy();
     
                     // args.Length + 1 takes into account the possibility of a last paramArray that can be omitted
                     paramOrder[i] = new int[(par.Length > args.Length) ? par.Length : args.Length];
@@ -105,7 +105,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                         continue;
     
                     // Validate the parameters.
-                    ParameterInfo[] par = candidates[i].GetParameters();
+                    ParameterInfo[] par = candidates[i].GetParametersNoCopy();
     
                     #region Match method by parameter count
                     if (par.Length == 0)
@@ -279,7 +279,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                     #region Found only one method
                     // If the parameters and the args are not the same length or there is a paramArray
                     //  then we need to create a argument array.
-                    ParameterInfo[] parms = candidates[0].GetParameters();
+                    ParameterInfo[] parms = candidates[0].GetParametersNoCopy();
     
                     if (parms.Length == args.Length)
                     {
@@ -353,7 +353,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
     
                 // If the parameters and the args are not the same length or there is a paramArray
                 //  then we need to create a argument array.
-                ParameterInfo[] parameters = candidates[currentMin].GetParameters();
+                ParameterInfo[] parameters = candidates[currentMin].GetParametersNoCopy();
                 if (parameters.Length == args.Length)
                 {
                     if (paramArrayTypes[currentMin] != null)
@@ -419,7 +419,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                 int CurIdx = 0;
                 for (i = 0; i < candidates.Length; i++)
                 {
-                    ParameterInfo[] par = candidates[i].GetParameters();
+                    ParameterInfo[] par = candidates[i].GetParametersNoCopy();
                     if (par.Length != types.Length)
                         continue;
                     for (j = 0; j < types.Length; j++)
@@ -740,8 +740,8 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                                                       Type[] types, Object[] args)
             {
                 // Find the most specific method based on the parameters.
-                int res = FindMostSpecific(m1.GetParameters(), paramOrder1, paramArrayType1,
-                                           m2.GetParameters(), paramOrder2, paramArrayType2, types, args);
+                int res = FindMostSpecific(m1.GetParametersNoCopy(), paramOrder1, paramArrayType1,
+                                           m2.GetParametersNoCopy(), paramOrder2, paramArrayType2, types, args);
     
                 // If the match was not ambigous then return the result.
                 if (res != 0)
@@ -797,8 +797,8 @@ namespace System.Reflection.Runtime.BindingFlagSupport
     
             private static bool CompareMethodSigAndName(MethodBase m1, MethodBase m2)
             {
-                ParameterInfo[] params1 = m1.GetParameters();
-                ParameterInfo[] params2 = m2.GetParameters();
+                ParameterInfo[] params1 = m1.GetParametersNoCopy();
+                ParameterInfo[] params2 = m2.GetParametersNoCopy();
     
                 if (params1.Length != params2.Length)
                     return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
@@ -67,8 +67,8 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                 return false;
             }
 
-            ParameterInfo[] p1 = method1.GetParameters();
-            ParameterInfo[] p2 = method2.GetParameters();
+            ParameterInfo[] p1 = method1.GetParametersNoCopy();
+            ParameterInfo[] p2 = method2.GetParametersNoCopy();
             if (p1.Length != p2.Length)
             {
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -101,7 +101,7 @@ namespace System.Reflection.Runtime.CustomAttributes
                 if (candidate.IsStatic)
                     continue;
 
-                ParameterInfo[] candidateParameters = candidate.GetParameters();
+                ParameterInfo[] candidateParameters = candidate.GetParametersNoCopy();
                 if (parameterCount != candidateParameters.Length)
                     continue;
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -213,7 +213,7 @@ namespace System.Reflection.Runtime.EventInfos
         public sealed override String ToString()
         {
             MethodInfo addMethod = this.AddMethod;
-            ParameterInfo[] parameters = addMethod.GetParameters();
+            ParameterInfo[] parameters = addMethod.GetParametersNoCopy();
             if (parameters.Length == 0)
                 throw new InvalidOperationException(); // Legacy: Why is a ToString() intentionally throwing an exception?
             RuntimeParameterInfo runtimeParameterInfo = (RuntimeParameterInfo)(parameters[0]);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -194,9 +194,9 @@ namespace System.Reflection.Runtime.MethodInfos
     //-----------------------------------------------------------------------------------------------------------
     internal sealed partial class RuntimeSyntheticConstructorInfo : RuntimeConstructorInfo
     {
-        internal static RuntimeSyntheticConstructorInfo GetRuntimeSyntheticConstructorInfo(SyntheticMethodId syntheticMethodId, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypesAndReturn, InvokerOptions options, Func<Object, Object[], Object> invoker)
+        internal static RuntimeSyntheticConstructorInfo GetRuntimeSyntheticConstructorInfo(SyntheticMethodId syntheticMethodId, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypes, InvokerOptions options, Func<Object, Object[], Object> invoker)
         {
-            return new RuntimeSyntheticConstructorInfo(syntheticMethodId, declaringType, runtimeParameterTypesAndReturn, options, invoker);
+            return new RuntimeSyntheticConstructorInfo(syntheticMethodId, declaringType, runtimeParameterTypes, options, invoker);
         }
     }
 
@@ -229,9 +229,9 @@ namespace System.Reflection.Runtime.MethodInfos
     //-----------------------------------------------------------------------------------------------------------
     internal sealed partial class RuntimeSyntheticMethodInfo : RuntimeMethodInfo
     {
-        internal static RuntimeMethodInfo GetRuntimeSyntheticMethodInfo(SyntheticMethodId syntheticMethodId, String name, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypesAndReturn, InvokerOptions options, Func<Object, Object[], Object> invoker)
+        internal static RuntimeMethodInfo GetRuntimeSyntheticMethodInfo(SyntheticMethodId syntheticMethodId, String name, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypes, RuntimeTypeInfo returnType, InvokerOptions options, Func<Object, Object[], Object> invoker)
         {
-            return new RuntimeSyntheticMethodInfo(syntheticMethodId, name, declaringType, runtimeParameterTypesAndReturn, options, invoker).WithDebugName();
+            return new RuntimeSyntheticMethodInfo(syntheticMethodId, name, declaringType, runtimeParameterTypes, returnType, options, invoker).WithDebugName();
         }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
@@ -157,9 +157,9 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
-        internal sealed override RuntimeParameterInfo[] GetRuntimeParametersAndReturn(RuntimeMethodInfo contextMethod)
+        internal sealed override RuntimeParameterInfo[] GetRuntimeParameters(RuntimeMethodInfo contextMethod, out RuntimeParameterInfo returnParameter)
         {
-            return _genericMethodDefinition.GetRuntimeParametersAndReturn(this);
+            return _genericMethodDefinition.GetRuntimeParameters(this, out returnParameter);
         }
 
         private readonly RuntimeNamedMethodInfo _genericMethodDefinition;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -52,13 +52,18 @@ namespace System.Reflection.Runtime.MethodInfos
                 ReflectionTrace.MethodBase_GetParameters(this);
 #endif
 
-            RuntimeParameterInfo[] runtimeParametersAndReturn = this.RuntimeParametersAndReturn;
-            if (runtimeParametersAndReturn.Length == 1)
+            RuntimeParameterInfo[] parameters = RuntimeParameters;
+            if (parameters.Length == 0)
                 return Array.Empty<ParameterInfo>();
-            ParameterInfo[] result = new ParameterInfo[runtimeParametersAndReturn.Length - 1];
+            ParameterInfo[] result = new ParameterInfo[parameters.Length];
             for (int i = 0; i < result.Length; i++)
-                result[i] = runtimeParametersAndReturn[i + 1];
+                result[i] = parameters[i];
             return result;
+        }
+
+        public sealed override ParameterInfo[] GetParametersNoCopy()
+        {
+            return RuntimeParameters;
         }
 
         public abstract override object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture);
@@ -157,7 +162,7 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
-        protected abstract RuntimeParameterInfo[] RuntimeParametersAndReturn { get; }
+        protected abstract RuntimeParameterInfo[] RuntimeParameters { get; }
 
         protected abstract MethodInvoker UncachedMethodInvoker { get; }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -193,9 +193,9 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
-        internal sealed override RuntimeParameterInfo[] GetRuntimeParametersAndReturn(RuntimeMethodInfo contextMethod)
+        internal sealed override RuntimeParameterInfo[] GetRuntimeParameters(RuntimeMethodInfo contextMethod, out RuntimeParameterInfo returnParameter)
         {
-            return _common.GetRuntimeParametersAndReturn(contextMethod, contextMethod.RuntimeGenericArgumentsOrParameters);
+            return _common.GetRuntimeParameters(contextMethod, contextMethod.RuntimeGenericArgumentsOrParameters, out returnParameter);
         }
 
         internal sealed override RuntimeTypeInfo RuntimeDeclaringType

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -150,11 +150,12 @@ namespace System.Reflection.Runtime.MethodInfos
             return _common.ComputeToString(this, Array.Empty<RuntimeTypeInfo>());
         }
 
-        protected sealed override RuntimeParameterInfo[] RuntimeParametersAndReturn
+        protected sealed override RuntimeParameterInfo[] RuntimeParameters
         {
             get
             {
-                return _common.GetRuntimeParametersAndReturn(this, Array.Empty<RuntimeTypeInfo>());
+                RuntimeParameterInfo ignore;
+                return _lazyParameters ?? (_lazyParameters = _common.GetRuntimeParameters(this, Array.Empty<RuntimeTypeInfo>(), out ignore));
             }
         }
 
@@ -172,6 +173,7 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
+        private volatile RuntimeParameterInfo[] _lazyParameters;
         private readonly RuntimeMethodCommon _common;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
@@ -21,14 +21,15 @@ namespace System.Reflection.Runtime.MethodInfos
     //
     internal sealed partial class RuntimeSyntheticMethodInfo : RuntimeMethodInfo
     {
-        private RuntimeSyntheticMethodInfo(SyntheticMethodId syntheticMethodId, String name, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypesAndReturn, InvokerOptions options, Func<Object, Object[], Object> invoker)
+        private RuntimeSyntheticMethodInfo(SyntheticMethodId syntheticMethodId, String name, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] parameterTypes, RuntimeTypeInfo returnType, InvokerOptions options, Func<Object, Object[], Object> invoker)
         {
             _syntheticMethodId = syntheticMethodId;
             _name = name;
             _declaringType = declaringType;
             _options = options;
             _invoker = invoker;
-            _runtimeParameterTypesAndReturn = runtimeParameterTypesAndReturn;
+            _runtimeParameterTypes = parameterTypes;
+            _returnType = returnType;
         }
 
         public sealed override MethodAttributes Attributes
@@ -116,16 +117,17 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override String ToString()
         {
-            return RuntimeMethodCommon.ComputeToString(this, Array.Empty<RuntimeTypeInfo>(), GetRuntimeParametersAndReturn(this));
+            return RuntimeMethodCommon.ComputeToString(this, Array.Empty<RuntimeTypeInfo>(), RuntimeParameters, RuntimeReturnParameter);
         }
 
         protected sealed override MethodInvoker UncachedMethodInvoker
         {
             get
             {
-                RuntimeTypeHandle[] runtimeParameterTypeHandles = new RuntimeTypeHandle[_runtimeParameterTypesAndReturn.Length - 1];
-                for (int i = 1; i < _runtimeParameterTypesAndReturn.Length; i++)
-                    runtimeParameterTypeHandles[i - 1] = _runtimeParameterTypesAndReturn[i].TypeHandle;
+                RuntimeTypeInfo[] runtimeParameterTypes = _runtimeParameterTypes;
+                RuntimeTypeHandle[] runtimeParameterTypeHandles = new RuntimeTypeHandle[runtimeParameterTypes.Length];
+                for (int i = 0; i < runtimeParameterTypes.Length; i++)
+                    runtimeParameterTypeHandles[i] = runtimeParameterTypes[i].TypeHandle;
                 return ReflectionCoreExecution.ExecutionEnvironment.GetSyntheticMethodInvoker(
                     _declaringType.TypeHandle,
                     runtimeParameterTypeHandles,
@@ -158,27 +160,23 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
-        internal sealed override RuntimeParameterInfo[] GetRuntimeParametersAndReturn(RuntimeMethodInfo contextMethod)
+        internal sealed override RuntimeParameterInfo[] GetRuntimeParameters(RuntimeMethodInfo contextMethod, out RuntimeParameterInfo returnParameter)
         {
-            RuntimeParameterInfo[] runtimeParametersAndReturn = _lazyRuntimeParametersAndReturn;
-            if (runtimeParametersAndReturn == null)
+            RuntimeTypeInfo[] runtimeParameterTypes = _runtimeParameterTypes;
+            RuntimeParameterInfo[] parameters = new RuntimeParameterInfo[runtimeParameterTypes.Length];
+            for (int i = 0; i < parameters.Length; i++)
             {
-                runtimeParametersAndReturn = new RuntimeParameterInfo[_runtimeParameterTypesAndReturn.Length];
-                for (int i = 0; i < runtimeParametersAndReturn.Length; i++)
-                {
-                    runtimeParametersAndReturn[i] = RuntimeSyntheticParameterInfo.GetRuntimeSyntheticParameterInfo(this, i - 1, _runtimeParameterTypesAndReturn[i]);
-                }
-                _lazyRuntimeParametersAndReturn = runtimeParametersAndReturn;
+                parameters[i] = RuntimeSyntheticParameterInfo.GetRuntimeSyntheticParameterInfo(this, i, runtimeParameterTypes[i]);
             }
-            return runtimeParametersAndReturn;
+            returnParameter = RuntimeSyntheticParameterInfo.GetRuntimeSyntheticParameterInfo(this, -1, _returnType);
+            return parameters;
         }
-
-        private volatile RuntimeParameterInfo[] _lazyRuntimeParametersAndReturn;
 
         private readonly String _name;
         private readonly SyntheticMethodId _syntheticMethodId;
         private readonly RuntimeTypeInfo _declaringType;
-        private readonly RuntimeTypeInfo[] _runtimeParameterTypesAndReturn;
+        private readonly RuntimeTypeInfo[] _runtimeParameterTypes;
+        private readonly RuntimeTypeInfo _returnType;
         private readonly InvokerOptions _options;
         private readonly Func<Object, Object[], Object> _invoker;
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -156,15 +156,15 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             bool useGetter = CanRead;
             RuntimeMethodInfo accessor = (useGetter ? Getter : Setter);
-            RuntimeParameterInfo[] runtimeMethodParameterInfos = accessor.GetRuntimeParametersAndReturn(accessor);
-            int count = runtimeMethodParameterInfos.Length - 1;  // Subtract one for the return parameter.
+            RuntimeParameterInfo[] runtimeMethodParameterInfos = accessor.RuntimeParameters;
+            int count = runtimeMethodParameterInfos.Length;
             if (!useGetter)
                 count--;  // If we're taking the parameters off the setter, subtract one for the "value" parameter.
             if (count == 0)
                 return Array.Empty<ParameterInfo>();
             ParameterInfo[] result = new ParameterInfo[count];
             for (int i = 0; i < count; i++)
-                result[i] = RuntimePropertyIndexParameterInfo.GetRuntimePropertyIndexParameterInfo(this, runtimeMethodParameterInfos[i + 1]);
+                result[i] = RuntimePropertyIndexParameterInfo.GetRuntimePropertyIndexParameterInfo(this, runtimeMethodParameterInfos[i]);
             return result;
         }
 
@@ -310,7 +310,7 @@ namespace System.Reflection.Runtime.PropertyInfos
                 for (int i = 0; i < indexParameters.Length; i++)
                     indexRuntimeParameters[i] = (RuntimeParameterInfo)(indexParameters[i]);
                 sb.Append(" [");
-                sb.Append(RuntimeMethodCommon.ComputeParametersString(indexRuntimeParameters, 0));
+                sb.Append(RuntimeMethodCommon.ComputeParametersString(indexRuntimeParameters));
                 sb.Append(']');
             }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
@@ -60,17 +60,15 @@ namespace System.Reflection.Runtime.TypeInfos
                 FoundationTypes foundationTypes = ReflectionCoreExecution.ExecutionDomain.FoundationTypes;
                 RuntimeTypeInfo arrayType = this;
                 RuntimeTypeInfo countType = foundationTypes.SystemInt32.CastToRuntimeTypeInfo();
-                RuntimeTypeInfo voidType = foundationTypes.SystemVoid.CastToRuntimeTypeInfo();
 
                 {
-                    RuntimeTypeInfo[] ctorParametersAndReturn = new RuntimeTypeInfo[rank + 1];
-                    ctorParametersAndReturn[0] = voidType;
+                    RuntimeTypeInfo[] ctorParameters = new RuntimeTypeInfo[rank];
                     for (int i = 0; i < rank; i++)
-                        ctorParametersAndReturn[i + 1] = countType;
+                        ctorParameters[i] = countType;
                     yield return RuntimeSyntheticConstructorInfo.GetRuntimeSyntheticConstructorInfo(
                         SyntheticMethodId.ArrayCtor,
                         arrayType,
-                        ctorParametersAndReturn,
+                        ctorParameters,
                         InvokerOptions.AllowNullThis | InvokerOptions.DontWrapException,
                         delegate (Object _this, Object[] args)
                         {
@@ -124,14 +122,13 @@ namespace System.Reflection.Runtime.TypeInfos
                     RuntimeTypeInfo elementType = this.InternalRuntimeElementType;
                     while (elementType.IsArray && elementType.GetArrayRank() == 1)
                     {
-                        RuntimeTypeInfo[] ctorParametersAndReturn = new RuntimeTypeInfo[parameterCount + 1];
-                        ctorParametersAndReturn[0] = voidType;
+                        RuntimeTypeInfo[] ctorParameters = new RuntimeTypeInfo[parameterCount];
                         for (int i = 0; i < parameterCount; i++)
-                            ctorParametersAndReturn[i + 1] = countType;
+                            ctorParameters[i] = countType;
                         yield return RuntimeSyntheticConstructorInfo.GetRuntimeSyntheticConstructorInfo(
                             SyntheticMethodId.ArrayCtorJagged + parameterCount,
                             arrayType,
-                            ctorParametersAndReturn,
+                            ctorParameters,
                             InvokerOptions.AllowNullThis | InvokerOptions.DontWrapException,
                             delegate (Object _this, Object[] args)
                             {
@@ -151,14 +148,13 @@ namespace System.Reflection.Runtime.TypeInfos
 
                 if (multiDim)
                 {
-                    RuntimeTypeInfo[] ctorParametersAndReturn = new RuntimeTypeInfo[rank * 2 + 1];
-                    ctorParametersAndReturn[0] = voidType;
+                    RuntimeTypeInfo[] ctorParameters = new RuntimeTypeInfo[rank * 2];
                     for (int i = 0; i < rank * 2; i++)
-                        ctorParametersAndReturn[i + 1] = countType;
+                        ctorParameters[i] = countType;
                     yield return RuntimeSyntheticConstructorInfo.GetRuntimeSyntheticConstructorInfo(
                         SyntheticMethodId.ArrayMultiDimCtor,
                         arrayType,
-                        ctorParametersAndReturn,
+                        ctorParameters,
                         InvokerOptions.AllowNullThis | InvokerOptions.DontWrapException,
                         delegate (Object _this, Object[] args)
                         {
@@ -189,15 +185,15 @@ namespace System.Reflection.Runtime.TypeInfos
                 RuntimeTypeInfo voidType = foundationTypes.SystemVoid.CastToRuntimeTypeInfo();
 
                 {
-                    RuntimeTypeInfo[] getParametersAndReturn = new RuntimeTypeInfo[rank + 1];
-                    getParametersAndReturn[0] = elementType;
+                    RuntimeTypeInfo[] getParameters = new RuntimeTypeInfo[rank];
                     for (int i = 0; i < rank; i++)
-                        getParametersAndReturn[i + 1] = indexType;
+                        getParameters[i] = indexType;
                     yield return RuntimeSyntheticMethodInfo.GetRuntimeSyntheticMethodInfo(
                         SyntheticMethodId.ArrayGet,
                         "Get",
                         arrayType,
-                        getParametersAndReturn,
+                        getParameters,
+                        elementType,
                         InvokerOptions.None,
                         delegate (Object _this, Object[] args)
                         {
@@ -211,16 +207,16 @@ namespace System.Reflection.Runtime.TypeInfos
                 }
 
                 {
-                    RuntimeTypeInfo[] setParametersAndReturn = new RuntimeTypeInfo[rank + 2];
-                    setParametersAndReturn[0] = voidType;
+                    RuntimeTypeInfo[] setParameters = new RuntimeTypeInfo[rank + 1];
                     for (int i = 0; i < rank; i++)
-                        setParametersAndReturn[i + 1] = indexType;
-                    setParametersAndReturn[rank + 1] = elementType;
+                        setParameters[i] = indexType;
+                    setParameters[rank] = elementType;
                     yield return RuntimeSyntheticMethodInfo.GetRuntimeSyntheticMethodInfo(
                         SyntheticMethodId.ArraySet,
                         "Set",
                         arrayType,
-                        setParametersAndReturn,
+                        setParameters,
+                        voidType,
                         InvokerOptions.None,
                         delegate (Object _this, Object[] args)
                         {
@@ -236,15 +232,15 @@ namespace System.Reflection.Runtime.TypeInfos
                 }
 
                 {
-                    RuntimeTypeInfo[] addressParametersAndReturn = new RuntimeTypeInfo[rank + 1];
-                    addressParametersAndReturn[0] = elementType.GetByRefType();
+                    RuntimeTypeInfo[] addressParameters = new RuntimeTypeInfo[rank];
                     for (int i = 0; i < rank; i++)
-                        addressParametersAndReturn[i + 1] = indexType;
+                        addressParameters[i] = indexType;
                     yield return RuntimeSyntheticMethodInfo.GetRuntimeSyntheticMethodInfo(
                         SyntheticMethodId.ArrayAddress,
                         "Address",
                         arrayType,
-                        addressParametersAndReturn,
+                        addressParameters,
+                        elementType.GetByRefType(),
                         InvokerOptions.None,
                         delegate (Object _this, Object[] args)
                         {

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -609,7 +609,7 @@ namespace Internal.Reflection.Execution
 
         private IntPtr GetDynamicMethodInvokerThunk(RuntimeTypeHandle[] argHandles, MethodBase methodInfo)
         {
-            ParameterInfo[] parameters = methodInfo.GetParameters();
+            ParameterInfo[] parameters = methodInfo.GetParametersNoCopy();
             // last entry in argHandles is the return type if the type is not typeof(void)
             Debug.Assert(parameters.Length == argHandles.Length || parameters.Length == (argHandles.Length - 1));
 
@@ -1597,7 +1597,7 @@ namespace Internal.Reflection.Execution
             {
                 get
                 {
-                    ParameterInfo[] parameters = _methodBase.GetParameters();
+                    ParameterInfo[] parameters = _methodBase.GetParametersNoCopy();
                     LowLevelList<RuntimeTypeHandle> result = new LowLevelList<RuntimeTypeHandle>(parameters.Length);
 
                     for (int i = 0; i < parameters.Length; i++)
@@ -1637,7 +1637,7 @@ namespace Internal.Reflection.Execution
             {
                 get
                 {
-                    ParameterInfo[] parameters = _methodBase.GetParameters();
+                    ParameterInfo[] parameters = _methodBase.GetParametersNoCopy();
                     bool[] result = new bool[parameters.Length + 1];
 
                     MethodInfo reflectionMethodInfo = _methodBase as MethodInfo;
@@ -1673,8 +1673,8 @@ namespace Internal.Reflection.Execution
                 {
                     Debug.Assert(_metadataReader != null && !_methodHandle.Equals(default(MethodHandle)));
 
-                    _returnTypeAndParametersHandlesCache = new Handle[_methodBase.GetParameters().Length + 1];
-                    _returnTypeAndParametersTypesCache = new Type[_methodBase.GetParameters().Length + 1];
+                    _returnTypeAndParametersHandlesCache = new Handle[_methodBase.GetParametersNoCopy().Length + 1];
+                    _returnTypeAndParametersTypesCache = new Type[_methodBase.GetParametersNoCopy().Length + 1];
 
                     MethodSignature signature = _methodHandle.GetMethod(_metadataReader).Signature.GetMethodSignature(_metadataReader);
 
@@ -1688,7 +1688,7 @@ namespace Internal.Reflection.Execution
                     foreach (Handle paramSigHandle in signature.Parameters)
                     {
                         _returnTypeAndParametersHandlesCache[index] = paramSigHandle;
-                        _returnTypeAndParametersTypesCache[index] = _methodBase.GetParameters()[index - 1].ParameterType;
+                        _returnTypeAndParametersTypesCache[index] = _methodBase.GetParametersNoCopy()[index - 1].ParameterType;
                         index++;
                     }
                 }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
@@ -134,7 +134,7 @@ namespace Internal.Reflection.Execution.PayForPlayExperience
                     // write out actual parameters
                     friendlyName.Append('(');
                     first = true;
-                    foreach (ParameterInfo parameter in method.GetParameters())
+                    foreach (ParameterInfo parameter in method.GetParametersNoCopy())
                     {
                         if (!first)
                             friendlyName.Append(',');

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -71,7 +71,7 @@ namespace Internal.Reflection.Execution
                 // The default binder rules allow omitting optional parameters but Activator.CreateInstance() doesn't. Thus, if the # of arguments doesn't match
                 // the # of parameters, do the pre-verification that the desktop does and ensure that the method has a "params" argument and that the argument count
                 // isn't shorter by more than one.
-                ParameterInfo[] parameters = constructor.GetParameters();
+                ParameterInfo[] parameters = constructor.GetParametersNoCopy();
                 if (args.Length != parameters.Length)
                 {
                     if (args.Length < parameters.Length - 1)
@@ -217,7 +217,7 @@ namespace Internal.Reflection.Execution
             fullMethodName.Append('(');
 
             // get parameter list
-            ParameterInfo[] paramArr = methodBase.GetParameters();
+            ParameterInfo[] paramArr = methodBase.GetParametersNoCopy();
             for (int i = 0; i < paramArr.Length; ++i)
             {
                 if (i != 0)
@@ -424,7 +424,7 @@ namespace Internal.Reflection.Execution
                 return false;
             }
 
-            ParameterInfo parameterInfo = methodInfo.GetParameters()[argIndex];
+            ParameterInfo parameterInfo = methodInfo.GetParametersNoCopy()[argIndex];
             if (!parameterInfo.HasDefaultValue)
             {
                 // If the parameter is optional, with no default value and we're asked for its default value,

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidatorSupport.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidatorSupport.cs
@@ -287,7 +287,7 @@ namespace Internal.Reflection.Execution
 
             foreach (var ctor in type.DeclaredConstructors)
             {
-                if (!ctor.IsStatic && ctor.IsPublic && ctor.GetParameters().Length == 0)
+                if (!ctor.IsStatic && ctor.IsPublic && ctor.GetParametersNoCopy().Length == 0)
                     return true;
             }
             return false;


### PR DESCRIPTION
The last commit reintroduced the internal GetParametersNoCopy()
method that's used all over the CoreClr Reflection code. This commit
makes good on the "NoCopy" part of the name.

Most of this noisy but mechanical change is about changing
the internal exchange type from "array that contains the return
parameter at index 0, and the real parameters starting at index 1"
to a properly separated return and parameter array. That form was
convenient for the lowest level that actually parsed the metadata
but it spread to the upper layers more than it should have.