### PR TITLE
Override CopyTo in NullStream

### DIFF
--- a/src/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -399,6 +399,13 @@ namespace System.IO
                 get { return 0; }
                 set { }
             }
+            
+            public override void CopyTo(Stream destination, int bufferSize)
+            {
+                StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
+                
+                // After we validate arguments this is a nop.
+            }
 
             public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             {


### PR DESCRIPTION
We can make it a nop and avoid virtual calls / allocating anything

cc @jkotas @stephentoub 