### PR TITLE
Revert "OSX unwind workaround"

### DIFF
--- a/src/Native/Runtime/unix/UnixContext.cpp
+++ b/src/Native/Runtime/unix/UnixContext.cpp
@@ -332,12 +332,9 @@ static void GetContextPointer(unw_cursor_t *cursor, unw_context_t *unwContext, i
 // Update REGDISPLAY from the unw_cursor_t and unw_context_t
 void UnwindCursorToRegDisplay(unw_cursor_t *cursor, unw_context_t *unwContext, REGDISPLAY *regDisplay)
 {
-    //TODO: Workaround for unwind on OSX: See https://github.com/dotnet/corert/pull/2166
-#if !defined(__APPLE__)
-    #define GET_CONTEXT_POINTER(unwReg, rdReg) GetContextPointer(cursor, unwContext, unwReg, &regDisplay->p##rdReg);
-        GET_CONTEXT_POINTERS
-    #undef GET_CONTEXT_POINTER
-#endif
+#define GET_CONTEXT_POINTER(unwReg, rdReg) GetContextPointer(cursor, unwContext, unwReg, &regDisplay->p##rdReg);
+    GET_CONTEXT_POINTERS
+#undef GET_CONTEXT_POINTER
 
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &regDisplay->IP);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &regDisplay->SP);


### PR DESCRIPTION
Reverts dotnet/corert#2166. No longer necessary with local libunwind build.