### PR TITLE
Update corert Stream to use StreamHelpers

### DIFF
--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -135,6 +135,7 @@
     <Compile Include="System\Reflection\Runtime\Assemblies\RuntimeAssemblyName.cs" />
     <Compile Include="System\IO\SeekOrigin.cs" />
     <Compile Include="System\IO\Stream.cs" />
+    <Compile Include="System\IO\StreamHelpers.CopyValidation.cs" />
     <Compile Include="System\Reflection\AmbiguousMatchException.cs" />
     <Compile Include="System\Reflection\Assembly.cs" />
     <Compile Include="System\Reflection\AssemblyContentType.cs" />

--- a/src/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -135,7 +135,7 @@ namespace System.IO
 
         public virtual Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            ValidateCopyToArguments(destination, bufferSize);
+            StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
 
             return CopyToAsyncInternal(destination, bufferSize, cancellationToken);
         }
@@ -187,7 +187,7 @@ namespace System.IO
 
         public virtual void CopyTo(Stream destination, int bufferSize)
         {
-            ValidateCopyToArguments(destination, bufferSize);
+            StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
 
             byte[] buffer = new byte[bufferSize];
             int read;
@@ -364,34 +364,6 @@ namespace System.IO
             Write(oneByteArray, 0, 1);
         }
 
-        internal void ValidateCopyToArguments(Stream destination, int bufferSize)
-        {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
-            if (bufferSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
-            }
-            if (!CanRead && !CanWrite)
-            {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
-            }
-            if (!destination.CanRead && !destination.CanWrite)
-            {
-                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
-            }
-            if (!CanRead)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
-            }
-            if (!destination.CanWrite)
-            {
-                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
-            }
-        }
-
         private sealed class NullStream : Stream
         {
             internal NullStream() { }
@@ -432,7 +404,7 @@ namespace System.IO
             {
                 // Validate arguments for compat, since previously this
                 // method was inherited from Stream, which did check its arguments.
-                ValidateCopyToArguments(destination, bufferSize);
+                StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
 
                 return cancellationToken.IsCancellationRequested ?
                     Task.FromCanceled(cancellationToken) :

--- a/src/System.Private.CoreLib/src/System/IO/StreamHelpers.CopyValidation.cs
+++ b/src/System.Private.CoreLib/src/System/IO/StreamHelpers.CopyValidation.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    /// <summary>Provides methods to help in the implementation of Stream-derived types.</summary>
+    internal static partial class StreamHelpers
+    {
+        /// <summary>Validate the arguments to CopyTo, as would Stream.CopyTo.</summary>
+        public static void ValidateCopyToArgs(Stream source, Stream destination, int bufferSize)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), bufferSize, SR.ArgumentOutOfRange_NeedPosNum);
+            }
+
+            bool sourceCanRead = source.CanRead;
+            if (!sourceCanRead && !source.CanWrite)
+            {
+                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+            }
+
+            bool destinationCanWrite = destination.CanWrite;
+            if (!destination.CanRead && !destinationCanWrite)
+            {
+                throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
+            }
+
+            if (!sourceCanRead)
+            {
+                throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+            }
+
+            if (!destinationCanWrite)
+            {
+                throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Corresponding change for dotnet/coreclr#7579. Should get merged when that gets merged.

Another thing I realized while making these changes is that we should override `NullStream.CopyTo`, so writing it here in case I forget.

cc @jkotas