### PR TITLE
Fix incorrect initialization of AssemblyName in EcmaModule

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -454,7 +454,7 @@ namespace Internal.TypeSystem.Ecma
             an.Version = assemblyReference.Version;
 
             var publicKeyOrToken = _metadataReader.GetBlobBytes(assemblyReference.PublicKeyOrToken);
-            if ((an.Flags & AssemblyNameFlags.PublicKey) != 0)
+            if ((assemblyReference.Flags & AssemblyFlags.PublicKey) != 0)
             {
                 an.SetPublicKey(publicKeyOrToken);
             }


### PR DESCRIPTION
- When setting the public key information, check the assemblyReference to identify if it contains a key or token, not the AssemblyName that is in the process of construction