### PR TITLE
Make SetValue()/Invoke() more useful with InvokeMember.

### DIFF
--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -270,4 +270,7 @@
   <data name="NotSupported_ChangeType" xml:space="preserve">
     <value>ChangeType operation is not supported.</value>
   </data>
+  <data name="PlatformNotSupported_CustomBinder" xml:space="preserve">
+    <value>Passing a binder object other than Type.DefaultBinder is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -159,8 +159,7 @@ namespace System.Reflection.Runtime.FieldInfos
                 ReflectionTrace.FieldInfo_SetValue(this, obj, value);
 #endif
 
-            if (invokeAttr != BindingFlags.Default || !(binder is DefaultBinder) || culture != null)
-                throw new NotImplementedException();
+            binder.EnsureNotCustomBinder();
 
             FieldAccessor fieldAccessor = this.FieldAccessor;
             fieldAccessor.SetField(obj, value);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -11,6 +11,7 @@ using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.TypeInfos;
 using System.Reflection.Runtime.Assemblies;
+using DefaultBinder = System.Reflection.Runtime.BindingFlagSupport.DefaultBinder;
 
 using IRuntimeImplementedType = Internal.Reflection.Core.NonPortable.IRuntimeImplementedType;
 using Internal.LowLevelLinq;
@@ -158,5 +159,12 @@ namespace System.Reflection.Runtime.General
         }
 
         private static readonly char[] s_charsToEscape = new char[] { '\\', '[', ']', '+', '*', '&', ',' };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void EnsureNotCustomBinder(this Binder binder)
+        {
+            if (!(binder == null || binder is DefaultBinder))
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_CustomBinder);
+        }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
 using System.Reflection.Runtime.ParameterInfos;
 
@@ -74,9 +75,7 @@ namespace System.Reflection.Runtime.MethodInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodBase_Invoke(this, obj, parameters);
 #endif
-
-            if (invokeAttr != BindingFlags.Default || binder != null || culture != null)
-                throw new NotImplementedException();
+            binder.EnsureNotCustomBinder();
 
             if (parameters == null)
                 parameters = Array.Empty<Object>();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -153,8 +153,7 @@ namespace System.Reflection.Runtime.MethodInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodBase_Invoke(this, obj, parameters);
 #endif
-            if (invokeAttr != BindingFlags.Default || binder != null || culture != null)
-                throw new NotImplementedException();
+            binder.EnsureNotCustomBinder();
 
             if (parameters == null)
                 parameters = Array.Empty<Object>();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -96,8 +96,7 @@ namespace System.Reflection.Runtime.MethodInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.ConstructorInfo_Invoke(this, parameters);
 #endif
-            if (invokeAttr != BindingFlags.Default || binder != null || culture != null)
-                throw new NotImplementedException();
+            binder.EnsureNotCustomBinder();
 
             if (parameters == null)
                 parameters = Array.Empty<Object>();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
@@ -65,8 +65,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
         {
-            if (invokeAttr != BindingFlags.Default || binder != null || culture != null)
-                throw new NotImplementedException();
+            binder.EnsureNotCustomBinder();
 
             if (parameters == null)
                 parameters = Array.Empty<Object>();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -190,8 +190,7 @@ namespace System.Reflection.Runtime.PropertyInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.PropertyInfo_GetValue(this, obj, index);
 #endif
-            if (invokeAttr != BindingFlags.Default || binder != null || culture != null)
-                throw new NotImplementedException();
+            binder.EnsureNotCustomBinder();
 
             if (_lazyGetterInvoker == null)
             {
@@ -277,8 +276,7 @@ namespace System.Reflection.Runtime.PropertyInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.PropertyInfo_SetValue(this, obj, value, index);
 #endif
-            if (invokeAttr != BindingFlags.Default || binder != null || culture != null)
-                throw new NotImplementedException();
+            binder.EnsureNotCustomBinder();
 
             if (_lazySetterInvoker == null)
             {


### PR DESCRIPTION
After a more rigorous study of these apis behavior,
loosen some of the restrictions we put in when
we first brought up these api.

- We don't need to restrict the value of BindingFlags.

  The only one that these apis pay attention to
  is BindingFlags.ExactBinding. Other bits tend to
  leak in (through InvokeMember() or careless apps)
  but the apis ignore them.

  ExactBinding only prevents calling out to a custom
  binder as a fallback if Reflection can't convert the
  arguments itself.

  If the binder is the DefaultBinder, there's no
  ill effect to not checking ExactBindings as the end
  result is the same. The code logic in CoreClr looks
  like this:

   // All of our attempts to convert the argument have
   // failed. Time to consult a binder?

   if ((invokeAttr & BindingFlags.ExactBinding) != 0)
   {
       // Nope - caller set the flag that says "don't call a binder."

       throw new ArgumentException("Can't convert argument.");
   }

   if (binder is DefaultBinder)
   {
       // Don't call the DefaultBinder - he's useless.
       // Type.DefaultBinder.ChangeType() throws a
       // NotSupportedException. We want an ArgumentException.

       throw new ArgumentException("Can't convert argument.");
   }

   // Call the third party binder.
   object convertedValue = binder.ChangeType(...);

- We don't need to restrict the value of "culture."

  The only time it's important is if we invoke a third party
  binder - then we pass the culture as-is (null or not)
  to the binder's ChangeType() method.

- We will continue to refuse third party binders.

  This is not a priority for November and it's quite
  a pain to implement as the ".NetCore 1.0" conversion
  policy is hard-wired in a number of places.