### PR TITLE
Add TypeSystemEntity.EntityKind

### DIFF
--- a/src/Common/src/TypeSystem/Common/FieldDesc.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.cs
@@ -26,6 +26,14 @@ namespace Internal.TypeSystem
             return Object.ReferenceEquals(this, o);
         }
 
+        public sealed override EntityKind EntityKind
+        {
+            get
+            {
+                return EntityKind.FieldDesc;
+            }
+        }
+
         public virtual string Name
         {
             get

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -26,7 +26,7 @@ namespace Internal.TypeSystem
     /// <summary>
     /// Represents the parameter types, the return type, and flags of a method.
     /// </summary>
-    public sealed class MethodSignature
+    public sealed class MethodSignature : TypeSystemEntity
     {
         internal MethodSignatureFlags _flags;
         internal int _genericParameterCount;
@@ -95,6 +95,22 @@ namespace Internal.TypeSystem
             get
             {
                 return _parameters.Length;
+            }
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return _returnType.Context;
+            }
+        }
+
+        public sealed override EntityKind EntityKind
+        {
+            get
+            {
+                return EntityKind.MethodSignature;
             }
         }
 
@@ -268,6 +284,14 @@ namespace Internal.TypeSystem
             // Its only valid to compare two MethodDescs in the same context
             Debug.Assert(Object.ReferenceEquals(o, null) || !(o is MethodDesc) || Object.ReferenceEquals(((MethodDesc)o).Context, this.Context));
             return Object.ReferenceEquals(this, o);
+        }
+
+        public sealed override EntityKind EntityKind
+        {
+            get
+            {
+                return EntityKind.MethodDesc;
+            }
         }
 
         /// <summary>

--- a/src/Common/src/TypeSystem/Common/ModuleDesc.cs
+++ b/src/Common/src/TypeSystem/Common/ModuleDesc.cs
@@ -13,6 +13,14 @@ namespace Internal.TypeSystem
             get;
         }
 
+        public sealed override EntityKind EntityKind
+        {
+            get
+            {
+                return EntityKind.ModuleDesc;
+            }
+        }
+
         public ModuleDesc(TypeSystemContext context)
         {
             Context = context;

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -27,6 +27,14 @@ namespace Internal.TypeSystem
             return Object.ReferenceEquals(this, o);
         }
 
+        public sealed override EntityKind EntityKind
+        {
+            get
+            {
+                return EntityKind.TypeDesc;
+            }
+        }
+
 #if DEBUG
         public static bool operator ==(TypeDesc left, TypeDesc right)
         {

--- a/src/Common/src/TypeSystem/Common/TypeSystemEntity.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemEntity.cs
@@ -10,5 +10,22 @@ namespace Internal.TypeSystem
         /// Gets the type system context this entity belongs to.
         /// </summary>
         public abstract TypeSystemContext Context { get; }
+
+        /// <summary>
+        /// Gets the kind of the type system entity (type, method, field, etc.).
+        /// </summary>
+        public abstract EntityKind EntityKind { get; }
+    }
+
+    /// <summary>
+    /// Specifies the kind of <see cref="TypeSystemEntity"/>. 
+    /// </summary>
+    public enum EntityKind
+    {
+        TypeDesc,
+        FieldDesc,
+        MethodDesc,
+        ModuleDesc,
+        MethodSignature,
     }
 }

--- a/src/ILCompiler.TypeSystem/src/project.json
+++ b/src/ILCompiler.TypeSystem/src/project.json
@@ -3,7 +3,8 @@
     "NETStandard.Library": "1.6.0",
     "System.IO.MemoryMappedFiles": "4.0.0",
     "System.Reflection.Metadata": "1.4.1-beta-24227-04",
-    "Microsoft.DiaSymReader": "1.0.8"
+    "Microsoft.DiaSymReader": "1.0.8",
+    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
This can be used for perf optimizations to avoid cascading `if/is` checks.

(There are more places this can be used, but I want to get a sense for how people feel about it first.)