### PR TITLE
Fix ValueTypeFieldPadding computation

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -486,7 +486,7 @@ namespace ILCompiler.DependencyAnalysis
             // Unfortunately, the name ValueTypeFieldPadding is now wrong to avoid integration conflicts.
 
             // Interfaces, sealed types, and non-DefTypes cannot be derived from
-            if (_type.IsInterface || !_type.IsDefType || _type.IsSealed())
+            if (_type.IsInterface || !_type.IsDefType || (_type.IsSealed() && !_type.IsValueType))
                 return;
 
             DefType defType = _type as DefType;


### PR DESCRIPTION
Recent changes to extend this to also cover unsealed reference types
hilariously made this stop working for value types (the thing this
concept was invented for in the first place...).