### PR TITLE
Allow GVMs to be present on types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -122,6 +122,9 @@ namespace ILCompiler.DependencyAnalysis
                 MethodDesc impl = defType.FindVirtualFunctionTargetMethodOnObjectType(decl);
                 if (impl.OwningType == defType && !impl.IsAbstract)
                 {
+                    if (decl.HasInstantiation)
+                        continue;
+
                     MethodDesc canonImpl = impl.GetCanonMethodTarget(CanonicalFormKind.Specific);
                     yield return new CombinedDependencyListEntry(factory.MethodEntrypoint(canonImpl, _type.IsValueType), factory.VirtualMethodUse(decl), "Virtual method");
                 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -22,11 +22,11 @@ namespace ILCompiler.DependencyAnalysis
         GetThreadStaticBase,
         DelegateCtor,
         ResolveVirtualFunction,
-
         TypeHandle,
         FieldHandle,
         MethodDictionary,
         MethodEntry,
+        ResolveGenericVirtualMethod
     }
 
     public partial class ReadyToRunHelperNode : AssemblyStubNode
@@ -114,6 +114,10 @@ namespace ILCompiler.DependencyAnalysis
                     break;
                 case ReadyToRunHelperId.ResolveVirtualFunction:
                     sb.Append("__ResolveVirtualFunction_");
+                    sb.Append(NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target));
+                    break;
+                case ReadyToRunHelperId.ResolveGenericVirtualMethod:
+                    sb.Append("__ResolveGenericVirtualMethod_");
                     sb.Append(NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target));
                     break;
                 default:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -185,6 +185,10 @@ namespace ILCompiler.DependencyAnalysis
                     }
                     break;
 
+                case ReadyToRunHelperId.ResolveGenericVirtualMethod:
+                    encoder.EmitINT3();
+                    break;
+
                 default:
                     throw new NotImplementedException();
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2616,6 +2616,15 @@ namespace Internal.JitInterface
 
                 pResult.nullInstanceCheck = resolvedCallVirt;
             }
+            else if (method.HasInstantiation)
+            {
+                // GVM Call Support
+                pResult.kind = CORINFO_CALL_KIND.CORINFO_CALL_CODE_POINTER;
+                pResult.codePointerOrStubLookup.constLookup.accessType = InfoAccessType.IAT_VALUE;
+                pResult.codePointerOrStubLookup.constLookup.addr =
+                    (void*)ObjectToHandle(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.ResolveGenericVirtualMethod, targetMethod));
+                pResult.nullInstanceCheck = false;
+            }
             else if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) != 0)
             {
                 pResult.kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_LDVIRTFTN;

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -15,6 +15,7 @@ class Program
         TestVirtualMethodUseTracking.Run();
         TestSlotsInHierarchy.Run();
         TestNameManglingCollisionRegression.Run();
+        TestUnusedGVMsDoNotCrashCompiler.Run();
 
         return 100;
     }
@@ -279,6 +280,39 @@ class Program
             g1[0] = new Gen1<object[]>(new object[] {new object[1]});
 
             Gen1<object[][]> g2 = new Gen1<object[][]>(new object[1][]);
+        }
+    }
+
+    class TestUnusedGVMsDoNotCrashCompiler
+    {
+        interface GvmItf
+        {
+            T Bar<T>(T t);
+        }
+
+        class HasGvm : GvmItf
+        {
+            public virtual T Foo<T>(T t)
+            {
+                return t;
+            }
+
+            public virtual T Bar<T>(T t)
+            {
+                return t;
+            }
+
+            public virtual string DoubleString(string s)
+            {
+                return s + s;
+            }
+        }
+
+        public static void Run()
+        {
+            HasGvm hasGvm = new HasGvm();
+            if (hasGvm.DoubleString("Hello") != "HelloHello")
+                throw new Exception();
         }
     }
 }


### PR DESCRIPTION
In order to compile larger bodies of code (such as XUnit) without full
GVM support, emit a R2R helper at GVM callsites that fails fast at
runtime. I left the check for GVMs in-place in
`ConstructedEETypeNode.OutputVirtualSlots` to make sure we don't
actually put them in the VTable since they'll eventually be dispatched
via a lookup table.