### PR TITLE
Fix constraint resolution for generic methods

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -217,7 +217,7 @@ namespace Internal.TypeSystem
             // If the method is a generic method then go and get the instantiated descriptor
             if (interfaceMethod.HasInstantiation)
             {
-                method = method.InstantiateSignature(interfaceType.Instantiation, interfaceMethod.Instantiation);
+                method = method.MakeInstantiatedMethod(interfaceMethod.Instantiation);
             }
 
             Debug.Assert(method != null);


### PR DESCRIPTION
`InstantiateSignature` is the wrong thing to call. The `method` is a
method definition (that's how we made it on line 172 above).