### PR TITLE
Make EEType the generic context for static methods on generic types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
@@ -59,20 +59,22 @@ namespace ILCompiler.DependencyAnalysis
             builder.EmitPointerReloc(factory.MethodEntrypoint(canonMethod));
 
             // Find out what's the context to use
-            GenericDictionaryNode dictionary;
+            ISymbolNode contextParameter;
             if (canonMethod.RequiresInstMethodDescArg())
             {
-                dictionary = factory.MethodGenericDictionary(Method);
+                contextParameter = factory.MethodGenericDictionary(Method);
             }
             else
             {
                 Debug.Assert(canonMethod.RequiresInstMethodTableArg());
-                dictionary = factory.TypeGenericDictionary(Method.OwningType);
+
+                // Ask for a constructed type symbol because we need the vtable to get to the dictionary
+                contextParameter = factory.ConstructedTypeSymbol(Method.OwningType);
             }
 
             // The next entry is a pointer to the pointer to the context to be used for the canonical method
             // TODO: in multi-module, this points to the import cell, and is no longer this weird pointer
-            builder.EmitPointerReloc(factory.Indirection(dictionary));
+            builder.EmitPointerReloc(factory.Indirection(contextParameter));
             
             return builder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -214,9 +214,9 @@ namespace ILCompiler.DependencyAnalysis
                 return new ReadyToRunGenericLookupFromDictionaryNode(this, data.Item1, data.Item2, data.Item3);
             });
 
-            _genericReadyToRunHelpersFromThis = new NodeCache<Tuple<ReadyToRunHelperId, object, TypeSystemEntity>, ISymbolNode>(data =>
+            _genericReadyToRunHelpersFromType = new NodeCache<Tuple<ReadyToRunHelperId, object, TypeSystemEntity>, ISymbolNode>(data =>
             {
-                return new ReadyToRunGenericLookupFromThisNode(this, data.Item1, data.Item2, data.Item3);
+                return new ReadyToRunGenericLookupFromTypeNode(this, data.Item1, data.Item2, data.Item3);
             });
 
             _indirectionNodes = new NodeCache<ISymbolNode, IndirectionNode>(symbol =>
@@ -592,11 +592,11 @@ namespace ILCompiler.DependencyAnalysis
             return _genericReadyToRunHelpersFromDict.GetOrAdd(new Tuple<ReadyToRunHelperId, object, TypeSystemEntity>(id, target, dictionaryOwner));
         }
 
-        private NodeCache<Tuple<ReadyToRunHelperId, Object, TypeSystemEntity>, ISymbolNode> _genericReadyToRunHelpersFromThis;
+        private NodeCache<Tuple<ReadyToRunHelperId, Object, TypeSystemEntity>, ISymbolNode> _genericReadyToRunHelpersFromType;
 
-        public ISymbolNode ReadyToRunHelperFromThisLookup(ReadyToRunHelperId id, Object target, TypeSystemEntity dictionaryOwner)
+        public ISymbolNode ReadyToRunHelperFromTypeLookup(ReadyToRunHelperId id, Object target, TypeSystemEntity dictionaryOwner)
         {
-            return _genericReadyToRunHelpersFromThis.GetOrAdd(new Tuple<ReadyToRunHelperId, object, TypeSystemEntity>(id, target, dictionaryOwner));
+            return _genericReadyToRunHelpersFromType.GetOrAdd(new Tuple<ReadyToRunHelperId, object, TypeSystemEntity>(id, target, dictionaryOwner));
         }
 
         private NodeCache<ISymbolNode, IndirectionNode> _indirectionNodes;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -123,9 +123,9 @@ namespace ILCompiler.DependencyAnalysis
         }
     }
 
-    public partial class ReadyToRunGenericLookupFromThisNode : ReadyToRunGenericHelperNode
+    public partial class ReadyToRunGenericLookupFromTypeNode : ReadyToRunGenericHelperNode
     {
-        public ReadyToRunGenericLookupFromThisNode(NodeFactory factory, ReadyToRunHelperId helperId, object target, TypeSystemEntity dictionaryOwner)
+        public ReadyToRunGenericLookupFromTypeNode(NodeFactory factory, ReadyToRunHelperId helperId, object target, TypeSystemEntity dictionaryOwner)
             : base(factory, helperId, target, dictionaryOwner)
         {
         }
@@ -140,7 +140,7 @@ namespace ILCompiler.DependencyAnalysis
                 else
                     mangledContextName = NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
 
-                return string.Concat("__GenericLookupFromThis_", mangledContextName, "_", _lookupSignature.GetMangledName(NodeFactory.NameMangler));
+                return string.Concat("__GenericLookupFromType_", mangledContextName, "_", _lookupSignature.GetMangledName(NodeFactory.NameMangler));
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -119,7 +119,7 @@ namespace ILCompiler.DependencyAnalysis
         }
     }
 
-    partial class ReadyToRunGenericLookupFromThisNode
+    partial class ReadyToRunGenericLookupFromTypeNode
     {
         protected override void EmitLoadGenericContext(NodeFactory factory, ref X64Emitter encoder, bool relocsOnly)
         {


### PR DESCRIPTION
For some reason I thought the context should be the dictionary, but it's
the EEType.