### PR TITLE
Implement Exception.get_StackTrace

### DIFF
--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -278,7 +278,7 @@ static const pfn c_classlibFunctions[] = {
     &GetRuntimeException,
     &FailFast,
     nullptr, // &UnhandledExceptionHandler,
-    nullptr, // &AppendExceptionStackFrame,
+    &AppendExceptionStackFrame,
 };
 
 #if defined(_WIN32)

--- a/src/Native/Runtime/ICodeManager.h
+++ b/src/Native/Runtime/ICodeManager.h
@@ -113,5 +113,7 @@ public:
 
     virtual bool EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClause) = 0;
 
+    virtual PTR_VOID GetMethodStartAddress(MethodInfo * pMethodInfo) = 0;
+
     virtual void * GetClasslibFunction(ClasslibFunctionId functionId) = 0;
 };

--- a/src/Native/Runtime/RuntimeInstance.cpp
+++ b/src/Native/Runtime/RuntimeInstance.cpp
@@ -147,12 +147,12 @@ COOP_PINVOKE_HELPER(UInt8 *, RhFindMethodStartAddress, (void * codeAddr))
 
 PTR_UInt8 RuntimeInstance::FindMethodStartAddress(PTR_VOID ControlPC)
 {
-	ICodeManager * pCodeManager = FindCodeManagerByAddress(ControlPC);
-	MethodInfo methodInfo;
-	if (pCodeManager != NULL && pCodeManager->FindMethodInfo(ControlPC, &methodInfo))
-	{
-		return (PTR_UInt8)pCodeManager->GetMethodStartAddress(&methodInfo);
-	}
+    ICodeManager * pCodeManager = FindCodeManagerByAddress(ControlPC);
+    MethodInfo methodInfo;
+    if (pCodeManager != NULL && pCodeManager->FindMethodInfo(ControlPC, &methodInfo))
+    {
+        return (PTR_UInt8)pCodeManager->GetMethodStartAddress(&methodInfo);
+    }
 
     return NULL;
 }

--- a/src/Native/Runtime/RuntimeInstance.cpp
+++ b/src/Native/Runtime/RuntimeInstance.cpp
@@ -147,14 +147,12 @@ COOP_PINVOKE_HELPER(UInt8 *, RhFindMethodStartAddress, (void * codeAddr))
 
 PTR_UInt8 RuntimeInstance::FindMethodStartAddress(PTR_VOID ControlPC)
 {
-    FOREACH_MODULE(pModule)
-    {
-        if (pModule->ContainsCodeAddress(ControlPC))
-        {
-            return pModule->FindMethodStartAddress(ControlPC);
-        }
-    }
-    END_FOREACH_MODULE;
+	ICodeManager * pCodeManager = FindCodeManagerByAddress(ControlPC);
+	MethodInfo methodInfo;
+	if (pCodeManager != NULL && pCodeManager->FindMethodInfo(ControlPC, &methodInfo))
+	{
+		return (PTR_UInt8)pCodeManager->GetMethodStartAddress(&methodInfo);
+	}
 
     return NULL;
 }

--- a/src/Native/Runtime/module.cpp
+++ b/src/Native/Runtime/module.cpp
@@ -585,6 +585,12 @@ bool Module::EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClauseOut)
     return true;
 }
 
+PTR_VOID Module::GetMethodStartAddress(MethodInfo * pMethodInfo)
+{
+    EEMethodInfo * pInfo = GetEEMethodInfo(pMethodInfo);
+    return pInfo->GetCode();
+}
+
 static PTR_VOID GetFuncletSafePointForIncomingLiveReferences(Module * pModule, EEMethodInfo * pInfo, UInt32 funcletStart)
 {
     // The binder will encode a GC safe point (as appropriate) at the first code offset after the 

--- a/src/Native/Runtime/module.h
+++ b/src/Native/Runtime/module.h
@@ -94,6 +94,8 @@ public:
     bool EHEnumInit(MethodInfo * pMethodInfo, PTR_VOID * pMethodStartAddressOut, EHEnumState * pEHEnumStateOut);
     bool EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClauseOut);
 
+    PTR_VOID GetMethodStartAddress(MethodInfo * pMethodInfo);
+
     PTR_VOID RemapHardwareFaultToGCSafePoint(MethodInfo * pMethodInfo, PTR_VOID controlPC);
 
     DispatchMap ** GetDispatchMapLookupTable();

