### PR TITLE
Fix walking base hierarchy when computing dictionary slots

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
@@ -44,10 +44,16 @@ namespace ILCompiler
         private static int GetNumberOfBaseSlots(NodeFactory factory, TypeDesc owningType)
         {
             int baseSlots = 0;
-            var baseType = owningType.BaseType;
+            TypeDesc baseType = owningType.BaseType;
 
             while (baseType != null)
             {
+                // Normalize the base type. Necessary to make this work with the lazy vtable slot
+                // concept - if we start with a canonical type, the base type could end up being
+                // something like Base<__Canon, string>. We would get "0 slots used" for weird
+                // base types like this.
+                baseType = baseType.ConvertToCanonForm(CanonicalFormKind.Specific);
+
                 // For types that have a generic dictionary, the introduced virtual method slots are
                 // prefixed with a pointer to the generic dictionary.
                 if (baseType.HasGenericDictionarySlot())

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -13,6 +13,7 @@ class Program
         TestInitThisClass.Run();
         TestDelegateFatFunctionPointers.Run();
         TestVirtualMethodUseTracking.Run();
+        TestSlotsInHierarchy.Run();
         TestNameManglingCollisionRegression.Run();
 
         return 100;
@@ -222,6 +223,42 @@ class Program
 
             C2 c2 = new C2();
             if (new Derived<C2>().AsToo(c2) != c2)
+                throw new Exception();
+        }
+    }
+
+    /// <summary>
+    /// Makes sure that during the base slot computation for types such as
+    /// Derived&lt;__Canon&gt; (where the base type ends up being Base&lt;__Canon, string&gt;),
+    /// the lazy vtable slot computation works.
+    /// </summary>
+    class TestSlotsInHierarchy
+    {
+        class Base<T, U>
+        {
+            public virtual int Do()
+            {
+                return 42;
+            }
+        }
+
+        class Derived<T> : Base<T, string> where T : class
+        {
+            public T Cast(object v)
+            {
+                return v as T;
+            }
+        }
+
+        public static void Run()
+        {
+            var derived = new Derived<string>();
+            var derivedAsBase = (Base<string, string>)derived;
+
+            if (derivedAsBase.Do() != 42)
+                throw new Exception();
+
+            if (derived.Cast("Hello") != "Hello")
                 throw new Exception();
         }
     }


### PR DESCRIPTION
When the generic ready to run lookup helper needs to know the generic
dictionary vtable slot, it passes the canonical type to the helper that
determines the slot. `GetNumberOfBaseSlots` needs to be able to deal
with this, and the fact that the slots might be lazily determined.

Converting to canon fixes this due to how we ensure canonically
equivalent types have the same vtable in #2096. The other option would
be to back out that change and completely revamp how we do lazy slots
for generic types.

I found this when I ran the reflection invoke test with shared generics
enabled.