### PR TITLE
Implement Type.GetType expansion

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/TypeGetTypeMethodThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/TypeGetTypeMethodThunk.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Helps model the behavior of calls to various Type.GetType overloads. Type.GetType is required to search
+    /// the calling assembly for a matching type if the type name supplied by the user code was not assembly qualified.
+    /// This thunk calls a helper method, passing it a string for what should be considered the "calling assembly".
+    /// </summary>
+    internal class TypeGetTypeMethodThunk : ILStubMethod
+    {
+        private readonly MethodDesc _helperMethod;
+
+        public TypeGetTypeMethodThunk(TypeDesc owningType, MethodSignature signature, MethodDesc helperMethod, string defaultAssemblyName)
+        {
+            OwningType = owningType;
+            Signature = signature;
+            DefaultAssemblyName = defaultAssemblyName;
+            _helperMethod = helperMethod;
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return OwningType.Context;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return $"{_helperMethod.Name}_{Signature.Length}_{DefaultAssemblyName}";
+            }
+        }
+
+        public override TypeDesc OwningType
+        {
+            get;
+        }
+
+        public override MethodSignature Signature
+        {
+            get;
+        }
+
+        public string DefaultAssemblyName
+        {
+            get;
+        }
+
+        public override MethodIL EmitIL()
+        {
+            ILEmitter emit = new ILEmitter();
+            ILCodeStream codeStream = emit.NewCodeStream();
+
+            Debug.Assert(Signature[0] == _helperMethod.Signature[0]);
+            codeStream.EmitLdArg(0);
+
+            Debug.Assert(_helperMethod.Signature[1].IsString);
+            codeStream.Emit(ILOpcode.ldstr, emit.NewToken(DefaultAssemblyName));
+
+            for (int i = 2; i < _helperMethod.Signature.Length; i++)
+            {
+                // The helper method could be expecting more arguments than what we have - check for that
+                // The thunk represents one of the 6 possible overloads:
+                // (String), (String, bool), (String, bool, bool)
+                // (String, Func<...>, Func<...>), (String, Func<...>, Func<...>, bool), (String, Func<...>, Func<...>, bool, bool)
+                // We only need 2 helpers to support all 6 overloads. The default value for the bools is false.
+
+                if (i - 1 < Signature.Length)
+                {
+                    // Pass user's parameter
+                    Debug.Assert(_helperMethod.Signature[i] == Signature[i - 1]);
+                    codeStream.EmitLdArg(i - 1);
+                }
+                else
+                {
+                    // Pass a default value
+                    Debug.Assert(_helperMethod.Signature[i].IsWellKnownType(WellKnownType.Boolean));
+                    codeStream.EmitLdc(0);
+                }
+            }
+
+            codeStream.Emit(ILOpcode.call, emit.NewToken(_helperMethod));
+            codeStream.Emit(ILOpcode.ret);
+
+            return emit.Link(this);
+        }
+    }
+
+    internal abstract class TypeGetTypeMethodThunkCache
+    {
+        private TypeDesc _owningTypeForThunks;
+        private Unifier _cache;
+
+        public TypeGetTypeMethodThunkCache(TypeDesc owningTypeForThunks)
+        {
+            _owningTypeForThunks = owningTypeForThunks;
+            _cache = new Unifier(this);
+        }
+
+        public MethodDesc GetHelper(MethodDesc getTypeOverload, string defaultAssemblyName)
+        {
+            return _cache.GetOrCreateValue(new Key(defaultAssemblyName, getTypeOverload));
+        }
+
+        protected abstract MethodDesc GetHelperForOverload(MethodDesc typeGetTypeOverload);
+
+        private struct Key
+        {
+            public readonly string DefaultAssemblyName;
+            public readonly MethodDesc GetTypeOverload;
+
+            public Key(string defaultAssemblyName, MethodDesc getTypeOverload)
+            {
+                DefaultAssemblyName = defaultAssemblyName;
+                GetTypeOverload = getTypeOverload;
+            }
+        }
+
+        private class Unifier : LockFreeReaderHashtable<Key, TypeGetTypeMethodThunk>
+        {
+            private TypeGetTypeMethodThunkCache _parent;
+
+            public Unifier(TypeGetTypeMethodThunkCache parent)
+            {
+                _parent = parent;
+            }
+
+            protected override int GetKeyHashCode(Key key)
+            {
+                return key.DefaultAssemblyName.GetHashCode() ^ key.GetTypeOverload.Signature.GetHashCode();
+            }
+            protected override int GetValueHashCode(TypeGetTypeMethodThunk value)
+            {
+                return value.DefaultAssemblyName.GetHashCode() ^ value.Signature.GetHashCode();
+            }
+            protected override bool CompareKeyToValue(Key key, TypeGetTypeMethodThunk value)
+            {
+                return key.DefaultAssemblyName == value.DefaultAssemblyName &&
+                    key.GetTypeOverload.Signature.Equals(value.Signature);
+            }
+            protected override bool CompareValueToValue(TypeGetTypeMethodThunk value1, TypeGetTypeMethodThunk value2)
+            {
+                return value1.DefaultAssemblyName == value2.DefaultAssemblyName &&
+                    value1.Signature.Equals(value2.Signature);
+            }
+            protected override TypeGetTypeMethodThunk CreateValueFromKey(Key key)
+            {
+                MethodDesc helper = _parent.GetHelperForOverload(key.GetTypeOverload);
+                return new TypeGetTypeMethodThunk(_parent._owningTypeForThunks, key.GetTypeOverload.Signature, helper, key.DefaultAssemblyName);
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -118,7 +118,7 @@ namespace ILCompiler
         /// <param name="intrinsicMethod">The intrinsic method called.</param>
         /// <param name="callsiteMethod">The callsite that calls the intrinsic.</param>
         /// <returns>The intrinsic implementation to be called for this specific callsite.</returns>
-        public MethodDesc ResolveIntrinsicMethodForCallsite(MethodDesc intrinsicMethod, MethodDesc callsiteMethod)
+        public MethodDesc ExpandIntrinsicForCallsite(MethodDesc intrinsicMethod, MethodDesc callsiteMethod)
         {
             Debug.Assert(intrinsicMethod.IsIntrinsic);
 

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -55,7 +55,7 @@ namespace ILCompiler
             foreach (var rootProvider in compilationRoots)
                 rootProvider.AddCompilationRoots(rootingService);
 
-            // TODO: use a better owning type for multi-file friendlyness
+            // TODO: use a better owning type for multi-file friendliness
             _typeGetTypeMethodThunks = new TypeGetTypeMethodThunkCache(TypeSystemContext.SystemModule.GetGlobalModuleType());
         }
 

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -74,6 +74,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\CreateInstanceIntrinsic.cs">
       <Link>IL\Stubs\CreateInstanceIntrinsic.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\TypeGetTypeMethodThunk.cs">
+      <Link>IL\Stubs\TypeGetTypeMethodThunk.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\TypeSystemThrowingILEmitter.cs">
       <Link>IL\Stubs\TypeSystemThrowingILEmitter.cs</Link>
     </Compile>

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -844,6 +844,17 @@ namespace Internal.JitInterface
             if (result is MethodDesc)
             {
                 MethodDesc method = result as MethodDesc;
+
+                // If this is an intrinsic method with a callsite-specific expansion, this will replace
+                // the method we just resolved with a method the intrinsic expands into. If it's not the
+                // special intrinsic, method stays unchanged.
+                // TODO: We should only do this if this is a call (we specifically don't want to do this kind of
+                // expansion if this is LDTOKEN/LDFTN/LDVIRTFTN).
+                if (method.IsIntrinsic)
+                {
+                    method = _compilation.ResolveIntrinsicMethodForCallsite(method, methodIL.OwningMethod);
+                }
+
                 pResolvedToken.hMethod = ObjectToHandle(method);
                 pResolvedToken.hClass = ObjectToHandle(method.OwningType);
             }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
@@ -26,7 +26,7 @@ namespace Internal.Runtime.Augments
     public abstract class ReflectionExecutionDomainCallbacks
     {
         // Api's that are exposed in System.Runtime but are really reflection apis.
-        public abstract Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase);
+        public abstract Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase, string defaultAssembly);
 
         public abstract IntPtr TryGetStaticClassConstructionContext(RuntimeTypeHandle runtimeTypeHandle);
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ReflectionHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ReflectionHelpers.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+using Internal.Runtime.Augments;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    /// <summary>
+    /// Set of helpers used to implement callsite-specific reflection intrinsics.
+    /// </summary>
+    internal static class ReflectionHelpers
+    {
+        // This entry is used to implement Type.GetType()'s ability to detect the calling assembly and use it as
+        // a default assembly name.
+        public static Type GetType(string typeName, string callingAssemblyName, bool throwOnError, bool ignoreCase)
+        {
+            return ExtensibleGetType(typeName, callingAssemblyName, null, null, throwOnError: throwOnError, ignoreCase: ignoreCase);
+        }
+
+        // This entry is used to implement Type.GetType()'s ability to detect the calling assembly and use it as
+        // a default assembly name.
+        public static Type ExtensibleGetType(string typeName, string callingAssemblyName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase)
+        {
+            return RuntimeAugments.Callbacks.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, callingAssemblyName);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="Internal\Diagnostics\ExceptionExtensions.cs" />
     <Compile Include="Internal\Diagnostics\StackTraceHelper.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\ReflectionHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\ThreadingHelpers.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">

--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -241,7 +241,7 @@ namespace System
         [Intrinsic]
         public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError) => GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: false);
         [Intrinsic]
-        public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase) => RuntimeAugments.Callbacks.GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: ignoreCase);
+        public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase) => RuntimeAugments.Callbacks.GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: ignoreCase, defaultAssembly: null);
 
         public virtual RuntimeTypeHandle TypeHandle { get { throw new NotSupportedException(); } }
         [Intrinsic]

