### PR TITLE
Remove all usage of ContainsGenericVariables

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -149,7 +149,10 @@ namespace ILCompiler
 
             public void AddCompilationRoot(TypeDesc type, string reason)
             {
-                _graph.AddRoot(_factory.ConstructedTypeSymbol(type), reason);
+                if (type.IsGenericDefinition)
+                    _graph.AddRoot(_factory.NecessaryTypeSymbol(type), reason);
+                else
+                    _graph.AddRoot(_factory.ConstructedTypeSymbol(type), reason);
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -23,8 +23,8 @@ namespace ILCompiler
         {
             foreach (TypeDesc type in _module.GetAllTypes())
             {
-                // Skip delegates (since their Invoke methods have no IL) and uninstantiated generic types
-                if (type.IsDelegate || type.HasInstantiation)
+                // Skip delegates (since their Invoke methods have no IL)
+                if (type.IsDelegate)
                     continue;
 
                 try
@@ -41,7 +41,9 @@ namespace ILCompiler
                     // TODO: Log as a warning
                 }
 
-                RootMethods(type, "Library module method", rootProvider);
+                // If this is not a generic definition, root all methods
+                if (!type.HasInstantiation)
+                    RootMethods(type, "Library module method", rootProvider);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -24,7 +24,7 @@ namespace ILCompiler
             foreach (TypeDesc type in _module.GetAllTypes())
             {
                 // Skip delegates (since their Invoke methods have no IL) and uninstantiated generic types
-                if (type.IsDelegate || type.ContainsGenericVariables)
+                if (type.IsDelegate || type.HasInstantiation)
                     continue;
 
                 try
@@ -50,7 +50,7 @@ namespace ILCompiler
             foreach (MethodDesc method in type.GetMethods())
             {
                 // Skip methods with no IL and uninstantiated generic methods
-                if (method.IsIntrinsic || method.IsAbstract || method.ContainsGenericVariables)
+                if (method.IsIntrinsic || method.IsAbstract || method.HasInstantiation)
                     continue;
 
                 if (method.IsInternalCall)

--- a/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
@@ -20,9 +20,6 @@ namespace ILCompiler
 
         public override bool ContainsType(TypeDesc type)
         {
-            if (type.ContainsGenericVariables)
-                return true;
-
             EcmaType ecmaType = type as EcmaType;
 
             if (ecmaType == null)
@@ -38,7 +35,7 @@ namespace ILCompiler
 
         public override bool ContainsMethod(MethodDesc method)
         {
-            if (method.GetTypicalMethodDefinition().ContainsGenericVariables)
+            if (method.HasInstantiation)
                 return true;
 
             return ContainsType(method.OwningType);


### PR DESCRIPTION
While this worked, I believe the intent is clearer with `HasInstantiation` in these places. It's also faster.

I'm making it so that the generic definition EEType gets generated into the module that defines it. This is where the reflection metadata should go too -  it's not allowed to duplicate it.

We have no use for ContainsGenericVariables after this.