### PR TITLE
Get rid of useless AsType()/GetTypeInfo() calls.

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInheritanceRules.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInheritanceRules.cs
@@ -43,9 +43,9 @@ namespace Internal.Reflection.Extensions.NonPortable
         public static IEnumerable<CustomAttributeData> GetMatchingCustomAttributes(this MemberInfo element, Type optionalAttributeTypeFilter, bool inherit, bool skipTypeValidation = false)
         {
             {
-                TypeInfo typeInfo = element as TypeInfo;
-                if (typeInfo != null)
-                    return TypeCustomAttributeSearcher.Default.GetMatchingCustomAttributes(typeInfo, optionalAttributeTypeFilter, inherit, skipTypeValidation: skipTypeValidation);
+                Type type = element as Type;
+                if (type != null)
+                    return TypeCustomAttributeSearcher.Default.GetMatchingCustomAttributes(type, optionalAttributeTypeFilter, inherit, skipTypeValidation: skipTypeValidation);
             }
             {
                 ConstructorInfo constructorInfo = element as ConstructorInfo;
@@ -111,14 +111,14 @@ namespace Internal.Reflection.Extensions.NonPortable
         //==============================================================================================================================
         // Searcher class for TypeInfos.
         //==============================================================================================================================
-        private sealed class TypeCustomAttributeSearcher : CustomAttributeSearcher<TypeInfo>
+        private sealed class TypeCustomAttributeSearcher : CustomAttributeSearcher<Type>
         {
-            protected sealed override IEnumerable<CustomAttributeData> GetDeclaredCustomAttributes(TypeInfo element)
+            protected sealed override IEnumerable<CustomAttributeData> GetDeclaredCustomAttributes(Type element)
             {
                 return element.CustomAttributes;
             }
 
-            public sealed override TypeInfo GetParent(TypeInfo e)
+            public sealed override Type GetParent(Type e)
             {
                 Type baseType = e.BaseType;
                 if (baseType == null)
@@ -129,7 +129,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                 if (baseType.Equals(CommonRuntimeTypes.Object) || baseType.Equals(CommonRuntimeTypes.ValueType))
                     return null;
 
-                return baseType.GetTypeInfo();
+                return baseType;
             }
 
             public static readonly TypeCustomAttributeSearcher Default = new TypeCustomAttributeSearcher();

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
@@ -31,7 +31,6 @@ namespace Internal.Reflection.Extensions.NonPortable
             if (cad == null)
                 return null;
             Type attributeType = cad.AttributeType;
-            TypeInfo attributeTypeInfo = attributeType.GetTypeInfo();
 
             //
             // Find the public constructor that matches the supplied arguments.
@@ -39,11 +38,8 @@ namespace Internal.Reflection.Extensions.NonPortable
             ConstructorInfo matchingCtor = null;
             ParameterInfo[] matchingParameters = null;
             IList<CustomAttributeTypedArgument> constructorArguments = cad.ConstructorArguments;
-            foreach (ConstructorInfo ctor in attributeTypeInfo.DeclaredConstructors)
+            foreach (ConstructorInfo ctor in attributeType.GetConstructors(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
             {
-                if ((ctor.Attributes & (MethodAttributes.Static | MethodAttributes.MemberAccessMask)) != (MethodAttributes.Public))
-                    continue;
-
                 ParameterInfo[] parameters = ctor.GetParametersNoCopy();
                 if (parameters.Length != constructorArguments.Count)
                     continue;
@@ -63,7 +59,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                 }
             }
             if (matchingCtor == null)
-                throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeTypeInfo); // No matching ctor.
+                throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeType); // No matching ctor.
 
             //
             // Found the right constructor. Instantiate the Attribute.
@@ -82,14 +78,14 @@ namespace Internal.Reflection.Extensions.NonPortable
             foreach (CustomAttributeNamedArgument namedArgument in cad.NamedArguments)
             {
                 Object argumentValue = namedArgument.TypedValue.Convert();
-                TypeInfo walk = attributeTypeInfo;
+                Type walk = attributeType;
                 String name = namedArgument.MemberName;
                 if (namedArgument.IsField)
                 {
                     // Field
                     for (;;)
                     {
-                        FieldInfo fieldInfo = walk.GetDeclaredField(name);
+                        FieldInfo fieldInfo = walk.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
                         if (fieldInfo != null)
                         {
                             fieldInfo.SetValue(newAttribute, argumentValue);
@@ -97,8 +93,8 @@ namespace Internal.Reflection.Extensions.NonPortable
                         }
                         Type baseType = walk.BaseType;
                         if (baseType == null)
-                            throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeTypeInfo); // No field matches named argument.
-                        walk = baseType.GetTypeInfo();
+                            throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeType); // No field matches named argument.
+                        walk = baseType;
                     }
                 }
                 else
@@ -106,7 +102,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                     // Property
                     for (;;)
                     {
-                        PropertyInfo propertyInfo = walk.GetDeclaredProperty(name);
+                        PropertyInfo propertyInfo = walk.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
                         if (propertyInfo != null)
                         {
                             propertyInfo.SetValue(newAttribute, argumentValue);
@@ -114,8 +110,8 @@ namespace Internal.Reflection.Extensions.NonPortable
                         }
                         Type baseType = walk.BaseType;
                         if (baseType == null)
-                            throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeTypeInfo); // No field matches named argument.
-                        walk = baseType.GetTypeInfo();
+                            throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeType); // No field matches named argument.
+                        walk = baseType;
                     }
                 }
             }
