### PR TITLE
Port https://github.com/dotnet/coreclr/pull/7803 to CoreRT

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -756,6 +756,9 @@
   <data name="ArgumentOutOfRange_LengthTooLarge" xml:space="preserve">
     <value>The specified length exceeds the maximum value of {0}.</value>
   </data>
+  <data name="ArgumentOutOfRange_LengthGreaterThanCapacity" xml:space="preserve">
+    <value>The length cannot be greater than the capacity.</value>
+  </data>
   <data name="ArgumentOutOfRange_ListInsert" xml:space="preserve">
     <value>Index must be within the bounds of the List.</value>
   </data>

--- a/src/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -51,7 +51,7 @@ namespace System.Text
         internal char[] m_ChunkChars;                // The characters in this block
         internal StringBuilder m_ChunkPrevious;      // Link to the block logically before this block
         internal int m_ChunkLength;                  // The index in m_ChunkChars that represent the end of the block
-        internal int m_ChunkOffset;                  // The logial offset (sum of all characters in previous blocks)
+        internal int m_ChunkOffset;                  // The logical offset (sum of all characters in previous blocks)
         internal int m_MaxCapacity = 0;
 
         //
@@ -467,6 +467,15 @@ namespace System.Text
             {
                 return this;
             }
+
+            // this is where we can check if the repeatCount will put us over m_MaxCapacity
+            // We are doing the check here to prevent the corruption of the StringBuilder.
+            int newLength = Length + repeatCount;
+            if (newLength > m_MaxCapacity || newLength < repeatCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(repeatCount), SR.ArgumentOutOfRange_LengthGreaterThanCapacity);
+            }
+
             int idx = m_ChunkLength;
             while (repeatCount > 0)
             {
@@ -1698,6 +1707,14 @@ namespace System.Text
             if (valueCount < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(valueCount), SR.ArgumentOutOfRange_NegativeCount);
+            }
+
+            // this is where we can check if the valueCount will put us over m_MaxCapacity
+            // We are doing the check here to prevent the corruption of the StringBuilder.
+            int newLength = Length + valueCount;
+            if (newLength > m_MaxCapacity || newLength < valueCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(valueCount), SR.ArgumentOutOfRange_LengthGreaterThanCapacity);
             }
 
             // This case is so common we want to optimize for it heavily. 


### PR DESCRIPTION
Ensures that StringBuilder has enough capacity to handle the number of
characters requested before we start writing to it

Fixes #2090