### PR TITLE
Multi-module framework assembly compilation

### DIFF
--- a/src/BuildIntegration/BuildFrameworkNativeObjects.proj
+++ b/src/BuildIntegration/BuildFrameworkNativeObjects.proj
@@ -1,0 +1,10 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <IlcCompileDependsOn>IlcFramework</IlcCompileDependsOn>
+    <IlcMultiModule>true</IlcMultiModule>
+  </PropertyGroup>
+  
+  <Import Project="Microsoft.NETCore.Native.targets" />
+  
+</Project>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -29,13 +29,16 @@ See the LICENSE file in the project root for more information.
     <NativeObjectExt Condition="'$(TargetOS)' == 'Windows_NT'">.obj</NativeObjectExt>
     <NativeObjectExt Condition="'$(TargetOS)' != 'Windows_NT'">.o</NativeObjectExt>
 
+    <IlcOutputFileExt>$(NativeObjectExt)</IlcOutputFileExt>
+    <IlcOutputFileExt Condition="$(NativeCodeGen) == 'cpp'">.cpp</IlcOutputFileExt>
+
+
     <NativeBinaryExt Condition="'$(OutputType)' ==  'Exe' and '$(TargetOS)' == 'Windows_NT'">.exe</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(OutputType)' ==  'Exe' and '$(TargetOS)' != 'Windows_NT'"></NativeBinaryExt>
     <NativeBinaryExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' == 'Windows_NT'">.dll</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' == 'OSX'">.dylib</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' != 'Windows_NT' and '$(TargetOS)' !=  'OSX'">.so</NativeBinaryExt>
 
-    <ManagedBinary>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ManagedBinary>
     <NativeObject>$(NativeIntermediateOutputPath)$(TargetName)$(NativeObjectExt)</NativeObject>
     <NativeBinary>$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)</NativeBinary>
 
@@ -48,21 +51,37 @@ See the LICENSE file in the project root for more information.
     <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang-3.5</CppCompilerAndLinker>
   </PropertyGroup>
 
-  <Target Name="IlcCompile" 
-      Inputs="$(ManagedBinary)"
-      Outputs="$(IlcCompileOutput)"
-      DependsOnTargets="Compile">
+  <ItemGroup>
+    <ManagedBinary Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <IlcReference Include="$(IlcPath)\sdk\*.dll" />
+    <IlcReference Include="$(IlcPath)\framework\*.dll" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <IlcCompileDependsOn Condition="'$(IlcCompileDependsOn)'==''">Compile</IlcCompileDependsOn>
+  </PropertyGroup>
+
+  <Target Name="IlcFramework">
     <ItemGroup>
-      <IlcReference Include="$(IlcPath)\sdk\*.dll" />
-      <IlcReference Include="$(IlcPath)\framework\*.dll" />
+      <ManagedBinary Include="@(IlcReference)" />
     </ItemGroup>
 
+  </Target>
+
+  <Target Name="IlcCompile" 
+      Inputs="@(ManagedBinary)"
+      Outputs="$(NativeIntermediateOutputPath)%(Filename)$(IlcOutputFileExt)"
+      DependsOnTargets="$(IlcCompileDependsOn)">
+
     <ItemGroup>
-      <IlcArg Include="$(ManagedBinary)" />
-      <IlcArg Include="-o:$(IlcCompileOutput)" />
+      <IlcArg Include="@(ManagedBinary)" />
+      <IlcArg Include="-o:$(NativeIntermediateOutputPath)%(Filename)$(IlcOutputFileExt)" />
       <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
       <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />
+      <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />

--- a/src/Common/src/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/DefType.FieldLayout.cs
@@ -282,7 +282,7 @@ namespace Internal.TypeSystem
         }
 
 
-        internal void ComputeInstanceLayout(InstanceLayoutKind layoutKind)
+        public void ComputeInstanceLayout(InstanceLayoutKind layoutKind)
         {
             if (_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedInstanceTypeFieldsLayout | FieldLayoutFlags.ComputedInstanceTypeLayout))
                 return;
