### PR TITLE
Make RuntimeDeterminedMethod non-generic

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -198,8 +198,8 @@ namespace ILCompiler.DependencyAnalysis
 
             _runtimeDeterminedMethods = new NodeCache<MethodDesc, IMethodNode>(method =>
             {
-                return new RuntimeDeterminedMethodNode<MethodCodeNode>(method,
-                    (MethodCodeNode)MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific)));
+                return new RuntimeDeterminedMethodNode(method,
+                    MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific)));
             });
 
             _virtMethods = new NodeCache<MethodDesc, VirtualMethodUseNode>((MethodDesc method) =>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
@@ -17,10 +17,9 @@ namespace ILCompiler.DependencyAnalysis
     /// This node is used to represent references from canonical method bodies to other
     /// canonical methods.
     /// </summary>
-    internal class RuntimeDeterminedMethodNode<T> : DependencyNodeCore<NodeFactory>, IMethodNode, INodeWithRuntimeDeterminedDependencies
-        where T : DependencyNodeCore<NodeFactory>, IMethodNode
+    internal class RuntimeDeterminedMethodNode : DependencyNodeCore<NodeFactory>, IMethodNode, INodeWithRuntimeDeterminedDependencies
     {
-        private readonly T _canonicalMethodNode;
+        private readonly IMethodNode _canonicalMethodNode;
 
         public MethodDesc Method { get; }
 
@@ -28,10 +27,11 @@ namespace ILCompiler.DependencyAnalysis
         int ISymbolNode.Offset => _canonicalMethodNode.Offset;
         string ISymbolNode.MangledName => _canonicalMethodNode.MangledName;
 
-        public RuntimeDeterminedMethodNode(MethodDesc method, T canonicalMethod)
+        public RuntimeDeterminedMethodNode(MethodDesc method, IMethodNode canonicalMethod)
         {
             Debug.Assert(!method.IsSharedByGenericInstantiations);
             Debug.Assert(method.IsRuntimeDeterminedExactMethod);
+            Debug.Assert(canonicalMethod is DependencyNodeCore<NodeFactory>);
             Method = method;
             _canonicalMethodNode = canonicalMethod;
         }


### PR DESCRIPTION
I made this generic so that we can statically enforce that the canonical
method node is both a `DependencyNodeCore` and an `IMethodNode`.
Unfortunately the cast to `MethodCodeNode` doesn't work in single method
compilation mode because the method could end up being an ExternMethod.
I'm removing the genericness because it's just getting in the way.