### PR TITLE
Port Type.InvokeMember()

### DIFF
--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -291,4 +291,62 @@
   <data name="Acc_CreateVoid" xml:space="preserve">
     <value>Cannot dynamically create an instance of System.Void.</value>
   </data>
+
+  <data name="Arg_GenericParameter" xml:space="preserve">
+    <value>Method must be called on a Type for which Type.IsGenericParameter is false.</value>
+  </data>
+  <data name="Arg_NoAccessSpec" xml:space="preserve">
+    <value>Must specify binding flags describing the invoke operation required (BindingFlags.InvokeMethod CreateInstance GetField SetField GetProperty SetProperty).</value>
+  </data>
+  <data name="Arg_NamedParamTooBig" xml:space="preserve">
+    <value>Named parameter array cannot be bigger than argument array.</value>
+  </data>
+  <data name="Arg_COMAccess" xml:space="preserve">
+    <value>Must specify property Set or Get or method call for a COM Object.</value>
+  </data>
+  <data name="Arg_PropSetGet" xml:space="preserve">
+    <value>Cannot specify both Get and Set on a property.</value>
+  </data>
+  <data name="Arg_PropSetInvoke" xml:space="preserve">
+    <value>Cannot specify Set on a property and Invoke on a method.</value>
+  </data>
+  <data name="Arg_COMPropSetPut" xml:space="preserve">
+    <value>Only one of the following binding flags can be set: BindingFlags.SetProperty, BindingFlags.PutDispProperty,  BindingFlags.PutRefDispProperty.</value>
+  </data>
+  <data name="Arg_NamedParamNull" xml:space="preserve">
+    <value>Named parameter value must not be null.</value>
+  </data>
+  <data name="Arg_CreatInstAccess" xml:space="preserve">
+    <value>Cannot specify both CreateInstance and another access type.</value>
+  </data>
+  <data name="Arg_FldSetGet" xml:space="preserve">
+    <value>Cannot specify both Get and Set on a field.</value>
+  </data>
+  <data name="Arg_FldGetPropSet" xml:space="preserve">
+    <value>Cannot specify both GetField and SetProperty.</value>
+  </data>
+  <data name="Arg_FldSetPropGet" xml:space="preserve">
+    <value>Cannot specify both SetField and GetProperty.</value>
+  </data>
+  <data name="Arg_FldSetInvoke" xml:space="preserve">
+    <value>Cannot specify Set on a Field and Invoke on a method.</value>
+  </data>
+  <data name="Arg_IndexMustBeInt" xml:space="preserve">
+    <value>All indexes must be of type Int32.</value>
+  </data>
+  <data name="Arg_FldGetArgErr" xml:space="preserve">
+    <value>No arguments can be provided to Get a field value.</value>
+  </data>
+  <data name="Arg_FldSetArgErr" xml:space="preserve">
+    <value>Only the field value can be specified to set a field value.</value>
+  </data>
+  <data name="Arg_PropSetGet" xml:space="preserve">
+    <value>Cannot specify both Get and Set on a property.</value>
+  </data>
+  <data name="Arg_PropSetInvoke" xml:space="preserve">
+    <value>Cannot specify Set on a property and Invoke on a method.</value>
+  </data>
+  <data name="Arg_PlatformNotSupportedInvokeMemberCom" xml:space="preserve">
+    <value>InvokeMember on a COM object is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -130,6 +130,7 @@
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.GetMember.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.BindingFlags.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.CoreGetDeclared.cs" />
+    <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.InvokeMember.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.TypeComponentsCache.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\GetTypeOptions.cs" />
     <Compile Include="System\Reflection\Runtime\TypeParsing\TypeName.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -120,6 +120,5 @@ namespace System.Reflection.Runtime.TypeInfos
 {
     internal abstract partial class RuntimeTypeInfo
     {
-        public sealed override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) { throw new NotImplementedException(); }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -191,26 +191,8 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override MemberInfo[] GetDefaultMembers()
         {
-            Type defaultMemberAttributeType = typeof(DefaultMemberAttribute);
-            for (Type type = this; type != null; type = type.BaseType)
-            {
-                foreach (CustomAttributeData attribute in type.CustomAttributes)
-                {
-                    if (attribute.AttributeType == defaultMemberAttributeType)
-                    {
-                        // NOTE: Neither indexing nor cast can fail here. Any attempt to use fewer than 1 argument
-                        // or a non-string argument would correctly trigger MissingMethodException before
-                        // we reach here as that would be an attempt to reference a non-existent DefaultMemberAttribute
-                        // constructor.
-                        Debug.Assert(attribute.ConstructorArguments.Count == 1 && attribute.ConstructorArguments[0].Value is string);
-
-                        string memberName = (string)(attribute.ConstructorArguments[0].Value);
-                        return GetMember(memberName);
-                    }
-                }
-            }
-
-            return Array.Empty<MemberInfo>();
+            string defaultMemberName = GetDefaultMemberName();
+            return defaultMemberName != null ? GetMember(defaultMemberName) : Array.Empty<MemberInfo>();
         }
 
         public sealed override InterfaceMapping GetInterfaceMap(Type interfaceType)
@@ -849,6 +831,30 @@ namespace System.Reflection.Runtime.TypeInfos
                 }
                 return baseType;
             }
+        }
+
+        private string GetDefaultMemberName()
+        {
+            Type defaultMemberAttributeType = typeof(DefaultMemberAttribute);
+            for (Type type = this; type != null; type = type.BaseType)
+            {
+                foreach (CustomAttributeData attribute in type.CustomAttributes)
+                {
+                    if (attribute.AttributeType == defaultMemberAttributeType)
+                    {
+                        // NOTE: Neither indexing nor cast can fail here. Any attempt to use fewer than 1 argument
+                        // or a non-string argument would correctly trigger MissingMethodException before
+                        // we reach here as that would be an attempt to reference a non-existent DefaultMemberAttribute
+                        // constructor.
+                        Debug.Assert(attribute.ConstructorArguments.Count == 1 && attribute.ConstructorArguments[0].Value is string);
+
+                        string memberName = (string)(attribute.ConstructorArguments[0].Value);
+                        return memberName;
+                    }
+                }
+            }
+
+            return null;
         }
 
         //


### PR DESCRIPTION
Fix: https://github.com/dotnet/corert/issues/1872

Limitation: Cannot use for RCW's. InvokeMember
turns into a completely different api when you
pass one in.