### PR TITLE
Latch accessor methods for Properties and Events.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -99,6 +99,7 @@
     <Compile Include="System\Reflection\Runtime\MethodInfos\OpenMethodInvoker.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\RuntimeConstructedGenericMethodInfo.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\RuntimeConstructorInfo.cs" />
+    <Compile Include="System\Reflection\Runtime\MethodInfos\RuntimeDummyMethodInfo.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\RuntimePlainConstructorInfo.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\RuntimeSyntheticConstructorInfo.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\RuntimeMethodCommon.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -64,15 +64,20 @@ namespace System.Reflection.Runtime.EventInfos
                     ReflectionTrace.EventInfo_AddMethod(this);
 #endif
 
-                foreach (MethodSemanticsHandle methodSemanticsHandle in _event.MethodSemantics)
+                MethodInfo adder = _lazyAdder;
+                if (adder == null)
                 {
-                    MethodSemantics methodSemantics = methodSemanticsHandle.GetMethodSemantics(_reader);
-                    if (methodSemantics.Attributes == MethodSemanticsAttributes.AddOn)
+                    foreach (MethodSemanticsHandle methodSemanticsHandle in _event.MethodSemantics)
                     {
-                        return RuntimeNamedMethodInfo.GetRuntimeNamedMethodInfo(methodSemantics.Method, _definingTypeInfo, _contextTypeInfo, _reflectedType);
+                        MethodSemantics methodSemantics = methodSemanticsHandle.GetMethodSemantics(_reader);
+                        if (methodSemantics.Attributes == MethodSemanticsAttributes.AddOn)
+                        {
+                            return _lazyAdder = RuntimeNamedMethodInfo.GetRuntimeNamedMethodInfo(methodSemantics.Method, _definingTypeInfo, _contextTypeInfo, _reflectedType);
+                        }
                     }
+                    throw new BadImageFormatException(); // Added is a required method.
                 }
-                throw new BadImageFormatException(); // Added is a required method.
+                return adder;
             }
         }
 
@@ -209,15 +214,20 @@ namespace System.Reflection.Runtime.EventInfos
                     ReflectionTrace.EventInfo_RemoveMethod(this);
 #endif
 
-                foreach (MethodSemanticsHandle methodSemanticsHandle in _event.MethodSemantics)
+                MethodInfo remover = _lazyRemover;
+                if (remover == null)
                 {
-                    MethodSemantics methodSemantics = methodSemanticsHandle.GetMethodSemantics(_reader);
-                    if (methodSemantics.Attributes == MethodSemanticsAttributes.RemoveOn)
+                    foreach (MethodSemanticsHandle methodSemanticsHandle in _event.MethodSemantics)
                     {
-                        return RuntimeNamedMethodInfo.GetRuntimeNamedMethodInfo(methodSemantics.Method, _definingTypeInfo, _contextTypeInfo, _reflectedType);
+                        MethodSemantics methodSemantics = methodSemanticsHandle.GetMethodSemantics(_reader);
+                        if (methodSemantics.Attributes == MethodSemanticsAttributes.RemoveOn)
+                        {
+                            return _lazyRemover = RuntimeNamedMethodInfo.GetRuntimeNamedMethodInfo(methodSemantics.Method, _definingTypeInfo, _contextTypeInfo, _reflectedType);
+                        }
                     }
+                    throw new BadImageFormatException(); // Removed is a required method.
                 }
-                throw new BadImageFormatException(); // Removed is a required method.
+                return remover;
             }
         }
 
@@ -271,6 +281,9 @@ namespace System.Reflection.Runtime.EventInfos
 
         private readonly MetadataReader _reader;
         private readonly Event _event;
+
+        private volatile MethodInfo _lazyAdder;
+        private volatile MethodInfo _lazyRemover;
 
         private String _debugName;
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeDummyMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeDummyMethodInfo.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection.Runtime.ParameterInfos;
+using System.Reflection.Runtime.TypeInfos;
+using Internal.Reflection.Core.Execution;
+
+namespace System.Reflection.Runtime.MethodInfos
+{
+    //
+    // Singleton MethodInfo used as a sentinel for _lazy* latches where we can't use "null" as a sentinel.
+    //
+    internal sealed class RuntimeDummyMethodInfo : RuntimeMethodInfo
+    {
+        private RuntimeDummyMethodInfo() { }
+
+        public sealed override bool Equals(object obj) => object.ReferenceEquals(this, obj);
+        public sealed override int GetHashCode() => 1;
+        public sealed override string ToString() => string.Empty;
+
+        public sealed override MethodInfo GetGenericMethodDefinition() { throw NotImplemented.ByDesign; }
+        public sealed override MethodInfo MakeGenericMethod(params Type[] typeArguments) { throw NotImplemented.ByDesign; }
+        public sealed override MethodAttributes Attributes { get { throw NotImplemented.ByDesign; } }
+        public sealed override Type ReflectedType { get { throw NotImplemented.ByDesign; } }
+        public sealed override CallingConventions CallingConvention { get { throw NotImplemented.ByDesign; } }
+        public sealed override IEnumerable<CustomAttributeData> CustomAttributes { get { throw NotImplemented.ByDesign; } }
+        public sealed override bool IsGenericMethod { get { throw NotImplemented.ByDesign; } }
+        public sealed override bool IsGenericMethodDefinition { get { throw NotImplemented.ByDesign; } }
+        public sealed override MethodImplAttributes MethodImplementationFlags { get { throw NotImplemented.ByDesign; } }
+        public sealed override Module Module { get { throw NotImplemented.ByDesign; } }
+        protected sealed override MethodInvoker UncachedMethodInvoker { get { throw NotImplemented.ByDesign; } }
+        internal sealed override RuntimeParameterInfo[] GetRuntimeParameters(RuntimeMethodInfo contextMethod, out RuntimeParameterInfo returnParameter) { throw NotImplemented.ByDesign; }
+        internal sealed override RuntimeTypeInfo RuntimeDeclaringType { get { throw NotImplemented.ByDesign; } }
+        internal sealed override string RuntimeName { get { throw NotImplemented.ByDesign; } }
+        internal sealed override RuntimeTypeInfo[] RuntimeGenericArgumentsOrParameters { get { throw NotImplemented.ByDesign; } }
+
+        public static readonly RuntimeDummyMethodInfo Instance = new RuntimeDummyMethodInfo();
+    }
+}
+


### PR DESCRIPTION
These are retrieved quite a lot during the Type.Get()
lookup process as they're the source-of-truth for
questions such as "Am I public? Am I static? What's
my signature?"