### PR TITLE
Change the mangled names to use Utf8String

### DIFF
--- a/src/Common/src/Internal/Text/Utf8String.cs
+++ b/src/Common/src/Internal/Text/Utf8String.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Internal.Text
+{
+    public struct Utf8String
+    {
+        private byte[] _value;
+
+        public Utf8String(byte[] underlyingArray)
+        {
+            _value = underlyingArray;
+        }
+
+        public Utf8String(string s)
+        {
+            _value = Encoding.UTF8.GetBytes(s);
+        }
+
+        // TODO: This should return ReadOnlySpan<byte> instead once available
+        public byte[] UnderlyingArray => _value;
+        public int Length => _value.Length;
+
+        // For now, define implicit conversions between string and Utf8String to aid the transition
+        // These conversions will be removed eventually
+        public static implicit operator Utf8String(string s)
+        {
+            return new Utf8String(s);
+        }
+
+        public override string ToString()
+        {
+            return Encoding.UTF8.GetString(_value);
+        }
+    }
+}

--- a/src/Common/src/Internal/Text/Utf8StringBuilder.cs
+++ b/src/Common/src/Internal/Text/Utf8StringBuilder.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+namespace Internal.Text
+{
+    public class Utf8StringBuilder
+    {
+        private byte[] _buffer = Array.Empty<byte>();
+        private int _length = 0;
+
+        public Utf8StringBuilder()
+        {
+        }
+
+        // TODO: This should return ReadOnlySpan<byte> instead once available
+        public byte[] UnderlyingArray => _buffer;
+        public int Length => _length;
+
+        public Utf8StringBuilder Clear()
+        {
+            _length = 0;
+            return this;
+        }
+
+        public Utf8StringBuilder Append(Utf8String value)
+        {
+            return Append(value.UnderlyingArray);
+        }
+
+        public Utf8StringBuilder Append(byte[] value)
+        {
+            Ensure(value.Length);
+            Buffer.BlockCopy(value, 0, _buffer, _length, value.Length);
+            _length += value.Length;
+            return this;
+        }
+
+        public Utf8StringBuilder Append(char value)
+        {
+            Ensure(1);
+            if (value > 0x7F)
+                return Append(Encoding.UTF8.GetBytes(new char[] { value }));
+            _buffer[_length++] = (byte)value;
+            return this;
+        }
+
+        public Utf8StringBuilder Append(string value)
+        {
+            Ensure(value.Length);
+
+            byte[] buffer = _buffer;
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                if (c > 0x7F)
+                    return Append(Encoding.UTF8.GetBytes(value));
+                buffer[_length+i] = (byte)c;
+            }
+            _length += value.Length;
+
+            return this;
+        }
+
+        public override string ToString()
+        {
+            return Encoding.UTF8.GetString(_buffer, 0, _length);
+        }
+
+        public Utf8String ToUtf8String()
+        {
+            var ret = new byte[_length];
+            Buffer.BlockCopy(_buffer, 0, ret, 0, _length);
+            return new Utf8String(ret);
+        }
+
+        private void Ensure(int extraSpace)
+        {
+            if ((uint)(_length + extraSpace) > (uint)_buffer.Length)
+                Grow(extraSpace);
+        }
+
+        private void Grow(int extraSpace)
+        {
+            int newSize = Math.Max(2 * _buffer.Length, _length + extraSpace);
+            byte[] newBuffer = new byte[newSize];
+            Buffer.BlockCopy(_buffer, 0, newBuffer, 0, _length);
+            _buffer = newBuffer;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -104,6 +104,7 @@ namespace ILCompiler
 
             string systemModuleName = ((IAssemblyDesc)NodeFactory.TypeSystemContext.SystemModule).GetName().Name;
 
+            // TODO: CompilationUnitPrefix is used even before this point!!!
             // TODO: just something to get Runtime.Base compiled
             if (systemModuleName != "System.Private.CoreLib")
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 
 using Internal.NativeFormat;
+using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -19,54 +20,23 @@ namespace ILCompiler.DependencyAnalysis
 
         public ArrayMapNode(ExternalReferencesTableNode externalReferences)
         {
-            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, this.GetMangledName() + "End");
             _externalReferences = externalReferences;
         }
 
-        public ISymbolNode EndSymbol
-        {
-            get
-            {
-                return _endSymbol;
-            }
-        }
+        public ISymbolNode EndSymbol => _endSymbol;
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__array_type_map";
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__array_type_map");
         }
+        public int Offset => 0;
 
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
@@ -31,21 +31,8 @@ namespace ILCompiler.DependencyAnalysis
             _sorter = nodeSorter;
         }
 
-        internal ObjectAndOffsetSymbolNode StartSymbol
-        {
-            get
-            {
-                return _startSymbol;
-            }
-        }
-
-        internal ObjectAndOffsetSymbolNode EndSymbol
-        {
-            get
-            {
-                return _endSymbol;
-            }
-        }
+        internal ObjectAndOffsetSymbolNode StartSymbol => _startSymbol;
+        internal ObjectAndOffsetSymbolNode EndSymbol => _endSymbol;
 
         public void AddEmbeddedObject(TEmbedded symbol)
         {
@@ -61,34 +48,13 @@ namespace ILCompiler.DependencyAnalysis
             return _nestedNodesList.IndexOf(symbol);
         }
 
-        protected override string GetName()
-        {
-            return "Region " + ((ISymbolNode)_startSymbol).MangledName;
-        }
+        protected override string GetName() => $"Region {_startSymbol.GetMangledName()}";
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        protected IEnumerable<TEmbedded> NodesList
-        {
-            get
-            {
-                return _nestedNodesList;
-            }
-        }
+        protected IEnumerable<TEmbedded> NodesList =>  _nestedNodesList;
 
         protected virtual void GetElementDataForNodes(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.Text;
+
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
@@ -77,10 +79,7 @@ namespace ILCompiler.DependencyAnalysis
                 _parentNode = futureParent;
             }
 
-            protected override string GetName()
-            {
-                return "Embedded pointer to " + Target.MangledName;
-            }
+            protected override string GetName() => $"Embedded pointer to {Target.GetMangledName()}";
 
             protected override void OnMarked(NodeFactory factory)
             {
@@ -109,12 +108,9 @@ namespace ILCompiler.DependencyAnalysis
                 _id = id;
             }
 
-            public string MangledName
+            public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
             {
-                get
-                {
-                    return String.Concat(_parentNode._startSymbolMangledName, "_", _id.ToStringInvariant());
-                }
+                sb.Append(_parentNode._startSymbolMangledName).Append("_").Append(_id.ToStringInvariant());
             }
         }
         

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
@@ -3,13 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ILCompiler.DependencyAnalysisFramework;
-using System.Diagnostics;
+
 using Internal.TypeSystem;
+
+using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -19,42 +16,12 @@ namespace ILCompiler.DependencyAnalysis
         {
         }
 
-        public ISymbolNode Symbol
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.TextSection;
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.TextSection;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
-
-        public abstract string MangledName
-        {
-            get;
-        }
+        public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
+        public int Offset => 0;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
@@ -4,16 +4,18 @@
 
 using System;
 