@@ -131,7 +127,7 @@ namespace Internal.Reflection.Extensions.NonPortable
             Type argumentType = typedArgument.ArgumentType;
             if (!argumentType.IsArray)
             {
-                bool isEnum = argumentType.GetTypeInfo().IsEnum;
+                bool isEnum = argumentType.IsEnum;
                 Object argumentValue = typedArgument.Value;
                 if (isEnum)
                     argumentValue = Enum.ToObject(argumentType, argumentValue);

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeSearcher.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeSearcher.cs
@@ -42,14 +42,13 @@ namespace Internal.Reflection.Extensions.NonPortable
             {
                 if (optionalAttributeTypeFilter == null)
                     throw new ArgumentNullException("type");
-                TypeInfo attributeTypeFilterInfo = optionalAttributeTypeFilter.GetTypeInfo();
                 if (!(optionalAttributeTypeFilter.Equals(CommonRuntimeTypes.Attribute) ||
-                      attributeTypeFilterInfo.IsSubclassOf(CommonRuntimeTypes.Attribute)))
+                      optionalAttributeTypeFilter.IsSubclassOf(CommonRuntimeTypes.Attribute)))
                     throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass);
 
                 try
                 {
-                    typeFilterKnownToBeSealed = attributeTypeFilterInfo.IsSealed;
+                    typeFilterKnownToBeSealed = optionalAttributeTypeFilter.IsSealed;
                 }
                 catch (MissingMetadataException)
                 {
@@ -85,7 +84,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                             return true;
                         if (typeFilterKnownToBeSealed)
                             return false;
-                        return actualType.GetTypeInfo().IsSubclassOf(optionalAttributeTypeFilter);
+                        return actualType.IsSubclassOf(optionalAttributeTypeFilter);
                     };
             }
 
