### PR TITLE
Change the way we emit optional fields

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -83,7 +83,7 @@ namespace ILCompiler.DependencyAnalysis
             // all of the interface usage has been stabilized. If we end up not needing it, the EEType node will not
             // generate any relocs to it, and the optional fields node will instruct the object writer to skip
             // emitting it.
-            dependencyList.Add(factory.EETypeOptionalFields(this), "Optional fields");
+            dependencyList.Add(_optionalFieldsNode, "Optional fields");
             
             return dependencyList;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -78,6 +78,12 @@ namespace ILCompiler.DependencyAnalysis
                 // at the final data emission phase. We need to report it as a non-relocation dependency.
                 dependencyList.Add(factory.TypeGenericDictionary(closestDefType), "Type generic dictionary");
             }
+
+            // Include the optional fields by default. We don't know if optional fields will be needed until
+            // all of the interface usage has been stabilized. If we end up not needing it, the EEType node will not
+            // generate any relocs to it, and the optional fields node will instruct the object writer to skip
+            // emitting it.
+            dependencyList.Add(factory.EETypeOptionalFields(this), "Optional fields");
             
             return dependencyList;
         }
@@ -142,24 +148,6 @@ namespace ILCompiler.DependencyAnalysis
                     }
                 }
             }
-        }
-
-        public override bool HasDynamicDependencies
-        {
-            get
-            {
-                // This node's EETypeOptionalFields node may change if this EEType implements interfaces
-                // that are used since the dispatch map table index is computed once we know the interface
-                // layout later on in compilation.
-                return _type.RuntimeInterfaces.Length > 0;
-            }
-        }
-
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
-        {
-            List<CombinedDependencyListEntry> dynamicNodes = new List<DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry>();
-            dynamicNodes.Add(new CombinedDependencyListEntry(factory.EETypeOptionalFields(_optionalFieldsBuilder), null, "EEType optional fields"));
-            return dynamicNodes;
         }
 
         protected override ISymbolNode GetBaseTypeNode(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -59,12 +59,14 @@ namespace ILCompiler.DependencyAnalysis
     {
         protected TypeDesc _type;
         protected EETypeOptionalFieldsBuilder _optionalFieldsBuilder = new EETypeOptionalFieldsBuilder();
+        protected EETypeOptionalFieldsNode _optionalFieldsNode;
 
         public EETypeNode(TypeDesc type)
         {
             Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Specific));
             Debug.Assert(!type.IsRuntimeDeterminedSubtype);
             _type = type;
+            _optionalFieldsNode = new EETypeOptionalFieldsNode(this);
         }
 
         protected override string GetName()
