### PR TITLE
Enable reflection invoke

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
@@ -1,0 +1,380 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+using Interlocked = System.Threading.Interlocked;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Thunk to dynamically invoke a method using reflection. The method accepts an object[] of parameters
+    /// to target method, lays them out on the stack, and calls the target method. This thunk has heavy
+    /// dependencies on the general dynamic invocation infrastructure in System.InvokeUtils and gets called from there
+    /// at runtime. See comments in System.InvokeUtils for a more thorough explanation.
+    /// </summary>
+    internal class DynamicInvokeMethodThunk : ILStubMethod
+    {
+        private TypeDesc _owningType;
+        private DynamicInvokeMethodSignature _targetSignature;
+
+        private TypeDesc[] _instantiation;
+        private MethodSignature _signature;
+
+        public DynamicInvokeMethodThunk(TypeDesc owningType, DynamicInvokeMethodSignature signature)
+        {
+            _owningType = owningType;
+            _targetSignature = signature;
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return _owningType.Context;
+            }
+        }
+
+        public override TypeDesc OwningType
+        {
+            get
+            {
+                return _owningType;
+            }
+        }
+
+        private MetadataType InvokeUtilsType
+        {
+            get
+            {
+                return Context.SystemModule.GetKnownType("System", "InvokeUtils");
+            }
+        }
+
+        private MetadataType ArgSetupStateType
+        {
+            get
+            {
+                return InvokeUtilsType.GetNestedType("ArgSetupState");
+            }
+        }
+
+        public override MethodSignature Signature
+        {
+            get
+            {
+                if (_signature == null)
+                {
+                    _signature = new MethodSignature(
+                        MethodSignatureFlags.Static,
+                        Instantiation.Length,
+                        Context.GetWellKnownType(WellKnownType.Object),
+                        new TypeDesc[]
+                        {
+                            Context.GetWellKnownType(WellKnownType.Object),  // thisPtr
+                            Context.GetWellKnownType(WellKnownType.IntPtr),  // methodToCall
+                            ArgSetupStateType.MakeByRefType(),               // argSetupState
+                            Context.GetWellKnownType(WellKnownType.Boolean), // targetIsThisCall
+                        });
+                }
+
+                return _signature;
+            }
+        }
+
+        public override Instantiation Instantiation
+        {
+            get
+            {
+                if (_instantiation == null)
+                {
+                    TypeDesc[] instantiation =
+                        new TypeDesc[_targetSignature.HasReturnValue ? _targetSignature.Length + 1 : _targetSignature.Length];
+
+                    for (int i = 0; i < _targetSignature.Length; i++)
+                        instantiation[i] = new DynamicInvokeThunkGenericParameter(Context, i);
+
+                    if (_targetSignature.HasReturnValue)
+                        instantiation[_targetSignature.Length] =
+                            new DynamicInvokeThunkGenericParameter(Context, _targetSignature.Length);
+
+                    Interlocked.CompareExchange(ref _instantiation, instantiation, null);
+                }
+
+                return new Instantiation(_instantiation);
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                StringBuilder sb = new StringBuilder("InvokeRet");
+
+                if (_targetSignature.HasReturnValue)
+                    sb.Append('O');
+                else
+                    sb.Append('V');
+
+                for (int i = 0; i < _targetSignature.Length; i++)
+                    sb.Append(_targetSignature[i] == DynamicInvokeMethodParameterKind.Value ? 'I' : 'R');
+
+                return sb.ToString();
+            }
+        }
+
+        public override MethodIL EmitIL()
+        {
+            ILEmitter emitter = new ILEmitter();
+            ILCodeStream argSetupStream = emitter.NewCodeStream();
+            ILCodeStream thisCallSiteSetupStream = emitter.NewCodeStream();
+            ILCodeStream staticCallSiteSetupStream = emitter.NewCodeStream();
+
+            // This function will look like
+            //
+            // !For each parameter to the method
+            //    !if (parameter is In Parameter)
+            //       localX is TypeOfParameterX&
+            //       ldtoken TypeOfParameterX
+            //       call DynamicInvokeParamHelperIn(RuntimeTypeHandle)
+            //       stloc localX
+            //    !else
+            //       localX is TypeOfParameter
+            //       ldtoken TypeOfParameterX
+            //       call DynamicInvokeParamHelperRef(RuntimeTypeHandle)
+            //       stloc localX
+
+            // ldarg.2
+            // call DynamicInvokeArgSetupComplete(ref ArgSetupState)
+
+            // *** Thiscall instruction stream starts here ***
+
+            // ldarg.3 // Load targetIsThisCall
+            // brfalse Not_this_call
+
+            // ldarg.0 // Load this pointer
+            // !For each parameter
+            //    !if (parameter is In Parameter)
+            //       ldloc localX
+            //       ldobj TypeOfParameterX
+            //    !else
+            //       ldloc localX
+            // ldarg.1
+            // calli ReturnType thiscall(TypeOfParameter1, ...)
+            // !if ((ReturnType == void)
+            //    ldnull
+            // !else
+            //    box ReturnType
+            // ret
+
+            // *** Static call instruction stream starts here ***
+
+            // Not_this_call:
+            // !For each parameter
+            //    !if (parameter is In Parameter)
+            //       ldloc localX
+            //       ldobj TypeOfParameterX
+            //    !else
+            //       ldloc localX
+            // ldarg.1
+            // calli ReturnType (TypeOfParameter1, ...)
+            // !if ((ReturnType == void)
+            //    ldnull
+            // !else
+            //    box ReturnType
+            // ret
+
+            ILCodeLabel lStaticCall = emitter.NewCodeLabel();
+            thisCallSiteSetupStream.EmitLdArg(3); // targetIsThisCall
+            thisCallSiteSetupStream.Emit(ILOpcode.brfalse, lStaticCall);
+            staticCallSiteSetupStream.EmitLabel(lStaticCall);
+
+            thisCallSiteSetupStream.EmitLdArg(0); // thisPtr
+
+            ILToken tokDynamicInvokeParamHelperRef =
+                emitter.NewToken(InvokeUtilsType.GetKnownMethod("DynamicInvokeParamHelperRef", null));
+            ILToken tokDynamicInvokeParamHelperIn =
+                emitter.NewToken(InvokeUtilsType.GetKnownMethod("DynamicInvokeParamHelperIn", null));
+
+            TypeDesc[] targetMethodSignature = new TypeDesc[_targetSignature.Length];
+
+            for (int paramIndex = 0; paramIndex < _targetSignature.Length; paramIndex++)
+            {
+                TypeDesc paramType = Context.GetSignatureVariable(paramIndex, true);
+                ILToken tokParamType = emitter.NewToken(paramType);
+                ILLocalVariable local = emitter.NewLocal(paramType.MakeByRefType());
+
+                thisCallSiteSetupStream.EmitLdLoc(local);
+                staticCallSiteSetupStream.EmitLdLoc(local);
+
+                argSetupStream.Emit(ILOpcode.ldtoken, tokParamType);
+
+                if (_targetSignature[paramIndex] == DynamicInvokeMethodParameterKind.Reference)
+                {
+                    argSetupStream.Emit(ILOpcode.call, tokDynamicInvokeParamHelperRef);
+
+                    targetMethodSignature[paramIndex] = paramType.MakeByRefType();
+                }
+                else
+                {
+                    argSetupStream.Emit(ILOpcode.call, tokDynamicInvokeParamHelperIn);
+
+                    thisCallSiteSetupStream.Emit(ILOpcode.ldobj, tokParamType);
+                    staticCallSiteSetupStream.Emit(ILOpcode.ldobj, tokParamType);
+
+                    targetMethodSignature[paramIndex] = paramType;
+                }
+                argSetupStream.EmitStLoc(local);
+            }
+
+            argSetupStream.EmitLdArg(2); // argSetupState
+            argSetupStream.Emit(ILOpcode.call, emitter.NewToken(InvokeUtilsType.GetKnownMethod("DynamicInvokeArgSetupComplete", null)));
+
+            thisCallSiteSetupStream.EmitLdArg(1); // methodToCall
+            staticCallSiteSetupStream.EmitLdArg(1); // methodToCall
+
+            TypeDesc returnType = _targetSignature.HasReturnValue ?
+                Context.GetSignatureVariable(_targetSignature.Length, true) :
+                Context.GetWellKnownType(WellKnownType.Void);
+
+            MethodSignature thisCallMethodSig = new MethodSignature(0, 0, returnType, targetMethodSignature);
+            thisCallSiteSetupStream.Emit(ILOpcode.calli, emitter.NewToken(thisCallMethodSig));
+
+            MethodSignature staticCallMethodSig = new MethodSignature(MethodSignatureFlags.Static, 0, returnType, targetMethodSignature);
+            staticCallSiteSetupStream.Emit(ILOpcode.calli, emitter.NewToken(staticCallMethodSig));
+
+            if (_targetSignature.HasReturnValue)
+            {
+                ILToken tokReturnType = emitter.NewToken(returnType);
+                thisCallSiteSetupStream.Emit(ILOpcode.box, tokReturnType);
+                staticCallSiteSetupStream.Emit(ILOpcode.box, tokReturnType);
+            }
+            else
+            {
+                thisCallSiteSetupStream.Emit(ILOpcode.ldnull);
+                staticCallSiteSetupStream.Emit(ILOpcode.ldnull);
+            }
+
+            thisCallSiteSetupStream.Emit(ILOpcode.ret);
+            staticCallSiteSetupStream.Emit(ILOpcode.ret);
+
+            return emitter.Link(this);
+        }
+
+        private class DynamicInvokeThunkGenericParameter : GenericParameterDesc
+        {
+            public DynamicInvokeThunkGenericParameter(TypeSystemContext context, int index)
+            {
+                Context = context;
+                Index = index;
+            }
+
+            public override TypeSystemContext Context
+            {
+                get;
+            }
+
+            public override int Index
+            {
+                get;
+            }
+
+            public override GenericParameterKind Kind
+            {
+                get
+                {
+                    return GenericParameterKind.Method;
+                }
+            }
+        }
+    }
+
+    internal enum DynamicInvokeMethodParameterKind
+    {
+        None,
+        Value,
+        Reference,
+    }
+
+    /// <summary>
+    /// Wraps a <see cref="MethodSignature"/> to reduce it's fidelity.
+    /// </summary>
+    internal struct DynamicInvokeMethodSignature : IEquatable<DynamicInvokeMethodSignature>
+    {
+        private MethodSignature _signature;
+
+        public bool HasReturnValue
+        {
+            get
+            {
+                return !_signature.ReturnType.IsVoid;
+            }
+        }
+
+        public int Length
+        {
+            get
+            {
+                return _signature.Length;
+            }
+        }
+
+        public DynamicInvokeMethodParameterKind this[int index]
+        {
+            get
+            {
+                return _signature[index].IsByRef ?
+                    DynamicInvokeMethodParameterKind.Reference :
+                    DynamicInvokeMethodParameterKind.Value;
+            }
+        }
+
+        public DynamicInvokeMethodSignature(MethodSignature concreteSignature)
+        {
+            // ByRef returns should have been filtered out elsewhere. We don't handle them
+            // because reflection can't invoke such methods.
+            Debug.Assert(!concreteSignature.ReturnType.IsByRef);
+            _signature = concreteSignature;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is DynamicInvokeMethodSignature && Equals((DynamicInvokeMethodSignature)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = HasReturnValue ? 17 : 23;
+
+            for (int i = 0; i < Length; i++)
+            {
+                int value = (int)this[i] * 0x5498341 + 0x832424;
+                hashCode = hashCode * 31 + value;
+            }
+
+            return hashCode;
+        }
+
+        public bool Equals(DynamicInvokeMethodSignature other)
+        {
+            if (HasReturnValue != other.HasReturnValue)
+                return false;
+            
+            if (Length != other.Length)
+                return false;
+
+            for (int i = 0; i < Length; i++)
+            {
+                if (this[i] != other[i])
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -108,6 +108,24 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
+            // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
+            // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
+            // we even start the compilation process (with the invocation stubs being compilation roots like any other).
+            // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
+            if (factory.MetadataManager.HasReflectionInvokeStub(_method)
+                && !_method.IsCanonicalMethod(CanonicalFormKind.Any) /* Shared generics handled in the shadow concrete method node */)
+            {
+                if (dependencies == null)
+                    dependencies = new DependencyList();
+
+                MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(Method);
+                MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                if (invokeStub != canonInvokeStub)
+                    dependencies.Add(new DependencyListEntry(factory.FatFunctionPointer(invokeStub), "Reflection invoke"));
+                else
+                    dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke"));
+            }
+
             return dependencies;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -1,0 +1,198 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+using InvokeTableFlags = Internal.Runtime.InvokeTableFlags;
+using FatFunctionPointerConstants = Internal.Runtime.FatFunctionPointerConstants;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between reflection metadata and generated method bodies.
+    /// </summary>
+    internal sealed class ReflectionInvokeMapNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        public ReflectionInvokeMapNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _externalReferences = externalReferences;
+        }
+
+        public ISymbolNode EndSymbol
+        {
+            get
+            {
+                return _endSymbol;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return NodeFactory.CompilationUnitPrefix + "__method_to_entrypoint_map";
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override ObjectNodeSection Section
+        {
+            get
+            {
+                return ObjectNodeSection.DataSection;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        protected override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            var writer = new NativeWriter();
+            var typeMapHashTable = new VertexHashtable();
+
+            Section hashTableSection = writer.NewSection();
+            hashTableSection.Place(typeMapHashTable);
+
+            // Get a list of all methods that have a method body and metadata from the metadata manager.
+            foreach (var mappingEntry in factory.MetadataManager.GetMethodMapping())
+            {
+                MethodDesc method = mappingEntry.Entity;
+
+                // The current format requires us to have an EEType for the owning type. We might want to lift this.
+                if (!factory.MetadataManager.TypeGeneratesEEType(method.OwningType))
+                    continue;
+
+                // We have a method body, we have a metadata token, but we can't get an invoke stub. Bail.
+                if (!factory.MetadataManager.HasReflectionInvokeStub(method))
+                    continue;
+
+                InvokeTableFlags flags = 0;
+
+                if (method.HasInstantiation)
+                    flags |= InvokeTableFlags.IsGenericMethod;
+
+                if (method.GetCanonMethodTarget(CanonicalFormKind.Specific).RequiresInstArg())
+                    flags |= InvokeTableFlags.RequiresInstArg;
+
+                // TODO: better check for default public(!) constructor
+                if (method.IsConstructor && method.Signature.Length == 0)
+                    flags |= InvokeTableFlags.IsDefaultConstructor;
+
+                // TODO: HasVirtualInvoke
+
+                if (!method.IsAbstract)
+                    flags |= InvokeTableFlags.HasEntrypoint;
+
+                // Once we have a true multi module compilation story, we'll need to start emitting entries where this is not set.
+                flags |= InvokeTableFlags.HasMetadataHandle;
+
+                // TODO: native signature for P/Invokes and NativeCallable methods
+                if (method.IsRawPInvoke() || method.IsNativeCallable)
+                    continue;
+
+                // Grammar of an entry in the hash table:
+                // Flags + DeclaringType + MetadataHandle/NameAndSig + Entrypoint + DynamicInvokeMethod + [NumGenericArgs + GenericArgs]
+
+                Vertex vertex = writer.GetUnsignedConstant((uint)flags);
+
+                if ((flags & InvokeTableFlags.HasMetadataHandle) != 0)
+                {
+                    // Only store the offset portion of the metadata handle to get better integer compression
+                    vertex = writer.GetTuple(vertex,
+                        writer.GetUnsignedConstant((uint)(mappingEntry.MetadataHandle & MetadataGeneration.MetadataOffsetMask)));
+                }
+                else
+                {
+                    // TODO: no MD handle case
+                }
+
+                // Go with a necessary type symbol. It will be upgraded to a constructed one if a constructed was emitted.
+                IEETypeNode owningTypeSymbol = factory.NecessaryTypeSymbol(method.OwningType);
+                vertex = writer.GetTuple(vertex,
+                    writer.GetUnsignedConstant(_externalReferences.GetIndex(owningTypeSymbol)));
+
+                if ((flags & InvokeTableFlags.HasEntrypoint) != 0)
+                {
+                    vertex = writer.GetTuple(vertex,
+                        writer.GetUnsignedConstant(_externalReferences.GetIndex(
+                            factory.MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific)))));
+                }
+
+                // TODO: data to generate the generic dictionary with the type loader
+                MethodDesc invokeStubMethod = factory.MetadataManager.GetReflectionInvokeStub(method);
+                MethodDesc canonInvokeStubMethod = invokeStubMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                if (invokeStubMethod != canonInvokeStubMethod)
+                {
+                    vertex = writer.GetTuple(vertex,
+                        writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.FatFunctionPointer(invokeStubMethod), FatFunctionPointerConstants.Offset) << 1));
+                }
+                else
+                {
+                    vertex = writer.GetTuple(vertex,
+                        writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.MethodEntrypoint(invokeStubMethod)) << 1));
+                }
+
+                if ((flags & InvokeTableFlags.IsGenericMethod) != 0)
+                {
+                    if ((flags & InvokeTableFlags.RequiresInstArg) == 0 || (flags & InvokeTableFlags.HasEntrypoint) == 0)
+                    {
+                        VertexSequence args = new VertexSequence();
+                        for (int i = 0; i < method.Instantiation.Length; i++)
+                        {
+                            uint argId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(method.Instantiation[i]));
+                            args.Append(writer.GetUnsignedConstant(argId));
+                        }
+                        vertex = writer.GetTuple(vertex, args);
+                    }
+                    else
+                    {
+                        uint dictionaryId = _externalReferences.GetIndex(factory.MethodGenericDictionary(method));
+                        vertex = writer.GetTuple(vertex, writer.GetUnsignedConstant(dictionaryId));
+                    }
+                }
+
+                int hashCode = method.GetCanonMethodTarget(CanonicalFormKind.Specific).OwningType.GetHashCode();
+                typeMapHashTable.Append((uint)hashCode, hashTableSection.Place(vertex));
+            }
+
+            MemoryStream ms = new MemoryStream();
+            writer.Save(ms);
+            byte[] hashTableBytes = ms.ToArray();
+
+            _endSymbol.SetSymbolOffset(hashTableBytes.Length);
+
+            return new ObjectData(hashTableBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -69,6 +69,20 @@ namespace ILCompiler.DependencyAnalysis
                     }
                 }
             }