+using Internal.Text;
+
 namespace ILCompiler.DependencyAnalysis
 {
     public class BlobNode : ObjectNode, ISymbolNode
     {
-        private string _name;
+        private Utf8String _name;
         private ObjectNodeSection _section;
         private byte[] _data;
         private int _alignment;
 
-        public BlobNode(string name, ObjectNodeSection section, byte[] data, int alignment)
+        public BlobNode(Utf8String name, ObjectNodeSection section, byte[] data, int alignment)
         {
             _name = name;
             _section = section;
@@ -21,46 +23,20 @@ namespace ILCompiler.DependencyAnalysis
             _alignment = alignment;
         }
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return _section;
-            }
-        }
+        public override ObjectNodeSection Section => _section;
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool StaticDependenciesAreComputed
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return true;
-            }
+            sb.Append(_name);
         }
-
-        string ISymbolNode.MangledName
-        {
-            get
-            {
-                return _name;
-            }
-        }
-
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public int Offset => 0;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             return new ObjectData(_data, Array.Empty<Relocation>(), _alignment, new ISymbolNode[] { this });
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClassConstructorContextMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClassConstructorContextMap.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 
 using Internal.NativeFormat;
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -19,24 +20,23 @@ namespace ILCompiler.DependencyAnalysis
 
         public ClassConstructorContextMap(ExternalReferencesTableNode externalReferences)
         {
-            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, this.GetMangledName() + "End");
             _externalReferences = externalReferences;
         }
 
         public ISymbolNode EndSymbol => _endSymbol;
 
-        string ISymbolNode.MangledName => NodeFactory.CompilationUnitPrefix + "__type_to_cctorContext_map";
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__type_to_cctorContext_map");
+        }
+        public int Offset => 0;
 
-        int ISymbolNode.Offset => 0;
-        
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
-            
+
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -12,21 +13,15 @@ namespace ILCompiler.DependencyAnalysis
         {
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName + " cloned";
-        }
+        protected override string GetName() => this.GetMangledName() + " cloned";
 
         //
         // A cloned type must be named differently than the type it is a clone of so the linker
         // will have an unambiguous symbol to resolve
         //
-        string ISymbolNode.MangledName
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return GetMangledName(_type) + "_Clone";
-            }
+            sb.Append("__Cloned_EEType_").Append(nameMangler.GetMangledTypeName(_type));
         }
 
         public override bool ShouldShareNodeAcrossModules(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -6,23 +6,20 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
-using ILCompiler.DependencyAnalysisFramework;
 using Internal.Runtime;
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    internal class ConstructedEETypeNode : EETypeNode, ISymbolNode
+    internal class ConstructedEETypeNode : EETypeNode
     {
         public ConstructedEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
         {
             Debug.Assert(!_type.IsGenericDefinition);
         }
-        
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName + " constructed";
-        }
+
+        protected override string GetName() => this.GetMangledName() + " constructed";
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
-using Internal.TypeSystem;
 
 using ILCompiler.DependencyAnalysisFramework;
-using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -45,58 +47,20 @@ namespace ILCompiler.DependencyAnalysis
                 return _method;
             }
         }
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return _methodCode != null;
-            }
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        string ISymbolNode.MangledName
-        {
-            get
-            {
-                return NodeFactory.NameMangler.GetMangledMethodName(_method);
-            }
-        }
+        public override bool StaticDependenciesAreComputed => _methodCode != null;
 
-        int ISymbolNode.Offset
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return 0;
-            }
+            sb.Append(NodeFactory.NameMangler.GetMangledMethodName(_method));
         }
+        public int Offset => 0;
 
-        public override bool InterestingForDynamicDependencyAnalysis
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool HasDynamicDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool HasConditionalStaticDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
@@ -108,14 +72,7 @@ namespace ILCompiler.DependencyAnalysis
             return dependencies;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
-        {
-            return null;
-        }
-
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
-        {
-            return null;
-        }
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -99,19 +99,15 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName()
-        {
-            return String.Concat("Dictionary layout for " + _owningMethodOrType.ToString());
-        }
+        protected override string GetName() => $"Dictionary layout for {_owningMethodOrType.ToString()}";
 
         public override bool HasConditionalStaticDependencies => false;
         public override bool HasDynamicDependencies => false;
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool StaticDependenciesAreComputed => true;
+
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
-            List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(
-            NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 using ILCompiler.DependencyAnalysisFramework;
+
 using Internal.IL;
 using Internal.Runtime;
+using Internal.Text;
 using Internal.TypeSystem;
-using System;
-using System.Collections.Generic;
 
 using Debug = System.Diagnostics.Debug;
 using GenericVariance = Internal.Runtime.GenericVariance;
@@ -71,10 +73,7 @@ namespace ILCompiler.DependencyAnalysis
             CheckCanGenerateEEType(factory, type);
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {
@@ -82,11 +81,8 @@ namespace ILCompiler.DependencyAnalysis
             return ((DependencyNode)factory.ConstructedTypeSymbol(_type)).Marked;
         }
 
-        public TypeDesc Type
-        {
-            get { return _type; }
-        }
-        
+        public TypeDesc Type => _type;
+
         public override ObjectNodeSection Section
         {
             get
@@ -113,39 +109,18 @@ namespace ILCompiler.DependencyAnalysis
             return factory.CompilationModuleGroup.ShouldShareAcrossModules(_type);
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public void SetDispatchMapIndex(int index)
         {
             _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldTag.DispatchMap, checked((uint)index));
         }
 
-        int ISymbolNode.Offset
+        public virtual void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return GCDescSize;
-            }
+            sb.Append("__EEType_").Append(nameMangler.GetMangledTypeName(_type));
         }
-
-        string ISymbolNode.MangledName
-        {
-            get
-            {
-                return GetMangledName(_type);
-            }
-        }
-
-        public static string GetMangledName(TypeDesc type)
-        {
-            return "__EEType_" + NodeFactory.NameMangler.GetMangledTypeName(type);
-        }
+        public int Offset => GCDescSize;
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.Runtime;
-using Internal.TypeSystem;
+using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -32,34 +31,16 @@ namespace ILCompiler.DependencyAnalysis
             return true;
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        int ISymbolNode.Offset
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return 0;
-            }
+            sb.Append("__optionalfields_");
+            _owner.AppendMangledName(nameMangler, sb);
         }
+        public int Offset => 0;
 
-        string ISymbolNode.MangledName
-        {
-            get
-            {
-                return "__optionalfields_" + ((ISymbolNode)_owner).MangledName;
-            }
-        }
-
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
@@ -35,39 +35,13 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
-        {
-            return null;
-        }
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
-        {
-            return null;
-        }
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
 
-        public override bool InterestingForDynamicDependencyAnalysis
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool HasDynamicDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool HasConditionalStaticDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
         public abstract void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
@@ -19,26 +19,14 @@ namespace ILCompiler.DependencyAnalysis
         /// <summary>
         /// Target symbol this node points to.
         /// </summary>
-        public TTarget Target
-        {
-            get
-            {
-                return _targetNode;
-            }
-        }
+        public TTarget Target => _targetNode;
 
         internal EmbeddedPointerIndirectionNode(TTarget target)
         {
             _targetNode = target;
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
@@ -22,12 +22,6 @@ namespace ILCompiler.DependencyAnalysis
             EETypeNode.CheckCanGenerateEEType(factory, type);
         }
 
-        public TypeDesc Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public TypeDesc Type => _type;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using ILCompiler.DependencyAnalysisFramework;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -16,79 +15,28 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     public class ExternSymbolNode : DependencyNodeCore<NodeFactory>, ISymbolNode
     {
-        private string _name;
+        private Utf8String _name;
 
-        public ExternSymbolNode(string name)
+        public ExternSymbolNode(Utf8String name)
         {
             _name = name;
         }
 
-        protected override string GetName()
-        {
-            return "ExternSymbol " + _name;
-        }
+        protected override string GetName() => $"ExternSymbol {_name.ToString()}";
 
-        public int Offset
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return 0;
-            }
+            sb.Append(_name);
         }
