### PR TITLE
Call the slow helper from delegate .ctor method

### DIFF
--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -11,10 +11,7 @@ class Program
         TestDictionaryDependencyTracking.Run();
         TestStaticBaseLookups.Run();
         TestInitThisClass.Run();
-
-        // Missing support in RyuJIT: we can't just call Func..ctor and hope for the best
-        //TestDelegateFatFunctionPointers.Run();
-
+        TestDelegateFatFunctionPointers.Run();
         TestVirtualMethodUseTracking.Run();
 
         return 100;


### PR DESCRIPTION
This lets us get at least some test coverage for delegate invocation in
shared generics mode before #2102 gets fixed.