### PR TITLE
Cleanup System.Environment implementation

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Environment.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Environment.cs
@@ -13,9 +13,6 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetEnvironmentVariable")]
         internal static unsafe extern int GetEnvironmentVariable(string name, out IntPtr result);
 
-        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetMachineName")]
-        internal static unsafe extern int GetMachineName(byte *hostNameBuffer, int hostNameBufferSize);
-
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_ExitProcess")]
         internal static extern void ExitProcess(int exitCode);
     }

--- a/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
@@ -14,12 +14,6 @@ internal static partial class Interop
         [DllImport(Libraries.ProcessEnvironment, EntryPoint = "GetEnvironmentVariableW")]
         internal static unsafe extern int GetEnvironmentVariable(char* lpName, char* lpValue, int size);
 
-        [DllImport(Libraries.ProcessEnvironment, EntryPoint = "ExpandEnvironmentStringsW")]
-        internal static unsafe extern int ExpandEnvironmentStrings(char* lpSrc, char* lpDst, int nSize);
-
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetComputerNameW")]
-        internal static unsafe extern int GetComputerName(char* nameBuffer, ref int bufferSize);
-
         [DllImport(Libraries.Kernel32, EntryPoint = "ExitProcess")]
         internal static extern void ExitProcess(int exitCode);
     }

--- a/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <unistd.h>
 #include <assert.h>
 #include <config.h>
 #include <sys/time.h>
@@ -37,27 +36,6 @@ extern "C" int32_t CoreLibNative_GetEnvironmentVariable(const char* variable, ch
     }
 
     return (int32_t)resultSize;
-}
-
-extern "C" int32_t CoreLibNative_GetMachineName(char* hostNameBuffer, int32_t hostNameBufferLength)
-{
-    assert(hostNameBuffer != NULL && hostNameBufferLength > 0);
-
-    int32_t res = gethostname(hostNameBuffer, hostNameBufferLength);
-    if (res < 0)
-        return res;
-
-    // If the hostname is truncated, it is unspecified whether the returned buffer includes a terminating null byte.
-    hostNameBuffer[hostNameBufferLength - 1] = '\0';
-
-    // truncate the domain from the host name if it exist    
-    char *pDot = strchr(hostNameBuffer, '.');
-    if (pDot != NULL)
-    {
-        *pDot = '\0';    
-    }
-    
-    return strlen(hostNameBuffer);
 }
 
 #define SECONDS_TO_MILLISECONDS 1000

