### PR TITLE
Skip unnecessary reload of GenericParameter information

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfo.cs
@@ -71,7 +71,7 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
             {
                 MetadataReader reader = Reader;
                 LowLevelList<QTypeDefRefOrSpec> constraints = new LowLevelList<QTypeDefRefOrSpec>();
-                foreach (Handle constraintHandle in GenericParameterHandle.GetGenericParameter(reader).Constraints)
+                foreach (Handle constraintHandle in _genericParameter.Constraints)
                 {
                     constraints.Add(new QTypeDefRefOrSpec(reader, constraintHandle));
                 }


### PR DESCRIPTION
- We already have a member variable with the result of GetGenericParameter, we should use it