### PR TITLE
Make it so that the desktop project is the default startup project

### DIFF
--- a/src/ILCompiler/ILCompiler.sln
+++ b/src/ILCompiler/ILCompiler.sln
@@ -3,6 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "desktop", "desktop\desktop.csproj", "{B2C35178-5E42-4010-A72A-938711D7F8F0}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FBA029C3-B184-4457-AEEC-38D0C2523067} = {FBA029C3-B184-4457-AEEC-38D0C2523067}
+	EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler", "src\ILCompiler.csproj", "{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "repro", "repro\repro.csproj", "{FBA029C3-B184-4457-AEEC-38D0C2523067}"
@@ -12,11 +17,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.DependencyAnalysisFramework", "..\ILCompiler.DependencyAnalysisFramework\src\ILCompiler.DependencyAnalysisFramework.csproj", "{DAC23E9F-F826-4577-AE7A-0849FF83280C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.Compiler", "..\ILCompiler.Compiler\src\ILCompiler.Compiler.csproj", "{13BB3788-C3EB-4046-8105-A95F8AE49404}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "desktop", "desktop\desktop.csproj", "{B2C35178-5E42-4010-A72A-938711D7F8F0}"
-	ProjectSection(ProjectDependencies) = postProject
-		{FBA029C3-B184-4457-AEEC-38D0C2523067} = {FBA029C3-B184-4457-AEEC-38D0C2523067}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.CoreLib", "..\System.Private.CoreLib\src\System.Private.CoreLib.csproj", "{BE95C560-B508-4588-8907-F9FC5BC1A0CF}"
 EndProject
@@ -30,6 +30,10 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|x64.ActiveCfg = Debug|x64
+		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|x64.Build.0 = Debug|x64
+		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.ActiveCfg = Release|x64
+		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.Build.0 = Release|x64
 		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Debug|x64.Build.0 = Debug|Any CPU
 		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Release|x64.ActiveCfg = Release|Any CPU
@@ -50,10 +54,6 @@ Global
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Debug|x64.Build.0 = Debug|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Release|x64.ActiveCfg = Release|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Release|x64.Build.0 = Release|Any CPU
-		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|x64.ActiveCfg = Debug|x64
-		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|x64.Build.0 = Debug|x64
-		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.ActiveCfg = Release|x64
-		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.Build.0 = Release|x64
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x64.ActiveCfg = Debug|x64
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x64.Build.0 = Debug|x64
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
VS picks the first project in the SLN file as the startup project
(unless the user already overrode it in their .SUO). This makes our
solution more friendly to people new to the repo.