@@ -357,7 +359,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (HasOptionalFields)
             {
-                objData.EmitPointerReloc(factory.EETypeOptionalFields(this));
+                objData.EmitPointerReloc(_optionalFieldsNode);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -94,6 +94,16 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        internal bool HasOptionalFields
+        {
+            get { return _optionalFieldsBuilder.IsAtLeastOneFieldUsed(); }
+        }
+
+        internal byte[] GetOptionalFieldsData()
+        {
+            return _optionalFieldsBuilder.GetBytes();
+        }
+
         public override bool ShouldShareNodeAcrossModules(NodeFactory factory)
         {
             return factory.CompilationModuleGroup.ShouldShareAcrossModules(_type);
@@ -224,7 +234,7 @@ namespace ILCompiler.DependencyAnalysis
             // Todo: RelatedTypeViaIATFlag when we support cross-module EETypes
             // Todo: Generic Type Definition EETypes
 
-            if (_optionalFieldsBuilder.IsAtLeastOneFieldUsed())
+            if (HasOptionalFields)
             {
                 flags |= (UInt16)EETypeFlags.OptionalFieldsFlag;
             }
@@ -345,9 +355,9 @@ namespace ILCompiler.DependencyAnalysis
 
         private void OutputOptionalFields(NodeFactory factory, ref ObjectDataBuilder objData)
         {
-            if(_optionalFieldsBuilder.IsAtLeastOneFieldUsed())
+            if (HasOptionalFields)
             {
-                objData.EmitPointerReloc(factory.EETypeOptionalFields(_optionalFieldsBuilder));
+                objData.EmitPointerReloc(factory.EETypeOptionalFields(this));
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -62,7 +62,7 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.EmitPointerReloc(factory.ModuleManagerIndirection);
             if (HasOptionalFields)
             {
-                dataBuilder.EmitPointerReloc(factory.EETypeOptionalFields(this));
+                dataBuilder.EmitPointerReloc(_optionalFieldsNode);
             }
 
             return dataBuilder.ToObjectData();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -49,7 +49,7 @@ namespace ILCompiler.DependencyAnalysis
             if (rareFlags != 0)
                 _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldTag.RareFlags, (uint)rareFlags);
 
-            if (_optionalFieldsBuilder.IsAtLeastOneFieldUsed())
+            if (HasOptionalFields)
                 flags |= (short)EETypeFlags.OptionalFieldsFlag;
 
             dataBuilder.EmitShort((short)_type.Instantiation.Length);
@@ -60,9 +60,9 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.EmitShort(0);       // No interface map
             dataBuilder.EmitInt(_type.GetHashCode());
             dataBuilder.EmitPointerReloc(factory.ModuleManagerIndirection);
-            if (_optionalFieldsBuilder.IsAtLeastOneFieldUsed())
+            if (HasOptionalFields)
             {
-                dataBuilder.EmitPointerReloc(factory.EETypeOptionalFields(_optionalFieldsBuilder));
+                dataBuilder.EmitPointerReloc(factory.EETypeOptionalFields(this));
             }
 
             return dataBuilder.ToObjectData();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -219,11 +219,6 @@ namespace ILCompiler.DependencyAnalysis
                 return new FrozenStringNode(data, Target);
             });
 
-            _typeOptionalFields = new NodeCache<EETypeNode, EETypeOptionalFieldsNode>((EETypeNode owner) =>
-            {
-                return new EETypeOptionalFieldsNode(owner);
-            });
-
             _interfaceDispatchCells = new NodeCache<MethodDesc, InterfaceDispatchCellNode>((MethodDesc method) =>
             {
                 return new InterfaceDispatchCellNode(method);
@@ -387,13 +382,6 @@ namespace ILCompiler.DependencyAnalysis
         public BlobNode ReadOnlyDataBlob(string name, byte[] blobData, int alignment)
         {
             return _readOnlyDataBlobs.GetOrAdd(new Tuple<string, byte[], int>(name, blobData, alignment));
-        }
-
-        private NodeCache<EETypeNode, EETypeOptionalFieldsNode> _typeOptionalFields;
-
-        internal EETypeOptionalFieldsNode EETypeOptionalFields(EETypeNode owner)
-        {
-            return _typeOptionalFields.GetOrAdd(owner);
         }
 
         private NodeCache<TypeDesc, InterfaceDispatchMapNode> _interfaceDispatchMaps;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -219,9 +219,9 @@ namespace ILCompiler.DependencyAnalysis
                 return new FrozenStringNode(data, Target);
             });
 
-            _typeOptionalFields = new NodeCache<EETypeOptionalFieldsBuilder, EETypeOptionalFieldsNode>((EETypeOptionalFieldsBuilder fieldBuilder) =>
+            _typeOptionalFields = new NodeCache<EETypeNode, EETypeOptionalFieldsNode>((EETypeNode owner) =>
             {
-                return new EETypeOptionalFieldsNode(fieldBuilder, this.Target);
+                return new EETypeOptionalFieldsNode(owner);
             });
 
             _interfaceDispatchCells = new NodeCache<MethodDesc, InterfaceDispatchCellNode>((MethodDesc method) =>
@@ -389,11 +389,11 @@ namespace ILCompiler.DependencyAnalysis
             return _readOnlyDataBlobs.GetOrAdd(new Tuple<string, byte[], int>(name, blobData, alignment));
         }
 
-        private NodeCache<EETypeOptionalFieldsBuilder, EETypeOptionalFieldsNode> _typeOptionalFields;
+        private NodeCache<EETypeNode, EETypeOptionalFieldsNode> _typeOptionalFields;
 
-        internal EETypeOptionalFieldsNode EETypeOptionalFields(EETypeOptionalFieldsBuilder fieldBuilder)
+        internal EETypeOptionalFieldsNode EETypeOptionalFields(EETypeNode owner)
         {
-            return _typeOptionalFields.GetOrAdd(fieldBuilder);
+            return _typeOptionalFields.GetOrAdd(owner);
         }
 
         private NodeCache<TypeDesc, InterfaceDispatchMapNode> _interfaceDispatchMaps;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -692,8 +692,6 @@ namespace ILCompiler.DependencyAnalysis
                     if (node == null)
                         continue;
 
-                    // TODO: Remove the need for the skip check
-                    // https://github.com/dotnet/corert/issues/1826
                     if (node.ShouldSkipEmittingObjectNode(factory))
                         continue;
 

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -759,8 +759,9 @@ namespace ILCompiler.CppCodeGen
             {
                 string mangledName = ((ISymbolNode)node).MangledName;
 
-                // Rename generic composition nodes to avoid name clash with types
-                nodeCode.Append(node is GenericCompositionNode ? mangledName.Replace("::", "_") : mangledName);
+                // Rename generic composition and optional fields nodes to avoid name clash with types
+                bool shouldReplaceNamespaceQualifier = node is GenericCompositionNode || node is EETypeOptionalFieldsNode;
+                nodeCode.Append(shouldReplaceNamespaceQualifier ? mangledName.Replace("::", "_") : mangledName);
             }
             nodeCode.Append("()");
             nodeCode.AppendLine();
@@ -835,7 +836,8 @@ namespace ILCompiler.CppCodeGen
             // Node is either an non-emitted type or a generic composition - both are ignored for CPP codegen
             else if ((reloc.Target is ModuleManagerIndirectionNode || reloc.Target is InterfaceDispatchMapNode || reloc.Target is EETypeOptionalFieldsNode || reloc.Target is GenericCompositionNode) && !(reloc.Target as ObjectNode).ShouldSkipEmittingObjectNode(factory))
             {
-                relocCode.Append(reloc.Target is GenericCompositionNode ? reloc.Target.MangledName.Replace("::", "_") : reloc.Target.MangledName);
+                bool shouldReplaceNamespaceQualifier = reloc.Target is GenericCompositionNode || reloc.Target is EETypeOptionalFieldsNode;
+                relocCode.Append(shouldReplaceNamespaceQualifier ? reloc.Target.MangledName.Replace("::", "_") : reloc.Target.MangledName);
                 relocCode.Append("()");
             }
             else if (reloc.Target is ObjectAndOffsetSymbolNode && (reloc.Target as ISymbolNode).MangledName.Contains("DispatchMap"))


### PR DESCRIPTION
Before this change, optional fields used to be represented by mutable
object nodes that created a bunch of problems: Besides the key-value
mismatches described in #1826, this was also causing e.g. garbage
unreferenced optional fields nodes getting generated (e.g. an EEType
thinks it will need an optional fields node of shape A, so we add it to
the graph and mark it. Later the EEType changes it's mind and now needs
shape B. But the shape A optional fields node has already been marked
and will be emitted into the object file.)

I'm making the optional fields node local to the EEType that needs it.
This disables the size on disk optimization that tried to reuse the
nodes. We can re-enable this later by adding a general purpose mechanism
to object writer that can collapse nodes with identical contents that
don't need to maintain identity (this can be e.g. also used to collapse
method code nodes).

Resolves #1826.