### PR TITLE
Match up NewMultiDimArray with AllocateArrayEx in CLR

### DIFF
--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -908,7 +908,7 @@ namespace System
                 if (length > MaxArrayLength)
                     maxArrayDimensionLengthOverflow = true;
                 totalLength = totalLength * (ulong)length;
-                if (totalLength > UInt32.MaxValue)
+                if (totalLength > Int32.MaxValue)
                     throw new OutOfMemoryException(); // "Array dimensions exceeded supported range."
             }
 


### PR DESCRIPTION
The `JIT\Directed\newarr\newarr.cs` test is unhappy about our exception
types.