### PR TITLE
Use a CompilationRootProvider to root CppCodegen dependencies

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -15,12 +15,6 @@ namespace ILCompiler.DependencyAnalysis
         {
         }
 
-        public override void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
-        {
-            AddWellKnownTypes(graph);
-            base.AttachToDependencyGraph(graph);
-        }
-        
         protected override IMethodNode CreateMethodEntrypointNode(MethodDesc method)
         {
             if (CompilationModuleGroup.ContainsMethod(method))
@@ -44,33 +38,5 @@ namespace ILCompiler.DependencyAnalysis
             // TODO: this is wrong: this returns an assembly stub node
             return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
         }
-
-        private void AddWellKnownType(WellKnownType wellKnownType, DependencyAnalysisFramework.DependencyAnalyzerBase<NodeFactory> graph)
-        {
-            var type = TypeSystemContext.GetWellKnownType(wellKnownType);
-            var typeNode = ConstructedTypeSymbol(type);
-            graph.AddRoot(typeNode, "Enables CPP codegen");
-        }
-        private void AddWellKnownTypes(DependencyAnalysisFramework.DependencyAnalyzerBase<NodeFactory> graph)
-        {
-
-            AddWellKnownType(WellKnownType.Void, graph);
-            AddWellKnownType(WellKnownType.Boolean, graph);
-            AddWellKnownType(WellKnownType.Char, graph);
-            AddWellKnownType(WellKnownType.SByte, graph);
-            AddWellKnownType(WellKnownType.Byte, graph);
-            AddWellKnownType(WellKnownType.Int16, graph);
-            AddWellKnownType(WellKnownType.UInt16, graph);
-            AddWellKnownType(WellKnownType.Int32, graph);
-            AddWellKnownType(WellKnownType.UInt32, graph);
-            AddWellKnownType(WellKnownType.Int64, graph);
-            AddWellKnownType(WellKnownType.UInt64, graph);
-            AddWellKnownType(WellKnownType.IntPtr, graph);
-            AddWellKnownType(WellKnownType.UIntPtr, graph);
-            AddWellKnownType(WellKnownType.Single, graph);
-            AddWellKnownType(WellKnownType.Double, graph);
-
-        }
-
     }
 }


### PR DESCRIPTION
It doesn't change much, but this is how we would have done this if roots
were represented as a separate thing.

NodeFactory::AttachToDependencyGraph needs to stay virtual because of a
TFS dependency, but we should be able to factor that differently too at
some point.