### PR TITLE
Improve HasStaticConstructor implementation

### DIFF
--- a/src/Common/src/TypeSystem/Canon/CanonTypes.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.cs
@@ -123,7 +123,6 @@ namespace Internal.TypeSystem
                 flags |= TypeFlags.HasGenericVarianceComputed;
             }
 
-            Debug.Assert((flags & mask) != 0);
             return flags;
         }
 
@@ -212,7 +211,6 @@ namespace Internal.TypeSystem
                 flags |= TypeFlags.ValueType;
             }
 
-            Debug.Assert((flags & mask) != 0);
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -12,14 +12,6 @@ namespace Internal.TypeSystem
     /// </summary>
     public abstract partial class MetadataType : DefType
     {
-        public override bool HasStaticConstructor
-        {
-            get
-            {
-                return GetStaticConstructor() != null;
-            }
-        }
-
         public override bool HasFinalizer
         {
             get

--- a/src/Common/src/TypeSystem/Common/MetadataTypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataTypeSystemContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem
@@ -74,6 +75,15 @@ namespace Internal.TypeSystem
         {
             Debug.Assert(_wellKnownTypes != null, "Forgot to call SetSystemModule?");
             return _wellKnownTypes[(int)wellKnownType - 1];
+        }
+
+        protected internal override bool ComputeHasStaticConstructor(TypeDesc type)
+        {
+            if (type is MetadataType)
+            {
+                return ((MetadataType)type).GetStaticConstructor() != null;
+            }
+            return false;
         }
     }
 }

--- a/src/Common/src/TypeSystem/Common/MetadataTypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataTypeSystemContext.cs
@@ -77,7 +77,7 @@ namespace Internal.TypeSystem
             return _wellKnownTypes[(int)wellKnownType - 1];
         }
 
-        protected internal override bool ComputeHasStaticConstructor(TypeDesc type)
+        protected sealed internal override bool ComputeHasStaticConstructor(TypeDesc type)
         {
             if (type is MetadataType)
             {

--- a/src/Common/src/TypeSystem/Common/SignatureVariable.cs
+++ b/src/Common/src/TypeSystem/Common/SignatureVariable.cs
@@ -73,7 +73,6 @@ namespace Internal.TypeSystem
 
             // Not all masks are valid to ask on signature variables. If you hit this assert, you might
             // need to special case, or you have a bug.
-            Debug.Assert((flags & mask) != 0);
             return flags;
         }
 
@@ -116,9 +115,6 @@ namespace Internal.TypeSystem
                 flags |= TypeFlags.SignatureMethodVariable;
             }
 
-            // Not all masks are valid to ask on signature variables. If you hit this assert, you might
-            // need to special case, or you have a bug.
-            Debug.Assert((flags & mask) != 0);
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/SignatureVariable.cs
+++ b/src/Common/src/TypeSystem/Common/SignatureVariable.cs
@@ -71,8 +71,6 @@ namespace Internal.TypeSystem
                 flags |= TypeFlags.SignatureTypeVariable;
             }
 
-            // Not all masks are valid to ask on signature variables. If you hit this assert, you might
-            // need to special case, or you have a bug.
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -131,7 +131,9 @@ namespace Internal.TypeSystem
         private TypeFlags InitializeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = ComputeTypeFlags(mask);
-            flags = Context.ComputeTypeFlags(this, flags, mask);
+
+            if ((flags & mask) == 0)
+                flags = Context.ComputeTypeFlags(this, flags, mask);
 
             Debug.Assert((flags & mask) != 0);
             _typeFlags |= flags;

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -131,6 +131,7 @@ namespace Internal.TypeSystem
         private TypeFlags InitializeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = ComputeTypeFlags(mask);
+            flags = Context.ComputeTypeFlags(this, flags, mask);
 
             Debug.Assert((flags & mask) != 0);
             _typeFlags |= flags;
@@ -452,11 +453,11 @@ namespace Internal.TypeSystem
         /// Gets a value indicating whether this type has a class constructor method.
         /// Use <see cref="GetStaticConstructor"/> to retrieve it.
         /// </summary>
-        public virtual bool HasStaticConstructor
+        public bool HasStaticConstructor
         {
             get
             {
-                return false;
+                return (GetTypeFlags(TypeFlags.HasStaticConstructor | TypeFlags.HasStaticConstructorComputed) & TypeFlags.HasStaticConstructor) != 0;
             }
         }
 

--- a/src/Common/src/TypeSystem/Common/TypeFlags.cs
+++ b/src/Common/src/TypeSystem/Common/TypeFlags.cs
@@ -53,5 +53,8 @@ namespace Internal.TypeSystem
 
         HasGenericVariance         = 0x400,
         HasGenericVarianceComputed = 0x800,
