### PR TITLE
Implement ByRef types in the runtime

### DIFF
--- a/src/Common/src/Internal/Runtime/EEType.Constants.cs
+++ b/src/Common/src/Internal/Runtime/EEType.Constants.cs
@@ -277,4 +277,15 @@ namespace Internal.Runtime
         Contravariant = 2,
         ArrayCovariant = 0x20,
     }
+
+    internal static class ParameterizedTypeShapeConstants
+    {
+        // NOTE: Parameterized type kind is stored in the BaseSize field of the EEType.
+        // Array types use their actual base size. Pointer and ByRef types are never boxed,
+        // so we can reuse the EEType BaseSize field to indicate the kind.
+        // It's important that these values always stay lower than any valid value of a base
+        // size for an actual array.
+        public const int Pointer = 0;
+        public const int ByRef = 1;
+    }
 }

--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -357,7 +357,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return IsParameterizedType && ParameterizedTypeShape != 0;
+                return IsParameterizedType && ParameterizedTypeShape >= SZARRAY_BASE_SIZE;
             }
         }
 
@@ -478,7 +478,17 @@ namespace Internal.Runtime
         {
             get
             {
-                return IsParameterizedType && ParameterizedTypeShape == 0;
+                return IsParameterizedType &&
+                    ParameterizedTypeShape == ParameterizedTypeShapeConstants.Pointer;
+            }
+        }
+
+        internal bool IsByRefType
+        {
+            get
+            {
+                return IsParameterizedType &&
+                    ParameterizedTypeShape == ParameterizedTypeShapeConstants.ByRef;
             }
         }
 
@@ -524,8 +534,8 @@ namespace Internal.Runtime
 
         // The parameterized type shape defines the particular form of parameterized type that
         // is being represented.
-        // Currently, the meaning is a shape of 0 indicates that this is a Pointer
-        // and non-zero indicates that this is an array.
+        // Currently, the meaning is a shape of 0 indicates that this is a Pointer,
+        // shape of 1 indicates a ByRef, and >=SZARRAY_BASE_SIZE indicates that this is an array.
         // Two types are not equivalent if their shapes do not exactly match.
         internal UInt32 ParameterizedTypeShape
         {

--- a/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -78,7 +78,7 @@ namespace Internal.Runtime
                 return flags;
             }
 
-            if (type.IsArray || type.IsPointer)
+            if (type.IsArray || type.IsPointer || type.IsByRef)
             {
                 flags = (UInt16)EETypeKind.ParameterizedEEType;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -255,8 +255,14 @@ namespace ILCompiler.DependencyAnalysis
             }
             else if (_type.IsPointer)
             {
-                // Object size 0 is a sentinel value in the runtime for parameterized types that means "Pointer Type"
-                objData.EmitInt(0);
+                // These never get boxed and don't have a base size. Use a sentinel value recognized by the runtime.
+                objData.EmitInt(ParameterizedTypeShapeConstants.Pointer);
+                return;
+            }
+            else if (_type.IsByRef)
+            {
+                // These never get boxed and don't have a base size. Use a sentinel value recognized by the runtime.
+                objData.EmitInt(ParameterizedTypeShapeConstants.ByRef);
                 return;
             }
             else

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -292,7 +292,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             ISymbolNode relatedTypeNode = null;
 
