### PR TITLE
Don't allow nulls in ILEmitter

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -341,6 +341,7 @@ namespace Internal.IL.Stubs
 
         private ILToken NewToken(Object value, int tokenType)
         {
+            Debug.Assert(value != null);
             _tokens.Add(value);
             return (ILToken)(_tokens.Count | tokenType);
         }


### PR DESCRIPTION
Simon hit this #2126. This really should fail earlier than in JitInterface.