### PR TITLE
Optimize calls to enum's GetHashCode/Equals

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/EnumThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/EnumThunks.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Thunk to call the underlying type's GetHashCode method on enum types.
+    /// This method prevents boxing of 'this' that would be required before a call to
+    /// the System.Enum's default implementation.
+    /// </summary>
+    internal class EnumGetHashCodeThunk : ILStubMethod
+    {
+        private TypeDesc _owningType;
+        private MethodSignature _signature;
+
+        public EnumGetHashCodeThunk(TypeDesc owningType)
+        {
+            Debug.Assert(owningType.IsEnum);
+            _owningType = owningType;
+            _signature = ObjectGetHashCodeMethod.Signature;
+        }
+
+        private MethodDesc ObjectGetHashCodeMethod
+        {
+            get
+            {
+                return Context.GetWellKnownType(WellKnownType.Object).GetKnownMethod("GetHashCode", null);
+            }
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return _owningType.Context;
+            }
+        }
+
+        public override TypeDesc OwningType
+        {
+            get
+            {
+                return _owningType;
+            }
+        }
+
+        public override MethodSignature Signature
+        {
+            get
+            {
+                return _signature;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return "GetHashCode";
+            }
+        }
+
+        public override bool IsVirtual
+        {
+            get
+            {
+                // This would be implicit (false is the default), but let's be very explicit.
+                // Making this an actual override would cause size bloat with very little benefit.
+                // The usefulness of this method lies in it's ability to prevent boxing of 'this'.
+                // The base implementation on System.Enum is adequate for everything else.
+                return false;
+            }
+        }
+
+        public override MethodIL EmitIL()
+        {
+            ILEmitter emitter = new ILEmitter();
+            ILCodeStream codeStream = emitter.NewCodeStream();
+
+            codeStream.EmitLdArg(0);
+            codeStream.Emit(ILOpcode.constrained, emitter.NewToken(_owningType.UnderlyingType));
+            codeStream.Emit(ILOpcode.callvirt, emitter.NewToken(ObjectGetHashCodeMethod));
+            codeStream.Emit(ILOpcode.ret);
+
+            return emitter.Link(this);
+        }
+    }
+
+    /// <summary>
+    /// Thunk to compare underlying values of enums in the Equals method.
+    /// This method prevents boxing of 'this' that would be required before a call to
+    /// the System.Enum's default implementation.
+    /// </summary>
+    internal class EnumEqualsThunk : ILStubMethod
+    {
+        private TypeDesc _owningType;
+        private MethodSignature _signature;
+
+        public EnumEqualsThunk(TypeDesc owningType)
+        {
+            Debug.Assert(owningType.IsEnum);
+            _owningType = owningType;
+            _signature = ObjectEqualsMethod.Signature;
+        }
+
+        private MethodDesc ObjectEqualsMethod
+        {
+            get
+            {
+                return Context.GetWellKnownType(WellKnownType.Object).GetKnownMethod("Equals", null);
+            }
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return _owningType.Context;
+            }
+        }
+
+        public override TypeDesc OwningType
+        {
+            get
+            {
+                return _owningType;
+            }
+        }
+
+        public override MethodSignature Signature
+        {
+            get
+            {
+                return _signature;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return "Equals";
+            }
+        }
+
+        public override bool IsVirtual
+        {
+            get
+            {
+                // This would be implicit (false is the default), but let's be very explicit.
+                // Making this an actual override would cause size bloat with very little benefit.
+                // The usefulness of this method lies in it's ability to prevent boxing of 'this'.
+                // The base implementation on System.Enum is adequate for everything else.
+                return false;
+            }
+        }
+
+        public override MethodIL EmitIL()
+        {
+            ILEmitter emitter = new ILEmitter();
+            ILCodeStream codeStream = emitter.NewCodeStream();
+
+            // InstantiateAsOpen covers the weird case of generic enums
+            TypeDesc owningTypeAsOpen = _owningType.InstantiateAsOpen();
+
+            ILCodeLabel lNotEqual = emitter.NewCodeLabel();
+
+            // if (!(obj is {enumtype}))
+            //     return false;
+
+            codeStream.EmitLdArg(1);
+            codeStream.Emit(ILOpcode.isinst, emitter.NewToken(owningTypeAsOpen));
+            codeStream.Emit(ILOpcode.dup);
+            codeStream.Emit(ILOpcode.brfalse, lNotEqual);
+
+            // return ({underlyingtype})this == ({underlyingtype})obj;
+
+            // PREFER: ILOpcode.unbox, but the codegen for that is pretty bad
+            codeStream.Emit(ILOpcode.ldflda, emitter.NewToken(Context.GetWellKnownType(WellKnownType.Object).GetKnownField("m_pEEType")));
+            codeStream.EmitLdc(Context.Target.PointerSize);
+            codeStream.Emit(ILOpcode.add);
+            codeStream.EmitLdInd(owningTypeAsOpen);
+
+            codeStream.EmitLdArg(0);
+            codeStream.EmitLdInd(owningTypeAsOpen);
+
+            codeStream.Emit(ILOpcode.ceq);
+
+            codeStream.Emit(ILOpcode.ret);
+
+            codeStream.EmitLabel(lNotEqual);
+            codeStream.Emit(ILOpcode.pop);
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.ret);
+
+            return emitter.Link(this);
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -206,7 +206,7 @@ namespace Internal.IL.Stubs
 
         public void EmitLdInd(TypeDesc type)
         {
-            switch (type.Category)
+            switch (type.UnderlyingType.Category)
             {
                 case TypeFlags.Byte:
                 case TypeFlags.SByte:
@@ -244,10 +244,6 @@ namespace Internal.IL.Stubs
                 case TypeFlags.Interface:
                     Emit(ILOpcode.ldind_ref);
                     break;
-                case TypeFlags.Enum:
-                    // Use more efficient encoding for enum
-                    EmitLdInd(type.UnderlyingType);
-                    break;
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:
                     Emit(ILOpcode.ldobj, _emitter.NewToken(type));
@@ -259,7 +255,7 @@ namespace Internal.IL.Stubs
         }
         public void EmitStInd(TypeDesc type)
         {
-            switch (type.Category)
+            switch (type.UnderlyingType.Category)
             {
                 case TypeFlags.Byte:
                 case TypeFlags.SByte:
@@ -297,10 +293,6 @@ namespace Internal.IL.Stubs
                 case TypeFlags.Interface:
                     Emit(ILOpcode.stind_ref);
                     break;
-                case TypeFlags.Enum:
-                    // Use more efficient encoding for enum
-                    EmitStInd(type.UnderlyingType);
-                    break;
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:
                     Emit(ILOpcode.stobj, _emitter.NewToken(type));
@@ -313,7 +305,7 @@ namespace Internal.IL.Stubs
 
         public void EmitStElem(TypeDesc type)
         {
-            switch (type.Category)
+            switch (type.UnderlyingType.Category)
             {
                 case TypeFlags.Byte:
                 case TypeFlags.SByte:
@@ -351,10 +343,6 @@ namespace Internal.IL.Stubs
                 case TypeFlags.Interface:
                     Emit(ILOpcode.stelem_ref);
                     break;
-                case TypeFlags.Enum:
-                    // Use more efficient encoding for enum
-                    EmitStElem(type.UnderlyingType);
-                    break;
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:
                     Emit(ILOpcode.stelem, _emitter.NewToken(type));
@@ -367,7 +355,7 @@ namespace Internal.IL.Stubs
 
         public void EmitLdElem(TypeDesc type)
         {
-            switch (type.Category)
+            switch (type.UnderlyingType.Category)
             {
                 case TypeFlags.Byte:
                 case TypeFlags.SByte:
@@ -404,10 +392,6 @@ namespace Internal.IL.Stubs
                 case TypeFlags.Class:
                 case TypeFlags.Interface:
                     Emit(ILOpcode.ldelem_ref);
-                    break;
-                case TypeFlags.Enum:
-                    // Use more efficient encoding for enum
-                    EmitLdElem(type.UnderlyingType);
                     break;
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:

--- a/src/Common/src/TypeSystem/IL/TypeSystemContext.EnumMethods.cs
+++ b/src/Common/src/TypeSystem/IL/TypeSystemContext.EnumMethods.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.IL.Stubs;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    public abstract partial class TypeSystemContext
+    {
+        private class EnumInfo
+        {
+            public TypeDesc Type => EqualsMethod.OwningType;
+
+            public MethodDesc EqualsMethod { get; }
+
+            public MethodDesc GetHashCodeMethod { get; }
+
+            public EnumInfo(TypeDesc enumType)
+            {
+                Debug.Assert(enumType.IsEnum && enumType.IsTypeDefinition);
+                EqualsMethod = new EnumEqualsThunk(enumType);
+                GetHashCodeMethod = new EnumGetHashCodeThunk(enumType);
+            }
+        }
+
+        private class EnumInfoHashtable : LockFreeReaderHashtable<TypeDesc, EnumInfo>
+        {
+            protected override int GetKeyHashCode(TypeDesc key) => key.GetHashCode();
+            protected override int GetValueHashCode(EnumInfo value) => value.Type.GetHashCode();
+            protected override bool CompareKeyToValue(TypeDesc key, EnumInfo value) => key == value.Type;
+            protected override bool CompareValueToValue(EnumInfo v1, EnumInfo v2) => v1.Type == v2.Type;
+
+            protected override EnumInfo CreateValueFromKey(TypeDesc key)
+            {
+                return new EnumInfo(key);
+            }
+        }
+
+        private EnumInfoHashtable _enumInfoHashtable = new EnumInfoHashtable();
+
+        public MethodDesc TryResolveConstrainedEnumMethod(TypeDesc enumType, MethodDesc virtualMethod)
+        {
+            Debug.Assert(enumType.IsEnum);
+
+            if (!virtualMethod.OwningType.IsObject)
+                return null;
+
+            // Also handle the odd case of generic enums
+
+            TypeDesc enumTypeDefinition = enumType.GetTypeDefinition();
+            EnumInfo info = _enumInfoHashtable.GetOrCreateValue(enumTypeDefinition);
+
+            MethodDesc resolvedMethod;
+            if (virtualMethod.Name == "Equals")
+                resolvedMethod = info.EqualsMethod;
+            else if (virtualMethod.Name == "GetHashCode")
+                resolvedMethod = info.GetHashCodeMethod;
+            else
+                return null;
+
+            if (enumType != enumTypeDefinition)
+                return GetMethodForInstantiatedType(resolvedMethod, (InstantiatedType)enumType);
+
+            return resolvedMethod;
+        }
+
+        protected IEnumerable<MethodDesc> GetAllMethodsForEnum(TypeDesc enumType)
+        {
+            TypeDesc enumTypeDefinition = enumType.GetTypeDefinition();
+            EnumInfo info = _enumInfoHashtable.GetOrCreateValue(enumTypeDefinition);
+
+            if (enumType != enumTypeDefinition)
+            {
+                yield return GetMethodForInstantiatedType(info.GetHashCodeMethod, (InstantiatedType)enumType);
+                yield return GetMethodForInstantiatedType(info.EqualsMethod, (InstantiatedType)enumType);
+            }
+            else
+            {
+                yield return info.GetHashCodeMethod;
+                yield return info.EqualsMethod;
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -311,6 +311,10 @@ namespace ILCompiler
             {
                 return GetAllMethodsForDelegate(type);
             }
+            else if (type.IsEnum)
+            {
+                return GetAllMethodsForEnum(type);
+            }
 
             return type.GetMethods();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -48,7 +48,7 @@ namespace ILCompiler
 
         private void RootMethods(TypeDesc type, string reason, IRootingServiceProvider rootProvider)
         {
-            foreach (MethodDesc method in type.GetMethods())
+            foreach (MethodDesc method in type.GetAllMethods())
             {
                 // Skip methods with no IL and uninstantiated generic methods
                 if (method.IsAbstract || method.HasInstantiation)

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -308,6 +308,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\DelegateInfo.cs">
       <Link>IL\DelegateInfo.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\EnumThunks.cs">
+      <Link>IL\Stubs\EnumThunks.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.DelegateInfo.cs">
       <Link>IL\TypeSystemContext.DelegateInfo.cs</Link>
     </Compile>
@@ -337,6 +340,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILOpcode.cs">
       <Link>IL\ILOpcode.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.EnumMethods.cs">
+      <Link>IL\TypeSystemContext.EnumMethods.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\IL\MarshalHelpers.cs">
       <Link>Interop\IL\MarshalHelpers.cs</Link>

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2600,6 +2600,13 @@ namespace Internal.JitInterface
                 // to call.
 
                 MethodDesc directMethod = constrainedType.GetClosestDefType().TryResolveConstraintMethodApprox(exactType, method, out forceUseRuntimeLookup);
+                if (directMethod == null && constrainedType.IsEnum)
+                {
+                    // Constrained calls to methods on enum methods resolve to System.Enum's methods. System.Enum is a reference
+                    // type though, so we would fail to resolve and box. We have a special path for those to avoid boxing.
+                    directMethod = _compilation.TypeSystemContext.TryResolveConstrainedEnumMethod(constrainedType, method);
+                }
+
                 if (directMethod != null)
                 {
                     // Either

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -65,6 +65,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\TypeSystemContext.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\ILEmitter.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateThunks.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\EnumThunks.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\HelperExtensions.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILDisassember.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILOpcode.cs" />
@@ -74,6 +75,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\MethodILDebugView.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\DelegateInfo.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.DelegateInfo.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.EnumMethods.cs" />
     <Compile Include="Internal\TypeSystem\ILStubMethod.Runtime.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\JitSupport.MethodEntrypointStubs.cs" />
   </ItemGroup>

--- a/tests/src/Simple/MultiModule/Library.cs
+++ b/tests/src/Simple/MultiModule/Library.cs
@@ -59,4 +59,9 @@ public class MultiModuleLibrary
         GenericClassWithTLS<int>.ThreadStaticInt += 1;
         return GenericClassWithTLS<int>.ThreadStaticInt == 1;
     }
+
+    public enum MyEnum
+    {
+        One, Two
+    }
 }

--- a/tests/src/Simple/MultiModule/MultiModule.cs
+++ b/tests/src/Simple/MultiModule/MultiModule.cs
@@ -23,6 +23,9 @@ public class ReflectionTest
         if (TestGenericTLS() == Fail)
             return Fail;
 
+        if (TestInjectedEnumMethods() == Fail)
+            return Fail;
+
         return Pass;
     }
     
@@ -72,6 +75,15 @@ public class ReflectionTest
 
         MultiModuleLibrary.GenericClassWithTLS<int>.ThreadStaticInt += 1;
         if (MultiModuleLibrary.GenericClassWithTLS<int>.ThreadStaticInt != 2)
+            return Fail;
+
+        return Pass;
+    }
+
+    public static int TestInjectedEnumMethods()
+    {
+        Console.WriteLine("Testing context-injected methods on enums..");
+        if (!MultiModuleLibrary.MyEnum.One.Equals(MultiModuleLibrary.MyEnum.One))
             return Fail;
 
         return Pass;


### PR DESCRIPTION
Generate synthetic instance methods into which constrained calls
can resolve. This prevents boxing 'this' that would be required
before a call to the System.Enum's implementation.

This is specifically not a synthetic virtual override. The thunk
only has very little perf advantage over System.Enum's implementation
if 'this' is already boxed and is not worth the size overhead.

This is an extended port of dotnet/coreclr#7895

Fixes #2111.