### PR TITLE
[WIP] Implement basic support for thread static fields

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaField.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.cs
@@ -155,8 +155,7 @@ namespace Internal.TypeSystem.Ecma
                     {
                         if (metadataReader.StringComparer.Equals(nameHandle, "ThreadStaticAttribute"))
                         {
-                            // TODO: Thread statics
-                            //flags |= FieldFlags.ThreadStatic;
+                            flags |= FieldFlags.ThreadStatic;
                         }
                     }
                 }

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -184,9 +184,20 @@ namespace ILCompiler
             public void AddCompilationRoot(TypeDesc type, string reason)
             {
                 if (type.IsGenericDefinition)
+                {
                     _graph.AddRoot(_factory.NecessaryTypeSymbol(type), reason);
+                }
                 else
+                {
                     _graph.AddRoot(_factory.ConstructedTypeSymbol(type), reason);
+
+                    // If the type has a thread static field then we should eagerly create a helper
+                    // to access such fields at runtime. This is required for multi-module compilation.
+                    if (type.IsDefType && (((DefType)type).ThreadStaticFieldSize > 0))
+                    {
+                        _graph.AddRoot(_factory.ReadyToRunHelper(ReadyToRunHelperId.GetThreadStaticBase, (MetadataType)type), reason);
+                    }
+                }
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -91,8 +91,8 @@ namespace ILCompiler.DependencyAnalysis
             totalSize = Math.Max(totalSize, _target.PointerSize * 3); // minimum GC eetype size is 3 pointers
             dataBuilder.EmitInt(totalSize);
 
-            // This is just so that EEType::Validate doesn't blow up at runtime
-            dataBuilder.EmitPointerReloc(this); // Related type: itself
+            // Related type: System.Object. This allows storing an instance of this type in an array of objects.
+            dataBuilder.EmitPointerReloc(factory.NecessaryTypeSymbol(factory.TypeSystemContext.GetWellKnownType(WellKnownType.Object)));
 
             return dataBuilder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -504,7 +504,9 @@ namespace ILCompiler.DependencyAnalysis
 
         private static readonly string[][] s_helperEntrypointNames = new string[][] {
             new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnGCStaticBase" },
-            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnNonGCStaticBase" }
+            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnNonGCStaticBase" },
+            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnThreadStaticBase" },
+            new string[] { "Internal.Runtime", "ThreadStatics", "GetThreadStaticBaseForType" }
         };
 
         private ISymbolNode[] _helperEntrypointSymbols;
@@ -716,5 +718,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         EnsureClassConstructorRunAndReturnGCStaticBase,
         EnsureClassConstructorRunAndReturnNonGCStaticBase,
+        EnsureClassConstructorRunAndReturnThreadStaticBase,
+        GetThreadStaticBaseForType,
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -156,6 +156,12 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Address Load");
                 return dependencyList;
             }
+            else if (_id == ReadyToRunHelperId.GetThreadStaticBase)
+            {
+                DependencyList dependencyList = new DependencyList();
+                dependencyList.Add(factory.TypeThreadStaticsSymbol((MetadataType)_target), "ReadyToRun Thread Static Storage");
+                return dependencyList;
+            }
             else
             {
                 return null;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -49,7 +49,19 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode CreateReadyToRunHelperNode(Tuple<ReadyToRunHelperId, object> helperCall)
         {
-            return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
+            ReadyToRunHelperNode node = new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
+
+            if ((node.Id != ReadyToRunHelperId.GetThreadStaticBase) ||
+                CompilationModuleGroup.ContainsType((TypeDesc)node.Target))
+            {
+                return node;
+            }
+            else
+            {
+                // The ReadyToRun helper for a type with thread static fields resides in the same module as the target type.
+                // Other modules should use an extern symbol node to access it.
+                return ExternSymbol(node.GetMangledName());
+            }
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -32,6 +32,14 @@ namespace ILCompiler.DependencyAnalysis.X64
             Builder.EmitByte((byte)(0xC0 | (((int)regSrc & 0x07) << 3) | (((int)regDst & 0x07))));
         }
 
+        public void EmitMOV(Register regDst, int imm32)
+        {
+            AddrMode rexAddrMode = new AddrMode(regDst, null, 0, 0, AddrModeSize.Int32);
+            EmitRexPrefix(regDst, ref rexAddrMode);
+            Builder.EmitByte((byte)(0xB8 | ((int)regDst & 0x07)));
+            Builder.EmitInt(imm32);
+        }
+
         public void EmitLEAQ(Register reg, ISymbolNode symbol, int delta = 0)
         {
             AddrMode rexAddrMode = new AddrMode(Register.RAX, null, 0, 0, AddrModeSize.Int64);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeManagerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeManagerIndirectionNode.cs
@@ -27,6 +27,7 @@ namespace ILCompiler.DependencyAnalysis
             objData.DefinedSymbols.Add(this);
             objData.RequirePointerAlignment();
             objData.EmitZeroPointer();
+            objData.EmitZeroPointer();
             return objData.ToObjectData();
         }
     }

