### PR TITLE
Set RyuJit IL offsets for prolog and epilog.

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -326,7 +326,15 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     foreach (var loc in locs)
                     {
-                        _offsetToDebugLoc.Add(loc.NativeOffset, loc);
+                        if (_offsetToDebugLoc.ContainsKey(loc.NativeOffset) == false)
+                        {
+                            _offsetToDebugLoc.Add(loc.NativeOffset, loc);
+                        }
+                        else
+                        {
+                            // Empty epilog has the same NativeOffset as the instruction with the biggest IL offset.
+                            Debug.Assert(_offsetToDebugLoc[loc.NativeOffset].Equals(loc));
+                        }
                     }
                 }
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -326,15 +326,9 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     foreach (var loc in locs)
                     {
-                        if (_offsetToDebugLoc.ContainsKey(loc.NativeOffset) == false)
-                        {
-                            _offsetToDebugLoc.Add(loc.NativeOffset, loc);
-                        }
-                        else
-                        {
-                            // Empty epilog has the same NativeOffset as the instruction with the biggest IL offset.
-                            Debug.Assert(_offsetToDebugLoc[loc.NativeOffset].Equals(loc));
-                        }
+                        // TODO #2206: process the case with 
+                        // several debug nodes with the same native offset.
+                        _offsetToDebugLoc[loc.NativeOffset] = loc;
                     }
                 }
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1750,7 +1750,7 @@ namespace Internal.JitInterface
             *implicitBoundaries = BoundaryTypes.DEFAULT_BOUNDARIES;
         }
 
-        // Create a DebugLocInfo which is a table from native offset to sourece line.
+        // Create a DebugLocInfo which is a table from native offset to source line.
         // using native to il offset (pMap) and il to source line (_sequencePoints).
         private void setBoundaries(CORINFO_METHOD_STRUCT_* ftn, uint cMap, OffsetMapping* pMap)
         {
@@ -1761,27 +1761,37 @@ namespace Internal.JitInterface
                 return;
             }
 
+            int largestILOffset = 0; // All epiloges point to the largest IL offset.
+            foreach(var s in _sequencePoints)
+            {
+                if (s.Key > largestILOffset)
+                {
+                    largestILOffset = s.Key;
+                }
+            }
+
             List<DebugLocInfo> debugLocInfos = new List<DebugLocInfo>();
             for (int i = 0; i < cMap; i++)
             {
+                OffsetMapping nativeToILInfo = pMap[i];
+                int ilOffset = (int)nativeToILInfo.ilOffset;
+                switch (ilOffset)
+                {
+                    case (int)ICorDebugInfo.PROLOG:
+                        ilOffset = 0;
+                        break;
+                    case (int)ICorDebugInfo.EPILOG:
+                        ilOffset = largestILOffset;
+                        break;
+                    case (int)ICorDebugInfo.NO_MAPPING:
+                        continue;
+                }
                 SequencePoint s;
-                if (_sequencePoints.TryGetValue((int)pMap[i].ilOffset, out s))
+                if (_sequencePoints.TryGetValue((int)ilOffset, out s))
                 {
                     Debug.Assert(!string.IsNullOrEmpty(s.Document));
                     int nativeOffset = (int)pMap[i].nativeOffset;
                     DebugLocInfo loc = new DebugLocInfo(nativeOffset, s.Document, s.LineNumber);
-
-                    // https://github.com/dotnet/corert/issues/270
-                    // We often miss line number at 0 offset, which prevents debugger from
-                    // stepping into callee.
-                    // Synthesize a location info at 0 offset assuming line number is minus one
-                    // from the first entry.
-                    if (debugLocInfos.Count == 0 && nativeOffset != 0)
-                    {
-                        DebugLocInfo firstLoc = new DebugLocInfo(0, loc.FileName, loc.LineNumber - 1, loc.ColNumber);
-                        debugLocInfos.Add(firstLoc);
-                    }
-
                     debugLocInfos.Add(loc);
                 }
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1762,11 +1762,13 @@ namespace Internal.JitInterface
             }
 
             int largestILOffset = 0; // All epiloges point to the largest IL offset.
-            foreach(var s in _sequencePoints)
+            for (int i = 0; i < cMap; i++)
             {
-                if (s.Key > largestILOffset)
+                OffsetMapping nativeToILInfo = pMap[i];
+                int currectILOffset = (int)nativeToILInfo.ilOffset;
+                if (currectILOffset > largestILOffset) // Special offsets are negative.
                 {
-                    largestILOffset = s.Key;
+                    largestILOffset = currectILOffset;
                 }
             }
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1779,13 +1779,13 @@ namespace Internal.JitInterface
                 int ilOffset = (int)nativeToILInfo.ilOffset;
                 switch (ilOffset)
                 {
-                    case (int)ICorDebugInfo.PROLOG:
+                    case (int)MappingTypes.PROLOG:
                         ilOffset = 0;
                         break;
-                    case (int)ICorDebugInfo.EPILOG:
+                    case (int)MappingTypes.EPILOG:
                         ilOffset = largestILOffset;
                         break;
-                    case (int)ICorDebugInfo.NO_MAPPING:
+                    case (int)MappingTypes.NO_MAPPING:
                         continue;
                 }
                 SequencePoint s;

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -1159,7 +1159,14 @@ namespace Internal.JitInterface
         public byte eightByteOffsets1;
     };
 
-    // DEBUGGER DATQA
+    // DEBUGGER DATA
+    public enum ICorDebugInfo
+    {
+        NO_MAPPING = -1, // -- The IL offset corresponds to no source code (such as EH step blocks).
+        PROLOG = -2,     // -- The IL offset indicates a prolog
+        EPILOG = -3      // -- The IL offset indicates an epilog
+    }
+
     public enum BoundaryTypes
     {
         NO_BOUNDARIES = 0x00,     // No implicit boundaries

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -1160,7 +1160,7 @@ namespace Internal.JitInterface
     };
 
     // DEBUGGER DATA
-    public enum ICorDebugInfo
+    public enum MappingTypes
     {
         NO_MAPPING = -1, // -- The IL offset corresponds to no source code (such as EH step blocks).
         PROLOG = -2,     // -- The IL offset indicates a prolog


### PR DESCRIPTION
Fix issue #270.

Repro case ( thanks Michal):
```
public static int Main(string[] args)
{ // breakpoint here works only with prolog symbol.
  {
    return 100;
  }
} // breakpoint here works only with epilog symbol.
```

RyuJit map from native to IL contains special symbols for Epilog, Prolog and NO_MAPPING.
PR supports Epilog and Prolog in CoreRT.