### PR TITLE
Add suport for Type.MakeArrayType and Array.CreateInstance

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -85,6 +85,9 @@ namespace ILCompiler.DependencyAnalysis
                 if (!arrayType.IsSzArray)
                     continue;
 
+                if (!factory.MetadataManager.TypeGeneratesEEType(arrayType))
+                    continue;
+
                 // TODO: This should only be emitted for arrays of value types. The type loader builds everything else.
 
                 // Go with a necessary type symbol. It will be upgraded to a constructed one if a constructed was emitted.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a hash table of array types generated into the image.
+    /// </summary>
+    internal sealed class ArrayMapNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        public ArrayMapNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, ((ISymbolNode)this).MangledName + "End");
+            _externalReferences = externalReferences;
+        }
+
+        public ISymbolNode EndSymbol
+        {
+            get
+            {
+                return _endSymbol;
+            }
+        }
+
+        string ISymbolNode.MangledName
+        {
+            get
+            {
+                return NodeFactory.CompilationUnitPrefix + "__array_type_map";
+            }
+        }
+
+        int ISymbolNode.Offset
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override ObjectNodeSection Section
+        {
+            get
+            {
+                return ObjectNodeSection.DataSection;
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        protected override string GetName()
+        {
+            return ((ISymbolNode)this).MangledName;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            var writer = new NativeWriter();
+            var typeMapHashTable = new VertexHashtable();
+
+            Section hashTableSection = writer.NewSection();
+            hashTableSection.Place(typeMapHashTable);
+
+            foreach (var arrayType in factory.MetadataManager.GetArrayTypeMapping())
+            {
+                if (!arrayType.IsSzArray)
+                    continue;
+
+                // TODO: This should only be emitted for arrays of value types. The type loader builds everything else.
+
+                // Go with a necessary type symbol. It will be upgraded to a constructed one if a constructed was emitted.
+                IEETypeNode arrayTypeSymbol = factory.NecessaryTypeSymbol(arrayType);
+
+                Vertex vertex = writer.GetUnsignedConstant(_externalReferences.GetIndex(arrayTypeSymbol));
+
+                int hashCode = arrayType.GetHashCode();
+                typeMapHashTable.Append((uint)hashCode, hashTableSection.Place(vertex));
+            }
+
+            MemoryStream ms = new MemoryStream();
+            writer.Save(ms);
+            byte[] hashTableBytes = ms.ToArray();
+
+            _endSymbol.SetSymbolOffset(hashTableBytes.Length);
+
+            return new ObjectData(hashTableBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -74,6 +74,7 @@
     <Compile Include="..\..\JitInterface\src\JitConfigProvider.cs">
       <Link>JitInterface\JitConfigProvider.cs</Link>
     </Compile>
+    <Compile Include="Compiler\DependencyAnalysis\ArrayMapNode.cs" />
     <Compile Include="Compiler\ICompilationRootProvider.cs" />
     <Compile Include="Compiler\Compilation.cs" />
     <Compile Include="Compiler\CompilationBuilder.cs" />

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -99,29 +99,18 @@ namespace ILCompiler
 
             string typeName = typeNameAttribute.Value;
 
-            string name;
-            string ns;
-            int namespaceEndIndex = typeName.LastIndexOf('.');
-            if (namespaceEndIndex > 0)
-            {
-                ns = typeName.Substring(0, namespaceEndIndex);
-                name = typeName.Substring(namespaceEndIndex + 1);
-            }
-            else
-            {
-                ns = string.Empty;
-                name = typeName;
-            }
-
-            MetadataType type = containingModule.GetType(ns, name);
+            TypeDesc type = containingModule.GetTypeByCustomAttributeTypeName(typeName);
             rootProvider.AddCompilationRoot(type, "RD.XML root");
 
-            foreach (var method in type.GetMethods())
+            if (type.IsDefType)
             {
-                if (method.IsAbstract || method.HasInstantiation)
-                    continue;
+                foreach (var method in type.GetMethods())
+                {
+                    if (method.IsAbstract || method.HasInstantiation)
+                        continue;
 
-                rootProvider.AddCompilationRoot(method, "RD.XML root");
+                    rootProvider.AddCompilationRoot(method, "RD.XML root");
+                }
             }
         }
     }


### PR DESCRIPTION
I thought this would require a `#if CORERT` hack in the classlib, but turns out this  is just about emitting another mapping table. On Project N, this mapping table only has arrays of value types in it (type loader builds the rest on demand), but on CoreRT we don't generate enough data structures to support type loader yet. Turns out that if we put the reference types in the table, the type loader is able to find them and won't try to build them.

I'm leaving a TODO to filter out the reference type arrays once we bring up the type loader.

Also adding support for parsing array type syntax in RD.XML. Instead of building yet another parser, I'm deferring to the custom attribute type name format. This change is not compatible with Project N's RD.XML since the syntax for generic type instantiations is different, but at this point I don't care.