### PR TITLE
Optimize InstantiateSignature for parameterized types

### DIFF
--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -118,8 +118,12 @@ namespace Internal.TypeSystem
 
         public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            TypeDesc instantiatedElementType = this.ElementType.InstantiateSignature(typeInstantiation, methodInstantiation);
-            return instantiatedElementType.Context.GetArrayType(instantiatedElementType, _rank);
+            TypeDesc elementType = this.ElementType;
+            TypeDesc instantiatedElementType = elementType.InstantiateSignature(typeInstantiation, methodInstantiation);
+            if (instantiatedElementType != elementType)
+                return Context.GetArrayType(instantiatedElementType, _rank);
+
+            return this;
         }
 
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)

--- a/src/Common/src/TypeSystem/Common/ByRefType.cs
+++ b/src/Common/src/TypeSystem/Common/ByRefType.cs
@@ -21,8 +21,12 @@ namespace Internal.TypeSystem
 
         public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            TypeDesc instantiatedParameterType = this.ParameterType.InstantiateSignature(typeInstantiation, methodInstantiation);
-            return instantiatedParameterType.MakeByRefType();
+            TypeDesc parameterType = this.ParameterType;
+            TypeDesc instantiatedParameterType = parameterType.InstantiateSignature(typeInstantiation, methodInstantiation);
+            if (instantiatedParameterType != parameterType)
+                return Context.GetByRefType(instantiatedParameterType);
+
+            return this;
         }
 
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)

--- a/src/Common/src/TypeSystem/Common/PointerType.cs
+++ b/src/Common/src/TypeSystem/Common/PointerType.cs
@@ -21,8 +21,12 @@ namespace Internal.TypeSystem
 
         public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            TypeDesc instantiatedParameterType = this.ParameterType.InstantiateSignature(typeInstantiation, methodInstantiation);
-            return instantiatedParameterType.Context.GetPointerType(instantiatedParameterType);
+            TypeDesc parameterType = this.ParameterType;
+            TypeDesc instantiatedParameterType = parameterType.InstantiateSignature(typeInstantiation, methodInstantiation);
+            if (instantiatedParameterType != parameterType)
+                return Context.GetPointerType(instantiatedParameterType);
+
+            return this;
         }
 
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)


### PR DESCRIPTION
I was making a change around these code paths when I noticed we don't do
the optimization for "no work needed" case.