--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -229,12 +229,18 @@ namespace System
 
         public virtual MemberInfo[] GetDefaultMembers() { throw NotImplemented.ByDesign; }
 
+        [Intrinsic]
         public static Type GetType(string typeName) => GetType(typeName, throwOnError: false, ignoreCase: false);
+        [Intrinsic]
         public static Type GetType(string typeName, bool throwOnError) => GetType(typeName, throwOnError: throwOnError, ignoreCase: false);
+        [Intrinsic]
         public static Type GetType(string typeName, bool throwOnError, bool ignoreCase) => GetType(typeName, null, null, throwOnError: throwOnError, ignoreCase: ignoreCase);
 
+        [Intrinsic]
         public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver) => GetType(typeName, assemblyResolver, typeResolver, throwOnError: false, ignoreCase: false);
+        [Intrinsic]
         public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError) => GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: false);
+        [Intrinsic]
         public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase) => RuntimeAugments.Callbacks.GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: ignoreCase);
 
         public virtual RuntimeTypeHandle TypeHandle { get { throw new NotSupportedException(); } }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -31,9 +31,19 @@ namespace Internal.Reflection.Execution
             _executionEnvironment = executionEnvironment;
         }
 
-        public sealed override Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase)
+        public sealed override Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase, string defaultAssemblyName)
         {
-            return _executionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, ReflectionExecution.DefaultAssemblyNamesForGetType);
+            if (defaultAssemblyName == null)
+            {
+                return _executionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, ReflectionExecution.DefaultAssemblyNamesForGetType);
+            }
+            else
+            {
+                LowLevelListWithIList<String> defaultAssemblies = new LowLevelListWithIList<String>();
+                defaultAssemblies.Add(defaultAssemblyName);
+                defaultAssemblies.AddRange(ReflectionExecution.DefaultAssemblyNamesForGetType);
+                return _executionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, defaultAssemblies);
+            }
         }
 
         public sealed override bool IsReflectionBlocked(RuntimeTypeHandle typeHandle)

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -54,7 +54,7 @@ public class ReflectionTest
         Console.WriteLine("Testing unification");
 
         // ReflectionTest type doesn't have an EEType and is metadata only.
-        Type programType = Type.GetType("ReflectionTest, Reflection");
+        Type programType = Type.GetType("ReflectionTest");
         TypeInfo programTypeInfo = programType.GetTypeInfo();
 
         Type programBaseType = programTypeInfo.BaseType;


### PR DESCRIPTION
`Type.GetType` needs to be compiled specially since for inputs that are
not assembly-qualified, the method is expected to search the calling
assembly.

The way we do this is by introducing a concept of callsite-specific
intrinsics. The expansion of these intrinsics depends on the callsite
from which the intrinsic is called.

We make calls to `Type.GetType` expand to overload+assembly specific
`ILStubMethod` that thunks to a helper that consumes a "default assembly
argument" in addition to the regular arguments.