### PR TITLE
Create a per-Type cache for BindingFlag results.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -49,6 +49,7 @@
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\InheritedPropertyInfo.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\MemberEnumerator.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\MemberPolicies.cs" />
+    <Compile Include="System\Reflection\Runtime\BindingFlagSupport\MemberTypeIndex.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\NameFilter.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\QueriedMemberList.cs" />
     <Compile Include="System\Reflection\Runtime\BindingFlagSupport\QueryResult.cs" />
@@ -125,6 +126,7 @@
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.GetMember.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.BindingFlags.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.CoreGetDeclared.cs" />
+    <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.TypeComponentsCache.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\GetTypeOptions.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\TypeName.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\TypeLexer.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberTypeIndex.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberTypeIndex.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reflection.Runtime.BindingFlagSupport
+{
+    // 
+    // When we want to store an object of type Foo<M> for each possible M, it's convenient to use
+    // an array of length MemberTypeIndex.Count, which each possible M assigned an index.
+    //
+    // This is defined as a set of consts rather than enum to avoid having to cast to int.
+    //
+    internal static class MemberTypeIndex
+    {
+        public const int Constructor = 0;
+        public const int Event = 1;
+        public const int Field = 2;
+        public const int Method = 3;
+        public const int NestedType = 4;
+        public const int Property = 5;
+
+        public const int Count = 6;
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/QueriedMemberList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/QueriedMemberList.cs
@@ -7,10 +7,16 @@ using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
 
+using Internal.Reflection.Core.Execution;
+
 namespace System.Reflection.Runtime.BindingFlagSupport
 {
     //
     // Stores the result of a member filtering that's filtered by name and visibility from base class (as defined by the Type.Get*() family of apis).
+    //
+    // The results are as if you'd passed in a bindingFlags value of "Public | NonPublic | Instance | Static | FlattenHierarchy"
+    // In addition, if "ignoreCase" was passed to Create(), BindingFlags.IgnoreCase is also in effect.
+    //
     // This object is a good candidate for long term caching.
     //
     internal sealed class QueriedMemberList<M> where M : MemberInfo
@@ -21,21 +27,39 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             _allFlagsThatMustMatch = new BindingFlags[Grow];
         }
 
-        private QueriedMemberList(int count, M[] members, BindingFlags[] allFlagsThatMustMatch)
+        private QueriedMemberList(int totalCount, int declaredOnlyCount, M[] members, BindingFlags[] allFlagsThatMustMatch, RuntimeTypeInfo typeThatBlockedBrowing)
         {
-            _count = count;
+            _totalCount = totalCount;
+            _declaredOnlyCount = declaredOnlyCount;
             _members = members;
             _allFlagsThatMustMatch = allFlagsThatMustMatch;
+            _typeThatBlockedBrowsing = typeThatBlockedBrowing;
         }
 
-        public int Count => _count;
+        /// <summary>
+        /// Returns the # of candidates for a non-DeclaredOnly search. Caution: Can throw MissingMetadataException. Use DeclaredOnlyCount if you don't want to search base classes.
+        /// </summary>
+        public int TotalCount
+        {
+            get
+            {
+                if (_typeThatBlockedBrowsing != null)
+                    throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(_typeThatBlockedBrowsing);
+                return _totalCount;
+            }
+        }
+
+        /// <summary>
+        /// Returns the # of candidates for a DeclaredOnly search
+        /// </summary>
+        public int DeclaredOnlyCount => _declaredOnlyCount;
 
         public M this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(index >= 0 && index < _count);
+                Debug.Assert(index >= 0 && index < _totalCount);
                 return _members[index];
             }
         }