+
+            // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
+            // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
+            // we even start the compilation process (with the invocation stubs being compilation roots like any other).
+            // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
+            if (factory.MetadataManager.HasReflectionInvokeStub(Method))
+            {
+                MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(Method);
+                MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                if (invokeStub != canonInvokeStub)
+                    yield return new DependencyListEntry(factory.FatFunctionPointer(invokeStub), "Reflection invoke");
+                else
+                    yield return new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke");
+            }
         }
 
         protected override string GetName()

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -127,7 +127,7 @@ namespace ILCompiler
                 return false;
 
             for (int i = 0; i < signature.Length; i++)
-                if (signature[i].IsPointer)
+                if (signature[i].IsByRef && ((ByRefType)signature[i]).ParameterType.IsPointer)
                     return false;
 
             // TODO: function pointer types are odd: https://github.com/dotnet/corert/issues/1929

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 
+using Internal.IL.Stubs;
 using Internal.TypeSystem;
 using Internal.Metadata.NativeFormat.Writer;
 
@@ -26,8 +27,11 @@ namespace ILCompiler
     /// </summary>
     public class MetadataGeneration
     {
+        internal const int MetadataOffsetMask = 0xFFFFFF;
+
         private byte[] _metadataBlob;
         private List<MetadataMapping<MetadataType>> _typeMappings = new List<MetadataMapping<MetadataType>>();
+        private List<MetadataMapping<MethodDesc>> _methodMappings = new List<MetadataMapping<MethodDesc>>();
 
         private NodeFactory _nodeFactory;
 
@@ -35,6 +39,10 @@ namespace ILCompiler
         private HashSet<MetadataType> _typeDefinitionsGenerated = new HashSet<MetadataType>();
         private List<NonGCStaticsNode> _cctorContextsGenerated = new List<NonGCStaticsNode>();
         private HashSet<TypeDesc> _typesWithEETypesGenerated = new HashSet<TypeDesc>();
+        private HashSet<MethodDesc> _methodDefinitionsGenerated = new HashSet<MethodDesc>();
+        private HashSet<MethodDesc> _methodsGenerated = new HashSet<MethodDesc>();
+
+        private Dictionary<DynamicInvokeMethodSignature, MethodDesc> _dynamicInvokeThunks = new Dictionary<DynamicInvokeMethodSignature, MethodDesc>();
 
         public MetadataGeneration(NodeFactory factory)
         {
@@ -66,6 +74,9 @@ namespace ILCompiler
             var cctorContextMapNode = new ClassConstructorContextMap(externalReferencesTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.CCtorContextMap), cctorContextMapNode, cctorContextMapNode, cctorContextMapNode.EndSymbol);
 
+            var invokeMapNode = new ReflectionInvokeMapNode(externalReferencesTableNode);
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.InvokeMap), invokeMapNode, invokeMapNode, invokeMapNode.EndSymbol);
+
             // This one should go last
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.CommonFixupsTable),
                 externalReferencesTableNode, externalReferencesTableNode, externalReferencesTableNode.EndSymbol);
