### PR TITLE
Fix virtual override detection on generic methods

### DIFF
--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -49,6 +49,9 @@ namespace System
         public virtual bool IsGenericType => false;
         public virtual bool IsGenericTypeDefinition => false;
 
+        // Not an api but can't be declared "internal" because of Corelib/Reflection.Core divide. Returns true if and only if type is a vector (not a multidim array of rank 1.)
+        public virtual bool IsSzArray {  get { throw NotImplemented.ByDesign; } }
+
         public bool HasElementType => HasElementTypeImpl();
         protected abstract bool HasElementTypeImpl();
         public abstract Type GetElementType();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/ConstructorPolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/ConstructorPolicies.cs
@@ -41,11 +41,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             isNewSlot = false;
         }
 
-        public sealed override bool AreNamesAndSignatureEqual(ConstructorInfo member1, ConstructorInfo member2)
-        {
-            Debug.Assert(false, "This code path should be unreachable as constructors are never \"virtual\".");
-            throw new NotSupportedException();
-        }
+        public sealed override bool ImplicitlyOverrides(ConstructorInfo baseMember, ConstructorInfo derivedMember) => false;
 
         public sealed override bool IsSuppressedByMoreDerivedMember(ConstructorInfo member, ConstructorInfo[] priorMembers, int startIndex, int endIndex)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/EventPolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/EventPolicies.cs
@@ -48,9 +48,11 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             return false;
         }
 
-        public sealed override bool AreNamesAndSignatureEqual(EventInfo member1, EventInfo member2)
+        public sealed override bool ImplicitlyOverrides(EventInfo baseMember, EventInfo derivedMember)
         {
-            return AreNamesAndSignaturesEqual(GetAccessorMethod(member1), GetAccessorMethod(member2));
+            MethodInfo baseAccessor = GetAccessorMethod(baseMember);
+            MethodInfo derivedAccessor = GetAccessorMethod(derivedMember);
+            return MemberPolicies<MethodInfo>.Default.ImplicitlyOverrides(baseAccessor, derivedAccessor);
         }
 
         public sealed override bool OkToIgnoreAmbiguity(EventInfo m1, EventInfo m2)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/FieldPolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/FieldPolicies.cs
@@ -34,11 +34,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             isNewSlot = false;
         }
 
-        public sealed override bool AreNamesAndSignatureEqual(FieldInfo member1, FieldInfo member2)
-        {
-            Debug.Assert(false, "This code path should be unreachable as fields are never \"virtual\".");
-            throw new NotSupportedException();
-        }
+        public sealed override bool ImplicitlyOverrides(FieldInfo baseMember, FieldInfo derivedMember) => false;
 
         public sealed override bool IsSuppressedByMoreDerivedMember(FieldInfo member, FieldInfo[] priorMembers, int startIndex, int endIndex)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MethodPolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MethodPolicies.cs
@@ -34,9 +34,10 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             isNewSlot = (0 != (methodAttributes & MethodAttributes.NewSlot));
         }
 
-        public sealed override bool AreNamesAndSignatureEqual(MethodInfo member1, MethodInfo member2)
+        public sealed override bool ImplicitlyOverrides(MethodInfo baseMember, MethodInfo derivedMember)
         {
-            return AreNamesAndSignaturesEqual(member1, member2);
+            // TODO (https://github.com/dotnet/corert/issues/1896) Comparing signatures is lame. The runtime and/or toolchain should have a way of sharing this info.
+            return AreNamesAndSignaturesEqual(baseMember, derivedMember);
         }
 
         //
@@ -53,7 +54,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                 MethodAttributes attributes = prior.Attributes & (MethodAttributes.Virtual | MethodAttributes.VtableLayoutMask);
                 if (attributes != (MethodAttributes.Virtual | MethodAttributes.ReuseSlot))
                     continue;
-                if (!AreNamesAndSignatureEqual(prior, member))
+                if (!ImplicitlyOverrides(member, prior))
                     continue;
 
                 return true;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/NestedTypePolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/NestedTypePolicies.cs
@@ -47,11 +47,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             visibility = member.IsNestedPublic ? MethodAttributes.Public : MethodAttributes.Private;
         }
 
-        public sealed override bool AreNamesAndSignatureEqual(Type member1, Type member2)
-        {
-            Debug.Assert(false, "This code path should be unreachable as nested types are never \"virtual\".");
-            throw new NotSupportedException();
-        }
+        public sealed override bool ImplicitlyOverrides(Type baseMember, Type derivedMember) => false;
 
         public sealed override bool IsSuppressedByMoreDerivedMember(Type member, Type[] priorMembers, int startIndex, int endIndex)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/PropertyPolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/PropertyPolicies.cs
@@ -48,9 +48,11 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             isNewSlot = (0 != (methodAttributes & MethodAttributes.NewSlot));
         }
 
-        public sealed override bool AreNamesAndSignatureEqual(PropertyInfo member1, PropertyInfo member2)
+        public sealed override bool ImplicitlyOverrides(PropertyInfo baseMember, PropertyInfo derivedMember)
         {
-            return AreNamesAndSignaturesEqual(GetAccessorMethod(member1), GetAccessorMethod(member2));
+            MethodInfo baseAccessor = GetAccessorMethod(baseMember);
+            MethodInfo derivedAccessor = GetAccessorMethod(derivedMember);
+            return MemberPolicies<MethodInfo>.Default.ImplicitlyOverrides(baseAccessor, derivedAccessor);
         }
 
         //
@@ -59,12 +61,14 @@ namespace System.Reflection.Runtime.BindingFlagSupport
         //
         public sealed override bool IsSuppressedByMoreDerivedMember(PropertyInfo member, PropertyInfo[] priorMembers, int startIndex, int endIndex)
         {
+            MethodInfo baseAccessor = GetAccessorMethod(member);
             for (int i = startIndex; i < endIndex; i++)
             {
                 PropertyInfo prior = priorMembers[i];
-                if (!AreNamesAndSignatureEqual(prior, member))
+                MethodInfo derivedAccessor = GetAccessorMethod(prior);
+                if (!AreNamesAndSignaturesEqual(baseAccessor, derivedAccessor))
                     continue;
-                if (GetAccessorMethod(prior).IsStatic != GetAccessorMethod(member).IsStatic)
+                if (derivedAccessor.IsStatic != baseAccessor.IsStatic)
                     continue;
                 if (!(prior.PropertyType.Equals(member.PropertyType)))
                     continue;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/Shared.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/Shared.cs
@@ -184,7 +184,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                     {
                         continue;
                     }
-                    if (!policies.AreNamesAndSignatureEqual(member, candidate))
+                    if (!policies.ImplicitlyOverrides(candidate, member))
                     {
                         continue;
                     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -335,6 +335,14 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        public sealed override bool IsSzArray
+        {
+            get
+            {
+                return IsArrayImpl() && !InternalIsMultiDimArray;
+            }
+        }
+
         public sealed override MemberTypes MemberType
         {
             get


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/9325

This also better separates out the functionality
of detecting virtual overrides (a task better left
to the runtime, but we don't have that protocol
now) and actually comparing signatures (which
sometimes we have to do to be compatible with
CoreClr.)

I've opened up a new issue

  (https://github.com/dotnet/corert/issues/1896)

to track the virtual override detection issue.