### PR TITLE
Port frozen string object support from internal

### DIFF
--- a/src/Common/src/Internal/Runtime/ModuleHeaders.cs
+++ b/src/Common/src/Internal/Runtime/ModuleHeaders.cs
@@ -51,6 +51,7 @@ namespace Internal.Runtime
         InterfaceDispatchTable      = 203,
         ModuleManagerIndirection    = 204,
         EagerCctor                  = 205,
+        FrozenObjectRegion          = 206,
 
         // Sections 300 - 399 are reserved for RhFindBlob backwards compatibility
         ReadonlyBlobRegionStart     = 300,

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
@@ -56,6 +56,11 @@ namespace ILCompiler
         /// and therefore needs a full VTable
         /// </summary>
         public abstract bool ShouldProduceFullType(TypeDesc type);
+        /// <summary>
+        /// If true, the type will not be linked into the same module as the current compilation and therefore
+        /// accessed through the target platform's import mechanism (ie, Import Address Table on Windows)
+        /// </summary>
+        public abstract bool ShouldReferenceThroughImportTable(TypeDesc type);
 
         public virtual void AddCompilationRoots(IRootingServiceProvider rootProvider)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
@@ -27,7 +27,8 @@ namespace ILCompiler.DependencyAnalysis
             : base(
                   startSymbolMangledName,
                   endSymbolMangledName,
-                  nodeSorter != null ? new PointerIndirectionNodeComparer(nodeSorter) : null)
+                  nodeSorter != null ? new PointerIndirectionNodeComparer(nodeSorter) : null,
+                  null)
         {
             _startSymbolMangledName = startSymbolMangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    internal sealed class ClonedConstructedEETypeNode : ConstructedEETypeNode, ISymbolNode
+    {
+        public ClonedConstructedEETypeNode(TypeDesc type) : base(type)
+        {
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName + " cloned";
+        }
+
+        //
+        // A cloned type must be named differently than the type it is a clone of so the linker
+        // will have an unambiguous symbol to resolve
+        //
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return GetMangledName(_type) + "_Clone";
+            }
+        }
+
+        public override bool ShouldShareNodeAcrossModules(NodeFactory factory)
+        {
+            return true;
+        }
+
+        protected override void OutputRelatedType(NodeFactory factory, ref ObjectDataBuilder objData)
+        {
+            //
+            // Cloned types use the related type field to point via an IAT slot at their true implementation
+            //
+            objData.EmitPointerReloc(factory.NecessaryTypeSymbol(_type));
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -12,7 +12,7 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    internal sealed class ConstructedEETypeNode : EETypeNode, ISymbolNode
+    internal class ConstructedEETypeNode : EETypeNode, ISymbolNode
     {
         public ConstructedEETypeNode(TypeDesc type) : base(type)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -122,8 +122,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return "__EEType_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
+                return GetMangledName(_type);
             }
+        }
+
+        public static string GetMangledName(TypeDesc type)
+        {
+            return "__EEType_" + NodeFactory.NameMangler.GetMangledTypeName(type);
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
@@ -275,7 +280,7 @@ namespace ILCompiler.DependencyAnalysis
             return _type.BaseType != null ? factory.NecessaryTypeSymbol(_type.BaseType) : null;
         }
 
-        private void OutputRelatedType(NodeFactory factory, ref ObjectDataBuilder objData)
+        protected virtual void OutputRelatedType(NodeFactory factory, ref ObjectDataBuilder objData)
         {
             ISymbolNode relatedTypeNode = null;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
@@ -21,7 +21,7 @@ namespace ILCompiler.DependencyAnalysis
             _offset = InvalidOffset;
         }
 
