### PR TITLE
Make CompilationRootProvider an interface

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -29,7 +29,7 @@ namespace ILCompiler
         protected Compilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
             NodeFactory nodeFactory,
-            IEnumerable<CompilationRootProvider> compilationRoots,
+            IEnumerable<ICompilationRootProvider> compilationRoots,
             NameMangler nameMangler,
             Logger logger)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -18,7 +18,7 @@ namespace ILCompiler
         // calling the Use/Configure methods and still get something reasonable back.
         protected Logger _logger = Logger.Null;
         private DependencyTrackingLevel _dependencyTrackingLevel = DependencyTrackingLevel.None;
-        protected IEnumerable<CompilationRootProvider> _compilationRoots = Array.Empty<CompilationRootProvider>();
+        protected IEnumerable<ICompilationRootProvider> _compilationRoots = Array.Empty<ICompilationRootProvider>();
 
         public CompilationBuilder(NodeFactory nodeFactory)
         {
@@ -37,7 +37,7 @@ namespace ILCompiler
             return this;
         }
 
-        public CompilationBuilder UseCompilationRoots(IEnumerable<CompilationRootProvider> compilationRoots)
+        public CompilationBuilder UseCompilationRoots(IEnumerable<ICompilationRootProvider> compilationRoots)
         {
             _compilationRoots = compilationRoots;
             return this;

--- a/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilation.cs
@@ -21,7 +21,7 @@ namespace ILCompiler
         internal CppCodegenCompilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
             NodeFactory nodeFactory,
-            IEnumerable<CompilationRootProvider> roots,
+            IEnumerable<ICompilationRootProvider> roots,
             Logger logger,
             CppCodegenConfigProvider options)
             : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), new NameMangler(true), logger)
@@ -29,7 +29,7 @@ namespace ILCompiler
             Options = options;
         }
 
-        private static IEnumerable<CompilationRootProvider> GetCompilationRoots(IEnumerable<CompilationRootProvider> existingRoots, NodeFactory factory)
+        private static IEnumerable<ICompilationRootProvider> GetCompilationRoots(IEnumerable<ICompilationRootProvider> existingRoots, NodeFactory factory)
         {
             yield return new CppCodegenCompilationRootProvider(factory.TypeSystemContext);
 
@@ -54,7 +54,7 @@ namespace ILCompiler
             }
         }
 
-        private class CppCodegenCompilationRootProvider : CompilationRootProvider
+        private class CppCodegenCompilationRootProvider : ICompilationRootProvider
         {
             private TypeSystemContext _context;
 
@@ -69,7 +69,7 @@ namespace ILCompiler
                 rootProvider.AddCompilationRoot(type, "Enables CPP codegen");
             }
 
