### PR TITLE
Make CctorContext refer to fat function pointers if needed

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
@@ -45,7 +45,8 @@ namespace Internal.IL.Stubs
 
             var signature = new MethodSignature(template.Flags, 0, returnType, parameters);
 
-            codeStream.Emit(ILOpcode.calli, emitter.NewToken(signature));
+            //codeStream.Emit(ILOpcode.calli, emitter.NewToken(signature));
+            DelegateThunk.EmitTransformedCalli(emitter, codeStream, signature);
             codeStream.Emit(ILOpcode.ret);
 
             return emitter.Link(target);

--- a/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.TypeSystem;
+
 using Debug = System.Diagnostics.Debug;
+using FatFunctionPointerConstants = Internal.Runtime.FatFunctionPointerConstants;
 
 namespace Internal.IL.Stubs
 {
@@ -45,11 +47,135 @@ namespace Internal.IL.Stubs
 
             var signature = new MethodSignature(template.Flags, 0, returnType, parameters);
 
-            //codeStream.Emit(ILOpcode.calli, emitter.NewToken(signature));
-            DelegateThunk.EmitTransformedCalli(emitter, codeStream, signature);
+            bool useTransformedCalli = true;
+
+            if ((signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) != 0)
+            {
+                // Fat function pointer only ever exist for managed targets.
+                useTransformedCalli = false;
+            }
+
+            if (((MetadataType)target.OwningType).Name == "RawCalliHelper")
+            {
+                // RawCalliHelper doesn't need the transform.
+                useTransformedCalli = false;
+            }
+
+            if (useTransformedCalli)
+                EmitTransformedCalli(emitter, codeStream, signature);
+            else
+                codeStream.Emit(ILOpcode.calli, emitter.NewToken(signature));
+            
             codeStream.Emit(ILOpcode.ret);
 
             return emitter.Link(target);
+        }
+
+        /// <summary>
+        /// Generates a calli sequence that is aware of fat function pointers and can unwrap them into
+        /// a function pointer + instantiation argument if necessary.
+        /// </summary>
+        public static void EmitTransformedCalli(ILEmitter emitter, ILCodeStream codestream, MethodSignature targetSignature)
+        {
+            TypeSystemContext context = targetSignature.ReturnType.Context;
+
+            int thisPointerParamDelta = 0;
+            if (!targetSignature.IsStatic)
+                thisPointerParamDelta = 1;
+
+            // Start by saving the pointer to call and all the args into locals
+
+            ILLocalVariable vPointerToCall = emitter.NewLocal(context.GetWellKnownType(WellKnownType.IntPtr));
+            codestream.EmitStLoc(vPointerToCall);
+
+            ILLocalVariable[] vParameters = new ILLocalVariable[targetSignature.Length + thisPointerParamDelta];
+            for (int i = thisPointerParamDelta; i < vParameters.Length; i++)
+            {
+                vParameters[vParameters.Length - i - 1 + thisPointerParamDelta] = emitter.NewLocal(targetSignature[targetSignature.Length - (i - thisPointerParamDelta) - 1]);
+                codestream.EmitStLoc(vParameters[vParameters.Length - i - 1 + thisPointerParamDelta]);
+            }
+            if (!targetSignature.IsStatic)
+            {
+                vParameters[0] = emitter.NewLocal(context.GetWellKnownType(WellKnownType.Object));
+                codestream.EmitStLoc(vParameters[0]);
+            }
+
+            // Is this a fat pointer?
+            codestream.EmitLdLoc(vPointerToCall);
+            Debug.Assert(((FatFunctionPointerConstants.Offset - 1) & FatFunctionPointerConstants.Offset) == 0);
+            codestream.EmitLdc(FatFunctionPointerConstants.Offset);
+            codestream.Emit(ILOpcode.and);
+
+            ILCodeLabel notAFatPointer = emitter.NewCodeLabel();
+            codestream.Emit(ILOpcode.brfalse, notAFatPointer);
+
+            //
+            // Fat pointer case
+            //
+            codestream.EmitLdLoc(vPointerToCall);
+            codestream.EmitLdc(FatFunctionPointerConstants.Offset);
+            codestream.Emit(ILOpcode.sub);
+
+            // Get the pointer to call from the fat pointer
+            codestream.Emit(ILOpcode.dup);
+            codestream.Emit(ILOpcode.ldind_i);
+            codestream.EmitStLoc(vPointerToCall);
+
+            // Get the instantiation argument
+            codestream.EmitLdc(context.Target.PointerSize);
+            codestream.Emit(ILOpcode.add);
+            codestream.Emit(ILOpcode.ldind_i);
+            codestream.Emit(ILOpcode.ldind_i);
+            ILLocalVariable instArg = emitter.NewLocal(context.GetWellKnownType(WellKnownType.IntPtr));
+            codestream.EmitStLoc(instArg);
+
+            // Load this
+            int firstRealParameter = 0;
+            if (!targetSignature.IsStatic)
+            {
+                codestream.EmitLdLoc(vParameters[0]);
+                firstRealParameter = 1;
+            }
+
+            // Load hidden arg
+            codestream.EmitLdLoc(instArg);
+
+            // Load rest of args
+            for (int i = firstRealParameter; i < vParameters.Length; i++)
+            {
+                codestream.EmitLdLoc(vParameters[i]);
+            }
+            codestream.EmitLdLoc(vPointerToCall);
+
+            // The signature has a hidden argument
+            TypeDesc[] newParameters = new TypeDesc[targetSignature.Length + 1];
+            for (int i = 0; i < targetSignature.Length; i++)
+                newParameters[i + 1] = targetSignature[i];
+            newParameters[0] = context.GetWellKnownType(WellKnownType.IntPtr);
+            MethodSignature newMethodSignature = new MethodSignature(targetSignature.Flags,
+                targetSignature.GenericParameterCount, targetSignature.ReturnType, newParameters);
+
+            codestream.Emit(ILOpcode.calli, emitter.NewToken(newMethodSignature));
+
+            ILCodeLabel done = emitter.NewCodeLabel();
+            codestream.Emit(ILOpcode.br, done);
+
+            //
+            // Not a fat pointer case
+            //
+            codestream.EmitLabel(notAFatPointer);
+
+            for (int i = 0; i < vParameters.Length; i++)
+            {
+                codestream.EmitLdLoc(vParameters[i]);
+            }
+            codestream.EmitLdLoc(vPointerToCall);
+            codestream.Emit(ILOpcode.calli, emitter.NewToken(targetSignature));
+
+            codestream.EmitLabel(done);
+
+            // Workaround for https://github.com/dotnet/corert/issues/2073
+            codestream.Emit(ILOpcode.nop);
         }
     }
 }

