### PR TITLE
Remove WinRT dependency for SHA1

### DIFF
--- a/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -11,5 +11,6 @@ internal static partial class Interop
         internal const string RealTime = "api-ms-win-core-realtime-l1-1-0.dll";
         internal const string SysInfo = "api-ms-win-core-sysinfo-l1-2-0.dll";
         internal const string Kernel32 = "api-ms-win-core-kernel32-legacy-l1-1-0.dll";
+        internal const string BCrypt = "bcrypt.dll";
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Cryptography/Sha1.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Cryptography/Sha1.Unix.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Internal.Cryptography
+{
+    internal static class Sha1
+    {
+        public static byte[] ComputeSha1(byte[] data)
+        {
+            // TODO - CORERT - Add a CoreLibNative_ComputeSha1() entrypoint to System.Private.CoreLib.Native
+            //  and P/Invoke to that. 
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Cryptography/Sha1.Windows.cs
+++ b/src/System.Private.CoreLib/src/Internal/Cryptography/Sha1.Windows.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Internal.Cryptography
+{
+    internal static class Sha1
+    {
+        public static byte[] ComputeSha1(byte[] data)
+        {
+            SafeBCryptAlgorithmHandle sha1AlgorithmHandle = Sha1AlgorithmHandle;  // Do not dispose - this is a shared handle.
+            SafeBCryptHashHandle hHash;
+            NTSTATUS nts = BCryptCreateHash(sha1AlgorithmHandle, out hHash, IntPtr.Zero, 0, null, 0, 0);
+            if (nts != NTSTATUS.STATUS_SUCCESS)
+                throw new InvalidOperationException(SR.Format(SR.CryptoError_Sha1, nts));
+            using (hHash)
+            {
+                nts = BCryptHashData(hHash, data, data.Length, 0);
+                if (nts != NTSTATUS.STATUS_SUCCESS)
+                    throw new InvalidOperationException(SR.Format(SR.CryptoError_Sha1, nts));
+
+                byte[] hash = new byte[Sha1HashSize];
+                nts = BCryptFinishHash(hHash, hash, hash.Length, 0);
+                if (nts != NTSTATUS.STATUS_SUCCESS)
+                    throw new InvalidOperationException(SR.Format(SR.CryptoError_Sha1, nts));
+
+                return hash;
+            }
+        }
+
+        private static SafeBCryptAlgorithmHandle Sha1AlgorithmHandle
+        {
+            get
+            {
+                SafeBCryptAlgorithmHandle hAlgorithm = s_lazySha1AlgorithmHandle;
+                if (hAlgorithm == null)
+                {
+                    NTSTATUS nts = BCryptOpenAlgorithmProvider(out hAlgorithm, BCRYPT_SHA1_ALGORITHM, null, 0);
+                    if (nts != NTSTATUS.STATUS_SUCCESS)
+                        throw new InvalidOperationException(SR.Format(SR.CryptoError_Sha1, nts));
+
+                    s_lazySha1AlgorithmHandle = hAlgorithm;
+                }
+                return hAlgorithm;
+            }
+        }
+
+        private static volatile SafeBCryptAlgorithmHandle s_lazySha1AlgorithmHandle;
+
+        private const int Sha1HashSize = 20;
+        private const string BCRYPT_SHA1_ALGORITHM = "SHA1";
+
+        [DllImport(Interop.Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static extern NTSTATUS BCryptOpenAlgorithmProvider(out SafeBCryptAlgorithmHandle phAlgorithm, string pszAlgId, string pszImplementation, int dwFlags);
+
+        [DllImport(Interop.Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static extern NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, byte[] pbSecret, int cbSecret, int dwFlags);
+
+        [DllImport(Interop.Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static extern NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, byte[] pbInput, int cbInput, int dwFlags);
+
+        [DllImport(Interop.Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static extern NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, [Out] byte[] pbOutput, int cbOutput, int dwFlags);
+
+        private enum NTSTATUS : uint
+        {
+            STATUS_SUCCESS = 0x0,
+            STATUS_NOT_FOUND = 0xc0000225,
+            STATUS_INVALID_PARAMETER = 0xc000000d,
+            STATUS_NO_MEMORY = 0xc0000017,
+        }
+
+        private sealed class SafeBCryptAlgorithmHandle : SafeHandle
+        {
+            private SafeBCryptAlgorithmHandle() : base(IntPtr.Zero, true) {}
+
+            public sealed override bool IsInvalid => handle == IntPtr.Zero;
+
+            protected sealed override bool ReleaseHandle()
+            {
+                NTSTATUS ntStatus = BCryptCloseAlgorithmProvider(handle, 0);
+                SetHandle(IntPtr.Zero);
+                return ntStatus == NTSTATUS.STATUS_SUCCESS;
+            }
+
+            [DllImport(Interop.Libraries.BCrypt, CharSet = CharSet.Unicode)]
+            private static extern NTSTATUS BCryptCloseAlgorithmProvider(IntPtr hAlgorithm, int dwFlags);
+        }
+
+        private sealed class SafeBCryptHashHandle : SafeHandle
+        {
+            private SafeBCryptHashHandle() : base(IntPtr.Zero, true) {}
+
+            public sealed override bool IsInvalid => handle == IntPtr.Zero;
+
+            protected sealed override bool ReleaseHandle()
+            {
+                NTSTATUS ntStatus = BCryptDestroyHash(handle);
+                SetHandle(IntPtr.Zero);
+                return ntStatus == NTSTATUS.STATUS_SUCCESS;
+            }
+
+            [DllImport(Interop.Libraries.BCrypt, CharSet = CharSet.Unicode)]
+            private static extern NTSTATUS BCryptDestroyHash(IntPtr hHash);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1681,4 +1681,7 @@
   <data name="Security_InvalidAssemblyPublicKey" xml:space="preserve">
     <value>Invalid assembly public key.</value>
   </data>
+  <data name="CryptoError_Sha1" xml:space="preserve">
+    <value>Unexpected cryptographic error while computing SHA1 ({0}).</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -606,6 +606,7 @@
   </ItemGroup>
   <!-- Windows is default build -->
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
+    <Compile Include="Internal\Cryptography\Sha1.Windows.cs" />
     <Compile Include="System\Globalization\CultureInfo.Windows.cs" />
     <Compile Include="System\Globalization\CompareInfo.Windows.cs" />
     <Compile Include="System\Globalization\CultureData.Windows.cs" />
@@ -677,6 +678,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
+    <Compile Include="Internal\Cryptography\Sha1.Unix.cs" />
     <Compile Include="System\Globalization\CultureInfo.Dummy.cs" />
     <Compile Include="System\Globalization\CompareInfo.Dummy.cs" />
     <Compile Include="System\Globalization\CultureData.Dummy.cs" />

--- a/src/System.Private.CoreLib/src/System/Reflection/Runtime/Assemblies/AssemblyNameHelpers.StrongName.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Runtime/Assemblies/AssemblyNameHelpers.StrongName.cs
@@ -2,22 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
-/*============================================================
-**
-  Type:  AssemblyNameHelpers
-**
-==============================================================*/
-
-using System;
-using System.IO;
-using System.Text;
-using System.Collections.Generic;
-using Internal.Runtime.Augments;
-using Buffer = System.Buffer;
-
-using SecurityException = System.Security.SecurityException;
+using System.Security;
+using Internal.Cryptography;
 
 namespace System.Reflection.Runtime.Assemblies
 {
@@ -38,7 +24,7 @@ namespace System.Reflection.Runtime.Assemblies
             // CORERT-TODO: ComputeSHA1
             return Array.Empty<byte>();
 #else
-            byte[] hash = WinRTInterop.Callbacks.ComputeSHA1(publicKey);
+            byte[] hash = Sha1.ComputeSha1(publicKey);
             byte[] pkt = new byte[PUBLIC_KEY_TOKEN_LEN];
             for (int i = 0; i < PUBLIC_KEY_TOKEN_LEN; i++)
             {


### PR DESCRIPTION
Things left undone:

* Delete the now unused ComputeSHA1() callback
  from WinRTInterop.

  That requires changing files in TFS-only areas.
  Will be done separately.

* Enable the new code path on CORERT.

  Tried this. ILC (on CORERT) doesn't yet
  support P/Invokes with SafeHandles in the signature.
  The P/Invoke stub it generates throws an exception.
  
  Unlike ProjectN, CoreRT also travels this code path
  during the initial AssemblyBinder initialization
  so letting it throw isn't an option.

* Put the P/Invokes in Common corefx-style
  because...

  - I don't anticipate any other crypto in
    S.P.Corelib and this is a lot of P/Invoke
    ceremony for a single-purpose function.

  - I'm not sure we're even striving to follow
    this style in CoreRt.

  - The very idea of a Common directory
    seems outdated in CoreRt given that
    all the *.Private.dll's form one
    encapsulation boundary. It seems we'd
    want to remove this as it's causing
    extra copies of code in the image.

  - I think those interop style rules
    are a bad idea even on CoreFx.

* The Unix veersion: CoreRt builds on Linux seems
  non-functional (someone else noticed this too

  https://github.com/dotnet/corert/issues/1892

  though he only seems to have gotten crickets
  for his trouble.)

  Main purpose was to open a discussion on where
  to put the implementation. Consensus seems to be
  to put in the PAL (S.P.Corelib.Native).
  Dependencies should do what S.S.Cryptography.Native
  on CoreFx does (openssl on unix, CommonCrypto on
  Mac/OSX as of this writing.)