@@ -111,7 +110,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                 delegate (Type attributeType)
                 {
                     // Windows prohibits instantiating WinRT custom attributes. Filter them from the search as the desktop CLR does.
-                    TypeAttributes typeAttributes = attributeType.GetTypeInfo().Attributes;
+                    TypeAttributes typeAttributes = attributeType.Attributes;
                     if (0 != (typeAttributes & TypeAttributes.WindowsRuntime))
                         return false;
                     return rawPassesFilter(attributeType);
@@ -197,7 +196,7 @@ namespace Internal.Reflection.Extensions.NonPortable
             // This behavior goes all the way back to at least 3.5 (and perhaps earlier). For compat reasons,
             // we won't-fixed this in 4.5 and we won't-fix this in Project N.
             //
-            AttributeUsageAttribute usage = attributeType.GetTypeInfo().GetCustomAttribute<AttributeUsageAttribute>(inherit: false);
+            AttributeUsageAttribute usage = attributeType.GetCustomAttribute<AttributeUsageAttribute>(inherit: false);
             if (usage == null)
                 return new AttributeUsageAttribute(AttributeTargets.All) { AllowMultiple = false, Inherited = true };
             return usage;

--- a/src/System.Private.CoreLib/src/System/Runtime/Serialization/SerializationInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Serialization/SerializationInfo.cs
@@ -39,7 +39,7 @@ namespace System.Runtime.Serialization
 
             _rootType = type;
             _rootTypeName = type.FullName;
-            _rootTypeAssemblyName = type.GetTypeInfo().Module.Assembly.FullName;
+            _rootTypeAssemblyName = type.Module.Assembly.FullName;
 
             _names = new string[DefaultSize];
             _values = new object[DefaultSize];
@@ -93,7 +93,7 @@ namespace System.Runtime.Serialization
             {
                 _rootType = type;
                 _rootTypeName = type.FullName;
-                _rootTypeAssemblyName = type.GetTypeInfo().Module.Assembly.FullName;
+                _rootTypeAssemblyName = type.Module.Assembly.FullName;
                 IsFullTypeNameSetExplicit = false;
                 IsAssemblyNameSetExplicit = false;
             }
@@ -331,7 +331,7 @@ namespace System.Runtime.Serialization
             object value;
 
             value = GetElement(name, out foundType);
-            if (ReferenceEquals(foundType, type) || type.GetTypeInfo().IsAssignableFrom(foundType.GetTypeInfo()) || value == null)
+            if (ReferenceEquals(foundType, type) || type.IsAssignableFrom(foundType) || value == null)
             {
                 return value;
             }
@@ -349,7 +349,7 @@ namespace System.Runtime.Serialization
             if (value == null)
                 return null;
 
-            if (ReferenceEquals(foundType, type) || type.GetTypeInfo().IsAssignableFrom(foundType.GetTypeInfo()) || value == null)
+            if (ReferenceEquals(foundType, type) || type.IsAssignableFrom(foundType) || value == null)
             {
                 return value;
             }

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -164,17 +164,17 @@ namespace Internal.Reflection.Core.Execution
             TypeDefinitionHandle typeDefinitionHandle;
             if (ExecutionEnvironment.TryGetMetadataForNamedType(typeHandle, out reader, out typeDefinitionHandle))
             {
-                return typeDefinitionHandle.GetNamedType(reader, typeHandle).AsType();
+                return typeDefinitionHandle.GetNamedType(reader, typeHandle);
             }
             else
             {
                 if (ExecutionEnvironment.IsReflectionBlocked(typeHandle))
                 {
-                    return RuntimeBlockedTypeInfo.GetRuntimeBlockedTypeInfo(typeHandle, isGenericTypeDefinition).AsType();
+                    return RuntimeBlockedTypeInfo.GetRuntimeBlockedTypeInfo(typeHandle, isGenericTypeDefinition);
                 }
                 else
                 {
-                    return RuntimeNoMetadataNamedTypeInfo.GetRuntimeNoMetadataNamedTypeInfo(typeHandle, isGenericTypeDefinition).AsType();
+                    return RuntimeNoMetadataNamedTypeInfo.GetRuntimeNoMetadataNamedTypeInfo(typeHandle, isGenericTypeDefinition);
                 }
             }
         }
@@ -185,7 +185,7 @@ namespace Internal.Reflection.Core.Execution
             if (!ExecutionEnvironment.TryGetArrayTypeElementType(typeHandle, out elementTypeHandle))
                 throw CreateMissingMetadataException((Type)null);
 
-            return elementTypeHandle.GetTypeForRuntimeTypeHandle().GetArrayType(typeHandle).AsType();
+            return elementTypeHandle.GetTypeForRuntimeTypeHandle().GetArrayType(typeHandle);
         }
 
         public Type GetMdArrayTypeForHandle(RuntimeTypeHandle typeHandle, int rank)
@@ -194,7 +194,7 @@ namespace Internal.Reflection.Core.Execution
             if (!ExecutionEnvironment.TryGetArrayTypeElementType(typeHandle, out elementTypeHandle))
                 throw CreateMissingMetadataException((Type)null);
 
-            return elementTypeHandle.GetTypeForRuntimeTypeHandle().GetMultiDimArrayType(rank, typeHandle).AsType();
+            return elementTypeHandle.GetTypeForRuntimeTypeHandle().GetMultiDimArrayType(rank, typeHandle);
         }
 
         public Type GetPointerTypeForHandle(RuntimeTypeHandle typeHandle)
@@ -203,7 +203,7 @@ namespace Internal.Reflection.Core.Execution
             if (!ExecutionEnvironment.TryGetPointerTypeTargetType(typeHandle, out targetTypeHandle))
                 throw CreateMissingMetadataException((Type)null);
 
