### PR TITLE
Add dependency analysis nodes related to generic dictionaries

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -1,0 +1,158 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.TypeSystem;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents the layout of the generic dictionary associated with a given canonical
+    /// generic type or generic method. Maintains a bag of <see cref="DictionaryEntry"/> associated
+    /// with the canonical entity.
+    /// </summary>
+    /// <remarks>
+    /// The generic dictionary doesn't have any dependent nodes because <see cref="DictionaryEntry"/>
+    /// are runtime-determined - the concrete dependency depends on the generic context the canonical
+    /// entity is instantiated with.
+    /// </remarks>
+    class DictionaryLayoutNode : DependencyNodeCore<NodeFactory>
+    {
+        private TypeSystemEntity _owningMethodOrType;
+        private HashSet<DictionaryEntry> _entries = new HashSet<DictionaryEntry>();
+        private DictionaryEntry[] _layout;
+
+        public DictionaryLayoutNode(TypeSystemEntity owningMethodOrType)
+        {
+            _owningMethodOrType = owningMethodOrType;
+            Validate();
+        }
+
+        public void EnsureEntry(DictionaryEntry entry)
+        {
+            // TODO: thread safety
+            Debug.Assert(_layout == null, "Trying to add entry but layout already computed");
+
+            _entries.Add(entry);
+        }
+
+        private void ComputeLayout()
+        {
+            HashSet<DictionaryEntry> entries = _entries;
+            _entries = null;
+
+            // TODO: deterministic ordering
+            DictionaryEntry[] layout = new DictionaryEntry[entries.Count];
+            int index = 0;
+            foreach (DictionaryEntry entry in entries)
+            {
+                layout[index++] = entry;
+            }
+
+            _layout = layout;
+        }
+
+        public int GetSlotForEntry(DictionaryEntry entry)
+        {
+            if (_layout == null)
+                ComputeLayout();
+
+            int index = Array.IndexOf(_layout, entry);
+            Debug.Assert(index >= 0);
+            return index;
+        }
+
+        public IEnumerable<DictionaryEntry> Entries
+        {
+            get
+            {
+                if (_layout == null)
+                    ComputeLayout();
+
+                return _layout;
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void Validate()
+        {
+            TypeDesc type = _owningMethodOrType as TypeDesc;
+            if (type != null)
+            {
+                Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
+            }
+            else
+            {
+                MethodDesc method = _owningMethodOrType as MethodDesc;
+                Debug.Assert(method != null && method.IsCanonicalMethod(CanonicalFormKind.Any));
+            }
+        }
+
+        public override string GetName()
+        {
+            return String.Concat("Dictionary layout for " + _owningMethodOrType.ToString());
+        }
+
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
+            List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(
+            NodeFactory factory) => null;
+    }
+
+    /// <summary>
+    /// Represents a single entry in a <see cref="DictionaryLayoutNode"/>.
+    /// </summary>
+    public abstract class DictionaryEntry
+    {
+        public abstract override bool Equals(object obj);
+        public abstract override int GetHashCode();
+        public abstract override string ToString();
+
+        public abstract ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation);
+        public abstract string GetMangledName(NameMangler nameMangler);
+
+        protected static bool SameType<T>(T thisEntry, object other)
+        {
+            Debug.Assert(thisEntry.GetType() == typeof(T));
+            return other != null && typeof(T) == other.GetType();
+        }
+    }
+
+    public class TypeHandleDictionaryEntry : DictionaryEntry
+    {
+        private TypeDesc _type;
+
+        public TypeHandleDictionaryEntry(TypeDesc type)
+        {
+            Debug.Assert(type.IsRuntimeDeterminedSubtype, "Concrete type in a generic dictionary?");
+            _type = type;
+        }
+
+        public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            return factory.NecessaryTypeSymbol(instantiatedType);
+        }
+
+        public override string GetMangledName(NameMangler nameMangler)
+        {
+            return $"TypeHandle_{nameMangler.GetMangledTypeName(_type)}";
+        }
+
+        public override bool Equals(object obj) => SameType(this, obj) && ((TypeHandleDictionaryEntry)obj)._type == _type;
+        public override int GetHashCode() => _type.GetHashCode();
+        public override string ToString() => $"TypeHandle: {_type}";
+    }
+
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a generic dictionary for a concrete generic type instantiation
+    /// or generic method instantiation. The dictionary is used from canonical code
+    /// at runtime to look up runtime artifacts that depend on the concrete
+    /// context the generic type or method was instantiated with.
+    /// </summary>
+    internal abstract class GenericDictionaryNode : ObjectNode, ISymbolNode
+    {
+        protected const string MangledNamePrefix = "__GenericDict_";
+
+        protected abstract TypeSystemContext Context { get; }
+
+        protected abstract Instantiation TypeInstantiation { get; }
+
+        protected abstract Instantiation MethodInstantiation { get; }
+
+        protected abstract DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory);
+
+        public sealed override ObjectNodeSection Section =>
+            Context.Target.IsWindows ? ObjectNodeSection.ReadOnlyDataSection : ObjectNodeSection.DataSection;
+        
+        public sealed override bool StaticDependenciesAreComputed => true;
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            return new DependencyList
+            {
+                new DependencyListEntry(GetDictionaryLayout(factory), "Dictionary layout"),
+            };
+        }
+
+        public abstract int Offset { get; }
+
+        public abstract string MangledName { get; }
+
+        public sealed override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory);
+            builder.DefinedSymbols.Add(this);
+            builder.RequirePointerAlignment();
+
+            // Node representing the generic dictionary doesn't have any dependencies for
+            // dependency analysis purposes. The dependencies are tracked as dependencies of the
+            // concrete method bodies. When we reach the object data emission phase, the dependencies
+            // should all already have been marked.
+            if (!relocsOnly)
+            {
+                EmitDataInternal(ref builder, factory);
+            }
+
+            return builder.ToObjectData();
+        }
+
+        protected virtual void EmitDataInternal(ref ObjectDataBuilder builder, NodeFactory factory)
+        {
+            DictionaryLayoutNode layout = GetDictionaryLayout(factory);
+
+            Instantiation typeInst = this.TypeInstantiation;
+            Instantiation methodInst = this.MethodInstantiation;
+
+            foreach (var entry in layout.Entries)
+            {
+                ISymbolNode targetNode = entry.GetTarget(factory, typeInst, methodInst);
+                builder.EmitPointerReloc(targetNode);
+            }
+        }
+
+        public sealed override string GetName()
+        {
+            return MangledName;
+        }
+    }
+
+    internal sealed class TypeGenericDictionaryNode : GenericDictionaryNode
+    {
+        private TypeDesc _owningType;
+
+        public override int Offset => 0;
+        public override string MangledName => MangledNamePrefix + NodeFactory.NameMangler.GetMangledTypeName(_owningType);
+
+        protected override Instantiation TypeInstantiation => _owningType.Instantiation;
+        protected override Instantiation MethodInstantiation => new Instantiation();
+        protected override TypeSystemContext Context => _owningType.Context;
+
+        protected override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)
+        {
+            return factory.GenericDictionaryLayout(_owningType.ConvertToCanonForm(CanonicalFormKind.Specific));
+        }
+
+        public TypeGenericDictionaryNode(TypeDesc owningType)
+        {
+            Debug.Assert(!owningType.IsCanonicalSubtype(CanonicalFormKind.Any));
+            Debug.Assert(!owningType.IsRuntimeDeterminedSubtype);
+            Debug.Assert(owningType.HasInstantiation);
+
+            _owningType = owningType;
+        }
+    }
+
+    internal sealed class MethodGenericDictionaryNode : GenericDictionaryNode
+    {
+        private MethodDesc _owningMethod;
+
+        public override int Offset => _owningMethod.Context.Target.PointerSize;
+        public override string MangledName => MangledNamePrefix + NodeFactory.NameMangler.GetMangledMethodName(_owningMethod);
+
+        protected override Instantiation TypeInstantiation => _owningMethod.OwningType.Instantiation;
+        protected override Instantiation MethodInstantiation => _owningMethod.Instantiation;
+        protected override TypeSystemContext Context => _owningMethod.Context;
+
+        protected override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)
+        {
+            return factory.GenericDictionaryLayout(_owningMethod.GetCanonMethodTarget(CanonicalFormKind.Specific));
+        }
+
+        protected override void EmitDataInternal(ref ObjectDataBuilder builder, NodeFactory factory)
+        {
+            // Method generic dictionaries get prefixed by the hash code of the owning method
+            // to allow quick lookups of additional details by the type loader.
+
+            if (builder.TargetPointerSize == 8)
+                builder.EmitInt(0);
+            builder.EmitInt(_owningMethod.GetHashCode());
+
+            Debug.Assert(builder.CountBytes == Offset);
+
+            base.EmitDataInternal(ref builder, factory);
+        }
+
+        public MethodGenericDictionaryNode(MethodDesc owningMethod)
+        {
+            Debug.Assert(!owningMethod.IsCanonicalMethod(CanonicalFormKind.Any));
+            Debug.Assert(owningMethod.HasInstantiation);
+
+            _owningMethod = owningMethod;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -238,6 +238,21 @@ namespace ILCompiler.DependencyAnalysis
                 else
                     return new LazilyBuiltVTableSliceNode(type);
             });
