### PR TITLE
Add TypeSystemEntity as a root type in the type system

### DIFF
--- a/src/Common/src/TypeSystem/Common/FieldDesc.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.cs
@@ -9,7 +9,7 @@ using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem
 {
-    public abstract partial class FieldDesc
+    public abstract partial class FieldDesc : TypeSystemEntity
     {
         public readonly static FieldDesc[] EmptyFields = new FieldDesc[0];
 
@@ -32,11 +32,6 @@ namespace Internal.TypeSystem
             {
                 return null;
             }
-        }
-
-        public abstract TypeSystemContext Context
-        {
-            get;
         }
 
         public abstract DefType OwningType

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -209,7 +209,7 @@ namespace Internal.TypeSystem
     /// <summary>
     /// Represents the fundamental base type for all methods within the type system.
     /// </summary>
-    public abstract partial class MethodDesc
+    public abstract partial class MethodDesc : TypeSystemEntity
     {
         public readonly static MethodDesc[] EmptyMethods = new MethodDesc[0];
 
@@ -258,14 +258,6 @@ namespace Internal.TypeSystem
             // Its only valid to compare two MethodDescs in the same context
             Debug.Assert(Object.ReferenceEquals(o, null) || !(o is MethodDesc) || Object.ReferenceEquals(((MethodDesc)o).Context, this.Context));
             return Object.ReferenceEquals(this, o);
-        }
-
-        /// <summary>
-        /// Gets the type system context this method belongs to.
-        /// </summary>
-        public abstract TypeSystemContext Context
-        {
-            get;
         }
 
         /// <summary>

--- a/src/Common/src/TypeSystem/Common/ModuleDesc.cs
+++ b/src/Common/src/TypeSystem/Common/ModuleDesc.cs
@@ -6,15 +6,11 @@ using System.Collections.Generic;
 
 namespace Internal.TypeSystem
 {
-    public abstract partial class ModuleDesc
+    public abstract partial class ModuleDesc : TypeSystemEntity
     {
-        /// <summary>
-        /// Gets the type system context the module belongs to.
-        /// </summary>
-        public TypeSystemContext Context
+        public override TypeSystemContext Context
         {
             get;
-            private set;
         }
 
         public ModuleDesc(TypeSystemContext context)

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -12,7 +12,7 @@ namespace Internal.TypeSystem
     /// <summary>
     /// Represents the fundamental base type of all types within the type system.
     /// </summary>
-    public abstract partial class TypeDesc
+    public abstract partial class TypeDesc : TypeSystemEntity
     {
         public static readonly TypeDesc[] EmptyTypes = new TypeDesc[0];
 
@@ -45,14 +45,6 @@ namespace Internal.TypeSystem
 
         // The most frequently used type properties are cached here to avoid excesive virtual calls
         private TypeFlags _typeFlags;
-
-        /// <summary>
-        /// Gets the type system context this type belongs to.
-        /// </summary>
-        public abstract TypeSystemContext Context
-        {
-            get;
-        }
 
         /// <summary>
         /// Gets the generic instantiation information of this type.

--- a/src/Common/src/TypeSystem/Common/TypeSystemEntity.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemEntity.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    public abstract class TypeSystemEntity
+    {
+        /// <summary>
+        /// Gets the type system context this entity belongs to.
+        /// </summary>
+        public abstract TypeSystemContext Context { get; }
+    }
+}

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -92,6 +92,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\ModuleDesc.cs">
       <Link>TypeSystem\Common\ModuleDesc.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeSystemEntity.cs">
+      <Link>TypeSystem\Common\TypeSystemEntity.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\CustomAttributeTypeNameParser.cs">
       <Link>Utilities\CustomAttributeTypeNameParser.cs</Link>
     </Compile>


### PR DESCRIPTION
In my shared generics work there are some spots where we carry a method or a type. In those places I have to type things as `object`, which is unfortunate. Having a common root type would make things at least a bit less gross.

There's also at least one spot where I would like to ask about the type system context the object-typed thing is associated with - this makes that part clean.

(I don't insist that we check this in, but sending it out for consideration. @davidwrighton didn't have objections when we chatted about it a few weeks ago.)