+        public int Offset => 0;
 
-        public string MangledName
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool InterestingForDynamicDependencyAnalysis
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool HasDynamicDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool HasConditionalStaticDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
-        {
-            return null;
-        }
-
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
-        {
-            return null;
-        }
-
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
-        {
-            return null;
-        }
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.Text;
+
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
@@ -19,32 +21,16 @@ namespace ILCompiler.DependencyAnalysis
 
         public ExternalReferencesTableNode()
         {
-            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, this.GetMangledName() + "End");
         }
 
-        public ISymbolNode EndSymbol
-        {
-            get
-            {
-                return _endSymbol;
-            }
-        }
+        public ISymbolNode EndSymbol => _endSymbol;
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__external_references";
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__external_references");
         }
-
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public int Offset => 0;
 
         /// <summary>
         /// Adds a new entry to the table. Thread safety: not thread safe. Expected to be called at the final
@@ -65,26 +51,11 @@ namespace ILCompiler.DependencyAnalysis
             return index;
         }
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -23,11 +24,13 @@ namespace ILCompiler.DependencyAnalysis
             Method = methodRepresented;
         }
 
-        public string MangledName => "__fatpointer_" + NodeFactory.NameMangler.GetMangledMethodName(Method);
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("__fatpointer_").Append(NodeFactory.NameMangler.GetMangledMethodName(Method));
+        }
+        public int Offset => 0;
 
         public MethodDesc Method { get; }
-
-        public int Offset => 0;
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
@@ -35,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool ShouldShareNodeAcrossModules(NodeFactory factory) => true;
 
-        protected override string GetName() => MangledName;
+        protected override string GetName() => this.GetMangledName();
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
@@ -4,14 +4,15 @@
 
 using System.Collections.Generic;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
     public class FrozenStringNode : EmbeddedObjectNode, ISymbolNode
     {
-        string _data;
-        int _syncBlockSize;
+        private string _data;
+        private int _syncBlockSize;
 
         public FrozenStringNode(string data, TargetDetails target)
         {
@@ -19,21 +20,12 @@ namespace ILCompiler.DependencyAnalysis
             _syncBlockSize = target.PointerSize;
         }
 
-        public string MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__Str_" + NodeFactory.NameMangler.GetMangledStringName(_data);
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__Str_").Append(NodeFactory.NameMangler.GetMangledStringName(_data));
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override int Offset
         {
@@ -75,10 +67,7 @@ namespace ILCompiler.DependencyAnalysis
 
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -6,6 +6,7 @@ using System;
 using System.Text;
 
 using Internal.Runtime;
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -28,10 +29,7 @@ namespace ILCompiler.DependencyAnalysis
             _target = target;
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectNodeSection Section
         {
@@ -44,27 +42,14 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override bool StaticDependenciesAreComputed
+        public override bool StaticDependenciesAreComputed => true;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return true;
-            }
+            sb.Append("__GCStaticEEType_").Append(_gcMap.ToString());
         }
 
-        string ISymbolNode.MangledName
-        {
-            get
-            {
-                StringBuilder nameBuilder = new StringBuilder();
-                nameBuilder.Append("__GCStaticEEType_");
-                nameBuilder.Append(_gcMap.ToString());
-
-                return nameBuilder.ToString();
-            }
-        }
-
-        int ISymbolNode.Offset
+        public int Offset
         {
             get
             {
@@ -97,7 +82,7 @@ namespace ILCompiler.DependencyAnalysis
                 GCDescEncoder.EncodeStandardGCDesc(ref dataBuilder, _gcMap, totalSize, 0);
             }
 
-            Debug.Assert(dataBuilder.CountBytes == ((ISymbolNode)this).Offset);
+            Debug.Assert(dataBuilder.CountBytes == Offset);
 
             dataBuilder.EmitShort(0); // ComponentSize is always 0
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -18,18 +19,13 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName()
+        protected override string GetName() => this.GetMangledName();
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            return ((ISymbolNode)this).MangledName;
+            sb.Append("__GCStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName(_type));
         }
-        
-        string ISymbolNode.MangledName
-        {
-            get
-            {
-                return "__GCStaticBase_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
-            }
-        }
+        public int Offset => 0;
 
         private ISymbolNode GetGCStaticEETypeNode(NodeFactory factory)
         {
@@ -57,29 +53,9 @@ namespace ILCompiler.DependencyAnalysis
             return factory.CompilationModuleGroup.ShouldShareAcrossModules(_type);
         }
 
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Text;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -25,32 +26,27 @@ namespace ILCompiler.DependencyAnalysis
             _details = details;
         }
 
-        public string MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
+            sb.Append("__GenericInstance");
+
+            bool hasVariance = false;
+
+            for (int i = 0; i < _details.Instantiation.Length; i++)
             {
-                StringBuilder sb = new StringBuilder("__GenericInstance");
+                sb.Append('_');
+                sb.Append(NodeFactory.NameMangler.GetMangledTypeName(_details.Instantiation[i]));
 
-                bool hasVariance = false;
+                hasVariance |= _details.Variance[i] != 0;
+            }
 
-                for (int i = 0; i < _details.Instantiation.Length; i++)
+            if (hasVariance)
+            {
+                for (int i = 0; i < _details.Variance.Length; i++)
                 {
                     sb.Append('_');
-                    sb.Append(NodeFactory.NameMangler.GetMangledTypeName(_details.Instantiation[i]));
-
-                    hasVariance |= _details.Variance[i] != 0;
+                    sb.Append((checked((byte)_details.Variance[i])).ToStringInvariant());
                 }
-
-                if (hasVariance)
-                {
-                    for (int i = 0; i < _details.Variance.Length; i++)
-                    {
-                        sb.Append('_');
-                        sb.Append((checked((byte)_details.Variance[i])).ToStringInvariant());
-                    }
-                }
-
-                return sb.ToString();
             }
         }
 
@@ -78,13 +74,7 @@ namespace ILCompiler.DependencyAnalysis
             return true;
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
@@ -124,10 +114,7 @@ namespace ILCompiler.DependencyAnalysis
             return builder.ToObjectData();
         }
 
-        protected override string GetName()
-        {
-            return MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
     }
 
     internal struct GenericCompositionDetails : IEquatable<GenericCompositionDetails>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using ILCompiler.DependencyAnalysisFramework;
 using Internal.Runtime;
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
-using GenericVariance = Internal.Runtime.GenericVariance;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -16,14 +15,6 @@ namespace ILCompiler.DependencyAnalysis
         public GenericDefinitionEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
         {
             Debug.Assert(type.IsGenericDefinition);
-        }
-        
-        string ISymbolNode.MangledName
-        {
-            get
-            {
-                return "__GenericDefinitionEEType_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
-            }
         }
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -40,9 +41,8 @@ namespace ILCompiler.DependencyAnalysis
             };
         }
 
+        public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
         public abstract int Offset { get; }
-
-        public abstract string MangledName { get; }
 
         public sealed override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
@@ -79,7 +79,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected sealed override string GetName()
         {
-            return MangledName;
+            return this.GetMangledName();
         }
     }
 
