### PR TITLE
Port dotnet/coreclr#7295 to CoreRT

### DIFF
--- a/src/Native/Runtime/gcenv.ee.h
+++ b/src/Native/Runtime/gcenv.ee.h
@@ -1,0 +1,38 @@
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _GCENV_EE_H_
+#define _GCENV_EE_H_
+
+#include "gcinterface.h"
+
+#ifdef FEATURE_STANDALONE_GC
+
+class GCToEEInterface : public IGCToCLR {
+public:
+    GCToEEInterface() = default;
+    ~GCToEEInterface() = default;
+
+    void SuspendEE(SUSPEND_REASON reason);
+    void RestartEE(bool bFinishedGC);
+    void GcScanRoots(promote_func* fn, int condemned, int max_gen, ScanContext* sc);
+    void GcStartWork(int condemned, int max_gen);
+    void AfterGcScanRoots(int condemned, int max_gen, ScanContext* sc);
+    void GcBeforeBGCSweepWork();
+    void GcDone(int condemned);
+    bool RefCountedHandleCallbacks(Object * pObject);
+    void SyncBlockCacheWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintptr_t lp2);
+    void SyncBlockCacheDemote(int max_gen);
+    void SyncBlockCachePromotionsGranted(int max_gen);
+    bool IsPreemptiveGCDisabled(Thread * pThread);
+    void EnablePreemptiveGC(Thread * pThread);
+    void DisablePreemptiveGC(Thread * pThread);
+    gc_alloc_context * GetAllocContext(Thread * pThread);
+    bool CatchAtSafePoint(Thread * pThread);
+    void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);
+    Thread* CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg);
+};
+
+#endif // FEATURE_STANDALONE_GC
+
+#endif // _GCENV_EE_H_

--- a/src/Native/Runtime/gcenv.h
+++ b/src/Native/Runtime/gcenv.h
@@ -13,7 +13,6 @@
 #include "gcenv.os.h"
 #include "gcenv.interlocked.h"
 #include "gcenv.base.h"
-#include "gcenv.ee.h"
 
 #include "Crst.h"
 #include "event.h"

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -13,6 +13,12 @@
 #include "gcenv.h"
 #include "gcheaputilities.h"
 
+#ifdef FEATURE_STANDALONE_GC
+#include "gcenv.ee.h"
+#else
+#include "../gc/env/gcenv.ee.h"
+#endif // FEATURE_STANDALONE_GC
+
 #include "RestrictedCallouts.h"
 
 #include "gcrhinterface.h"
@@ -197,7 +203,15 @@ bool RedhawkGCInterface::InitializeSubsystems(GCType gcType)
     InitializeHeapType(fUseServerGC);
 
     // Create the GC heap itself.
-    IGCHeap *pGCHeap = InitializeGarbageCollector(nullptr);
+#ifdef FEATURE_STANDALONE_GC
+    IGCToCLR* gcToClr = new (nothrow) GCToEEInterface();
+    if (!gcToClr)
+        return false;
+#else
+    IGCToCLR* gcToClr = nullptr;
+#endif // FEATURE_STANDALONE_GC
+
+    IGCHeap *pGCHeap = InitializeGarbageCollector(gcToClr);
     if (!pGCHeap)
         return false;
 
@@ -941,7 +955,7 @@ void RedhawkGCInterface::SetLastAllocEEType(EEType * pEEType)
     tls_pLastAllocationEEType = pEEType;
 }
 
