### PR TITLE
Split TypeLoadException throw helper into two

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemException.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemException.cs
@@ -62,8 +62,15 @@ namespace Internal.TypeSystem
 
             public string AssemblyName { get; }
 
-            private TypeLoadException(ExceptionStringID id, string typeName, string assemblyName, string messageArg = null)
+            private TypeLoadException(ExceptionStringID id, string typeName, string assemblyName, string messageArg)
                 : base(id, new string[] { typeName, assemblyName, messageArg })
+            {
+                TypeName = typeName;
+                AssemblyName = assemblyName;
+            }
+
+            private TypeLoadException(ExceptionStringID id, string typeName, string assemblyName)
+                : base(id, new string[] { typeName, assemblyName })
             {
                 TypeName = typeName;
                 AssemblyName = assemblyName;
@@ -84,8 +91,13 @@ namespace Internal.TypeSystem
             {
             }
 
-            public TypeLoadException(ExceptionStringID id, TypeDesc type, string messageArg = null)
+            public TypeLoadException(ExceptionStringID id, TypeDesc type, string messageArg)
                 : this(id, Format.Type(type), Format.OwningModule(type), messageArg)
+            {
+            }
+
+            public TypeLoadException(ExceptionStringID id, TypeDesc type)
+                : this(id, Format.Type(type), Format.OwningModule(type))
             {
             }
         }

--- a/src/Common/src/TypeSystem/IL/Stubs/TypeSystemThrowingILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/TypeSystemThrowingILEmitter.cs
@@ -26,7 +26,16 @@ namespace Internal.IL.Stubs
             Type exceptionType = exception.GetType();
             if (exceptionType == typeof(TypeSystemException.TypeLoadException))
             {
+                //
+                // There are two ThrowTypeLoadException helpers. Find the one which matches the number of
+                // arguments "exception" was initialized with.
+                //
                 helper = context.GetHelperEntryPoint("ThrowHelpers", "ThrowTypeLoadException");
+
+                if (helper.Signature.Length != exception.Arguments.Count + 1)
+                {
+                    helper = context.GetHelperEntryPoint("ThrowHelpers", "ThrowTypeLoadExceptionWithArgument");
+                }
             }
             else if (exceptionType == typeof(TypeSystemException.MissingFieldException))
             {

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -45,7 +45,12 @@ namespace Internal.Runtime.CompilerHelpers
             throw new PlatformNotSupportedException();
         }
 
-        public static void ThrowTypeLoadException(ExceptionStringID id, string className, string typeName, string messageArg)
+        public static void ThrowTypeLoadException(ExceptionStringID id, string className, string typeName)
+        {
+            throw TypeLoaderExceptionHelper.CreateTypeLoadException(id, className, typeName);
+        }
+
+        public static void ThrowTypeLoadExceptionWithArgument(ExceptionStringID id, string className, string typeName, string messageArg)
         {
             throw TypeLoaderExceptionHelper.CreateTypeLoadException(id, className, typeName, messageArg);
         }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
@@ -18,6 +18,11 @@ namespace Internal.Runtime
     /// </summary>
     internal static class TypeLoaderExceptionHelper
     {
+        public static Exception CreateTypeLoadException(ExceptionStringID id, string typeName, string moduleName)
+        {
+            return new TypeLoadException(SR.Format(GetFormatString(id), typeName, moduleName), typeName);
+        }
+
         public static Exception CreateTypeLoadException(ExceptionStringID id, string typeName, string moduleName, string messageArg)
         {
             return new TypeLoadException(SR.Format(GetFormatString(id), typeName, moduleName, messageArg), typeName);


### PR DESCRIPTION
The optional messageArg parameter causes a request for a null string
token when building the TypeSystemThrowingIL helper if one of the
TypeLoadException constructors is called using the default null value
for messageArg.

Split the constructors in `TypeSystemException` to ensure the base
exception args array only contains the arguments passed in. This
requires a new ThrowHelper which takes one fewer parameters, along with
a new `CreateTypeLoadException` helper with the same signature.