### PR TITLE
Remove one virtual call from StreamHelpers.ValidateCopyToArgs

### DIFF
--- a/src/System.Private.CoreLib/src/System/IO/StreamHelpers.CopyValidation.cs
+++ b/src/System.Private.CoreLib/src/System/IO/StreamHelpers.CopyValidation.cs
@@ -27,7 +27,7 @@ namespace System.IO
             }
 
             bool destinationCanWrite = destination.CanWrite;
-            if (!destination.CanRead && !destinationCanWrite)
+            if (!destinationCanWrite && !destination.CanRead)
             {
                 throw new ObjectDisposedException(nameof(destination), SR.ObjectDisposed_StreamClosed);
             }


### PR DESCRIPTION
Check CanWrite on the destination stream first.

In the common case CanWrite is true, and CanRead is only needed to
determine which kind of exception to throw when CanWrite is false.