### PR TITLE
Name Mangling Robustness for Parameterized Types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -74,7 +74,15 @@ namespace ILCompiler
                 // TODO: We assume that there won't be collisions with our own or C++ built-in identifiers.
                 sb.Append("_");
             }
-            return (sb != null) ? sb.ToString() : s;
+
+            string santizedName = (sb != null) ? sb.ToString() : s;
+
+            // The character sequences denoting generic instantiations, arrays, byrefs, or pointers must be
+            // restricted to that use only. Replace them if they happened to be used in any identifiers in 
+            // the compilation input.
+            return _mangleForCplusPlus
+                ? santizedName.Replace(EnterNameScopeSequence, "_AA_").Replace(ExitNameScopeSequence, "_VV_")
+                : santizedName;
         }
 
         /// <summary>
@@ -107,6 +115,14 @@ namespace ILCompiler
                 return mangledName;
 
             return ComputeMangledTypeName(type);
+        }
+
+        private string EnterNameScopeSequence => _mangleForCplusPlus ? "_A_" : "<";
+        private string ExitNameScopeSequence => _mangleForCplusPlus ? "_V_" : ">";
+
+        private string NestMangledName(string name)
+        {
+            return EnterNameScopeSequence + name + ExitNameScopeSequence;
         }
 
         /// <summary>
@@ -165,41 +181,52 @@ namespace ILCompiler
                 return _mangledTypeNames[type];
             }
 
-
             string mangledName;
 
             switch (type.Category)
             {
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
-                    // mangledName = "Array<" + GetSignatureCPPTypeName(((ArrayType)type).ElementType) + ">";
-                    mangledName = GetMangledTypeName(((ArrayType)type).ElementType) + "__Array";
+                    mangledName = GetMangledTypeName(((ArrayType) type).ElementType) + "__";
+                    
                     if (type.IsMdArray)
-                        mangledName += "Rank" + ((ArrayType)type).Rank.ToStringInvariant();
+                    {
+                        mangledName += NestMangledName("ArrayRank" + ((ArrayType) type).Rank.ToStringInvariant());
+                    }
+                    else
+                    {
+                        mangledName += NestMangledName("Array");
+                    }
                     break;
                 case TypeFlags.ByRef:
-                    mangledName = GetMangledTypeName(((ByRefType)type).ParameterType) + "__ByRef";
+                    mangledName = GetMangledTypeName(((ByRefType)type).ParameterType) + NestMangledName("ByRef");
                     break;
                 case TypeFlags.Pointer:
-                    mangledName = GetMangledTypeName(((PointerType)type).ParameterType) + "__Pointer";
+                    mangledName = GetMangledTypeName(((PointerType)type).ParameterType) + NestMangledName("Pointer");
                     break;
                 default:
                     // Case of a generic type. If `type' is a type definition we use the type name
                     // for mangling, otherwise we use the mangling of the type and its generic type
-                    // parameters, e.g. A <B> becomes A__B.
+                    // parameters, e.g. A <B> becomes A_<___B_>_ in RyuJIT compilation, or A_A___B_V_
+                    // in C++ compilation.
                     var typeDefinition = type.GetTypeDefinition();
                     if (typeDefinition != type)
                     {
                         mangledName = GetMangledTypeName(typeDefinition);
 
                         var inst = type.Instantiation;
+                        string mangledInstantiation = "";
                         for (int i = 0; i < inst.Length; i++)
                         {
                             string instArgName = GetMangledTypeName(inst[i]);
                             if (_mangleForCplusPlus)
                                 instArgName = instArgName.Replace("::", "_");
-                            mangledName += "__" + instArgName;
+                            if (i > 0)
+                                mangledInstantiation += "__";
+                                        
+                            mangledInstantiation += instArgName;
                         }
+                        mangledName += NestMangledName(mangledInstantiation);
                     }
                     else
                     {
@@ -268,13 +295,17 @@ namespace ILCompiler
                 mangledName = GetMangledMethodName(methodDefinition.GetMethodDefinition());
 
                 var inst = method.Instantiation;
+                string mangledInstantiation = "";
                 for (int i = 0; i < inst.Length; i++)
                 {
                     string instArgName = GetMangledTypeName(inst[i]);
                     if (_mangleForCplusPlus)
                         instArgName = instArgName.Replace("::", "_");
-                    mangledName += "__" + instArgName;
+                    if (i > 0)
+                        mangledInstantiation += "__";
+                    mangledInstantiation += instArgName;
                 }
+                mangledName += NestMangledName(mangledInstantiation);
             }
             else
             {

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -13,6 +13,7 @@ class Program
         TestInitThisClass.Run();
         TestDelegateFatFunctionPointers.Run();
         TestVirtualMethodUseTracking.Run();
+        TestNameManglingCollisionRegression.Run();
 
         return 100;
     }
@@ -224,5 +225,23 @@ class Program
                 throw new Exception();
         }
     }
-}
 
+    //
+    // Regression test for issue https://github.com/dotnet/corert/issues/1964
+    //
+    class TestNameManglingCollisionRegression
+    {
+        class Gen1<T>
+        {
+            public Gen1(T t) {}
+        }
+
+        public static void Run()
+        {
+            Gen1<object[]>[] g1 = new Gen1<object[]>[1];
+            g1[0] = new Gen1<object[]>(new object[] {new object[1]});
+
+            Gen1<object[][]> g2 = new Gen1<object[][]>(new object[1][]);
+        }
+    }
+}


### PR DESCRIPTION
Fix issue https://github.com/dotnet/corert/issues/1964 and provide robustness for mangled type names.