--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -93,8 +93,15 @@ namespace Internal.IL.Stubs
             }
         }
 
-        protected void EmitTransformedCalli(ILEmitter emitter, ILCodeStream codestream, MethodSignature targetSignature)
+        public static void EmitTransformedCalli(ILEmitter emitter, ILCodeStream codestream, MethodSignature targetSignature)
         {
+            if ((targetSignature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) != 0)
+            {
+                // Fat function pointer only ever exist for managed targets
+                codestream.Emit(ILOpcode.calli, emitter.NewToken(targetSignature));
+                return;
+            }
+
             TypeSystemContext context = targetSignature.ReturnType.Context;
 
             int thisPointerParamDelta = 0;

--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -4,7 +4,6 @@
 
 using Internal.TypeSystem;
 
-using FatFunctionPointerConstants = Internal.Runtime.FatFunctionPointerConstants;
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.IL.Stubs
@@ -92,116 +91,6 @@ namespace Internal.IL.Stubs
                 return SystemDelegateType.GetKnownField("m_functionPointer");
             }
         }
-
-        public static void EmitTransformedCalli(ILEmitter emitter, ILCodeStream codestream, MethodSignature targetSignature)
-        {
-            if ((targetSignature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) != 0)
-            {
-                // Fat function pointer only ever exist for managed targets
-                codestream.Emit(ILOpcode.calli, emitter.NewToken(targetSignature));
-                return;
-            }
-
-            TypeSystemContext context = targetSignature.ReturnType.Context;
-
-            int thisPointerParamDelta = 0;
-            if (!targetSignature.IsStatic)
-                thisPointerParamDelta = 1;
-
-            // Start by saving the pointer to call and all the args into locals
-
-            ILLocalVariable vPointerToCall = emitter.NewLocal(context.GetWellKnownType(WellKnownType.IntPtr));
-            codestream.EmitStLoc(vPointerToCall);
-
-            ILLocalVariable[] vParameters = new ILLocalVariable[targetSignature.Length + thisPointerParamDelta];
-            for (int i = thisPointerParamDelta; i < vParameters.Length; i++)
-            {
-                vParameters[vParameters.Length - i - 1 + thisPointerParamDelta] = emitter.NewLocal(targetSignature[targetSignature.Length - (i - thisPointerParamDelta) - 1]);
-                codestream.EmitStLoc(vParameters[vParameters.Length - i - 1 + thisPointerParamDelta]);
-            }
-            if (!targetSignature.IsStatic)
-            {
-                vParameters[0] = emitter.NewLocal(context.GetWellKnownType(WellKnownType.Object));
-                codestream.EmitStLoc(vParameters[0]);
-            }
-
-            // Is this a fat pointer?
-            codestream.EmitLdLoc(vPointerToCall);
-            Debug.Assert(((FatFunctionPointerConstants.Offset - 1) & FatFunctionPointerConstants.Offset) == 0);
-            codestream.EmitLdc(FatFunctionPointerConstants.Offset);
-            codestream.Emit(ILOpcode.and);
-
-            ILCodeLabel notAFatPointer = emitter.NewCodeLabel();
-            codestream.Emit(ILOpcode.brfalse, notAFatPointer);
-
-            //
-            // Fat pointer case
-            //
-            codestream.EmitLdLoc(vPointerToCall);
-            codestream.EmitLdc(FatFunctionPointerConstants.Offset);
-            codestream.Emit(ILOpcode.sub);
-
-            // Get the pointer to call from the fat pointer
-            codestream.Emit(ILOpcode.dup);
-            codestream.Emit(ILOpcode.ldind_i);
-            codestream.EmitStLoc(vPointerToCall);
-
-            // Get the instantiation argument
-            codestream.EmitLdc(context.Target.PointerSize);
-            codestream.Emit(ILOpcode.add);
-            codestream.Emit(ILOpcode.ldind_i);
-            codestream.Emit(ILOpcode.ldind_i);
-            ILLocalVariable instArg = emitter.NewLocal(context.GetWellKnownType(WellKnownType.IntPtr));
-            codestream.EmitStLoc(instArg);
-
-            // Load this
-            int firstRealParameter = 0;
-            if (!targetSignature.IsStatic)
-            {
-                codestream.EmitLdLoc(vParameters[0]);
-                firstRealParameter = 1;
-            }
-
-            // Load hidden arg
-            codestream.EmitLdLoc(instArg);
-
-            // Load rest of args
-            for (int i = firstRealParameter; i < vParameters.Length; i++)
-            {
-                codestream.EmitLdLoc(vParameters[i]);
-            }
-            codestream.EmitLdLoc(vPointerToCall);
-
-            // The signature has a hidden argument
-            TypeDesc[] newParameters = new TypeDesc[targetSignature.Length + 1];
-            for (int i = 0; i < targetSignature.Length; i++)
-                newParameters[i + 1] = targetSignature[i];
-            newParameters[0] = context.GetWellKnownType(WellKnownType.IntPtr);
-            MethodSignature newMethodSignature = new MethodSignature(targetSignature.Flags,
-                targetSignature.GenericParameterCount, targetSignature.ReturnType, newParameters);
-
-            codestream.Emit(ILOpcode.calli, emitter.NewToken(newMethodSignature));
-
-            ILCodeLabel done = emitter.NewCodeLabel();
-            codestream.Emit(ILOpcode.br, done);
-
-            //
-            // Not a fat pointer case
-            //
-            codestream.EmitLabel(notAFatPointer);
-
-            for (int i = 0; i < vParameters.Length; i++)
-            {
-                codestream.EmitLdLoc(vParameters[i]);
-            }
-            codestream.EmitLdLoc(vPointerToCall);
-            codestream.Emit(ILOpcode.calli, emitter.NewToken(targetSignature));
-
-            codestream.EmitLabel(done);
-
-            // Workaround for https://github.com/dotnet/corert/issues/2073
-            codestream.Emit(ILOpcode.nop);
-        }
     }
 
     /// <summary>
