### PR TITLE
Update type map metadata format

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a node that points to various symbols and can be sequentially addressed.
+    /// </summary>
+    internal sealed class ExternalReferencesTableNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+
+        private Dictionary<ISymbolNode, uint> _insertedSymbolsDictionary = new Dictionary<ISymbolNode, uint>();
+        private List<ISymbolNode> _insertedSymbols = new List<ISymbolNode>();
+
+        public ExternalReferencesTableNode()
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+        }
+
+        public ISymbolNode EndSymbol
+        {
+            get
+            {
+                return _endSymbol;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return NodeFactory.CompilationUnitPrefix + "__external_references";
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Adds a new entry to the table. Thread safety: not thread safe. Expected to be called at the final
+        /// object data emission phase from a single thread.
+        /// </summary>
+        public uint GetIndex(ISymbolNode symbol)
+        {
+            uint index;
+            if (!_insertedSymbolsDictionary.TryGetValue(symbol, out index))
+            {
+                index = (uint)_insertedSymbols.Count;
+                _insertedSymbolsDictionary[symbol] = index;
+                _insertedSymbols.Add(symbol);
+            }
+
+            return index;
+        }
+
+        public override ObjectNodeSection Section
+        {
+            get
+            {
+                return ObjectNodeSection.DataSection;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        protected override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            // Zero out the dictionary so that we AV if someone tries to insert after we're done.
+            _insertedSymbolsDictionary = null;
+
+            var builder = new ObjectDataBuilder(factory);
+
+            foreach (ISymbolNode symbol in _insertedSymbols)
+            {
+                // TODO: set low bit if the linkage of the symbol is IAT_PVALUE.
+                builder.EmitPointerReloc(symbol);
+            }
+
+            _endSymbol.SetSymbolOffset(builder.CountBytes);
+            
+            builder.DefinedSymbols.Add(this);
+            builder.DefinedSymbols.Add(_endSymbol);
+
+            return builder.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -49,8 +49,14 @@ namespace ILCompiler
             var metadataNode = new MetadataNode();
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.EmbeddedMetadata), metadataNode, metadataNode, metadataNode.EndSymbol);
 
-            var typeMapNode = new TypeMetadataMapNode();
+            var externalReferencesTableNode = new ExternalReferencesTableNode();
+
+            var typeMapNode = new TypeMetadataMapNode(externalReferencesTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.TypeMap), typeMapNode, typeMapNode, typeMapNode.EndSymbol);
+
+            // This one should go last
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.CommonFixupsTable),
+                externalReferencesTableNode, externalReferencesTableNode, externalReferencesTableNode.EndSymbol);
         }
 
         private void Graph_NewMarkedNode(DependencyNodeCore<NodeFactory> obj)

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ConstructedEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CppCodegenNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\DictionaryLayoutNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ExternalReferencesTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternEETypeSymbolNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenObjectSentinelNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenStringNode.cs" />

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
@@ -32,7 +32,7 @@ namespace Internal.Runtime.TypeLoader
             }
 
             _RVAs = (IntPtr)pBlob;
-            _RVAsCount = cbBlob / sizeof(uint);
+            _RVAsCount = (uint)(cbBlob / sizeof(IntPtr));
             return true;
         }
 
@@ -68,26 +68,17 @@ namespace Internal.Runtime.TypeLoader
 
         unsafe public uint GetRvaFromIndex(uint index)
         {
+            throw new PlatformNotSupportedException();
+        }
+
+        unsafe public IntPtr GetIntPtrFromIndex(uint index)
+        {
             Debug.Assert(_moduleHandle != IntPtr.Zero);
 
             if (index >= _RVAsCount)
                 throw new BadImageFormatException();
 
-            return ((uint*)_RVAs)[index];
-        }
-
-        unsafe public IntPtr GetIntPtrFromIndex(uint index)
-        {
-            uint rva = GetRvaFromIndex(index);
-            if ((rva & 0x80000000) != 0)
-            {
-                // indirect through IAT
-                return *(IntPtr*)((byte*)_moduleHandle + (rva & ~0x80000000));
-            }
-            else
-            {
-                return (IntPtr)((byte*)_moduleHandle + rva);
-            }
+            return ((IntPtr*)_RVAs)[index];
         }
 
         public RuntimeTypeHandle GetRuntimeTypeHandleFromIndex(uint index)

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -64,6 +64,8 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\LowLevelStringConverter.cs" >
       <Link>LowLevelStringConverter.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Internal\Metadata\NativeFormat\MetadataTypeHashingAlgorithms.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeHashingAlgorithms.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\MetadataReaderExtensions.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\MetadataTable.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\ModuleList.cs" />


### PR DESCRIPTION
The mapping table format was updated in Project N a couple months ago.
This updates the writer and (forked) reader to the latest version. The
type map table is now a hash table, same as on Project N.