-            return targetTypeHandle.GetTypeForRuntimeTypeHandle().GetPointerType(typeHandle).AsType();
+            return targetTypeHandle.GetTypeForRuntimeTypeHandle().GetPointerType(typeHandle);
         }
 
         public Type GetConstructedGenericTypeForHandle(RuntimeTypeHandle typeHandle)
@@ -225,7 +225,7 @@ namespace Internal.Reflection.Core.Execution
             // generic type definitions.
             if (ExecutionEnvironment.IsReflectionBlocked(genericTypeDefinitionHandle))
             {
-                return RuntimeBlockedTypeInfo.GetRuntimeBlockedTypeInfo(typeHandle, isGenericTypeDefinition: false).AsType();
+                return RuntimeBlockedTypeInfo.GetRuntimeBlockedTypeInfo(typeHandle, isGenericTypeDefinition: false);
             }
 
             RuntimeTypeInfo genericTypeDefinition = genericTypeDefinitionHandle.GetTypeForRuntimeTypeHandle();
@@ -235,7 +235,7 @@ namespace Internal.Reflection.Core.Execution
             {
                 genericTypeArguments[i] = genericTypeArgumentHandles[i].GetTypeForRuntimeTypeHandle();
             }
-            return genericTypeDefinition.GetConstructedGenericType(genericTypeArguments, typeHandle).AsType();
+            return genericTypeDefinition.GetConstructedGenericType(genericTypeArguments, typeHandle);
         }
 
         //=======================================================================================

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/DefaultBinder.CanConvert.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/DefaultBinder.CanConvert.cs
@@ -119,7 +119,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             if (type == CommonRuntimeTypes.DateTime)
                 return TypeCode.DateTime;
 
