### PR TITLE
Make CastableObjectSupport constructor eager

### DIFF
--- a/src/Runtime.Base/src/System/Runtime/CastableObjectSupport.cs
+++ b/src/Runtime.Base/src/System/Runtime/CastableObjectSupport.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Runtime
 {
+    [System.Runtime.CompilerServices.EagerStaticClassConstructionAttribute]
     static class CastableObjectSupport
     {
         private static object s_castFailCanary = new object();


### PR DESCRIPTION
This was breaking Test.CoreLib since we don't have a class constructor runner there.

In the longer term, we'll probably want the compiler to detect if a class constructor runner is available in the classlib and make everything eager if it isn't.

In general this is a bigger feature because at that point we also need to topologically sort the constructors based on their dependencies. (We might already have a problem there...)