+
+        HasStaticConstructor         = 0x1000,
+        HasStaticConstructorComputed = 0x2000,
     }
 }

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -752,17 +752,18 @@ namespace Internal.TypeSystem
             if (((mask & TypeFlags.HasStaticConstructorComputed) == TypeFlags.HasStaticConstructorComputed) &&
                 ((flags & TypeFlags.HasStaticConstructorComputed) == 0))
             {
-                MetadataType metadataType = type.GetTypeDefinition() as MetadataType;
-                if (metadataType != null)
+                TypeDesc typeDefinition = type.GetTypeDefinition();
+                
+                if (typeDefinition != type)
                 {
-                    if (metadataType != type)
-                    {
-                        // If we're the metadata type is different, the code was working with an instantiated generic.
-                        // In that case, just query the HasStaticConstructor property, as it can cache the answer
-                        if (metadataType.HasStaticConstructor)
-                            flags |= TypeFlags.HasStaticConstructor;
-                    }
-                    else if (metadataType.GetStaticConstructor() != null)
+                    // If the type definition is different, the code was working with an instantiated generic or some such.
+                    // In that case, just query the HasStaticConstructor property, as it can cache the answer
+                    if (type.HasStaticConstructor)
+                        flags |= TypeFlags.HasStaticConstructor;
+                }
+                else if (typeDefinition is MetadataType)
+                {
+                    if (((MetadataType)typeDefinition).GetStaticConstructor() != null)
                     {
                         flags |= TypeFlags.HasStaticConstructor;
                     }

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -741,7 +741,7 @@ namespace Internal.TypeSystem
         /// TypeSystemContext controlled type flags computation. This allows computation of flags which depend
         /// on the particular TypeSystemContext in use
         /// </summary>
-        protected internal virtual TypeFlags ComputeTypeFlags(TypeDesc type, TypeFlags flags, TypeFlags mask)
+        internal TypeFlags ComputeTypeFlags(TypeDesc type, TypeFlags flags, TypeFlags mask)
         {
             // If we are looking to compute HasStaticConstructor, and we haven't yet assigned a value
             if ((mask & TypeFlags.HasStaticConstructorComputed) == TypeFlags.HasStaticConstructorComputed)

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -738,19 +738,13 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Extension point for computation of type flags. This extension point may be overriden to customize
-        /// type flags that are not computed by the ComputeTypeFlags api on TypeDesc.
-        /// At this time, the flag so computed are:
-        /// HasStaticConstructor
-        /// 
-        /// When overriding, return the value of calling this base implementation passing the flags value computed
-        /// in the override.
+        /// TypeSystemContext controlled type flags computation. This allows computation of flags which depend
+        /// on the particular TypeSystemContext in use
         /// </summary>
         protected internal virtual TypeFlags ComputeTypeFlags(TypeDesc type, TypeFlags flags, TypeFlags mask)
         {
             // If we are looking to compute HasStaticConstructor, and we haven't yet assigned a value
-            if (((mask & TypeFlags.HasStaticConstructorComputed) == TypeFlags.HasStaticConstructorComputed) &&
-                ((flags & TypeFlags.HasStaticConstructorComputed) == 0))
+            if ((mask & TypeFlags.HasStaticConstructorComputed) == TypeFlags.HasStaticConstructorComputed)
             {
                 TypeDesc typeDefinition = type.GetTypeDefinition();
                 
@@ -758,12 +752,12 @@ namespace Internal.TypeSystem
                 {
                     // If the type definition is different, the code was working with an instantiated generic or some such.
                     // In that case, just query the HasStaticConstructor property, as it can cache the answer
-                    if (type.HasStaticConstructor)
+                    if (typeDefinition.HasStaticConstructor)
                         flags |= TypeFlags.HasStaticConstructor;
                 }
-                else if (typeDefinition is MetadataType)
+                else
                 {
-                    if (((MetadataType)typeDefinition).GetStaticConstructor() != null)
+                    if (ComputeHasStaticConstructor(typeDefinition))
                     {
                         flags |= TypeFlags.HasStaticConstructor;
                     }
@@ -774,5 +768,10 @@ namespace Internal.TypeSystem
 
             return flags;
         }
+
+        /// <summary>
+        /// Algorithm to control which types are considered to have static constructors
+        /// </summary>
+        protected internal abstract bool ComputeHasStaticConstructor(TypeDesc type);
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
@@ -82,7 +82,6 @@ namespace Internal.TypeSystem.Ecma
 
             flags |= TypeFlags.HasGenericVarianceComputed;
 
-            Debug.Assert((flags & mask) != 0);
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -241,7 +241,6 @@ namespace Internal.TypeSystem.Ecma
                 }
             }
 
-            Debug.Assert((flags & mask) != 0);
             return flags;
         }
 


### PR DESCRIPTION
- Make it cached, by using the TypeFlags logic
- Utilize cache for generics in computation for related types
- Build infrastructure for TypeFlags computation in the TypeSystemContext to allow runtimes to adjust behavior around computation of type flags.
- Consolidate the various asserts for making sure the flags are properly computed so that there is only one assert which is in the TypeDesc.