### PR TITLE
Make a few writable properties immutable

### DIFF
--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -43,7 +43,7 @@ namespace Internal.TypeSystem
         /// </summary>
         public TargetArchitecture Architecture
         {
-            get; private set;
+            get;
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace Internal.TypeSystem
         /// </summary>
         public TargetOS OperatingSystem
         {
-            get; private set;
+            get;
         }
 
         /// <summary>

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -39,7 +39,7 @@ namespace Internal.TypeSystem
 
         public TargetDetails Target
         {
-            get; private set;
+            get;
         }
 
         public ModuleDesc SystemModule

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.Symbols.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.Symbols.cs
@@ -12,7 +12,7 @@ namespace Internal.TypeSystem.Ecma
     {
         public PdbSymbolReader PdbReader
         {
-            get; private set;
+            get;
         }
 
         internal EcmaModule(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, PdbSymbolReader pdbReader)

--- a/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
@@ -24,7 +24,7 @@ namespace ILCompiler
         /// </summary>
         public IMethodNode Constructor
         {
-            get; private set;
+            get;
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace ILCompiler
         /// </summary>
         public ISymbolNode Target
         {
-            get; private set;
+            get;
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace ILCompiler
         /// </summary>
         public IMethodNode Thunk
         {
-            get; private set;
+            get;
         }
 
         private DelegateCreationInfo(IMethodNode constructor, ISymbolNode target, IMethodNode thunk = null)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -56,7 +56,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public MetadataGeneration MetadataManager
         {
-            get; private set;
+            get;
         }
 
         private struct NodeCache<TKey, TValue>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
@@ -18,9 +18,9 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     public class ObjectNodeSection
     {
-        public string Name { get; private set; }
-        public SectionType Type { get; private set; }
-        public string ComdatName { get; private set; }
+        public string Name { get; }
+        public SectionType Type { get; }
+        public string ComdatName { get; }
 
         private ObjectNodeSection(string name, SectionType type, string comdatName)
         {

--- a/src/ILCompiler.Compiler/src/CppCodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/EvaluationStack.cs
@@ -159,12 +159,12 @@ namespace Internal.IL
         /// <summary>
         /// Evaluation stack kind of the entry. 
         /// </summary>
-        public StackValueKind Kind { get; private set; }
+        public StackValueKind Kind { get; }
 
         /// <summary>
         /// Managed type if any of the entry.
         /// </summary>
-        public TypeDesc Type { get; private set; }
+        public TypeDesc Type { get; }
 
         /// <summary>
         /// Initializes a new instance of StackEntry.
@@ -251,7 +251,7 @@ namespace Internal.IL
 
     internal abstract class ConstantEntry<T> : ConstantEntry where T : IConvertible
     {
-        public T Value { get; private set; }
+        public T Value { get; }
 
         protected ConstantEntry(StackValueKind kind, T value, TypeDesc type = null) : base(kind, type)
         {

--- a/src/ILCompiler.DependencyAnalysisFramework/src/FirstMarkLogStrategy.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/FirstMarkLogStrategy.cs
@@ -27,19 +27,16 @@ namespace ILCompiler.DependencyAnalysisFramework
             public string Reason
             {
                 get;
-                private set;
             }
 
             public DependencyNodeCore<DependencyContextType> Reason1
             {
                 get;
-                private set;
             }
 
             public DependencyNodeCore<DependencyContextType> Reason2
             {
                 get;
-                private set;
             }
         }
 

--- a/src/ILCompiler.DependencyAnalysisFramework/src/FullGraphLogStrategy.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/FullGraphLogStrategy.cs
@@ -27,19 +27,16 @@ namespace ILCompiler.DependencyAnalysisFramework
             public string Reason
             {
                 get;
-                private set;
             }
 
             public DependencyNodeCore<DependencyContextType> Reason1
             {
                 get;
-                private set;
             }
 
             public DependencyNodeCore<DependencyContextType> Reason2
             {
                 get;
-                private set;
             }
 
             private static int CombineHashCodes(int h1, int h2)


### PR DESCRIPTION
Today I learned: omitting the `private set;` part will make the C#
compiler emit a `initonly` backing field (and as such, allow assigning
the property in the constructor only).