### PR TITLE
Store the relocation offset delta in the code stream

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -219,25 +219,19 @@ namespace ILCompiler.DependencyAnalysis
             _data[offset + 3] = (byte)((emit >> 24) & 0xFF);
         }
 
-        public void AddRelocAtOffset(ISymbolNode symbol, RelocType relocType, int offset, int delta = 0)
-        {
-            Relocation symbolReloc = new Relocation(relocType, offset, symbol, delta);
-            _relocs.Add(symbolReloc);
-        }
-
         public void EmitReloc(ISymbolNode symbol, RelocType relocType, int delta = 0)
         {
-            AddRelocAtOffset(symbol, relocType, _data.Count, delta);
+            _relocs.Add(new Relocation(relocType, _data.Count, symbol));
 
             // And add space for the reloc
             switch (relocType)
             {
                 case RelocType.IMAGE_REL_BASED_REL32:
                 case RelocType.IMAGE_REL_BASED_ABSOLUTE:
-                    EmitInt(0);
+                    EmitInt(delta);
                     break;
                 case RelocType.IMAGE_REL_BASED_DIR64:
-                    EmitLong(0);
+                    EmitLong(delta);
                     break;
                 default:
                     throw new NotImplementedException();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -613,7 +613,15 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     Relocation reloc = relocs[nextRelocIndex];
 
-                    int size = EmitSymbolReference(reloc.Target, reloc.Delta, reloc.RelocType);
+                    long delta;
+                    unsafe
+                    {
+                        fixed (void* location = &blob[i])
+                        {
+                            delta = Relocation.ReadValue(reloc.RelocType, location);
+                        }
+                    }
+                    int size = EmitSymbolReference(reloc.Target, (int)delta, reloc.RelocType);
 
                     // Update nextRelocIndex/Offset
                     if (++nextRelocIndex < relocs.Length)
@@ -791,7 +799,15 @@ namespace ILCompiler.DependencyAnalysis
                         {
                             Relocation reloc = relocs[nextRelocIndex];
 
-                            int size = objectWriter.EmitSymbolReference(reloc.Target, reloc.Delta, reloc.RelocType);
+                            long delta;
+                            unsafe
+                            {
+                                fixed (void* location = &nodeContents.Data[i])
+                                {
+                                    delta = Relocation.ReadValue(reloc.RelocType, location);
+                                }
+                            }
+                            int size = objectWriter.EmitSymbolReference(reloc.Target, (int)delta, reloc.RelocType);
 
                             // Update nextRelocIndex/Offset
                             if (++nextRelocIndex < relocs.Length)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -22,14 +18,46 @@ namespace ILCompiler.DependencyAnalysis
         public readonly RelocType RelocType;
         public readonly int Offset;
         public readonly ISymbolNode Target;
-        public readonly int Delta;
 
-        public Relocation(RelocType relocType, int offset, ISymbolNode target, int delta)
+        public Relocation(RelocType relocType, int offset, ISymbolNode target)
         {
             RelocType = relocType;
             Offset = offset;
             Target = target;
-            Delta = delta;
+        }
+
+        public unsafe static void WriteValue(RelocType relocType, void* location, long value)
+        {
+            switch (relocType)
+            {
+                case RelocType.IMAGE_REL_BASED_ABSOLUTE:
+                case RelocType.IMAGE_REL_BASED_HIGHLOW:
+                case RelocType.IMAGE_REL_BASED_REL32:
+                    *(int*)location = (int)value;
+                    break;
+                case RelocType.IMAGE_REL_BASED_DIR64:
+                    *(long*)location = value;
+                    break;
+                default:
+                    Debug.Fail("Invalid RelocType: " + relocType);
+                    break;
+            }
+        }
+
+        public unsafe static long ReadValue(RelocType relocType, void* location)
+        {
+            switch (relocType)
+            {
+                case RelocType.IMAGE_REL_BASED_ABSOLUTE:
+                case RelocType.IMAGE_REL_BASED_HIGHLOW:
+                case RelocType.IMAGE_REL_BASED_REL32:
+                    return *(int*)location;
+                case RelocType.IMAGE_REL_BASED_DIR64:
+                    return *(long*)location;
+                default:
+                    Debug.Fail("Invalid RelocType: " + relocType);
+                    return 0;
+            }
         }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2954,6 +2954,9 @@ namespace Internal.JitInterface
 
         private void recordRelocation(void* location, void* target, ushort fRelocType, ushort slotNum, int addlDelta)
         {
+            // slotNum is not unused
+            Debug.Assert(slotNum == 0);
+
             int relocOffset;
             BlockType locationBlock = findKnownBlock(location, out relocOffset);
             Debug.Assert(locationBlock != BlockType.Unknown, "BlockType.Unknown not expected");
@@ -2996,9 +2999,12 @@ namespace Internal.JitInterface
 
             relocDelta += addlDelta;
 
+            // relocDelta is stored as the value
+            Relocation.WriteValue((RelocType)fRelocType, location, relocDelta);
+
             if (_relocs.Count == 0)
                 _relocs.EnsureCapacity(_code.Length / 32 + 1);
-            _relocs.Add(new Relocation((RelocType)fRelocType, relocOffset, relocTarget, relocDelta));
+            _relocs.Add(new Relocation((RelocType)fRelocType, relocOffset, relocTarget));
         }
 
         private ushort getRelocTypeHint(void* target)

--- a/tests/Top200.CoreCLR.issues.targets
+++ b/tests/Top200.CoreCLR.issues.targets
@@ -172,7 +172,7 @@
     <IncludeList Include="$(XunitTestBinBase)\JIT\Directed\ExcepFilters\excepobj\excepobj\excepobj.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\JIT\Directed\ExcepFilters\fault\fault\fault.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\JIT\Directed\ExcepFilters\mixed\mixed\mixed.cmd" />
-    <IncludeList Include="$(XunitTestBinBase)\JIT\Directed\ExcepFilters\mixed3\mixed3\mixed3.cmd" />
+    <IncludeList Include="$(XunitTestBinBase)\JIT\Directed\FaultHandlers\Nesting\Nesting\Nesting.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst_d\isinst_d.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst_do\isinst_do.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_142976\DevDiv_142976\DevDiv_142976.cmd" />


### PR DESCRIPTION
RyuJIT depends on the relocation offset delta to be stored in the code stream because of it applies additional fixups to it.

Tweak the list of Top200 tests to include coverage for this issue.

Fixes #2254