@@ -81,10 +92,22 @@ namespace ILCompiler
                 return;
             }
 
-            var methodNode = obj as MethodCodeNode;
+            IMethodNode methodNode = obj as MethodCodeNode;
+            if (methodNode == null)
+                methodNode = obj as ShadowConcreteMethodNode<MethodCodeNode>;
+
             if (methodNode != null)
             {
-                AddGeneratedType(methodNode.Method.OwningType);
+                MethodDesc method = methodNode.Method;
+                if (method.IsCanonicalMethod(CanonicalFormKind.Specific))
+                {
+                    // Canonical methods are not interesting.
+                    return;
+                }
+
+                AddGeneratedType(method.OwningType);
+                _methodDefinitionsGenerated.Add(method.GetTypicalMethodDefinition());
+                _methodsGenerated.Add(method);
                 return;
             }
 
@@ -93,6 +116,122 @@ namespace ILCompiler
             {
                 _cctorContextsGenerated.Add(nonGcStaticSectionNode);
             }
+        }
+
+        public bool HasReflectionInvokeStub(MethodDesc method)
+        {
+            var signature = method.Signature;
+
+            // TODO: support for methods returning pointer types - https://github.com/dotnet/corert/issues/2113
+            if (signature.ReturnType.IsPointer)
+                return false;
+
+            for (int i = 0; i < signature.Length; i++)
+                if (signature[i].IsPointer)
+                    return false;
+
+            // TODO: function pointer types are odd: https://github.com/dotnet/corert/issues/1929
+            if (signature.ReturnType.IsFunctionPointer)
+                return false;
+
+            for (int i = 0; i < signature.Length; i++)
+                if (signature[i].IsFunctionPointer)
+                    return false;
+
+            // Methods with ByRef returns can't be reflection invoked
+            if (signature.ReturnType.IsByRef)
+                return false;
+
+            // Delegate construction is only allowed through specific IL sequences
+            if (method.OwningType.IsDelegate && method.IsConstructor)
+                return false;
+
+            // Everything else should get a stub.
+            return true;
+        }
+
+        /// <summary>
+        /// Gets a stub that can be used to reflection-invoke a method with a given signature.
+        /// </summary>
+        public MethodDesc GetReflectionInvokeStub(MethodDesc method)
+        {
+            // Methods we see here shouldn't be canonicalized, or we'll end up creating bastardized instantiations
+            // (e.g. we instantiate over System.Object below.)
+            Debug.Assert(!method.IsCanonicalMethod(CanonicalFormKind.Any));
+
+            TypeSystemContext context = method.Context;
+            var sig = method.Signature;
+
+            // Get a generic method that can be used to invoke method with this shape.
+            MethodDesc thunk;
+            var lookupSig = new DynamicInvokeMethodSignature(sig);
+            if (!_dynamicInvokeThunks.TryGetValue(lookupSig, out thunk))
+            {
+                // TODO: figure out a better owning type (for multifile)
+                thunk = new DynamicInvokeMethodThunk(context.SystemModule.GetGlobalModuleType(), lookupSig);
+                _dynamicInvokeThunks.Add(lookupSig, thunk);
+            }
+
+            // If the method has no parameters and returns void, we don't need to specialize
+            if (sig.ReturnType.IsVoid && sig.Length == 0)
+            {
+                Debug.Assert(!thunk.HasInstantiation);
+                return thunk;
+            }
+
+            //
+            // Instantiate the generic thunk over the parameters and the return type of the target method
+            //
+
+            TypeDesc[] instantiation = new TypeDesc[sig.ReturnType.IsVoid ? sig.Length : sig.Length + 1];
+            Debug.Assert(thunk.Instantiation.Length == instantiation.Length);
+            for (int i = 0; i < sig.Length; i++)
+            {
+                TypeDesc parameterType = sig[i];
+                if (parameterType.IsByRef)
+                {
+                    // strip ByRefType off the parameter (the method already has ByRef in the signature)
+                    parameterType = ((ByRefType)parameterType).ParameterType;
+                }
+
+                if (parameterType.IsPointer || parameterType.IsFunctionPointer)
+                {
+                    // For pointer typed parameters, instantiate the method over IntPtr
+                    parameterType = context.GetWellKnownType(WellKnownType.IntPtr);
+                }
+                else if (parameterType.IsDefType)
+                {
+                    // TODO: optimize enum types with no default value
+                    // DefType* paramDefType = parameterType->as<DefType> ();
+                    // // If the invoke method takes an enum as an input paramter and there is no default value for
+                    // // that paramter, we don't need to specialize on the exact enum type (we only need to specialize
+                    // // on the underlying integral type of the enum.)
+                    // if (paramDefType && (!IsPdHasDefault(methodToInvoke->Parameters()[index].Attributes())) && paramDefType->IsEnum())
+                    // {
+                    //     CorElementType underlyingElemType = paramDefType->InternalElementType();
+                    //     parameterType = paramDefType->GetLoaderContext()->GetElementType(underlyingElemType);
+                    // }
+                }
+
+                instantiation[i] = parameterType;
+            }
+
+            if (!sig.ReturnType.IsVoid)
+            {
+                TypeDesc returnType = sig.ReturnType;
+                Debug.Assert(!returnType.IsByRef);
+
+                // If the invoke method return an object reference, we don't need to specialize on the
+                // exact type of the object reference, as the behavior is not different.
+                if ((returnType.IsDefType && !returnType.IsValueType) || returnType.IsArray)
+                {
+                    returnType = context.GetWellKnownType(WellKnownType.Object);
+                }
+
+                instantiation[sig.Length] = returnType;
+            }
+
+            return context.GetInstantiatedMethod(thunk, new Instantiation(instantiation));
         }
 
         private void AddGeneratedType(TypeDesc type)