@@ -87,8 +87,11 @@ namespace ILCompiler.DependencyAnalysis
     {
         private TypeDesc _owningType;
 
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(MangledNamePrefix).Append(NodeFactory.NameMangler.GetMangledTypeName(_owningType));
+        }
         public override int Offset => 0;
-        public override string MangledName => MangledNamePrefix + NodeFactory.NameMangler.GetMangledTypeName(_owningType);
 
         protected override Instantiation TypeInstantiation => _owningType.Instantiation;
         protected override Instantiation MethodInstantiation => new Instantiation();
@@ -139,8 +142,11 @@ namespace ILCompiler.DependencyAnalysis
     {
         private MethodDesc _owningMethod;
 
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(MangledNamePrefix).Append(NodeFactory.NameMangler.GetMangledMethodName(_owningMethod));
+        }
         public override int Offset => _owningMethod.Context.Target.PointerSize;
-        public override string MangledName => MangledNamePrefix + NodeFactory.NameMangler.GetMangledMethodName(_owningMethod);
 
         protected override Instantiation TypeInstantiation => _owningMethod.OwningType.Instantiation;
         protected override Instantiation MethodInstantiation => _owningMethod.Instantiation;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using FatFunctionPointerConstants = Internal.Runtime.FatFunctionPointerConstants;
@@ -20,7 +21,7 @@ namespace ILCompiler.DependencyAnalysis
     public abstract class GenericLookupResult
     {
         public abstract ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation);
-        public abstract string GetMangledName(NameMangler nameMangler);
+        public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
         public abstract override string ToString();
 
         /// <summary>
@@ -50,9 +51,10 @@ namespace ILCompiler.DependencyAnalysis
             return factory.ConstructedTypeSymbol(instantiatedType);
         }
 
-        public override string GetMangledName(NameMangler nameMangler)
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            return $"TypeHandle_{nameMangler.GetMangledTypeName(_type)}";
+            sb.Append("TypeHandle_");
+            sb.Append(nameMangler.GetMangledTypeName(_type));
         }
 
         public override string ToString() => $"TypeHandle: {_type}";
@@ -77,9 +79,10 @@ namespace ILCompiler.DependencyAnalysis
             return factory.MethodGenericDictionary(instantiatedMethod);
         }
 
-        public override string GetMangledName(NameMangler nameMangler)
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            return $"MethodHandle_{nameMangler.GetMangledMethodName(_method)}";
+            sb.Append("MethodHandle_");
+            sb.Append(nameMangler.GetMangledMethodName(_method));
         }
 
         public override string ToString() => $"MethodHandle: {_method}";
@@ -106,9 +109,10 @@ namespace ILCompiler.DependencyAnalysis
             return factory.FatFunctionPointer(instantiatedMethod);
         }
 
-        public override string GetMangledName(NameMangler nameMangler)
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            return $"MethodEntry_{nameMangler.GetMangledMethodName(_method)}";
+            sb.Append("MethodEntry_");
+            sb.Append(nameMangler.GetMangledMethodName(_method));
         }
 
         public override string ToString() => $"MethodEntry: {_method}";
@@ -133,9 +137,10 @@ namespace ILCompiler.DependencyAnalysis
             return factory.ReadyToRunHelper(ReadyToRunHelperId.VirtualCall, instantiatedMethod);
         }
 
-        public override string GetMangledName(NameMangler nameMangler)
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            return $"VirtualCall_{nameMangler.GetMangledMethodName(_method)}";
+            sb.Append("VirtualCall_");
+            sb.Append(nameMangler.GetMangledMethodName(_method));
         }
 
         public override string ToString() => $"VirtualCall: {_method}";
@@ -161,9 +166,10 @@ namespace ILCompiler.DependencyAnalysis
             return factory.TypeNonGCStaticsSymbol(instantiatedType);
         }
 
-        public override string GetMangledName(NameMangler nameMangler)
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            return $"NonGCStaticBase_{nameMangler.GetMangledTypeName(_type)}";
+            sb.Append("NonGCStaticBase_");
+            sb.Append(nameMangler.GetMangledTypeName(_type));
         }
 
         public override string ToString() => $"NonGCStaticBase: {_type}";
@@ -189,9 +195,10 @@ namespace ILCompiler.DependencyAnalysis
             return factory.TypeGCStaticsSymbol(instantiatedType);
         }
 
-        public override string GetMangledName(NameMangler nameMangler)
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            return $"GCStaticBase_{nameMangler.GetMangledTypeName(_type)}";
+            sb.Append("GCStaticBase_");
+            sb.Append(nameMangler.GetMangledTypeName(_type));
         }
 
         public override string ToString() => $"GCStaticBase: {_type}";

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
@@ -3,23 +3,35 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
 {
     public interface ISymbolNode
     {
-        int Offset
-        {
-            get;
-        }
+        void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
+        int Offset { get; }
+    }
 
-        string MangledName
+    static public class ISymbolNodeExtensions
+    {
+        [ThreadStatic]
+        static Utf8StringBuilder s_cachedUtf8StringBuilder;
+
+        static public string GetMangledName(this ISymbolNode symbolNode)
         {
-            get;
+            Utf8StringBuilder sb = s_cachedUtf8StringBuilder;
+            if (sb == null)
+                sb = new Utf8StringBuilder();
+
+            symbolNode.AppendMangledName(NodeFactory.NameMangler, sb);
+            string ret = sb.ToString();
+
+            sb.Clear();
+            s_cachedUtf8StringBuilder = sb;
+
+            return ret;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Text;
+
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
@@ -16,14 +18,18 @@ namespace ILCompiler.DependencyAnalysis
             _indirectedNode = indirectedNode;
         }
 
-        string ISymbolNode.MangledName => "__indirection" + _indirectedNode.MangledName;
-        int ISymbolNode.Offset => 0;
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("__indirection");
+            _indirectedNode.AppendMangledName(nameMangler, sb);
+        }
+        public int Offset => 0;
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => ((ISymbolNode)this).MangledName;
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.TypeSystem;
 using System;
 using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -19,47 +21,23 @@ namespace ILCompiler.DependencyAnalysis
             _targetMethod = targetMethod;
         }
 
-        public string MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return "__InterfaceDispatchCell_" + NodeFactory.NameMangler.GetMangledMethodName(_targetMethod);
-            }
+            sb.Append("__InterfaceDispatchCell_");
+            sb.Append(NodeFactory.NameMangler.GetMangledMethodName(_targetMethod));
         }
+        public int Offset => 0;
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        public int Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
-
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
         public override bool ShouldShareNodeAcrossModules(NodeFactory factory)
         {
             return true;
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.TypeSystem;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -21,40 +23,22 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
             _dispatchMapTableIndex = IndexNotSet;
         }
-        
-        protected override string GetName()
+
+        protected override string GetName() => this.GetMangledName();
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            return ((ISymbolNode)this).MangledName;
-        }
-        
-        string ISymbolNode.MangledName
-        {
-            get
+            if (_dispatchMapTableIndex == IndexNotSet)
             {
-                if (_dispatchMapTableIndex == IndexNotSet)
-                {
-                    throw new InvalidOperationException("MangledName called before InterfaceDispatchMap index was initialized.");
-                }
-                    
-                return NodeFactory.CompilationUnitPrefix + "__InterfaceDispatchMap_" + _dispatchMapTableIndex;
+                throw new InvalidOperationException("MangledName called before InterfaceDispatchMap index was initialized.");
             }
-        }
-        
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
+
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__InterfaceDispatchMap_").Append(_dispatchMapTableIndex.ToStringInvariant());
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public int Offset => 0;
+
+        public override bool StaticDependenciesAreComputed => true;
 
         public override ObjectNodeSection Section
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
@@ -3,9 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 
-using ILCompiler.DependencyAnalysisFramework;
+using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -19,53 +18,22 @@ namespace ILCompiler.DependencyAnalysis
 
         public MetadataNode()
         {
-            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, this.GetMangledName() + "End");
         }
 
