### PR TITLE
Fix shutdown hang when running CoreCLR tests

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Environment.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Environment.cs
@@ -16,4 +16,9 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_ExitProcess")]
         internal static extern void ExitProcess(int exitCode);
     }
+
+    internal static void ExitProcess(int exitCode)
+    {
+        Sys.ExitProcess(exitCode);
+    }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
@@ -17,4 +17,9 @@ internal static partial class Interop
         [DllImport(Libraries.Kernel32, EntryPoint = "ExitProcess")]
         internal static extern void ExitProcess(int exitCode);
     }
+
+    internal static void ExitProcess(int exitCode)
+    {
+        mincore.ExitProcess(exitCode);
+    }
 }

--- a/src/Native/Runtime/PalRedhawkFunctions.h
+++ b/src/Native/Runtime/PalRedhawkFunctions.h
@@ -56,12 +56,6 @@ inline UInt32 PalEventWrite(REGHANDLE arg1, const EVENT_DESCRIPTOR * arg2, UInt3
     return EventWrite(arg1, arg2, arg3, arg4);
 }
 
-extern "C" void __stdcall ExitProcess(UInt32);
-inline void PalExitProcess(UInt32 arg1)
-{
-    ExitProcess(arg1);
-}
-
 extern "C" void __stdcall FlushProcessWriteBuffers();
 inline void PalFlushProcessWriteBuffers()
 {

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -1031,11 +1031,6 @@ extern "C" void TerminateProcess(HANDLE arg1, UInt32 arg2)
     PORTABILITY_ASSERT("UNIXTODO: Implement this function");
 }
 
-extern "C" void ExitProcess(UInt32 exitCode)
-{
-    exit(exitCode);
-}
-
 extern "C" UInt32_BOOL SetEvent(HANDLE event)
 {
     EventUnixHandle* unixHandle = (EventUnixHandle*)event;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
@@ -14,7 +14,26 @@ namespace Internal.Runtime.Augments
         public static int CurrentManagedThreadId => System.Threading.ManagedThreadId.Current;
         public static void FailFast(string message, Exception error) => RuntimeExceptionHelpers.FailFast(message, error);
 
-        public static void Exit(int exitCode) => Environment.Exit(exitCode);
+        public static void Exit(int exitCode)
+        {
+#if CORERT
+            s_latchedExitCode = exitCode;
+
+            ShutdownCore();
+
+            RuntimeImports.RhpShutdown();
+
+            Interop.ExitProcess(s_latchedExitCode);
+#else
+            // This needs to be implemented for ProjectN.
+            throw new PlatformNotSupportedException();
+#endif
+        }
+
+        internal static void ShutdownCore()
+        {
+            // Here we'll handle AppDomain.ProcessExit, shut down threading etc.
+        }
 
         private static int s_latchedExitCode;
         public static int ExitCode

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
@@ -56,7 +56,7 @@ namespace Internal.Runtime.CompilerHelpers
         // Shuts down the class library and returns the process exit code.
         private static int Shutdown()
         {
-            // Here we'll handle AppDomain.ProcessExit, shut down threading etc.
+            EnvironmentAugments.ShutdownCore();
 
             return EnvironmentAugments.ExitCode;
         }

--- a/src/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -70,11 +70,5 @@ namespace System
 
             return Encoding.UTF8.GetString((byte*)result, size);
         }
-
-        public static void Exit(int exitCode)
-        {
-            // CORERT-TODO: Shut down the runtime
-            Interop.Sys.ExitProcess(exitCode);
-        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Environment.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Win32.cs
@@ -58,11 +58,5 @@ namespace System
 
             return new string(newblob);
         }
-
-        public static void Exit(int exitCode)
-        {
-            // CORERT-TODO: Shut down the runtime
-            Interop.mincore.ExitProcess(exitCode);
-        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -121,5 +121,7 @@ namespace System
                 EnvironmentAugments.ExitCode = value;
             }
         }
+
+        public static void Exit(int exitCode) => EnvironmentAugments.Exit(exitCode);
     }
 }

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -118,6 +118,10 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhpRegisterFrozenSegment")]
         internal static extern bool RhpRegisterFrozenSegment(IntPtr pSegmentStart, int length);
 
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhpShutdown")]
+        internal static extern void RhpShutdown();
+
         //
         // calls for GCHandle.
         // These methods are needed to implement GCHandle class like functionality (optional)


### PR DESCRIPTION
- Call RhpShutdown before returning from C++ main method. This will tell the runtime skip thread cleanup that otherwise leads to intermittent deadlock in half-torn down process state.
- Apply the same fix to Environment.Exit.
- Switch CppCodeGen to the fixed bootstrap main method so that it can naturally get this fix as well.

Fixes #2222.