### PR TITLE
Rename DictionaryEntry to GenericLookupResult

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -104,16 +104,11 @@ namespace ILCompiler.DependencyAnalysis
             return String.Concat("Dictionary layout for " + _owningMethodOrType.ToString());
         }
 
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
-        {
-            foreach (GenericLookupResultNode entry in EntryHashTable.Enumerator.Get(_entries))
-                yield return new DependencyListEntry(entry, "Canonical dependency");
-        }
-
         public override bool HasConditionalStaticDependencies => false;
         public override bool HasDynamicDependencies => false;
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
             List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -14,28 +14,28 @@ namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
     /// Represents the layout of the generic dictionary associated with a given canonical
-    /// generic type or generic method. Maintains a bag of <see cref="DictionaryEntry"/> associated
+    /// generic type or generic method. Maintains a bag of <see cref="GenericLookupResultNode"/> associated
     /// with the canonical entity.
     /// </summary>
     /// <remarks>
-    /// The generic dictionary doesn't have any dependent nodes because <see cref="DictionaryEntry"/>
+    /// The generic dictionary doesn't have any dependent nodes because <see cref="GenericLookupResultNode"/>
     /// are runtime-determined - the concrete dependency depends on the generic context the canonical
     /// entity is instantiated with.
     /// </remarks>
     class DictionaryLayoutNode : DependencyNodeCore<NodeFactory>
     {
-        class EntryHashTable : LockFreeReaderHashtable<DictionaryEntry, DictionaryEntry>
+        class EntryHashTable : LockFreeReaderHashtable<GenericLookupResultNode, GenericLookupResultNode>
         {
-            protected override bool CompareKeyToValue(DictionaryEntry key, DictionaryEntry value) => Object.Equals(key, value);
-            protected override bool CompareValueToValue(DictionaryEntry value1, DictionaryEntry value2) => Object.Equals(value1, value2);
-            protected override DictionaryEntry CreateValueFromKey(DictionaryEntry key) => key;
-            protected override int GetKeyHashCode(DictionaryEntry key) => key.GetHashCode();
-            protected override int GetValueHashCode(DictionaryEntry value) => value.GetHashCode();
+            protected override bool CompareKeyToValue(GenericLookupResultNode key, GenericLookupResultNode value) => Object.Equals(key, value);
+            protected override bool CompareValueToValue(GenericLookupResultNode value1, GenericLookupResultNode value2) => Object.Equals(value1, value2);
+            protected override GenericLookupResultNode CreateValueFromKey(GenericLookupResultNode key) => key;
+            protected override int GetKeyHashCode(GenericLookupResultNode key) => key.GetHashCode();
+            protected override int GetValueHashCode(GenericLookupResultNode value) => value.GetHashCode();
         }
 
         private TypeSystemEntity _owningMethodOrType;
         private EntryHashTable _entries = new EntryHashTable();
-        private volatile DictionaryEntry[] _layout;
+        private volatile GenericLookupResultNode[] _layout;
 
         public DictionaryLayoutNode(TypeSystemEntity owningMethodOrType)
         {
@@ -43,7 +43,7 @@ namespace ILCompiler.DependencyAnalysis
             Validate();
         }
 
-        public void EnsureEntry(DictionaryEntry entry)
+        public void EnsureEntry(GenericLookupResultNode entry)
         {
             Debug.Assert(_layout == null, "Trying to add entry but layout already computed");
             _entries.AddOrGetExisting(entry);
@@ -52,9 +52,9 @@ namespace ILCompiler.DependencyAnalysis
         private void ComputeLayout()
         {
             // TODO: deterministic ordering
-            DictionaryEntry[] layout = new DictionaryEntry[_entries.Count];
+            GenericLookupResultNode[] layout = new GenericLookupResultNode[_entries.Count];
             int index = 0;
-            foreach (DictionaryEntry entry in EntryHashTable.Enumerator.Get(_entries))
+            foreach (GenericLookupResultNode entry in EntryHashTable.Enumerator.Get(_entries))
             {
                 layout[index++] = entry;
             }
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis
             _layout = layout;
         }
 
-        public int GetSlotForEntry(DictionaryEntry entry)
+        public int GetSlotForEntry(GenericLookupResultNode entry)
         {
             if (_layout == null)
                 ComputeLayout();
@@ -73,7 +73,7 @@ namespace ILCompiler.DependencyAnalysis
             return index;
         }
 
-        public IEnumerable<DictionaryEntry> Entries
+        public IEnumerable<GenericLookupResultNode> Entries
         {
             get
             {
@@ -106,7 +106,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            foreach (DictionaryEntry entry in EntryHashTable.Enumerator.Get(_entries))
+            foreach (GenericLookupResultNode entry in EntryHashTable.Enumerator.Get(_entries))
                 yield return new DependencyListEntry(entry, "Canonical dependency");
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -14,28 +14,28 @@ namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
     /// Represents the layout of the generic dictionary associated with a given canonical
-    /// generic type or generic method. Maintains a bag of <see cref="GenericLookupResultNode"/> associated
+    /// generic type or generic method. Maintains a bag of <see cref="GenericLookupResult"/> associated
     /// with the canonical entity.
     /// </summary>
     /// <remarks>
-    /// The generic dictionary doesn't have any dependent nodes because <see cref="GenericLookupResultNode"/>
+    /// The generic dictionary doesn't have any dependent nodes because <see cref="GenericLookupResult"/>
     /// are runtime-determined - the concrete dependency depends on the generic context the canonical
     /// entity is instantiated with.
     /// </remarks>
     class DictionaryLayoutNode : DependencyNodeCore<NodeFactory>
     {
-        class EntryHashTable : LockFreeReaderHashtable<GenericLookupResultNode, GenericLookupResultNode>
+        class EntryHashTable : LockFreeReaderHashtable<GenericLookupResult, GenericLookupResult>
         {
-            protected override bool CompareKeyToValue(GenericLookupResultNode key, GenericLookupResultNode value) => Object.Equals(key, value);
-            protected override bool CompareValueToValue(GenericLookupResultNode value1, GenericLookupResultNode value2) => Object.Equals(value1, value2);
-            protected override GenericLookupResultNode CreateValueFromKey(GenericLookupResultNode key) => key;
-            protected override int GetKeyHashCode(GenericLookupResultNode key) => key.GetHashCode();
-            protected override int GetValueHashCode(GenericLookupResultNode value) => value.GetHashCode();
+            protected override bool CompareKeyToValue(GenericLookupResult key, GenericLookupResult value) => Object.Equals(key, value);
+            protected override bool CompareValueToValue(GenericLookupResult value1, GenericLookupResult value2) => Object.Equals(value1, value2);
+            protected override GenericLookupResult CreateValueFromKey(GenericLookupResult key) => key;
+            protected override int GetKeyHashCode(GenericLookupResult key) => key.GetHashCode();
+            protected override int GetValueHashCode(GenericLookupResult value) => value.GetHashCode();
         }
 
         private TypeSystemEntity _owningMethodOrType;
         private EntryHashTable _entries = new EntryHashTable();
-        private volatile GenericLookupResultNode[] _layout;
+        private volatile GenericLookupResult[] _layout;
 
         public DictionaryLayoutNode(TypeSystemEntity owningMethodOrType)
         {
@@ -43,7 +43,7 @@ namespace ILCompiler.DependencyAnalysis
             Validate();
         }
 
-        public void EnsureEntry(GenericLookupResultNode entry)
+        public void EnsureEntry(GenericLookupResult entry)
         {
             Debug.Assert(_layout == null, "Trying to add entry but layout already computed");
             _entries.AddOrGetExisting(entry);
@@ -52,9 +52,9 @@ namespace ILCompiler.DependencyAnalysis
         private void ComputeLayout()
         {
             // TODO: deterministic ordering
-            GenericLookupResultNode[] layout = new GenericLookupResultNode[_entries.Count];
+            GenericLookupResult[] layout = new GenericLookupResult[_entries.Count];
             int index = 0;
-            foreach (GenericLookupResultNode entry in EntryHashTable.Enumerator.Get(_entries))
+            foreach (GenericLookupResult entry in EntryHashTable.Enumerator.Get(_entries))
             {
                 layout[index++] = entry;
             }
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis
             _layout = layout;
         }
 
-        public int GetSlotForEntry(GenericLookupResultNode entry)
+        public int GetSlotForEntry(GenericLookupResult entry)
         {
             if (_layout == null)
                 ComputeLayout();
@@ -73,7 +73,7 @@ namespace ILCompiler.DependencyAnalysis
             return index;
         }
 
-        public IEnumerable<GenericLookupResultNode> Entries
+        public IEnumerable<GenericLookupResult> Entries
         {
             get
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -25,11 +25,11 @@ namespace ILCompiler.DependencyAnalysis
     /// <summary>
     /// Generic lookup result that points to an EEType.
     /// </summary>
-    internal sealed class TypeHandleDictionaryEntry : GenericLookupResult
+    internal sealed class TypeHandleGenericLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
 
-        public TypeHandleDictionaryEntry(TypeDesc type)
+        public TypeHandleGenericLookupResult(TypeDesc type)
         {
             Debug.Assert(type.IsRuntimeDeterminedSubtype, "Concrete type in a generic dictionary?");
             _type = type;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.DependencyAnalysis
     /// <see cref="GetTarget(NodeFactory, Instantiation, Instantiation)"/> to obtain the concrete
     /// node the result points to.
     /// </summary>
-    public abstract class GenericLookupResultNode
+    public abstract class GenericLookupResult
     {
         public abstract ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation);
         public abstract string GetMangledName(NameMangler nameMangler);
@@ -25,7 +25,7 @@ namespace ILCompiler.DependencyAnalysis
     /// <summary>
     /// Generic lookup result that points to an EEType.
     /// </summary>
-    internal sealed class TypeHandleDictionaryEntry : GenericLookupResultNode
+    internal sealed class TypeHandleDictionaryEntry : GenericLookupResult
     {
         private TypeDesc _type;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResultNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResultNode.cs
@@ -2,38 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 using Internal.TypeSystem;
-
-using ILCompiler.DependencyAnalysisFramework;
 
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
     /// Represents the result of a generic lookup within a canonical method body.
-    /// This node is abstract and doesn't get emitted into the object file. The concrete
-    /// artifact the generic lookup will result in can only be determined after substituting
+    /// The concrete artifact the generic lookup will result in can only be determined after substituting
     /// runtime determined types with a concrete generic context. Use
     /// <see cref="GetTarget(NodeFactory, Instantiation, Instantiation)"/> to obtain the concrete
     /// node the result points to.
     /// </summary>
-    public abstract class GenericLookupResultNode : DependencyNodeCore<NodeFactory>
+    public abstract class GenericLookupResultNode
     {
         public abstract ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation);
         public abstract string GetMangledName(NameMangler nameMangler);
-
-        public sealed override bool HasConditionalStaticDependencies => false;
-        public sealed override bool HasDynamicDependencies => false;
-        public sealed override bool InterestingForDynamicDependencyAnalysis => false;
-        public sealed override bool StaticDependenciesAreComputed => true;
-        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
-        public sealed override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
-            List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
-        public sealed override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(
-            NodeFactory factory) => null;
+        public abstract override string ToString();
     }
 
     /// <summary>
@@ -60,6 +46,6 @@ namespace ILCompiler.DependencyAnalysis
             return $"TypeHandle_{nameMangler.GetMangledTypeName(_type)}";
         }
 
-        protected override string GetName() => $"TypeHandle: {_type}";
+        public override string ToString() => $"TypeHandle: {_type}";
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResultNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResultNode.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.TypeSystem;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents the result of a generic lookup within a canonical method body.
+    /// This node is abstract and doesn't get emitted into the object file. The concrete
+    /// artifact the generic lookup will result in can only be determined after substituting
+    /// runtime determined types with a concrete generic context. Use
+    /// <see cref="GetTarget(NodeFactory, Instantiation, Instantiation)"/> to obtain the concrete
+    /// node the result points to.
+    /// </summary>
+    public abstract class DictionaryEntry : DependencyNodeCore<NodeFactory>
+    {
+        public abstract ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation);
+        public abstract string GetMangledName(NameMangler nameMangler);
+
+        public sealed override bool HasConditionalStaticDependencies => false;
+        public sealed override bool HasDynamicDependencies => false;
+        public sealed override bool InterestingForDynamicDependencyAnalysis => false;
+        public sealed override bool StaticDependenciesAreComputed => true;
+        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+        public sealed override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
+            List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+        public sealed override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(
+            NodeFactory factory) => null;
+    }
+
+    /// <summary>
+    /// Generic lookup result that points to an EEType.
+    /// </summary>
+    internal sealed class TypeHandleDictionaryEntry : DictionaryEntry
+    {
+        private TypeDesc _type;
+
+        public TypeHandleDictionaryEntry(TypeDesc type)
+        {
+            Debug.Assert(type.IsRuntimeDeterminedSubtype, "Concrete type in a generic dictionary?");
+            _type = type;
+        }
+
+        public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            return factory.NecessaryTypeSymbol(instantiatedType);
+        }
+
+        public override string GetMangledName(NameMangler nameMangler)
+        {
+            return $"TypeHandle_{nameMangler.GetMangledTypeName(_type)}";
+        }
+
+        protected override string GetName() => $"TypeHandle: {_type}";
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResultNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResultNode.cs
@@ -20,7 +20,7 @@ namespace ILCompiler.DependencyAnalysis
     /// <see cref="GetTarget(NodeFactory, Instantiation, Instantiation)"/> to obtain the concrete
     /// node the result points to.
     /// </summary>
-    public abstract class DictionaryEntry : DependencyNodeCore<NodeFactory>
+    public abstract class GenericLookupResultNode : DependencyNodeCore<NodeFactory>
     {
         public abstract ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation);
         public abstract string GetMangledName(NameMangler nameMangler);
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis
     /// <summary>
     /// Generic lookup result that points to an EEType.
     /// </summary>
-    internal sealed class TypeHandleDictionaryEntry : DictionaryEntry
+    internal sealed class TypeHandleDictionaryEntry : GenericLookupResultNode
     {
         private TypeDesc _type;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 _typeSymbols = new NodeCache<TypeDesc, GenericLookupResult>(type =>
                 {
-                    return new TypeHandleDictionaryEntry(type);
+                    return new TypeHandleGenericLookupResult(type);
                 });
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -7,7 +7,7 @@ using Internal.TypeSystem;
 namespace ILCompiler.DependencyAnalysis
 {
     /// Part of Node factory that deals with nodes describing results of generic lookups.
-    /// See: <see cref="GenericLookupResultNode"/>.
+    /// See: <see cref="GenericLookupResult"/>.
     partial class NodeFactory
     {
         /// <summary>
@@ -22,15 +22,15 @@ namespace ILCompiler.DependencyAnalysis
 
             private void CreateNodeCaches()
             {
-                _typeSymbols = new NodeCache<TypeDesc, GenericLookupResultNode>(type =>
+                _typeSymbols = new NodeCache<TypeDesc, GenericLookupResult>(type =>
                 {
                     return new TypeHandleDictionaryEntry(type);
                 });
             }
 
-            private NodeCache<TypeDesc, GenericLookupResultNode> _typeSymbols;
+            private NodeCache<TypeDesc, GenericLookupResult> _typeSymbols;
 
-            public GenericLookupResultNode Type(TypeDesc type)
+            public GenericLookupResult Type(TypeDesc type)
             {
                 return _typeSymbols.GetOrAdd(type);
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// Part of Node factory that deals with nodes describing results of generic lookups.
+    /// See: <see cref="DictionaryEntry"/>.
+    partial class NodeFactory
+    {
+        /// <summary>
+        /// Helper class that provides a level of grouping for all the generic lookup result kinds.
+        /// </summary>
+        public class GenericLookupResults
+        {
+            public GenericLookupResults()
+            {
+                CreateNodeCaches();
+            }
+
+            private void CreateNodeCaches()
+            {
+                _typeSymbols = new NodeCache<TypeDesc, DictionaryEntry>(type =>
+                {
+                    return new TypeHandleDictionaryEntry(type);
+                });
+            }
+
+            private NodeCache<TypeDesc, DictionaryEntry> _typeSymbols;
+
+            public DictionaryEntry Type(TypeDesc type)
+            {
+                return _typeSymbols.GetOrAdd(type);
+            }
+        }
+
+        public GenericLookupResults GenericLookup = new GenericLookupResults();
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -7,7 +7,7 @@ using Internal.TypeSystem;
 namespace ILCompiler.DependencyAnalysis
 {
     /// Part of Node factory that deals with nodes describing results of generic lookups.
-    /// See: <see cref="DictionaryEntry"/>.
+    /// See: <see cref="GenericLookupResultNode"/>.
     partial class NodeFactory
     {
         /// <summary>
@@ -22,15 +22,15 @@ namespace ILCompiler.DependencyAnalysis
 
             private void CreateNodeCaches()
             {
-                _typeSymbols = new NodeCache<TypeDesc, DictionaryEntry>(type =>
+                _typeSymbols = new NodeCache<TypeDesc, GenericLookupResultNode>(type =>
                 {
                     return new TypeHandleDictionaryEntry(type);
                 });
             }
 
-            private NodeCache<TypeDesc, DictionaryEntry> _typeSymbols;
+            private NodeCache<TypeDesc, GenericLookupResultNode> _typeSymbols;
 
-            public DictionaryEntry Type(TypeDesc type)
+            public GenericLookupResultNode Type(TypeDesc type)
             {
                 return _typeSymbols.GetOrAdd(type);
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -14,7 +14,7 @@ using Internal.IL;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public abstract class NodeFactory
+    public abstract partial class NodeFactory
     {
         private TargetDetails _target;
         private CompilerTypeSystemContext _context;

--- a/src/ILCompiler.Compiler/src/Compiler/GenericLookupDescriptor.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/GenericLookupDescriptor.cs
@@ -14,9 +14,9 @@ namespace ILCompiler.DependencyAnalysis
     {
         public readonly TypeSystemEntity CanonicalOwner;
 
-        public readonly DictionaryEntry Signature;
+        public readonly GenericLookupResultNode Signature;
 
-        public GenericLookupDescriptor(TypeSystemEntity canonicalOwner, DictionaryEntry signature)
+        public GenericLookupDescriptor(TypeSystemEntity canonicalOwner, GenericLookupResultNode signature)
         {
             // Owner should be a canonical type or canonical method
             Debug.Assert((

--- a/src/ILCompiler.Compiler/src/Compiler/GenericLookupDescriptor.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/GenericLookupDescriptor.cs
@@ -14,9 +14,9 @@ namespace ILCompiler.DependencyAnalysis
     {
         public readonly TypeSystemEntity CanonicalOwner;
 
-        public readonly GenericLookupResultNode Signature;
+        public readonly GenericLookupResult Signature;
 
-        public GenericLookupDescriptor(TypeSystemEntity canonicalOwner, GenericLookupResultNode signature)
+        public GenericLookupDescriptor(TypeSystemEntity canonicalOwner, GenericLookupResult signature)
         {
             // Owner should be a canonical type or canonical method
             Debug.Assert((

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -75,7 +75,9 @@
     <Compile Include="Compiler\DependencyAnalysis\GenericCompositionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDefinitionEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDictionaryNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericLookupResultNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IEETypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NodeFactory.GenericLookups.cs" />
     <Compile Include="Compiler\DependencyAnalysis\PInvokeMethodFixupNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\PInvokeModuleFixupNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RyuJitNodeFactory.cs" />

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -75,7 +75,7 @@
     <Compile Include="Compiler\DependencyAnalysis\GenericCompositionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDefinitionEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDictionaryNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\GenericLookupResultNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericLookupResult.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\NodeFactory.GenericLookups.cs" />
     <Compile Include="Compiler\DependencyAnalysis\PInvokeMethodFixupNode.cs" />

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1156,7 +1156,7 @@ namespace Internal.JitInterface
             return type.IsNullable ? CorInfoHelpFunc.CORINFO_HELP_UNBOX_NULLABLE : CorInfoHelpFunc.CORINFO_HELP_UNBOX;
         }
 
-        private DictionaryEntry GetTargetForFixup(object resolvedToken, ReadyToRunFixupKind fixupKind)
+        private GenericLookupResultNode GetTargetForFixup(object resolvedToken, ReadyToRunFixupKind fixupKind)
         {
             switch (fixupKind)
             {
@@ -1229,7 +1229,7 @@ namespace Internal.JitInterface
 
                         ReadyToRunFixupKind fixupKind = (ReadyToRunFixupKind)pGenericLookupKind.runtimeLookupFlags;
                         object fixupTarget = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
-                        DictionaryEntry target = GetTargetForFixup(fixupTarget, fixupKind);
+                        GenericLookupResultNode target = GetTargetForFixup(fixupTarget, fixupKind);
 
                         ReadyToRunHelperId helper;
                         TypeSystemEntity dictionaryOwner;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1156,7 +1156,7 @@ namespace Internal.JitInterface
             return type.IsNullable ? CorInfoHelpFunc.CORINFO_HELP_UNBOX_NULLABLE : CorInfoHelpFunc.CORINFO_HELP_UNBOX;
         }
 
-        private GenericLookupResultNode GetTargetForFixup(object resolvedToken, ReadyToRunFixupKind fixupKind)
+        private GenericLookupResult GetTargetForFixup(object resolvedToken, ReadyToRunFixupKind fixupKind)
         {
             switch (fixupKind)
             {
@@ -1229,7 +1229,7 @@ namespace Internal.JitInterface
 
                         ReadyToRunFixupKind fixupKind = (ReadyToRunFixupKind)pGenericLookupKind.runtimeLookupFlags;
                         object fixupTarget = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
-                        GenericLookupResultNode target = GetTargetForFixup(fixupTarget, fixupKind);
+                        GenericLookupResult target = GetTargetForFixup(fixupTarget, fixupKind);
 
                         ReadyToRunHelperId helper;
                         TypeSystemEntity dictionaryOwner;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1156,15 +1156,15 @@ namespace Internal.JitInterface
             return type.IsNullable ? CorInfoHelpFunc.CORINFO_HELP_UNBOX_NULLABLE : CorInfoHelpFunc.CORINFO_HELP_UNBOX;
         }
 
-        private static DictionaryEntry GetTargetForFixup(object resolvedToken, ReadyToRunFixupKind fixupKind)
+        private DictionaryEntry GetTargetForFixup(object resolvedToken, ReadyToRunFixupKind fixupKind)
         {
             switch (fixupKind)
             {
                 case ReadyToRunFixupKind.TypeHandle:
                     if (resolvedToken is TypeDesc)
-                        return new TypeHandleDictionaryEntry((TypeDesc)resolvedToken);
+                        return _compilation.NodeFactory.GenericLookup.Type((TypeDesc)resolvedToken);
                     else
-                        return new TypeHandleDictionaryEntry(((MethodDesc)resolvedToken).OwningType);
+                        return _compilation.NodeFactory.GenericLookup.Type(((MethodDesc)resolvedToken).OwningType);
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
And use interning to avoid unnecessary allocations and remove the requirement to override Equals/GetHashCode in each lookup result.