-        public int Offset
+        public virtual int Offset
         {
             get
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenObjectSentinelNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenObjectSentinelNode.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// A sentinel node used to match the expected encoding of an array of frozen objects in the runtime.
+    /// An extra pointer is expected by the GC at the end for correctness.
+    /// </summary>
+    class FrozenObjectSentinelNode : EmbeddedObjectNode
+    {
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            dataBuilder.EmitZeroPointer();
+        }
+
+        public override string GetName()
+        {
+            return "FrozenObjectSentinelNode";
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public class FrozenStringNode : EmbeddedObjectNode, ISymbolNode
+    {
+        string _data;
+        int _syncBlockSize;
+
+        public FrozenStringNode(string data, TargetDetails target)
+        {
+            _data = data;
+            _syncBlockSize = target.PointerSize;
+        }
+
+        public string MangledName
+        {
+            get
+            {
+                return NodeFactory.CompilationUnitPrefix + "__Str_" + NodeFactory.NameMangler.GetMangledStringName(_data);
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override int Offset
+        {
+            get
+            {
+                // The frozen string symbol points at the EEType portion of the object, skipping over the sync block
+                return base.Offset + _syncBlockSize;
+            }
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            dataBuilder.EmitZeroPointer(); // Sync block
+
+            DefType systemStringType = factory.TypeSystemContext.GetWellKnownType(WellKnownType.String);
+
+            //
+            // The GC requires a direct reference to frozen objects' EETypes. If System.String will be compiled into a separate
+            // binary, it must be cloned into this one.
+            //
+            if (factory.CompilationModuleGroup.ShouldReferenceThroughImportTable(systemStringType))
+            {
+                dataBuilder.EmitPointerReloc(factory.ConstructedClonedTypeSymbol(systemStringType));
+            }
+            else
+            {
+                dataBuilder.EmitPointerReloc(factory.ConstructedTypeSymbol(systemStringType));
+            }
+
+            dataBuilder.EmitInt(_data.Length);
+
+            foreach (char c in _data)
+            {
+                dataBuilder.EmitShort((short)c);
+            }
+
+            // Null-terminate for friendliness with interop
+            dataBuilder.EmitShort(0);
+
+        }
+
+        public override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return null;
+        }
+
+        protected override void OnMarked(NodeFactory factory)
+        {
+            factory.FrozenSegmentRegion.AddEmbeddedObject(this);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -120,7 +120,14 @@ namespace ILCompiler.DependencyAnalysis
                     return new ExternEETypeSymbolNode(type);
                 }
             });
-            
+
+            _clonedTypeSymbols = new NodeCache<TypeDesc, IEETypeNode>((TypeDesc type) =>
+            {
+                // Only types that reside in other binaries should be cloned
+                Debug.Assert(_compilationModuleGroup.ShouldReferenceThroughImportTable(type));
+                return new ClonedConstructedEETypeNode(type);
+            });
+
             _nonGCStatics = new NodeCache<MetadataType, NonGCStaticsNode>((MetadataType type) =>
             {
                 return new NonGCStaticsNode(type, this);
@@ -193,6 +200,11 @@ namespace ILCompiler.DependencyAnalysis
             _stringIndirectionNodes = new NodeCache<string, StringIndirectionNode>((string data) =>
             {
                 return new StringIndirectionNode(data);
+            });
+
+            _frozenStringNodes = new NodeCache<string, FrozenStringNode>((string data) =>
+            {
+                return new FrozenStringNode(data, Target);
             });
 
             _typeOptionalFields = new NodeCache<EETypeOptionalFieldsBuilder, EETypeOptionalFieldsNode>((EETypeOptionalFieldsBuilder fieldBuilder) =>
@@ -273,6 +285,13 @@ namespace ILCompiler.DependencyAnalysis
         public IEETypeNode ConstructedTypeSymbol(TypeDesc type)
         {
             return _constructedTypeSymbols.GetOrAdd(type);
+        }
+
+        private NodeCache<TypeDesc, IEETypeNode> _clonedTypeSymbols;
+
+        public IEETypeNode ConstructedClonedTypeSymbol(TypeDesc type)
+        {
+            return _clonedTypeSymbols.GetOrAdd(type);
         }
 
         private NodeCache<MetadataType, NonGCStaticsNode> _nonGCStatics;
@@ -549,6 +568,13 @@ namespace ILCompiler.DependencyAnalysis
             return _stringIndirectionNodes.GetOrAdd(data);
         }
 
+        private NodeCache<string, FrozenStringNode> _frozenStringNodes;
+
+        public FrozenStringNode SerializedStringObject(string data)
+        {
+            return _frozenStringNodes.GetOrAdd(data);
+        }
+
         private NodeCache<MethodDesc, EmbeddedObjectNode> _eagerCctorIndirectionNodes;
 
         public EmbeddedObjectNode EagerCctorIndirection(MethodDesc cctorMethod)
@@ -591,6 +617,12 @@ namespace ILCompiler.DependencyAnalysis
             CompilationUnitPrefix + "__DispatchMapTableEnd",
             null);
 
+        public ArrayOfEmbeddedDataNode<FrozenStringNode> FrozenSegmentRegion = new ArrayOfEmbeddedDataNode<FrozenStringNode>(
+            "__FrozenSegmentRegionStart",
+            "__FrozenSegmentRegionEnd",
+            null,
+            new FrozenObjectSentinelNode());
+
         public ReadyToRunHeaderNode ReadyToRunHeader;
 
         public Dictionary<ISymbolNode, string> NodeAliases = new Dictionary<ISymbolNode, string>();
@@ -613,6 +645,7 @@ namespace ILCompiler.DependencyAnalysis
             graph.AddRoot(EagerCctorTable, "EagerCctorTable is always generated");
             graph.AddRoot(ModuleManagerIndirection, "ModuleManagerIndirection is always generated");
             graph.AddRoot(DispatchMapTable, "DispatchMapTable is always generated");
+            graph.AddRoot(FrozenSegmentRegion, "FrozenSegmentRegion is always generated");
 
             ReadyToRunHeader.Add(ReadyToRunSectionType.GCStaticRegion, GCStaticsRegion, GCStaticsRegion.StartSymbol, GCStaticsRegion.EndSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.ThreadStaticRegion, ThreadStaticsRegion, ThreadStaticsRegion.StartSymbol, ThreadStaticsRegion.EndSymbol);
@@ -620,6 +653,7 @@ namespace ILCompiler.DependencyAnalysis
             ReadyToRunHeader.Add(ReadyToRunSectionType.EagerCctor, EagerCctorTable, EagerCctorTable.StartSymbol, EagerCctorTable.EndSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.ModuleManagerIndirection, ModuleManagerIndirection, ModuleManagerIndirection);
             ReadyToRunHeader.Add(ReadyToRunSectionType.InterfaceDispatchTable, DispatchMapTable, DispatchMapTable.StartSymbol);
+            ReadyToRunHeader.Add(ReadyToRunSectionType.FrozenObjectRegion, FrozenSegmentRegion, FrozenSegmentRegion.StartSymbol, FrozenSegmentRegion.EndSymbol);
 
             MetadataManager.AddToReadyToRunHeader(ReadyToRunHeader);
             MetadataManager.AttachToDependencyGraph(graph);

--- a/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
@@ -151,6 +151,11 @@ namespace ILCompiler
             }
         }
 
+        public override bool ShouldReferenceThroughImportTable(TypeDesc type)
+        {
+            return false;
+        }
+
         private HashSet<EcmaModule> InputModules
         {
             get

--- a/src/ILCompiler.Compiler/src/Compiler/SingleFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleFileCompilationModuleGroup.cs
@@ -52,5 +52,10 @@ namespace ILCompiler
         {
             return false;
         }
+
+        public override bool ShouldReferenceThroughImportTable(TypeDesc type)
+        {
+            return false;
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -57,5 +57,10 @@ namespace ILCompiler
         {
             rootProvider.AddCompilationRoot(_method, "Single method mode");
         }
+
+        public override bool ShouldReferenceThroughImportTable(TypeDesc type)
+        {
+            return false;
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -65,10 +65,13 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.cs" />
     <Compile Include="Compiler\DelegateCreationInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ClonedConstructedEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ConstructedEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CppCodegenNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\DictionaryLayoutNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternEETypeSymbolNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\FrozenObjectSentinelNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\FrozenStringNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericCompositionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDefinitionEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDictionaryNode.cs" />

--- a/src/ILCompiler.Compiler/src/project.json
+++ b/src/ILCompiler.Compiler/src/project.json
@@ -3,7 +3,9 @@
     "NETStandard.Library": "1.6.0",
     "System.IO.MemoryMappedFiles": "4.0.0",
     "System.Reflection.Metadata": "1.4.1-beta-24227-04",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Runtime.CompilerServices.Unsafe": "4.0.0",
+    "System.Security.Cryptography.Algorithms": "4.2.0",
+    "System.Security.Cryptography.Primitives": "4.0.0"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
Add suport for embedding literal string objects into the output image. This provides startup wins over the existing implementation, which stores a set of UTF8 strings in the image and creates String objects for them on the heap at startup.

Currently, this support is disabled pending JIT work. In particular, the JIT incorrectly emits 'xor edx, edx' when using string literals returned from property getters such as Environment.NewLine.