### PR TITLE
Replace all uses of FoundationTypes and typeof()

### DIFF
--- a/src/Common/src/System/CommonRuntimeTypes.cs
+++ b/src/Common/src/System/CommonRuntimeTypes.cs
@@ -12,6 +12,7 @@ namespace System
     {
         internal static Type Object { get { return s_object; } }
         internal static Type ValueType { get { return s_valuetype; } }
+        internal static Type Type { get { return s_type; } }
         internal static Type Attribute { get { return s_attribute; } }
         internal static Type String { get { return s_string; } }
         internal static Type Array { get { return s_array; } }
@@ -37,6 +38,7 @@ namespace System
 
         private static Type s_object = typeof(Object);
         private static Type s_valuetype = typeof(ValueType);
+        private static Type s_type = typeof(Type);
         private static Type s_attribute = typeof(Attribute);
         private static Type s_string = typeof(String);
         private static Type s_array = typeof(Array);

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -314,37 +314,24 @@ namespace Internal.Reflection.Core.Execution
 
         internal ReflectionDomainSetup ReflectionDomainSetup { get; }
 
-        internal FoundationTypes FoundationTypes
-        {
-            get
-            {
-                return this.ReflectionDomainSetup.FoundationTypes;
-            }
-        }
+        internal IEnumerable<Type> PrimitiveTypes => s_primitiveTypes;
 
-        internal IEnumerable<Type> PrimitiveTypes
+        private static readonly Type[] s_primitiveTypes =
         {
-            get
-            {
-                FoundationTypes foundationTypes = this.FoundationTypes;
-                return new Type[]
-                {
-                    foundationTypes.SystemBoolean,
-                    foundationTypes.SystemChar,
-                    foundationTypes.SystemSByte,
-                    foundationTypes.SystemByte,
-                    foundationTypes.SystemInt16,
-                    foundationTypes.SystemUInt16,
-                    foundationTypes.SystemInt32,
-                    foundationTypes.SystemUInt32,
-                    foundationTypes.SystemInt64,
-                    foundationTypes.SystemUInt64,
-                    foundationTypes.SystemSingle,
-                    foundationTypes.SystemDouble,
-                    foundationTypes.SystemIntPtr,
-                    foundationTypes.SystemUIntPtr,
-                };
-            }
-        }
+                    CommonRuntimeTypes.Boolean,
+                    CommonRuntimeTypes.Char,
+                    CommonRuntimeTypes.SByte,
+                    CommonRuntimeTypes.Byte,
+                    CommonRuntimeTypes.Int16,
+                    CommonRuntimeTypes.UInt16,
+                    CommonRuntimeTypes.Int32,
+                    CommonRuntimeTypes.UInt32,
+                    CommonRuntimeTypes.Int64,
+                    CommonRuntimeTypes.UInt64,
+                    CommonRuntimeTypes.Single,
+                    CommonRuntimeTypes.Double,
+                    CommonRuntimeTypes.IntPtr,
+                    CommonRuntimeTypes.UIntPtr,
+        };
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/DefaultBinder.CanConvert.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/DefaultBinder.CanConvert.cs
@@ -77,46 +77,46 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
         private static TypeCode GetTypeCode(Type type)
         {
-            if (type == typeof(Boolean))
+            if (type == CommonRuntimeTypes.Boolean)
                 return TypeCode.Boolean;
 
-            if (type == typeof(Char))
+            if (type == CommonRuntimeTypes.Char)
                 return TypeCode.Char;
 
-            if (type == typeof(SByte))
+            if (type == CommonRuntimeTypes.SByte)
                 return TypeCode.SByte;
 
-            if (type == typeof(Byte))
+            if (type == CommonRuntimeTypes.Byte)
                 return TypeCode.Byte;
 
-            if (type == typeof(Int16))
+            if (type == CommonRuntimeTypes.Int16)
                 return TypeCode.Int16;
 
-            if (type == typeof(UInt16))
+            if (type == CommonRuntimeTypes.UInt16)
                 return TypeCode.UInt16;
 
-            if (type == typeof(Int32))
+            if (type == CommonRuntimeTypes.Int32)
                 return TypeCode.Int32;
 
-            if (type == typeof(UInt32))
+            if (type == CommonRuntimeTypes.UInt32)
                 return TypeCode.UInt32;
 
-            if (type == typeof(Int64))
+            if (type == CommonRuntimeTypes.Int64)
                 return TypeCode.Int64;
 
-            if (type == typeof(UInt64))
+            if (type == CommonRuntimeTypes.UInt64)
                 return TypeCode.UInt64;
 
-            if (type == typeof(Single))
+            if (type == CommonRuntimeTypes.Single)
                 return TypeCode.Single;
 
-            if (type == typeof(Double))
+            if (type == CommonRuntimeTypes.Double)
                 return TypeCode.Double;
 
-            if (type == typeof(Decimal))
+            if (type == CommonRuntimeTypes.Decimal)
                 return TypeCode.Decimal;
 
-            if (type == typeof(DateTime))
+            if (type == CommonRuntimeTypes.DateTime)
                 return TypeCode.DateTime;
 
             if (type.GetTypeInfo().IsEnum)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/DefaultBinder.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/DefaultBinder.cs
@@ -206,7 +206,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                         continue;
 
                     // the type is Object, so it will match everything
-                    if (pCls == typeof(Object))
+                    if (pCls == CommonRuntimeTypes.Object)
                         continue;
 
                     // now do a "classic" type check
@@ -463,7 +463,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                             continue;
                         }
                     }
