### PR TITLE
Unhandled exception handling on Unix

### DIFF
--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -68,12 +68,11 @@ extern "C"
 
     void OutputDebugStringW()
     {
-        throw "OutputDebugStringW";
     }
 
     uint32_t GetCurrentThreadId()
     {
-        throw "GetCurrentThreadId";
+        return 42;
     }
 
     uint32_t RhCompatibleReentrantWaitAny(uint32_t alertable, uint32_t timeout, uint32_t count, void* pHandles)

--- a/src/Native/Runtime/unix/UnixContext.cpp
+++ b/src/Native/Runtime/unix/UnixContext.cpp
@@ -403,6 +403,10 @@ void UnwindCursorToRegDisplay(unw_cursor_t *cursor, unw_context_t *unwContext, R
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &regDisplay->IP);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &regDisplay->SP);
 
+#if defined(_AMD64_)
+    regDisplay->pIP = PTR_PCODE(regDisplay->SP - sizeof(TADDR));
+#endif
+
 #if defined(_ARM_) || defined(_ARM64_)
     regDisplay->IP |= 1;
 #endif

--- a/src/Native/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/Native/Runtime/unix/UnixNativeCodeManager.cpp
@@ -14,6 +14,9 @@
 
 #include "CommonMacros.inl"
 
+#define GCINFODECODER_NO_EE
+#include "coreclr/gcinfodecoder.cpp"
+
 #include "UnixContext.h"
 
 #define UBF_FUNC_KIND_MASK      0x03
@@ -23,11 +26,13 @@
 
 #define UBF_FUNC_HAS_EHINFO     0x04
 
+#define UBF_FUNC_REVERSE_PINVOKE 0x08
+
 struct UnixNativeMethodInfo
 {
     PTR_VOID pMethodStartAddress;
-    PTR_UInt8 pEhInfo;
-    uint8_t funcFlags;
+    PTR_UInt8 pMainLSDA;
+    PTR_UInt8 pLSDA;
     bool executionAborted;
 };
 
@@ -57,30 +62,26 @@ bool UnixNativeCodeManager::FindMethodInfo(PTR_VOID        ControlPC,
         return false;
     }
 
-    PTR_UInt8 lsdaPtr = dac_cast<PTR_UInt8>(lsda);
+    PTR_UInt8 p = dac_cast<PTR_UInt8>(lsda);
 
-    int offsetFromMainFunction = *dac_cast<PTR_Int32>(lsdaPtr);
-    lsdaPtr += sizeof(int);
-    pMethodInfo->funcFlags = *lsdaPtr;
-    ++lsdaPtr;
+    pMethodInfo->pLSDA = p;
 
-    PTR_UInt8 ehInfoPtr = NULL;
-    if (pMethodInfo->funcFlags & UBF_FUNC_HAS_EHINFO)
+    uint8_t unwindBlockFlags = *p++;
+
+    if ((unwindBlockFlags & UBF_FUNC_KIND_MASK) != UBF_FUNC_KIND_ROOT)
     {
-        // main function contains the EH info blob in its LSDA, funclets just refer
-        // to the main function's blob
-        if (offsetFromMainFunction == 0)
-        {
-            ehInfoPtr = lsdaPtr;
-        }
-        else
-        {
-            ehInfoPtr = lsdaPtr + *dac_cast<PTR_Int32>(lsdaPtr);
-        }
+        // Funclets just refer to the main function's blob
+        pMethodInfo->pMainLSDA = p + *dac_cast<PTR_Int32>(p);
+        p += sizeof(int32_t);
+
+        pMethodInfo->pMethodStartAddress = dac_cast<PTR_VOID>(startAddress - *dac_cast<PTR_Int32>(p));
+    }
+    else
+    {
+        pMethodInfo->pMainLSDA = dac_cast<PTR_UInt8>(lsda);
+        pMethodInfo->pMethodStartAddress = dac_cast<PTR_VOID>(startAddress);
     }
 
-    pMethodInfo->pMethodStartAddress = (PTR_VOID)(startAddress - offsetFromMainFunction);
-    pMethodInfo->pEhInfo = ehInfoPtr;
     pMethodInfo->executionAborted = false;
 
     return true;
