### PR TITLE
Implement fat function pointers

### DIFF
--- a/src/Common/src/Internal/Runtime/RuntimeConstants.cs
+++ b/src/Common/src/Internal/Runtime/RuntimeConstants.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.Runtime
+{
+    internal static class FatFunctionPointerConstants
+    {
+        /// <summary>
+        /// Offset by which fat function pointers are shifted to distinguish them
+        /// from real function pointers.
+        /// </summary>
+        public const int Offset = 2;
+    }
+}

--- a/src/Common/src/TypeSystem/IL/DelegateInfo.cs
+++ b/src/Common/src/TypeSystem/IL/DelegateInfo.cs
@@ -97,6 +97,7 @@ namespace Internal.IL
         private MethodDesc _multicastThunk;
         private MethodDesc _closedStaticThunk;
         private MethodDesc _invokeThunk;
+        private MethodDesc _closedInstanceOverGeneric;
 
         internal DelegateThunkCollection(DelegateInfo owningDelegate)
         {
@@ -104,6 +105,7 @@ namespace Internal.IL
             _multicastThunk = new DelegateInvokeMulticastThunk(owningDelegate);
             _closedStaticThunk = new DelegateInvokeClosedStaticThunk(owningDelegate);
             _invokeThunk = new DelegateDynamicInvokeThunk(owningDelegate);
+            _closedInstanceOverGeneric = new DelegateInvokeInstanceClosedOverGenericMethodThunk(owningDelegate);
         }
 
         public MethodDesc this[DelegateThunkKind kind]
@@ -120,6 +122,8 @@ namespace Internal.IL
                         return _closedStaticThunk;
                     case DelegateThunkKind.DelegateInvokeThunk:
                         return _invokeThunk;
+                    case DelegateThunkKind.ClosedInstanceThunkOverGenericMethod:
+                        return _closedInstanceOverGeneric;
                     default:
                         return null;
                 }

--- a/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
@@ -111,8 +111,20 @@ namespace ILCompiler
 
                 bool useUnboxingStub = targetMethod.OwningType.IsValueType;
 
+                string intializeMethodName = "InitializeClosedInstance";
+                if (targetMethod.HasInstantiation)
+                {
+                    Debug.Assert(!targetMethod.IsVirtual, "TODO: delegate to generic virtual method");
+
+                    // Closed delegates to generic instance methods need to be constructed through a slow helper that
+                    // checks for the fat function pointer case (function pointer + instantiation argument in a single
+                    // pointer) and injects an invocation thunk to unwrap the fat function pointer as part of
+                    // the invocation if necessary.
+                    intializeMethodName = "InitializeClosedInstanceSlow";
+                }
+
                 return new DelegateCreationInfo(
-                    factory.MethodEntrypoint(systemDelegate.GetKnownMethod("InitializeClosedInstance", null)),
+                    factory.MethodEntrypoint(systemDelegate.GetKnownMethod(intializeMethodName, null)),
                     factory.MethodEntrypoint(targetMethod, useUnboxingStub));
             }
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
@@ -111,7 +111,7 @@ namespace ILCompiler
 
                 bool useUnboxingStub = targetMethod.OwningType.IsValueType;
 
