### PR TITLE
Fix comment on System.Void

### DIFF
--- a/src/Runtime.Base/src/System/Void.cs
+++ b/src/Runtime.Base/src/System/Void.cs
@@ -5,8 +5,6 @@
 namespace System
 {
     // This class represents the void return type
-    // For RH, this type wont be available at runtime
-    // typeof(void) would fail.
     public struct Void
     {
     }

--- a/src/System.Private.CoreLib/src/System/Void.cs
+++ b/src/System.Private.CoreLib/src/System/Void.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// 
-
-// 
-
 ////////////////////////////////////////////////////////////////////////////////
 // Void
 //    This class represents the void return type
@@ -14,8 +10,6 @@
 namespace System
 {
     // This class represents the void return type
-    // For RH, this type wont be available at runtime
-    // typeof(void) would fail.
     [System.Runtime.InteropServices.ComVisible(true)]
     public struct Void
     {


### PR DESCRIPTION
`typeof(void)` is a legit construct and we do have EETypes for this.