### PR TITLE
Add function pointer types to the type system

### DIFF
--- a/src/Common/src/TypeSystem/Canon/FunctionPointerType.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/FunctionPointerType.Canon.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Internal.TypeSystem
+{
+    // Holds code for canonicalizing a function pointer type
+    partial class FunctionPointerType
+    {
+        public override bool IsCanonicalSubtype(CanonicalFormKind policy)
+        {
+            if (_signature.ReturnType.IsCanonicalSubtype(policy))
+                return true;
+
+            for (int i = 0; i < _signature.Length; i++)
+                if (_signature[i].IsCanonicalSubtype(policy))
+                    return true;
+
+            return false;
+        }
+
+        protected override TypeDesc ConvertToCanonFormImpl(CanonicalFormKind kind)
+        {
+            MethodSignatureBuilder sigBuilder = new MethodSignatureBuilder(_signature);
+            sigBuilder.ReturnType = Context.ConvertToCanon(_signature.ReturnType, kind);
+            for (int i = 0; i < _signature.Length; i++)
+                sigBuilder[i] = Context.ConvertToCanon(_signature[i], kind);
+
+            MethodSignature canonSignature = sigBuilder.ToSignature();
+            if (canonSignature != _signature)
+                return Context.GetFunctionPointerType(canonSignature);
+
+            return this;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
+++ b/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Represents an unmanaged pointer to a method with a signature compatible with the signature of the pointer.
+    /// </summary>
+    public sealed partial class FunctionPointerType : TypeDesc
+    {
+        private MethodSignature _signature;
+        private int _hashCode;
+
+        internal FunctionPointerType(MethodSignature signature)
+        {
+            _signature = signature;
+        }
+
+        /// <summary>
+        /// Gets the signature of the method this pointer points to.
+        /// </summary>
+        public MethodSignature Signature
+        {
+            get
+            {
+                return _signature;
+            }
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return _signature.ReturnType.Context;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            if (_hashCode == 0)
+                _hashCode = _signature.GetHashCode();
+            return _hashCode;
+        }
+
+        public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            MethodSignatureBuilder sigBuilder = new MethodSignatureBuilder(_signature);
+            sigBuilder.ReturnType = _signature.ReturnType.InstantiateSignature(typeInstantiation, methodInstantiation);
+            for (int i = 0; i < _signature.Length; i++)
+                sigBuilder[i] = _signature[i].InstantiateSignature(typeInstantiation, methodInstantiation);
+
+            MethodSignature instantiatedSignature = sigBuilder.ToSignature();
+            if (instantiatedSignature != _signature)
+                return Context.GetFunctionPointerType(instantiatedSignature);
+
+            return this;
+        }
+
+        protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
+        {
+            TypeFlags flags = TypeFlags.FunctionPointer;
+
+            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
+            {
+                flags |= TypeFlags.ContainsGenericVariablesComputed;
+
+                if (_signature.ReturnType.ContainsGenericVariables)
+                    flags |= TypeFlags.ContainsGenericVariables;
+                else
+                {
+                    for (int i = 0; i < _signature.Length; i++)
+                    {
+                        if (_signature[i].ContainsGenericVariables)
+                        {
+                            flags |= TypeFlags.ContainsGenericVariables;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            flags |= TypeFlags.HasGenericVarianceComputed;
+
+            return flags;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(_signature.ReturnType);
+
+            sb.Append(" *(");
+            for (int i = 0; i < _signature.Length; i++)
+            {
+                if (i > 0)
+                    sb.Append(", ");
+                sb.Append(_signature[i]);
+            }
+            sb.Append(')');
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -425,7 +425,7 @@ namespace Internal.TypeSystem
                 result.Size = fieldType.Context.Target.PointerSize;
                 result.Alignment = fieldType.Context.Target.PointerSize;
             }
-            else if (fieldType.IsPointer)
+            else if (fieldType.IsPointer || fieldType.IsFunctionPointer)
             {
                 result.Size = fieldType.Context.Target.PointerSize;
                 result.Alignment = fieldType.Context.Target.PointerSize;

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -121,6 +121,16 @@ namespace Internal.TypeSystem
 
             return true;
         }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MethodSignature && Equals((MethodSignature)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return TypeHashingAlgorithms.ComputeMethodSignatureHashCode(_returnType.GetHashCode(), _parameters);
+        }
     }
 
     /// <summary>

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -310,6 +310,17 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
+        /// Gets a value indicating whether this is an unmanaged function pointer type (<see cref="FunctionPointerType"/>).
+        /// </summary>
+        public bool IsFunctionPointer
+        {
+            get
+            {
+                return this.GetType() == typeof(FunctionPointerType);
+            }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether this is a <see cref="SignatureTypeVariable"/> or <see cref="SignatureMethodVariable"/>.
         /// </summary>
         public bool IsSignatureVariable

--- a/src/Common/src/TypeSystem/Common/TypeFlags.cs
+++ b/src/Common/src/TypeSystem/Common/TypeFlags.cs
@@ -42,6 +42,7 @@ namespace Internal.TypeSystem
         SzArray         = 0x18,
         ByRef           = 0x19,
         Pointer         = 0x1A,
+        FunctionPointer = 0x1B,
 
         GenericParameter        = 0x1C,
         SignatureTypeVariable   = 0x1D,

--- a/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
+++ b/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
@@ -210,7 +210,9 @@ namespace Internal.NativeFormat
 
         public static int ComputeMethodSignatureHashCode<ARG>(int returnTypeHashCode, ARG[] parameters)
         {
-            // TODO: Do we need calling conventions in the mix too?
+            // We're not taking calling conventions into consideration here mostly because there's no
+            // exchange enum type that would define them. We could define one, but the amount of additional
+            // information it would bring (16 or so possibilities) is likely not worth it.
             int hashcode = returnTypeHashCode;
             for (int i = 0; i < parameters.Length; i++)
             {

--- a/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
+++ b/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
@@ -208,6 +208,18 @@ namespace Internal.NativeFormat
             return (hashcode + _rotl(hashcode, 15));
         }
 
+        public static int ComputeMethodSignatureHashCode<ARG>(int returnTypeHashCode, ARG[] parameters)
+        {
+            // TODO: Do we need calling conventions in the mix too?
+            int hashcode = returnTypeHashCode;
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                int parameterHashCode = parameters[i].GetHashCode();
+                hashcode = (hashcode + _rotl(hashcode, 13)) ^ parameterHashCode;
+            }
+            return (hashcode + _rotl(hashcode, 15));
+        }
+
         /// <summary>
         /// Produce a hashcode for a specific method
         /// </summary>

--- a/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
@@ -28,6 +28,9 @@ namespace Internal.TypeSystem
                 case TypeFlags.Pointer:
                     AppendName(sb, (PointerType)type);
                     return;
+                case TypeFlags.FunctionPointer:
+                    AppendName(sb, (FunctionPointerType)type);
+                    return;
                 case TypeFlags.GenericParameter:
                     AppendName(sb, (GenericParameterDesc)type);
                     return;
@@ -63,6 +66,7 @@ namespace Internal.TypeSystem
         public abstract void AppendName(StringBuilder sb, ArrayType type);
         public abstract void AppendName(StringBuilder sb, ByRefType type);
         public abstract void AppendName(StringBuilder sb, PointerType type);
+        public abstract void AppendName(StringBuilder sb, FunctionPointerType type);
         public abstract void AppendName(StringBuilder sb, GenericParameterDesc type);
         public abstract void AppendName(StringBuilder sb, SignatureMethodVariable type);
         public abstract void AppendName(StringBuilder sb, SignatureTypeVariable type);

--- a/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -113,7 +113,7 @@ namespace Internal.TypeSystem.Ecma
                 case SignatureTypeCode.TypedReference:
                     throw new PlatformNotSupportedException("TypedReference not supported in .NET Core");
                 case SignatureTypeCode.FunctionPointer:
-                    throw new PlatformNotSupportedException("Function pointer types are not supported in .NET Core");
+                    return _module.Context.GetFunctionPointerType(ParseMethodSignature());
                 default:
                     throw new BadImageFormatException();
             }

--- a/src/Common/src/TypeSystem/IL/ILDisassember.cs
+++ b/src/Common/src/TypeSystem/IL/ILDisassember.cs
@@ -456,6 +456,29 @@ namespace Internal.IL
                 sb.Append('*');
             }
 
+            public override void AppendName(StringBuilder sb, FunctionPointerType type)
+            {
+                MethodSignature signature = type.Signature;
+
+                sb.Append("method ");
+
+                if (!signature.IsStatic)
+                    sb.Append("instance ");
+
+                // TODO: rest of calling conventions
+
+                AppendName(sb, signature.ReturnType);
+
+                sb.Append(" *(");
+                for (int i = 0; i < signature.Length; i++)
+                {
+                    if (i > 0)
+                        sb.Append(", ");
+                    AppendName(sb, signature[i]);
+                }
+                sb.Append(')');
+            }
+
             public override void AppendName(StringBuilder sb, SignatureMethodVariable type)
             {
                 sb.Append("!!");

--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -538,7 +538,7 @@ namespace Internal.IL.Stubs
 
         private TypeDesc ConvertToBoxableType(TypeDesc type)
         {
-            if (type.IsPointer)
+            if (type.IsPointer || type.IsFunctionPointer)
             {
                 return type.Context.GetWellKnownType(WellKnownType.IntPtr);
             }

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -115,7 +115,7 @@ namespace Internal.IL.Stubs
                 return true;
             }
 
-            if (type.IsPointer)
+            if (type.IsPointer || type.IsFunctionPointer)
                 return true;
 
             return false;

--- a/src/Common/src/TypeSystem/RuntimeDetermined/FunctionPointerType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/FunctionPointerType.RuntimeDetermined.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class FunctionPointerType
+    {
+        public override bool IsRuntimeDeterminedSubtype
+        {
+            get
+            {
+                if (_signature.ReturnType.IsRuntimeDeterminedSubtype)
+                    return true;
+
+                for (int i = 0; i < _signature.Length; i++)
+                    if (_signature[i].IsRuntimeDeterminedSubtype)
+                        return true;
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
@@ -128,7 +128,7 @@ namespace ILCompiler
 
         public override bool ShouldShareAcrossModules(TypeDesc type)
         {
-            if (type is ParameterizedType || type is InstantiatedType)
+            if (type.IsParameterizedType || type.IsFunctionPointer || type is InstantiatedType)
             {
                 return true;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -23,15 +23,20 @@ namespace ILCompiler
             return true;
         }
 
+        /// <summary>
+        /// Gets the type that defines virtual method slots for the specified type.
+        /// </summary>
         static public DefType GetClosestDefType(this TypeDesc type)
         {
-            if (type.IsSzArray && !((ArrayType)type).ElementType.IsPointer)
+            if (type.IsArray)
             {
-                MetadataType arrayType = type.Context.SystemModule.GetKnownType("System", "Array`1");
-                return arrayType.MakeInstantiatedType(((ArrayType)type).ElementType);
-            }
-            else if (type.IsArray)
-            {
+                var arrayType = (ArrayType)type;
+                TypeDesc elementType = arrayType.ElementType;
+                if (arrayType.IsSzArray && !elementType.IsPointer && !elementType.IsFunctionPointer)
+                {
+                    MetadataType arrayShadowType = type.Context.SystemModule.GetKnownType("System", "Array`1");
+                    return arrayShadowType.MakeInstantiatedType(elementType);
+                }
                 return type.Context.GetWellKnownType(WellKnownType.Array);
             }
 

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -53,6 +53,8 @@ namespace ILCompiler.Metadata
                 case Cts.TypeFlags.Pointer:
                     rec = _types.Create((Cts.PointerType)type, _initPointer ?? (_initPointer = InitializePointer));
                     break;
+                case Cts.TypeFlags.FunctionPointer:
+                    throw new NotImplementedException();
                 case Cts.TypeFlags.SignatureTypeVariable:
                     rec = _types.Create((Cts.SignatureTypeVariable)type, _initTypeVar ?? (_initTypeVar = InitializeTypeVariable));
                     break;

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -29,6 +29,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Canon\CanonTypes.cs">
       <Link>TypeSystem\Canon\CanonTypes.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Canon\FunctionPointerType.Canon.cs">
+      <Link>TypeSystem\Canon\FunctionPointerType.Canon.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Canon\StandardCanonicalizationAlgorithm.cs">
       <Link>TypeSystem\Canon\StandardCanonicalizationAlgorithm.cs</Link>
     </Compile>
@@ -79,6 +82,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\ConstructedTypeRewritingHelpers.cs">
       <Link>TypeSystem\Common\ConstructedTypeRewritingHelpers.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FunctionPointerType.cs">
+      <Link>TypeSystem\Common\FunctionPointerType.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\IAssemblyDesc.cs">
       <Link>TypeSystem\Common\IAssemblyDesc.cs</Link>
@@ -328,6 +334,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\LocalVariableDefinition.cs">
       <Link>TypeSystem\Common\LocalVariableDefinition.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\FunctionPointerType.RuntimeDetermined.cs">
+      <Link>TypeSystem\RuntimeDetermined\FunctionPointerType.RuntimeDetermined.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\MethodDesc.RuntimeDetermined.cs">
       <Link>TypeSystem\RuntimeDetermined\MethodDesc.RuntimeDetermined.cs</Link>

--- a/src/ILCompiler.TypeSystem/tests/HashcodeTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/HashcodeTests.cs
@@ -157,6 +157,22 @@ namespace TypeSystemTests
         }
 
         [Fact]
+        public void TestFunctionPointerTypes()
+        {
+            DefType intType = _context.GetWellKnownType(WellKnownType.Int32);
+            DefType objectType = _context.GetWellKnownType(WellKnownType.Object);
+
+            int expHashInt = TypeHashingAlgorithms.ComputeNameHashCode("System.Int32");
+            int expHashObject = TypeHashingAlgorithms.ComputeNameHashCode("System.Object");
+
+            int expHashFnPtr = TypeHashingAlgorithms.ComputeMethodSignatureHashCode(expHashInt, new[] { expHashObject });
+
+            MethodSignature fnPtrSig = new MethodSignature(MethodSignatureFlags.None, 0, intType, new TypeDesc[] { objectType });
+            var fnPtrType = _context.GetFunctionPointerType(fnPtrSig);
+            Assert.Equal(expHashFnPtr, fnPtrType.GetHashCode());
+        }
+
+        [Fact]
         public void TestByRefTypes()
         {
             DefType intType = _context.GetWellKnownType(WellKnownType.Int32);

--- a/src/ILCompiler.TypeSystem/tests/ILTestAssembly/StaticFieldLayout.il
+++ b/src/ILCompiler.TypeSystem/tests/ILTestAssembly/StaticFieldLayout.il
@@ -8,3 +8,10 @@
   .field private static int32 StaticInitedInt at D_00004000
   .data D_00004000 = bytearray (12 34 56 78) 
 }
+
+.class public auto ansi beforefieldinit StaticFieldLayout.FunctionPointerType
+       extends [CoreTestAssembly]System.Object
+{
+  .field private static int32 StaticIntField;
+  .field private static method object *(object) StaticMethodField;
+}

--- a/src/ILCompiler.TypeSystem/tests/StaticFieldLayoutTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/StaticFieldLayoutTests.cs
@@ -289,5 +289,20 @@ namespace TypeSystemTests
 
             Assert.Equal(0x78563412, value);
         }
+
+        [Fact]
+        public void TestFunctionPointer()
+        {
+            //
+            // Test layout with a function pointer typed-field.
+            //
+
+            var ilModule = _context.GetModuleForSimpleName("ILTestAssembly");
+            var t = ilModule.GetType("StaticFieldLayout", "FunctionPointerType");
+            var field = t.GetField("StaticMethodField");
+
+            Assert.Equal(8, field.Offset);
+            Assert.False(field.HasGCStaticBase);
+        }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -472,7 +472,7 @@ namespace Internal.JitInterface
                 return (CorInfoType)type.Category;
             }
 
-            if (type.IsPointer)
+            if (type.IsPointer || type.IsFunctionPointer)
             {
                 return CorInfoType.CORINFO_TYPE_PTR;
             }


### PR DESCRIPTION
Even though these can't be expressed in C#, we still have a bunch of test collateral that exercises them. Instead of coming up with excuses as to why we should just ignore the tests every time it shows up, I decided to just implement this.

Native metadata schema update and emission will follow later.

I tweaked all places where I think we need to do extra work in the compiler (and added some with dubious value - such as canonicalization). I didn't touch CppCodegen. We might need `CanCastTo` tweaks too (but maybe not?).

Fixes #371.