-                string intializeMethodName = "InitializeClosedInstance";
+                string initializeMethodName = "InitializeClosedInstance";
                 if (targetMethod.HasInstantiation)
                 {
                     Debug.Assert(!targetMethod.IsVirtual, "TODO: delegate to generic virtual method");
@@ -120,11 +120,11 @@ namespace ILCompiler
                     // checks for the fat function pointer case (function pointer + instantiation argument in a single
                     // pointer) and injects an invocation thunk to unwrap the fat function pointer as part of
                     // the invocation if necessary.
-                    intializeMethodName = "InitializeClosedInstanceSlow";
+                    initializeMethodName = "InitializeClosedInstanceSlow";
                 }
 
                 return new DelegateCreationInfo(
-                    factory.MethodEntrypoint(systemDelegate.GetKnownMethod(intializeMethodName, null)),
+                    factory.MethodEntrypoint(systemDelegate.GetKnownMethod(initializeMethodName, null)),
                     factory.MethodEntrypoint(targetMethod, useUnboxingStub));
             }
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a fat function pointer - a data structure that captures a pointer to a canonical
+    /// method body along with the instantiation context the canonical body requires.
+    /// Pointers to these structures can be created by e.g. ldftn/ldvirtftn of a method with a canonical body.
+    /// </summary>
+    public class FatFunctionPointerNode : ObjectNode, IMethodNode
+    {
+        public FatFunctionPointerNode(MethodDesc methodRepresented)
+        {
+            // We should not create these for methods that don't have a canonical method body
+            Debug.Assert(methodRepresented.GetCanonMethodTarget(CanonicalFormKind.Specific) != methodRepresented);
+
+            Method = methodRepresented;
+        }
+
+        public string MangledName => "__fatpointer_" + NodeFactory.NameMangler.GetMangledMethodName(Method);
+
+        public MethodDesc Method { get; }
+
+        public int Offset => 0;
+
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override bool ShouldShareNodeAcrossModules(NodeFactory factory) => true;
+
+        protected override string GetName() => MangledName;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            var builder = new ObjectDataBuilder(factory);
+
+            // These need to be aligned the same as methods because they show up in same contexts
+            builder.RequireAlignment(factory.Target.MinimumFunctionAlignment);
+
+            builder.DefinedSymbols.Add(this);
+
+            MethodDesc canonMethod = Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
+            // Pointer to the canonical body of the method
+            builder.EmitPointerReloc(factory.MethodEntrypoint(canonMethod));
+
+            // Find out what's the context to use
+            GenericDictionaryNode dictionary;
+            if (canonMethod.RequiresInstMethodDescArg())
+            {
+                dictionary = factory.MethodGenericDictionary(Method);
+            }
+            else
+            {
+                Debug.Assert(canonMethod.RequiresInstMethodTableArg());
+                dictionary = factory.TypeGenericDictionary(Method.OwningType);
+            }
+
+            // The next entry is a pointer to the pointer to the context to be used for the canonical method
+            // TODO: in multi-module, this points to the import cell, and is no longer this weird pointer
+            builder.EmitPointerReloc(factory.Indirection(dictionary));
+            
+            return builder.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -72,7 +72,8 @@ namespace ILCompiler.DependencyAnalysis
             foreach (var entry in layout.Entries)
             {
                 ISymbolNode targetNode = entry.GetTarget(factory, typeInst, methodInst);
-                builder.EmitPointerReloc(targetNode);
+                int targetDelta = entry.TargetDelta;
+                builder.EmitPointerReloc(targetNode, targetDelta);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a general-purpose pointer indirection to another symbol.
+    /// </summary>
+    public class IndirectionNode : ObjectNode, ISymbolNode
+    {
+        private ISymbolNode _indirectedNode;
+
+        public IndirectionNode(ISymbolNode indirectedNode)
+        {
+            _indirectedNode = indirectedNode;
+        }
+
+        string ISymbolNode.MangledName => "__indirection" + _indirectedNode.MangledName;
+        int ISymbolNode.Offset => 0;
+
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override string GetName() => ((ISymbolNode)this).MangledName;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            var builder = new ObjectDataBuilder(factory);
+            builder.RequirePointerAlignment();
+            builder.DefinedSymbols.Add(this);
+
+            builder.EmitPointerReloc(_indirectedNode);
+
+            return builder.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -32,6 +32,11 @@ namespace ILCompiler.DependencyAnalysis
                     return new MethodDictionaryGenericLookupResult(method);
                 });
 
+                _methodEntrypoints = new NodeCache<MethodDesc, GenericLookupResult>(method =>
+                {
+                    return new MethodEntryGenericLookupResult(method);
+                });
+
                 _virtualCallHelpers = new NodeCache<MethodDesc, GenericLookupResult>(method =>
                 {
                     return new VirtualDispatchGenericLookupResult(method);
@@ -57,6 +62,13 @@ namespace ILCompiler.DependencyAnalysis
             public GenericLookupResult VirtualCall(MethodDesc method)
             {
                 return _virtualCallHelpers.GetOrAdd(method);
+            }
+
+            private NodeCache<MethodDesc, GenericLookupResult> _methodEntrypoints;
+
+            public GenericLookupResult MethodEntry(MethodDesc method)
+            {
+                return _methodEntrypoints.GetOrAdd(method);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -185,6 +185,11 @@ namespace ILCompiler.DependencyAnalysis
 
             _unboxingStubs = new NodeCache<MethodDesc, IMethodNode>(CreateUnboxingStubNode);
 
+            _fatFunctionPointers = new NodeCache<MethodDesc, FatFunctionPointerNode>(method =>
+            {
+                return new FatFunctionPointerNode(method);
+            });
+
             _shadowConcreteMethods = new NodeCache<MethodDesc, IMethodNode>(method =>
             {
                 return new ShadowConcreteMethodNode<MethodCodeNode>(method,
@@ -212,6 +217,11 @@ namespace ILCompiler.DependencyAnalysis
             _stringIndirectionNodes = new NodeCache<string, StringIndirectionNode>((string data) =>
             {
                 return new StringIndirectionNode(data);
+            });
+
+            _indirectionNodes = new NodeCache<ISymbolNode, IndirectionNode>(symbol =>
+            {
+                return new IndirectionNode(symbol);
             });
 
             _frozenStringNodes = new NodeCache<string, FrozenStringNode>((string data) =>
@@ -471,6 +481,13 @@ namespace ILCompiler.DependencyAnalysis
             return _methodEntrypoints.GetOrAdd(method);
         }
 
+        private NodeCache<MethodDesc, FatFunctionPointerNode> _fatFunctionPointers;
+
+        public IMethodNode FatFunctionPointer(MethodDesc method)
+        {
+            return _fatFunctionPointers.GetOrAdd(method);
+        }
+
         private NodeCache<MethodDesc, IMethodNode> _shadowConcreteMethods;
 
         public IMethodNode ShadowConcreteMethod(MethodDesc method)
@@ -580,6 +597,13 @@ namespace ILCompiler.DependencyAnalysis
         public StringIndirectionNode StringIndirection(string data)
         {
             return _stringIndirectionNodes.GetOrAdd(data);
+        }
+
+        private NodeCache<ISymbolNode, IndirectionNode> _indirectionNodes;
+
+        public IndirectionNode Indirection(ISymbolNode symbol)
+        {
+            return _indirectionNodes.GetOrAdd(symbol);
         }
 
         private NodeCache<string, FrozenStringNode> _frozenStringNodes;

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -47,6 +47,9 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs">
       <Link>Common\MetadataBlob.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Internal\Runtime\RuntimeConstants.cs">
+      <Link>Common\RuntimeConstants.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\DelegateInfo.cs">
       <Link>IL\DelegateInfo.cs</Link>
     </Compile>
@@ -74,10 +77,12 @@
     <Compile Include="Compiler\DependencyAnalysis\DictionaryLayoutNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternalReferencesTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternEETypeSymbolNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\FatFunctionPointerNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenObjectSentinelNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenStringNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericCompositionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDefinitionEETypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\IndirectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeDeterminedMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ShadowConcreteMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDictionaryNode.cs" />

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/FunctionPointerOps.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/FunctionPointerOps.cs
@@ -64,7 +64,6 @@ namespace Internal.Runtime.CompilerServices
 
         private static uint s_genericFunctionPointerNextIndex = 0;
         private const uint c_genericDictionaryChunkSize = 1024;
-        private const int c_genericFunctionPointerOffset = 2;
         private static LowLevelList<IntPtr> s_genericFunctionPointerCollection = new LowLevelList<IntPtr>();
         private static LowLevelDictionary<GenericMethodDescriptorInfo, uint> s_genericFunctionPointerDictionary = new LowLevelDictionary<GenericMethodDescriptorInfo, uint>();
 
@@ -118,7 +117,7 @@ namespace Internal.Runtime.CompilerServices
                 System.Diagnostics.Debug.Assert(canonFunctionPointer == genericFunctionPointer->MethodFunctionPointer);
                 System.Diagnostics.Debug.Assert(instantiationArgument == genericFunctionPointer->InstantiationArgument);
 
-                return (IntPtr)((byte*)genericFunctionPointer + c_genericFunctionPointerOffset);
+                return (IntPtr)((byte*)genericFunctionPointer + FatFunctionPointerConstants.Offset);
             }
         }
 
@@ -126,9 +125,9 @@ namespace Internal.Runtime.CompilerServices
         {
             // Check the low bit to find out what kind of function pointer we have here.
 #if BIT64
-            if ((functionPointer.ToInt64() & c_genericFunctionPointerOffset) == c_genericFunctionPointerOffset)
+            if ((functionPointer.ToInt64() & FatFunctionPointerConstants.Offset) == FatFunctionPointerConstants.Offset)
 #else
-            if ((functionPointer.ToInt32() & c_genericFunctionPointerOffset) == c_genericFunctionPointerOffset)
+            if ((functionPointer.ToInt32() & FatFunctionPointerConstants.Offset) == FatFunctionPointerConstants.Offset)
 #endif
             {
                 return true;
@@ -139,7 +138,7 @@ namespace Internal.Runtime.CompilerServices
         [CLSCompliant(false)]
         public static unsafe GenericMethodDescriptor* ConvertToGenericDescriptor(IntPtr functionPointer)
         {
-            return (GenericMethodDescriptor*)((byte*)functionPointer - c_genericFunctionPointerOffset);
+            return (GenericMethodDescriptor*)((byte*)functionPointer - FatFunctionPointerConstants.Offset);
         }
 
         public static unsafe bool Compare(IntPtr functionPointerA, IntPtr functionPointerB)

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -44,6 +44,9 @@
     <DefineConstants>ARM64;BIT64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\Common\src\Internal\Runtime\RuntimeConstants.cs">
+      <Link>Internal\Runtime\RuntimeConstants.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\ExceptionStringID.cs">
       <Link>ExceptionStringID.cs</Link>
     </Compile>


### PR DESCRIPTION
Fat function pointers are function pointers that point to a small
structure that captures a method pointer along with a hidden argument
containing instantiation details (the generic context of the method).

They are distinguishable from real pointers by checking one of the low
bits. If the bit is set, this is a fat function pointer. These can show
up as targets of a (managed) calli.

In this change I'm implementing the compiler infrastructure to emit fat
function pointers along with changes to delegate thunks to do the check
for fat pointers before the calli. This will eventually move into the
codegen and will be a part of regular calli lowering.

With this we can compile and run (modulo a new Ready to Run limitation
issue):

```csharp
internal class Program
{
T Generic<T>(object o) where T: class
{
Func<object, T> f = OtherGeneric<T>;
return f(o);
}

T OtherGeneric<T>(object o) where T: class
{
return o as T;
}

private static int Main()
{
return new Program().Generic<string>("Hello world").Length;
}
}
```