### PR TITLE
Adapt VirtualMethodUse to shared generics

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -80,6 +80,10 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
+            MethodDesc canonDecl = _decl.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            if (canonDecl != _decl)
+                return new[] { new DependencyListEntry(factory.VirtualMethodUse(canonDecl), "Canonical method") };
+
             return null;
         }
 


### PR DESCRIPTION
This ensures that the vtable layout of `Foo<SomeType>` and
`Foo<OtherType>` are the same if their canonical forms are the same.

Fixes:

```csharp
using System;

class C1 { }
class C2 { }

class Base<T> where T : class
{
    public virtual T As(object o)
    {
        return o as T;
    }
}

class Derived<T> : Base<T> where T : class
{
    public T AsToo(object o)
    {
        return o as T;
    }
}

internal class Program
{
    private static void Main(string[] args)
    {
        Console.WriteLine(new Derived<C1>().As(new C1()) != null);
        Console.WriteLine(new Derived<C2>().AsToo(new C2()) != null);
    }
}
```