### PR TITLE
Cache the result of EEType validation

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -41,6 +41,9 @@ namespace ILCompiler
             _dependencyGraph.ComputeDependencyRoutine += ComputeDependencyNodeDependencies;
             NodeFactory.AttachToDependencyGraph(_dependencyGraph);
 
+            // TODO: hacky static field
+            NodeFactory.NameMangler = nameMangler;
+
             var rootingService = new RootingServiceProvider(dependencyGraph, nodeFactory);
             foreach (var rootProvider in compilationRoots)
                 rootProvider.AddCompilationRoots(rootingService);
@@ -100,9 +103,7 @@ namespace ILCompiler
 
         void ICompilation.Compile(string outputFile)
         {
-            // TODO: Hacky static fields
-
-            NodeFactory.NameMangler = NameMangler;
+            // TODO: Hacky static field
 
             string systemModuleName = ((IAssemblyDesc)NodeFactory.TypeSystemContext.SystemModule).GetName().Name;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -521,13 +521,13 @@ namespace ILCompiler.DependencyAnalysis
             TypeDesc baseType = type.BaseType;
             if (baseType != null)
             {
-                CheckCanGenerateEEType(factory, baseType);
+                factory.NecessaryTypeSymbol(baseType);
             }
             
             // We need EETypes for interfaces
             foreach (var intf in type.RuntimeInterfaces)
             {
-                CheckCanGenerateEEType(factory, intf);
+                factory.NecessaryTypeSymbol(intf);
             }
 
             // Validate classes, structs, enums, interfaces, and delegates
@@ -571,7 +571,7 @@ namespace ILCompiler.DependencyAnalysis
             if (parameterizedType != null)
             {
                 TypeDesc parameterType = parameterizedType.ParameterType;
-                CheckCanGenerateEEType(factory, parameterType);
+                factory.NecessaryTypeSymbol(parameterType);
 
                 if (parameterizedType.IsArray)
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -69,7 +69,10 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(!type.IsRuntimeDeterminedSubtype);
             _type = type;
             _optionalFieldsNode = new EETypeOptionalFieldsNode(this);
-            
+
+            // Note: The fact that you can't create invalid EETypeNode is used from many places that grab
+            // an EETypeNode from the factory with the sole purpose of making sure the validation has run
+            // and that the result of the positive validation is "cached" (by the presence of an EETypeNode).
             CheckCanGenerateEEType(factory, type);
         }
 
@@ -521,12 +524,14 @@ namespace ILCompiler.DependencyAnalysis
             TypeDesc baseType = type.BaseType;
             if (baseType != null)
             {
+                // Make sure EEType can be created for this.
                 factory.NecessaryTypeSymbol(baseType);
             }
             
             // We need EETypes for interfaces
             foreach (var intf in type.RuntimeInterfaces)
             {
+                // Make sure EEType can be created for this.
                 factory.NecessaryTypeSymbol(intf);
             }
 
@@ -571,6 +576,8 @@ namespace ILCompiler.DependencyAnalysis
             if (parameterizedType != null)
             {
                 TypeDesc parameterType = parameterizedType.ParameterType;
+
+                // Make sure EEType can be created for this.
                 factory.NecessaryTypeSymbol(parameterType);
 
                 if (parameterizedType.IsArray)


### PR DESCRIPTION
The `Loader\classloader\generics\Constraints\General\ManyGenConstraints`
CoreCLR test was taking forever to compile. (And I'm not even
exaggerating too much.)