-            if (_type.IsArray || _type.IsPointer)
+            if (_type.IsArray || _type.IsPointer || _type.IsByRef)
             {
                 var parameterType = ((ParameterizedType)_type).ParameterType;
                 relatedTypeNode = factory.NecessaryTypeSymbol(parameterType);

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -378,10 +378,7 @@ public:
         { return ((m_usFlags & (UInt16)RelatedTypeViaIATFlag) != 0); }
 
     bool IsArray()
-        { return IsParameterizedType() && get_ParameterizedTypeShape() != 0; }
-
-    bool IsPointerType()
-        { return IsParameterizedType() && get_ParameterizedTypeShape() == 0; }
+        { return IsParameterizedType() && get_ParameterizedTypeShape() > 1; }
 
     bool IsParameterizedType()
         { return (get_Kind() == ParameterizedEEType); }

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -377,8 +377,9 @@ public:
     bool IsRelatedTypeViaIAT()
         { return ((m_usFlags & (UInt16)RelatedTypeViaIATFlag) != 0); }
 
+    // PREFER: get_ParameterizedTypeShape() >= SZARRAY_BASE_SIZE
     bool IsArray()
-        { return IsParameterizedType() && get_ParameterizedTypeShape() > 1; }
+        { return IsParameterizedType() && get_ParameterizedTypeShape() > 1 /* ParameterizedTypeShapeConstants.ByRef */; }
 
     bool IsParameterizedType()
         { return (get_Kind() == ParameterizedEEType); }
@@ -398,8 +399,9 @@ public:
 
     EEType * get_RelatedParameterType();
 
-    // A parameterized type shape is 0 to indicate that it is a pointer type, 
-    // and non-zero to indicate that it is an array type
+    // A parameterized type shape less than SZARRAY_BASE_SIZE indicates that this is not
+    // an array but some other parameterized type (see: ParameterizedTypeShapeConstants)
+    // For arrays, this number uniquely captures both Sz/Md array flavor and rank.
     UInt32 get_ParameterizedTypeShape() { return m_uBaseSize; }
 
     bool get_IsValueType()

--- a/src/Runtime.Base/src/System/Runtime/EEType.Runtime.cs
+++ b/src/Runtime.Base/src/System/Runtime/EEType.Runtime.cs
@@ -73,8 +73,8 @@ namespace Internal.Runtime
                 if (!IsRuntimeAllocated && !IsDynamicType)
                     return (IntPtr)pThis;
 
-                // There are currently three types of runtime allocated EETypes, arrays, pointers, and generic types.
-                // Arrays/Pointers can be handled by looking at their element type.
+                // There are currently four types of runtime allocated EETypes, arrays, pointers, byrefs, and generic types.
+                // Arrays/Pointers/ByRefs can be handled by looking at their element type.
                 if (IsParameterizedType)
                     return pThis->RelatedParameterType->GetAssociatedModuleAddress();
 

--- a/src/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -647,7 +647,9 @@ namespace System.Runtime
                     }
                     else if (pSourceType->RelatedParameterType->IsByRefType)
                     {
-                        // Only allow exact matches for ByRef types - same as pointers above.
+                        // Only allow exact matches for ByRef types - same as pointers above. This should
+                        // be unreachable and it's only a defense in depth. ByRefs can't be parameters
+                        // of any parameterized type.
                         return false;
                     }
                     else

--- a/src/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -645,6 +645,11 @@ namespace System.Runtime
                         // int** is not compatible with uint**, nor is int*[] oompatible with uint*[].
                         return false;
                     }
+                    else if (pSourceType->RelatedParameterType->IsByRefType)
+                    {
+                        // Only allow exact matches for ByRef types - same as pointers above.
+                        return false;
+                    }
                     else
                     {
                         // Note that using AreTypesAssignableInternal with AssignmentVariation.AllowSizeEquivalence 

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeTypeUnifier.Internals.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeTypeUnifier.Internals.cs
@@ -63,6 +63,10 @@ namespace Internal.Reflection.Core.NonPortable
                 {
                     return callbacks.GetPointerTypeForHandle(runtimeTypeHandle);
                 }
+                else if (eeType.IsByRef)
+                {
+                    return callbacks.GetByRefTypeForHandle(runtimeTypeHandle);
+                }
                 else
                 {
                     throw new ArgumentException(SR.Arg_InvalidRuntimeTypeHandle);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
@@ -45,6 +45,7 @@ namespace Internal.Runtime.Augments
         public abstract Type GetArrayTypeForHandle(RuntimeTypeHandle typeHandle);
         public abstract Type GetMdArrayTypeForHandle(RuntimeTypeHandle typeHandle, int rank);
         public abstract Type GetPointerTypeForHandle(RuntimeTypeHandle typeHandle);
+        public abstract Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle);
         public abstract Type GetConstructedGenericTypeForHandle(RuntimeTypeHandle typeHandle);
 
         // Flotsam and jetsam.

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -413,7 +413,7 @@ namespace Internal.Runtime.Augments
         public static bool TryGetBaseType(RuntimeTypeHandle typeHandle, out RuntimeTypeHandle baseTypeHandle)
         {
             EETypePtr eeType = typeHandle.ToEETypePtr();
-            if (eeType.IsGenericTypeDefinition || eeType.IsPointer)
+            if (eeType.IsGenericTypeDefinition || eeType.IsPointer || eeType.IsByRef)
             {
                 baseTypeHandle = default(RuntimeTypeHandle);
                 return false;
@@ -430,7 +430,7 @@ namespace Internal.Runtime.Augments
         public static IEnumerable<RuntimeTypeHandle> TryGetImplementedInterfaces(RuntimeTypeHandle typeHandle)
         {
             EETypePtr eeType = typeHandle.ToEETypePtr();
-            if (eeType.IsGenericTypeDefinition || eeType.IsPointer)
+            if (eeType.IsGenericTypeDefinition || eeType.IsPointer || eeType.IsByRef)
                 return null;
 
             LowLevelList<RuntimeTypeHandle> implementedInterfaces = new LowLevelList<RuntimeTypeHandle>();
@@ -610,6 +610,8 @@ namespace Internal.Runtime.Augments
             if (srcEEType.IsGenericTypeDefinition || dstEEType.IsGenericTypeDefinition)
                 return false;
             if (srcEEType.IsPointer || dstEEType.IsPointer)
+                return false;
+            if (srcEEType.IsByRef || dstEEType.IsByRef)
                 return false;
 
             if (!srcEEType.IsPrimitive)

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -114,7 +114,7 @@ namespace System
         {
             get
             {
-                return IsArray && BaseSize == Array.SZARRAY_BASE_SIZE;
+                return _value->IsSzArray;
             }
         }
 
@@ -123,6 +123,14 @@ namespace System
             get
             {
                 return _value->IsPointerType;
+            }
+        }
+
+        internal bool IsByRef
+        {
+            get
+            {
+                return _value->IsByRefType;
             }
         }
 
@@ -287,7 +295,7 @@ namespace System
                 if (IsArray)
                     return EETypePtr.EETypePtrOf<Array>();
 
-                if (IsPointer)
+                if (IsPointer || IsByRef)
                     return new EETypePtr(default(IntPtr));
 
                 EETypePtr baseEEType = new EETypePtr((IntPtr)_value->NonArrayBaseType);

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -207,6 +207,15 @@ namespace Internal.Reflection.Core.Execution
             return targetTypeHandle.GetTypeForRuntimeTypeHandle().GetPointerType(typeHandle);
         }
 
+        public Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle)
+        {
+            RuntimeTypeHandle targetTypeHandle;
+            if (!ExecutionEnvironment.TryGetByRefTypeTargetType(typeHandle, out targetTypeHandle))
+                throw CreateMissingMetadataException((Type)null);
+
+            return targetTypeHandle.GetTypeForRuntimeTypeHandle().GetByRefType(typeHandle);
+        }
+
         public Type GetConstructedGenericTypeForHandle(RuntimeTypeHandle typeHandle)
         {
             RuntimeTypeHandle genericTypeDefinitionHandle;

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -67,6 +67,9 @@ namespace Internal.Reflection.Core.Execution
         public abstract bool TryGetPointerTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle pointerTypeHandle);
         public abstract bool TryGetPointerTypeTargetType(RuntimeTypeHandle pointerTypeHandle, out RuntimeTypeHandle targetTypeHandle);
 
+        public abstract bool TryGetByRefTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle byRefTypeHandle);
+        public abstract bool TryGetByRefTypeTargetType(RuntimeTypeHandle byRefTypeHandle, out RuntimeTypeHandle targetTypeHandle);
+
         public abstract bool TryGetConstructedGenericTypeForComponents(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle);
 
         public abstract bool TryGetMetadataNameForRuntimeTypeHandle(RuntimeTypeHandle rtth, out string name);

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -436,6 +436,37 @@ namespace Internal.Reflection.Execution
         }
 
         //
