### PR TITLE
Make GetName protected internal

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis
             return _nestedNodesList.IndexOf(symbol);
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return "Region " + ((ISymbolNode)_startSymbol).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
@@ -78,7 +78,7 @@ namespace ILCompiler.DependencyAnalysis
                 _parentNode = futureParent;
             }
 
-            public override string GetName()
+            protected override string GetName()
             {
                 return "Embedded pointer to " + Target.MangledName;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
@@ -58,7 +58,7 @@ namespace ILCompiler.DependencyAnalysis
             return new ObjectData(_data, Array.Empty<Relocation>(), _alignment, new ISymbolNode[] { this });
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
@@ -12,7 +12,7 @@ namespace ILCompiler.DependencyAnalysis
         {
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName + " cloned";
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(!_type.IsGenericDefinition);
         }
         
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName + " constructed";
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.DependencyAnalysis
                 return _method;
             }
         }
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -99,7 +99,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return String.Concat("Dictionary layout for " + _owningMethodOrType.ToString());
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -66,7 +66,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -62,7 +62,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.DependencyAnalysis
             _name = name;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return "ExternSymbol " + _name;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenObjectSentinelNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenObjectSentinelNode.cs
@@ -26,7 +26,7 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.EmitZeroPointer();
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return "FrozenObjectSentinelNode";
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
@@ -75,7 +75,7 @@ namespace ILCompiler.DependencyAnalysis
 
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.DependencyAnalysis
             _target = target;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
@@ -124,7 +124,7 @@ namespace ILCompiler.DependencyAnalysis
             return builder.ToObjectData();
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -75,7 +75,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public sealed override string GetName()
+        protected sealed override string GetName()
         {
             return MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -27,7 +27,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis
             _dispatchMapTableIndex = IndexNotSet;
         }
         
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
@@ -62,7 +62,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -41,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis
                 return _method;
             }
         }
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModuleManagerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModuleManagerIndirectionNode.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
@@ -21,7 +21,7 @@ namespace ILCompiler.DependencyAnalysis
             _name = name;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return "Symbol " + _name + " at offset " + _offset.ToStringInvariant();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -697,10 +697,13 @@ namespace ILCompiler.DependencyAnalysis
                     if (node.ShouldSkipEmittingObjectNode(factory))
                         continue;
 
-#if DEBUG
-                    Debug.Assert(_previouslyWrittenNodeNames.Add(node.GetName()), "Duplicate node name emitted to file", "Node {0} has already been written to the output object file {1}", node.GetName(), objectFilePath);
-#endif
                     ObjectNode.ObjectData nodeContents = node.GetData(factory);
+
+#if DEBUG
+                    foreach (ISymbolNode definedSymbol in nodeContents.DefinedSymbols)
+                        Debug.Assert(_previouslyWrittenNodeNames.Add(definedSymbol.MangledName), "Duplicate node name emitted to file", "Symbol {0} has already been written to the output object file {1}", definedSymbol.MangledName, objectFilePath);
+#endif
+
 
                     ObjectNodeSection section = node.Section;
                     if (node.ShouldShareNodeAcrossModules(factory) && factory.Target.OperatingSystem == TargetOS.Windows)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -42,7 +42,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
@@ -40,7 +40,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
@@ -49,7 +49,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
             _target = target;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringDataNode.cs
@@ -82,7 +82,7 @@ namespace ILCompiler.DependencyAnalysis
             return new ObjectData(objectData, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringIndirectionNode.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.EmitPointerReloc(stringDataNode);
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -20,7 +20,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
@@ -61,7 +61,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
@@ -37,7 +37,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return ((ISymbolNode)this).MangledName;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
             get;
         }
         
-        public override string GetName()
+        protected override string GetName()
         {
             return "__vtable_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -27,7 +27,7 @@ namespace ILCompiler.DependencyAnalysis
             _decl = decl;
         }
 
-        public override string GetName()
+        protected override string GetName()
         {
             return "VirtualMethodUse" + _decl.ToString();
         }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -770,7 +770,7 @@ namespace ILCompiler.CppCodeGen
             }
             else
             {
-                nodeCode.Append(node.GetName());
+                nodeCode.Append(((ISymbolNode)node).MangledName);
             }
             nodeCode.Append("()");
             nodeCode.AppendLine();
@@ -847,7 +847,7 @@ namespace ILCompiler.CppCodeGen
                 relocCode.Append(reloc.Target.MangledName);
                 relocCode.Append("()");
             }
-            else if (reloc.Target is ObjectAndOffsetSymbolNode && (reloc.Target as ObjectAndOffsetSymbolNode).GetName().Contains("DispatchMap"))
+            else if (reloc.Target is ObjectAndOffsetSymbolNode && (reloc.Target as ISymbolNode).MangledName.Contains("DispatchMap"))
             {
                 relocCode.Append("dispatchMapModule");
             }
@@ -972,7 +972,7 @@ namespace ILCompiler.CppCodeGen
                 else if (node is InterfaceDispatchMapNode)
                 {
                     dispatchPointers.Append("(void *)");
-                    dispatchPointers.Append(node.GetName());
+                    dispatchPointers.Append(((ISymbolNode)node).MangledName);
                     dispatchPointers.Append("(),");
                     dispatchPointers.AppendLine();
                     dispatchMapCount++;
@@ -1193,7 +1193,7 @@ namespace ILCompiler.CppCodeGen
             rtrHeader.Append("{ 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 },");
             rtrHeader.AppendLine();
             rtrHeader.Append("(void*)");
-            rtrHeader.Append(headerNode.GetName());
+            rtrHeader.Append(((ISymbolNode)headerNode).MangledName);
             rtrHeader.Append("(),");
             rtrHeader.AppendLine();
             rtrHeader.Append("{ 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 }");

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNode.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNode.cs
@@ -40,9 +40,9 @@ namespace ILCompiler.DependencyAnalysisFramework
         }
 
         // Force all non-abstract nodes to provide a name
-        public abstract string GetName();
+        protected internal abstract string GetName();
 
-        public sealed override string ToString()
+        public override string ToString()
         {
             return GetName();
         }

--- a/src/ILCompiler.DependencyAnalysisFramework/tests/TestGraph.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/TestGraph.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysisFramework.Tests
                 }
             }
 
-            public override string GetName()
+            protected override string GetName()
             {
                 return _data;
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -153,7 +153,7 @@ namespace Internal.JitInterface
                 catch (Exception e)
                 {
                     // Debug info not successfully loaded.
-                    _compilation.Log.WriteLine(e.Message + " (" + methodCodeNodeNeedingCode.GetName() + ")");
+                    _compilation.Log.WriteLine(e.Message + " (" + methodCodeNodeNeedingCode.ToString() + ")");
                 }
 
                 CorInfoImpl _this = this;


### PR DESCRIPTION
`GetName` is "get the name to be used in the diagnostic log". The rules
around it in the compier are:

* if the node is a `ISymbolNode` it should include the mangled name so
that it's easy to crossreference it with the object file (doesn't
necessarily have to be equal to the mangled name - see EETypeNode and
friends that append "constructed", etc.)
* if the node is not an `ISymbolNode`, get something that will be useful
to search for in the dependency log

I'm making the API protected and internal to avoid misuse and fixing the
places misusing this API (the spot in ObjectWriter was just wrong,
CppWriter was okay, but with problems waiting to happen).

I'm also unsealing ToString. We'll want to override it on a case-by-case
basis to make debugger experience more pleasant.