### PR TITLE
Fixed Join(string separator, params object[] values) method

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -484,15 +484,13 @@ namespace System
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            if (values.Length == 0 || values[0] == null)
+            if (values.Length == 0)
                 return string.Empty;
 
-            string firstString = values[0].ToString();
+            string firstString = values[0]?.ToString();
 
             if (values.Length == 1)
-            {
                 return firstString ?? string.Empty;
-            }
 
             StringBuilder result = StringBuilderCache.Acquire();
             result.Append(firstString);


### PR DESCRIPTION
Fixed Join(string separator, params object[] values) method.
Calling string.Join(",", null, 1, 2, 3); return empty string but should ",1,2,3".