+
+            _methodGenericDictionaries = new NodeCache<MethodDesc, GenericDictionaryNode>(method =>
+            {
+                return new MethodGenericDictionaryNode(method);
+            });
+
+            _typeGenericDictionaries = new NodeCache<TypeDesc, GenericDictionaryNode>(type =>
+            {
+                return new TypeGenericDictionaryNode(type);
+            });
+
+            _genericDictionaryLayouts = new NodeCache<TypeSystemEntity, DictionaryLayoutNode>(methodOrType =>
+            {
+                return new DictionaryLayoutNode(methodOrType);
+            });
         }
 
         protected abstract IMethodNode CreateMethodEntrypointNode(MethodDesc method);
@@ -404,6 +419,24 @@ namespace ILCompiler.DependencyAnalysis
         internal VTableSliceNode VTable(TypeDesc type)
         {
             return _vTableNodes.GetOrAdd(type);
+        }
+
+        private NodeCache<MethodDesc, GenericDictionaryNode> _methodGenericDictionaries;
+        internal GenericDictionaryNode MethodGenericDictionary(MethodDesc method)
+        {
+            return _methodGenericDictionaries.GetOrAdd(method);
+        }
+
+        private NodeCache<TypeDesc, GenericDictionaryNode> _typeGenericDictionaries;
+        internal GenericDictionaryNode TypeGenericDictionary(TypeDesc type)
+        {
+            return _typeGenericDictionaries.GetOrAdd(type);
+        }
+
+        private NodeCache<TypeSystemEntity, DictionaryLayoutNode> _genericDictionaryLayouts;
+        internal DictionaryLayoutNode GenericDictionaryLayout(TypeSystemEntity methodOrType)
+        {
+            return _genericDictionaryLayouts.GetOrAdd(methodOrType);
         }
 
         private NodeCache<MethodDesc, IMethodNode> _methodEntrypoints;

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -67,9 +67,11 @@
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ConstructedEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CppCodegenNodeFactory.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\DictionaryLayoutNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternEETypeSymbolNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericCompositionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDefinitionEETypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericDictionaryNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\PInvokeMethodFixupNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\PInvokeModuleFixupNode.cs" />


### PR DESCRIPTION
* `DictionaryLayoutNode` that represents the layout of all dictionaries
associated with a canonical type instantiation or a canonical generic
method instantiation. (Dependency-only node, not emitted into the
executable.)
* `GenericDictionaryNode` that represents the concrete dictionary for a
generic type/method instantiation. (Object node, emitted into the
executable.)
* Add a pointer the the generic dictionary in the first vtable slot of
all types that need it.