### PR TITLE
Pass command line options to RyuJIT

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -28,6 +28,8 @@ namespace ILCompiler
         public string DgmlLog;
         public bool FullLog;
         public bool Verbose;
+
+        public IReadOnlyList<string> CodegenOptions = Array.Empty<string>();
     }
 
     public partial class Compilation
@@ -163,7 +165,7 @@ namespace ILCompiler
             }
             else
             {
-                _corInfo = new CorInfoImpl(this);
+                _corInfo = new CorInfoImpl(this, new JitConfigProvider(_options.CodegenOptions));
 
                 _dependencyGraph.ComputeDependencyRoutine += ComputeDependencyNodeDependencies;
 

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -59,6 +59,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\CreateInstanceIntrinsic.cs">
       <Link>IL\Stubs\CreateInstanceIntrinsic.cs</Link>
     </Compile>
+    <Compile Include="..\..\JitInterface\src\JitConfigProvider.cs">
+      <Link>JitInterface\JitConfigProvider.cs</Link>
+    </Compile>
     <Compile Include="Compiler\Compilation.cs" />
     <Compile Include="Compiler\CompilationModuleGroup.cs" />
     <Compile Include="Compiler\CompilerMetadataFieldLayoutAlgorithm.cs" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -115,6 +115,7 @@ namespace ILCompiler
                 syntax.DefineOption("multifile", ref _multiFile, "Compile only input files (do not compile referenced assemblies)");
                 syntax.DefineOption("waitfordebugger", ref waitForDebugger, "Pause to give opportunity to attach debugger");
                 syntax.DefineOption("usesharedgenerics", ref _useSharedGenerics, "Enable shared generics");
+                syntax.DefineOptionList("codegenopt", ref _options.CodegenOptions, "Define a codegen option");
 
                 syntax.DefineOption("singlemethodtypename", ref _singleMethodTypeName, "Single method compilation: name of the owning type");
                 syntax.DefineOption("singlemethodname", ref _singleMethodName, "Single method compilation: name of the method");

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -38,7 +38,7 @@ namespace Internal.JitInterface
         private extern static IntPtr getJit();
 
         [DllImport("jitinterface")]
-        private extern static IntPtr GetJitHost();
+        private extern static IntPtr GetJitHost(IntPtr configProvider);
 
         //
         // Per-method initialization and state
@@ -79,15 +79,17 @@ namespace Internal.JitInterface
         private extern static char* GetExceptionMessage(IntPtr obj);
 
         private Compilation _compilation;
+        private JitConfigProvider _jitConfig;
 
-        public CorInfoImpl(Compilation compilation)
+        public CorInfoImpl(Compilation compilation, JitConfigProvider jitConfig)
         {
             //
             // Global initialization
             //
             _compilation = compilation;
+            _jitConfig = jitConfig;
 
-            jitStartup(GetJitHost());
+            jitStartup(GetJitHost(_jitConfig.UnmanagedInstance));
 
             _jit = getJit();
             if (_jit == IntPtr.Zero)

--- a/src/JitInterface/src/JitConfigProvider.cs
+++ b/src/JitInterface/src/JitConfigProvider.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.JitInterface
+{
+    internal sealed class JitConfigProvider
+    {
+        private Dictionary<string, string> _config = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private object _keepAlive; // Keeps callback delegates alive
+
+        public IntPtr UnmanagedInstance
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="JitConfigProvider"/>.
+        /// </summary>
+        /// <param name="parameters">Name-value pairs separated by an equals sign.</param>
+        public JitConfigProvider(IEnumerable<string> parameters)
+        {
+            foreach (var param in parameters)
+            {
+                int indexOfEquals = param.IndexOf('=');
+
+                // We're skipping bad parameters without reporting.
+                // This is not a mainstream feature that would need to be friendly.
+                // Besides, to really validate this, we would also need to check that the config name is known.
+                if (indexOfEquals < 1)
+                    continue;
+
+                string name = param.Substring(0, indexOfEquals);
+                string value = param.Substring(indexOfEquals + 1);
+
+                _config[name] = value;
+            }
+
+            UnmanagedInstance = CreateUnmanagedInstance();
+        }
+
+        public int GetIntConfigValue(string name, int defaultValue)
+        {
+            string stringValue;
+            int intValue;
+            if (_config.TryGetValue(name, out stringValue) &&
+                Int32.TryParse(stringValue, out intValue))
+            {
+                return intValue;
+            }
+
+            return defaultValue;
+        }
+
+        public string GetStringConfigValue(string name)
+        {
+            string stringValue;
+            if (_config.TryGetValue(name, out stringValue))
+            {
+                return stringValue;
+            }
+
+            return String.Empty;
+        }
+
+        #region Unmanaged instance
+
+        private unsafe IntPtr CreateUnmanagedInstance()
+        {
+            // TODO: this potentially leaks memory, but since we only expect to have one per compilation,
+            // it shouldn't matter...
+
+            const int numCallbacks = 2;
+
+            IntPtr* callbacks = (IntPtr*)Marshal.AllocCoTaskMem(sizeof(IntPtr) * numCallbacks);
+            object[] delegates = new object[numCallbacks];
+
+            var d0 = new __getIntConfigValue(getIntConfigValue);
+            callbacks[0] = Marshal.GetFunctionPointerForDelegate(d0);
+            delegates[0] = d0;
+
+            var d1 = new __getStringConfigValue(getStringConfigValue);
+            callbacks[1] = Marshal.GetFunctionPointerForDelegate(d1);
+            delegates[1] = d1;
+
+            _keepAlive = delegates;
+            IntPtr instance = Marshal.AllocCoTaskMem(sizeof(IntPtr));
+            *(IntPtr**)instance = callbacks;
+
+            return instance;
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private unsafe delegate int __getIntConfigValue(IntPtr thisHandle, [MarshalAs(UnmanagedType.LPWStr)] string name, int defaultValue);
+        private unsafe int getIntConfigValue(IntPtr thisHandle, string name, int defaultValue)
+        {
+            return GetIntConfigValue(name, defaultValue);
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private unsafe delegate int __getStringConfigValue(IntPtr thisHandle, [MarshalAs(UnmanagedType.LPWStr)] string name, char* retBuffer, int retBufferLength);
+        private unsafe int getStringConfigValue(IntPtr thisHandle, string name, char* retBuffer, int retBufferLength)
+        {
+            string result = GetStringConfigValue(name);
+
+            for (int i = 0; i < Math.Min(retBufferLength, result.Length); i++)
+                retBuffer[i] = result[i];
+
+            return result.Length;
+        }
+
+        #endregion
+    }
+}

--- a/src/JitInterface/src/JitConfigProvider.cs
+++ b/src/JitInterface/src/JitConfigProvider.cs
@@ -4,10 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-using Debug = System.Diagnostics.Debug;
+using NumberStyles = System.Globalization.NumberStyles;
 
 namespace Internal.JitInterface
 {
@@ -48,10 +47,11 @@ namespace Internal.JitInterface
 
         public int GetIntConfigValue(string name, int defaultValue)
         {
+            // Note: Parse the string as hex
             string stringValue;
             int intValue;
             if (_config.TryGetValue(name, out stringValue) &&
-                Int32.TryParse(stringValue, out intValue))
+                Int32.TryParse(stringValue, NumberStyles.AllowHexSpecifier, null, out intValue))
             {
                 return intValue;
             }

--- a/src/Native/jitinterface/jithost.cpp
+++ b/src/Native/jitinterface/jithost.cpp
@@ -21,6 +21,13 @@ public:
         ) = 0;
 };
 
+// Native implementation of the JIT host.
+// The native implementation calls into JitConfigProvider (implemented on the managed side) to get the actual
+// configuration values.
+// This dance is necessary because RyuJIT calls into the JitHost as part of the process shutdown (to free up
+// strings). JitHost therefore can't be implemented in managed code (because managed runtime might have
+// already shut down).
+
 class JitHost
 {
     JitConfigProvider* pConfigProvider;


### PR DESCRIPTION
This interface is equivalent to the various `COMPlus_` flags passed to
RyuJIT when hosted on CoreCLR.

You can now e.g. use `--codegenopt NgenDump=*` to have CHK RyuJIT dump
things to stdout.

Note: don't pass the `COMPlus_` part.

Fixes #697.