### PR TITLE
Fix pinvoke string literal handling

### DIFF
--- a/src/Common/src/Internal/Text/Utf8String.cs
+++ b/src/Common/src/Internal/Text/Utf8String.cs
@@ -2,11 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Internal.Text
 {
-    public struct Utf8String
+    public struct Utf8String : IEquatable<Utf8String>
     {
         private byte[] _value;
 
@@ -34,6 +37,21 @@ namespace Internal.Text
         public override string ToString()
         {
             return Encoding.UTF8.GetString(_value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return (obj is Utf8String) && Equals((Utf8String)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)_value).GetHashCode(EqualityComparer<byte>.Default);
+        }
+
+        public bool Equals(Utf8String other)
+        {
+            return ((IStructuralEquatable)_value).Equals(other._value, EqualityComparer<byte>.Default);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 
 using ILCompiler.DependencyAnalysisFramework;
 
@@ -617,6 +618,28 @@ namespace ILCompiler.DependencyAnalysis
         public EmbeddedObjectNode EagerCctorIndirection(MethodDesc cctorMethod)
         {
             return _eagerCctorIndirectionNodes.GetOrAdd(cctorMethod);
+        }
+
+        public ISymbolNode ConstantUtf8String(string str)
+        {
+            int stringBytesCount = Encoding.UTF8.GetByteCount(str);
+            byte[] stringBytes = new byte[stringBytesCount + 1];
+            Encoding.UTF8.GetBytes(str, 0, str.Length, stringBytes, 0);
+
+            string symbolName = "__utf8str_" + NameMangler.GetMangledStringName(str);
+
+            return ReadOnlyDataBlob(symbolName, stringBytes, 1);
+        }
+
+        public ISymbolNode ConstantUtf16String(string str)
+        {
+            int stringBytesCount = Encoding.Unicode.GetByteCount(str);
+            byte[] stringBytes = new byte[stringBytesCount + 2];
+            Encoding.Unicode.GetBytes(str, 0, str.Length, stringBytes, 0);
+
+            string symbolName = "__utf16str_" + NameMangler.GetMangledStringName(str);
+
+            return ReadOnlyDataBlob(symbolName, stringBytes, 2);
         }
 
         /// <summary>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text;
-
 using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
@@ -53,12 +50,7 @@ namespace ILCompiler.DependencyAnalysis
             //
 
             builder.EmitZeroPointer();
-
-            int entryPointBytesCount = Encoding.UTF8.GetByteCount(_entryPointName);
-            byte[] entryPointNameBytes = new byte[entryPointBytesCount + 1];
-            Encoding.UTF8.GetBytes(_entryPointName, 0, _entryPointName.Length, entryPointNameBytes, 0);
-
-            builder.EmitPointerReloc(factory.ReadOnlyDataBlob("__pinvokename_" + _entryPointName, entryPointNameBytes, 1));
+            builder.EmitPointerReloc(factory.ConstantUtf8String(_entryPointName));
             builder.EmitPointerReloc(factory.PInvokeModuleFixup(_moduleName));
 
             return builder.ToObjectData();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text;
-
 using Internal.Text;
 
 namespace ILCompiler.DependencyAnalysis
@@ -45,18 +42,16 @@ namespace ILCompiler.DependencyAnalysis
             ObjectDataBuilder builder = new ObjectDataBuilder(factory);
             builder.DefinedSymbols.Add(this);
 
+            ISymbolNode nameSymbol = factory.Target.IsWindows ?
+                factory.ConstantUtf16String(_moduleName) :
+                factory.ConstantUtf8String(_moduleName);
+
             //
             // Emit a ModuleFixupCell struct
             //
 
             builder.EmitZeroPointer();
-
-            Encoding encoding = factory.Target.IsWindows ? Encoding.Unicode : Encoding.UTF8;
-
-            int moduleNameBytesCount = encoding.GetByteCount(_moduleName);
-            byte[] moduleNameBytes = new byte[moduleNameBytesCount + 2];
-            encoding.GetBytes(_moduleName, 0, _moduleName.Length, moduleNameBytes, 0);
-            builder.EmitPointerReloc(factory.ReadOnlyDataBlob("__modulename_" + _moduleName, moduleNameBytes, 2));
+            builder.EmitPointerReloc(nameSymbol);
 
             return builder.ToObjectData();
         }


### PR DESCRIPTION
Addresses two issues:

* The name mangling I previously chose was not unique enough. We could
end up defining multiple `__pinvokename_` symbols if an app e.g. imports
`MessageBoxW` from `user32` and `user32.dll`. I'm centralizing string
literal handling to `NodeFactory`
* While doing that, I hit a latent bug introduced by the `Utf8String`
work - we have places (such as the `ReadOnlyBlob` node) where we need to
hash & compare these for equality.