### PR TITLE
Wrap the call to Main() method by another method

### DIFF
--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -182,7 +182,7 @@ namespace Internal.IL.Stubs.StartupCode
             {
                 get
                 {
-                    return "StartupCodeSafetyWrapper";
+                    return "MainMethodWrapper";
                 }
             }
 

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -148,9 +148,9 @@ namespace Internal.IL.Stubs.StartupCode
 
         /// <summary>
         /// Wraps the main method in a layer of indirection. This is necessary to protect the startup code
-        /// infrastructure from situation when the owning type of the main method cannot be loaded, and codegen
+        /// infrastructure from situations when the owning type of the main method cannot be loaded, and codegen
         /// is instructed to generate a throwing body. Without wrapping, this behavior would result in
-        /// replacing the entire startup code sequence with a throwing body, causing us to enter managed
+        /// replacing the entire startup code sequence with a throwing body, causing us to enter the "rich" managed
         /// environment without it being fully initialized. (In particular, the unhandled exception experience
         /// won't be initialized, making this difficult to diagnose.)
         /// </summary>


### PR DESCRIPTION
This is necessary to protect the startup code infrastructure from
situation when the owning type of the main method cannot be loaded, and
codegen is instructed to generate a throwing body. Without wrapping,
this behavior would result in replacing the entire startup code sequence
with a throwing body, causing us to enter managed environment without it
being fully initialized. (In particular, the unhandled exception
experience won't be initialized, making this difficult to diagnose.)