@@ -43,34 +67,37 @@ namespace System.Reflection.Runtime.BindingFlagSupport
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Matches(int index, BindingFlags bindingAttr)
         {
-            Debug.Assert(index >= 0 && index < Count);
+            Debug.Assert(index >= 0 && index < _totalCount);
             BindingFlags allFlagsThatMustMatch = _allFlagsThatMustMatch[index];
             return ((bindingAttr & allFlagsThatMustMatch) == allFlagsThatMustMatch);
         }
 
         public QueriedMemberList<M> Filter(Func<M, bool> predicate)
         {
-            BindingFlags[] newAllFlagsThatMustMatch = new BindingFlags[_count];
-            M[] newMembers = new M[_count];
-            int newCount = 0;
-            for (int i = 0; i < _count; i++)
+            BindingFlags[] newAllFlagsThatMustMatch = new BindingFlags[_totalCount];
+            M[] newMembers = new M[_totalCount];
+            int newDeclaredOnlyCount = 0;
+            int newTotalCount = 0;
+            for (int i = 0; i < _totalCount; i++)
             {
                 M member = _members[i];
                 if (predicate(member))
                 {
-                    newMembers[newCount] = member;
-                    newAllFlagsThatMustMatch[newCount] = _allFlagsThatMustMatch[i];
-                    newCount++;
+                    newMembers[newTotalCount] = member;
+                    newAllFlagsThatMustMatch[newTotalCount] = _allFlagsThatMustMatch[i];
+                    newTotalCount++;
+                    if (i < _declaredOnlyCount)
+                        newDeclaredOnlyCount++;
                 }
             }
 
-            return new QueriedMemberList<M>(newCount, newMembers, newAllFlagsThatMustMatch);
+            return new QueriedMemberList<M>(newTotalCount, newDeclaredOnlyCount, newMembers, newAllFlagsThatMustMatch, _typeThatBlockedBrowsing);
         }
 
         //
         // Filter by name and visibility from the ReflectedType.
         //
-        public static QueriedMemberList<M> Create(RuntimeTypeInfo type, string optionalNameFilter, bool ignoreCase, bool declaredOnly)
+        public static QueriedMemberList<M> Create(RuntimeTypeInfo type, string optionalNameFilter, bool ignoreCase)
         {
             RuntimeTypeInfo reflectedType = type;
 
@@ -88,7 +115,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             QueriedMemberList<M> queriedMembers = new QueriedMemberList<M>();
             while (type != null)
             {
-                int numCandidatesInDerivedTypes = queriedMembers.Count;
+                int numCandidatesInDerivedTypes = queriedMembers._totalCount;
 
                 foreach (M member in policies.CoreGetDeclaredMembers(type, nameFilter, reflectedType))
                 {
@@ -120,14 +147,34 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                     }
                 }
 
-                if (declaredOnly)
-                    break;
+                if (!inBaseClass)
+                {
+                    queriedMembers._declaredOnlyCount = queriedMembers._totalCount;
+                    if (policies.AlwaysTreatAsDeclaredOnly)
+                        break;
+                    inBaseClass = true;
+                }
 
-                inBaseClass = true;
                 type = type.BaseType.CastToRuntimeTypeInfo();
+
+                if (type != null && !type.CanBrowseWithoutMissingMetadataExceptions)
+                {
+                    // If we got here, one of the base classes is missing metadata. We don't want to throw a MissingMetadataException now because we may be 
+                    // building a cached result for a caller who passed BindingFlags.DeclaredOnly. So we'll mark the results in a way that 
+                    // it will throw a MissingMetadataException if a caller attempts to iterate past the declared-only subset.
+                    queriedMembers._typeThatBlockedBrowsing = type;
+                    queriedMembers._totalCount = queriedMembers._declaredOnlyCount;
+                    break;
+                }
             }
 
             return queriedMembers;
+        }
+
+        public void Compact()
+        {
+            Array.Resize(ref _members, _totalCount);
+            Array.Resize(ref _allFlagsThatMustMatch, _totalCount);
         }
 
         private void Add(M member, BindingFlags allFlagsThatMustMatch)
@@ -138,7 +185,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             Debug.Assert(((allFlagsThatMustMatch & BindingFlags.Instance) == 0) != ((allFlagsThatMustMatch & BindingFlags.Static) == 0));
             Debug.Assert((allFlagsThatMustMatch & BindingFlags.FlattenHierarchy) == 0 || (allFlagsThatMustMatch & BindingFlags.Static) != 0);
 
-            int count = _count;
+            int count = _totalCount;
             if (count == _members.Length)
             {
                 Array.Resize(ref _members, count + Grow);
@@ -147,12 +194,14 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
             _members[count] = member;
             _allFlagsThatMustMatch[count] = allFlagsThatMustMatch;
-            _count++;
+            _totalCount++;
         }
 