@@ -235,7 +124,7 @@ namespace Internal.IL.Stubs
             codeStream.EmitLdArg(0);
             codeStream.Emit(ILOpcode.ldfld, emitter.NewToken(ExtraFunctionPointerOrDataField));
 
-            EmitTransformedCalli(emitter, codeStream, builder.ToSignature());
+            CalliIntrinsic.EmitTransformedCalli(emitter, codeStream, builder.ToSignature());
             //codeStream.Emit(ILOpcode.calli, emitter.NewToken(builder.ToSignature()));
 
             codeStream.Emit(ILOpcode.ret);
@@ -296,7 +185,7 @@ namespace Internal.IL.Stubs
             codeStream.EmitLdArg(0);
             codeStream.Emit(ILOpcode.ldfld, emitter.NewToken(ExtraFunctionPointerOrDataField));
 
-            EmitTransformedCalli(emitter, codeStream, targetMethodSignature);
+            CalliIntrinsic.EmitTransformedCalli(emitter, codeStream, targetMethodSignature);
             //codeStream.Emit(ILOpcode.calli, emitter.NewToken(targetMethodSignature));
 
             codeStream.Emit(ILOpcode.ret);
@@ -413,7 +302,7 @@ namespace Internal.IL.Stubs
             codeStream.EmitLdLoc(delegateToCallLocal);
             codeStream.Emit(ILOpcode.ldfld, emitter.NewToken(FunctionPointerField));
 