-void GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_REASON reason)
+void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
 {
 #ifdef FEATURE_EVENT_TRACE
     ETW::GCLog::ETW_GC_INFO Info;

--- a/src/Native/Runtime/gcrhscan.cpp
+++ b/src/Native/Runtime/gcrhscan.cpp
@@ -4,9 +4,14 @@
 #include "common.h"
 
 #include "gcenv.h"
-#include "gcscan.h"
 #include "gcheaputilities.h"
 #include "objecthandle.h"
+
+#ifdef FEATURE_STANDALONE_GC
+#include "gcenv.ee.h"
+#else
+#include "../gc/env/gcenv.ee.h"
+#endif // FEATURE_STANDALONE_GC
 
 #include "PalRedhawkCommon.h"
 

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -7,36 +7,11 @@
 #ifndef __GCENV_EE_H__
 #define __GCENV_EE_H__
 
-struct ScanContext;
-class CrawlFrame;
-struct gc_alloc_context;
-
-typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
-
-typedef void enum_alloc_context_func(gc_alloc_context*, void*);
-
-typedef struct
-{
-    promote_func*  f;
-    ScanContext*   sc;
-    CrawlFrame *   cf;
-} GCCONTEXT;
-
-// GC background thread function prototype
-typedef uint32_t (__stdcall *GCBackgroundThreadFunction)(void* param);
+#include "gcinterface.h"
 
 class GCToEEInterface
 {
 public:
-    //
-    // Suspend/Resume callbacks
-    //
-    typedef enum
-    {
-        SUSPEND_FOR_GC = 1,
-        SUSPEND_FOR_GC_PREP = 6
-    } SUSPEND_REASON;
-
     static void SuspendEE(SUSPEND_REASON reason);
     static void RestartEE(bool bFinishedGC); //resume threads.
 

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -5231,7 +5231,7 @@ void gc_heap::gc_thread_function ()
             gc_heap::ee_suspend_event.Wait(INFINITE, FALSE);
 
             BEGIN_TIMING(suspend_ee_during_log);
-            GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_FOR_GC);
+            GCToEEInterface::SuspendEE(SUSPEND_FOR_GC);
             END_TIMING(suspend_ee_during_log);
 
             proceed_with_gc_p = TRUE;
@@ -26046,9 +26046,9 @@ gc_heap::suspend_EE ()
     dprintf (2, ("suspend_EE"));
 #ifdef MULTIPLE_HEAPS
     gc_heap* hp = gc_heap::g_heaps[0];
-    GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_FOR_GC_PREP);
+    GCToEEInterface::SuspendEE(SUSPEND_FOR_GC_PREP);
 #else
-    GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_FOR_GC_PREP);
+    GCToEEInterface::SuspendEE(SUSPEND_FOR_GC_PREP);
 #endif //MULTIPLE_HEAPS
 }
 
@@ -26062,7 +26062,7 @@ gc_heap::bgc_suspend_EE ()
     }
     gc_started = TRUE;
     dprintf (2, ("bgc_suspend_EE"));
-    GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_FOR_GC_PREP);
+    GCToEEInterface::SuspendEE(SUSPEND_FOR_GC_PREP);
 
     gc_started = FALSE;
     for (int i = 0; i < n_heaps; i++)
@@ -26077,7 +26077,7 @@ gc_heap::bgc_suspend_EE ()
     reset_gc_done();
     gc_started = TRUE;
     dprintf (2, ("bgc_suspend_EE"));
-    GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_FOR_GC_PREP);
+    GCToEEInterface::SuspendEE(SUSPEND_FOR_GC_PREP);
     gc_started = FALSE;
     set_gc_done();
 }
@@ -35204,7 +35204,7 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
 
         dprintf (2, ("Suspending EE"));
         BEGIN_TIMING(suspend_ee_during_log);
-        GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_FOR_GC);
+        GCToEEInterface::SuspendEE(SUSPEND_FOR_GC);
         END_TIMING(suspend_ee_during_log);
         gc_heap::proceed_with_gc_p = gc_heap::should_proceed_with_gc();
         gc_heap::disable_preemptive (current_thread, cooperative_mode);

--- a/src/Native/gc/gc.h
+++ b/src/Native/gc/gc.h
@@ -15,7 +15,11 @@ Module Name:
 #define __GC_H
 
 #include "gcinterface.h"
+#include "env/gcenv.ee.h"
 
+#ifdef FEATURE_STANDALONE_GC
+#include "gcenv.ee.standalone.inl"
+#endif // FEATURE_STANDALONE_GC
 
 /*
  * Promotion Function Prototypes

--- a/src/Native/gc/gccommon.cpp
+++ b/src/Native/gc/gccommon.cpp
@@ -22,6 +22,10 @@ SVAL_IMPL_INIT(uint32_t,IGCHeap,maxGeneration,2);
 
 IGCHeapInternal* g_theGCHeap;
 
+#ifdef FEATURE_STANDALONE_GC
+IGCToCLR* g_theGCToCLR;
+#endif // FEATURE_STANDALONE_GC
+
 /* global versions of the card table and brick table */ 
 GPTR_IMPL(uint32_t,g_card_table);
 
@@ -148,6 +152,14 @@ IGCHeap* InitializeGarbageCollector(IGCToCLR* clrToGC)
 #endif
 
     g_theGCHeap = heap;