@@ -90,7 +91,8 @@ bool UnixNativeCodeManager::IsFunclet(MethodInfo * pMethodInfo)
 {
     UnixNativeMethodInfo * pNativeMethodInfo = (UnixNativeMethodInfo *)pMethodInfo;
 
-    return (pNativeMethodInfo->funcFlags & UBF_FUNC_KIND_MASK) != UBF_FUNC_KIND_ROOT;
+    uint8_t unwindBlockFlags = *(pNativeMethodInfo->pLSDA);
+    return (unwindBlockFlags & UBF_FUNC_KIND_MASK) != UBF_FUNC_KIND_ROOT;
 }
 
 PTR_VOID UnixNativeCodeManager::GetFramePointer(MethodInfo *   pMethodInfo,
@@ -99,7 +101,7 @@ PTR_VOID UnixNativeCodeManager::GetFramePointer(MethodInfo *   pMethodInfo,
     UnixNativeMethodInfo * pNativeMethodInfo = (UnixNativeMethodInfo *)pMethodInfo;
 
     // Return frame pointer for methods with EH and funclets
-    uint8_t unwindBlockFlags = pNativeMethodInfo->funcFlags;
+    uint8_t unwindBlockFlags = *(pNativeMethodInfo->pLSDA);
     if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0 || (unwindBlockFlags & UBF_FUNC_KIND_MASK) != UBF_FUNC_KIND_ROOT)
     {
         return (PTR_VOID)pRegisterSet->GetFP();
@@ -127,13 +129,36 @@ bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
                                              REGDISPLAY *    pRegisterSet,                 // in/out
                                              PTR_VOID *      ppPreviousTransitionFrame)    // out
 {
+    UnixNativeMethodInfo * pNativeMethodInfo = (UnixNativeMethodInfo *)pMethodInfo;
+
+    PTR_UInt8 p = pNativeMethodInfo->pMainLSDA;
+
+    uint8_t unwindBlockFlags = *p++;
+
+    if ((unwindBlockFlags & UBF_FUNC_REVERSE_PINVOKE) != 0)
+    {
+        // Reverse PInvoke transition should on the main function body only
+        assert(pNativeMethodInfo->pMainLSDA == pNativeMethodInfo->pLSDA);
+
+        if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)
+            p += sizeof(int32_t);
+
+        GcInfoDecoder decoder(GCInfoToken(p), DECODE_REVERSE_PINVOKE_VAR);
+
+        // @TODO: CORERT: Encode reverse PInvoke frame slot in GCInfo: https://github.com/dotnet/corert/issues/2115
+        // INT32 slot = decoder.GetReversePInvokeFrameStackSlot();
+        // assert(slot != NO_REVERSE_PINVOKE_FRAME);
+
+        *ppPreviousTransitionFrame = (PTR_VOID)-1;
+        return true;
+    }
+
+    *ppPreviousTransitionFrame = NULL;
+
     if (!VirtualUnwind(pRegisterSet))
     {
         return false;
     }
-
-    // @TODO: CORERT: PInvoke transitions
-    *ppPreviousTransitionFrame = NULL;
 
     return true;
 }
@@ -187,8 +212,12 @@ bool UnixNativeCodeManager::EHEnumInit(MethodInfo * pMethodInfo, PTR_VOID * pMet
 
     UnixNativeMethodInfo * pNativeMethodInfo = (UnixNativeMethodInfo *)pMethodInfo;
 
+    PTR_UInt8 p = pNativeMethodInfo->pMainLSDA;
+
+    uint8_t unwindBlockFlags = *p++;
+
     // return if there is no EH info associated with this method
-    if ((pNativeMethodInfo->funcFlags & UBF_FUNC_HAS_EHINFO) == 0)
+    if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) == 0)
     {
         return false;
     }
@@ -198,7 +227,7 @@ bool UnixNativeCodeManager::EHEnumInit(MethodInfo * pMethodInfo, PTR_VOID * pMet
     *pMethodStartAddress = pNativeMethodInfo->pMethodStartAddress;
 
     pEnumState->pMethodStartAddress = dac_cast<PTR_UInt8>(pNativeMethodInfo->pMethodStartAddress);
-    pEnumState->pEHInfo = pNativeMethodInfo->pEhInfo;
+    pEnumState->pEHInfo = dac_cast<PTR_UInt8>(p + *dac_cast<PTR_Int32>(p));
     pEnumState->uClause = 0;
     pEnumState->nClauses = VarInt::ReadUnsigned(pEnumState->pEHInfo);
 


### PR DESCRIPTION
- Reduced differences between the unwind info, gc info and eh info encodings between Windows and Unix.
- Miscellaneous tweaks to get unhandled exceptions fail with gracefully with error message and abort with this change