### PR TITLE
Implement reflection field get/set

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
@@ -1,0 +1,140 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+using FieldTableFlags = Internal.Runtime.FieldTableFlags;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between reflection metadata and native field offsets.
+    /// </summary>
+    internal sealed class ReflectionFieldMapNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        public ReflectionFieldMapNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, this.GetMangledName() + "End");
+            _externalReferences = externalReferences;
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(NodeFactory.CompilationUnitPrefix).Append("__field_to_offset_map");
+        }
+
+        public int Offset => 0;
+
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override string GetName() => this.GetMangledName();
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            var writer = new NativeWriter();
+            var fieldMapHashTable = new VertexHashtable();
+
+            Section hashTableSection = writer.NewSection();
+            hashTableSection.Place(fieldMapHashTable);
+
+            foreach (var fieldMapping in factory.MetadataManager.GetFieldMapping())
+            {
+                FieldDesc field = fieldMapping.Entity;
+
+                if (field.IsLiteral || field.HasRva)
+                    continue;
+
+                FieldTableFlags flags;
+                if (field.IsThreadStatic)
+                {
+                    flags = FieldTableFlags.ThreadStatic;
+                }
+                else if (field.IsStatic)
+                {
+                    flags = FieldTableFlags.Static;
+
+                    if (field.HasGCStaticBase)
+                        flags |= FieldTableFlags.IsGcSection;
+                }
+                else
+                {
+                    flags = FieldTableFlags.Instance;
+                }
+
+                // TODO: support emitting field info without a handle for generics in multifile
+                flags |= FieldTableFlags.HasMetadataHandle;
+
+                if (field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Universal))
+                    flags |= FieldTableFlags.IsUniversalCanonicalEntry;
+
+                // Grammar of a hash table entry:
+                // Flags + DeclaringType + MdHandle or Name + Cookie or Ordinal or Offset
+
+                Vertex vertex = writer.GetUnsignedConstant((uint)flags);
+
+                uint declaringTypeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(field.OwningType));
+                vertex = writer.GetTuple(vertex,
+                    writer.GetUnsignedConstant(declaringTypeId));
+
+                if ((flags & FieldTableFlags.HasMetadataHandle) != 0)
+                {
+                    // Only store the offset portion of the metadata handle to get better integer compression
+                    vertex = writer.GetTuple(vertex,
+                        writer.GetUnsignedConstant((uint)(fieldMapping.MetadataHandle & MetadataGeneration.MetadataOffsetMask)));
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+
+                if ((flags & FieldTableFlags.IsUniversalCanonicalEntry) != 0)
+                {
+                    throw new NotImplementedException();
+                }
+                else
+                {
+                    switch (flags & FieldTableFlags.StorageClass)
+                    {
+                        case FieldTableFlags.ThreadStatic:
+                        case FieldTableFlags.Static:
+                            // TODO: statics and thread statics
+                            continue;
+
+                        case FieldTableFlags.Instance:
+                            vertex = writer.GetTuple(vertex,
+                                writer.GetUnsignedConstant((uint)field.Offset));
+                            break;
+                    }
+                }
+
+                int hashCode = field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific).GetHashCode();
+                fieldMapHashTable.Append((uint)hashCode, hashTableSection.Place(vertex));
+            }
+
+            MemoryStream ms = new MemoryStream();
+            writer.Save(ms);
+            byte[] hashTableBytes = ms.ToArray();
+
+            _endSymbol.SetSymbolOffset(hashTableBytes.Length);
+
+            return new ObjectData(hashTableBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -81,6 +81,7 @@
       <Link>JitInterface\JitConfigProvider.cs</Link>
     </Compile>
     <Compile Include="Compiler\DependencyAnalysis\ArrayMapNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReflectionFieldMapNode.cs" />
     <Compile Include="Compiler\ICompilationRootProvider.cs" />
     <Compile Include="Compiler\Compilation.cs" />
     <Compile Include="Compiler\CompilationBuilder.cs" />

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.FieldAccess.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.FieldAccess.cs
@@ -195,7 +195,11 @@ namespace Internal.Runtime.TypeLoader
                     }
                     else
                     {
+#if CORERT
+                        fieldOffset = cookieOrOffsetOrOrdinal;
+#else
                         fieldOffset = (int)externalReferences.GetRvaFromIndex((uint)cookieOrOffsetOrOrdinal);
+#endif
                     }
 
                     if ((entryFlags & FieldTableFlags.StorageClass) == FieldTableFlags.ThreadStatic)

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -28,6 +28,9 @@ public class ReflectionTest
         if (TestReflectionInvoke() == Fail)
             return Fail;
 
+        if (TestReflectionFieldAccess() == Fail)
+            return Fail;
+
         return Pass;
     }
 
@@ -181,6 +184,46 @@ public class ReflectionTest
         //}
 
         return Pass;
+    }
+
+    public class FieldInvokeSample
+    {
+        public String InstanceField;
+    }
+
+    private static int TestReflectionFieldAccess()
+    {
+        Console.WriteLine("Testing reflection field access");
+
+        if (string.Empty.Length > 0)
+        {
+            new FieldInvokeSample().ToString();
+        }
+
+        TypeInfo ti = typeof(FieldInvokeSample).GetTypeInfo();
+        {
+            FieldInfo instanceField = ti.GetDeclaredField("InstanceField");
+            FieldInvokeSample obj = new FieldInvokeSample();
+
+            String value = (String)(instanceField.GetValue(obj));
+            if (value != null)
+                return Fail;
+
+            obj.InstanceField = "Hi!";
+            value = (String)(instanceField.GetValue(obj));
+            if (value != "Hi!")
+                return Fail;
+
+            instanceField.SetValue(obj, "Bye!");
+            if (obj.InstanceField != "Bye!")
+                return Fail;
+
+            value = (String)(instanceField.GetValue(obj));
+            if (value != "Bye!")
+                return Fail;
+
+            return Pass;
+        }
     }
 }
 


### PR DESCRIPTION
For now, it's for instance fields only. I decided to make a slight
change to the format to avoid a usless indirection through the external
reflerences table to get the field offset. We might want to port that to
Project N too...