### PR TITLE
Change ArraySortHelper to use Comparison<T>

### DIFF
--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -1987,23 +1987,7 @@ namespace System
                 throw new ArgumentNullException(nameof(comparison));
             }
 
-            IComparer<T> comparer = new FunctorComparer<T>(comparison);
-            Array.Sort(array, comparer);
-        }
-
-        internal sealed class FunctorComparer<T> : IComparer<T>
-        {
-            private Comparison<T> _comparison;
-
-            public FunctorComparer(Comparison<T> comparison)
-            {
-                _comparison = comparison;
-            }
-
-            public int Compare(T x, T y)
-            {
-                return _comparison(x, y);
-            }
+            ArraySortHelper<T>.Sort(array, 0, array.Length, comparison);
         }
 
         public static void Sort<TKey, TValue>(TKey[] keys, TValue[] items)

--- a/src/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -1103,8 +1103,7 @@ namespace System.Collections.Generic
 
             if (_size > 0)
             {
-                IComparer<T> comparer = Comparer<T>.Create(comparison);
-                Array.Sort(_items, 0, _size, comparer);
+                ArraySortHelper<T>.Sort(_items, 0, _size, comparison);
             }
         }
 


### PR DESCRIPTION
The Array/List.Sort overloads that take a `Comparison<T>` have worse performance than the ones that take a `IComparer<T>`. That's because sorting is implemented around `IComparer<T>` and a `Comparison<T>` needs to be wrapped in a comparer object to be used.

At the same time, interface calls are slower than delegate calls so the existing implementation doesn't offer the best performance even when the `IComparer<T>` based overloads are used.

By changing the implementation to use `Comparison<T>` we avoid interface calls in both cases.

When `IComparer<T>` overloads are used a `Comparison<T>` delegate is created from `IComparer<T>.Compare`, that's an extra object allocation but sorting is faster and we avoid having two separate sorting implementations.

Port of https://github.com/dotnet/coreclr/pull/8504