-                    if (pCls == typeof(Object))
+                    if (pCls == CommonRuntimeTypes.Object)
                     {
                         candidates[CurIdx++] = candidates[i];
                         continue;
@@ -549,7 +549,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                     Type pCls = par[j].ParameterType;
                     if (pCls == types[j])
                         continue;
-                    if (pCls == typeof(Object))
+                    if (pCls == CommonRuntimeTypes.Object)
                         continue;
                     if (pCls.IsPrimitive)
                     {
@@ -637,7 +637,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                         // If the classes  exactly match continue
                         if (pCls == indexes[j])
                             continue;
-                        if (pCls == typeof(Object))
+                        if (pCls == CommonRuntimeTypes.Object)
                             continue;
 
                         if (pCls.IsPrimitive)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -2,20 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
-using System.Diagnostics;
-using System.Globalization;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Reflection.Runtime.General;
-using System.Reflection.Runtime.TypeInfos;
 
-using Internal.LowLevelLinq;
-using Internal.Reflection.Core;
-using Internal.Reflection.Core.Execution;
 using Internal.Reflection.Tracing;
-using Internal.Metadata.NativeFormat;
 
 namespace System.Reflection.Runtime.CustomAttributes
 {
@@ -138,7 +128,6 @@ namespace System.Reflection.Runtime.CustomAttributes
             if (argumentType == null)
                 return cat.ToString();
 
-            FoundationTypes foundationTypes = ReflectionCoreExecution.ExecutionDomain.FoundationTypes;
             Object value = cat.Value;
             TypeInfo argumentTypeInfo = argumentType.GetTypeInfo();
             if (argumentTypeInfo.IsEnum)
@@ -147,13 +136,13 @@ namespace System.Reflection.Runtime.CustomAttributes
             if (value == null)
                 return String.Format(typed ? "null" : "({0})null", argumentType.Name);
 
-            if (argumentType.Equals(foundationTypes.SystemString))
+            if (argumentType.Equals(CommonRuntimeTypes.String))
                 return String.Format("\"{0}\"", value);
 
-            if (argumentType.Equals(foundationTypes.SystemChar))
+            if (argumentType.Equals(CommonRuntimeTypes.Char))
                 return String.Format("'{0}'", value);
 
-            if (argumentType.Equals(foundationTypes.SystemType))
+            if (argumentType.Equals(CommonRuntimeTypes.Type))
                 return String.Format("typeof({0})", ((Type)value).FullName);
 
             else if (argumentType.IsArray)
@@ -165,7 +154,7 @@ namespace System.Reflection.Runtime.CustomAttributes
                 result = String.Format(@"new {0}[{1}] {{ ", elementType.GetTypeInfo().IsEnum ? elementType.FullName : elementType.Name, array.Count);
 
                 for (int i = 0; i < array.Count; i++)
-                    result += String.Format(i == 0 ? "{0}" : ", {0}", ComputeTypedArgumentString(array[i], elementType != foundationTypes.SystemObject));
+                    result += String.Format(i == 0 ? "{0}" : ", {0}", ComputeTypedArgumentString(array[i], elementType != CommonRuntimeTypes.Object));
 
                 return result += " }";
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeNormalCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeNormalCustomAttributeData.cs
@@ -245,13 +245,13 @@ namespace System.Reflection.Runtime.CustomAttributes
         //
         private CustomAttributeTypedArgument WrapInCustomAttributeTypedArgument(Object value, Type argumentType)
         {
-            if (argumentType.Equals(typeof(Object)))
+            if (argumentType.Equals(CommonRuntimeTypes.Object))
             {
                 // If the declared attribute type is System.Object, we must report the type based on the runtime value.
                 if (value == null)
-                    argumentType = typeof(String);  // Why is null reported as System.String? Because that's what the desktop CLR does.
+                    argumentType = CommonRuntimeTypes.String;  // Why is null reported as System.String? Because that's what the desktop CLR does.
                 else if (value is Type)
-                    argumentType = typeof(Type);    // value.GetType() will not actually be System.Type - rather it will be some internal implementation type. We only want to report it as System.Type.
+                    argumentType = CommonRuntimeTypes.Type;    // value.GetType() will not actually be System.Type - rather it will be some internal implementation type. We only want to report it as System.Type.
                 else
                     argumentType = value.GetType();
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
@@ -228,7 +228,7 @@ namespace System.Reflection.Runtime.General
                 {
                     case HandleType.ConstantByteValue:
                         {
-                            if (underlyingType != typeof(byte))
+                            if (underlyingType != CommonRuntimeTypes.Byte)
                                 throw new BadImageFormatException();
 
                             byte v = record.Value.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value;
@@ -237,7 +237,7 @@ namespace System.Reflection.Runtime.General
                         }
                     case HandleType.ConstantSByteValue:
                         {
-                            if (underlyingType != typeof(sbyte))
+                            if (underlyingType != CommonRuntimeTypes.SByte)
                                 throw new BadImageFormatException();
 
                             sbyte v = record.Value.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value;
@@ -246,7 +246,7 @@ namespace System.Reflection.Runtime.General
                         }
                     case HandleType.ConstantInt16Value:
                         {
-                            if (underlyingType != typeof(short))
+                            if (underlyingType != CommonRuntimeTypes.Int16)
                                 throw new BadImageFormatException();
 
                             short v = record.Value.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value;
@@ -255,7 +255,7 @@ namespace System.Reflection.Runtime.General
                         }
                     case HandleType.ConstantUInt16Value:
                         {
-                            if (underlyingType != typeof(ushort))
+                            if (underlyingType != CommonRuntimeTypes.UInt16)
                                 throw new BadImageFormatException();
 
                             ushort v = record.Value.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value;
@@ -264,7 +264,7 @@ namespace System.Reflection.Runtime.General
                         }
                     case HandleType.ConstantInt32Value:
                         {
-                            if (underlyingType != typeof(int))
+                            if (underlyingType != CommonRuntimeTypes.Int32)
                                 throw new BadImageFormatException();
 
                             int v = record.Value.ToConstantInt32ValueHandle(reader).GetConstantInt32Value(reader).Value;
@@ -273,7 +273,7 @@ namespace System.Reflection.Runtime.General
                         }
                     case HandleType.ConstantUInt32Value:
                         {
-                            if (underlyingType != typeof(uint))
+                            if (underlyingType != CommonRuntimeTypes.UInt32)
                                 throw new BadImageFormatException();
 
                             uint v = record.Value.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value;
@@ -282,7 +282,7 @@ namespace System.Reflection.Runtime.General
                         }
                     case HandleType.ConstantInt64Value:
                         {
-                            if (underlyingType != typeof(long))
+                            if (underlyingType != CommonRuntimeTypes.Int64)
                                 throw new BadImageFormatException();
 
                             long v = record.Value.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value;
@@ -291,7 +291,7 @@ namespace System.Reflection.Runtime.General
                         }
                     case HandleType.ConstantUInt64Value:
                         {
-                            if (underlyingType != typeof(ulong))
+                            if (underlyingType != CommonRuntimeTypes.UInt64)
                                 throw new BadImageFormatException();
 
                             ulong v = record.Value.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ToStringUtils.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ToStringUtils.cs
@@ -2,18 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
-using System.Diagnostics;
-using System.Collections.Generic;
-
-using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
-using System.Reflection.Runtime.Assemblies;
-using System.Reflection.Runtime.TypeParsing;
-
-using Internal.LowLevelLinq;
-using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
 
 using Internal.Metadata.NativeFormat;
@@ -76,13 +65,12 @@ namespace System.Reflection.Runtime.General
 
                 // Legacy: why removing "System"? Is it just because C# has keywords for these types?
                 // If so why don't we change it to lower case to match the C# keyword casing?
-                FoundationTypes foundationTypes = ReflectionCoreExecution.ExecutionDomain.FoundationTypes;
                 String typeName = runtimeType.ToString();
                 if (typeName.StartsWith("System."))
                 {
                     foreach (Type pt in ReflectionCoreExecution.ExecutionDomain.PrimitiveTypes)
                     {
-                        if (pt.Equals(rootElementType) || rootElementType.Equals(foundationTypes.SystemVoid))
+                        if (pt.Equals(rootElementType) || rootElementType.Equals(CommonRuntimeTypes.Void))
                         {
                             typeName = typeName.Substring("System.".Length);
                             break;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
@@ -57,9 +57,8 @@ namespace System.Reflection.Runtime.TypeInfos
                 bool multiDim = this.InternalIsMultiDimArray;
                 int rank = this.GetArrayRank();
 
-                FoundationTypes foundationTypes = ReflectionCoreExecution.ExecutionDomain.FoundationTypes;
                 RuntimeTypeInfo arrayType = this;
-                RuntimeTypeInfo countType = foundationTypes.SystemInt32.CastToRuntimeTypeInfo();
+                RuntimeTypeInfo countType = CommonRuntimeTypes.Int32.CastToRuntimeTypeInfo();
 
                 {
                     RuntimeTypeInfo[] ctorParameters = new RuntimeTypeInfo[rank];
@@ -178,11 +177,10 @@ namespace System.Reflection.Runtime.TypeInfos
             {
                 int rank = this.GetArrayRank();
 
-                FoundationTypes foundationTypes = ReflectionCoreExecution.ExecutionDomain.FoundationTypes;
-                RuntimeTypeInfo indexType = foundationTypes.SystemInt32.CastToRuntimeTypeInfo();
+                RuntimeTypeInfo indexType = CommonRuntimeTypes.Int32.CastToRuntimeTypeInfo();
                 RuntimeTypeInfo arrayType = this;
                 RuntimeTypeInfo elementType = arrayType.InternalRuntimeElementType;
-                RuntimeTypeInfo voidType = foundationTypes.SystemVoid.CastToRuntimeTypeInfo();
+                RuntimeTypeInfo voidType = CommonRuntimeTypes.Void.CastToRuntimeTypeInfo();
 
                 {
                     RuntimeTypeInfo[] getParameters = new RuntimeTypeInfo[rank];

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -44,7 +44,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return typeof(Object).GetTypeInfo().Assembly;
+                return CommonRuntimeTypes.Object.GetTypeInfo().Assembly;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -184,7 +184,7 @@ namespace System.Reflection.Runtime.TypeInfos
                     return constraints[i];
                 }
 
-                RuntimeNamedTypeInfo objectTypeInfo = ReflectionCoreExecution.ExecutionDomain.FoundationTypes.SystemObject.CastToRuntimeNamedTypeInfo();
+                RuntimeNamedTypeInfo objectTypeInfo = CommonRuntimeTypes.Object.CastToRuntimeNamedTypeInfo();
                 return new QTypeDefRefOrSpec(objectTypeInfo.Reader, objectTypeInfo.TypeDefinitionHandle);
             }
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.InvokeMember.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.InvokeMember.cs
@@ -161,7 +161,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 if (selFld != null)
                 {
                     #region Invocation on a field
-                    if (selFld.FieldType.IsArray || Object.ReferenceEquals(selFld.FieldType, typeof(System.Array)))
+                    if (selFld.FieldType.IsArray || Object.ReferenceEquals(selFld.FieldType, CommonRuntimeTypes.Array))
                     {
                         #region Invocation of an array Field
                         int idxCnt;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -2,19 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.MethodInfos;
-using System.Reflection.Runtime.FieldInfos;
-using System.Reflection.Runtime.PropertyInfos;
-using System.Reflection.Runtime.EventInfos;
 
-using Internal.LowLevelLinq;
-using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
 using Internal.Reflection.Tracing;
 using Internal.Reflection.Augments;
@@ -98,7 +91,7 @@ namespace System.Reflection.Runtime.TypeInfos
                     // unless that other generic parameter has a "class" constraint.
                     GenericParameterAttributes genericParameterAttributes = baseType.GetTypeInfo().GenericParameterAttributes;
                     if (0 == (genericParameterAttributes & GenericParameterAttributes.ReferenceTypeConstraint))
-                        baseType = ReflectionCoreExecution.ExecutionDomain.FoundationTypes.SystemObject;
+                        baseType = CommonRuntimeTypes.Object;
                 }
                 return baseType;
             }
@@ -299,7 +292,7 @@ namespace System.Reflection.Runtime.TypeInfos
             }
 
             // If we got here, the types are open, or reduced away, or otherwise lacking in type handles. Perform the IsAssignability check in managed code.
-            return Assignability.IsAssignableFrom(this, typeInfo, ReflectionCoreExecution.ExecutionDomain.FoundationTypes);
+            return Assignability.IsAssignableFrom(this, typeInfo);
         }
 
         //
@@ -878,9 +871,8 @@ namespace System.Reflection.Runtime.TypeInfos
                     Type baseType = this.BaseType;
                     if (baseType != null)
                     {
-                        FoundationTypes foundationTypes = ReflectionCoreExecution.ExecutionDomain.FoundationTypes;
-                        Type enumType = foundationTypes.SystemEnum;
-                        Type valueType = foundationTypes.SystemValueType;
+                        Type enumType = CommonRuntimeTypes.Enum;
+                        Type valueType = CommonRuntimeTypes.ValueType;
 
                         if (baseType.Equals(enumType))
                             classification |= TypeClassification.IsEnum | TypeClassification.IsValueType;


### PR DESCRIPTION
... in Reflection.Core with CommonRuntimeTypes.X
where possible. FoundationTypes is a relic from
a time where Reflection.Core was supposed to handle
multiple type universes. typeof() for commonly used
type still incurs the overhead of a hash lookup at
best (and the recreation of the Type object at worst.)

Holding off on getting rid of FoundationTypes
itself for now to avoid colliding with the
AssemblyBinder migration.