-        public ISymbolNode EndSymbol
-        {
-            get
-            {
-                return _endSymbol;
-            }
-        }
+        public ISymbolNode EndSymbol => _endSymbol;
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__embedded_metadata";
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__embedded_metadata");
         }
+        public int Offset => 0;
 
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.ReadOnlyDataSection;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
@@ -88,4 +56,3 @@ namespace ILCompiler.DependencyAnalysis
         }
     }
 }
-

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -36,17 +37,9 @@ namespace ILCompiler.DependencyAnalysis
             _methodCode = data;
         }
 
-        public MethodDesc Method
-        {
-            get
-            {
-                return _method;
-            }
-        }
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        public MethodDesc Method =>  _method;
+
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectNodeSection Section
         {
@@ -61,29 +54,13 @@ namespace ILCompiler.DependencyAnalysis
             return factory.CompilationModuleGroup.ShouldShareAcrossModules(_method);
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return _methodCode != null;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => _methodCode != null;
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.NameMangler.GetMangledMethodName(_method);
-            }
+            sb.Append(NodeFactory.NameMangler.GetMangledMethodName(_method));
         }
-
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public int Offset => 0;
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
@@ -134,29 +111,9 @@ namespace ILCompiler.DependencyAnalysis
             return _methodCode;
         }
 
-        public FrameInfo[] FrameInfos
-        {
-            get
-            {
-                return _frameInfos;
-            }
-        }
-
-        public byte[] GCInfo
-        {
-            get
-            {
-                return _gcInfo;
-            }
-        }
-
-        public ObjectData EHInfo
-        {
-            get
-            {
-                return _ehInfo;
-            }
-        }
+        public FrameInfo[] FrameInfos => _frameInfos;
+        public byte[] GCInfo => _gcInfo;
+        public ObjectData EHInfo => _ehInfo;
 
         public void InitializeFrameInfos(FrameInfo[] frameInfos)
         {
@@ -176,21 +133,8 @@ namespace ILCompiler.DependencyAnalysis
             _ehInfo = ehInfo;
         }
 
-        public DebugLocInfo[] DebugLocInfos
-        {
-            get
-            {
-                return _debugLocInfos;
-            }
-        }
-
-        public DebugVarInfo[] DebugVarInfos
-        {
-            get
-            {
-                return _debugVarInfos;
-            }
-        }
+        public DebugLocInfo[] DebugLocInfos => _debugLocInfos;
+        public DebugVarInfo[] DebugVarInfos => _debugVarInfos;
 
         public void InitializeDebugLocInfos(DebugLocInfo[] debugLocInfos)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -31,34 +32,15 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__Module";
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__Module");
         }
-
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public int Offset => 0;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -26,42 +28,17 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return "__NonGCStaticBase_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
-            }
+            sb.Append("__NonGCStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName(_type));
         }
+        public int Offset => 0;
 
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
-
-        public MetadataType Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public MetadataType Type => _type;
 
         public override bool ShouldShareNodeAcrossModules(NodeFactory factory)
         {
@@ -88,13 +65,7 @@ namespace ILCompiler.DependencyAnalysis
             return target.PointerSize;
         }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
@@ -6,92 +6,49 @@ using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysisFramework;
 
+using Internal.Text;
+
 namespace ILCompiler.DependencyAnalysis
 {
     internal class ObjectAndOffsetSymbolNode : DependencyNodeCore<NodeFactory>, ISymbolNode
     {
         private ObjectNode _object;
         private int _offset;
-        private string _name;
+        private Utf8String _name;
 
-        public ObjectAndOffsetSymbolNode(ObjectNode obj, int offset, string name)
+        public ObjectAndOffsetSymbolNode(ObjectNode obj, int offset, Utf8String name)
         {
             _object = obj;
             _offset = offset;
             _name = name;
         }
 
-        protected override string GetName()
-        {
-            return "Symbol " + _name + " at offset " + _offset.ToStringInvariant();
-        }
+        protected override string GetName() => $"Symbol {_name.ToString()} at offset {_offset.ToStringInvariant()}";
 
-        public override bool HasConditionalStaticDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool HasDynamicDependencies
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return false;
-            }
+            sb.Append(_name);
         }
-
-        public override bool InterestingForDynamicDependencyAnalysis
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        string ISymbolNode.MangledName
-        {
-            get
-            {
-                return _name;
-            }
-        }
-
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return _offset;
-            }
-        }
+        public int Offset => _offset;
 
         public void SetSymbolOffset(int offset)
         {
             _offset = offset;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
-        {
-            return null;
-        }
+        public ObjectNode Target => _object;
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             return new DependencyListEntry[] { new DependencyListEntry(_object, "ObjectAndOffsetDependency") };
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
-        {
-            return null;
-        }
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNode.cs
@@ -28,10 +28,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public abstract ObjectData GetData(NodeFactory factory, bool relocsOnly = false);
 
-        public abstract ObjectNodeSection Section
-        {
-            get;
-        }
+        public abstract ObjectNodeSection Section { get; }
 
         /// <summary>
         /// Override this function for node types that can be shared amongst object files
@@ -56,34 +53,9 @@ namespace ILCompiler.DependencyAnalysis
             return false;
         }
 
-        public override bool HasConditionalStaticDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool HasDynamicDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool InterestingForDynamicDependencyAnalysis
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
-        {
-            return null;
-        }
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
 
         public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
@@ -112,9 +84,7 @@ namespace ILCompiler.DependencyAnalysis
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
-        {
-            return null;
-        }
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Text;
 
+using Internal.Text;
+
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
@@ -26,42 +28,20 @@ namespace ILCompiler.DependencyAnalysis
             return true;
         }
 
-        public int Offset
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return 0;
-            }
+            sb.Append("__pinvoke_");
+            sb.Append(_moduleName);
+            sb.Append("__");
+            sb.Append(_entryPointName);
         }
+        public int Offset => 0;
 
-        public string MangledName
-        {
-            get
-            {
-                return String.Concat("__pinvoke_", _moduleName, "__", _entryPointName);
-            }
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        protected override string GetName()
-        {
-            return MangledName;
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
-
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Text;
 
+using Internal.Text;
+
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
@@ -24,42 +26,19 @@ namespace ILCompiler.DependencyAnalysis
             return true;
         }
 
-        public int Offset
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return 0;
-            }
+            sb.Append("__nativemodule_");
+            sb.Append(_moduleName);
         }
+        public int Offset => 0;
 
-        public string MangledName
-        {
-            get
-            {
-                return String.Concat("__nativemodule_", _moduleName);
-            }
-        }
 
-        protected override string GetName()
-        {
-            return MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -46,10 +47,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected sealed override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected sealed override string GetName() => this.GetMangledName();
 
         public sealed override bool ShouldShareNodeAcrossModules(NodeFactory factory)
         {
@@ -110,18 +108,16 @@ namespace ILCompiler.DependencyAnalysis
         {
         }
 
-        public override string MangledName
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                string mangledContextName;
-                if (_dictionaryOwner is MethodDesc)
-                    mangledContextName = NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_dictionaryOwner);
-                else
-                    mangledContextName = NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
+            Utf8String mangledContextName;
+            if (_dictionaryOwner is MethodDesc)
+                mangledContextName = NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_dictionaryOwner);
+            else
+                mangledContextName = NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
 
