### PR TITLE
Fix passing parameters to tests

### DIFF
--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -48,7 +48,17 @@ if errorlevel 1 (
 shift
 shift
 
-%TestFolder%\native\%TestExecutable% %*
+set TestParameters=
+set Delimiter=
+:GetNextParameter
+if "%1"=="" goto :RunTest
+set "TestParameters=%TestParameters%%Delimiter%%1"
+set "Delimiter= "
+shift
+goto :GetNextParameter
+
+:RunTest
+%TestFolder%\native\%TestExecutable% %TestParameters%
 
 set TestExitCode=!ERRORLEVEL!
 


### PR DESCRIPTION
`shift` doesn't actually affect the `%*` so unfortunately we need to do
a bunch of weirdness to skip over the first two parameters.