### PR TITLE
Move a few properties to GenericParameterDesc

### DIFF
--- a/src/Common/src/TypeSystem/Canon/GenericParameterDesc.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/GenericParameterDesc.Canon.cs
@@ -1,20 +1,22 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Debug = System.Diagnostics.Debug;
 
-namespace Internal.TypeSystem.Ecma
+namespace Internal.TypeSystem
 {
-    // Implements canonicalization of ECMA generic parameters 
-    public partial class EcmaGenericParameter
+    // Implements canonicalization of generic parameters 
+    public partial class GenericParameterDesc
     {
+        // TODO: seal the override
         public override bool IsCanonicalSubtype(CanonicalFormKind policy)
         {
             Debug.Assert(false, "IsCanonicalSubtype of an indefinite type");
             return false;
         }
 
+        // TODO: seal the override
         protected override TypeDesc ConvertToCanonFormImpl(CanonicalFormKind kind)
         {
             Debug.Assert(false, "ConvertToCanonFormImpl for an indefinite type");

--- a/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
+++ b/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
@@ -86,17 +86,35 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets a value indicating the variance of this generic parameter.
         /// </summary>
-        public abstract GenericVariance Variance { get; }
+        public virtual GenericVariance Variance
+        {
+            get
+            {
+                return GenericVariance.None;
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating generic constraints of this generic parameter.
         /// </summary>
-        public abstract GenericConstraints Constraints { get; }
+        public virtual GenericConstraints Constraints
+        {
+            get
+            {
+                return GenericConstraints.None;
+            }
+        }
         
         /// <summary>
         /// Gets type constraints imposed on substitutions.
         /// </summary>
-        public abstract IEnumerable<TypeDesc> TypeConstraints { get; }
+        public virtual IEnumerable<TypeDesc> TypeConstraints
+        {
+            get
+            {
+                return TypeDesc.EmptyTypes;
+            }
+        }
 
         public bool HasNotNullableValueTypeConstraint
         {
@@ -136,6 +154,28 @@ namespace Internal.TypeSystem
             {
                 return (Variance & GenericVariance.Contravariant) != 0;
             }
+        }
+
+        // TODO: seal this
+        protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
+        {
+            TypeFlags flags = 0;
+
+            flags |= TypeFlags.ContainsGenericVariablesComputed | TypeFlags.ContainsGenericVariables;
+
+            flags |= TypeFlags.GenericParameter;
+
+            flags |= TypeFlags.HasGenericVarianceComputed;
+
+            return flags;
+        }
+
+        // TODO: seal this
+        public override int GetHashCode()
+        {
+            // TODO: Determine what a the right hash function should be. Use stable hashcode based on the type name?
+            // For now, use the same hash as a SignatureVariable type.
+            return Internal.NativeFormat.TypeHashingAlgorithms.ComputeSignatureVariableHashCode(Index, Kind == GenericParameterKind.Method);
         }
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
@@ -23,14 +23,6 @@ namespace Internal.TypeSystem.Ecma
             _handle = handle;
         }
 
-        public override int GetHashCode()
-        {
-            // TODO: Determine what a the right hash function should be. Use stable hashcode based on the type name?
-            // For now, use the same hash as a SignatureVariable type.
-            GenericParameter parameter = _module.MetadataReader.GetGenericParameter(_handle);
-            return TypeHashingAlgorithms.ComputeSignatureVariableHashCode(parameter.Index, parameter.Parent.Kind == HandleKind.MethodDefinition);
-        }
-
         public GenericParameterHandle Handle
         {
             get
@@ -70,19 +62,6 @@ namespace Internal.TypeSystem.Ecma
                 MetadataReader reader = _module.MetadataReader;
                 return reader.GetString(reader.GetGenericParameter(_handle).Name);
             }
-        }
-
-        protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
-        {
-            TypeFlags flags = 0;
-
-            flags |= TypeFlags.ContainsGenericVariablesComputed | TypeFlags.ContainsGenericVariables;
-
-            flags |= TypeFlags.GenericParameter;
-
-            flags |= TypeFlags.HasGenericVarianceComputed;
-
-            return flags;
         }
 
         public override GenericParameterKind Kind

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -32,6 +32,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Canon\FunctionPointerType.Canon.cs">
       <Link>TypeSystem\Canon\FunctionPointerType.Canon.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Canon\GenericParameterDesc.Canon.cs">
+      <Link>TypeSystem\Canon\GenericParameterDesc.Canon.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Canon\StandardCanonicalizationAlgorithm.cs">
       <Link>TypeSystem\Canon\StandardCanonicalizationAlgorithm.cs</Link>
     </Compile>
@@ -241,9 +244,6 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaAssembly.Symbols.cs">
       <Link>Ecma\EcmaAssembly.Symbols.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaGenericParameter.Canon.cs">
-      <Link>Ecma\EcmaGenericParameter.Canon.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaModule.Symbols.cs">
       <Link>Ecma\EcmaModule.Symbols.cs</Link>


### PR DESCRIPTION
While working on reflection invoke stubs I had the need to define a new
child of `GenericParameterDesc`. That's when I noticed there's a lot of
boilerplate I would need to replicate. I'm moving the boilerplate to
`GenericParameterDesc`.

I'm leaving sealable things unsealed with TODOs to avoid unnecessary
breakage in the TFS-land.