-        private int _count;
-        private M[] _members;
-        private BindingFlags[] _allFlagsThatMustMatch;
+        private int _totalCount; // # of entries including members in base classes.
+        private int _declaredOnlyCount; // # of entries for members only in the most derived class.
+        private M[] _members;  // Length is equal to or greater than _totalCount. Entries beyond _totalCount contain null or garbage and should be read.
+        private BindingFlags[] _allFlagsThatMustMatch; // Length will be equal to _members.Length
+        private RuntimeTypeInfo _typeThatBlockedBrowsing; // If non-null, one of the base classes was missing metadata.
 
         private const int Grow = 64;
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.cs
@@ -35,7 +35,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                     if (_queriedMembers == null)
                         return 0;  // This is an uninitialized QueryResult<M>, which is supported and represents a 0-length list of matches.
 
-                    int unfilteredCount = _queriedMembers.Count;
+                    int unfilteredCount = UnfilteredCount;
                     for (int i = 0; i < unfilteredCount; i++)
                     {
                         if (_queriedMembers.Matches(i, _bindingAttr))
@@ -78,7 +78,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             if (_queriedMembers == null)
                 return; // This is an uninitialized QueryResult<M>, which is supported and represents a 0-length list of matches.
 
-            int unfilteredCount = _queriedMembers.Count;
+            int unfilteredCount = UnfilteredCount;
             for (int i = 0; i < unfilteredCount; i++)
             {
                 if (_queriedMembers.Matches(i, _bindingAttr))
@@ -96,7 +96,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             if (_queriedMembers == null)
                 return null; // This is an uninitialized QueryResult<M>, which is supported and represents a 0-length list of matches.
 
-            int unfilteredCount = _queriedMembers.Count;
+            int unfilteredCount = UnfilteredCount;
 
             M match = null;
             for (int i = 0; i < unfilteredCount; i++)
@@ -116,6 +116,8 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             }
             return match;
         }
+
+        private int UnfilteredCount => ((_bindingAttr & BindingFlags.DeclaredOnly) != 0) ? _queriedMembers.DeclaredOnlyCount : _queriedMembers.TotalCount;
 
         private readonly BindingFlags _bindingAttr;
         private int _lazyCount; // Intentionally not marking as volatile. QueryResult is for short-term use within a single method call - no aspiration to be thread-safe.

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -158,6 +158,8 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        internal sealed override bool CanBrowseWithoutMissingMetadataExceptions => true;
+
         internal sealed override RuntimeTypeInfo[] RuntimeGenericTypeParameters
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -236,6 +236,8 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        internal sealed override bool CanBrowseWithoutMissingMetadataExceptions => GenericTypeDefinitionTypeInfo.CanBrowseWithoutMissingMetadataExceptions;
+
         internal sealed override Type InternalDeclaringType
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -141,6 +141,8 @@ namespace System.Reflection.Runtime.TypeInfos
 
         protected MetadataReader Reader { get; }
 
+        internal sealed override bool CanBrowseWithoutMissingMetadataExceptions => true;
+
         internal sealed override string InternalFullNameOfAssembly
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
@@ -129,6 +129,8 @@ namespace System.Reflection.Runtime.TypeInfos
             return _key.ElementType.GetHashCode();
         }
 
+        internal sealed override bool CanBrowseWithoutMissingMetadataExceptions => true;
+
         internal sealed override Type InternalDeclaringType
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -302,6 +302,8 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        internal sealed override bool CanBrowseWithoutMissingMetadataExceptions => true;
+
         internal sealed override Type InternalDeclaringType
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
@@ -142,6 +142,8 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        internal sealed override bool CanBrowseWithoutMissingMetadataExceptions => false;
+
         internal sealed override Type InternalDeclaringType
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
@@ -116,8 +116,14 @@ namespace System.Reflection.Runtime.TypeInfos
             MemberPolicies<M> policies = MemberPolicies<M>.Default;
             bindingAttr = policies.ModifyBindingFlags(bindingAttr);
             bool ignoreCase = (bindingAttr & BindingFlags.IgnoreCase) != 0;