-                return string.Concat("__GenericLookupFromDict_", mangledContextName, "_", _lookupSignature.GetMangledName(NodeFactory.NameMangler));
-            }
+            sb.Append("__GenericLookupFromDict_").Append(mangledContextName).Append("_");
+            _lookupSignature.AppendMangledName(nameMangler, sb);
         }
     }
 
@@ -132,18 +128,16 @@ namespace ILCompiler.DependencyAnalysis
         {
         }
 
-        public override string MangledName
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                string mangledContextName;
-                if (_dictionaryOwner is MethodDesc)
-                    mangledContextName = NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_dictionaryOwner);
-                else
-                    mangledContextName = NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
+            Utf8String mangledContextName;
+            if (_dictionaryOwner is MethodDesc)
+                mangledContextName = NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_dictionaryOwner);
+            else
+                mangledContextName = NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
 
-                return string.Concat("__GenericLookupFromType_", mangledContextName, "_", _lookupSignature.GetMangledName(NodeFactory.NameMangler));
-            }
+            sb.Append("__GenericLookupFromType_").Append(mangledContextName).Append("_");
+            _lookupSignature.AppendMangledName(nameMangler, sb);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 using Internal.Runtime;
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -41,26 +41,16 @@ namespace ILCompiler.DependencyAnalysis
             _items.Add(new HeaderItem(id, node, startSymbol, endSymbol));
         }
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__ReadyToRunHeader";
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix);
+            sb.Append("__ReadyToRunHeader");
         }
+        public int Offset => 0;
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override ObjectNodeSection Section
         {
@@ -70,14 +60,6 @@ namespace ILCompiler.DependencyAnalysis
                     return ObjectNodeSection.ReadOnlyDataSection;
                 else
                     return ObjectNodeSection.DataSection;
-            }
-        }
-
-        public int Offset
-        {
-            get
-            {
-                return 0;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -3,11 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using ILCompiler.DependencyAnalysisFramework;
-using Internal.TypeSystem;
 
-using Debug = System.Diagnostics.Debug;
+using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -67,63 +65,59 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        public ReadyToRunHelperId Id
-        {
-            get
-            {
-                return _id;
-            }
-        }
+        public ReadyToRunHelperId Id => _id;
+        public Object Target =>  _target;
 
-        public Object Target
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
+            switch (_id)
             {
-                return _target;
-            }
-        }
-
-        public override string MangledName
-        {
-            get
-            {
-                switch (_id)
-                {
-                    case ReadyToRunHelperId.NewHelper:
-                        return "__NewHelper_" + NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target);
-                    case ReadyToRunHelperId.NewArr1:
-                        return "__NewArr1_" + NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target);
-                    case ReadyToRunHelperId.VirtualCall:
-                        return "__VirtualCall_" + NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target);
-                    case ReadyToRunHelperId.IsInstanceOf:
-                        return "__IsInstanceOf_" + NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target);
-                    case ReadyToRunHelperId.CastClass:
-                        return "__CastClass_" + NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target);
-                    case ReadyToRunHelperId.GetNonGCStaticBase:
-                        return "__GetNonGCStaticBase_" + NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target);
-                    case ReadyToRunHelperId.GetGCStaticBase:
-                        return "__GetGCStaticBase_" + NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target);
-                    case ReadyToRunHelperId.GetThreadStaticBase:
-                        return "__GetThreadStaticBase_" + NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target);
-                    case ReadyToRunHelperId.DelegateCtor:
+                case ReadyToRunHelperId.NewHelper:
+                    sb.Append("__NewHelper_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    break;
+                case ReadyToRunHelperId.NewArr1:
+                    sb.Append("__NewArr1_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    break;
+                case ReadyToRunHelperId.VirtualCall:
+                    sb.Append("__VirtualCall_").Append(NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target));
+                    break;
+                case ReadyToRunHelperId.IsInstanceOf:
+                    sb.Append("__IsInstanceOf_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    break;
+                case ReadyToRunHelperId.CastClass:
+                    sb.Append("__CastClass_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    break;
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    sb.Append("__GetNonGCStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    break;
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    sb.Append("__GetGCStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    break;
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    sb.Append("__GetThreadStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    break;
+                case ReadyToRunHelperId.DelegateCtor:
+                    {
+                        var createInfo = (DelegateCreationInfo)_target;
+                        sb.Append("__DelegateCtor_");
+                        createInfo.Constructor.AppendMangledName(nameMangler, sb);
+                        sb.Append("__");
+                        createInfo.Target.AppendMangledName(nameMangler, sb);
+                        if (createInfo.Thunk != null)
                         {
-                            var createInfo = (DelegateCreationInfo)_target;
-                            string mangledName = String.Concat("__DelegateCtor_",
-                                createInfo.Constructor.MangledName, "__", createInfo.Target.MangledName);
-                            if (createInfo.Thunk != null)
-                                mangledName += String.Concat("__", createInfo.Thunk.MangledName);
-                            return mangledName;
+                            sb.Append("__");
+                            createInfo.Thunk.AppendMangledName(nameMangler, sb);
                         }
-                    case ReadyToRunHelperId.ResolveVirtualFunction:
-                        return "__ResolveVirtualFunction_" + NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target);
-                    default:
-                        throw new NotImplementedException();
-                }
+                    }
+                    break;
+                case ReadyToRunHelperId.ResolveVirtualFunction:
+                    sb.Append("__ResolveVirtualFunction_");
+                    sb.Append(NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target));
+                    break;
+                default:
+                    throw new NotImplementedException();
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.NativeFormat;
 
@@ -23,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public ReflectionInvokeMapNode(ExternalReferencesTableNode externalReferences)
         {
-            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, this.GetMangledName() + "End");
             _externalReferences = externalReferences;
         }
 
@@ -35,42 +36,17 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__method_to_entrypoint_map";
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__method_to_entrypoint_map");
         }
+        public int Offset => 0;
 
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
@@ -4,8 +4,10 @@
 
 using System.Collections.Generic;
 
-using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.Text;
+using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -24,8 +26,11 @@ namespace ILCompiler.DependencyAnalysis
         public MethodDesc Method { get; }
 
         // Implementation of ISymbolNode that makes this node act as a symbol for the canonical body
-        int ISymbolNode.Offset => _canonicalMethodNode.Offset;
-        string ISymbolNode.MangledName => _canonicalMethodNode.MangledName;
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            _canonicalMethodNode.AppendMangledName(nameMangler, sb);
+        }
+        public int Offset => _canonicalMethodNode.Offset;
 
         public RuntimeDeterminedMethodNode(MethodDesc method, IMethodNode canonicalMethod)
         {
@@ -41,10 +46,7 @@ namespace ILCompiler.DependencyAnalysis
             yield return new DependencyListEntry(_canonicalMethodNode, "Canonical body");
         }
 