-            EmitTransformedCalli(emitter, codeStream, Signature);
+            CalliIntrinsic.EmitTransformedCalli(emitter, codeStream, Signature);
             //codeStream.Emit(ILOpcode.calli, emitter.NewToken(Signature));
 
             if (returnValueLocal != 0)
@@ -490,7 +379,7 @@ namespace Internal.IL.Stubs
             codeStream.EmitLdArg(0);
             codeStream.Emit(ILOpcode.ldfld, emitter.NewToken(ExtraFunctionPointerOrDataField));
 
-            EmitTransformedCalli(emitter, codeStream, Signature);
+            CalliIntrinsic.EmitTransformedCalli(emitter, codeStream, Signature);
             //codeStream.Emit(ILOpcode.calli, emitter.NewToken(Signature));
 
             codeStream.Emit(ILOpcode.ret);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
@@ -37,6 +37,13 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName() => MangledName;
 
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            DependencyList result = new DependencyList();
+            result.Add(new DependencyListEntry(factory.ShadowConcreteMethod(Method), "Method represented"));
+            return result;
+        }
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             var builder = new ObjectDataBuilder(factory);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -4,6 +4,8 @@
 
 using Internal.TypeSystem;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace ILCompiler.DependencyAnalysis
 {
     public class GCStaticsNode : ObjectNode, ISymbolNode
@@ -12,6 +14,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public GCStaticsNode(MetadataType type)
         {
+            Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Specific));
             _type = type;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -25,6 +25,7 @@ namespace ILCompiler.DependencyAnalysis
         public MethodCodeNode(MethodDesc method)
         {
             Debug.Assert(!method.IsAbstract);
+            Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) == method);
             _method = method;
         }
 


### PR DESCRIPTION
Running a class constructor that is backed by a shared generic method
body requires passing an instantiation argument.

* Emit a fat function pointer into the cctor context is necessary
* Make sure the calli in the class constructor runner goes through the
transform that makes it check for the special bit
* Sprinkle asserts - we should no longer be compiling concrete method
bodies at this point.

I didn't bother finding a good home for `EmitTransformedCalli` on
account of it being temporary.