-            bool declaredOnly = (bindingAttr & BindingFlags.DeclaredOnly) != 0;
-            QueriedMemberList<M> queriedMembers = QueriedMemberList<M>.Create(this, optionalName, ignoreCase: ignoreCase, declaredOnly: declaredOnly);
+
+            TypeComponentsCache cache = Cache;
+            QueriedMemberList<M> queriedMembers;
+            if (optionalName == null)
+                queriedMembers = cache.GetQueriedMembers<M>();
+            else
+                queriedMembers = cache.GetQueriedMembers<M>(optionalName, ignoreCase: ignoreCase);
+
             if (optionalPredicate != null)
                 queriedMembers = queriedMembers.Filter(optionalPredicate);
             return new QueryResult<M>(bindingAttr, queriedMembers);
@@ -128,6 +134,10 @@ namespace System.Reflection.Runtime.TypeInfos
             const BindingFlags SearchRelatedBits = BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
             return (bindingFlags & ~SearchRelatedBits) == 0;
         }
+
+        private TypeComponentsCache Cache => _lazyCache ?? (_lazyCache = new TypeComponentsCache(this));
+
+        private volatile TypeComponentsCache _lazyCache;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.TypeComponentsCache.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.TypeComponentsCache.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Reflection.Runtime.BindingFlagSupport;
+
+using Unsafe = System.Runtime.CompilerServices.Unsafe;
+
+namespace System.Reflection.Runtime.TypeInfos
+{
+    internal abstract partial class RuntimeTypeInfo
+    {
+        //================================================================================================================
+        // TypeComponentsCache objects are allocated on-demand on a per-Type basis to cache hot data for key scenarios.
+        // To maximize throughput once the cache is created, the object creates all of its internal caches up front
+        // and holds entries strongly (and relying on the fact that Types themselves are held weakly to avoid immortality.)
+        //
+        // Note that it is possible that two threads racing to query the same TypeInfo may allocate and query two different
+        // cache objects. Thus, this object must not be relied upon to preserve object identity.
+        //================================================================================================================
+
+        private sealed class TypeComponentsCache
+        {
+            public TypeComponentsCache(RuntimeTypeInfo type)
+            {
+                _type = type;
+
+                _perNameQueryCaches_CaseSensitive = CreatePerNameQueryCaches(type, ignoreCase: false);
+                _perNameQueryCaches_CaseInsensitive = CreatePerNameQueryCaches(type, ignoreCase: true);
+
+                _nameAgnosticQueryCaches = new object[MemberTypeIndex.Count];
+            }
+
+            //
+            // Returns the cached result of a name-specific query on the Type's members, as if you'd passed in
+            //
+            //  BindingFlags == Public | NonPublic | Instance | Static | FlattenHierarchy
+            //
+            public QueriedMemberList<M> GetQueriedMembers<M>(string name, bool ignoreCase) where M : MemberInfo
+            {
+                int index = MemberPolicies<M>.MemberTypeIndex;
+                object obj = ignoreCase ? _perNameQueryCaches_CaseInsensitive[index] : _perNameQueryCaches_CaseSensitive[index];
+                Debug.Assert(obj is PerNameQueryCache<M>);
+                PerNameQueryCache<M> unifier = Unsafe.As<PerNameQueryCache<M>>(obj);
+                QueriedMemberList<M> result = unifier.GetOrAdd(name);
+                return result;
+            }
+
+            //
+            // Returns the cached result of a name-agnostic query on the Type's members, as if you'd passed in
+            //
+            //  BindingFlags == Public | NonPublic | Instance | Static | FlattenHierarchy
+            //
+            public QueriedMemberList<M> GetQueriedMembers<M>() where M : MemberInfo
+            {
+                int index = MemberPolicies<M>.MemberTypeIndex;
+                object result = Volatile.Read(ref _nameAgnosticQueryCaches[index]);
+                if (result == null)
+                {
+                    QueriedMemberList<M> newResult = QueriedMemberList<M>.Create(_type, optionalNameFilter: null, ignoreCase: false);
+                    newResult.Compact();
+                    result = newResult;
+                    Volatile.Write(ref _nameAgnosticQueryCaches[index], result);
+                }
+
+                Debug.Assert(result is QueriedMemberList<M>);
+                return Unsafe.As<QueriedMemberList<M>>(result);
+            }
+
+            private static object[] CreatePerNameQueryCaches(RuntimeTypeInfo type, bool ignoreCase)
+            {
+                object[] perNameCaches = new object[MemberTypeIndex.Count];
+                perNameCaches[MemberTypeIndex.Constructor] = new PerNameQueryCache<ConstructorInfo>(type, ignoreCase: ignoreCase);
+                perNameCaches[MemberTypeIndex.Event] = new PerNameQueryCache<EventInfo>(type, ignoreCase: ignoreCase);
+                perNameCaches[MemberTypeIndex.Field] = new PerNameQueryCache<FieldInfo>(type, ignoreCase: ignoreCase);
+                perNameCaches[MemberTypeIndex.Method] = new PerNameQueryCache<MethodInfo>(type, ignoreCase: ignoreCase);
+                perNameCaches[MemberTypeIndex.Property] = new PerNameQueryCache<PropertyInfo>(type, ignoreCase: ignoreCase);
+                perNameCaches[MemberTypeIndex.NestedType] = new PerNameQueryCache<Type>(type, ignoreCase: ignoreCase);
+                return perNameCaches;
+            }
+
+            // This array holds six PerNameQueryCache<M> objects, one for each of the possible M types (ConstructorInfo, EventInfo, etc.)
+            // The caches are configured to do a case-sensitive query.
+            private readonly object[] _perNameQueryCaches_CaseSensitive;
+
+            // This array holds six PerNameQueryCache<M> objects, one for each of the possible M types (ConstructorInfo, EventInfo, etc.)
+            // The caches are configured to do a case-insensitive query.
+            private readonly object[] _perNameQueryCaches_CaseInsensitive;
+
+            // This array holds six lazily created QueriedMemberList<M> objects, one for each of the possible M types (ConstructorInfo, EventInfo, etc.).
+            // The objects are the results of a name-agnostic query.
+            private readonly object[] _nameAgnosticQueryCaches;
+
+            private readonly RuntimeTypeInfo _type;
+
+            //
+            // Each PerName cache persists the results of a Type.Get(name, bindingFlags) for a particular MemberInfoType "M".
+            //
+            // where "bindingFlags" == Public | NonPublic | Instance | Static | FlattenHierarchy
+            //
+            // In addition, if "ignoreCase" was passed to the constructor, BindingFlags.IgnoreCase is also in effect.
+            //
+            private sealed class PerNameQueryCache<M> : ConcurrentUnifier<string, QueriedMemberList<M>> where M : MemberInfo
+            {
+                public PerNameQueryCache(RuntimeTypeInfo type, bool ignoreCase)
+                {
+                    _type = type;
+                    _ignoreCase = ignoreCase;
+                }
+
+                protected sealed override QueriedMemberList<M> Factory(string key)
+                {
+                    QueriedMemberList<M> result = QueriedMemberList<M>.Create(_type, key, ignoreCase: _ignoreCase);
+                    result.Compact();
+                    return result;
+                }
+
+                private readonly RuntimeTypeInfo _type;
+                private readonly bool _ignoreCase;
+            }
+        }
+    }
+}
+

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -706,6 +706,11 @@ namespace System.Reflection.Runtime.TypeInfos
         internal abstract RuntimeTypeHandle InternalTypeHandleIfAvailable { get; }
 
         //
+        // Returns true if it's possible to ask for a list of members and the base type without triggering a MissingMetadataException.
+        //
+        internal abstract bool CanBrowseWithoutMissingMetadataExceptions { get; }
+
+        //
         // The non-public version of TypeInfo.GenericTypeParameters (does not array-copy.)
         //
         internal virtual RuntimeTypeInfo[] RuntimeGenericTypeParameters


### PR DESCRIPTION
This mirrors CoreClr's strategy (organize caches
by the name used to lookup, then filter it for BindingFlags
combinations on each lookup.)

The cache is its own object so Types that don't
get queried pay the storage cost. In addition,
the creation of the cache is a useful signal
that the Type is being queried. This could be
used as a heuristic for keeping the Type alive
for longer than the normal weak-reference lifetime.

There are safeguards built in to ensure
that DeclaredOnly searches don't get bollixed due
to MissingMetadataExceptions in base classes they
have no interest in (not sure if the reducer
can generate this case today, but it's cheap
insurance.)