-        protected override string GetName()
-        {
-            return $"{Method.ToString()} backed by {_canonicalMethodNode.MangledName}";
-        }
+        protected override string GetName() => $"{Method.ToString()} backed by {_canonicalMethodNode.GetMangledName()}";
 
         public IEnumerable<DependencyListEntry> InstantiateDependencies(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
@@ -56,9 +58,8 @@ namespace ILCompiler.DependencyAnalysis
         public override bool HasDynamicDependencies => false;
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool StaticDependenciesAreComputed => true;
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
-            List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(
-            NodeFactory factory) => null;
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -4,8 +4,10 @@
 
 using System.Collections.Generic;
 
-using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.Text;
+using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -32,8 +34,11 @@ namespace ILCompiler.DependencyAnalysis
         public MethodDesc Method { get; }
 
         // Implementation of ISymbolNode that makes this node act as a symbol for the canonical body
-        int ISymbolNode.Offset => CanonicalMethodNode.Offset;
-        string ISymbolNode.MangledName => CanonicalMethodNode.MangledName;
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            CanonicalMethodNode.AppendMangledName(nameMangler, sb);
+        }
+        public int Offset => CanonicalMethodNode.Offset;
 
         public override bool StaticDependenciesAreComputed
             => CanonicalMethodNode.StaticDependenciesAreComputed;
@@ -85,17 +90,13 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName()
-        {
-            return $"{Method.ToString()} backed by {CanonicalMethodNode.MangledName}";
-        }
+        protected override string GetName() => $"{Method.ToString()} backed by {CanonicalMethodNode.GetMangledName()}";
 
         public sealed override bool HasConditionalStaticDependencies => false;
         public sealed override bool HasDynamicDependencies => false;
         public sealed override bool InterestingForDynamicDependencyAnalysis => false;
-        public sealed override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
-            List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
-        public sealed override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(
-            NodeFactory factory) => null;
+
+        public sealed override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+        public sealed override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringAllocatorMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringAllocatorMethodNode.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysisFramework;
+
 using Internal.IL;
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -25,9 +26,11 @@ namespace ILCompiler.DependencyAnalysis
 
         public MethodDesc Method => _allocationMethod;
 
-        int ISymbolNode.Offset => 0;
-
-        string ISymbolNode.MangledName => NodeFactory.NameMangler.GetMangledMethodName(_allocationMethod);
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(NodeFactory.NameMangler.GetMangledMethodName(_allocationMethod));
+        }
+        public int Offset => 0;
 
         public StringAllocatorMethodNode(MethodDesc constructorMethod)
         {
@@ -59,6 +62,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
-        protected override string GetName() => ((ISymbolNode)this).MangledName;
+
+        protected override string GetName() => this.GetMangledName();
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.TypeSystem;
 using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -20,22 +22,16 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         protected override void OnMarked(NodeFactory factory)
         {
             factory.ThreadStaticsRegion.AddEmbeddedObject(this);
         }
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return "__ThreadStaticBase_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
-            }
+            sb.Append("__ThreadStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName(_type));
         }
 
         private ISymbolNode GetGCStaticEETypeNode(NodeFactory factory)
@@ -60,21 +56,7 @@ namespace ILCompiler.DependencyAnalysis
             return result;
         }
 
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return Offset;
-            }
-        }
-
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override void EncodeData(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeManagerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeManagerIndirectionNode.cs
@@ -2,50 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.TypeSystem;
-using System;
-using System.Diagnostics;
+using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
 {
     class TypeManagerIndirectionNode : ObjectNode, ISymbolNode
     {
-        public string MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__typemanager_indirection";
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__typemanager_indirection");
         }
+        public int Offset => 0;
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
-        public int Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
-
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 
 using Internal.NativeFormat;
+using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -19,54 +20,23 @@ namespace ILCompiler.DependencyAnalysis
 
         public TypeMetadataMapNode(ExternalReferencesTableNode externalReferences)
         {
-            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, this.GetMangledName() + "End");
             _externalReferences = externalReferences;
         }
 
-        public ISymbolNode EndSymbol
-        {
-            get
-            {
-                return _endSymbol;
-            }
-        }
+        public ISymbolNode EndSymbol => _endSymbol;
 
-        string ISymbolNode.MangledName
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return NodeFactory.CompilationUnitPrefix + "__type_to_metadata_map";
-            }
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__type_to_metadata_map");
         }
+        public int Offset => 0;
 
-        int ISymbolNode.Offset
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 
-        public override ObjectNodeSection Section
-        {
-            get
-            {
-                return ObjectNodeSection.DataSection;
-            }
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -29,17 +30,11 @@ namespace ILCompiler.DependencyAnalysis
             _target = target;
         }
 
-        public override string MangledName
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            get
-            {
-                return "unbox_" + NodeFactory.NameMangler.GetMangledMethodName(_target);
-            }
+            sb.Append("unbox_").Append(NodeFactory.NameMangler.GetMangledMethodName(_target));
         }
 
-        protected override string GetName()
-        {
-            return ((ISymbolNode)this).MangledName;
-        }
+        protected override string GetName() => this.GetMangledName();
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -23,58 +23,22 @@ namespace ILCompiler.DependencyAnalysis
         {
             _type = type;
         }
-        
+
         public abstract IReadOnlyList<MethodDesc> Slots
         {
             get;
         }
-        
-        protected override string GetName()
-        {
-            return "__vtable_" + NodeFactory.NameMangler.GetMangledTypeName(_type);
-        }
 
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override string GetName() => $"__vtable_{NodeFactory.NameMangler.GetMangledTypeName(_type).ToString()}";
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
-        {
-            return null;
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
-        {
-            return null;
-        }
-        
-        public override bool InterestingForDynamicDependencyAnalysis
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
 
-        public override bool HasDynamicDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool HasConditionalStaticDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
     }
 
     /// <summary>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using ILCompiler.DependencyAnalysisFramework;
+
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -27,10 +25,7 @@ namespace ILCompiler.DependencyAnalysis
             _decl = decl;
         }
 
-        protected override string GetName()
-        {
-            return "VirtualMethodUse" + _decl.ToString();
-        }
+        protected override string GetName() => $"VirtualMethodUse {_decl.ToString()}";
 
         protected override void OnMarked(NodeFactory factory)
         {
@@ -41,42 +36,11 @@ namespace ILCompiler.DependencyAnalysis
                 lazyVTableSlice.AddEntry(factory, _decl);
         }
 
-        public override bool HasConditionalStaticDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
 
-        public override bool HasDynamicDependencies
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool InterestingForDynamicDependencyAnalysis
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool StaticDependenciesAreComputed
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
-        {
-            return null;
-        }
+        public override bool StaticDependenciesAreComputed => true;
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
@@ -87,9 +51,7 @@ namespace ILCompiler.DependencyAnalysis
             return null;
         }
 
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
-        {
-            return null;
-        }
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -5,10 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -244,18 +244,18 @@ namespace ILCompiler
             return mangledName;
         }
 
-        private ImmutableDictionary<MethodDesc, string> _mangledMethodNames = ImmutableDictionary<MethodDesc, string>.Empty;
+        private ImmutableDictionary<MethodDesc, Utf8String> _mangledMethodNames = ImmutableDictionary<MethodDesc, Utf8String>.Empty;
 
-        public string GetMangledMethodName(MethodDesc method)
+        public Utf8String GetMangledMethodName(MethodDesc method)
         {
-            string mangledName;
+            Utf8String mangledName;
             if (_mangledMethodNames.TryGetValue(method, out mangledName))
                 return mangledName;
 
             return ComputeMangledMethodName(method);
         }
 
