### PR TITLE
Make sure FieldDesc.IsThreadStatic is checked before HasGCStaticBase

### DIFF
--- a/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
@@ -40,6 +40,8 @@ namespace Internal.TypeSystem
         {
             get
             {
+                // If this assert fires then make sure the caller checks the IsThreadStatic attribute
+                // of FieldDesc before checking its HasGCStaticBase property.
                 Debug.Assert(IsStatic && !IsThreadStatic);
                 return Context.ComputeHasGCStaticBase(this);
             }

--- a/src/Common/src/TypeSystem/Common/Utilities/GCPointerMap.Algorithm.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/GCPointerMap.Algorithm.cs
@@ -31,7 +31,7 @@ namespace Internal.TypeSystem
             foreach (FieldDesc field in type.GetFields())
             {
                 if (!field.IsStatic || field.HasRva || field.IsLiteral
-                    || !field.HasGCStaticBase || field.IsThreadStatic)
+                    || field.IsThreadStatic || !field.HasGCStaticBase)
                     continue;
 
                 TypeDesc fieldType = field.FieldType;


### PR DESCRIPTION
This change reorders the sequence of checks in GCPointerMap.FromStaticLayout to make sure FieldDesc.HasGCStaticBase is not queried for thread static fields.