--- a/src/System.Private.CoreLib/src/Internal/Diagnostics/StackTraceHelper.cs
+++ b/src/System.Private.CoreLib/src/Internal/Diagnostics/StackTraceHelper.cs
@@ -17,10 +17,15 @@ namespace Internal.Diagnostics
     {
         public static string FormatStackTrace(IntPtr[] ips, bool includeFileInfo)
         {
+            return FormatStackTrace(ips, 0, includeFileInfo);
+        }
+
+        public static string FormatStackTrace(IntPtr[] ips, int skipFrames, bool includeFileInfo)
+        {
             StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < ips.Length; i++)
+            for (int i = skipFrames; i < ips.Length; i++)
             {
-                if (i != 0)
+                if (i != skipFrames)
                     sb.AppendLine();
 
                 IntPtr ip = ips[i];

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
@@ -3,19 +3,61 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime;
+using System.Runtime.CompilerServices;
 
 namespace Internal.Runtime.Augments
 {
     /// <summary>For internal use only.  Exposes runtime functionality to the Environments implementation in corefx.</summary>
     public static class EnvironmentAugments
     {
-        public static int CurrentManagedThreadId => Environment.CurrentManagedThreadId;
+        public static int CurrentManagedThreadId => System.Threading.ManagedThreadId.Current;
+        public static void FailFast(string message, Exception error) => RuntimeExceptionHelpers.FailFast(message, error);
+
         public static void Exit(int exitCode) => Environment.Exit(exitCode);
         public static int ExitCode { get { return 0; } set { throw new PlatformNotSupportedException(); } }
-        public static void FailFast(string message, Exception error) => Environment.FailFast(message, error);
-        public static string[] GetCommandLineArgs() => Environment.GetCommandLineArgs();
-        public static bool HasShutdownStarted => Environment.HasShutdownStarted;
-        public static string StackTrace => Environment.StackTrace;
+
+        private static string[] s_commandLineArgs;
+
+        internal static void SetCommandLineArgs(string[] args)
+        {
+            s_commandLineArgs = args;
+        }
+
+        public static string[] GetCommandLineArgs()
+        {
+            return (string[])s_commandLineArgs?.Clone();
+        }
+
+        public static bool HasShutdownStarted => false; // .NET Core does not have shutdown finalization
+
+        public static string StackTrace
+        {
+            // Disable inlining to have predictable stack frame to skip
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get
+            {
+                // RhGetCurrentThreadStackTrace returns the number of frames(cFrames) added to input buffer.
+                // It returns a negative value, -cFrames which is the required array size, if the buffer is too small.
+                // Initial array length is deliberately chosen to be 0 so that we reallocate to exactly the right size
+                // for StackFrameHelper.FormatStackTrace call. If we want to do this optimistically with one call change
+                // FormatStackTrace to accept an explicit length.
+                IntPtr[] frameIPs = Array.Empty<IntPtr>();
+                int cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
+                if (cFrames < 0)
+                {
+                    frameIPs = new IntPtr[-cFrames];
+                    cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
+                    if (cFrames < 0)
+                    {
+                        return "";
+                    }
+                }
+
+                return Internal.Diagnostics.StackTraceHelper.FormatStackTrace(frameIPs, 1, true);
+            }
+        }
+
         public static int TickCount => Environment.TickCount;
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 
 using Internal.NativeFormat;
+using Internal.Runtime.Augments;
 
 using Debug = Internal.Runtime.CompilerHelpers.StartupDebug;
 
@@ -23,7 +24,7 @@ namespace Internal.Runtime.CompilerHelpers
             {
                 args[i] = new string(argv[i]);
             }
-            Environment.SetCommandLineArgs(args);
+            EnvironmentAugments.SetCommandLineArgs(args);
         }
 
         internal static unsafe void InitializeCommandLineArgs(int argc, byte** argv)
@@ -35,13 +36,13 @@ namespace Internal.Runtime.CompilerHelpers
                 int len = CStrLen(argval);
                 args[i] = Encoding.UTF8.GetString(argval, len);
             }
-            Environment.SetCommandLineArgs(args);
+            EnvironmentAugments.SetCommandLineArgs(args);
         }
 
         private static string[] GetMainMethodArguments()
         {
             // GetCommandLineArgs includes the executable name, Main() arguments do not.
-            string[] args = Environment.GetCommandLineArgs();
+            string[] args = EnvironmentAugments.GetCommandLineArgs();
 
             Debug.Assert(args.Length > 0);
 

--- a/src/System.Private.CoreLib/src/System/Environment.Uap.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Uap.cs
@@ -38,15 +38,6 @@ namespace System
             return null;
         }
 
-        public static string MachineName
-        {
-            get
-            {
-                // Store apps don't support MachineName
-                throw new PlatformNotSupportedException();
-            }
-        }
-
         public static void Exit(int exitCode)
         {
             // Store apps have their lifetime managed by the PLM

--- a/src/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -69,22 +69,6 @@ namespace System
             return Encoding.UTF8.GetString((byte*)result, size);
         }
 
-        private const int MAX_HOST_NAME = 256; // 255 max and null 
-        public static unsafe string MachineName
-        {
-            get
-            {
-                byte *hostName = stackalloc byte[MAX_HOST_NAME];
-                int hostNameLength = Interop.Sys.GetMachineName(hostName, MAX_HOST_NAME);
-                if (hostNameLength < 0)
-                {
-                    throw new InvalidOperationException(SR.InvalidOperation_ComputerName);
-                }
-
-                return Encoding.UTF8.GetString(hostName, hostNameLength);
-            }
-        }
-
         public static void Exit(int exitCode)
         {
             // CORERT-TODO: Shut down the runtime

--- a/src/System.Private.CoreLib/src/System/Environment.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Win32.cs
@@ -6,59 +6,6 @@ namespace System
 {
     public static partial class Environment
     {
-        public unsafe static String ExpandEnvironmentVariables(String name)
-        {
-            if (name == null)
-                throw new ArgumentNullException("name");
-
-            if (name.Length == 0)
-            {
-                return name;
-            }
-
-            int currentSize = 128;
-            char* blob = stackalloc char[currentSize]; // A somewhat reasonable default size
-            int requiredSize;
-            fixed (char* pName = name)
-            {
-                requiredSize = Interop.mincore.ExpandEnvironmentStrings(pName, blob, currentSize);
-            }
-
-            if (requiredSize == 0)
-            {
-                // TODO: This used to throw an exception:
-                // Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-                throw new ArgumentException();
-            }
-
-            if (requiredSize <= currentSize)
-            {
-                return new string(blob);
-            }
-
-            // Fallback to using heap allocated buffers.
-            char[] newBlob = null;
-            while (requiredSize > currentSize)
-            {
-                currentSize = requiredSize;
-                newBlob = new char[currentSize];
-
-                fixed (char* pName = name, pBlob = newBlob)
-                {
-                    requiredSize = Interop.mincore.ExpandEnvironmentStrings(pName, pBlob, currentSize);
-                }
-
-                if (requiredSize == 0)
-                {
-                    // TODO: This used to throw an exception:
-                    // Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-                    throw new ArgumentException();
-                }
-            }
-
-            return new string(newBlob);
-        }
-
         public unsafe static String GetEnvironmentVariable(String variable)
         {
             if (variable == null)
@@ -110,19 +57,6 @@ namespace System
             Diagnostics.Debug.Assert(newblob != null);
 
             return new string(newblob);
-        }
-
-        public unsafe static string MachineName
-        {
-            get
-            {
-                const int MaxMachineNameLength = 256;
-                char* buf = stackalloc char[MaxMachineNameLength];
-                int len = MaxMachineNameLength;
-                if (Interop.mincore.GetComputerName(buf, ref len) == 0)
-                    throw new InvalidOperationException(SR.InvalidOperation_ComputerName);
-                return new String(buf);
-            }
         }
 
         public static void Exit(int exitCode)

--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -20,7 +20,8 @@ using System.Runtime.InteropServices;
 using Microsoft.Win32;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Internal.DeveloperExperience;
+
+using Internal.Runtime.Augments;
 
 namespace System
 {
@@ -105,40 +106,13 @@ namespace System
             }
         }
 
-        private static string[] s_commandLineArgs;
-
-        internal static void SetCommandLineArgs(string[] args)
-        {
-            s_commandLineArgs = args;
-        }
-
-        public static string[] GetCommandLineArgs()
-        {
-            return (string[])s_commandLineArgs?.Clone();
-        }
-
         public static String StackTrace
         {
+            // Disable inlining to have predictable stack frame that EnvironmentAugments can skip
+            [MethodImpl(MethodImplOptions.NoInlining)]
             get
             {
-                // RhGetCurrentThreadStackTrace returns the number of frames(cFrames) added to input buffer.
-                // It returns a negative value, -cFrames which is the required array size, if the buffer is too small.
-                // Initial array length is deliberately chosen to be 0 so that we reallocate to exactly the right size
-                // for StackFrameHelper.FormatStackTrace call. If we want to do this optimistically with one call change
-                // FormatStackTrace to accept an explicit length.
-                IntPtr[] frameIPs = Array.Empty<IntPtr>();
-                int cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
-                if (cFrames < 0)
-                {
-                    frameIPs = new IntPtr[-cFrames];
-                    cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
-                    if (cFrames < 0)
-                    {
-                        return "";
-                    }
-                }
-
-                return Internal.Diagnostics.StackTraceHelper.FormatStackTrace(frameIPs, true);
+                return EnvironmentAugments.StackTrace;
             }
         }
     }


### PR DESCRIPTION
The full netstandard20 Environment implementation lives in corefx. This change is first pass on getting things cleanup - with the eventual goal of not having public Environment type in CoreLib at all.