### PR TITLE
Make the existence of startup code private to compilation group

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
@@ -16,11 +16,16 @@ namespace ILCompiler
 {
     public abstract class CompilationModuleGroup
     {
+        /// <summary>
+        /// Symbolic name under which the managed entrypoint is exported.
+        /// </summary>
+        public const string ManagedEntryPointMethodName = "__managed__Main";
+
         protected CompilerTypeSystemContext _typeSystemContext;
 
-        public MethodDesc StartupCodeMain
+        private MethodDesc StartupCodeMain
         {
-            get; private set;
+            get; set;
         }
 
         protected CompilationModuleGroup(CompilerTypeSystemContext typeSystemContext)
@@ -151,7 +156,7 @@ namespace ILCompiler
             TypeDesc owningType = module.GetGlobalModuleType();
             StartupCodeMain = new StartupCodeMainMethod(_typeSystemContext, owningType, mainMethod);
 
-            rootProvider.AddCompilationRoot(StartupCodeMain, "Startup Code Main Method", "__managed__Main");
+            rootProvider.AddCompilationRoot(StartupCodeMain, "Startup Code Main Method", ManagedEntryPointMethodName);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilation.cs
@@ -32,7 +32,7 @@ namespace ILCompiler
 
             var nodes = _dependencyGraph.MarkedNodeList;
 
-            _cppWriter.OutputCode(nodes, NodeFactory.CompilationModuleGroup.StartupCodeMain, NodeFactory);
+            _cppWriter.OutputCode(nodes, NodeFactory);
         }
 
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -1267,7 +1267,7 @@ namespace ILCompiler.CppCodeGen
             Out.Write(sb.ToString());
         }
 
-        public void OutputCode(IEnumerable<DependencyNode> nodes, MethodDesc entrypoint, NodeFactory factory)
+        public void OutputCode(IEnumerable<DependencyNode> nodes, NodeFactory factory)
         {
             BuildMethodLists(nodes);
 
@@ -1305,6 +1305,12 @@ namespace ILCompiler.CppCodeGen
                 if (node is CppMethodCodeNode)
                     OutputMethodNode(node as CppMethodCodeNode);
             }
+
+            // Try to locate the entrypoint method
+            MethodDesc entrypoint = null;
+            foreach (var alias in factory.NodeAliases)
+                if (alias.Value == CompilationModuleGroup.ManagedEntryPointMethodName)
+                    entrypoint = ((IMethodNode)alias.Key).Method;
 
             if (entrypoint != null)
             {


### PR DESCRIPTION
The existence of the public StartupCode property has been a thorn in my eye for a while. I'm switching CppCodegen to use the same convention-based mechanism to locate the managed entrypoint as is used by the RyuJIT codebase.

(This is part of a larger refactoring of CompilationModuleGroup to gel better with reflection that will follow, but it's nicely reviewable.)