+
+#ifdef FEATURE_STANDALONE_GC
+    assert(clrToGC != nullptr);
+    g_theGCToCLR = clrToGC;
+#else
+    assert(clrToGC == nullptr);
+#endif
+
     return heap;
 }
 

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __GCTOENV_EE_STANDALONE_INL__
+#define __GCTOENV_EE_STANDALONE_INL__
+
+#include "env/gcenv.ee.h"
+
+// The singular interface instance. All calls in GCToEEInterface
+// will be fowarded to this interface instance.
+extern IGCToCLR* g_theGCToCLR;
+
+// When we are building the GC in a standalone environment, we
+// will be dispatching virtually against g_theGCToCLR to call
+// into the EE. This class provides an identical API to the existing
+// GCToEEInterface, but only forwards the call onto the global
+// g_theGCToCLR instance.
+inline void GCToEEInterface::SuspendEE(SUSPEND_REASON reason) 
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->SuspendEE(reason);
+}
+
+inline void GCToEEInterface::RestartEE(bool bFinishedGC)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->RestartEE(bFinishedGC);
+}
+
+inline void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, ScanContext* sc)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->GcScanRoots(fn, condemned, max_gen, sc);
+}
+
+inline void GCToEEInterface::GcStartWork(int condemned, int max_gen)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->GcStartWork(condemned, max_gen);
+}
+
+inline void GCToEEInterface::AfterGcScanRoots(int condemned, int max_gen, ScanContext* sc)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->AfterGcScanRoots(condemned, max_gen, sc);
+}
+
+inline void GCToEEInterface::GcBeforeBGCSweepWork()
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->GcBeforeBGCSweepWork();
+}
+
+inline void GCToEEInterface::GcDone(int condemned)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->GcDone(condemned);
+}
+
+inline bool GCToEEInterface::RefCountedHandleCallbacks(Object * pObject)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->RefCountedHandleCallbacks(pObject);
+}
+
+inline void GCToEEInterface::SyncBlockCacheWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintptr_t lp2)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->SyncBlockCacheWeakPtrScan(scanProc, lp1, lp2);
+}
+
+inline void GCToEEInterface::SyncBlockCacheDemote(int max_gen)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->SyncBlockCacheDemote(max_gen);
+}
+
+inline void GCToEEInterface::SyncBlockCachePromotionsGranted(int max_gen)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->SyncBlockCachePromotionsGranted(max_gen);
+}
+
+inline bool GCToEEInterface::IsPreemptiveGCDisabled(Thread * pThread)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->IsPreemptiveGCDisabled(pThread);
+}
+
+
+inline void GCToEEInterface::EnablePreemptiveGC(Thread * pThread)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->EnablePreemptiveGC(pThread);
+}
+
+inline void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->DisablePreemptiveGC(pThread);
+}
+
+inline gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetAllocContext(pThread);
+}
+
+inline bool GCToEEInterface::CatchAtSafePoint(Thread * pThread)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->CatchAtSafePoint(pThread);
+}
+
+inline void GCToEEInterface::GcEnumAllocContexts(enum_alloc_context_func* fn, void* param)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->GcEnumAllocContexts(fn, param);
+}
+
+inline Thread* GCToEEInterface::CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->CreateBackgroundThread(threadStart, arg);
+}
+
+#endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _GCINTERFACE_EE_H_
+#define _GCINTERFACE_EE_H_
+
+// This interface provides the interface that the GC will use to speak to the rest
+// of the execution engine. Everything that the GC does that requires the EE
+// to be informed or that requires EE action must go through this interface.
+//
+// When FEATURE_STANDALONE_GC is defined, this class is named IGCToCLR and is
+// an abstract class. The EE will provide a class that fulfills this interface,
+// and the GC will dispatch virtually on it to call into the EE. When FEATURE_STANDALONE_GC
+// is not defined, this class is named GCToEEInterface and the GC will dispatch statically on it.
+class IGCToCLR {
+public:
+    // Suspends the EE for the given reason.
+    virtual
+    void SuspendEE(SUSPEND_REASON reason) = 0;
+    
+    // Resumes all paused threads, with a boolean indicating
+    // if the EE is being restarted because a GC is complete.
+    virtual
+    void RestartEE(bool bFinishedGC) = 0;
+
+    // Performs a stack walk of all managed threads and invokes the given promote_func
+    // on all GC roots encountered on the stack. Depending on the condemned generation,
+    // this function may also enumerate all static GC refs if necessary.
+    virtual
+    void GcScanRoots(promote_func* fn, int condemned, int max_gen, ScanContext* sc) = 0;
+
+    // Callback from the GC informing the EE that it is preparing to start working.
+    virtual
+    void GcStartWork(int condemned, int max_gen) = 0;
+
+    // Callback from the GC informing the EE that it has completed the managed stack
+    // scan. User threads are still suspended at this point.
+    virtual
+    void AfterGcScanRoots(int condemned, int max_gen, ScanContext* sc) = 0;
+
+    // Callback from the GC informing the EE that the background sweep phase of a BGC is
+    // about to begin.
+    virtual
+    void GcBeforeBGCSweepWork() = 0;
+
+    // Callback from the GC informing the EE that a GC has completed.
+    virtual
+    void GcDone(int condemned) = 0;
+
+    // Predicate for the GC to query whether or not a given refcounted handle should
+    // be promoted.
+    virtual
+    bool RefCountedHandleCallbacks(Object * pObject) = 0;
+
+    // Performs a weak pointer scan of the sync block cache.
+    virtual
+    void SyncBlockCacheWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintptr_t lp2) = 0;
+
+    // Indicates to the EE that the GC intends to demote objects in the sync block cache.
+    virtual
+    void SyncBlockCacheDemote(int max_gen) = 0;
+
+    // Indicates to the EE that the GC has granted promotion to objects in the sync block cache.
+    virtual
+    void SyncBlockCachePromotionsGranted(int max_gen) = 0;
+
+    // Queries whether or not the given thread has preemptive GC disabled.
+    virtual
+    bool IsPreemptiveGCDisabled(Thread * pThread) = 0;
+
+    // Enables preemptive GC on the given thread.
+    virtual
+    void EnablePreemptiveGC(Thread * pThread) = 0;
+
+    // Disables preemptive GC on the given thread.
+    virtual
+    void DisablePreemptiveGC(Thread * pThread) = 0;
+
+    // Retrieves the alloc context associated with a given thread.
+    virtual
+    gc_alloc_context * GetAllocContext(Thread * pThread) = 0;
+
+    // Returns true if this thread is waiting to reach a safe point.
+    virtual
+    bool CatchAtSafePoint(Thread * pThread) = 0;
+
+    // Calls the given enum_alloc_context_func with every active alloc context.
+    virtual
+    void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param) = 0;
+
+    // Creates and returns a new background thread.
+    virtual
+    Thread* CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg) = 0;
+};
+
+#endif // _GCINTERFACE_EE_H_

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -5,6 +5,37 @@
 #ifndef _GC_INTERFACE_H_
 #define _GC_INTERFACE_H_
 
