### PR TITLE
Add IsMdArray property to make working with multidimensional arrays s…

### DIFF
--- a/src/Common/src/Internal/Runtime/GCDescEncoder.cs
+++ b/src/Common/src/Internal/Runtime/GCDescEncoder.cs
@@ -73,7 +73,7 @@ namespace Internal.Runtime
                 // 2 means m_pEEType and _numComponents. Syncblock is sort of appended at the end of the object layout in this case.
                 int baseSize = 2 * builder.TargetPointerSize;
 
-                if (!type.IsSzArray)
+                if (type.IsMdArray)
                 {
                     // Multi-dim arrays include upper and lower bounds for each rank
                     baseSize += 2 * type.Context.GetWellKnownType(WellKnownType.Int32).GetElementSize() * ((ArrayType)type).Rank;

--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -61,6 +61,17 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
+        /// Gets a value indicating whether this type is an mdarray.
+        /// </summary>
+        public new bool IsMdArray
+        {
+            get
+            {
+                return _rank > 0;
+            }
+        }
+
+        /// <summary>
         /// Gets the rank of this array. Note this returns "1" for both vectors, and
         /// for general arrays of rank 1. Use <see cref="IsSzArray"/> to disambiguate.
         /// </summary>

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -288,6 +288,18 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
+        /// Gets a value indicating whether this is a non-vector array type.
+        /// To check for arrays in general, use <see cref="IsArray"/>.
+        /// </summary>
+        public bool IsMdArray
+        {
+            get
+            {
+                return this.IsArray && ((ArrayType)this).IsMdArray;
+            }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether this is a managed pointer type (<see cref="ByRefType"/>).
         /// </summary>
         public bool IsByRef

--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -68,7 +68,7 @@ namespace Internal.IL.Stubs
 
         private void EmitILForAccessor()
         {
-            Debug.Assert(!_method.OwningType.IsSzArray);
+            Debug.Assert(_method.OwningType.IsMdArray);
 
             var codeStream = _emitter.NewCodeStream();
             var context = _method.Context;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -242,7 +242,7 @@ namespace ILCompiler.DependencyAnalysis
             else if (_type.IsArray)
             {
                 objectSize = 3 * pointerSize; // SyncBlock + EETypePtr + Length
-                if (!_type.IsSzArray)
+                if (_type.IsMdArray)
                     objectSize +=
                         2 * _type.Context.GetWellKnownType(WellKnownType.Int32).GetElementSize() * ((ArrayType)_type).Rank;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -171,7 +171,7 @@ namespace ILCompiler
                 case TypeFlags.SzArray:
                     // mangledName = "Array<" + GetSignatureCPPTypeName(((ArrayType)type).ElementType) + ">";
                     mangledName = GetMangledTypeName(((ArrayType)type).ElementType) + "__Array";
-                    if (!type.IsSzArray)
+                    if (type.IsMdArray)
                         mangledName += "Rank" + ((ArrayType)type).Rank.ToStringInvariant();
                     break;
                 case TypeFlags.ByRef:

--- a/src/ILCompiler.TypeSystem/tests/GenericTypeAndMethodTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/GenericTypeAndMethodTests.cs
@@ -161,7 +161,14 @@ namespace TypeSystemTests
 
             // Test Arrays
             TypeDesc arrayChar = _context.GetArrayType(charType);
+            Assert.False(arrayChar.IsMdArray);
+            Assert.True(arrayChar.IsSzArray);
+            Assert.True(arrayChar.IsArray);
+
             TypeDesc arrayInt = _context.GetArrayType(intType);
+            Assert.False(arrayInt.IsMdArray);
+            Assert.True(arrayInt.IsSzArray);
+            Assert.True(arrayInt.IsArray);
 
             InstantiatedType genericOfCharArrayObject = genericOpenType.MakeInstantiatedType(arrayChar, objectType);
             InstantiatedType genericOfIntArrayObject = genericOpenType.MakeInstantiatedType(arrayInt, objectType);
@@ -170,7 +177,14 @@ namespace TypeSystemTests
 
             // Test multidimensional arrays
             TypeDesc mdArrayChar = _context.GetArrayType(charType, 3);
+            Assert.True(mdArrayChar.IsMdArray);
+            Assert.False(mdArrayChar.IsSzArray);
+            Assert.True(mdArrayChar.IsArray);
+
             TypeDesc mdArrayInt = _context.GetArrayType(intType, 3);
+            Assert.True(mdArrayInt.IsMdArray);
+            Assert.False(mdArrayInt.IsSzArray);
+            Assert.True(mdArrayInt.IsArray);
 
             InstantiatedType genericOfCharMdArrayObject = genericOpenType.MakeInstantiatedType(mdArrayChar, objectType);
             InstantiatedType genericOfIntMdArrayObject = genericOpenType.MakeInstantiatedType(mdArrayInt, objectType);


### PR DESCRIPTION
…impler

- Existing pattern looked something like type.IsArray && !type.IsSzArray.
- Replace with type.IsMdArray
- Also add some tests to verify the behavior of IsArray, IsSzArray, and IsMdArray