### PR TITLE
Allow shared generics in single method mode parameters

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -200,11 +200,18 @@ namespace ILCompiler
 
         private TypeDesc FindType(CompilerTypeSystemContext context, string typeName)
         {
-            TypeDesc foundType = context.SystemModule.GetTypeByCustomAttributeTypeName(typeName);
+            ModuleDesc systemModule = context.SystemModule;
+
+            TypeDesc foundType = systemModule.GetTypeByCustomAttributeTypeName(typeName);
             if (foundType == null)
                 throw new CommandLineException($"Type '{typeName}' not found");
 
-            return foundType;
+            TypeDesc classLibCanon = systemModule.GetType("System", "__Canon", false);
+            TypeDesc classLibUniCanon = systemModule.GetType("System", "__UniversalCanon", false);
+
+            return foundType.ReplaceTypesInConstructionOfType(
+                new TypeDesc[] { classLibCanon, classLibUniCanon },
+                new TypeDesc[] { context.CanonType, context.UniversalCanonType });
         }
 
         private MethodDesc CheckAndParseSingleMethodModeArguments(CompilerTypeSystemContext context)


### PR DESCRIPTION
We don't really need System.__Canon in the class library in order to
support shared generics, but it turns out it's useful for the single
method compilation mode since our string parsing logic is not __Canon
aware.