### PR TITLE
Fix BindingFlags corner cases.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -50,6 +50,7 @@
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\LowLevelTypeExtensions.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\MemberEnumerator.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\MemberPolicies.cs" />
+    <Compile Include="System\Reflection\Runtime\BindingFlagSupport\QueriedMemberList.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimeCustomAttributeData.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimeNormalCustomAttributeData.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimePseudoCustomAttributeData.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/LowLevelTypeExtensions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/LowLevelTypeExtensions.cs
@@ -277,12 +277,12 @@ namespace System.Reflection.Runtime.BindingFlagSupport
         {
             LowLevelList<MemberInfo> members = new LowLevelList<MemberInfo>();
 
-            members.AddRange(MemberEnumerator.GetMembers<MethodInfo>(type, nameFilterOrAnyName, bindingAttr));
-            members.AddRange(MemberEnumerator.GetMembers<ConstructorInfo>(type, nameFilterOrAnyName, bindingAttr));
-            members.AddRange(MemberEnumerator.GetMembers<PropertyInfo>(type, nameFilterOrAnyName, bindingAttr));
-            members.AddRange(MemberEnumerator.GetMembers<EventInfo>(type, nameFilterOrAnyName, bindingAttr));
-            members.AddRange(MemberEnumerator.GetMembers<FieldInfo>(type, nameFilterOrAnyName, bindingAttr));
-            members.AddRange(MemberEnumerator.GetMembers<TypeInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<MethodInfo>(type, nameFilterOrAnyName, bindingAttr, allowPrefixing: true));
+            members.AddRange(MemberEnumerator.GetMembers<ConstructorInfo>(type, nameFilterOrAnyName, bindingAttr, allowPrefixing: true));
+            members.AddRange(MemberEnumerator.GetMembers<PropertyInfo>(type, nameFilterOrAnyName, bindingAttr, allowPrefixing: true));
+            members.AddRange(MemberEnumerator.GetMembers<EventInfo>(type, nameFilterOrAnyName, bindingAttr, allowPrefixing: true));
+            members.AddRange(MemberEnumerator.GetMembers<FieldInfo>(type, nameFilterOrAnyName, bindingAttr, allowPrefixing: true));
+            members.AddRange(MemberEnumerator.GetMembers<TypeInfo>(type, nameFilterOrAnyName, bindingAttr, allowPrefixing: true));
 
             return members;
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/QueriedMemberList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/QueriedMemberList.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+namespace System.Reflection.Runtime.BindingFlagSupport
+{
+    //
+    // Stores the result of a stage 1 member filtering (filtering by name and visibility from the reflected type.) May be cached long term.
+    // Allows copy-minimizing but unsafe access - use caution.
+    //
+    internal sealed class QueriedMemberList<M> where M : MemberInfo
+    {
+        public QueriedMemberList()
+        {
+            _members = new M[Grow];
+            _allFlagsThatMustMatch = new BindingFlags[Grow];
+        }
+
+        public void Add(M member, BindingFlags allFlagsThatMustMatch)
+        {
+            const BindingFlags validBits = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+            Debug.Assert((allFlagsThatMustMatch & ~validBits) == 0);
+            Debug.Assert(((allFlagsThatMustMatch & BindingFlags.Public) == 0) != ((allFlagsThatMustMatch & BindingFlags.NonPublic) == 0));
+            Debug.Assert(((allFlagsThatMustMatch & BindingFlags.Instance) == 0) != ((allFlagsThatMustMatch & BindingFlags.Static) == 0));
+            Debug.Assert((allFlagsThatMustMatch & BindingFlags.FlattenHierarchy) == 0 || (allFlagsThatMustMatch & BindingFlags.Static) != 0);
+
+            int count = _count;
+            if (count == _members.Length)
+            {
+                Array.Resize(ref _members, count + Grow);
+                Array.Resize(ref _allFlagsThatMustMatch, count + Grow);
+            }
+
+            _members[count] = member;
+            _allFlagsThatMustMatch[count] = allFlagsThatMustMatch;
+            _count++;
+        }
+
+        public int Count => _count;
+
+        /// <summary>
+        /// Caution: Will have extra null entries - use QueriedMember.Count to stop iterating rather than MembersNoCopy.Length. Contents are invalidated if an Add occurs.
+        /// </summary>
+        public M[] MembersNoCopy => _members;
+
+        /// <summary>
+        /// Caution: Will have extra null entries - use QueriedMember.Count to stop iterating rather than MembersNoCopy.Length. Contents are invalidated if an Add occurs.
+        /// </summary>
+        public BindingFlags[] AllFlagsThatMustMatchNoCopy => _allFlagsThatMustMatch;
+
+        private int _count;
+        private M[] _members;
+        private BindingFlags[] _allFlagsThatMustMatch;
+
+        private const int Grow = 64;
+    }
+}
+


### PR DESCRIPTION
Re-examining the BindingFlags-based query methods on Type
showed a number of corner-case compat differences with
the desktop. Eliminating these now before starting perf
work. The workflow now more closely mirrors CoreClr:

- Prefix searches (type.GetMember("Foo*",...)
  are only meant to work on GetMember(), not
  GetField, GetMethod, GetEvent, GetProperty or
  GetNestedType.

- Special rule for events: Events in derived types suppress
  events in base types if they have the same name. Differences in
  event delegate type, static/instance, virtual/non-virtual
  are ignored.

  [This is a previously documented .NetNative behavior change.
  We're unchanging that now.]

- Special rule for properties; Properties in
  derived types suppress properties in base types if they have
  the same name, return type, parameter types and static/instance
  attribute, *even if they don't share the same vtable slot.*

  [This is a previously documented .NetNative behavior change.
  We're unchanging that now.]

- BindingFlag filtering (including the IsStatic|FlattenHierarchy
  checks) happen after these suppressions have been done.
  So an event named "Foo" in the derived type will still prevent
  an event named "Foo" in the base type from showing up, even
  if the derived "Foo" wouldn't even have been returned because
  they don't match the BindingFlags criteria.