### PR TITLE
String.SplitInternal: Remove unnecessary stackalloc

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -963,9 +963,7 @@ namespace System
 
         private unsafe String[] SplitInternal(char separator, int count, StringSplitOptions options)
         {
-            char* pSeparators = stackalloc char[1];
-            pSeparators[0] = separator;
-            return SplitInternal(pSeparators, /*separatorsLength*/ 1, count, options);
+            return SplitInternal(&separator, 1, count, options);
         }
 
         private unsafe String[] SplitInternal(char[] separator, int count, StringSplitOptions options)


### PR DESCRIPTION
Port https://github.com/dotnet/coreclr/pull/7623

cc: @jkotas