-        private string ComputeMangledMethodName(MethodDesc method)
+        private Utf8String ComputeMangledMethodName(MethodDesc method)
         {
             string prependTypeName = null;
             if (!_mangleForCplusPlus)
@@ -292,7 +292,7 @@ namespace ILCompiler
             var methodDefinition = method.GetTypicalMethodDefinition();
             if (methodDefinition != method)
             {
-                mangledName = GetMangledMethodName(methodDefinition.GetMethodDefinition());
+                mangledName = GetMangledMethodName(methodDefinition.GetMethodDefinition()).ToString();
 
                 var inst = method.Instantiation;
                 string mangledInstantiation = "";
@@ -316,26 +316,28 @@ namespace ILCompiler
             if (prependTypeName != null)
                 mangledName = prependTypeName + "__" + mangledName;
 
+            Utf8String utf8MangledName = new Utf8String(mangledName);
+
             lock (this)
             {
-                _mangledMethodNames = _mangledMethodNames.Add(method, mangledName);
+                _mangledMethodNames = _mangledMethodNames.Add(method, utf8MangledName);
             }
 
-            return mangledName;
+            return utf8MangledName;
         }
 
-        private ImmutableDictionary<FieldDesc, string> _mangledFieldNames = ImmutableDictionary<FieldDesc, string>.Empty;
+        private ImmutableDictionary<FieldDesc, Utf8String> _mangledFieldNames = ImmutableDictionary<FieldDesc, Utf8String>.Empty;
 
-        public string GetMangledFieldName(FieldDesc field)
+        public Utf8String GetMangledFieldName(FieldDesc field)
         {
-            string mangledName;
+            Utf8String mangledName;
             if (_mangledFieldNames.TryGetValue(field, out mangledName))
                 return mangledName;
 
             return ComputeMangledFieldName(field);
         }
 
-        private string ComputeMangledFieldName(FieldDesc field)
+        private Utf8String ComputeMangledFieldName(FieldDesc field)
         {
             string prependTypeName = null;
             if (!_mangleForCplusPlus)
@@ -372,12 +374,14 @@ namespace ILCompiler
             if (prependTypeName != null)
                 mangledName = prependTypeName + "__" + mangledName;
 
+            Utf8String utf8MangledName = new Utf8String(mangledName);
+
             lock (this)
             {
-                _mangledFieldNames = _mangledFieldNames.Add(field, mangledName);
+                _mangledFieldNames = _mangledFieldNames.Add(field, utf8MangledName);
             }
 
-            return mangledName;
+            return utf8MangledName;
         }
 
         private ImmutableDictionary<string, string> _mangledStringLiterals = ImmutableDictionary<string, string>.Empty;

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -7,15 +7,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ILCompiler.Compiler.CppCodeGen;
+using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 
+using Internal.IL;
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
-
-using Internal.Runtime;
-
-using Internal.IL;
-using ILCompiler.DependencyAnalysis;
 
 namespace ILCompiler.CppCodeGen
 {
@@ -256,7 +254,7 @@ namespace ILCompiler.CppCodeGen
                 case TypeFlags.Pointer:
                     return GetCppSignatureTypeName(((ParameterizedType)type).ParameterType) + "*";
                 default:
-                    return _compilation.NameMangler.GetMangledTypeName(type);
+                    return _compilation.NameMangler.GetMangledTypeName(type).ToString();
             }
         }
 
@@ -281,12 +279,12 @@ namespace ILCompiler.CppCodeGen
 
         public string GetCppMethodName(MethodDesc method)
         {
-            return _compilation.NameMangler.GetMangledMethodName(method);
+            return _compilation.NameMangler.GetMangledMethodName(method).ToString();
         }
 
         public string GetCppFieldName(FieldDesc field)
         {
-            return _compilation.NameMangler.GetMangledFieldName(field);
+            return _compilation.NameMangler.GetMangledFieldName(field).ToString();
         }
 
         public string GetCppStaticFieldName(FieldDesc field)
@@ -757,7 +755,7 @@ namespace ILCompiler.CppCodeGen
             }
             else
             {
-                string mangledName = ((ISymbolNode)node).MangledName;
+                string mangledName = ((ISymbolNode)node).GetMangledName();
 
                 // Rename generic composition and optional fields nodes to avoid name clash with types
                 bool shouldReplaceNamespaceQualifier = node is GenericCompositionNode || node is EETypeOptionalFieldsNode;
@@ -836,11 +834,13 @@ namespace ILCompiler.CppCodeGen
             // Node is either an non-emitted type or a generic composition - both are ignored for CPP codegen
             else if ((reloc.Target is TypeManagerIndirectionNode || reloc.Target is InterfaceDispatchMapNode || reloc.Target is EETypeOptionalFieldsNode || reloc.Target is GenericCompositionNode) && !(reloc.Target as ObjectNode).ShouldSkipEmittingObjectNode(factory))
             {
+                string mangledTargetName = reloc.Target.GetMangledName();
                 bool shouldReplaceNamespaceQualifier = reloc.Target is GenericCompositionNode || reloc.Target is EETypeOptionalFieldsNode;
-                relocCode.Append(shouldReplaceNamespaceQualifier ? reloc.Target.MangledName.Replace("::", "_") : reloc.Target.MangledName);
+                relocCode.Append(shouldReplaceNamespaceQualifier ? mangledTargetName.Replace("::", "_") : mangledTargetName);
                 relocCode.Append("()");
             }
-            else if (reloc.Target is ObjectAndOffsetSymbolNode && (reloc.Target as ISymbolNode).MangledName.Contains("DispatchMap"))
+            else if (reloc.Target is ObjectAndOffsetSymbolNode &&
+                (reloc.Target as ObjectAndOffsetSymbolNode).Target is ArrayOfEmbeddedPointersNode<InterfaceDispatchMapNode>)
             {
                 relocCode.Append("dispatchMapModule");
             }
@@ -964,7 +964,7 @@ namespace ILCompiler.CppCodeGen
                 else if (node is InterfaceDispatchMapNode)
                 {
                     dispatchPointers.Append("(void *)");
-                    dispatchPointers.Append(((ISymbolNode)node).MangledName);
+                    dispatchPointers.Append(((ISymbolNode)node).GetMangledName());
                     dispatchPointers.Append("(),");
                     dispatchPointers.AppendLine();
                     dispatchMapCount++;
@@ -1183,7 +1183,7 @@ namespace ILCompiler.CppCodeGen
             rtrHeader.Append("{ 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 },");
             rtrHeader.AppendLine();
             rtrHeader.Append("(void*)");
-            rtrHeader.Append(((ISymbolNode)headerNode).MangledName);
+            rtrHeader.Append(headerNode.GetMangledName());
             rtrHeader.Append("(),");
             rtrHeader.AppendLine();
             rtrHeader.Append("{ 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 }");

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -53,6 +53,12 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\RuntimeConstants.cs">
       <Link>Common\RuntimeConstants.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Internal\Text\Utf8String.cs">
+      <Link>Common\Utf8String.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Internal\Text\Utf8StringBuilder.cs">
+      <Link>Common\Utf8StringBuilder.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\DelegateInfo.cs">
       <Link>IL\DelegateInfo.cs</Link>
     </Compile>


### PR DESCRIPTION
- Introduce Utf8String and Utf8StringBuilder types
- Change some of the name mangling to use these types
- Change ISymbolNode.Mangled property to AppendMangledName method that takes Utf8StringBuilder to append the mangled name to, and NameMangler object to use
- Switch implementation of number of simple properties to the more compact declarative syntax

This change reduces amount of GC allocations in the compiler and creates opportunities for further reductions. E.g. Total GC heap allocs for the Simple/Reflection test goes from 366 MB to 310 MB. It does not make anything measurably faster though.

Part of https://github.com/dotnet/corert/issues/2178