-            internal override void AddCompilationRoots(IRootingServiceProvider rootProvider)
+            public void AddCompilationRoots(IRootingServiceProvider rootProvider)
             {
                 RootWellKnownType(WellKnownType.Void, rootProvider);
                 RootWellKnownType(WellKnownType.Boolean, rootProvider);

--- a/src/ILCompiler.Compiler/src/Compiler/ExportedMethodsRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ExportedMethodsRootProvider.cs
@@ -9,7 +9,7 @@ namespace ILCompiler
     /// <summary>
     /// Computes a set of roots based on managed and unmanaged methods exported from a module.
     /// </summary>
-    public class ExportedMethodsRootProvider : CompilationRootProvider
+    public class ExportedMethodsRootProvider : ICompilationRootProvider
     {
         private EcmaModule _module;
 
@@ -18,7 +18,7 @@ namespace ILCompiler
             _module = module;
         }
 
-        internal override void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        public void AddCompilationRoots(IRootingServiceProvider rootProvider)
         {
             foreach (var type in _module.GetAllTypes())
             {

--- a/src/ILCompiler.Compiler/src/Compiler/ICompilationRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ICompilationRootProvider.cs
@@ -7,8 +7,12 @@ namespace ILCompiler
     /// <summary>
     /// Provides a set of seeds from which compilation will start.
     /// </summary>
-    public abstract class CompilationRootProvider
+    public interface ICompilationRootProvider
     {
-        internal abstract void AddCompilationRoots(IRootingServiceProvider rootProvider);
+        /// <summary>
+        /// When implemented in a class, uses <paramref name="rootProvider"/> to add compilation
+        /// roots to the compilation.
+        /// </summary>
+        void AddCompilationRoots(IRootingServiceProvider rootProvider);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -10,7 +10,7 @@ namespace ILCompiler
     /// <summary>
     /// Provides compilation group for a library that compiles everything in the input IL module.
     /// </summary>
-    public class LibraryRootProvider : CompilationRootProvider
+    public class LibraryRootProvider : ICompilationRootProvider
     {
         private EcmaModule _module;
 
@@ -19,7 +19,7 @@ namespace ILCompiler
             _module = module;
         }
 
-        internal override void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        public void AddCompilationRoots(IRootingServiceProvider rootProvider)
         {
             foreach (TypeDesc type in _module.GetAllTypes())
             {

--- a/src/ILCompiler.Compiler/src/Compiler/MainMethodRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MainMethodRootProvider.cs
@@ -13,7 +13,7 @@ namespace ILCompiler
     /// <summary>
     /// Computes a compilation root based on the entrypoint of the assembly.
     /// </summary>
-    public class MainMethodRootProvider : CompilationRootProvider
+    public class MainMethodRootProvider : ICompilationRootProvider
     {
         /// <summary>
         /// Symbolic name under which the managed entrypoint is exported.
@@ -27,7 +27,7 @@ namespace ILCompiler
             _module = module;
         }
 
-        internal override void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        public void AddCompilationRoots(IRootingServiceProvider rootProvider)
         {
             MethodDesc mainMethod = _module.EntryPoint;
             if (mainMethod == null)

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
@@ -22,7 +22,7 @@ namespace ILCompiler
         internal RyuJitCompilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
             NodeFactory nodeFactory,
-            IEnumerable<CompilationRootProvider> roots,
+            IEnumerable<ICompilationRootProvider> roots,
             Logger logger,
             JitConfigProvider configProvider)
             : base(dependencyGraph, nodeFactory, roots, new NameMangler(false), logger)

--- a/src/ILCompiler.Compiler/src/Compiler/SingleMethodRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleMethodRootProvider.cs
@@ -9,7 +9,7 @@ namespace ILCompiler
     /// <summary>
     /// Compilation root that is a single method.
     /// </summary>
-    public class SingleMethodRootProvider : CompilationRootProvider
+    public class SingleMethodRootProvider : ICompilationRootProvider
     {
         private MethodDesc _method;
 
@@ -18,7 +18,7 @@ namespace ILCompiler
             _method = method;
         }
 
-        internal override void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        public void AddCompilationRoots(IRootingServiceProvider rootProvider)
         {
             rootProvider.AddCompilationRoot(_method, "Single method root");
         }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -74,7 +74,7 @@
     <Compile Include="..\..\JitInterface\src\JitConfigProvider.cs">
       <Link>JitInterface\JitConfigProvider.cs</Link>
     </Compile>
-    <Compile Include="Compiler\CompilationRootProvider.cs" />
+    <Compile Include="Compiler\ICompilationRootProvider.cs" />
     <Compile Include="Compiler\Compilation.cs" />
     <Compile Include="Compiler\CompilationBuilder.cs" />
     <Compile Include="Compiler\CompilationModuleGroup.cs" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -179,7 +179,7 @@ namespace ILCompiler
             MethodDesc singleMethod = CheckAndParseSingleMethodModeArguments(typeSystemContext);
 
             CompilationModuleGroup compilationGroup;
-            List<CompilationRootProvider> compilationRoots = new List<CompilationRootProvider>();
+            List<ICompilationRootProvider> compilationRoots = new List<ICompilationRootProvider>();
             if (singleMethod != null)
             {
                 // Compiling just a single method


### PR DESCRIPTION
I should have done this yesterday. This should be an interface so that
the class that manages reflection roots can implement it without having
to derive from it.