-            if (type.GetTypeInfo().IsEnum)
+            if (type.IsEnum)
                 return GetTypeCode(Enum.GetUnderlyingType(type));
 
             return TypeCode.Object;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -86,11 +86,8 @@ namespace System.Reflection.Runtime.CustomAttributes
         protected static ConstructorInfo ResolveAttributeConstructor(Type attributeType, Type[] parameterTypes)
         {
             int parameterCount = parameterTypes.Length;
-            foreach (ConstructorInfo candidate in attributeType.GetTypeInfo().DeclaredConstructors)
+            foreach (ConstructorInfo candidate in attributeType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
             {
-                if (candidate.IsStatic)
-                    continue;
-
                 ParameterInfo[] candidateParameters = candidate.GetParametersNoCopy();
                 if (parameterCount != candidateParameters.Length)
                     continue;
@@ -129,8 +126,7 @@ namespace System.Reflection.Runtime.CustomAttributes
                 return cat.ToString();
 
             Object value = cat.Value;
-            TypeInfo argumentTypeInfo = argumentType.GetTypeInfo();
-            if (argumentTypeInfo.IsEnum)
+            if (argumentType.IsEnum)
                 return String.Format(typed ? "{0}" : "({1}){0}", value, argumentType.FullName);
 
             if (value == null)
@@ -151,7 +147,7 @@ namespace System.Reflection.Runtime.CustomAttributes
                 IList<CustomAttributeTypedArgument> array = value as IList<CustomAttributeTypedArgument>;
 
                 Type elementType = argumentType.GetElementType();
-                result = String.Format(@"new {0}[{1}] {{ ", elementType.GetTypeInfo().IsEnum ? elementType.FullName : elementType.Name, array.Count);
+                result = String.Format(@"new {0}[{1}] {{ ", elementType.IsEnum ? elementType.FullName : elementType.Name, array.Count);
 
                 for (int i = 0; i < array.Count; i++)
                     result += String.Format(i == 0 ? "{0}" : ", {0}", ComputeTypedArgumentString(array[i], elementType != CommonRuntimeTypes.Object));

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -114,7 +114,7 @@ namespace System.Reflection.Runtime.EventInfos
                     ReflectionTrace.EventInfo_DeclaringType(this);
 #endif
 
-                return _contextTypeInfo.AsType();
+                return _contextTypeInfo;
             }
         }
 
@@ -253,7 +253,7 @@ namespace System.Reflection.Runtime.EventInfos
         {
             get
             {
-                return _contextTypeInfo.AsType();
+                return _contextTypeInfo;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -92,7 +92,7 @@ namespace System.Reflection.Runtime.FieldInfos
                     ReflectionTrace.FieldInfo_DeclaringType(this);
 #endif
 
-                return _contextTypeInfo.AsType();
+                return _contextTypeInfo;
             }
         }
 
@@ -205,7 +205,7 @@ namespace System.Reflection.Runtime.FieldInfos
         {
             get
             {
-                return _contextTypeInfo.AsType();
+                return _contextTypeInfo;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -49,6 +49,13 @@ namespace System.Reflection.Runtime.General
             return type is IRuntimeImplementedType;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Type[] GetGenericTypeParameters(this Type type)
+        {
+            Debug.Assert(type.IsGenericTypeDefinition);
+            return type.GetGenericArguments();
+        }
+
         public static RuntimeTypeInfo[] ToRuntimeTypeInfoArray(this Type[] types)
         {
             int count = types.Length;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.cs
@@ -216,7 +216,7 @@ namespace System.Reflection.Runtime.General
                 return exception;
             }
 
-            if (!enumType.GetTypeInfo().IsEnum)
+            if (!enumType.IsEnum)
                 throw new BadImageFormatException();
 
             Type underlyingType = Enum.GetUnderlyingType(enumType);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -324,7 +324,7 @@ namespace System.Reflection.Runtime.TypeInfos
             // We only permit creating parameterized types if the pay-for-play policy specifically allows them *or* if the result
             // type would be an open type.
             if (typeHandle.IsNull() && !elementType.ContainsGenericParameters)
-                throw ReflectionCoreExecution.ExecutionDomain.CreateMissingArrayTypeException(elementType.AsType(), multiDim, rank);
+                throw ReflectionCoreExecution.ExecutionDomain.CreateMissingArrayTypeException(elementType, multiDim, rank);
         }
     }
 
@@ -445,7 +445,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 // We only permit creating parameterized types if the pay-for-play policy specifically allows them *or* if the result
                 // type would be an open type.
                 if (key.TypeHandle.IsNull() && !atLeastOneOpenType)
-                    throw ReflectionCoreExecution.ExecutionDomain.CreateMissingConstructedGenericTypeException(key.GenericTypeDefinition.AsType(), key.GenericTypeArguments.CloneTypeArray());
+                    throw ReflectionCoreExecution.ExecutionDomain.CreateMissingConstructedGenericTypeException(key.GenericTypeDefinition, key.GenericTypeArguments.CloneTypeArray());
 
                 return new RuntimeConstructedGenericTypeInfo(key);
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -32,7 +32,7 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
-                return DeclaringType.GetTypeInfo().ContainsGenericParameters;
+                return DeclaringType.ContainsGenericParameters;
             }
         }
 
@@ -119,7 +119,7 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
-                return DeclaringType.GetTypeInfo().Module;
+                return DeclaringType.Module;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -44,7 +44,7 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
-                if (DeclaringType.GetTypeInfo().ContainsGenericParameters)
+                if (DeclaringType.ContainsGenericParameters)
                     return true;
 
                 if (!IsGenericMethod)
@@ -53,7 +53,7 @@ namespace System.Reflection.Runtime.MethodInfos
                 Type[] pis = GetGenericArguments();
                 for (int i = 0; i < pis.Length; i++)
                 {
-                    if (pis[i].GetTypeInfo().ContainsGenericParameters)
+                    if (pis[i].ContainsGenericParameters)
                         return true;
                 }
 
@@ -444,12 +444,12 @@ namespace System.Reflection.Runtime.MethodInfos
             // they are not compatible yet enums can go into each other if their underlying element type is the same
             // or into their equivalent integral type
             Type dstTypeUnderlying = dstType;
-            if (dstType.GetTypeInfo().IsEnum)
+            if (dstType.IsEnum)
             {
                 dstTypeUnderlying = Enum.GetUnderlyingType(dstType);
             }
             Type srcTypeUnderlying = srcType;
-            if (srcType.GetTypeInfo().IsEnum)
+            if (srcType.IsEnum)
             {
                 srcTypeUnderlying = Enum.GetUnderlyingType(srcType);
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
@@ -111,7 +111,7 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
-                return this.DeclaringType.GetTypeInfo().Assembly.ManifestModule;
+                return this.DeclaringType.Assembly.ManifestModule;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -110,7 +110,7 @@ namespace System.Reflection.Runtime.PropertyInfos
                     ReflectionTrace.PropertyInfo_DeclaringType(this);
 #endif
 
-                return _contextTypeInfo.AsType();
+                return _contextTypeInfo;
             }
         }
 
