### PR TITLE
Add support for a subset of RD.XML

### DIFF
--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -32,6 +32,9 @@
     <Compile Include="..\src\Program.cs">
       <Link>src\Program.cs</Link>
     </Compile>
+    <Compile Include="..\src\RdXmlRootProvider.cs">
+      <Link>src\RdXmlRootProvider.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\CommandLine\CommandLineException.cs">
@@ -58,6 +61,8 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\bin\Product\Windows_NT.$(Platform).$(Configuration)\packaging\publish1\jitinterface.dll">

--- a/src/ILCompiler/src/ILCompiler.csproj
+++ b/src/ILCompiler/src/ILCompiler.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
+    <Compile Include="RdXmlRootProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\CommandLine\CommandLineException.cs">

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -39,6 +39,8 @@ namespace ILCompiler
 
         private IReadOnlyList<string> _codegenOptions = Array.Empty<string>();
 
+        private IReadOnlyList<string> _rdXmlFilePaths = Array.Empty<string>();
+
         private bool _help;
 
         private Program()
@@ -120,6 +122,7 @@ namespace ILCompiler
                 syntax.DefineOption("waitfordebugger", ref waitForDebugger, "Pause to give opportunity to attach debugger");
                 syntax.DefineOption("usesharedgenerics", ref _useSharedGenerics, "Enable shared generics");
                 syntax.DefineOptionList("codegenopt", ref _codegenOptions, "Define a codegen option");
+                syntax.DefineOptionList("rdxml", ref _rdXmlFilePaths, "RD.XML file(s) for compilation");
 
                 syntax.DefineOption("singlemethodtypename", ref _singleMethodTypeName, "Single method compilation: name of the owning type");
                 syntax.DefineOption("singlemethodname", ref _singleMethodName, "Single method compilation: name of the method");
@@ -249,6 +252,11 @@ namespace ILCompiler
                     }
 
                     compilationGroup = new SingleFileCompilationModuleGroup();
+                }
+
+                foreach (var rdXmlFilePath in _rdXmlFilePaths)
+                {
+                    compilationRoots.Add(new RdXmlRootProvider(typeSystemContext, rdXmlFilePath));
                 }
             }
 

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using AssemblyName = System.Reflection.AssemblyName;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Compilation root provider that provides roots based on the RD.XML file format.
+    /// Only supports a subset of the Runtime Directives configuration file format.
+    /// </summary>
+    /// <remarks>https://msdn.microsoft.com/en-us/library/dn600639(v=vs.110).aspx</remarks>
+    internal class RdXmlRootProvider : ICompilationRootProvider
+    {
+        private XElement _documentRoot;
+        private TypeSystemContext _context;
+
+        public RdXmlRootProvider(TypeSystemContext context, string rdXmlFileName)
+        {
+            _context = context;
+            _documentRoot = XElement.Load(rdXmlFileName);
+        }
+
+        public void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        {
+            var libraryOrApplication = _documentRoot.Elements().Single();
+
+            if (libraryOrApplication.Name.LocalName != "Library" && libraryOrApplication.Name.LocalName != "Application")
+                throw new Exception();
+
+            if (libraryOrApplication.Attributes().Any())
+                throw new NotSupportedException();
+
+            foreach (var element in libraryOrApplication.Elements())
+            {
+                switch (element.Name.LocalName)
+                {
+                    case "Assembly":
+                        ProcessAssemblyDirective(rootProvider, element);
+                        break;
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+        }
+
+        private void ProcessAssemblyDirective(IRootingServiceProvider rootProvider, XElement assemblyElement)
+        {
+            var assemblyNameAttribute = assemblyElement.Attribute("Name");
+            if (assemblyNameAttribute == null)
+                throw new Exception();
+
+            ModuleDesc assembly = _context.ResolveAssembly(new AssemblyName(assemblyNameAttribute.Value));
+
+            var dynamicDegreeAttribute = assemblyElement.Attribute("Dynamic");
+            if (dynamicDegreeAttribute != null)
+            {
+                if (dynamicDegreeAttribute.Value != "Required All")
+                    throw new NotSupportedException();
+
+                // Reuse LibraryRootProvider to root everything
+                new LibraryRootProvider((EcmaModule)assembly).AddCompilationRoots(rootProvider);
+            }
+
+            foreach (var element in assemblyElement.Elements())
+            {
+                switch (element.Name.LocalName)
+                {
+                    case "Type":
+                        ProcessTypeDirective(rootProvider, assembly, element);
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+        }
+
+        private void ProcessTypeDirective(IRootingServiceProvider rootProvider, ModuleDesc containingModule, XElement typeElement)
+        {
+            var typeNameAttribute = typeElement.Attribute("Name");
+            if (typeNameAttribute == null)
+                throw new Exception();
+
+            var dynamicDegreeAttribute = typeElement.Attribute("Dynamic");
+            if (dynamicDegreeAttribute != null)
+            {
+                if (dynamicDegreeAttribute.Value != "Required All")
+                    throw new NotSupportedException();
+            }
+
+            string typeName = typeNameAttribute.Value;
+
+            string name;
+            string ns;
+            int namespaceEndIndex = typeName.LastIndexOf('.');
+            if (namespaceEndIndex > 0)
+            {
+                ns = typeName.Substring(0, namespaceEndIndex);
+                name = typeName.Substring(namespaceEndIndex + 1);
+            }
+            else
+            {
+                ns = string.Empty;
+                name = typeName;
+            }
+
+            MetadataType type = containingModule.GetType(ns, name);
+            rootProvider.AddCompilationRoot(type, "RD.XML root");
+
+            foreach (var method in type.GetMethods())
+            {
+                if (method.IsAbstract || method.HasInstantiation)
+                    continue;
+
+                rootProvider.AddCompilationRoot(method, "RD.XML root");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This lets us specify an additional set of compilation roots for things
that aren't statically reachable. Useful when reflection is involved.