### PR TITLE
Make tests with managed/unmanaged dependencies work

### DIFF
--- a/tests/CoreCLR/Test.csproj
+++ b/tests/CoreCLR/Test.csproj
@@ -7,6 +7,11 @@
     <OutputPath>$(MSBuildProjectDirectory)\</OutputPath>
     <IntermediateOutputPath>$(MSBuildProjectDirectory)\</IntermediateOutputPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Some tests consist of multiple assemblies - make sure ILC sees them -->
+    <IlcReference Include="$(MSBuildProjectDirectory)\*.dll" />
+  </ItemGroup>
   
   <Import Project="$(CoreRT_TestRoot)\Test.Common.targets" />
   

--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -43,6 +43,9 @@ if errorlevel 1 (
     exit /b !ERRORLEVEL!
 )
 
+:: Some tests (interop) have native artifacts they depend on. Copy all DLLs to be sure we have them.
+copy %TestFolder%\*.dll %TestFolder%\native\
+
 :: Remove the first two parameters passed by the test cmd file which are added to communicate test
 :: information to custom test runners
 shift


### PR DESCRIPTION
Some tests have more artifacts than just the test EXE.

* Pass all DLL files to ILC (technically, we only need managed DLLs, but
this shouldn't hurt)
* Copy all DLL files to the output directory (technically, we only need
native DLLs, but this shouldn't hurt)

This should fix/get further along with about 500 test failures.