### PR TITLE
Add missing license header to GenericUnification.h

### DIFF
--- a/src/Native/Runtime/GenericUnification.h
+++ b/src/Native/Runtime/GenericUnification.h
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 #pragma once
 
 class GenericUnificationHashtable


### PR DESCRIPTION
I have just noticed that this file is missing the license header, so
I am adding it.