### PR TITLE
Update CoreCLR tests.zip due to CI removing it

### DIFF
--- a/CoreCLRTestsURL.txt
+++ b/CoreCLRTestsURL.txt
@@ -1,1 +1,1 @@
-https://ci.dot.net/job/dotnet_coreclr/job/master/job/debug_windows_nt_prtest/842/artifact/bin/tests/tests.zip
+https://ci.dot.net/job/dotnet_coreclr/job/master/job/debug_windows_nt_prtest/4/artifact/bin/tests/tests.zip

--- a/Documentation/engineering/updating-coreclr-tests.md
+++ b/Documentation/engineering/updating-coreclr-tests.md
@@ -1,0 +1,14 @@
+# Updating CoreCLR Tests Zip
+
+The set of CoreCLR tests run as part of CoreRT's CI and available via `tests\runtest.cmd /coreclr` download are downloaded as a zip file from the CoreCLR build. We use a specific build number to ensure we're running against a set of tests known to be compatible with CoreRT. Rolling forward to a new set of tests involves these steps:
+
+1. Find a known good tests.zip from the CoreCLR build
+   1. Go to https://github.com/dotnet/coreclr/pulls and open the most-recently passing PR (it should have a green check mark next to it)
+   2. In the CI checks, open the details for `Windows_NT x64 Debug Build and Test`
+   3. Navigate through `Build Artifacts` -> `bin` -> `tests`
+   4. Copy the URL to `tests.zip`
+2. Retain the CI build so Jenkins doesn't delete `tests.zip`
+   1. In the PR job page (where you clicked `Build Artifacts` earlier) ensure you're logged in to Jenkins
+   2. Click the `Keep this build forever` button at the top-right
+3. Paste the `tests.zip` URL into `CoreCLRTestsURL.txt`
+4. Check your work by building and then running `tests\runtest.cmd /coreclr`


### PR DESCRIPTION
The CoreCLR set of CI jobs was altered and the job containing the
tests.zip we rely on for CoreRT was removed. That caused all permanently
retained builds to be deleted. Update tests.zip to use the new job.