### PR TITLE
Emit a map of type initialization contexts

### DIFF
--- a/src/Common/src/Internal/Runtime/MetadataBlob.cs
+++ b/src/Common/src/Internal/Runtime/MetadataBlob.cs
@@ -8,21 +8,21 @@ namespace Internal.Runtime
     {
         TypeMap                                     = 1,
         ArrayMap                                    = 2,
-        GenericInstanceMap                          = 3,
-        GenericParameterMap                         = 4,
+        GenericInstanceMap                          = 3, // unused
+        GenericParameterMap                         = 4, // unused
         BlockReflectionTypeMap                      = 5,
         InvokeMap                                   = 6,
         VirtualInvokeMap                            = 7,
         CommonFixupsTable                           = 8,
         FieldAccessMap                              = 9,
         CCtorContextMap                             = 10,
-        DiagGenericInstanceMap                      = 11,
-        DiagGenericParameterMap                     = 12,
+        DiagGenericInstanceMap                      = 11, // unused
+        DiagGenericParameterMap                     = 12, // unused
         EmbeddedMetadata                            = 13,
         DefaultConstructorMap                       = 14,
         UnboxingAndInstantiatingStubMap             = 15,
         InvokeInstantiations                        = 16, // unused
-        PointerTypeMap                              = 17,
+        PointerTypeMap                              = 17, // unused
         GenericVirtualMethodTable                   = 18,
         InterfaceGenericVirtualMethodTable          = 19,
 
@@ -30,6 +30,7 @@ namespace Internal.Runtime
         TypeTemplateMap                             = 21,
         GenericMethodsTemplateMap                   = 22,
         DynamicInvokeTemplateData                   = 23,
+
         //Native layout blobs:
         NativeLayoutInfo                            = 30, // Created by MDIL binder
         NativeReferences                            = 31, // Created by MDIL binder

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClassConstructorContextMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClassConstructorContextMap.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+using Internal.NativeFormat;
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    class ClassConstructorContextMap : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        public ClassConstructorContextMap(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _externalReferences = externalReferences;
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+
+        string ISymbolNode.MangledName => NodeFactory.CompilationUnitPrefix + "__type_to_cctorContext_map";
+
+        int ISymbolNode.Offset => 0;
+        
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+            
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            var writer = new NativeWriter();
+            var typeMapHashTable = new VertexHashtable();
+
+            Section hashTableSection = writer.NewSection();
+            hashTableSection.Place(typeMapHashTable);
+
+            foreach (var node in factory.MetadataManager.GetCctorContextMapping())
+            {
+                MetadataType type = node.Type;
+
+                Debug.Assert(factory.TypeSystemContext.HasLazyStaticConstructor(type));
+
+                // If this type doesn't generate an EEType in the current compilation, don't report it in the table.
+                // If nobody can get to the EEType, they can't ask to run the cctor. We don't need to force generate it.
+                if (!factory.MetadataManager.TypeGeneratesEEType(type))
+                    continue;
+
+                // Hash table is hashed by the hashcode of the owning type.
+                // Each entry has: the EEType of the type, followed by the non-GC static base.
+                // The non-GC static base is prefixed by the class constructor context.
+
+                // Unfortunately we need to adjust for the cctor context just so that we can subtract it again at runtime...
+                int delta = NonGCStaticsNode.GetClassConstructorContextStorageSize(factory.TypeSystemContext.Target, type);
+
+                Vertex vertex = writer.GetTuple(
+                    writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.NecessaryTypeSymbol(type))),
+                    writer.GetUnsignedConstant(_externalReferences.GetIndex(node, delta))
+                    );
+
+                int hashCode = type.GetHashCode();
+                typeMapHashTable.Append((uint)hashCode, hashTableSection.Place(vertex));
+            }
+
+            MemoryStream ms = new MemoryStream();
+            writer.Save(ms);
+            byte[] hashTableBytes = ms.ToArray();
+
+            _endSymbol.SetSymbolOffset(hashTableBytes.Length);
+
+            return new ObjectData(hashTableBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -84,7 +84,14 @@ namespace ILCompiler.DependencyAnalysis
             // generate any relocs to it, and the optional fields node will instruct the object writer to skip
             // emitting it.
             dependencyList.Add(_optionalFieldsNode, "Optional fields");
-            
+
+            // The fact that we generated an EEType means that someone can call RuntimeHelpers.RunClassConstructor.
+            // We need to make sure this is possible - we need the class constructor context.
+            if (factory.TypeSystemContext.HasLazyStaticConstructor(_type))
+            {
+                dependencyList.Add(factory.TypeNonGCStaticsSymbol((MetadataType)_type), "Class constructor");
+            }
+
             return dependencyList;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -145,6 +145,21 @@ namespace ILCompiler.DependencyAnalysis
             return "__EEType_" + NodeFactory.NameMangler.GetMangledTypeName(type);
         }
 
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            if (factory.TypeSystemContext.HasLazyStaticConstructor(_type))
+            {
+                // The fact that we generated an EEType means that someone can call RuntimeHelpers.RunClassConstructor.
+                // We need to make sure this is possible.
+                return new DependencyList
+                {
+                    new DependencyListEntry(factory.TypeNonGCStaticsSymbol((MetadataType)_type), "Class constructor")
+                };
+            }
+
+            return null;
+        }
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using ILCompiler.DependencyAnalysisFramework;
 using Internal.Runtime;
 using Internal.TypeSystem;
 
@@ -28,6 +29,11 @@ namespace ILCompiler.DependencyAnalysis
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {
             return false;
+        }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            return null;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -27,7 +27,7 @@ namespace ILCompiler.DependencyAnalysis
             _compilationModuleGroup = compilationModuleGroup;
             CreateNodeCaches();
 
-            MetadataManager = new MetadataGeneration();
+            MetadataManager = new MetadataGeneration(this);
         }
 
         public TargetDetails Target

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -53,6 +53,14 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        public MetadataType Type
+        {
+            get
+            {
+                return _type;
+            }
+        }
+
         public override bool ShouldShareNodeAcrossModules(NodeFactory factory)
         {
             return factory.CompilationModuleGroup.ShouldShareAcrossModules(_type);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
@@ -87,7 +87,9 @@ namespace ILCompiler.DependencyAnalysis
             builder.Alignment = factory.Target.PointerSize;
             builder.DefinedSymbols.Add(this);
 
-            _items.Sort((x, y) => Comparer<int>.Default.Compare((int)x.Id, (int)y.Id));
+            // Don't bother sorting if we're not emitting the contents
+            if (!relocsOnly)
+                _items.Sort((x, y) => Comparer<int>.Default.Compare((int)x.Id, (int)y.Id));
 
             // ReadyToRunHeader.Magic
             builder.EmitInt((int)(ReadyToRunHeaderConstants.Signature));

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.cs" />
     <Compile Include="Compiler\DelegateCreationInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ClassConstructorContextMap.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ClonedConstructedEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ConstructedEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CppCodegenNodeFactory.cs" />

--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -100,4 +100,9 @@ extern "C"
     {
         throw "GetTimeZoneInformationForYear";
     }
+
+    void GetCPInfo()
+    {
+        throw "GetCPInfo";
+    }
 }


### PR DESCRIPTION
This is a hash table holding a mapping between the EEType and the type's cctor
context. This is used to support reflection and `RuntimeHelpers.RunClassConstructor`.