--- a/src/Native/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/Native/Runtime/unix/UnixNativeCodeManager.cpp
@@ -289,6 +289,12 @@ bool UnixNativeCodeManager::EHEnumNext(EHEnumState * pEHEnumState, EHClause * pE
     return true;
 }
 
+PTR_VOID UnixNativeCodeManager::GetMethodStartAddress(MethodInfo * pMethodInfo)
+{
+    UnixNativeMethodInfo * pNativeMethodInfo = (UnixNativeMethodInfo *)pMethodInfo;
+    return pNativeMethodInfo->pMethodStartAddress;
+}
+
 void * UnixNativeCodeManager::GetClasslibFunction(ClasslibFunctionId functionId)
 {
     uint32_t id = (uint32_t)functionId;

--- a/src/Native/Runtime/unix/UnixNativeCodeManager.h
+++ b/src/Native/Runtime/unix/UnixNativeCodeManager.h
@@ -53,5 +53,7 @@ public:
 
     bool EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClause);
 
+    PTR_VOID GetMethodStartAddress(MethodInfo * pMethodInfo);
+
     void * GetClasslibFunction(ClasslibFunctionId functionId);
 };

--- a/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
@@ -510,6 +510,12 @@ bool CoffNativeCodeManager::EHEnumNext(EHEnumState * pEHEnumState, EHClause * pE
     return true;
 }
 
+PTR_VOID CoffNativeCodeManager::GetMethodStartAddress(MethodInfo * pMethodInfo)
+{
+    CoffNativeMethodInfo * pNativeMethodInfo = (CoffNativeMethodInfo *)pMethodInfo;
+    return dac_cast<PTR_VOID>(m_moduleBase + pNativeMethodInfo->mainRuntimeFunction->BeginAddress);
+}
+
 void * CoffNativeCodeManager::GetClasslibFunction(ClasslibFunctionId functionId)
 {
     uint32_t id = (uint32_t)functionId;

--- a/src/Native/Runtime/windows/CoffNativeCodeManager.h
+++ b/src/Native/Runtime/windows/CoffNativeCodeManager.h
@@ -89,5 +89,7 @@ public:
 
     bool EHEnumNext(EHEnumState * pEHEnumState, EHClause * pEHClause);
 
+    PTR_VOID GetMethodStartAddress(MethodInfo * pMethodInfo);
+
     void * GetClasslibFunction(ClasslibFunctionId functionId);
 };

--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -410,6 +410,8 @@ namespace System
                 if (!outOfMemory)
                     ex.AppendStackIP(IP, isFirstRethrowFrame);
 
+                // CORERT-TODO: RhpEtwExceptionThrown
+#if !CORERT
                 if (isFirstFrame)
                 {
                     string typeName = !outOfMemory ? ex.GetType().ToString() : "System.OutOfMemoryException";
@@ -422,6 +424,7 @@ namespace System
                             RuntimeImports.RhpEtwExceptionThrown(exceptionTypeName, exceptionMessage, IP, ex.HResult);
                     }
                 }
+#endif
             }
             catch
             {

--- a/tests/src/Simple/Exceptions/Exceptions.cs
+++ b/tests/src/Simple/Exceptions/Exceptions.cs
@@ -21,6 +21,12 @@ public class BringUpTest
 
     public static int Main()
     {
+        if (string.Empty.Length > 0)
+        {
+            // Just something to make sure we generate reflection metadata for the type
+            new BringUpTest().ToString();
+        }
+
         int counter = 0;
 
         try
@@ -42,6 +48,13 @@ public class BringUpTest
             {
                  Console.WriteLine("Unexpected exception message!");
                  return Fail;
+            }
+
+            string stackTrace = e.StackTrace;
+            if (!stackTrace.Contains("BringUpTest.Main"))
+            {
+                Console.WriteLine("Unexpected stack trace: " + stackTrace);
+                return Fail;
             }
             counter++;
         }


### PR DESCRIPTION
This relies on the existing logic that tries DIA first, and then falls
back to reflection metadata to find method names. If fallback fails, you
get RVAs. Conveniently, the DIA path doesn't even try to run.