@@ -359,7 +359,7 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             get
             {
-                return _contextTypeInfo.AsType();
+                return _contextTypeInfo;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -44,7 +44,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return CommonRuntimeTypes.Object.GetTypeInfo().Assembly;
+                return CommonRuntimeTypes.Object.Assembly;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -105,7 +105,7 @@ namespace System.Reflection.Runtime.TypeInfos
 
         public sealed override Type GetGenericTypeDefinition()
         {
-            return GenericTypeDefinitionTypeInfo.AsType();
+            return GenericTypeDefinitionTypeInfo;
         }
 
         public sealed override Guid GUID

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -34,7 +34,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return DeclaringType.GetTypeInfo().Assembly;
+                return DeclaringType.Assembly;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfoForTypes.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfoForTypes.cs
@@ -39,7 +39,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                return _declaringRuntimeNamedTypeInfo.AsType();
+                return _declaringRuntimeNamedTypeInfo;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
@@ -144,7 +144,7 @@ namespace System.Reflection.Runtime.TypeInfos
             string elementTypeName = _key.ElementType.InternalGetNameIfAvailable(ref rootCauseForFailure);
             if (elementTypeName == null)
             {
-                rootCauseForFailure = _key.ElementType.AsType();
+                rootCauseForFailure = _key.ElementType;
                 return null;
             }
             return elementTypeName + Suffix;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -187,7 +187,7 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override Type GetGenericTypeDefinition()
         {
             if (_typeDefinition.GenericParameters.GetEnumerator().MoveNext())
-                return this.AsType();
+                return this;
             return base.GetGenericTypeDefinition();
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
@@ -154,7 +154,7 @@ namespace System.Reflection.Runtime.TypeInfos
 
         internal sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
         {
-            rootCauseForFailure = this.AsType();
+            rootCauseForFailure = this;
             return null;
         }
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/DefaultValueParser.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/DefaultValueParser.cs
@@ -25,7 +25,7 @@ namespace Internal.Reflection.Execution
             if (!(constantHandle.IsNull(reader)))
             {
                 defaultValue = ParseMetadataConstant(reader, constantHandle);
-                if (declaredType.GetTypeInfo().IsEnum)
+                if (declaredType.IsEnum)
                     defaultValue = Enum.ToObject(declaredType, defaultValue);
                 return true;
             }
@@ -36,8 +36,7 @@ namespace Internal.Reflection.Execution
                 foreach (CustomAttributeData cad in customAttributes)
                 {
                     Type attributeType = cad.AttributeType;
-                    TypeInfo attributeTypeInfo = attributeType.GetTypeInfo();
-                    if (attributeTypeInfo.IsSubclassOf(typeof(CustomConstantAttribute)))
+                    if (attributeType.IsSubclassOf(typeof(CustomConstantAttribute)))
                     {
                         CustomConstantAttribute customConstantAttribute = (CustomConstantAttribute)(cad.Instantiate());
                         defaultValue = customConstantAttribute.Value;

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/EnumInfoImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/EnumInfoImplementation.cs
@@ -269,7 +269,7 @@ namespace Internal.Reflection.Execution
                     EnumInfoFlags flags = EnumInfoFlags.Computed;
 
                     Type flagsAttributeType = typeof(FlagsAttribute);
-                    foreach (CustomAttributeData cad in _enumType.GetTypeInfo().CustomAttributes)
+                    foreach (CustomAttributeData cad in _enumType.CustomAttributes)
                     {
                         if (cad.AttributeType.Equals(flagsAttributeType))
                         {


### PR DESCRIPTION
We no longer need most of those now that we've backtracked
out of that api refactoring and they're just wasting
cycles.

And yes, I realize that a lot of the variables
in Assignability.cs are still named "TypeInfo".
Maybe in a future cleanup, but right now, leaving
those names as is makes this commit easier to diff.

The new GetGenericTypeParameters() extension method
gives us the moral equivalent of TypeInfo.GenericTypeParameters
on Type. (And yes, I know we could just call Type.GetGenericArguments()
but I detest that semantic overloading.)