+struct ScanContext;
+struct gc_alloc_context;
+class CrawlFrame;
+
+// Callback passed to GcScanRoots.
+typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
+
+// Callback passed to GcEnumAllocContexts.
+typedef void enum_alloc_context_func(gc_alloc_context*, void*);
+
+// Callback passed to CreateBackgroundThread.
+typedef uint32_t (__stdcall *GCBackgroundThreadFunction)(void* param);
+
+// Struct often used as a parameter to callbacks.
+typedef struct
+{
+    promote_func*  f;
+    ScanContext*   sc;
+    CrawlFrame *   cf;
+} GCCONTEXT;
+
+// SUSPEND_REASON is the reason why the GC wishes to suspend the EE,
+// used as an argument to IGCToCLR::SuspendEE.
+typedef enum
+{
+    SUSPEND_FOR_GC = 1,
+    SUSPEND_FOR_GC_PREP = 6
+} SUSPEND_REASON;
+
+#include "gcinterface.ee.h"
+
 // The allocation context must be known to the VM for use in the allocation
 // fast path and known to the GC for performing the allocation. Every Thread
 // has its own allocation context that it hands to the GC when allocating.

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -129,7 +129,7 @@ void ThreadStore::AttachCurrentThread()
     g_pThreadList = pThread;
 }
 
-void GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_REASON reason)
+void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
 {
     g_theGCHeap->SetGCInProgress(TRUE);
 

--- a/src/Native/gc/sample/gcenv.h
+++ b/src/Native/gc/sample/gcenv.h
@@ -2,6 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// The sample is to be kept simple, so building the sample
+// in tandem with a standalone GC is currently not supported.
+#ifdef FEATURE_STANDALONE_GC
+#undef FEATURE_STANDALONE_GC
+#endif // FEATURE_STANDALONE_GC
+
 #if defined(_DEBUG)
 #ifndef _DEBUG_IMPL
 #define _DEBUG_IMPL 1
@@ -17,12 +23,12 @@
 
 #include "gcenv.structs.h"
 #include "gcenv.base.h"
-#include "gcenv.ee.h"
 #include "gcenv.os.h"
 #include "gcenv.interlocked.h"
 #include "gcenv.interlocked.inl"
 #include "gcenv.object.h"
 #include "gcenv.sync.h"
+#include "gcenv.ee.h"
 
 #define MAX_LONGPATH 1024
 


### PR DESCRIPTION
This PR brings dotnet/coreclr#7295 to CoreRT to align the GCs. Like the CoreCLR PR, this introduces a `FEATURE_STANDALONE_GC` flag that causes the GC to CLR interface to dispatch virtually instead of linking statically, although I imagine that won't ever be defined for CoreRT. The changes here are very similar to the CoreCLR PR and there shouldn't be any surprises. (In particular, everything in the `Native/gc` directory is taken verbatim from the CoreCLR PR)