### PR TITLE
Fix a few more CoreCLR compile failures

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -141,7 +141,12 @@ namespace Internal.TypeSystem.Ecma
                         item = _module.ResolveStandaloneSignature((StandaloneSignatureHandle)handle);
                         break;
 
-                    // TODO: Resolve other tokens
+                    case HandleKind.ModuleDefinition:
+                        // ECMA-335 Partition 2 II.22.38 1d: This should not occur in a CLI ("compressed metadata") module,
+                        // but resolves to "current module".
+                        item = _module;
+                        break;
+
                     default:
                         throw new BadImageFormatException("Unknown metadata token type: " + handle.Kind);
                 }

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -79,6 +79,8 @@ namespace ILCompiler
             }
             else
             {
+                // Use the typical field definition in case this is an instantiated generic type
+                field = field.GetTypicalFieldDefinition();
                 return NodeFactory.ReadOnlyDataBlob(NameMangler.GetMangledFieldName(field),
                     ((EcmaField)field).GetFieldRvaData(), NodeFactory.Target.PointerSize);
             }


### PR DESCRIPTION
I'm done with fixing compilation failures after this, because the rest are not quickly fixable.

I'll bucket the rest, file issues as needed, and update baseline. We had more than 300 failures yesterday and now we're down to less than 50.