### PR TITLE
Extend ScopeDefinition metadata schema

### DIFF
--- a/src/Common/src/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/Common/src/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -461,6 +461,8 @@ class SchemaDef
                 new MemberDef("PublicKey", "Byte", MemberDefFlags.Array | MemberDefFlags.Compare),
                 new MemberDef("Culture", "ConstantStringValue", MemberDefFlags.RecordRef | MemberDefFlags.Child | MemberDefFlags.Compare),
                 new MemberDef("RootNamespaceDefinition", "NamespaceDefinition", MemberDefFlags.RecordRef | MemberDefFlags.Child),
+                new MemberDef("EntryPoint", "QualifiedMethod", MemberDefFlags.RecordRef),
+                new MemberDef("GlobalModuleType", "TypeDefinition", MemberDefFlags.RecordRef),
                 new MemberDef("CustomAttributes", "CustomAttribute", MemberDefFlags.List | MemberDefFlags.RecordRef | MemberDefFlags.Child),
             }
         ),

--- a/src/Common/src/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/Common/src/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -6750,6 +6750,26 @@ namespace Internal.Metadata.NativeFormat
 
         internal NamespaceDefinitionHandle _rootNamespaceDefinition;
 
+        public QualifiedMethodHandle EntryPoint
+        {
+            get
+            {
+                return _entryPoint;
+            }
+        } // EntryPoint
+
+        internal QualifiedMethodHandle _entryPoint;
+
+        public TypeDefinitionHandle GlobalModuleType
+        {
+            get
+            {
+                return _globalModuleType;
+            }
+        } // GlobalModuleType
+
+        internal TypeDefinitionHandle _globalModuleType;
+
         public CustomAttributeHandleCollection CustomAttributes
         {
             get
@@ -11356,6 +11376,8 @@ namespace Internal.Metadata.NativeFormat
             offset = _streamReader.Read(offset, out record._publicKey);
             offset = _streamReader.Read(offset, out record._culture);
             offset = _streamReader.Read(offset, out record._rootNamespaceDefinition);
+            offset = _streamReader.Read(offset, out record._entryPoint);
+            offset = _streamReader.Read(offset, out record._globalModuleType);
             offset = _streamReader.Read(offset, out record._customAttributes);
             return record;
         } // GetScopeDefinition

--- a/src/Common/src/TypeSystem/Common/ModuleDesc.cs
+++ b/src/Common/src/TypeSystem/Common/ModuleDesc.cs
@@ -26,7 +26,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the global &lt;Module&gt; type.
         /// </summary>
-        public abstract TypeDesc GetGlobalModuleType();
+        public abstract MetadataType GetGlobalModuleType();
 
         /// <summary>
         /// Retrieves a collection of all types defined in the current module. This includes nested types.

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -498,13 +498,13 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public sealed override TypeDesc GetGlobalModuleType()
+        public sealed override MetadataType GetGlobalModuleType()
         {
             int typeDefinitionsCount = _metadataReader.TypeDefinitions.Count;
             if (typeDefinitionsCount == 0)
                 return null;
 
-            return GetType(MetadataTokens.EntityHandle(0x02000001 /* COR_GLOBAL_PARENT_TOKEN */));
+            return (MetadataType)GetType(MetadataTokens.EntityHandle(0x02000001 /* COR_GLOBAL_PARENT_TOKEN */));
         }
 
         protected static AssemblyContentType GetContentTypeFromAssemblyFlags(AssemblyFlags flags)

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/ExplicitScopeAssemblyPolicyMixin.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/ExplicitScopeAssemblyPolicyMixin.cs
@@ -99,7 +99,7 @@ namespace ILCompiler.Metadata
                 return null;
             }
 
-            public override Cts.TypeDesc GetGlobalModuleType()
+            public override Cts.MetadataType GetGlobalModuleType()
             {
                 return null;
             }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -65,6 +65,12 @@ namespace ILCompiler.Metadata
                     scopeDefinition.PublicKey = assemblyName.GetPublicKeyToken();
                 }
 
+                Cts.MetadataType moduleType = module.GetGlobalModuleType();
+                if (_policy.GeneratesMetadata(moduleType))
+                {
+                    scopeDefinition.GlobalModuleType = (TypeDefinition)HandleType(moduleType);
+                }
+
                 Cts.Ecma.EcmaAssembly ecmaAssembly = module as Cts.Ecma.EcmaAssembly;
                 if (ecmaAssembly != null)
                 {
@@ -72,6 +78,12 @@ namespace ILCompiler.Metadata
                     if (customAttributes.Count > 0)
                     {
                         scopeDefinition.CustomAttributes = HandleCustomAttributes(ecmaAssembly, customAttributes);
+                    }
+
+                    Cts.MethodDesc entryPoint = ecmaAssembly.EntryPoint;
+                    if (entryPoint != null && _policy.GeneratesMetadata(entryPoint))
+                    {
+                        scopeDefinition.EntryPoint = (QualifiedMethod)HandleQualifiedMethod(entryPoint);
                     }
                 }
             }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -66,7 +66,7 @@ namespace ILCompiler.Metadata
                 }
 
                 Cts.MetadataType moduleType = module.GetGlobalModuleType();
-                if (_policy.GeneratesMetadata(moduleType))
+                if (moduleType != null && _policy.GeneratesMetadata(moduleType))
                 {
                     scopeDefinition.GlobalModuleType = (TypeDefinition)HandleType(moduleType);
                 }

--- a/src/ILCompiler.MetadataWriter/src/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
+++ b/src/ILCompiler.MetadataWriter/src/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
@@ -4286,6 +4286,8 @@ namespace Internal.Metadata.NativeFormat.Writer
             Name = visitor.Visit(this, Name);
             Culture = visitor.Visit(this, Culture);
             RootNamespaceDefinition = visitor.Visit(this, RootNamespaceDefinition);
+            EntryPoint = visitor.Visit(this, EntryPoint);
+            GlobalModuleType = visitor.Visit(this, GlobalModuleType);
             CustomAttributes = visitor.Visit(this, CustomAttributes);
         } // Visit
 
@@ -4344,6 +4346,8 @@ namespace Internal.Metadata.NativeFormat.Writer
             writer.Write(PublicKey);
             writer.Write(Culture);
             writer.Write(RootNamespaceDefinition);
+            writer.Write(EntryPoint);
+            writer.Write(GlobalModuleType);
             writer.Write(CustomAttributes);
         } // Save
 
@@ -4377,6 +4381,8 @@ namespace Internal.Metadata.NativeFormat.Writer
         public Byte[] PublicKey;
         public ConstantStringValue Culture;
         public NamespaceDefinition RootNamespaceDefinition;
+        public QualifiedMethod EntryPoint;
+        public TypeDefinition GlobalModuleType;
         public List<CustomAttribute> CustomAttributes = new List<CustomAttribute>();
     } // ScopeDefinition
 


### PR DESCRIPTION
Add support for representing EntryPoint and the global `<Module>` type.

Note: this does not include updates to the Project N metadata writer.
The schedule for that is TBD.

Fixes #1782.