--- a/src/Native/Runtime/thread.h
+++ b/src/Native/Runtime/thread.h
@@ -91,6 +91,11 @@ struct ThreadBuffer
     // Thread Statics Storage for dynamic types
     UInt32          m_numDynamicTypesTlsCells;
     PTR_PTR_UInt8   m_pDynamicTypesTlsCells;
+
+#if CORERT
+    PTR_PTR_VOID    m_pThreadLocalModuleStatics;
+    UInt32          m_numThreadLocalModuleStatics;
+#endif // CORERT
 };
 
 struct ReversePInvokeFrame
@@ -248,6 +253,11 @@ public:
 
     bool InlineTryFastReversePInvoke(ReversePInvokeFrame * pFrame);
     void InlineReversePInvokeReturn(ReversePInvokeFrame * pFrame);
+
+#if CORERT
+    Object* GetThreadStaticStorageForModule(UInt32 moduleIndex);
+    Boolean SetThreadStaticStorageForModule(Object * pStorage, UInt32 moduleIndex);
+#endif // CORERT
 };
 
 #ifndef GCENV_INCLUDED

--- a/src/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime;
+using Internal.Runtime.CompilerHelpers;
+
+namespace Internal.Runtime
+{
+    /// <summary>
+    /// This class is used by ReadyToRun helpers to get access to thread static fields of a type
+    /// and to allocate required TLS memory.
+    /// </summary>
+    internal static class ThreadStatics
+    {
+        /// <summary>
+        /// This method is called from a ReadyToRun helper to get base address of thread
+        /// static storage for the given type.
+        /// </summary>
+        internal static unsafe object GetThreadStaticBaseForType(TypeManagerSlot* pModuleData, Int32 typeTlsIndex)
+        {
+            // Get the array that holds thread static memory blocks for each type in the given module
+            Int32 moduleIndex = pModuleData->ModuleIndex;
+            object[] storage = (object[])RuntimeImports.RhGetThreadStaticStorageForModule(moduleIndex);
+
+            // Check whether thread static storage has already been allocated for this module and type.
+            if ((storage != null) && (typeTlsIndex < storage.Length) && (storage[typeTlsIndex] != null))
+            {
+                return storage[typeTlsIndex];
+            }
+
+            // This the first access to the thread statics of the type corresponding to typeTlsIndex.
+            // Make sure there is enough storage allocated to hold it.
+            storage = EnsureThreadStaticStorage(moduleIndex, storage, requiredSize: typeTlsIndex + 1);
+
+            // Allocate an object that will represent a memory block for all thread static fields of the type
+            object threadStaticBase = AllocateThreadStaticStorageForType(pModuleData->TypeManager, typeTlsIndex);
+            storage[typeTlsIndex] = threadStaticBase;
+
+            return threadStaticBase;
+
+        }
+
+        /// <summary>
+        /// if it is required, this method extends thread static storage of the given module
+        /// to the specified size and then registers the memory with the runtime.
+        /// </summary>
+        private static object[] EnsureThreadStaticStorage(Int32 moduleIndex, object[] existingStorage, Int32 requiredSize)
+        {
+            if ((existingStorage != null) && (requiredSize < existingStorage.Length))
+            {
+                return existingStorage;
+            }
+
+            object[] newStorage = new object[requiredSize];
+            if (existingStorage != null)
+            {
+                Array.Copy(existingStorage, newStorage, existingStorage.Length);
+            }
+
+            // Install the newly created array as thread static storage for the given module
+            // on the current thread. This call can fail due to a failure to allocate/extend required
+            // internal thread specific resources.
+            if (!RuntimeImports.RhSetThreadStaticStorageForModule(newStorage, moduleIndex))
+            {
+                throw new OutOfMemoryException();
+            }
+
+            return newStorage;
+        }
+
+        /// <summary>
+        /// This method allocates an object that represents a memory block for all thread static fields of the type
+        /// that corresponds to the specified TLS index.
+        /// </summary>
+        private static unsafe object AllocateThreadStaticStorageForType(IntPtr typeManager, Int32 typeTlsIndex)
+        {
+            Int32 length;
+            IntPtr* threadStaticRegion;
+
+            // Get a pointer to the beginning of the module's Thread Static section. Then get a pointer
+            // to the EEType that represents a memory map for thread statics storage.
+            threadStaticRegion = (IntPtr*)RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.ThreadStaticRegion, out length);
+            return RuntimeImports.RhNewObject(new EETypePtr(threadStaticRegion[typeTlsIndex]));
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -76,6 +76,7 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\CompilerHelpers\StartupDebug.cs">
       <Link>Internal\Runtime\CompilerHelpers\StartupCode\StartupDebug.cs</Link>
     </Compile>
+    <Compile Include="Internal\Runtime\ThreadStatics.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\StartupCodeHelpers.Extensions.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\ArrayHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\InteropHelpers.cs" />

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -8,6 +8,9 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
+using Internal.Runtime;
+using Internal.Runtime.CompilerHelpers;
+
 namespace System.Runtime.CompilerServices
 {
     // Marked [EagerStaticClassConstruction] because Cctor.GetCctor
@@ -48,6 +51,13 @@ namespace System.Runtime.CompilerServices
         {
             EnsureClassConstructorRun(context);
             return nonGcStaticBase;
+        }
+
+        private unsafe static object CheckStaticClassConstructionReturnThreadStaticBase(TypeManagerSlot* pModuleData, Int32 typeTlsIndex, StaticClassConstructionContext* context)
+        {
+            object threadStaticBase = ThreadStatics.GetThreadStaticBaseForType(pModuleData, typeTlsIndex);
+            EnsureClassConstructorRun(context);
+            return threadStaticBase;
         }
 #endif
 

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using Internal.Runtime;
 
 namespace System.Runtime
 {
@@ -418,6 +419,10 @@ namespace System.Runtime
         internal static unsafe extern bool RhFindBlob(IntPtr hOsModule, uint blobId, byte** ppbBlob, uint* pcbBlob);
 
 #if CORERT
+        [RuntimeImport(RuntimeLibrary, "RhpGetModuleSection")]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern IntPtr RhGetModuleSection(IntPtr module, ReadyToRunSectionType section, out int length);
+
         internal static uint RhGetLoadedModules(IntPtr[] resultArray)
         {
             IntPtr[] loadedModules = Internal.Runtime.CompilerHelpers.StartupCodeHelpers.Modules;
@@ -444,6 +449,16 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetThreadStaticFieldAddress")]
         internal static unsafe extern byte* RhGetThreadStaticFieldAddress(EETypePtr pEEType, IntPtr fieldCookie);
+
+#if CORERT
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhGetThreadStaticStorageForModule")]
+        internal static unsafe extern Array RhGetThreadStaticStorageForModule(Int32 moduleIndex);
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhSetThreadStaticStorageForModule")]
+        internal static unsafe extern bool RhSetThreadStaticStorageForModule(Array storage, Int32 moduleIndex);
+#endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetCodeTarget")]

--- a/src/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using Internal.Runtime;
 
 namespace System.Runtime
 {
@@ -43,6 +44,10 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpRegisterFrozenSegment")]
         internal static extern bool RhpRegisterFrozenSegment(IntPtr pSegmentStart, int length);
+
+        [RuntimeImport(RuntimeLibrary, "RhpGetModuleSection")]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern IntPtr RhGetModuleSection(IntPtr module, ReadyToRunSectionType section, out int length);
 
         //
         // calls to runtime for allocation

--- a/tests/src/Simple/BasicThreading/BasicThreading.cmd
+++ b/tests/src/Simple/BasicThreading/BasicThreading.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+"%1\%2"
+set ErrorCode=%ERRORLEVEL%
+IF "%ErrorCode%"=="100" (
+    echo %~n0: pass
+    EXIT /b 0
+) ELSE (
+    echo %~n0: fail
+    EXIT /b 1
+)
+endlocal

--- a/tests/src/Simple/BasicThreading/BasicThreading.cs
+++ b/tests/src/Simple/BasicThreading/BasicThreading.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    static int Main()
+    {
+        SimpleReadWriteThreadStaticTest.Run(42, "SimpleReadWriteThreadStatic");
+        ThreadStaticsTestWithTasks.Run();
+        return 100;
+    }
+}
+
+class SimpleReadWriteThreadStaticTest
+{
+    public static void Run(int intValue, string stringValue)
+    {
+        NonGenericReadWriteThreadStaticsTest(intValue, "NonGeneric" + stringValue);
+        GenericReadWriteThreadStaticsTest(intValue + 1, "Generic" + stringValue);
+    }
+
+    class NonGenericType
+    {
+        [ThreadStatic]
+        public static int IntValue;
+
+        [ThreadStatic]
+        public static string StringValue;
+    }
+
+    class GenericType<T, V>
+    {
+        [ThreadStatic]
+        public static T ValueT;
+
+        [ThreadStatic]
+        public static V ValueV;
+    }
+
+    static void NonGenericReadWriteThreadStaticsTest(int intValue, string stringValue)
+    {
+        NonGenericType.IntValue = intValue;
+        NonGenericType.StringValue = stringValue;
+
+        if (NonGenericType.IntValue != intValue)
+        {
+            throw new Exception("SimpleReadWriteThreadStaticsTest: wrong integer value: " + NonGenericType.IntValue.ToString());
+        }
+
+        if (NonGenericType.StringValue != stringValue)
+        {
+            throw new Exception("SimpleReadWriteThreadStaticsTest: wrong string value: " + NonGenericType.StringValue);
+        }
+    }
+
+    static void GenericReadWriteThreadStaticsTest(int intValue, string stringValue)
+    {
+        GenericType<int, string>.ValueT = intValue;
+        GenericType<int, string>.ValueV = stringValue;
+
+        if (GenericType<int, string>.ValueT != intValue)
+        {
+            throw new Exception("GenericReadWriteThreadStaticsTest1a: wrong integer value: " + GenericType<int, string>.ValueT.ToString());
+        }
+
+        if (GenericType<int, string>.ValueV != stringValue)
+        {
+            throw new Exception("GenericReadWriteThreadStaticsTest1b: wrong string value: " + GenericType<int, string>.ValueV);
+        }
+
+        intValue++;
+        GenericType<int, int>.ValueT = intValue;
+        GenericType<int, int>.ValueV = intValue + 1;
+
+        if (GenericType<int, int>.ValueT != intValue)
+        {
+            throw new Exception("GenericReadWriteThreadStaticsTest2a: wrong integer value: " + GenericType<int, string>.ValueT.ToString());
+        }
+
+        if (GenericType<int, int>.ValueV != (intValue + 1))
+        {
+            throw new Exception("GenericReadWriteThreadStaticsTest2b: wrong integer value: " + GenericType<int, string>.ValueV.ToString());
+        }
+
+        GenericType<string, string>.ValueT = stringValue + "a";
+        GenericType<string, string>.ValueV = stringValue + "b";
+
+        if (GenericType<string, string>.ValueT != (stringValue + "a"))
+        {
+            throw new Exception("GenericReadWriteThreadStaticsTest3a: wrong string value: " + GenericType<string, string>.ValueT);
+        }
+
+        if (GenericType<string, string>.ValueV != (stringValue + "b"))
+        {
+            throw new Exception("GenericReadWriteThreadStaticsTest3b: wrong string value: " + GenericType<string, string>.ValueV);
+        }
+    }
+}
+
+class ThreadStaticsTestWithTasks
+{
+    static object lockObject = new object();
+    const int TotalTaskCount = 32;
+
+    public static void Run()
+    {
+        Task[] tasks = new Task[TotalTaskCount];
+        for (int i = 0; i < tasks.Length; ++i)
+        {
+            tasks[i] = Task.Factory.StartNew((param) =>
+            {
+                int index = (int)param;
+                int intTestValue = index * 10;
+                string stringTestValue = "ThreadStaticsTestWithTasks" + index;
+
+                // Try to run the on every other task
+                if ((index % 2) == 0)
+                {
+                    lock (lockObject)
+                    {
+                        SimpleReadWriteThreadStaticTest.Run(intTestValue, stringTestValue);
+                    }
+                }
+                else
+                {
+                    SimpleReadWriteThreadStaticTest.Run(intTestValue, stringTestValue);
+                }
+            }, i);
+        }
+        for (int i = 0; i < tasks.Length; ++i)
+        {
+            tasks[i].Wait();
+        }
+    }
+}

--- a/tests/src/Simple/BasicThreading/BasicThreading.csproj
+++ b/tests/src/Simple/BasicThreading/BasicThreading.csproj
@@ -1,0 +1,7 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="*.cs" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SimpleTest.targets))\SimpleTest.targets" />
+</Project>

--- a/tests/src/Simple/BasicThreading/BasicThreading.sh
+++ b/tests/src/Simple/BasicThreading/BasicThreading.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+$1/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/BasicThreading/no_cpp
+++ b/tests/src/Simple/BasicThreading/no_cpp
@@ -1,0 +1,1 @@
+Skip this test for cpp codegen mode

--- a/tests/src/Simple/BasicThreading/no_unix
+++ b/tests/src/Simple/BasicThreading/no_unix
@@ -1,0 +1,1 @@
+Doesn't work on OSX.


### PR DESCRIPTION
This change implements basic support for thread static fields. Most things
are already functional, performance could definitely be improved in the
future but it should be sufficient to get things off the ground.

This code passes CoreRT and Top200 CoreCLR tests on Windows. The
BasicThreading test in this change verifies that thread static fields work
for both non-generic and generic types in the single-threaded and
multi-thread environment (using Tasks).

One thing that does not work yet is multi-module compilation because the
driver creates a separate ReadyToRun helper for a type in every module
that accesses thread statics of the type. I am currently working on fixing
this.

The existing code has already implemented a good chuck of required
functionality so this simply builds on top of that.
Each module has a ThreadStatic region. Each entry in the region points to
an EEType that represents a GC map for the thread static fields of a given
type. The index of the entry in the region is the TLS index of the type.
The TypeManager indirection node of the module has been extended to
contain the index of the module in addition to a pointer to the type
manager (which is also used for initialization on first access).

The generated ReadyToRun helpers (that return thread static base for a
type) look like this:
```
__GetThreadStaticBase_System_Private_CoreLib_System_Threading_ManagedThreadId:
    lea         rcx,[__typemanager_indirection] <= module information (type manager, module index)
    mov         edx,3 <= TLS index of the type
    jmp
System_Private_CoreLib_Internal_Runtime_ThreadStatics__GetThreadStaticBaseForType
```
