### PR TITLE
Fix CPP test warning on Windows

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -27,7 +27,9 @@ See the LICENSE file in the project root for more information.
       <CppCompilerAndLinkerArg Include="/Fo$(NativeObject)" />
       <CppCompilerAndLinkerArg Condition="'$(Configuration)' == 'Debug'" Include="/Od" />
       <CppCompilerAndLinkerArg Condition="'$(Configuration)' != 'Debug'" Include="/O2" />
-      <CppCompilerAndLinkerArg Include="/c /nologo /W3 /GS /DCPPCODEGEN /EHs /MT /Zi" />
+      <CppCompilerAndLinkerArg Include="/c /nologo /W3 /GS /DCPPCODEGEN /EHs /Zi" />
+      <CppCompilerAndLinkerArg Condition="'$(UseDebugCrt)' == 'true'" Include="/MTd" />
+      <CppCompilerAndLinkerArg Condition="'$(UseDebugCrt)' != 'true'" Include="/MT" />
       <CppCompilerAndLinkerArg Include="$(AdditionalCppCompilerFlags)" />
     </ItemGroup>
 

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -177,7 +177,7 @@ goto :eof
     if /i "%__Mode%" == "cpp" (
         set extraArgs=!extraArgs! /p:NativeCodeGen=cpp
         if /i "%CoreRT_BuildType%" == "debug" (
-            set extraArgs=!extraArgs! /p:AdditionalCppCompilerFlags=/MTd
+            set extraArgs=!extraArgs! /p:UseDebugCrt=true
         )
     )
 


### PR DESCRIPTION
We pass in /MTd flag to cl.exe when running tests but unconditionally
pass /MD for all compilations using the BuildIntegration targets. Pass a
more constrained property `UseDebugCrt` and select the appropriate
switch in the build targets.