### PR TITLE
Use invariant culture in test

### DIFF
--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -13,6 +14,8 @@ public class ReflectionTest
 
     public static int Main()
     {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
         if (TestNames() == Fail)
             return Fail;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corert/issues/2286.

After this change, `build.cmd` succeeds for me.

(I didn't see a point to restore the culture to the original value here.)

cc: @jkotas, @MichalStrehovsky 