### PR TITLE
Disable caching of binding flag results.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
@@ -135,7 +135,7 @@ namespace System.Reflection.Runtime.TypeInfos
             return (bindingFlags & ~SearchRelatedBits) == 0;
         }
 
-        private TypeComponentsCache Cache => _lazyCache ?? (_lazyCache = new TypeComponentsCache(this));
+        private TypeComponentsCache Cache => /* _lazyCache ?? (_lazyCache =*/ (new TypeComponentsCache(this));
 
         private volatile TypeComponentsCache _lazyCache;
     }


### PR DESCRIPTION
Until we can-root cause why this breaks
managed language support.