@@ -149,6 +288,14 @@ namespace ILCompiler
                 if (record != null)
                     _typeMappings.Add(new MetadataMapping<MetadataType>(definition, writer.GetRecordHandle(record)));
             }
+
+            foreach (var method in _methodsGenerated)
+            {
+                MetadataRecord record = transformed.GetTransformedMethodDefinition(method.GetTypicalMethodDefinition());
+
+                if (record != null)
+                    _methodMappings.Add(new MetadataMapping<MethodDesc>(method, writer.GetRecordHandle(record)));
+            }
         }
 
         public byte[] GetMetadataBlob()
@@ -161,6 +308,12 @@ namespace ILCompiler
         {
             EnsureMetadataGenerated();
             return _typeMappings;
+        }
+
+        public IEnumerable<MetadataMapping<MethodDesc>> GetMethodMapping()
+        {
+            EnsureMetadataGenerated();
+            return _methodMappings;
         }
 
         internal IEnumerable<NonGCStaticsNode> GetCctorContextMapping()
@@ -197,7 +350,7 @@ namespace ILCompiler
 
             public bool GeneratesMetadata(MethodDesc methodDef)
             {
-                return false;
+                return _parent._methodDefinitionsGenerated.Contains(methodDef);
             }
 
             public bool GeneratesMetadata(MetadataType typeDef)

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -44,6 +44,9 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\ITargetBinaryWriter.cs">
       <Link>Common\ITargetBinaryWriter.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Internal\Runtime\MappingTableFlags.cs">
+      <Link>Common\MappingTableFlags.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs">
       <Link>Common\MetadataBlob.cs</Link>
     </Compile>
@@ -55,6 +58,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateMethodILEmitter.cs">
       <Link>IL\Stubs\DelegateMethodILEmitter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DynamicInvokeMethodThunk.cs">
+      <Link>IL\Stubs\DynamicInvokeMethodThunk.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\EETypePtrOfIntrinsic.cs">
       <Link>IL\Stubs\EETypePtrOfIntrinsic.cs</Link>
@@ -91,6 +97,7 @@
     <Compile Include="Compiler\DependencyAnalysis\GenericCompositionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDefinitionEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IndirectionNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReflectionInvokeMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeDeterminedMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ShadowConcreteMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDictionaryNode.cs" />


### PR DESCRIPTION
This is basically three parts:

* Generate a mapping table of method entrypoints to their metadata.
* Generate invocation stubs to lay out `object[]` arguments passed to `MethodBase.Invoke` on the stack.
* A small test.

Only methods that were compiled are eligible to be added to the map.