### PR TITLE
Redirect git rev-parse HEAD error output

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -18,6 +18,20 @@
   <!-- Override corefx multi targeting support -->
   <Target Name="ConvertCommonMetadataToAdditionalProperties" BeforeTargets="AssignProjectConfiguration" />
 
+  <!-- Remove once we pick up buildtools with the fix - https://github.com/dotnet/buildtools/pull/1082 -->
+  <!-- Override GetLatestCommitHash with redirected error output to avoid bogus messages 
+       about missing git tool when building inside VS -->
+  <Target Name="GetLatestCommitHash" Condition="'$(LatestCommit)'==''">
+    <Exec Command="git rev-parse HEAD 2>&amp;1" StandardOutputImportance="Low" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="LatestCommit" />
+      <Output TaskParameter="ExitCode" PropertyName="LatestCommitExitCode" />
+    </Exec>
+    <!-- We shouldn't fail the build if we can't retreive the commit hash, so in this case just set it to N/A -->
+    <PropertyGroup Condition="'$(LatestCommitExitCode)'!='0'">
+      <LatestCommit>N/A</LatestCommit>
+    </PropertyGroup>
+  </Target>
+
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder that exists to skip
          the GenerateReferenceAssemblyPaths task (not target) and to prevent it from outputting a warning (MSB3644). -->


### PR DESCRIPTION
Redirect git rev-parse HEAD error output to avoid bogus messages about missing git tool when building inside VS and not having git on the path.