+        // Given a RuntimeTypeHandle for any type E, return a RuntimeTypeHandle for type E&, if the pay-for-play policy denotes E& as browsable. This is used to
+        // ensure that "typeof(E&)" and "typeof(E).MakeByRefType()" returns the same Type object.
+        //
+        // Preconditions:
+        //     targetTypeHandle is a valid RuntimeTypeHandle.
+        //
+        public unsafe sealed override bool TryGetByRefTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle byRefTypeHandle)
+        {
+#if CORERT
+            throw new NotImplementedException();
+#else
+            // Project N is not capable of emitting EETypes for ByRefs.
+            byRefTypeHandle = default(RuntimeTypeHandle);
+            return false;
+#endif
+        }
+
+        //
+        // Given a RuntimeTypeHandle for any byref type E&, return a RuntimeTypeHandle for type E, if the pay-for-play policy denotes E& as browsable. 
+        // This is used to implement Type.GetElementType() for byrefs.
+        //
+        // Preconditions:
+        //      byRefTypeHandle is a valid RuntimeTypeHandle of a byref.
+        //
+        public unsafe sealed override bool TryGetByRefTypeTargetType(RuntimeTypeHandle byRefTypeHandle, out RuntimeTypeHandle targetTypeHandle)
+        {
+            targetTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(byRefTypeHandle);
+            return true;
+        }
+
+        //
         // Given a RuntimeTypeHandle for a generic type G and a set of RuntimeTypeHandles T1, T2.., return the RuntimeTypeHandle for the generic
         // instance G<T1,T2...> if the pay-for-play policy denotes G<T1,T2...> as browsable. This is used to implement Type.MakeGenericType().
         //

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -70,6 +70,11 @@ namespace Internal.Reflection.Execution
             return _executionDomain.GetPointerTypeForHandle(typeHandle);
         }
 
+        public sealed override Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle)
+        {
+            return _executionDomain.GetByRefTypeForHandle(typeHandle);
+        }
+
         public sealed override Type GetConstructedGenericTypeForHandle(RuntimeTypeHandle typeHandle)
         {
             return _executionDomain.GetConstructedGenericTypeForHandle(typeHandle);


### PR DESCRIPTION
Making it possible for ByRef types to be represented by an EEType at
runtime. This unblocks `ldtoken SomeType&`.

I'm taking the same approach as with pointer types - a special sentinel
value in the `BaseSize` field.