@@ -307,7 +307,7 @@ namespace Internal.TypeSystem
             _fieldLayoutFlags.AddFlags(FieldLayoutFlags.ComputedInstanceTypeLayout);
         }
 
-        internal void ComputeStaticFieldLayout(StaticLayoutKind layoutKind)
+        public void ComputeStaticFieldLayout(StaticLayoutKind layoutKind)
         {
             if (_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedStaticFieldsLayout | FieldLayoutFlags.ComputedStaticRegionLayout))
                 return;
@@ -340,8 +340,11 @@ namespace Internal.TypeSystem
             _fieldLayoutFlags.AddFlags(FieldLayoutFlags.ComputedStaticRegionLayout);
         }
 
-        private void ComputeTypeContainsGCPointers()
+        public void ComputeTypeContainsGCPointers()
         {
+            if (_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedContainsGCPointers))
+                return;
+
             int flagsToAdd = FieldLayoutFlags.ComputedContainsGCPointers;
 
             if (!IsValueType && HasBaseType && BaseType.ContainsGCPointers)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
@@ -8,7 +8,7 @@ namespace ILCompiler.DependencyAnalysis
 {
     internal sealed class ClonedConstructedEETypeNode : ConstructedEETypeNode, ISymbolNode
     {
-        public ClonedConstructedEETypeNode(TypeDesc type) : base(type)
+        public ClonedConstructedEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
         {
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -14,7 +14,7 @@ namespace ILCompiler.DependencyAnalysis
 {
     internal class ConstructedEETypeNode : EETypeNode, ISymbolNode
     {
-        public ConstructedEETypeNode(TypeDesc type) : base(type)
+        public ConstructedEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
         {
             Debug.Assert(!_type.IsGenericDefinition);
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -42,7 +42,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override ISymbolNode CreateReadyToRunHelperNode(Tuple<ReadyToRunHelperId, object> helperCall)
         {
             // TODO: this is wrong: this returns an assembly stub node
-            return new ReadyToRunHelperNode(helperCall.Item1, helperCall.Item2);
+            return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
         }
 
         private void AddWellKnownType(WellKnownType wellKnownType, DependencyAnalysisFramework.DependencyAnalyzerBase<NodeFactory> graph)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
@@ -14,10 +14,12 @@ namespace ILCompiler.DependencyAnalysis
     {
         private TypeDesc _type;
 
-        public ExternEETypeSymbolNode(TypeDesc type)
+        public ExternEETypeSymbolNode(NodeFactory factory, TypeDesc type)
             : base("__EEType_" + NodeFactory.NameMangler.GetMangledTypeName(type))
         {
             _type = type;
+
+            EETypeNode.CheckCanGenerateEEType(factory, type);
         }
 
         public TypeDesc Type

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.DependencyAnalysis
 {
     internal sealed class GenericDefinitionEETypeNode : EETypeNode, ISymbolNode
     {
-        public GenericDefinitionEETypeNode(TypeDesc type) : base(type)
+        public GenericDefinitionEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
         {
             Debug.Assert(type.IsGenericDefinition);
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -96,16 +96,16 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     if (type.IsGenericDefinition)
                     {
-                        return new GenericDefinitionEETypeNode(type);
+                        return new GenericDefinitionEETypeNode(this, type);
                     }
                     else
                     {
-                        return new EETypeNode(type);
+                        return new EETypeNode(this, type);
                     }
                 }
                 else
                 {
-                    return new ExternEETypeSymbolNode(type);
+                    return new ExternEETypeSymbolNode(this, type);
                 }
             });
 
@@ -113,11 +113,11 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (_compilationModuleGroup.ContainsType(type))
                 {
-                    return new ConstructedEETypeNode(type);
+                    return new ConstructedEETypeNode(this, type);
                 }
                 else
                 {
-                    return new ExternEETypeSymbolNode(type);
+                    return new ExternEETypeSymbolNode(this, type);
                 }
             });
 
@@ -125,7 +125,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 // Only types that reside in other binaries should be cloned
                 Debug.Assert(_compilationModuleGroup.ShouldReferenceThroughImportTable(type));
-                return new ClonedConstructedEETypeNode(type);
+                return new ClonedConstructedEETypeNode(this, type);
             });
 
             _nonGCStatics = new NodeCache<MetadataType, NonGCStaticsNode>((MetadataType type) =>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode CreateReadyToRunHelperNode(Tuple<ReadyToRunHelperId, object> helperCall)
         {
-            return new ReadyToRunHelperNode(helperCall.Item1, helperCall.Item2);
+            return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
         }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1485,7 +1485,11 @@ namespace Internal.JitInterface
         }
 
         private uint getArrayRank(CORINFO_CLASS_STRUCT_* cls)
-        { throw new NotImplementedException("getArrayRank"); }
+        {
+            var td = HandleToObject(cls) as ArrayType;
+            Debug.Assert(td != null);
+            return (uint) td.Rank;
+        }
 
         private void* getArrayInitializationData(CORINFO_FIELD_STRUCT_* field, uint size)
         {
@@ -2999,6 +3003,9 @@ namespace Internal.JitInterface
 
             if (this.MethodBeingCompiled.IsNativeCallable)
                 flags.corJitFlags2 |= CorJitFlag2.CORJIT_FLG2_REVERSE_PINVOKE;
+
+            if (this.MethodBeingCompiled.IsPInvoke)
+                flags.corJitFlags |= CorJitFlag.CORJIT_FLG_IL_STUB;
 
             return (uint)sizeof(CORJIT_FLAGS);
         }

--- a/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.cmd
+++ b/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.cmd
@@ -1,0 +1,6 @@
+@echo off
+
+:: Intentionally empty since we're just testing we can compile the framework
+:: assemblies to their own library obj files
+
+exit /b 0

--- a/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.csproj
+++ b/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.csproj
@@ -1,0 +1,5 @@
+<Project ToolsVersion="14.0" DefaultTargets="IlcCompile" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="..\..\..\..\src\BuildIntegration\BuildFrameworkNativeObjects.proj" />
+
+</Project>

--- a/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.sh
+++ b/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Intentionally empty since we're just testing we can compile the framework
+# assemblies to their own library obj files
+
+exit 0

--- a/tests/src/Simple/BuildMultiModuleLibraries/no_cpp
+++ b/tests/src/Simple/BuildMultiModuleLibraries/no_cpp
@@ -1,0 +1,1 @@
+Skip this test for cpp codegen mode


### PR DESCRIPTION
Enable compiling all framework / SDK assemblies in multi-module library
mode

Add a work-around to compile System.Console as a library in PInvokeILEmitter.cs

System.Console has a p/invoke to GetLargestConsoleWindowSize which
returns a COORD struct containing two 16 byte ints.  The struct return
type prevents the JIT from emitting an inline p/invoke in the IL stub we
generate and instead it treats the external p/invoke target as a managed
call and tries to compile it.  This work-around alters the return type
marshalling to be a 32bit int and allows the JIT to generate a proper
unmanaged call.

Fix bug in TypeSystemThrowingILEmitter where a null message argument
caused the jit to fail creating a string literal

Address library module compilation failures due to unsuccessful type
loads by checking on EEType creation whether the type can be loaded
sufficiently to write out the EETypeNode. Code for this stolen from one of Michal's previous PRs :)

Eagerly create EETypeNodes in ReadyToRunHelperNode so the failure point
happens during the referencing method compilation, not later on when
emitting the graph

Check method signatures on library compilation method rooting

Methods whose signatures contain types that cannot be loaded (they are
in a separate, non-existent assembly for example) should be skipped
since we cannot even replace their IL body with a throw helper. The JIT
will fail trying to getClassAttribs on the argument types.

This check is done when rooting methods instead of in MethodCodeNode's
constructor because MethodCodeNodes are created during graph sweeping
for things like virtual method combined dependencies.

Add a test that verifies we can compile all framework assemblies to their own separate object files successfully.