### PR TITLE
Make ordering of modifiers more consistent

### DIFF
--- a/src/Common/src/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/Common/src/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -176,7 +176,7 @@ public class PrimitiveType
 /// </summary>
 class SchemaDef
 {
-    public readonly static EnumType[] EnumTypes = new EnumType[]
+    public static readonly EnumType[] EnumTypes = new EnumType[]
     {
         new EnumType("AssemblyFlags", "uint"),
         new EnumType("AssemblyHashAlgorithm", "uint"),
@@ -196,7 +196,7 @@ class SchemaDef
         new EnumType("TypeAttributes", "uint"),
     };
 
-    public readonly static PrimitiveType[] PrimitiveTypes = new PrimitiveType[]
+    public static readonly PrimitiveType[] PrimitiveTypes = new PrimitiveType[]
     {
         new PrimitiveType("bool", "Boolean"),
         new PrimitiveType("char", "Char"),
@@ -214,7 +214,7 @@ class SchemaDef
     };
 
     // These enums supplement those defined by System.Reflection.Primitives.
-    public readonly static RecordDef[] EnumSchema = new RecordDef[]
+    public static readonly RecordDef[] EnumSchema = new RecordDef[]
     {
         // AssemblyFlags - as defined in ECMA
         new RecordDef(
@@ -287,7 +287,7 @@ class SchemaDef
     // that represent contant primitive type values. Adds concept of constant managed reference, which
     // must always have a null value (thus the use of the NotPersisted flag).
 
-    private readonly static RecordDef[] ConstantValueRecordSchema =
+    private static readonly RecordDef[] ConstantValueRecordSchema =
         (
             from primitiveType in PrimitiveTypes select
                 new RecordDef(
@@ -315,7 +315,7 @@ class SchemaDef
     // an array TypeDefOrRefOrSpec handles corresponding to System.Type arguments to the instantiation of a custom attribute, or to store
     // custom initialized object[] arrays in custom attributes).
 
-    private readonly static RecordDef[] ConstantArrayRecordSchema =
+    private static readonly RecordDef[] ConstantArrayRecordSchema =
         (
             from primitiveType in PrimitiveTypes select
                 new RecordDef(
@@ -338,7 +338,7 @@ class SchemaDef
         )
         .ToArray();
 
-    private readonly static RecordDef[] ConstantRecordSchema = 
+    private static readonly RecordDef[] ConstantRecordSchema = 
         ConstantValueRecordSchema.Concat(ConstantArrayRecordSchema)
         .OrderBy(record => record.Name, StringComparer.Ordinal)
         .ToArray();
@@ -347,7 +347,7 @@ class SchemaDef
     // Common tuple definitions
     //
 
-    private readonly static string[] EnumConstantValue = new string[]
+    private static readonly string[] EnumConstantValue = new string[]
     {
         "ConstantByteValue",
         "ConstantSByteValue",
@@ -359,20 +359,20 @@ class SchemaDef
         "ConstantUInt64Value",
     };
 
-    private readonly static string[] TypeDefOrRef = new string[]
+    private static readonly string[] TypeDefOrRef = new string[]
     {
         "TypeDefinition",
         "TypeReference",
     };
 
-    private readonly static string[] TypeDefOrRefOrSpec = new string[]
+    private static readonly string[] TypeDefOrRefOrSpec = new string[]
     {
         "TypeDefinition",
         "TypeReference",
         "TypeSpecification",
     };
 
-    private readonly static string[] TypeDefOrRefOrSpecOrMod = new string[]
+    private static readonly string[] TypeDefOrRefOrSpecOrMod = new string[]
     {
         "TypeDefinition",
         "TypeReference",
@@ -380,7 +380,7 @@ class SchemaDef
         "ModifiedType",
     };
 
-    private readonly static string[] TypeSig = new string[]
+    private static readonly string[] TypeSig = new string[]
     {
         "TypeInstantiationSignature",
         "SZArraySignature",
@@ -392,10 +392,10 @@ class SchemaDef
         "MethodTypeVariableSignature",
     };
 
-    private readonly static string[] TypeDefOrRefOrSpecOrConstant =
+    private static readonly string[] TypeDefOrRefOrSpecOrConstant =
         TypeDefOrRefOrSpec.Concat(from constantRecord in ConstantRecordSchema select constantRecord.Name).ToArray();
 
-    private readonly static string[] MethodDefOrRef = new string[]
+    private static readonly string[] MethodDefOrRef = new string[]
     {
         "QualifiedMethod",
         "MemberReference",
@@ -408,7 +408,7 @@ class SchemaDef
     // Member tuple format: (name, type, flags)
     // These are largely based on the definitions in ECMA335.
     //
-    public readonly static RecordDef[] RecordSchema = new RecordDef[]
+    public static readonly RecordDef[] RecordSchema = new RecordDef[]
     {
         new RecordDef(
             name: "TypeDefinition",
@@ -742,9 +742,9 @@ class SchemaDef
     /// <summary>
     // Contains a list of records with corresponding Handle types (currently all of them).
     /// </summary>
-    public readonly static string[] HandleSchema = (from record in RecordSchema select record.Name).ToArray();
+    public static readonly string[] HandleSchema = (from record in RecordSchema select record.Name).ToArray();
 
-    public readonly static string[] TypeNamesWithCollectionTypes =
+    public static readonly string[] TypeNamesWithCollectionTypes =
         RecordSchema.SelectMany(r =>
             from member in r.Members
             let memberTypeName = member.TypeName as string

--- a/src/Common/src/Internal/Metadata/NativeFormat/MdBinaryReader.cs
+++ b/src/Common/src/Internal/Metadata/NativeFormat/MdBinaryReader.cs
@@ -15,18 +15,18 @@ namespace Internal.Metadata.NativeFormat
 {
     internal static partial class MdBinaryReader
     {
-        static public uint Read(this NativeReader reader, uint offset, out bool value)
+        public static uint Read(this NativeReader reader, uint offset, out bool value)
         {
             value = (reader.ReadUInt8(offset) != 0) ? true : false;
             return offset + 1;
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out string value)
+        public static uint Read(this NativeReader reader, uint offset, out string value)
         {
             return reader.DecodeString(offset, out value);
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out char value)
+        public static uint Read(this NativeReader reader, uint offset, out char value)
         {
             uint val;
             offset = reader.DecodeUnsigned(offset, out val);
@@ -34,7 +34,7 @@ namespace Internal.Metadata.NativeFormat
             return offset;
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out short value)
+        public static uint Read(this NativeReader reader, uint offset, out short value)
         {
             int val;
             offset = reader.DecodeSigned(offset, out val);
@@ -42,34 +42,34 @@ namespace Internal.Metadata.NativeFormat
             return offset;
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out sbyte value)
+        public static uint Read(this NativeReader reader, uint offset, out sbyte value)
         {
             value = (sbyte)reader.ReadUInt8(offset);
             return offset + 1;
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out ulong value)
+        public static uint Read(this NativeReader reader, uint offset, out ulong value)
         {
             return reader.DecodeUnsignedLong(offset, out value);
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out int value)
+        public static uint Read(this NativeReader reader, uint offset, out int value)
         {
             return reader.DecodeSigned(offset, out value);
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out uint value)
+        public static uint Read(this NativeReader reader, uint offset, out uint value)
         {
             return reader.DecodeUnsigned(offset, out value);
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out byte value)
+        public static uint Read(this NativeReader reader, uint offset, out byte value)
         {
             value = reader.ReadUInt8(offset);
             return offset + 1;
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out ushort value)
+        public static uint Read(this NativeReader reader, uint offset, out ushort value)
         {
             uint val;
             offset = reader.DecodeUnsigned(offset, out val);
@@ -77,12 +77,12 @@ namespace Internal.Metadata.NativeFormat
             return offset;
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out long value)
+        public static uint Read(this NativeReader reader, uint offset, out long value)
         {
             return reader.DecodeSignedLong(offset, out value);
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out Handle handle)
+        public static uint Read(this NativeReader reader, uint offset, out Handle handle)
         {
             uint rawValue;
             offset = reader.DecodeUnsigned(offset, out rawValue);
@@ -90,13 +90,13 @@ namespace Internal.Metadata.NativeFormat
             return offset;
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out float value)
+        public static uint Read(this NativeReader reader, uint offset, out float value)
         {
             value = reader.ReadFloat(offset);
             return offset + 4;
         }
 
-        static public uint Read(this NativeReader reader, uint offset, out double value)
+        public static uint Read(this NativeReader reader, uint offset, out double value)
         {
             value = reader.ReadDouble(offset);
             return offset + 8;

--- a/src/Common/src/Internal/NativeFormat/NativeFormatReader.Primitives.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormatReader.Primitives.cs
@@ -16,47 +16,47 @@ namespace Internal.NativeFormat
     // Minimal functionality that is low level enough for use in the managed runtime.
     unsafe partial struct NativePrimitiveDecoder
     {
-        static public byte ReadUInt8(ref byte* stream)
+        public static byte ReadUInt8(ref byte* stream)
         {
             byte result = *(stream); // Assumes little endian and unaligned access
             stream++;
             return result;
         }
 
-        static public ushort ReadUInt16(ref byte* stream)
+        public static ushort ReadUInt16(ref byte* stream)
         {
             ushort result = *(ushort*)(stream); // Assumes little endian and unaligned access
             stream += 2;
             return result;
         }
 
-        static public uint ReadUInt32(ref byte* stream)
+        public static uint ReadUInt32(ref byte* stream)
         {
             uint result = *(uint*)(stream); // Assumes little endian and unaligned access
             stream += 4;
             return result;
         }
 
-        static public ulong ReadUInt64(ref byte* stream)
+        public static ulong ReadUInt64(ref byte* stream)
         {
             ulong result = *(ulong*)(stream); // Assumes little endian and unaligned access
             stream += 8;
             return result;
         }
 
-        static public unsafe float ReadFloat(ref byte* stream)
+        public static unsafe float ReadFloat(ref byte* stream)
         {
             uint value = ReadUInt32(ref stream);
             return *(float*)(&value);
         }
 
-        static public double ReadDouble(ref byte* stream)
+        public static double ReadDouble(ref byte* stream)
         {
             ulong value = ReadUInt64(ref stream);
             return *(double*)(&value);
         }
 
-        static public uint GetUnsignedEncodingSize(uint value)
+        public static uint GetUnsignedEncodingSize(uint value)
         {
             if (value < 128) return 1;
             if (value < 128 * 128) return 2;
@@ -65,7 +65,7 @@ namespace Internal.NativeFormat
             return 5;
         }
 
-        static public uint DecodeUnsigned(ref byte* stream)
+        public static uint DecodeUnsigned(ref byte* stream)
         {
             uint value = 0;
 
@@ -110,7 +110,7 @@ namespace Internal.NativeFormat
             return value;
         }
 
-        static public int DecodeSigned(ref byte* stream)
+        public static int DecodeSigned(ref byte* stream)
         {
             int value = 0;
 
@@ -155,7 +155,7 @@ namespace Internal.NativeFormat
             return value;
         }
 
-        static public ulong DecodeUnsignedLong(ref byte* stream)
+        public static ulong DecodeUnsignedLong(ref byte* stream)
         {
             ulong value = 0;
 
@@ -178,7 +178,7 @@ namespace Internal.NativeFormat
             return value;
         }
 
-        static public long DecodeSignedLong(ref byte* stream)
+        public static long DecodeSignedLong(ref byte* stream)
         {
             long value = 0;
 

--- a/src/Common/src/Internal/NativeFormat/NativeFormatReader.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormatReader.cs
@@ -15,13 +15,13 @@ namespace Internal.NativeFormat
 {
     internal unsafe partial struct NativePrimitiveDecoder
     {
-        static public void ThrowBadImageFormatException()
+        public static void ThrowBadImageFormatException()
         {
             Debug.Assert(false);
             throw new BadImageFormatException();
         }
 
-        static public uint DecodeUnsigned(ref byte* stream, byte* streamEnd)
+        public static uint DecodeUnsigned(ref byte* stream, byte* streamEnd)
         {
             if (stream >= streamEnd)
                 ThrowBadImageFormatException();
@@ -75,7 +75,7 @@ namespace Internal.NativeFormat
             return value;
         }
 
-        static public int DecodeSigned(ref byte* stream, byte* streamEnd)
+        public static int DecodeSigned(ref byte* stream, byte* streamEnd)
         {
             if (stream >= streamEnd)
                 ThrowBadImageFormatException();
@@ -129,7 +129,7 @@ namespace Internal.NativeFormat
             return value;
         }
 
-        static public ulong DecodeUnsignedLong(ref byte* stream, byte* streamEnd)
+        public static ulong DecodeUnsignedLong(ref byte* stream, byte* streamEnd)
         {
             if (stream >= streamEnd)
                 ThrowBadImageFormatException();
@@ -155,7 +155,7 @@ namespace Internal.NativeFormat
             return value;
         }
 
-        static public long DecodeSignedLong(ref byte* stream, byte* streamEnd)
+        public static long DecodeSignedLong(ref byte* stream, byte* streamEnd)
         {
             if (stream >= streamEnd)
                 ThrowBadImageFormatException();
@@ -181,7 +181,7 @@ namespace Internal.NativeFormat
             return value;
         }
 
-        static public void SkipInteger(ref byte* stream)
+        public static void SkipInteger(ref byte* stream)
         {
             byte val = *stream;
             if ((val & 1) == 0)

--- a/src/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -164,6 +164,6 @@ namespace Internal.Runtime.CompilerHelpers
 
         [RuntimeImport(".", "RhpCreateTypeManager")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static unsafe extern IntPtr CreateTypeManager(IntPtr moduleHeader);
+        private static extern unsafe IntPtr CreateTypeManager(IntPtr moduleHeader);
     }
 }

--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -145,7 +145,7 @@ namespace Internal.Runtime
             public EEType** _ppRelatedParameterTypeViaIAT;
         }
 
-        unsafe static class OptionalFieldsReader
+        static unsafe class OptionalFieldsReader
         {
             internal static UInt32 GetInlineField(byte* pFields, EETypeOptionalFieldTag eTag, UInt32 uiDefaultValue)
             {
@@ -1283,7 +1283,7 @@ namespace Internal.Runtime
         }
 
 #if TYPE_LOADER_IMPLEMENTATION
-        static internal UInt32 GetSizeofEEType(
+        internal static UInt32 GetSizeofEEType(
             UInt16 cVirtuals,
             UInt16 cInterfaces,
             bool fHasFinalizer,

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Environment.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Environment.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     internal unsafe partial class Sys
     {
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetEnvironmentVariable")]
-        internal static unsafe extern int GetEnvironmentVariable(string name, out IntPtr result);
+        internal static extern unsafe int GetEnvironmentVariable(string name, out IntPtr result);
 
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_ExitProcess")]
         internal static extern void ExitProcess(int exitCode);

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.FormatProvider.FormatAndParse.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.FormatProvider.FormatAndParse.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal unsafe partial class Sys
     {
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_DoubleToString")]
-        internal static unsafe extern int DoubleToString(double value, byte *format, byte *buffer, int bufferLength);
+        internal static extern unsafe int DoubleToString(double value, byte *format, byte *buffer, int bufferLength);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.GetTickCount64.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.GetTickCount64.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal unsafe partial class Sys
     {
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetTickCount64")]
-        internal static unsafe extern ulong GetTickCount64();
+        internal static extern unsafe ulong GetTickCount64();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.MemReAlloc.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.MemReAlloc.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
         internal static extern IntPtr MemReAlloc(IntPtr ptr, UIntPtr newSize);
     }
 
-    internal unsafe static IntPtr MemReAlloc(IntPtr ptr, UIntPtr newSize)
+    internal static unsafe IntPtr MemReAlloc(IntPtr ptr, UIntPtr newSize)
     {
         IntPtr allocatedMemory = Interop.Sys.MemReAlloc(ptr, newSize);
         if (allocatedMemory == IntPtr.Zero)

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.SysConf.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.SysConf.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal unsafe static partial class Sys
+    internal static unsafe partial class Sys
     {
         internal enum SysConfName
         {

--- a/src/Common/src/Interop/Windows/mincore/Interop.CommandLine.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.CommandLine.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static unsafe partial class mincore
     {
         [DllImport(Libraries.ProcessEnvironment, EntryPoint = "GetCommandLineW")]
-        internal static unsafe extern char* GetCommandLine();
+        internal static extern unsafe char* GetCommandLine();
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         // TODO: Once we have marshalling setup we probably want to revisit these PInvokes
         [DllImport(Libraries.ProcessEnvironment, EntryPoint = "GetEnvironmentVariableW")]
-        internal static unsafe extern int GetEnvironmentVariable(char* lpName, char* lpValue, int size);
+        internal static extern unsafe int GetEnvironmentVariable(char* lpName, char* lpValue, int size);
 
         [DllImport(Libraries.Kernel32, EntryPoint = "ExitProcess")]
         internal static extern void ExitProcess(int exitCode);

--- a/src/Common/src/Interop/Windows/mincore/Interop.MemReAlloc.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.MemReAlloc.cs
@@ -11,10 +11,10 @@ internal static partial class Interop
     internal static unsafe partial class mincore
     {
         [DllImport("api-ms-win-core-heap-l1-1-0.dll")]
-        internal static unsafe extern IntPtr HeapReAlloc(IntPtr hHeap, UInt32 dwFlags, IntPtr lpMem, UIntPtr dwBytes);
+        internal static extern unsafe IntPtr HeapReAlloc(IntPtr hHeap, UInt32 dwFlags, IntPtr lpMem, UIntPtr dwBytes);
     }
 
-    internal unsafe static IntPtr MemReAlloc(IntPtr ptr, UIntPtr newSize)
+    internal static unsafe IntPtr MemReAlloc(IntPtr ptr, UIntPtr newSize)
     {
         IntPtr allocatedMemory = Interop.mincore.HeapReAlloc(Interop.mincore.GetProcessHeap(), 0, ptr, newSize);
         if (allocatedMemory == IntPtr.Zero)

--- a/src/Common/src/Interop/Windows/mincore/Interop.RegEnumKeyEx.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.RegEnumKeyEx.cs
@@ -12,7 +12,7 @@ internal partial class Interop
     internal partial class mincore
     {
         [DllImport(Libraries.Registry_L1, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumKeyExW")]
-        internal unsafe static extern int RegEnumKeyEx(
+        internal static extern unsafe int RegEnumKeyEx(
             SafeRegistryHandle hKey,
             int dwIndex,
             char* lpName,

--- a/src/Common/src/Interop/Windows/mincore/Interop.RegEnumValue.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.RegEnumValue.cs
@@ -11,7 +11,7 @@ internal partial class Interop
     internal partial class mincore
     {
         [DllImport(Libraries.Registry_L1, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumValueW")]
-        internal unsafe static extern int RegEnumValue(
+        internal static extern unsafe int RegEnumValue(
             SafeRegistryHandle hKey,
             int dwIndex,
             char* lpValueName,

--- a/src/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -296,7 +296,7 @@ namespace System.Globalization
                 return (((ch) == 0x20) || ((ch) >= 0x09 && (ch) <= 0x0D));
             }
 
-            private unsafe static char* MatchChars(char* p, string str)
+            private static unsafe char* MatchChars(char* p, string str)
             {
                 fixed (char* stringPointer = str)
                 {
@@ -304,7 +304,7 @@ namespace System.Globalization
                 }
             }
 
-            private unsafe static char* MatchChars(char* p, char* str)
+            private static unsafe char* MatchChars(char* p, char* str)
             {
                 Debug.Assert(p != null && str != null);
 
@@ -325,7 +325,7 @@ namespace System.Globalization
                 return null;
             }
 
-            private unsafe static bool ParseNumber(ref char* str, NumberStyles options, ref NumberBuffer number, StringBuilder sb, NumberFormatInfo numfmt, bool parseDecimal)
+            private static unsafe bool ParseNumber(ref char* str, NumberStyles options, ref NumberBuffer number, StringBuilder sb, NumberFormatInfo numfmt, bool parseDecimal)
             {
                 const int StateSign = 0x0001;
                 const int StateParens = 0x0002;
@@ -555,7 +555,7 @@ namespace System.Globalization
                 return true;
             }
 
-            internal unsafe static bool TryStringToNumber(string str, NumberStyles options, ref NumberBuffer number, StringBuilder sb, NumberFormatInfo numfmt, bool parseDecimal)
+            internal static unsafe bool TryStringToNumber(string str, NumberStyles options, ref NumberBuffer number, StringBuilder sb, NumberFormatInfo numfmt, bool parseDecimal)
             {
                 if (str == null)
                 {
@@ -622,7 +622,7 @@ namespace System.Globalization
 
             private static string s_posNumberFormat = "#";
 
-            internal unsafe static void Int32ToDecChars(char* buffer, ref int index, uint value, int digits)
+            internal static unsafe void Int32ToDecChars(char* buffer, ref int index, uint value, int digits)
             {
                 while (--digits >= 0 || value != 0)
                 {

--- a/src/Common/src/TypeSystem/Common/CastingHelper.cs
+++ b/src/Common/src/TypeSystem/Common/CastingHelper.cs
@@ -141,7 +141,7 @@ namespace Internal.TypeSystem
         }
 
         // Returns true of the two types are equivalent primitive types. Used by array casts.
-        static private bool ArePrimitveTypesEquivalentSize(TypeDesc type1, TypeDesc type2)
+        private static bool ArePrimitveTypesEquivalentSize(TypeDesc type1, TypeDesc type2)
         {
             Debug.Assert(type1.IsPrimitive && type2.IsPrimitive);
 

--- a/src/Common/src/TypeSystem/Common/ConstructedTypeRewritingHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/ConstructedTypeRewritingHelpers.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 
 namespace Internal.TypeSystem
 {
-    static public class ConstructedTypeRewritingHelpers
+    public static class ConstructedTypeRewritingHelpers
     {
         /// <summary>
         /// Determine if the construction of a type contains one of a given set of types. This is a deep

--- a/src/Common/src/TypeSystem/Common/FieldDesc.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.cs
@@ -11,7 +11,7 @@ namespace Internal.TypeSystem
 {
     public abstract partial class FieldDesc : TypeSystemEntity
     {
-        public readonly static FieldDesc[] EmptyFields = new FieldDesc[0];
+        public static readonly FieldDesc[] EmptyFields = new FieldDesc[0];
 
         public override int GetHashCode()
         {

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -221,7 +221,7 @@ namespace Internal.TypeSystem
     /// </summary>
     public abstract partial class MethodDesc : TypeSystemEntity
     {
-        public readonly static MethodDesc[] EmptyMethods = new MethodDesc[0];
+        public static readonly MethodDesc[] EmptyMethods = new MethodDesc[0];
 
         private int _hashcode;
 

--- a/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
+++ b/src/Common/src/TypeSystem/Common/TypeHashingAlgorithms.cs
@@ -13,7 +13,7 @@ using System.Text;
 
 namespace Internal.NativeFormat
 {
-    static public class TypeHashingAlgorithms
+    public static class TypeHashingAlgorithms
     {
         public struct HashCodeBuilder
         {

--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -8,35 +8,35 @@ using System.Diagnostics;
 
 namespace Internal.TypeSystem
 {
-    static public class TypeSystemHelpers
+    public static class TypeSystemHelpers
     {
-        static public bool IsWellKnownType(this TypeDesc type, WellKnownType wellKnownType)
+        public static bool IsWellKnownType(this TypeDesc type, WellKnownType wellKnownType)
         {
             return type == type.Context.GetWellKnownType(wellKnownType);
         }
 
-        static public InstantiatedType MakeInstantiatedType(this MetadataType typeDef, Instantiation instantiation)
+        public static InstantiatedType MakeInstantiatedType(this MetadataType typeDef, Instantiation instantiation)
         {
             return typeDef.Context.GetInstantiatedType(typeDef, instantiation);
         }
 
-        static public InstantiatedType MakeInstantiatedType(this MetadataType typeDef, params TypeDesc[] genericParameters)
+        public static InstantiatedType MakeInstantiatedType(this MetadataType typeDef, params TypeDesc[] genericParameters)
         {
             return typeDef.Context.GetInstantiatedType(typeDef, new Instantiation(genericParameters));
         }
 
 
-        static public InstantiatedMethod MakeInstantiatedMethod(this MethodDesc methodDef, Instantiation instantiation)
+        public static InstantiatedMethod MakeInstantiatedMethod(this MethodDesc methodDef, Instantiation instantiation)
         {
             return methodDef.Context.GetInstantiatedMethod(methodDef, instantiation);
         }
 
-        static public InstantiatedMethod MakeInstantiatedMethod(this MethodDesc methodDef, params TypeDesc[] genericParameters)
+        public static InstantiatedMethod MakeInstantiatedMethod(this MethodDesc methodDef, params TypeDesc[] genericParameters)
         {
             return methodDef.Context.GetInstantiatedMethod(methodDef, new Instantiation(genericParameters));
         }
 
-        static public ArrayType MakeArrayType(this TypeDesc type)
+        public static ArrayType MakeArrayType(this TypeDesc type)
         {
             return type.Context.GetArrayType(type);
         }
@@ -45,22 +45,22 @@ namespace Internal.TypeSystem
         /// Creates a multidimensional array type with the specified rank.
         /// To create a vector, use the <see cref="MakeArrayType(TypeDesc)"/> overload.
         /// </summary>
-        static public ArrayType MakeArrayType(this TypeDesc type, int rank)
+        public static ArrayType MakeArrayType(this TypeDesc type, int rank)
         {
             return type.Context.GetArrayType(type, rank);
         }
 
-        static public ByRefType MakeByRefType(this TypeDesc type)
+        public static ByRefType MakeByRefType(this TypeDesc type)
         {
             return type.Context.GetByRefType(type);
         }
 
-        static public PointerType MakePointerType(this TypeDesc type)
+        public static PointerType MakePointerType(this TypeDesc type)
         {
             return type.Context.GetPointerType(type);
         }
 
-        static public int GetElementSize(this TypeDesc type)
+        public static int GetElementSize(this TypeDesc type)
         {
             if (type.IsValueType)
             {
@@ -72,14 +72,14 @@ namespace Internal.TypeSystem
             }
         }
 
-        static public MethodDesc GetDefaultConstructor(this TypeDesc type)
+        public static MethodDesc GetDefaultConstructor(this TypeDesc type)
         {
             // TODO: Do we want check for specialname/rtspecialname? Maybe add another overload on GetMethod?
             var sig = new MethodSignature(0, 0, type.Context.GetWellKnownType(WellKnownType.Void), TypeDesc.EmptyTypes);
             return type.GetMethod(".ctor", sig);
         }
 
-        static internal MethodDesc FindMethodOnExactTypeWithMatchingTypicalMethod(this TypeDesc type, MethodDesc method)
+        internal static MethodDesc FindMethodOnExactTypeWithMatchingTypicalMethod(this TypeDesc type, MethodDesc method)
         {
             MethodDesc methodTypicalDefinition = method.GetTypicalMethodDefinition();
 
@@ -110,7 +110,7 @@ namespace Internal.TypeSystem
         /// </summary>
         /// <param name="targetType">A potentially derived type</param>
         /// <param name="method">A base class's virtual method</param>
-        static public MethodDesc FindMethodOnTypeWithMatchingTypicalMethod(this TypeDesc targetType, MethodDesc method)
+        public static MethodDesc FindMethodOnTypeWithMatchingTypicalMethod(this TypeDesc targetType, MethodDesc method)
         {
             // If method is nongeneric and on a nongeneric type, then it is the matching method
             if (!method.HasInstantiation && !method.OwningType.HasInstantiation)
@@ -150,7 +150,7 @@ namespace Internal.TypeSystem
         /// for generic code.
         /// </summary>
         /// <returns>The resolved method or null if the constraint couldn't be resolved.</returns>
-        static public MethodDesc TryResolveConstraintMethodApprox(this TypeDesc constrainedType, TypeDesc interfaceType, MethodDesc interfaceMethod, out bool forceRuntimeLookup)
+        public static MethodDesc TryResolveConstraintMethodApprox(this TypeDesc constrainedType, TypeDesc interfaceType, MethodDesc interfaceMethod, out bool forceRuntimeLookup)
         {
             forceRuntimeLookup = false;
 

--- a/src/Common/src/TypeSystem/IL/EcmaMethodIL.cs
+++ b/src/Common/src/TypeSystem/IL/EcmaMethodIL.cs
@@ -23,7 +23,7 @@ namespace Internal.IL
         private LocalVariableDefinition[] _locals;
         private ILExceptionRegion[] _ilExceptionRegions;
 
-        static public EcmaMethodIL Create(EcmaMethod method)
+        public static EcmaMethodIL Create(EcmaMethod method)
         {
             var rva = method.MetadataReader.GetMethodDefinition(method.Handle).RelativeVirtualAddress;
             if (rva == 0)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -174,7 +174,7 @@ namespace ILCompiler
             return AddModule(filePath, null);
         }
 
-        private unsafe static PEReader OpenPEFile(string filePath, out MemoryMappedViewAccessor mappedViewAccessor)
+        private static unsafe PEReader OpenPEFile(string filePath, out MemoryMappedViewAccessor mappedViewAccessor)
         {
             // System.Reflection.Metadata has heuristic that tries to save virtual address space. This heuristic does not work
             // well for us since it can make IL access very slow (call to OS for each method IL query). We will map the file

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
@@ -14,12 +14,12 @@ namespace ILCompiler.DependencyAnalysis
         int Offset { get; }
     }
 
-    static public class ISymbolNodeExtensions
+    public static class ISymbolNodeExtensions
     {
         [ThreadStatic]
         static Utf8StringBuilder s_cachedUtf8StringBuilder;
 
-        static public string GetMangledName(this ISymbolNode symbolNode)
+        public static string GetMangledName(this ISymbolNode symbolNode)
         {
             Utf8StringBuilder sb = s_cachedUtf8StringBuilder;
             if (sb == null)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
@@ -26,7 +26,7 @@ namespace ILCompiler.DependencyAnalysis
             Target = target;
         }
 
-        public unsafe static void WriteValue(RelocType relocType, void* location, long value)
+        public static unsafe void WriteValue(RelocType relocType, void* location, long value)
         {
             switch (relocType)
             {
@@ -44,7 +44,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public unsafe static long ReadValue(RelocType relocType, void* location)
+        public static unsafe long ReadValue(RelocType relocType, void* location)
         {
             switch (relocType)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
@@ -16,7 +16,7 @@ namespace ILCompiler
         /// Returns JIT helper entrypoint. JIT helpers can be either implemented by entrypoint with given mangled name or 
         /// by a method in class library.
         /// </summary>
-        static public void GetEntryPoint(TypeSystemContext context, ReadyToRunHelper id, out string mangledName, out MethodDesc methodDesc)
+        public static void GetEntryPoint(TypeSystemContext context, ReadyToRunHelper id, out string mangledName, out MethodDesc methodDesc)
         {
             mangledName = null;
             methodDesc = null;
@@ -167,7 +167,7 @@ namespace ILCompiler
         //
         // These methods are static compiler equivalent of RhGetRuntimeHelperForType
         //
-        static public string GetNewObjectHelperForType(TypeDesc type)
+        public static string GetNewObjectHelperForType(TypeDesc type)
         {
             if (EETypeBuilderHelpers.ComputeRequiresAlign8(type))
             {
@@ -186,7 +186,7 @@ namespace ILCompiler
             return "RhpNewFast";
         }
 
-        static public string GetNewArrayHelperForType(TypeDesc type)
+        public static string GetNewArrayHelperForType(TypeDesc type)
         {
             if (EETypeBuilderHelpers.ComputeRequiresAlign8(type))
                 return "RhpNewArrayAlign8";
@@ -194,7 +194,7 @@ namespace ILCompiler
             return "RhpNewArray";
         }
 
-        static public string GetCastingHelperNameForType(TypeDesc type, bool throwing)
+        public static string GetCastingHelperNameForType(TypeDesc type, bool throwing)
         {
             if (type.IsArray)
                 return throwing ? "RhTypeCast_CheckCastArray" : "RhTypeCast_IsInstanceOfArray";

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -26,7 +26,7 @@ namespace ILCompiler
         /// <summary>
         /// Gets the type that defines virtual method slots for the specified type.
         /// </summary>
-        static public DefType GetClosestDefType(this TypeDesc type)
+        public static DefType GetClosestDefType(this TypeDesc type)
         {
             if (type.IsArray)
             {

--- a/src/ILCompiler.DependencyAnalysisFramework/tests/TestGraph.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/TestGraph.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.DependencyAnalysisFramework.Tests
         public class TestNode : ComputedStaticDependencyNode<TestGraph>
         {
             private readonly string _data;
-            private readonly static CombinedDependencyListEntry[] s_emptyDynamicList = new CombinedDependencyListEntry[0];
+            private static readonly CombinedDependencyListEntry[] s_emptyDynamicList = new CombinedDependencyListEntry[0];
 
             public TestNode(string data)
             {

--- a/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadata.cs
+++ b/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadata.cs
@@ -1209,7 +1209,7 @@ namespace SampleMetadataRex
 
         internal static int B_StaticFieldAssembly;
 
-        protected static internal int B_StaticFieldFamOrAssembly;
+        protected internal static int B_StaticFieldFamOrAssembly;
 
         // Instance methods
 
@@ -1244,7 +1244,7 @@ namespace SampleMetadataRex
         private static void B_StaticMethPrivate() { }
 
         internal static void B_StaticMethAssembly() { }
-        protected static internal void B_StaticMethFamOrAssembly() { }
+        protected internal static void B_StaticMethFamOrAssembly() { }
 
         // Virtual methods
 
@@ -1290,7 +1290,7 @@ namespace SampleMetadataRex
 
         internal static int B_StaticPropAssembly { get { return 5; } }
 
-        protected static internal int B_StaticPropFamOrAssembly { get { return 5; } }
+        protected internal static int B_StaticPropFamOrAssembly { get { return 5; } }
 
         // Virtual properties
 
@@ -1336,7 +1336,7 @@ namespace SampleMetadataRex
 
         internal static event Action B_StaticEventAssembly { add { } remove { } }
 
-        protected static internal event Action B_StaticEventFamOrAssembly { add { } remove { } }
+        protected internal static event Action B_StaticEventFamOrAssembly { add { } remove { } }
 
         // Virtual events
 
@@ -1385,7 +1385,7 @@ namespace SampleMetadataRex
 
         internal static int M_StaticFieldAssembly;
 
-        protected static internal int M_StaticFieldFamOrAssembly;
+        protected internal static int M_StaticFieldFamOrAssembly;
 
         // Instance methods
 
@@ -1421,7 +1421,7 @@ namespace SampleMetadataRex
 
         internal static void M_StaticMethAssembly() { }
 
-        protected static internal void M_StaticMethFamOrAssembly() { }
+        protected internal static void M_StaticMethFamOrAssembly() { }
 
         // Overriding Virtual methods
 
@@ -1467,7 +1467,7 @@ namespace SampleMetadataRex
 
         internal static int M_StaticPropAssembly { get { return 5; } }
 
-        protected static internal int M_StaticPropFamOrAssembly { get { return 5; } }
+        protected internal static int M_StaticPropFamOrAssembly { get { return 5; } }
 
         // Overriding Virtual properties
 
@@ -1513,7 +1513,7 @@ namespace SampleMetadataRex
 
         internal static event Action M_StaticEventAssembly { add { } remove { } }
 
-        protected static internal event Action M_StaticEventFamOrAssembly { add { } remove { } }
+        protected internal static event Action M_StaticEventFamOrAssembly { add { } remove { } }
 
         // Overriding Virtual events
 

--- a/src/Runtime.Base/src/System/Primitives.cs
+++ b/src/Runtime.Base/src/System/Primitives.cs
@@ -344,7 +344,7 @@ namespace System
         [Intrinsic]
         public static readonly IntPtr Zero;
 
-        public unsafe static int Size
+        public static unsafe int Size
         {
             [Intrinsic]
             get
@@ -422,19 +422,19 @@ namespace System
         }
 
         [Intrinsic]
-        public unsafe static bool operator ==(IntPtr value1, IntPtr value2)
+        public static unsafe bool operator ==(IntPtr value1, IntPtr value2)
         {
             return value1._value == value2._value;
         }
 
         [Intrinsic]
-        public unsafe static bool operator !=(IntPtr value1, IntPtr value2)
+        public static unsafe bool operator !=(IntPtr value1, IntPtr value2)
         {
             return value1._value != value2._value;
         }
 
         [Intrinsic]
-        public unsafe static IntPtr operator +(IntPtr pointer, int offset)
+        public static unsafe IntPtr operator +(IntPtr pointer, int offset)
         {
 #if BIT64
             return new IntPtr((long)pointer._value + offset);
@@ -504,7 +504,7 @@ namespace System
         }
 
         [Intrinsic]
-        public unsafe static explicit operator uint (UIntPtr value)
+        public static unsafe explicit operator uint (UIntPtr value)
         {
 #if BIT64
             return checked((uint)value._value);
@@ -514,19 +514,19 @@ namespace System
         }
 
         [Intrinsic]
-        public unsafe static explicit operator ulong (UIntPtr value)
+        public static unsafe explicit operator ulong (UIntPtr value)
         {
             return (ulong)value._value;
         }
 
         [Intrinsic]
-        public unsafe static bool operator ==(UIntPtr value1, UIntPtr value2)
+        public static unsafe bool operator ==(UIntPtr value1, UIntPtr value2)
         {
             return value1._value == value2._value;
         }
 
         [Intrinsic]
-        public unsafe static bool operator !=(UIntPtr value1, UIntPtr value2)
+        public static unsafe bool operator !=(UIntPtr value1, UIntPtr value2)
         {
             return value1._value != value2._value;
         }

--- a/src/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
+++ b/src/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
@@ -10,7 +10,7 @@ using Internal.Runtime;
 
 namespace System.Runtime
 {
-    internal unsafe static class CachedInterfaceDispatch
+    internal static unsafe class CachedInterfaceDispatch
     {
         [RuntimeExport("RhpCidResolve")]
         unsafe private static IntPtr RhpCidResolve(IntPtr callerTransitionBlockParam, IntPtr pCell)
@@ -100,7 +100,7 @@ namespace System.Runtime
                                                                           slot);
         }
 
-        private unsafe static IntPtr RhResolveDispatchWorker(object pObject, void* cell, ref DispatchCellInfo cellInfo)
+        private static unsafe IntPtr RhResolveDispatchWorker(object pObject, void* cell, ref DispatchCellInfo cellInfo)
         {
             // Type of object we're dispatching on.
             EEType* pInstanceType = pObject.EEType;

--- a/src/Runtime.Base/src/System/Runtime/CastableObjectSupport.cs
+++ b/src/Runtime.Base/src/System/Runtime/CastableObjectSupport.cs
@@ -82,7 +82,7 @@ namespace System.Runtime
             return default(V);
         }
 
-        internal unsafe static int GetCachePopulation<V>(CastableObjectCacheEntry<V>[] cache)
+        internal static unsafe int GetCachePopulation<V>(CastableObjectCacheEntry<V>[] cache)
         {
             int population = 0;
             for (int i = 0; i < cache.Length; i++)
@@ -94,7 +94,7 @@ namespace System.Runtime
             return population;
         }
 
-        internal unsafe static void AddToExistingCache<V>(CastableObjectCacheEntry<V>[] cache, IntPtr key, V value)
+        internal static unsafe void AddToExistingCache<V>(CastableObjectCacheEntry<V>[] cache, IntPtr key, V value)
         {
             uint hashcode = unchecked((uint)key.ToInt64());
             uint cacheMask = (uint)cache.Length - 1;
@@ -135,7 +135,7 @@ namespace System.Runtime
         /// Add the newly allocated thunk of a CastableObject dispatch cell call to the cache if possible. (OOM errors may cause caching failure. 
         /// An OOM is specified not to introduce new failure points though.)
         /// </summary>
-        internal unsafe static void AddToThunkCache(IntPtr pDispatchCell, IntPtr pThunkTarget)
+        internal static unsafe void AddToThunkCache(IntPtr pDispatchCell, IntPtr pThunkTarget)
         {
             // Expand old cache if it isn't big enough.
             if (GetCachePopulation(s_ThunkBasedDispatchCellTargets) > (s_ThunkBasedDispatchCellTargets.Length / 2))
@@ -166,7 +166,7 @@ namespace System.Runtime
         /// Add the results of a CastableObject call to the cache if possible. (OOM errors may cause caching failure. An OOM is specified not
         /// to introduce new failure points though.)
         /// </summary>
-        internal unsafe static void AddToCastableCache(ICastableObject castableObject, EEType* interfaceType, object objectForType)
+        internal static unsafe void AddToCastableCache(ICastableObject castableObject, EEType* interfaceType, object objectForType)
         {
             CastableObjectCacheEntry<object>[] cache = Unsafe.As<CastableObject>(castableObject).Cache;
             bool setNewCache = false;

--- a/src/Runtime.Base/src/System/Runtime/DispatchResolve.cs
+++ b/src/Runtime.Base/src/System/Runtime/DispatchResolve.cs
@@ -8,7 +8,7 @@ using Internal.Runtime;
 
 namespace System.Runtime
 {
-    internal unsafe static class DispatchResolve
+    internal static unsafe class DispatchResolve
     {
         // CS0649: Field '{blah}' is never assigned to, and will always have its default value
 #pragma warning disable 649

--- a/src/Runtime.Base/src/System/Runtime/EEType.Runtime.cs
+++ b/src/Runtime.Base/src/System/Runtime/EEType.Runtime.cs
@@ -109,7 +109,7 @@ namespace Internal.Runtime
         /// <summary>
         /// Return true if both types are good for simple casting: canonical, no related type via IAT, no generic variance
         /// </summary>
-        static internal bool BothSimpleCasting(EEType* pThis, EEType* pOther)
+        internal static bool BothSimpleCasting(EEType* pThis, EEType* pOther)
         {
             return ((pThis->_usFlags | pOther->_usFlags) & (ushort)EETypeFlags.ComplexCastingMask) == (ushort)EETypeKind.CanonicalEEType;
         }

--- a/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -34,7 +34,7 @@ namespace System.Runtime
         FirstPassFrameEntered = 8
     }
 
-    internal unsafe static class DebuggerNotify
+    internal static unsafe class DebuggerNotify
     {
         // We cache the events a debugger is interested on the C# side to avoid p/invokes when the
         // debugger isn't attached.
@@ -88,7 +88,7 @@ namespace System.Runtime
         }
     }
 
-    internal unsafe static class EH
+    internal static unsafe class EH
     {
         internal static UIntPtr MaxSP
         {
@@ -204,7 +204,7 @@ namespace System.Runtime
         private const int c_IPAdjustForHardwareFault = 1;
 #endif
 
-        internal unsafe static void* PointerAlign(void* ptr, int alignmentInBytes)
+        internal static unsafe void* PointerAlign(void* ptr, int alignmentInBytes)
         {
             int alignMask = alignmentInBytes - 1;
 #if BIT64
@@ -216,7 +216,7 @@ namespace System.Runtime
 
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal unsafe static void UnhandledExceptionFailFastViaClasslib(
+        internal static unsafe void UnhandledExceptionFailFastViaClasslib(
             RhFailFastReason reason, object unhandledException, IntPtr classlibAddress, ref ExInfo exInfo)
         {
             IntPtr pFailFastFunction =
@@ -900,12 +900,12 @@ namespace System.Runtime
         }
 
         [NativeCallable(EntryPoint = "RhpFailFastForPInvokeExceptionPreemp", CallingConvention = CallingConvention.Cdecl)]
-        static public void RhpFailFastForPInvokeExceptionPreemp(IntPtr PInvokeCallsiteReturnAddr, void* pExceptionRecord, void* pContextRecord)
+        public static void RhpFailFastForPInvokeExceptionPreemp(IntPtr PInvokeCallsiteReturnAddr, void* pExceptionRecord, void* pContextRecord)
         {
             FailFastViaClasslib(RhFailFastReason.PN_UnhandledExceptionFromPInvoke, null, PInvokeCallsiteReturnAddr);
         }
         [RuntimeExport("RhpFailFastForPInvokeExceptionCoop")]
-        static public void RhpFailFastForPInvokeExceptionCoop(IntPtr classlibBreadcrumb, void* pExceptionRecord, void* pContextRecord)
+        public static void RhpFailFastForPInvokeExceptionCoop(IntPtr classlibBreadcrumb, void* pExceptionRecord, void* pContextRecord)
         {
             FailFastViaClasslib(RhFailFastReason.PN_UnhandledExceptionFromPInvoke, null, classlibBreadcrumb);
         }

--- a/src/Runtime.Base/src/System/Runtime/GCStress.cs
+++ b/src/Runtime.Base/src/System/Runtime/GCStress.cs
@@ -60,9 +60,9 @@ namespace System.Runtime
         }
 
 #if FEATURE_GC_STRESS
-        static internal bool Initialized { get; private set; }
-        static private GCStress Head;
-        static private GCStress Tail;
+        internal static bool Initialized { get; private set; }
+        private static GCStress Head;
+        private static GCStress Tail;
 
         private GCStress Next;
 #endif // FEATURE_GC_STRESS

--- a/src/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -103,59 +103,59 @@ namespace System.Runtime
         [RuntimeImport(Redhawk.BaseName, "RhpNewFast")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static object RhpNewFast(EEType* pEEType);  // BEWARE: not for finalizable objects!
+        internal extern static unsafe object RhpNewFast(EEType* pEEType);  // BEWARE: not for finalizable objects!
 
         [RuntimeImport(Redhawk.BaseName, "RhpNewFinalizable")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static object RhpNewFinalizable(EEType* pEEType);
+        internal extern static unsafe object RhpNewFinalizable(EEType* pEEType);
 
         [RuntimeImport(Redhawk.BaseName, "RhpNewArray")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static object RhpNewArray(EEType* pEEType, int length);
+        internal extern static unsafe object RhpNewArray(EEType* pEEType, int length);
 
 #if FEATURE_64BIT_ALIGNMENT
         [RuntimeImport(Redhawk.BaseName, "RhpNewFastAlign8")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static object RhpNewFastAlign8(EEType * pEEType);  // BEWARE: not for finalizable objects!
+        internal extern static unsafe object RhpNewFastAlign8(EEType * pEEType);  // BEWARE: not for finalizable objects!
 
         [RuntimeImport(Redhawk.BaseName, "RhpNewFinalizableAlign8")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static object RhpNewFinalizableAlign8(EEType* pEEType);
+        internal extern static unsafe object RhpNewFinalizableAlign8(EEType* pEEType);
 
         [RuntimeImport(Redhawk.BaseName, "RhpNewArrayAlign8")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static object RhpNewArrayAlign8(EEType* pEEType, int length);
+        internal extern static unsafe object RhpNewArrayAlign8(EEType* pEEType, int length);
 
         [RuntimeImport(Redhawk.BaseName, "RhpNewFastMisalign")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static object RhpNewFastMisalign(EEType * pEEType);
+        internal extern static unsafe object RhpNewFastMisalign(EEType * pEEType);
 #endif // FEATURE_64BIT_ALIGNMENT
 
         [RuntimeImport(Redhawk.BaseName, "RhpBox")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static void RhpBox(object obj, ref byte data);
+        internal extern static unsafe void RhpBox(object obj, ref byte data);
 
         [RuntimeImport(Redhawk.BaseName, "RhUnbox")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Sometimes)]
-        internal unsafe extern static void RhUnbox(object obj, ref byte data, EEType* pUnboxToEEType);
+        internal extern static unsafe void RhUnbox(object obj, ref byte data, EEType* pUnboxToEEType);
 
         [RuntimeImport(Redhawk.BaseName, "RhpCopyObjectContents")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static void RhpCopyObjectContents(object objDest, object objSrc);
+        internal extern static unsafe void RhpCopyObjectContents(object objDest, object objSrc);
 
         [RuntimeImport(Redhawk.BaseName, "RhpAssignRef")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static void RhpAssignRef(ref Object address, object obj);
+        internal extern static unsafe void RhpAssignRef(ref Object address, object obj);
 
 #if FEATURE_GC_STRESS
         //
@@ -164,58 +164,58 @@ namespace System.Runtime
         [RuntimeImport(Redhawk.BaseName, "RhpInitializeGcStress")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static void RhpInitializeGcStress();
+        internal extern static unsafe void RhpInitializeGcStress();
 #endif // FEATURE_GC_STRESS
 
         [RuntimeImport(Redhawk.BaseName, "RhpEHEnumInitFromStackFrameIterator")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static bool RhpEHEnumInitFromStackFrameIterator(ref StackFrameIterator pFrameIter, byte** pMethodStartAddress, void* pEHEnum);
+        internal extern static unsafe bool RhpEHEnumInitFromStackFrameIterator(ref StackFrameIterator pFrameIter, byte** pMethodStartAddress, void* pEHEnum);
 
         [RuntimeImport(Redhawk.BaseName, "RhpEHEnumNext")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static bool RhpEHEnumNext(void* pEHEnum, void* pEHClause);
+        internal extern static unsafe bool RhpEHEnumNext(void* pEHEnum, void* pEHClause);
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetArrayBaseType")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static EEType* RhpGetArrayBaseType(EEType* pEEType);
+        internal extern static unsafe EEType* RhpGetArrayBaseType(EEType* pEEType);
 
         [RuntimeImport(Redhawk.BaseName, "RhpHasDispatchMap")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static bool RhpHasDispatchMap(EEType* pEETypen);
+        internal extern static unsafe bool RhpHasDispatchMap(EEType* pEETypen);
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetDispatchMap")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static DispatchResolve.DispatchMap* RhpGetDispatchMap(EEType* pEEType);
+        internal extern static unsafe DispatchResolve.DispatchMap* RhpGetDispatchMap(EEType* pEEType);
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetSealedVirtualSlot")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static IntPtr RhpGetSealedVirtualSlot(EEType* pEEType, ushort slot);
+        internal extern static unsafe IntPtr RhpGetSealedVirtualSlot(EEType* pEEType, ushort slot);
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetDispatchCellInfo")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static void RhpGetDispatchCellInfo(IntPtr pCell, out DispatchCellInfo newCellInfo);
+        internal extern static unsafe void RhpGetDispatchCellInfo(IntPtr pCell, out DispatchCellInfo newCellInfo);
 
         [RuntimeImport(Redhawk.BaseName, "RhpSearchDispatchCellCache")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static IntPtr RhpSearchDispatchCellCache(IntPtr pCell, EEType* pInstanceType);
+        internal extern static unsafe IntPtr RhpSearchDispatchCellCache(IntPtr pCell, EEType* pInstanceType);
 
         [RuntimeImport(Redhawk.BaseName, "RhpUpdateDispatchCellCache")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static IntPtr RhpUpdateDispatchCellCache(IntPtr pCell, IntPtr pTargetCode, EEType* pInstanceType, ref DispatchCellInfo newCellInfo);
+        internal extern static unsafe IntPtr RhpUpdateDispatchCellCache(IntPtr pCell, IntPtr pTargetCode, EEType* pInstanceType, ref DispatchCellInfo newCellInfo);
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetClasslibFunction")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static void* RhpGetClasslibFunction(IntPtr address, EH.ClassLibFunctionId id);
+        internal extern static unsafe void* RhpGetClasslibFunction(IntPtr address, EH.ClassLibFunctionId id);
 
         [RuntimeImport(Redhawk.BaseName, "RhGetModuleFromPointer")]
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -348,7 +348,7 @@ namespace System.Runtime
         [RuntimeImport(Redhawk.BaseName, "RhpSetTLSDispatchCell")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal unsafe extern static void RhpSetTLSDispatchCell(IntPtr pCell);
+        internal extern static unsafe void RhpSetTLSDispatchCell(IntPtr pCell);
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetNumThunkBlocksPerMapping")]
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -20,7 +20,7 @@ namespace System.Runtime
         // internal calls for allocation
         //
         [RuntimeExport("RhNewObject")]
-        public unsafe static object RhNewObject(EETypePtr pEEType)
+        public static unsafe object RhNewObject(EETypePtr pEEType)
         {
             EEType* ptrEEType = (EEType*)pEEType.ToPointer();
 #if FEATURE_64BIT_ALIGNMENT
@@ -42,7 +42,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhNewArray")]
-        public unsafe static object RhNewArray(EETypePtr pEEType, int length)
+        public static unsafe object RhNewArray(EETypePtr pEEType, int length)
         {
             EEType* ptrEEType = (EEType*)pEEType.ToPointer();
 #if FEATURE_64BIT_ALIGNMENT
@@ -58,7 +58,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhBox")]
-        public unsafe static object RhBox(EETypePtr pEEType, ref byte data)
+        public static unsafe object RhBox(EETypePtr pEEType, ref byte data)
         {
             EEType* ptrEEType = (EEType*)pEEType.ToPointer();
             int dataOffset = 0;
@@ -93,7 +93,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhBoxAny")]
-        public unsafe static object RhBoxAny(ref byte data, EETypePtr pEEType)
+        public static unsafe object RhBoxAny(ref byte data, EETypePtr pEEType)
         {
             EEType* ptrEEType = (EEType*)pEEType.ToPointer();
             if (ptrEEType->IsValueType)
@@ -106,7 +106,7 @@ namespace System.Runtime
             }
         }
 
-        private unsafe static bool UnboxAnyTypeCompare(EEType *pEEType, EEType *ptrUnboxToEEType)
+        private static unsafe bool UnboxAnyTypeCompare(EEType *pEEType, EEType *ptrUnboxToEEType)
         {
             bool result = false;
 
@@ -140,7 +140,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhUnboxAny")]
-        public unsafe static void RhUnboxAny(object o, ref byte data, EETypePtr pUnboxToEEType)
+        public static unsafe void RhUnboxAny(object o, ref byte data, EETypePtr pUnboxToEEType)
         {
             EEType* ptrUnboxToEEType = (EEType*)pUnboxToEEType.ToPointer();
             if (ptrUnboxToEEType->IsValueType)
@@ -183,7 +183,7 @@ namespace System.Runtime
         // Unbox helpers with RyuJIT conventions
         //
         [RuntimeExport("RhUnbox2")]
-        static public unsafe ref byte RhUnbox2(EETypePtr pUnboxToEEType, Object obj)
+        public static unsafe ref byte RhUnbox2(EETypePtr pUnboxToEEType, Object obj)
         {
             EEType * ptrUnboxToEEType = (EEType *)pUnboxToEEType.ToPointer();
             if (obj.EEType != ptrUnboxToEEType)
@@ -198,7 +198,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhUnboxNullable")]
-        static public unsafe void RhUnboxNullable(ref byte data, EETypePtr pUnboxToEEType, Object obj)
+        public static unsafe void RhUnboxNullable(ref byte data, EETypePtr pUnboxToEEType, Object obj)
         {
             EEType* ptrUnboxToEEType = (EEType*)pUnboxToEEType.ToPointer();
             if ((obj != null) && (obj.EEType != ptrUnboxToEEType->NullableType))
@@ -209,7 +209,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhArrayStoreCheckAny")]
-        static public unsafe void RhArrayStoreCheckAny(object array, ref byte data)
+        public static unsafe void RhArrayStoreCheckAny(object array, ref byte data)
         {
             if (array == null)
             {
@@ -228,7 +228,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhBoxAndNullCheck")]
-        static public unsafe bool RhBoxAndNullCheck(ref byte data, EETypePtr pEEType)
+        public static unsafe bool RhBoxAndNullCheck(ref byte data, EETypePtr pEEType)
         {
             EEType* ptrEEType = (EEType*)pEEType.ToPointer();
             if (ptrEEType->IsValueType)
@@ -245,7 +245,7 @@ namespace System.Runtime
 #pragma warning restore 169
 
         [RuntimeExport("RhAllocLocal")]
-        public unsafe static object RhAllocLocal(EETypePtr pEEType)
+        public static unsafe object RhAllocLocal(EETypePtr pEEType)
         {
             EEType* ptrEEType = (EEType*)pEEType.ToPointer();
             if (ptrEEType->IsValueType)
@@ -261,7 +261,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhMemberwiseClone")]
-        public unsafe static object RhMemberwiseClone(object src)
+        public static unsafe object RhMemberwiseClone(object src)
         {
             object objClone;
 
@@ -293,7 +293,7 @@ namespace System.Runtime
         }
 
         [DllImport(Redhawk.BaseName, CallingConvention = CallingConvention.Cdecl)]
-        private static unsafe extern int RhpGetCurrentThreadStackTrace(IntPtr* pOutputBuffer, uint outputBufferLength);
+        private static extern unsafe int RhpGetCurrentThreadStackTrace(IntPtr* pOutputBuffer, uint outputBufferLength);
 
         // Worker for RhGetCurrentThreadStackTrace.  RhGetCurrentThreadStackTrace just allocates a transition
         // frame that will be used to seed the stack trace and this method does all the real work.

--- a/src/Runtime.Base/src/System/Runtime/ThunkPool.cs
+++ b/src/Runtime.Base/src/System/Runtime/ThunkPool.cs
@@ -126,7 +126,7 @@ namespace System.Runtime
             }
         }
 
-        public unsafe static ThunksHeap CreateThunksHeap(IntPtr commonStubAddress)
+        public static unsafe ThunksHeap CreateThunksHeap(IntPtr commonStubAddress)
         {
             try
             {
@@ -356,7 +356,7 @@ namespace System.Runtime
         private static IntPtr[] s_currentlyMappedThunkBlocks = new IntPtr[Constants.NumThunkBlocksPerMapping];
         private static int s_currentlyMappedThunkBlocksIndex = Constants.NumThunkBlocksPerMapping;
 
-        public unsafe static IntPtr GetNewThunksBlock()
+        public static unsafe IntPtr GetNewThunksBlock()
         {
             IntPtr nextThunksBlock;
 
@@ -422,7 +422,7 @@ namespace System.Runtime
         }
 
         // TODO: [Feature] Keep track of mapped sections and free them if we need to.
-        // public unsafe static void FreeThunksBlock()
+        // public static unsafe void FreeThunksBlock()
         // {
         // }
     }

--- a/src/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -43,7 +43,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_IsInstanceOfClass")]
-        static public unsafe object IsInstanceOfClass(object obj, void* pvTargetType)
+        public static unsafe object IsInstanceOfClass(object obj, void* pvTargetType)
         {
             if (obj == null)
             {
@@ -153,7 +153,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_CheckCastClass")]
-        static public unsafe object CheckCastClass(Object obj, void* pvTargetEEType)
+        public static unsafe object CheckCastClass(Object obj, void* pvTargetEEType)
         {
             // a null value can be cast to anything
             if (obj == null)
@@ -173,7 +173,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_CheckUnbox")]
-        static public unsafe void CheckUnbox(Object obj, byte expectedCorElementType)
+        public static unsafe void CheckUnbox(Object obj, byte expectedCorElementType)
         {
             if (obj == null)
             {
@@ -190,7 +190,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_IsInstanceOfArray")]
-        static public unsafe object IsInstanceOfArray(object obj, void* pvTargetType)
+        public static unsafe object IsInstanceOfArray(object obj, void* pvTargetType)
         {
             if (obj == null)
             {
@@ -230,7 +230,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_CheckCastArray")]
-        static public unsafe object CheckCastArray(Object obj, void* pvTargetEEType)
+        public static unsafe object CheckCastArray(Object obj, void* pvTargetEEType)
         {
             // a null value can be cast to anything
             if (obj == null)
@@ -250,7 +250,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_IsInstanceOfInterface")]
-        static public unsafe object IsInstanceOfInterface(object obj, void* pvTargetType)
+        public static unsafe object IsInstanceOfInterface(object obj, void* pvTargetType)
         {
             if (obj == null)
             {
@@ -271,7 +271,7 @@ namespace System.Runtime
             return null;
         }
 
-        unsafe static bool IsInstanceOfInterfaceViaCastableObject(object obj, EEType* pTargetType)
+        static unsafe bool IsInstanceOfInterfaceViaCastableObject(object obj, EEType* pTargetType)
         {
             // To avoid stack overflow, it is not possible to implement the ICastableObject interface
             // itself via ICastableObject
@@ -304,7 +304,7 @@ namespace System.Runtime
             return false;
         }
 
-        unsafe static bool IsInstanceOfInterfaceViaCastableObjectWithException(object obj, EEType* pTargetType, ref Exception castError)
+        static unsafe bool IsInstanceOfInterfaceViaCastableObjectWithException(object obj, EEType* pTargetType, ref Exception castError)
         {
             // TODO!! BEGIN REMOVE THIS CODE WHEN WE REMOVE ICASTABLE
             // Call the ICastable.IsInstanceOfInterface method directly rather than via an interface
@@ -324,7 +324,7 @@ namespace System.Runtime
             // TODO!! END REMOVE THIS CODE WHEN WE REMOVE ICASTABLE
         }
 
-        static internal unsafe bool ImplementsInterface(EEType* pObjType, EEType* pTargetType)
+        internal static unsafe bool ImplementsInterface(EEType* pObjType, EEType* pTargetType)
         {
             Debug.Assert(!pTargetType->IsParameterizedType, "did not expect paramterized type");
             Debug.Assert(pTargetType->IsInterface, "IsInstanceOfInterface called with non-interface EEType");
@@ -426,7 +426,7 @@ namespace System.Runtime
         }
 
         // Compare two types to see if they are compatible via generic variance.
-        static private unsafe bool TypesAreCompatibleViaGenericVariance(EEType* pSourceType, EEType* pTargetType)
+        private static unsafe bool TypesAreCompatibleViaGenericVariance(EEType* pSourceType, EEType* pTargetType)
         {
             EEType* pTargetGenericType = pTargetType->GenericDefinition;
             EEType* pSourceGenericType = pSourceType->GenericDefinition;
@@ -471,7 +471,7 @@ namespace System.Runtime
         // implies their arities are the same as well). The fForceCovariance argument tells the method to
         // override the defined variance of each parameter and instead assume it is covariant. This is used to
         // implement covariant array interfaces.
-        static internal unsafe bool TypeParametersAreCompatible(int arity,
+        internal static unsafe bool TypeParametersAreCompatible(int arity,
                                                                EETypeRef* pSourceInstantiation,
                                                                EETypeRef* pTargetInstantiation,
                                                                GenericVariance* pVarianceInfo,
@@ -561,7 +561,7 @@ namespace System.Runtime
         // compatible with Object and ValueType and an enum source is additionally compatible with Enum.
         //
         [RuntimeExport("RhTypeCast_AreTypesAssignable")]
-        static public unsafe bool AreTypesAssignable(void* pvSourceType, void* pvTargetType)
+        public static unsafe bool AreTypesAssignable(void* pvSourceType, void* pvTargetType)
         {
             EEType* pSourceType = (EEType*)pvSourceType;
             EEType* pTargetType = (EEType*)pvTargetType;
@@ -593,7 +593,7 @@ namespace System.Runtime
         //                            compatible with Object, ValueType and Enum (if applicable)
         //  fAllowSizeEquivalence   : allow identically sized integral types and enums to be considered
         //                            equivalent (currently used only for array element types)
-        static internal unsafe bool AreTypesAssignableInternal(EEType* pSourceType, EEType* pTargetType, AssignmentVariation variation)
+        internal static unsafe bool AreTypesAssignableInternal(EEType* pSourceType, EEType* pTargetType, AssignmentVariation variation)
         {
             bool fBoxedSource = ((variation & AssignmentVariation.BoxedSource) == AssignmentVariation.BoxedSource);
             bool fAllowSizeEquivalence = ((variation & AssignmentVariation.AllowSizeEquivalence ) == AssignmentVariation.AllowSizeEquivalence);
@@ -725,7 +725,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_CheckCastInterface")]
-        static public unsafe object CheckCastInterface(Object obj, void* pvTargetEEType)
+        public static unsafe object CheckCastInterface(Object obj, void* pvTargetEEType)
         {
             // a null value can be cast to anything
             if (obj == null)
@@ -760,7 +760,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_CheckArrayStore")]
-        static public unsafe void CheckArrayStore(object array, object obj)
+        public static unsafe void CheckArrayStore(object array, object obj)
         {
             if (array == null || obj == null)
             {
@@ -785,7 +785,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_CheckVectorElemAddr")]
-        static public unsafe void CheckVectorElemAddr(void* pvElemType, object array)
+        public static unsafe void CheckVectorElemAddr(void* pvElemType, object array)
         {
             if (array == null)
             {
@@ -819,7 +819,7 @@ namespace System.Runtime
         // Array stelem/ldelema helpers with RyuJIT conventions
         //
         [RuntimeExport("RhpStelemRef")]
-        static public unsafe void StelemRef(Array array, int index, object obj)
+        public static unsafe void StelemRef(Array array, int index, object obj)
         {
             // This is supported only on arrays
             Debug.Assert(array.EEType->IsArray, "first argument must be an array");
@@ -861,7 +861,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhpLdelemaRef")]
-        static public unsafe ref Object LdelemaRef(Array array, int index, IntPtr elementType)
+        public static unsafe ref Object LdelemaRef(Array array, int index, IntPtr elementType)
         {
             Debug.Assert(array.EEType->IsArray, "first argument must be an array");
 
@@ -880,7 +880,7 @@ namespace System.Runtime
             return ref Unsafe.Add(ref rawData, index);
         }
 
-        static internal unsafe bool IsDerived(EEType* pDerivedType, EEType* pBaseType)
+        internal static unsafe bool IsDerived(EEType* pDerivedType, EEType* pBaseType)
         {
             Debug.Assert(!pDerivedType->IsArray, "did not expect array type");
             Debug.Assert(!pDerivedType->IsParameterizedType, "did not expect parameterType");
@@ -925,7 +925,7 @@ namespace System.Runtime
         //   1. The pointers are Equal => true
         //   2. Either one or both the types are CLONED, follow to the canonical EEType and check
         //   3. For Arrays/Pointers, we have to further check for rank and element type equality
-        static internal unsafe bool AreTypesEquivalentInternal(EEType* pType1, EEType* pType2)
+        internal static unsafe bool AreTypesEquivalentInternal(EEType* pType1, EEType* pType2)
         {
             if (pType1 == pType2)
                 return true;
@@ -946,7 +946,7 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_IsInstanceOf2")]  // Helper with RyuJIT calling convention
-        static public unsafe object IsInstanceOf2(void* pvTargetType, object obj)
+        public static unsafe object IsInstanceOf2(void* pvTargetType, object obj)
         {
             return IsInstanceOf(obj, pvTargetType);
         }
@@ -954,7 +954,7 @@ namespace System.Runtime
         // this is necessary for shared generic code - Foo<T> may be executing
         // for T being an interface, an array or a class
         [RuntimeExport("RhTypeCast_IsInstanceOf")]
-        static public unsafe object IsInstanceOf(object obj, void* pvTargetType)
+        public static unsafe object IsInstanceOf(object obj, void* pvTargetType)
         {
             // @TODO: consider using the cache directly, but beware of ICastable in the interface case
             EEType* pTargetType = (EEType*)pvTargetType;
@@ -967,13 +967,13 @@ namespace System.Runtime
         }
 
         [RuntimeExport("RhTypeCast_CheckCast2")] // Helper with RyuJIT calling convention
-        static public unsafe object CheckCast2(void* pvTargetType, Object obj)
+        public static unsafe object CheckCast2(void* pvTargetType, Object obj)
         {
             return CheckCast(obj, pvTargetType);
         }
 
         [RuntimeExport("RhTypeCast_CheckCast")]
-        static public unsafe object CheckCast(Object obj, void* pvTargetType)
+        public static unsafe object CheckCast(Object obj, void* pvTargetType)
         {
             // @TODO: consider using the cache directly, but beware of ICastable in the interface case
             EEType* pTargetType = (EEType*)pvTargetType;
@@ -986,7 +986,7 @@ namespace System.Runtime
         }
 
         // Returns true of the two types are equivalent primitive types. Used by array casts.
-        static private unsafe bool ArePrimitveTypesEquivalentSize(EEType* pType1, EEType* pType2)
+        private static unsafe bool ArePrimitveTypesEquivalentSize(EEType* pType1, EEType* pType2)
         {
             CorElementType sourceCorType = pType1->CorElementType;
             int sourcePrimitiveTypeEquivalenceSize = GetIntegralTypeMatchSize(sourceCorType);
@@ -1001,7 +1001,7 @@ namespace System.Runtime
             return sourcePrimitiveTypeEquivalenceSize == targetPrimitiveTypeEquivalenceSize;
         }
 
-        private unsafe static int GetIntegralTypeMatchSize(CorElementType corType)
+        private static unsafe int GetIntegralTypeMatchSize(CorElementType corType)
         {
             switch (corType)
             {
@@ -1095,7 +1095,7 @@ namespace System.Runtime
 
             }
 
-            public unsafe static bool AreTypesAssignableInternal(EEType* pSourceType, EEType* pTargetType, AssignmentVariation variation)
+            public static unsafe bool AreTypesAssignableInternal(EEType* pSourceType, EEType* pTargetType, AssignmentVariation variation)
             {
                 // Important special case -- it breaks infinite recursion in CastCache itself!
                 if (pSourceType == pTargetType)
@@ -1123,7 +1123,7 @@ namespace System.Runtime
                 return entry;
             }
 
-            private unsafe static bool CacheMiss(ref Key key)
+            private static unsafe bool CacheMiss(ref Key key)
             {
                 bool result = false;
                 bool previouslyCached = false;

--- a/src/Runtime.Base/src/System/Runtime/__Finalizer.cs
+++ b/src/Runtime.Base/src/System/Runtime/__Finalizer.cs
@@ -53,7 +53,7 @@ namespace System.Runtime
         // objects that came off of the finalizer queue.  If such temps were reported across the duration of the 
         // finalizer thread wait operation, it could cause unpredictable behavior with weak handles.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private unsafe static void DrainQueue()
+        private static unsafe void DrainQueue()
         {
             // Drain the queue of finalizable objects.
             while (true)
@@ -73,7 +73,7 @@ namespace System.Runtime
         // objects derived from that class library's System.Object are finalized.  This is where we make those
         // callbacks.  When a class library is loaded, we set the s_fHasNewClasslibs flag and then the next
         // time the finalizer runs, we call this function to make any outstanding callbacks.
-        private unsafe static void MakeFinalizerInitCallbacks()
+        private static unsafe void MakeFinalizerInitCallbacks()
         {
             while (true)
             {

--- a/src/Runtime.Base/src/System/RuntimeTypeHandle.cs
+++ b/src/Runtime.Base/src/System/RuntimeTypeHandle.cs
@@ -23,7 +23,7 @@ namespace System
 
 #if CORERT
         [Intrinsic]
-        internal unsafe static IntPtr GetValueInternal(RuntimeTypeHandle handle)
+        internal static unsafe IntPtr GetValueInternal(RuntimeTypeHandle handle)
         {
             return (IntPtr)handle._pEEType.ToPointer();
         }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -233,22 +233,22 @@ namespace Internal.Runtime.Augments
             return new RuntimeTypeHandle(new EETypePtr(ldTokenResult));
         }
 
-        public unsafe static IntPtr GetThreadStaticFieldAddress(RuntimeTypeHandle typeHandle, IntPtr fieldCookie)
+        public static unsafe IntPtr GetThreadStaticFieldAddress(RuntimeTypeHandle typeHandle, IntPtr fieldCookie)
         {
             return new IntPtr(RuntimeImports.RhGetThreadStaticFieldAddress(typeHandle.ToEETypePtr(), fieldCookie));
         }
 
-        public unsafe static void StoreValueTypeField(IntPtr address, Object fieldValue, RuntimeTypeHandle fieldType)
+        public static unsafe void StoreValueTypeField(IntPtr address, Object fieldValue, RuntimeTypeHandle fieldType)
         {
             RuntimeImports.RhUnbox(fieldValue, *(void**)&address, fieldType.ToEETypePtr());
         }
 
-        public unsafe static Object LoadValueTypeField(IntPtr address, RuntimeTypeHandle fieldType)
+        public static unsafe Object LoadValueTypeField(IntPtr address, RuntimeTypeHandle fieldType)
         {
             return RuntimeImports.RhBox(fieldType.ToEETypePtr(), *(void**)&address);
         }
 
-        public unsafe static void StoreValueTypeField(Object obj, int fieldOffset, Object fieldValue, RuntimeTypeHandle fieldType)
+        public static unsafe void StoreValueTypeField(Object obj, int fieldOffset, Object fieldValue, RuntimeTypeHandle fieldType)
         {
             fixed (IntPtr* pObj = &obj.m_pEEType)
             {
@@ -258,7 +258,7 @@ namespace Internal.Runtime.Augments
             }
         }
 
-        public unsafe static Object LoadValueTypeField(Object obj, int fieldOffset, RuntimeTypeHandle fieldType)
+        public static unsafe Object LoadValueTypeField(Object obj, int fieldOffset, RuntimeTypeHandle fieldType)
         {
             fixed (IntPtr* pObj = &obj.m_pEEType)
             {
@@ -278,7 +278,7 @@ namespace Internal.Runtime.Augments
             return Volatile.Read<Object>(ref Unsafe.As<IntPtr, Object>(ref *(IntPtr *)address));
         }
 
-        public unsafe static void StoreReferenceTypeField(Object obj, int fieldOffset, Object fieldValue)
+        public static unsafe void StoreReferenceTypeField(Object obj, int fieldOffset, Object fieldValue)
         {
             fixed (IntPtr* pObj = &obj.m_pEEType)
             {
@@ -288,7 +288,7 @@ namespace Internal.Runtime.Augments
             }
         }
 
-        public unsafe static Object LoadReferenceTypeField(Object obj, int fieldOffset)
+        public static unsafe Object LoadReferenceTypeField(Object obj, int fieldOffset)
         {
             fixed (IntPtr* pObj = &obj.m_pEEType)
             {
@@ -324,7 +324,7 @@ namespace Internal.Runtime.Augments
             return result;
         }
 
-        public unsafe static void EnsureClassConstructorRun(IntPtr staticClassConstructionContext)
+        public static unsafe void EnsureClassConstructorRun(IntPtr staticClassConstructionContext)
         {
             StaticClassConstructionContext* context = (StaticClassConstructionContext*)staticClassConstructionContext;
             ClassConstructorRunner.EnsureClassConstructorRun(context);
@@ -462,7 +462,7 @@ namespace Internal.Runtime.Augments
             return RuntimeImports.RhGetGCDescSize(eeType);
         }
 
-        public unsafe static bool CreateGenericInstanceDescForType(RuntimeTypeHandle typeHandle, int arity, int nonGcStaticDataSize,
+        public static unsafe bool CreateGenericInstanceDescForType(RuntimeTypeHandle typeHandle, int arity, int nonGcStaticDataSize,
             int nonGCStaticDataOffset, int gcStaticDataSize, int threadStaticsOffset, IntPtr gcStaticsDesc, IntPtr threadStaticsDesc, int[] genericVarianceFlags)
         {
             EETypePtr eeType = CreateEETypePtr(typeHandle);
@@ -775,7 +775,7 @@ namespace Internal.Runtime.Augments
             RuntimeExceptionHelpers.GenerateExceptionInformationForDump(currentException, exceptionCCWPtr);
         }
 
-        public unsafe static RuntimeTypeHandle GetRuntimeTypeHandleFromObjectReference(object obj)
+        public static unsafe RuntimeTypeHandle GetRuntimeTypeHandleFromObjectReference(object obj)
         {
             return new RuntimeTypeHandle(obj.EETypePtr);
         }
@@ -788,7 +788,7 @@ namespace Internal.Runtime.Augments
         // Move memory which may be on the heap which may have object references in it.
         // In general, a memcpy on the heap is unsafe, but this is able to perform the
         // correct write barrier such that the GC is not incorrectly impacted.
-        public unsafe static void BulkMoveWithWriteBarrier(IntPtr dmem, IntPtr smem, int size)
+        public static unsafe void BulkMoveWithWriteBarrier(IntPtr dmem, IntPtr smem, int size)
         {
             RuntimeImports.RhBulkMoveWithWriteBarrier((byte*)dmem.ToPointer(), (byte*)smem.ToPointer(), size);
         }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -49,7 +49,7 @@ namespace Internal.Runtime.CompilerHelpers
                 sb.ReplaceBuffer(p);
         }
 
-        internal unsafe static IntPtr ResolvePInvoke(MethodFixupCell* pCell)
+        internal static unsafe IntPtr ResolvePInvoke(MethodFixupCell* pCell)
         {
             if (pCell->Target != IntPtr.Zero)
                 return pCell->Target;
@@ -57,7 +57,7 @@ namespace Internal.Runtime.CompilerHelpers
             return ResolvePInvokeSlow(pCell);
         }
 
-        internal unsafe static IntPtr ResolvePInvokeSlow(MethodFixupCell* pCell)
+        internal static unsafe IntPtr ResolvePInvokeSlow(MethodFixupCell* pCell)
         {
             ModuleFixupCell* pModuleCell = pCell->Module;
             IntPtr hModule = pModuleCell->Handle;
@@ -71,7 +71,7 @@ namespace Internal.Runtime.CompilerHelpers
             return pCell->Target;
         }
 
-        internal unsafe static void FixupModuleCell(ModuleFixupCell* pCell)
+        internal static unsafe void FixupModuleCell(ModuleFixupCell* pCell)
         {
 #if !PLATFORM_UNIX
             char* moduleName = (char*)pCell->ModuleName;
@@ -112,7 +112,7 @@ namespace Internal.Runtime.CompilerHelpers
 #endif
         }
 
-        internal unsafe static void FixupMethodCell(IntPtr hModule, MethodFixupCell* pCell)
+        internal static unsafe void FixupMethodCell(IntPtr hModule, MethodFixupCell* pCell)
         {
             byte* methodName = (byte*)pCell->MethodName;
 
@@ -128,7 +128,7 @@ namespace Internal.Runtime.CompilerHelpers
             }
         }
 
-        internal unsafe static int strlen(byte* pString)
+        internal static unsafe int strlen(byte* pString)
         {
             int length = 0;
             for (; *pString != 0; pString++)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/GenericVirtualMethodSupport.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/GenericVirtualMethodSupport.cs
@@ -12,7 +12,7 @@ namespace Internal.Runtime.CompilerServices
 {
     internal static class GenericVirtualMethodSupport
     {
-        private unsafe static IntPtr GVMLookupForSlotWorker(RuntimeTypeHandle type, RuntimeTypeHandle declaringType, RuntimeTypeHandle[] genericArguments, MethodNameAndSignature methodNameAndSignature)
+        private static unsafe IntPtr GVMLookupForSlotWorker(RuntimeTypeHandle type, RuntimeTypeHandle declaringType, RuntimeTypeHandle[] genericArguments, MethodNameAndSignature methodNameAndSignature)
         {
             bool slotChanged = false;
 
@@ -56,7 +56,7 @@ namespace Internal.Runtime.CompilerServices
             return resolution;
         }
 
-        internal unsafe static IntPtr GVMLookupForSlot(RuntimeTypeHandle type, RuntimeMethodHandle slot)
+        internal static unsafe IntPtr GVMLookupForSlot(RuntimeTypeHandle type, RuntimeMethodHandle slot)
         {
             RuntimeTypeHandle declaringTypeHandle;
             MethodNameAndSignature nameAndSignature;

--- a/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
+++ b/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
@@ -175,8 +175,8 @@ internal partial class Interop
                     IntPtr pContextRecord,
                     uint dwFlags);
 
-        private readonly static System.Threading.WaitHandle s_sleepHandle = new System.Threading.ManualResetEvent(false);
-        static internal void Sleep(uint milliseconds)
+        private static readonly System.Threading.WaitHandle s_sleepHandle = new System.Threading.ManualResetEvent(false);
+        internal static void Sleep(uint milliseconds)
         {
             if (milliseconds == 0)
                 System.Threading.SpinWait.Yield();
@@ -193,7 +193,7 @@ internal partial class Interop
             RO_INIT_MULTITHREADED = 1
         }
 
-        static internal unsafe void RoInitialize(RO_INIT_TYPE initType)
+        internal static unsafe void RoInitialize(RO_INIT_TYPE initType)
         {
             int hr = RoInitialize((uint)initType);
 
@@ -209,10 +209,10 @@ internal partial class Interop
         [DllImport(Interop.CORE_WINRT)]
         [McgGeneratedNativeCallCodeAttribute]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        static internal extern unsafe int RoInitialize(uint initType);
+        internal static extern unsafe int RoInitialize(uint initType);
 #else
         // Right now do what is necessary to ensure that the tools still work on pre-Win8 platforms
-        static internal unsafe int RoInitialize(uint initType)
+        internal static unsafe int RoInitialize(uint initType)
         {
             // RoInitialize gets called on startup so it can't throw a not implemented exception
             return 0;

--- a/src/System.Private.CoreLib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/System.Private.CoreLib/src/Microsoft/Win32/RegistryKey.cs
@@ -425,11 +425,11 @@ namespace Microsoft.Win32
         {
         }
 
-        static private void ValidateKeyOptions(RegistryOptions options)
+        private static void ValidateKeyOptions(RegistryOptions options)
         {
         }
 
-        static private void ValidateKeyView(RegistryView view)
+        private static void ValidateKeyView(RegistryView view)
         {
         }
 

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -232,7 +232,7 @@ namespace System
         // If you use C#'s 'fixed' statement to get the address of m_pEEType, you want to pass it into this
         // function to get the address of the first field.  NOTE: If you use GetAddrOfPinnedObject instead,
         // C# may optimize away the pinned local, producing incorrect results.
-        static internal unsafe byte* GetAddrOfPinnedArrayFromEETypeField(IntPtr* ppEEType)
+        internal static unsafe byte* GetAddrOfPinnedArrayFromEETypeField(IntPtr* ppEEType)
         {
             // -POINTER_SIZE to account for the sync block
             return (byte*)ppEEType + new EETypePtr(*ppEEType).BaseSize - POINTER_SIZE;
@@ -938,7 +938,7 @@ namespace System
         }
 
         // Allocate new multidimensional array of given dimensions. Assumes that that pLengths is immutable.
-        internal unsafe static Array NewMultiDimArray(EETypePtr eeType, int * pLengths, int rank)
+        internal static unsafe Array NewMultiDimArray(EETypePtr eeType, int * pLengths, int rank)
         {
             Debug.Assert(eeType.IsArray && !eeType.IsSzArray);
             Debug.Assert(rank == eeType.ArrayRank);

--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -71,7 +71,7 @@ namespace System
         // It is however cross platform as the CRT hasn't ported their fast version to 64-bit
         // platforms.
         //
-        internal unsafe static int IndexOfByte(byte* src, byte value, int index, int count)
+        internal static unsafe int IndexOfByte(byte* src, byte value, int index, int count)
         {
             byte* pByte = src + index;
 
@@ -140,7 +140,7 @@ namespace System
             return -1;
         }
 
-        internal unsafe static void ZeroMemory(byte* src, long len)
+        internal static unsafe void ZeroMemory(byte* src, long len)
         {
             while (len-- > 0)
                 *(src + len) = 0;
@@ -226,7 +226,7 @@ namespace System
             Memmove((byte*)destination, (byte*)source, checked((nuint)sourceBytesToCopy));
         }
 
-        internal unsafe static void Memmove(byte* dest, byte* src, nuint len)
+        internal static unsafe void Memmove(byte* dest, byte* src, nuint len)
         {
             // P/Invoke into the native version when the buffers are overlapping and the copy needs to be performed backwards
             // This check can produce false positives for lengths greater than Int32.MaxInt. It is fine because we want to use PInvoke path for the large lengths anyway.
@@ -447,7 +447,7 @@ namespace System
         // Non-inlinable wrapper around the QCall that avoids poluting the fast path
         // with P/Invoke prolog/epilog.
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        private unsafe static void _Memmove(byte* dest, byte* src, nuint len)
+        private static unsafe void _Memmove(byte* dest, byte* src, nuint len)
         {
             RuntimeImports.memmove(dest, src, len);
         }

--- a/src/System.Private.CoreLib/src/System/Char.cs
+++ b/src/System.Private.CoreLib/src/System/Char.cs
@@ -42,7 +42,7 @@ namespace System
         internal const char LOW_SURROGATE_END_CHAR = '\udfff';
 
         // Unicode category values from Unicode U+0000 ~ U+00FF. Store them in byte[] array to save space.
-        private readonly static byte[] s_categoryForLatin1 = {
+        private static readonly byte[] s_categoryForLatin1 = {
             (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0000 - 0007
             (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0008 - 000F
             (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0010 - 0017

--- a/src/System.Private.CoreLib/src/System/DateTime.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/DateTime.Windows.cs
@@ -8,7 +8,7 @@ namespace System
 {
     public partial struct DateTime : IComparable, IFormattable, IComparable<DateTime>, IEquatable<DateTime>, IConvertible
     {
-        public unsafe static DateTime UtcNow
+        public static unsafe DateTime UtcNow
         {
             get
             {

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -30,12 +30,12 @@ namespace System
 
         // New Delegate Implementation
 
-        internal protected object m_firstParameter;
-        internal protected object m_helperObject;
+        protected internal object m_firstParameter;
+        protected internal object m_helperObject;
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2111:PointersShouldNotBeVisible")]
-        internal protected IntPtr m_extraFunctionPointerOrData;
+        protected internal IntPtr m_extraFunctionPointerOrData;
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2111:PointersShouldNotBeVisible")]
-        internal protected IntPtr m_functionPointer;
+        protected internal IntPtr m_functionPointer;
 
         [ThreadStatic]
         protected static string s_DefaultValueString;
@@ -312,7 +312,7 @@ namespace System
             }
         }
 
-        public unsafe static Delegate Combine(Delegate a, Delegate b)
+        public static unsafe Delegate Combine(Delegate a, Delegate b)
         {
             if (a == null)
                 return b;

--- a/src/System.Private.CoreLib/src/System/Double.cs
+++ b/src/System.Private.CoreLib/src/System/Double.cs
@@ -47,7 +47,7 @@ namespace System
         }
 
         [Pure]
-        public unsafe static bool IsInfinity(double d)
+        public static unsafe bool IsInfinity(double d)
         {
             return (*(long*)(&d) & 0x7FFFFFFFFFFFFFFF) == 0x7FF0000000000000;
         }
@@ -82,14 +82,14 @@ namespace System
 
 
         [Pure]
-        internal unsafe static bool IsNegative(double d)
+        internal static unsafe bool IsNegative(double d)
         {
             return (*(UInt64*)(&d) & 0x8000000000000000) == 0x8000000000000000;
         }
 
 
         [Pure]
-        public unsafe static bool IsNaN(double d)
+        public static unsafe bool IsNaN(double d)
         {
             return (*(UInt64*)(&d) & 0x7FFFFFFFFFFFFFFFL) > 0x7FF0000000000000L;
         }

--- a/src/System.Private.CoreLib/src/System/Environment.Uap.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Uap.cs
@@ -18,7 +18,7 @@ namespace System
 {
     public static partial class Environment
     {
-        public unsafe static String ExpandEnvironmentVariables(String name)
+        public static unsafe String ExpandEnvironmentVariables(String name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -28,7 +28,7 @@ namespace System
             return name;
         }
 
-        public unsafe static String GetEnvironmentVariable(String variable)
+        public static unsafe String GetEnvironmentVariable(String variable)
         {
             if (variable == null)
                 throw new ArgumentNullException(nameof(variable));

--- a/src/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -16,7 +16,7 @@ namespace System
             }
         }
 
-        public unsafe static String ExpandEnvironmentVariables(String name)
+        public static unsafe String ExpandEnvironmentVariables(String name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -53,7 +53,7 @@ namespace System
 
         public static int ProcessorCount => (int)Interop.Sys.SysConf(Interop.Sys.SysConfName._SC_NPROCESSORS_ONLN);
 
-        public unsafe static String GetEnvironmentVariable(String variable)
+        public static unsafe String GetEnvironmentVariable(String variable)
         {
             if (variable == null)
                 throw new ArgumentNullException(nameof(variable));

--- a/src/System.Private.CoreLib/src/System/Environment.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Win32.cs
@@ -6,7 +6,7 @@ namespace System
 {
     public static partial class Environment
     {
-        public unsafe static String GetEnvironmentVariable(String variable)
+        public static unsafe String GetEnvironmentVariable(String variable)
         {
             if (variable == null)
                 throw new ArgumentNullException(nameof(variable));

--- a/src/System.Private.CoreLib/src/System/Globalization/CalendricalCalculationsHelper.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CalendricalCalculationsHelper.cs
@@ -125,7 +125,7 @@ namespace System.Globalization
             return longitude;
         }
 
-        static public double AsDayFraction(double longitude)
+        public static double AsDayFraction(double longitude)
         {
             return longitude / FullCircleOfArc;
         }
@@ -219,7 +219,7 @@ namespace System.Globalization
             return DefaultEphemerisCorrection(year);
         }
 
-        static public double JulianCenturies(double moment)
+        public static double JulianCenturies(double moment)
         {
             double dynamicalMoment = moment + EphemerisCorrection(moment);
             return (dynamicalMoment - Noon2000Jan01) / DaysInUniformLengthCentury;
@@ -273,7 +273,7 @@ namespace System.Globalization
         }
 
         // midday
-        static public double Midday(double date, double longitude)
+        public static double Midday(double date, double longitude)
         {
             return AsLocalTime(date + TwelveHours, longitude) - AsDayFraction(longitude);
         }
@@ -284,7 +284,7 @@ namespace System.Globalization
         }
 
         // midday-in-tehran
-        static public double MiddayAtPersianObservationSite(double date)
+        public static double MiddayAtPersianObservationSite(double date)
         {
             return Midday(date, InitLongitude(52.5)); // 52.5 degrees east - longitude of UTC+3:30 which defines Iranian Standard Time
         }
@@ -361,7 +361,7 @@ namespace System.Globalization
             return (-0.004778 * SinOfDegree(a)) - (0.0003667 * SinOfDegree(b));
         }
 
-        static public double Compute(double time)
+        public static double Compute(double time)
         {
             double julianCenturies = JulianCenturies(time);
             double lambda = 282.7771834
@@ -372,7 +372,7 @@ namespace System.Globalization
             return InitLongitude(longitude);
         }
 
-        static public double AsSeason(double longitude)
+        public static double AsSeason(double longitude)
         {
             return (longitude < 0) ? (longitude + FullCircleOfArc) : longitude;
         }

--- a/src/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
@@ -165,7 +165,7 @@ namespace System.Globalization
         //
         // Note that for ch in the range D800-DFFF we just treat it as any other non-numeric character
         //
-        internal unsafe static double InternalGetNumericValue(int ch)
+        internal static unsafe double InternalGetNumericValue(int ch)
         {
             Debug.Assert(ch >= 0 && ch <= 0x10ffff, "ch is not in valid Unicode range.");
             // Get the level 2 item from the highest 12 bit (8 - 19) of ch.
@@ -186,7 +186,7 @@ namespace System.Globalization
             }
         }
 
-        internal unsafe static ushort InternalGetDigitValues(int ch)
+        internal static unsafe ushort InternalGetDigitValues(int ch)
         {
             Contract.Assert(ch >= 0 && ch <= 0x10ffff, "ch is not in valid Unicode range.");
             // Get the level 2 item from the highest 12 bit (8 - 19) of ch.
@@ -297,7 +297,7 @@ namespace System.Globalization
             return InternalGetUnicodeCategory(s, index);
         }
 
-        internal unsafe static UnicodeCategory InternalGetUnicodeCategory(int ch)
+        internal static unsafe UnicodeCategory InternalGetUnicodeCategory(int ch)
         {
             return ((UnicodeCategory)InternalGetCategoryValue(ch, UNICODE_CATEGORY_OFFSET));
         }
@@ -317,7 +317,7 @@ namespace System.Globalization
         //
         ////////////////////////////////////////////////////////////////////////
 
-        internal unsafe static byte InternalGetCategoryValue(int ch, int offset)
+        internal static unsafe byte InternalGetCategoryValue(int ch, int offset)
         {
             Debug.Assert(ch >= 0 && ch <= 0x10ffff, "ch is not in valid Unicode range.");
             // Get the level 2 item from the highest 12 bit (8 - 19) of ch.

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Dummy.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Dummy.cs
@@ -15,7 +15,7 @@ namespace System.Globalization
             _sortName = culture.SortName;
         }
 
-        internal unsafe static int IndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
+        internal static unsafe int IndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             fixed (char *pSource = source) fixed (char *pValue = value)
             {
@@ -29,7 +29,7 @@ namespace System.Globalization
             }
         }
 
-        internal unsafe static int LastIndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
+        internal static unsafe int LastIndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             fixed (char *pSource = source) fixed (char *pValue = value)
             {
@@ -141,7 +141,7 @@ namespace System.Globalization
         }
 
 
-        private unsafe static int FindStringOrdinal(char *source, int sourceCount, char *value,int valueCount, FindStringOptions option, bool ignoreCase)
+        private static unsafe int FindStringOrdinal(char *source, int sourceCount, char *value,int valueCount, FindStringOptions option, bool ignoreCase)
         {
             int ctrSource = 0;  // index value into source
             int ctrValue = 0;   // index value into value
@@ -405,7 +405,7 @@ namespace System.Globalization
             throw new NotImplementedException();
         }
 
-        private unsafe static bool IsSortable(char *text, int length)
+        private static unsafe bool IsSortable(char *text, int length)
         {
             // CompareInfo c = CultureInfo.InvariantCulture.CompareInfo;
             // return (InternalIsSortable(c.m_dataHandle, c.m_handleOrigin, c.m_sortName, text, text.Length));

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -353,7 +353,7 @@ namespace System.Globalization
             throw new NotImplementedException();
         }
 
-        private unsafe static bool IsSortable(char *text, int length)
+        private static unsafe bool IsSortable(char *text, int length)
         {
             // CompareInfo c = CultureInfo.InvariantCulture.CompareInfo;
             // return (InternalIsSortable(c.m_dataHandle, c.m_handleOrigin, c.m_sortName, text, text.Length));

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -162,13 +162,13 @@ namespace System.Globalization
             return CultureInfo.GetCultureInfo(name).CompareInfo;
         }
 
-        public unsafe static bool IsSortable(char ch)
+        public static unsafe bool IsSortable(char ch)
         {
             char *pChar = &ch;
             return IsSortable(pChar, 1);
         }
 
-        public unsafe static bool IsSortable(string text)
+        public static unsafe bool IsSortable(string text)
         {
             if (text == null) 
             {

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -825,7 +825,7 @@ namespace System.Globalization
             }
         }
 
-        static private bool OkayToCacheClassWithCompatibilityBehavior
+        private static bool OkayToCacheClassWithCompatibilityBehavior
         {
             get
             {

--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.DateTimeFormat.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.DateTimeFormat.cs
@@ -175,7 +175,7 @@ namespace System.Globalization
             }
 
             // auto-generated
-            internal unsafe static void FormatDigits(StringBuilder outputBuffer, int value, int len, bool overrideLengthLimit)
+            internal static unsafe void FormatDigits(StringBuilder outputBuffer, int value, int len, bool overrideLengthLimit)
             {
                 // Limit the use of this function to be two-digits, so that we have the same behavior
                 // as RTM bits.

--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.FormatAndParse.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.FormatAndParse.cs
@@ -34,7 +34,7 @@ namespace System.Globalization
                 return returnValue;
             }
 
-            private unsafe static Boolean HexNumberToUInt32(ref NumberBuffer number, ref UInt32 value)
+            private static unsafe Boolean HexNumberToUInt32(ref NumberBuffer number, ref UInt32 value)
             {
                 Int32 i = number.scale;
                 if (i > UINT32_PRECISION || i < number.precision)
@@ -88,7 +88,7 @@ namespace System.Globalization
                 return true;
             }
 
-            private unsafe static Boolean HexNumberToUInt64(ref NumberBuffer number, ref UInt64 value)
+            private static unsafe Boolean HexNumberToUInt64(ref NumberBuffer number, ref UInt64 value)
             {
                 Int32 i = number.scale;
                 if (i > UINT64_PRECISION || i < number.precision)
@@ -142,7 +142,7 @@ namespace System.Globalization
                 return true;
             }
 
-            private unsafe static Boolean NumberToInt32(ref NumberBuffer number, ref Int32 value)
+            private static unsafe Boolean NumberToInt32(ref NumberBuffer number, ref Int32 value)
             {
                 Int32 i = number.scale;
                 if (i > INT32_PRECISION || i < number.precision)
@@ -183,7 +183,7 @@ namespace System.Globalization
                 return true;
             }
 
-            private unsafe static Boolean NumberToInt64(ref NumberBuffer number, ref Int64 value)
+            private static unsafe Boolean NumberToInt64(ref NumberBuffer number, ref Int64 value)
             {
                 Int32 i = number.scale;
                 if (i > INT64_PRECISION || i < number.precision)
@@ -224,7 +224,7 @@ namespace System.Globalization
                 return true;
             }
 
-            private unsafe static Boolean NumberToUInt32(ref NumberBuffer number, ref UInt32 value)
+            private static unsafe Boolean NumberToUInt32(ref NumberBuffer number, ref UInt32 value)
             {
                 Int32 i = number.scale;
                 if (i > UINT32_PRECISION || i < number.precision || number.sign)
@@ -256,7 +256,7 @@ namespace System.Globalization
                 return true;
             }
 
-            private unsafe static Boolean NumberToUInt64(ref NumberBuffer number, ref UInt64 value)
+            private static unsafe Boolean NumberToUInt64(ref NumberBuffer number, ref UInt64 value)
             {
                 Int32 i = number.scale;
                 if (i > UINT64_PRECISION || i < number.precision || number.sign)
@@ -302,7 +302,7 @@ namespace System.Globalization
                 return result;
             }
 
-            internal unsafe static Double ParseDouble(String value, NumberStyles options, IFormatProvider provider)
+            internal static unsafe Double ParseDouble(String value, NumberStyles options, IFormatProvider provider)
             {
                 if (value == null)
                 {
@@ -342,7 +342,7 @@ namespace System.Globalization
                 return d;
             }
 
-            internal unsafe static Int32 ParseInt32(String s, NumberStyles style, IFormatProvider provider)
+            internal static unsafe Int32 ParseInt32(String s, NumberStyles style, IFormatProvider provider)
             {
                 NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -368,7 +368,7 @@ namespace System.Globalization
                 return i;
             }
 
-            internal unsafe static Int64 ParseInt64(String value, NumberStyles options, IFormatProvider provider)
+            internal static unsafe Int64 ParseInt64(String value, NumberStyles options, IFormatProvider provider)
             {
                 NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -394,7 +394,7 @@ namespace System.Globalization
                 return i;
             }
 
-            internal unsafe static Single ParseSingle(String value, NumberStyles options, IFormatProvider provider)
+            internal static unsafe Single ParseSingle(String value, NumberStyles options, IFormatProvider provider)
             {
                 if (value == null)
                 {
@@ -438,7 +438,7 @@ namespace System.Globalization
                 return castSingle;
             }
 
-            internal unsafe static UInt32 ParseUInt32(String value, NumberStyles options, IFormatProvider provider)
+            internal static unsafe UInt32 ParseUInt32(String value, NumberStyles options, IFormatProvider provider)
             {
                 NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -465,7 +465,7 @@ namespace System.Globalization
                 return i;
             }
 
-            internal unsafe static UInt64 ParseUInt64(String value, NumberStyles options, IFormatProvider provider)
+            internal static unsafe UInt64 ParseUInt64(String value, NumberStyles options, IFormatProvider provider)
             {
                 NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = new NumberBuffer();
@@ -489,7 +489,7 @@ namespace System.Globalization
                 return i;
             }
 
-            private unsafe static void StringToNumber(String str, NumberStyles options, ref NumberBuffer number, NumberFormatInfo info, Boolean parseDecimal)
+            private static unsafe void StringToNumber(String str, NumberStyles options, ref NumberBuffer number, NumberFormatInfo info, Boolean parseDecimal)
             {
                 if (str == null)
                 {
@@ -508,7 +508,7 @@ namespace System.Globalization
                 }
             }
 
-            internal unsafe static Boolean TryParseDecimal(String value, NumberStyles options, IFormatProvider provider, out Decimal result)
+            internal static unsafe Boolean TryParseDecimal(String value, NumberStyles options, IFormatProvider provider, out Decimal result)
             {
                 NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -527,7 +527,7 @@ namespace System.Globalization
                 return true;
             }
 
-            internal unsafe static Boolean TryParseDouble(String value, NumberStyles options, IFormatProvider provider, out Double result)
+            internal static unsafe Boolean TryParseDouble(String value, NumberStyles options, IFormatProvider provider, out Double result)
             {
                 NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = new NumberBuffer();
@@ -545,7 +545,7 @@ namespace System.Globalization
                 return true;
             }
 
-            internal unsafe static Boolean TryParseInt32(String s, NumberStyles style, IFormatProvider provider, out Int32 result)
+            internal static unsafe Boolean TryParseInt32(String s, NumberStyles style, IFormatProvider provider, out Int32 result)
             {
                 NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -574,7 +574,7 @@ namespace System.Globalization
                 return true;
             }
 
-            internal unsafe static Boolean TryParseInt64(String s, NumberStyles style, IFormatProvider provider, out Int64 result)
+            internal static unsafe Boolean TryParseInt64(String s, NumberStyles style, IFormatProvider provider, out Int64 result)
             {
                 NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -603,7 +603,7 @@ namespace System.Globalization
                 return true;
             }
 
-            internal unsafe static Boolean TryParseSingle(String value, NumberStyles options, IFormatProvider provider, out Single result)
+            internal static unsafe Boolean TryParseSingle(String value, NumberStyles options, IFormatProvider provider, out Single result)
             {
                 NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = new NumberBuffer();
@@ -628,7 +628,7 @@ namespace System.Globalization
                 return true;
             }
 
-            internal unsafe static Boolean TryParseUInt32(String s, NumberStyles style, IFormatProvider provider, out UInt32 result)
+            internal static unsafe Boolean TryParseUInt32(String s, NumberStyles style, IFormatProvider provider, out UInt32 result)
             {
                 NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -657,7 +657,7 @@ namespace System.Globalization
                 return true;
             }
 
-            internal unsafe static Boolean TryParseUInt64(String s, NumberStyles style, IFormatProvider provider, out UInt64 result)
+            internal static unsafe Boolean TryParseUInt64(String s, NumberStyles style, IFormatProvider provider, out UInt64 result)
             {
                 NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -1043,7 +1043,7 @@ namespace System.Globalization
                 return true;
             }
 
-            internal unsafe static void Int32ToDecChars(char[] buffer, ref int index, uint value, int digits)
+            internal static unsafe void Int32ToDecChars(char[] buffer, ref int index, uint value, int digits)
             {
                 while (--digits >= 0 || value != 0)
                 {
@@ -1052,19 +1052,19 @@ namespace System.Globalization
                 }
             }
 
-            static public bool IsPositiveInfinity(string s, IFormatProvider provider)
+            public static bool IsPositiveInfinity(string s, IFormatProvider provider)
             {
                 NumberFormatInfo nfi = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
                 return s.Equals(nfi.PositiveInfinitySymbol);
             }
 
-            static public bool IsNegativeInfinity(string s, IFormatProvider provider)
+            public static bool IsNegativeInfinity(string s, IFormatProvider provider)
             {
                 NumberFormatInfo nfi = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
                 return s.Equals(nfi.NegativeInfinitySymbol);
             }
 
-            static public bool IsNaNSymbol(string s, IFormatProvider provider)
+            public static bool IsNaNSymbol(string s, IFormatProvider provider)
             {
                 NumberFormatInfo nfi = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
                 return s.Equals(nfi.NaNSymbol);

--- a/src/System.Private.CoreLib/src/System/Globalization/HebrewNumber.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/HebrewNumber.cs
@@ -328,7 +328,7 @@ namespace System.Globalization
         // 
         // The state machine for Hebrew number pasing.
         //
-        private readonly static HS[] s_numberPasingState =
+        private static readonly HS[] s_numberPasingState =
         {
             // 400            300/200         100             90~10           8~1      6,       7,       9,          '           "
             /* 0 */

--- a/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -328,7 +328,7 @@ namespace System.Globalization
             return c;
         }
 
-        static private bool IsAscii(Char c)
+        private static bool IsAscii(Char c)
         {
             return c < 0x80;
         }

--- a/src/System.Private.CoreLib/src/System/Intptr.cs
+++ b/src/System.Private.CoreLib/src/System/Intptr.cs
@@ -96,22 +96,14 @@ namespace System
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static explicit operator IntPtr(int value)
+        public static unsafe explicit operator IntPtr(int value)
         {
             return new IntPtr(value);
         }
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static explicit operator IntPtr(long value)
-        {
-            return new IntPtr(value);
-        }
-
-        [CLSCompliant(false)]
-        [Intrinsic]
-        [NonVersionable]
-        public unsafe static explicit operator IntPtr(void* value)
+        public static unsafe explicit operator IntPtr(long value)
         {
             return new IntPtr(value);
         }
@@ -119,14 +111,22 @@ namespace System
         [CLSCompliant(false)]
         [Intrinsic]
         [NonVersionable]
-        public unsafe static explicit operator void* (IntPtr value)
+        public static unsafe explicit operator IntPtr(void* value)
+        {
+            return new IntPtr(value);
+        }
+
+        [CLSCompliant(false)]
+        [Intrinsic]
+        [NonVersionable]
+        public static unsafe explicit operator void* (IntPtr value)
         {
             return value._value;
         }
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static explicit operator int (IntPtr value)
+        public static unsafe explicit operator int (IntPtr value)
         {
 #if BIT64
             long l = (long)value._value;
@@ -138,7 +138,7 @@ namespace System
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static explicit operator long (IntPtr value)
+        public static unsafe explicit operator long (IntPtr value)
         {
 #if BIT64
             return (long)value._value;
@@ -154,14 +154,14 @@ namespace System
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static bool operator ==(IntPtr value1, IntPtr value2)
+        public static unsafe bool operator ==(IntPtr value1, IntPtr value2)
         {
             return value1._value == value2._value;
         }
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static bool operator !=(IntPtr value1, IntPtr value2)
+        public static unsafe bool operator !=(IntPtr value1, IntPtr value2)
         {
             return value1._value != value2._value;
         }
@@ -179,7 +179,7 @@ namespace System
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static IntPtr operator +(IntPtr pointer, int offset)
+        public static unsafe IntPtr operator +(IntPtr pointer, int offset)
         {
 #if BIT64
             return new IntPtr((long)pointer._value + offset);
@@ -196,7 +196,7 @@ namespace System
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static IntPtr operator -(IntPtr pointer, int offset)
+        public static unsafe IntPtr operator -(IntPtr pointer, int offset)
         {
 #if BIT64
             return new IntPtr((long)pointer._value - offset);
@@ -205,7 +205,7 @@ namespace System
 #endif
         }
 
-        public unsafe static int Size
+        public static unsafe int Size
         {
             [Intrinsic]
             [NonVersionable]

--- a/src/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -382,7 +382,7 @@ namespace System
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        public unsafe static void DynamicInvokeArgSetupPtrComplete(IntPtr argSetupStatePtr)
+        public static unsafe void DynamicInvokeArgSetupPtrComplete(IntPtr argSetupStatePtr)
         {
             // argSetupStatePtr is a pointer to a *pinned* ArgSetupState object
             DynamicInvokeArgSetupComplete(ref Unsafe.As<byte, ArgSetupState>(ref *(byte*)argSetupStatePtr));

--- a/src/System.Private.CoreLib/src/System/ParseNumbers.cs
+++ b/src/System.Private.CoreLib/src/System/ParseNumbers.cs
@@ -37,7 +37,7 @@ namespace System
         private const int MinRadix = 2;
         private const int MaxRadix = 36;
 
-        public unsafe static long StringToLong(System.String s, int radix, int flags)
+        public static unsafe long StringToLong(System.String s, int radix, int flags)
         {
             int pos = 0;
             return StringToLong(s, radix, flags, ref pos);

--- a/src/System.Private.CoreLib/src/System/PrimitivesRuntimeContracts.cs
+++ b/src/System.Private.CoreLib/src/System/PrimitivesRuntimeContracts.cs
@@ -349,7 +349,7 @@ namespace System
             return new IntPtr(value);
         }
 
-        public unsafe static explicit operator long (IntPtr value)
+        public static unsafe explicit operator long (IntPtr value)
         {
 #if BIT64
             return (long)value.m_value;
@@ -358,12 +358,12 @@ namespace System
 #endif
         }
 
-        public unsafe static bool operator ==(IntPtr value1, IntPtr value2)
+        public static unsafe bool operator ==(IntPtr value1, IntPtr value2)
         {
             return value1.m_value == value2.m_value;
         }
 
-        public unsafe static bool operator !=(IntPtr value1, IntPtr value2)
+        public static unsafe bool operator !=(IntPtr value1, IntPtr value2)
         {
             return value1.m_value != value2.m_value;
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/CommandLine.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CommandLine.Windows.cs
@@ -13,7 +13,7 @@ namespace System.Runtime
     internal static class CommandLine
     {
         [RuntimeExport("CreateCommandLine")]
-        public unsafe static string[] InternalCreateCommandLine()
+        public static unsafe string[] InternalCreateCommandLine()
         {
             char * pCmdLine = Interop.mincore.GetCommandLine();
 
@@ -31,7 +31,7 @@ namespace System.Runtime
         //
         // This functions interface mimics the CommandLineToArgvW api.
         //
-        private unsafe static int SegmentCommandLine(char * pCmdLine, string[] argArray)
+        private static unsafe int SegmentCommandLine(char * pCmdLine, string[] argArray)
         {
             int nArgs = 0;
             char c;
@@ -97,7 +97,7 @@ namespace System.Runtime
             return nArgs;
         }
 
-        private unsafe static int ScanArgument(ref char* psrc, ref bool inquote, char[] arg)
+        private static unsafe int ScanArgument(ref char* psrc, ref bool inquote, char[] arg)
         {
             int charIdx = 0;
             // loop through scanning one argument

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -208,7 +208,7 @@ namespace System.Runtime.CompilerServices
     public struct AsyncTaskMethodBuilder
     {
         /// <summary>A cached VoidTaskResult task used for builders that complete synchronously.</summary>
-        private readonly static Task<VoidTaskResult> s_cachedCompleted = AsyncTaskCache.CreateCacheableTask<VoidTaskResult>(default(VoidTaskResult));
+        private static readonly Task<VoidTaskResult> s_cachedCompleted = AsyncTaskCache.CreateCacheableTask<VoidTaskResult>(default(VoidTaskResult));
 
         private Action m_moveNextAction;
 
@@ -401,7 +401,7 @@ namespace System.Runtime.CompilerServices
     {
 #if false
         /// <summary>A cached task for default(TResult).</summary>
-        internal readonly static Task<TResult> s_defaultResultTask = AsyncTaskCache.CreateCacheableTask(default(TResult));
+        internal static readonly Task<TResult> s_defaultResultTask = AsyncTaskCache.CreateCacheableTask(default(TResult));
 #endif
 
         private Action m_moveNextAction;
@@ -685,12 +685,12 @@ namespace System.Runtime.CompilerServices
         // All static members are initialized inline to ensure type is beforefieldinit
 #if false
         /// <summary>A cached Task{Boolean}.Result == true.</summary>
-        internal readonly static Task<Boolean> TrueTask = CreateCacheableTask(true);
+        internal static readonly Task<Boolean> TrueTask = CreateCacheableTask(true);
         /// <summary>A cached Task{Boolean}.Result == false.</summary>
-        internal readonly static Task<Boolean> FalseTask = CreateCacheableTask(false);
+        internal static readonly Task<Boolean> FalseTask = CreateCacheableTask(false);
 
         /// <summary>The cache of Task{Int32}.</summary>
-        internal readonly static Task<Int32>[] Int32Tasks = CreateInt32Tasks();
+        internal static readonly Task<Int32>[] Int32Tasks = CreateInt32Tasks();
         /// <summary>The minimum value, inclusive, for which we want a cached task.</summary>
         internal const Int32 INCLUSIVE_INT32_MIN = -1;
         /// <summary>The maximum value, exclusive, for which we want a cached task.</summary>

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -38,13 +38,13 @@ namespace System.Runtime.CompilerServices
             return returnValue;
         }
 #else
-        private unsafe static object CheckStaticClassConstructionReturnGCStaticBase(StaticClassConstructionContext* context, object gcStaticBase)
+        private static unsafe object CheckStaticClassConstructionReturnGCStaticBase(StaticClassConstructionContext* context, object gcStaticBase)
         {
             EnsureClassConstructorRun(context);
             return gcStaticBase;
         }
 
-        private unsafe static IntPtr CheckStaticClassConstructionReturnNonGCStaticBase(StaticClassConstructionContext* context, IntPtr nonGcStaticBase)
+        private static unsafe IntPtr CheckStaticClassConstructionReturnNonGCStaticBase(StaticClassConstructionContext* context, IntPtr nonGcStaticBase)
         {
             EnsureClassConstructorRun(context);
             return nonGcStaticBase;
@@ -509,7 +509,7 @@ namespace System.Runtime.CompilerServices
 
             return unchecked((char)('a' + (u - 10)));
         }
-        static public unsafe string ToHexStringUnsignedLong(ulong u, bool zeroPrepad, int numChars)
+        public static unsafe string ToHexStringUnsignedLong(ulong u, bool zeroPrepad, int numChars)
         {
             char[] chars = new char[numChars];
 

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -39,7 +39,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Used for methods in System.Private.Interop.dll that need to work from offsets on boxed structs
-        public unsafe static void PinObjectAndCall(Object obj, Action<IntPtr> del)
+        public static unsafe void PinObjectAndCall(Object obj, Action<IntPtr> del)
         {
             fixed (IntPtr* pEEType = &obj.m_pEEType)
             {
@@ -434,7 +434,7 @@ namespace System.Runtime.InteropServices
             return new TypeInitializationException(message);
         }
 
-        public unsafe static IntPtr GetObjectID(object obj)
+        public static unsafe IntPtr GetObjectID(object obj)
         {
             fixed (void* p = &obj.m_pEEType)
             {

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -256,19 +256,19 @@ namespace System.Runtime
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhBox")]
-        internal static unsafe extern object RhBox(EETypePtr pEEType, void* pData);
+        internal static extern unsafe object RhBox(EETypePtr pEEType, void* pData);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhBox")]
-        internal static unsafe extern object RhBox(EETypePtr pEEType, ref byte data);
+        internal static extern unsafe object RhBox(EETypePtr pEEType, ref byte data);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhUnbox")]
-        internal static unsafe extern void RhUnbox(object obj, void* pData, EETypePtr pUnboxToEEType);
+        internal static extern unsafe void RhUnbox(object obj, void* pData, EETypePtr pUnboxToEEType);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhUnbox")]
-        internal static unsafe extern void RhUnbox(object obj, ref byte data, EETypePtr pUnboxToEEType);
+        internal static extern unsafe void RhUnbox(object obj, ref byte data, EETypePtr pUnboxToEEType);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhMemberwiseClone")]
@@ -287,7 +287,7 @@ namespace System.Runtime
         // Wait for any object to be signalled, in a way that's compatible with the CLR's behavior in an STA.
         // ExactSpelling = 'true' to force MCG to resolve it to default
         [DllImport(RuntimeLibrary, ExactSpelling = true)]
-        private static unsafe extern int RhCompatibleReentrantWaitAny(int alertable, int timeout, int count, IntPtr* handles);
+        private static extern unsafe int RhCompatibleReentrantWaitAny(int alertable, int timeout, int count, IntPtr* handles);
 
         // Temporary workaround to unblock shareable assembly bring-up - without shared interop,
         // we must prevent RhCompatibleReentrantWaitAny from using marshaling because it would
@@ -309,12 +309,12 @@ namespace System.Runtime
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhCreateGenericInstanceDescForType2")]
-        internal static unsafe extern bool RhCreateGenericInstanceDescForType2(EETypePtr pEEType, int arity, int nonGcStaticDataSize,
+        internal static extern unsafe bool RhCreateGenericInstanceDescForType2(EETypePtr pEEType, int arity, int nonGcStaticDataSize,
             int nonGCStaticDataOffset, int gcStaticDataSize, int threadStaticsOffset, void* pGcStaticsDesc, void* pThreadStaticsDesc, int* pGenericVarianceFlags);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhNewInterfaceDispatchCell")]
-        internal static unsafe extern IntPtr RhNewInterfaceDispatchCell(EETypePtr pEEType, int slotNumber);
+        internal static extern unsafe IntPtr RhNewInterfaceDispatchCell(EETypePtr pEEType, int slotNumber);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhResolveDispatch")]
@@ -322,11 +322,11 @@ namespace System.Runtime
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetNonGcStaticFieldData")]
-        internal static unsafe extern IntPtr RhGetNonGcStaticFieldData(EETypePtr pEEType);
+        internal static extern unsafe IntPtr RhGetNonGcStaticFieldData(EETypePtr pEEType);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetGcStaticFieldData")]
-        internal static unsafe extern IntPtr RhGetGcStaticFieldData(EETypePtr pEEType);
+        internal static extern unsafe IntPtr RhGetGcStaticFieldData(EETypePtr pEEType);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhCreateThunksHeap")]
@@ -372,11 +372,11 @@ namespace System.Runtime
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetRuntimeHelperForType")]
-        internal static unsafe extern IntPtr RhGetRuntimeHelperForType(EETypePtr pEEType, RuntimeHelperKind kind);
+        internal static extern unsafe IntPtr RhGetRuntimeHelperForType(EETypePtr pEEType, RuntimeHelperKind kind);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetDispatchMapForType")]
-        internal static unsafe extern IntPtr RhGetDispatchMapForType(EETypePtr pEEType);
+        internal static extern unsafe IntPtr RhGetDispatchMapForType(EETypePtr pEEType);
 
         //
         // Support for GC and HandleTable callouts.
@@ -415,7 +415,7 @@ namespace System.Runtime
         //
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhFindBlob")]
-        internal static unsafe extern bool RhFindBlob(IntPtr hOsModule, uint blobId, byte** ppbBlob, uint* pcbBlob);
+        internal static extern unsafe bool RhFindBlob(IntPtr hOsModule, uint blobId, byte** ppbBlob, uint* pcbBlob);
 
 #if CORERT
         internal static uint RhGetLoadedModules(IntPtr[] resultArray)
@@ -443,7 +443,7 @@ namespace System.Runtime
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetThreadStaticFieldAddress")]
-        internal static unsafe extern byte* RhGetThreadStaticFieldAddress(EETypePtr pEEType, IntPtr fieldCookie);
+        internal static extern unsafe byte* RhGetThreadStaticFieldAddress(EETypePtr pEEType, IntPtr fieldCookie);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetCodeTarget")]
@@ -713,20 +713,20 @@ namespace System.Runtime
         [Intrinsic]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "modf")]
-        internal static unsafe extern double modf(double x, double* intptr);
+        internal static extern unsafe double modf(double x, double* intptr);
 
 #if !PLATFORM_UNIX
         // ExactSpelling = 'true' to force MCG to resolve it to default
         [DllImport(RuntimeImports.RuntimeLibrary, ExactSpelling = true)]
-        internal static unsafe extern void _ecvt_s(byte* buffer, int sizeInBytes, double value, int count, int* dec, int* sign);
+        internal static extern unsafe void _ecvt_s(byte* buffer, int sizeInBytes, double value, int count, int* dec, int* sign);
 #endif
 
 #if BIT64
         [DllImport(RuntimeImports.RuntimeLibrary, ExactSpelling = true)]
-        internal static unsafe extern void memmove(byte* dmem, byte* smem, ulong size);
+        internal static extern unsafe void memmove(byte* dmem, byte* smem, ulong size);
 #else
         [DllImport(RuntimeImports.RuntimeLibrary, ExactSpelling = true)]
-        internal static unsafe extern void memmove(byte* dmem, byte* smem, uint size);
+        internal static extern unsafe void memmove(byte* dmem, byte* smem, uint size);
 #endif
 
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -146,7 +146,7 @@ namespace System.Runtime
             return RawCalliHelper.Call<Object>(entry.Result, arg, entry.AuxResult);
         }
 
-        public unsafe static IntPtr GetDelegateThunk(object delegateObj, int whichThunk)
+        public static unsafe IntPtr GetDelegateThunk(object delegateObj, int whichThunk)
         {
             Entry entry = LookupInCache(s_cache, delegateObj.m_pEEType, new IntPtr(whichThunk));
             if (entry == null)
@@ -156,7 +156,7 @@ namespace System.Runtime
             return entry.Result;
         }
 
-        public unsafe static IntPtr GVMLookupForSlot(object obj, RuntimeMethodHandle slot)
+        public static unsafe IntPtr GVMLookupForSlot(object obj, RuntimeMethodHandle slot)
         {
             Entry entry = LookupInCache(s_cache, obj.m_pEEType, *(IntPtr*)&slot);
             if (entry == null)
@@ -243,7 +243,7 @@ namespace System.Runtime
             return entry.Result;
         }
 
-        private unsafe static Entry CacheMiss(IntPtr context, IntPtr signature, SignatureKind signatureKind = SignatureKind.GenericDictionary, object contextObject = null)
+        private static unsafe Entry CacheMiss(IntPtr context, IntPtr signature, SignatureKind signatureKind = SignatureKind.GenericDictionary, object contextObject = null)
         {
             IntPtr result = IntPtr.Zero, auxResult = IntPtr.Zero;
             bool previouslyCached = false;

--- a/src/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -347,7 +347,7 @@ namespace System
         /// <summary>
         /// Table of exceptions that were on stacks triggering GenerateExceptionInformationForDump
         /// </summary>
-        private readonly static ConditionalWeakTable<Exception, ExceptionData> s_exceptionDataTable = new ConditionalWeakTable<Exception, ExceptionData>();
+        private static readonly ConditionalWeakTable<Exception, ExceptionData> s_exceptionDataTable = new ConditionalWeakTable<Exception, ExceptionData>();
 
         /// <summary>
         /// Counter for exception ID assignment
@@ -521,7 +521,7 @@ namespace System
             }
         }
 
-        private unsafe static void GenerateErrorReportForDump(LowLevelList<byte[]> serializedExceptions)
+        private static unsafe void GenerateErrorReportForDump(LowLevelList<byte[]> serializedExceptions)
         {
             checked
             {
@@ -587,7 +587,7 @@ namespace System
         private static GCHandle s_ExceptionInfoBufferPinningHandle;
         private static Lock s_ExceptionInfoBufferLock = new Lock();
 
-        private unsafe static void UpdateErrorReportBuffer(byte[] finalBuffer)
+        private static unsafe void UpdateErrorReportBuffer(byte[] finalBuffer)
         {
             using (LockHolder.Hold(s_ExceptionInfoBufferLock))
             {

--- a/src/System.Private.CoreLib/src/System/Single.cs
+++ b/src/System.Private.CoreLib/src/System/Single.cs
@@ -36,25 +36,25 @@ namespace System
         public const float NaN = (float)0.0 / (float)0.0;
 
         [Pure]
-        public unsafe static bool IsInfinity(float f)
+        public static unsafe bool IsInfinity(float f)
         {
             return (*(int*)(&f) & 0x7FFFFFFF) == 0x7F800000;
         }
 
         [Pure]
-        public unsafe static bool IsPositiveInfinity(float f)
+        public static unsafe bool IsPositiveInfinity(float f)
         {
             return *(int*)(&f) == 0x7F800000;
         }
 
         [Pure]
-        public unsafe static bool IsNegativeInfinity(float f)
+        public static unsafe bool IsNegativeInfinity(float f)
         {
             return *(int*)(&f) == unchecked((int)0xFF800000);
         }
 
         [Pure]
-        public unsafe static bool IsNaN(float f)
+        public static unsafe bool IsNaN(float f)
         {
             return (*(int*)(&f) & 0x7FFFFFFF) > 0x7F800000;
         }

--- a/src/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -158,7 +158,7 @@ namespace System
         // both strings are non-null and that their lengths are equal. Ther caller should also have
         // done the Object.ReferenceEquals() fastpath check as we won't repeat it here.
         //
-        private unsafe static bool EqualsHelper(String strA, String strB)
+        private static unsafe bool EqualsHelper(String strA, String strB)
         {
             Debug.Assert(strA != null);
             Debug.Assert(strB != null);
@@ -217,7 +217,7 @@ namespace System
             }
         }
 
-        private unsafe static bool StartsWithOrdinalHelper(String str, String startsWith)
+        private static unsafe bool StartsWithOrdinalHelper(String str, String startsWith)
         {
             Debug.Assert(str != null);
             Debug.Assert(startsWith != null);
@@ -272,7 +272,7 @@ namespace System
             }
         }
 
-        private unsafe static int CompareOrdinalHelper(String strA, String strB)
+        private static unsafe int CompareOrdinalHelper(String strA, String strB)
         {
             Debug.Assert(strA != null);
             Debug.Assert(strB != null);
@@ -391,7 +391,7 @@ namespace System
             }
         }
 
-        internal unsafe static int CompareOrdinalHelper(string strA, int indexA, int countA, string strB, int indexB, int countB)
+        internal static unsafe int CompareOrdinalHelper(string strA, int indexA, int countA, string strB, int indexB, int countB)
         {
             // Argument validation should be handled by callers.
             Debug.Assert(strA != null && strB != null);

--- a/src/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -480,19 +480,19 @@ namespace System
             return Join(separator, value, 0, value.Length);
         }
 
-        public unsafe static string Join(char separator, params object[] values)
+        public static unsafe string Join(char separator, params object[] values)
         {
             // Defer argument validation to the internal function
             return JoinCore(&separator, 1, values);
         }
 
-        public unsafe static string Join<T>(char separator, IEnumerable<T> values)
+        public static unsafe string Join<T>(char separator, IEnumerable<T> values)
         {
             // Defer argument validation to the internal function
             return JoinCore(&separator, 1, values);
         }
 
-        public unsafe static string Join(char separator, string[] value, int startIndex, int count)
+        public static unsafe string Join(char separator, string[] value, int startIndex, int count)
         {
             // Defer argument validation to the internal function
             return JoinCore(&separator, 1, value, startIndex, count);
@@ -509,7 +509,7 @@ namespace System
             return Join(separator, value, 0, value.Length);
         }
 
-        public unsafe static string Join(string separator, params object[] values)
+        public static unsafe string Join(string separator, params object[] values)
         {
             separator = separator ?? string.Empty;
             fixed (char* pSeparator = &separator._firstChar)
@@ -519,7 +519,7 @@ namespace System
             }
         }
 
-        public unsafe static string Join<T>(string separator, IEnumerable<T> values)
+        public static unsafe string Join<T>(string separator, IEnumerable<T> values)
         {
             separator = separator ?? string.Empty;
             fixed (char* pSeparator = &separator._firstChar)
@@ -568,7 +568,7 @@ namespace System
 
         // Joins an array of strings together as one string with a separator between each original string.
         //
-        public unsafe static string Join(string separator, string[] value, int startIndex, int count)
+        public static unsafe string Join(string separator, string[] value, int startIndex, int count)
         {
             separator = separator ?? string.Empty;
             fixed (char* pSeparator = &separator._firstChar)
@@ -578,7 +578,7 @@ namespace System
             }
         }
 
-        private unsafe static string JoinCore(char* separator, int separatorLength, object[] values)
+        private static unsafe string JoinCore(char* separator, int separatorLength, object[] values)
         {
             if (values == null)
             {
@@ -613,7 +613,7 @@ namespace System
             return StringBuilderCache.GetStringAndRelease(result);
         }
 
-        private unsafe static string JoinCore<T>(char* separator, int separatorLength, IEnumerable<T> values)
+        private static unsafe string JoinCore<T>(char* separator, int separatorLength, IEnumerable<T> values)
         {
             if (values == null)
             {
@@ -665,7 +665,7 @@ namespace System
             }
         }
 
-        private unsafe static string JoinCore(char* separator, int separatorLength, string[] value, int startIndex, int count)
+        private static unsafe string JoinCore(char* separator, int separatorLength, string[] value, int startIndex, int count)
         {
             // If the separator is null, it is converted to an empty string before entering this function.
             // Even for empty strings, fixed should never return null (it should return a pointer to a null char).

--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -415,7 +415,7 @@ namespace System
 
         // Helper for encodings so they can talk to our buffer directly
         // stringLength must be the exact size we'll expect
-        unsafe static internal String CreateStringFromEncoding(
+        unsafe internal static String CreateStringFromEncoding(
             byte* bytes, int byteLength, Encoding encoding)
         {
             Debug.Assert(bytes != null);

--- a/src/System.Private.CoreLib/src/System/Text/EncodingForwarder.cs
+++ b/src/System.Private.CoreLib/src/System/Text/EncodingForwarder.cs
@@ -31,7 +31,7 @@ namespace System.Text
         // the parameter, it will call the same method again, which will eventually
         // lead to a StackOverflowException.
 
-        public unsafe static int GetByteCount(Encoding encoding, char[] chars, int index, int count)
+        public static unsafe int GetByteCount(Encoding encoding, char[] chars, int index, int count)
         {
             // Validate parameters
 
@@ -59,7 +59,7 @@ namespace System.Text
                 return encoding.GetByteCount(pChars + index, count, encoder: null);
         }
 
-        public unsafe static int GetByteCount(Encoding encoding, string s)
+        public static unsafe int GetByteCount(Encoding encoding, string s)
         {
             Debug.Assert(encoding != null);
             if (s == null)
@@ -82,7 +82,7 @@ namespace System.Text
                 return encoding.GetByteCount(pChars, s.Length, encoder: null);
         }
 
-        public unsafe static int GetByteCount(Encoding encoding, char* chars, int count)
+        public static unsafe int GetByteCount(Encoding encoding, char* chars, int count)
         {
             Debug.Assert(encoding != null);
             if (chars == null)
@@ -99,7 +99,7 @@ namespace System.Text
             return encoding.GetByteCount(chars, count, encoder: null);
         }
 
-        public unsafe static int GetBytes(Encoding encoding, string s, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        public static unsafe int GetBytes(Encoding encoding, string s, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             Debug.Assert(encoding != null);
             if (s == null || bytes == null)
@@ -135,7 +135,7 @@ namespace System.Text
             }
         }
 
-        public unsafe static int GetBytes(Encoding encoding, char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        public static unsafe int GetBytes(Encoding encoding, char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             Debug.Assert(encoding != null);
             if (chars == null || bytes == null)
@@ -175,7 +175,7 @@ namespace System.Text
             }
         }
 
-        public unsafe static int GetBytes(Encoding encoding, char* chars, int charCount, byte* bytes, int byteCount)
+        public static unsafe int GetBytes(Encoding encoding, char* chars, int charCount, byte* bytes, int byteCount)
         {
             Debug.Assert(encoding != null);
             if (bytes == null || chars == null)
@@ -191,7 +191,7 @@ namespace System.Text
             return encoding.GetBytes(chars, charCount, bytes, byteCount, encoder: null);
         }
 
-        public unsafe static int GetCharCount(Encoding encoding, byte[] bytes, int index, int count)
+        public static unsafe int GetCharCount(Encoding encoding, byte[] bytes, int index, int count)
         {
             Debug.Assert(encoding != null);
             if (bytes == null)
@@ -217,7 +217,7 @@ namespace System.Text
                 return encoding.GetCharCount(pBytes + index, count, decoder: null);
         }
 
-        public unsafe static int GetCharCount(Encoding encoding, byte* bytes, int count)
+        public static unsafe int GetCharCount(Encoding encoding, byte* bytes, int count)
         {
             Debug.Assert(encoding != null);
             if (bytes == null)
@@ -233,7 +233,7 @@ namespace System.Text
             return encoding.GetCharCount(bytes, count, decoder: null);
         }
 
-        public unsafe static int GetChars(Encoding encoding, byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+        public static unsafe int GetChars(Encoding encoding, byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
             Debug.Assert(encoding != null);
             if (bytes == null || chars == null)
@@ -271,7 +271,7 @@ namespace System.Text
             }
         }
 
-        public unsafe static int GetChars(Encoding encoding, byte* bytes, int byteCount, char* chars, int charCount)
+        public static unsafe int GetChars(Encoding encoding, byte* bytes, int byteCount, char* chars, int charCount)
         {
             Debug.Assert(encoding != null);
             if (bytes == null || chars == null)
@@ -287,7 +287,7 @@ namespace System.Text
             return encoding.GetChars(bytes, byteCount, chars, charCount, decoder: null);
         }
 
-        public unsafe static string GetString(Encoding encoding, byte[] bytes, int index, int count)
+        public static unsafe string GetString(Encoding encoding, byte[] bytes, int index, int count)
         {
             Debug.Assert(encoding != null);
             if (bytes == null)

--- a/src/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
@@ -159,7 +159,7 @@ namespace System.Threading
         /* Methods */
 
 
-        private readonly static Action<Object> s_ActionToActionObjShunt = new Action<Object>(ActionToActionObjShunt);
+        private static readonly Action<Object> s_ActionToActionObjShunt = new Action<Object>(ActionToActionObjShunt);
         private static void ActionToActionObjShunt(object obj)
         {
             Action action = obj as Action;

--- a/src/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -97,7 +97,7 @@ namespace System.Threading
                 OnContextChanged(previous, executionContext);
         }
 
-        static internal void EstablishCopyOnWriteScope(ref ExecutionContextSwitcher ecsw)
+        internal static void EstablishCopyOnWriteScope(ref ExecutionContextSwitcher ecsw)
         {
             ecsw.m_ec = Capture();
             ecsw.m_sc = SynchronizationContext.CurrentExplicit;

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelThread.cs
@@ -24,12 +24,12 @@ namespace System.Threading
         internal const int WAIT_TIMEOUT = (int)Interop.Constants.WaitTimeout;
         internal const int WAIT_FAILED = unchecked((int)Interop.Constants.WaitFailed);
 
-        internal unsafe static int WaitForSingleObject(IntPtr handle, int millisecondsTimeout)
+        internal static unsafe int WaitForSingleObject(IntPtr handle, int millisecondsTimeout)
         {
             return WaitForMultipleObjects(&handle, 1, false, millisecondsTimeout);
         }
 
-        internal unsafe static int WaitForMultipleObjects(IntPtr[] handles, bool waitAll, int millisecondsTimeout)
+        internal static unsafe int WaitForMultipleObjects(IntPtr[] handles, bool waitAll, int millisecondsTimeout)
         {
             fixed (IntPtr* pHandles = handles)
             {
@@ -37,7 +37,7 @@ namespace System.Threading
             }
         }
 
-        internal unsafe static int WaitForMultipleObjects(IntPtr* pHandles, int numHandles, bool waitAll, int millisecondsTimeout)
+        internal static unsafe int WaitForMultipleObjects(IntPtr* pHandles, int numHandles, bool waitAll, int millisecondsTimeout)
         {
             Debug.Assert(millisecondsTimeout >= -1);
 

--- a/src/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -71,7 +71,7 @@ namespace System.Threading
         private TaskNode m_asyncTail;
 
         // A pre-completed task with Result==true
-        private readonly static Task<bool> s_trueTask =
+        private static readonly Task<bool> s_trueTask =
             new Task<bool>(false, true, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default(CancellationToken));
 
         // No maximum constant

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/FutureFactory.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/FutureFactory.cs
@@ -1223,7 +1223,7 @@ namespace System.Threading.Tasks
         private sealed class FromAsyncTrimPromise<TInstance> : Task<TResult> where TInstance : class
         {
             /// <summary>A cached delegate used as the callback for the BeginXx method.</summary>
-            internal readonly static AsyncCallback s_completeFromAsyncResult = CompleteFromAsyncResult;
+            internal static readonly AsyncCallback s_completeFromAsyncResult = CompleteFromAsyncResult;
 
             /// <summary>A reference to the object on which the begin/end methods are invoked.</summary>
             private TInstance m_thisRef;

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -660,7 +660,7 @@ namespace System.Threading.Tasks
 
         // Static delegate to be used as a cancellation callback on unstarted tasks that have a valid cancellation token.
         // This is necessary to transition them into canceled state if their cancellation token is signalled while they are still not queued
-        private readonly static Action<Object> s_taskCancelCallback = new Action<Object>(TaskCancelCallback);
+        private static readonly Action<Object> s_taskCancelCallback = new Action<Object>(TaskCancelCallback);
         private static void TaskCancelCallback(Object o)
         {
             var targetTask = o as Task;
@@ -2098,7 +2098,7 @@ namespace System.Threading.Tasks
         }
 
         // statically allocated delegate for the removeall expression in Finish()
-        private readonly static Predicate<Task> s_IsExceptionObservedByParentPredicate = new Predicate<Task>((t) => { return t.IsExceptionObservedByParent; });
+        private static readonly Predicate<Task> s_IsExceptionObservedByParentPredicate = new Predicate<Task>((t) => { return t.IsExceptionObservedByParent; });
 
         /// <summary>
         /// FinishStageTwo is to be executed as soon as we known there are no more children to complete. 
@@ -4315,7 +4315,7 @@ namespace System.Threading.Tasks
         }
 
         // statically allocated delegate for the RemoveAll expression in RemoveContinuations() and AddContinuationComplex()
-        private readonly static Predicate<object> s_IsTaskContinuationNullPredicate =
+        private static readonly Predicate<object> s_IsTaskContinuationNullPredicate =
             new Predicate<object>((tc) => { return (tc == null); });
 
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -381,7 +381,7 @@ namespace System.Threading.Tasks
     internal sealed class SynchronizationContextAwaitTaskContinuation : AwaitTaskContinuation
     {
         /// <summary>SendOrPostCallback delegate to invoke the action.</summary>
-        private readonly static SendOrPostCallback s_postCallback = state => ((Action)state)(); // can't use InvokeAction as it's SecurityCritical
+        private static readonly SendOrPostCallback s_postCallback = state => ((Action)state)(); // can't use InvokeAction as it's SecurityCritical
         /// <summary>Cached delegate for PostAction</summary>
         private static ContextCallback s_postActionCallback;
         /// <summary>The context with which to run the action.</summary>

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskExceptionHolder.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskExceptionHolder.cs
@@ -34,7 +34,7 @@ namespace System.Threading.Tasks
     internal class TaskExceptionHolder
     {
         /// <summary>Whether we should propagate exceptions on the finalizer.</summary>
-        private readonly static bool s_failFastOnUnobservedException = ShouldFailFastOnUnobservedException();
+        private static readonly bool s_failFastOnUnobservedException = ShouldFailFastOnUnobservedException();
 
         /// <summary>The task with which this holder is associated.</summary>
         private readonly Task m_task;

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Win32.cs
@@ -48,7 +48,7 @@ namespace System.Threading
             callback();
         }
 
-        internal unsafe static void QueueLongRunningWork(Action callback)
+        internal static unsafe void QueueLongRunningWork(Action callback)
         {
             var environ = default(Interop.mincore.TP_CALLBACK_ENVIRON);
 

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -675,7 +675,7 @@ namespace System.Threading
         //requests in the current domain.
         const uint tpQuantum = 30U;
 
-        static internal void Dispatch()
+        internal static void Dispatch()
         {
             var workQueue = ThreadPoolGlobals.workQueue;
 
@@ -886,9 +886,9 @@ namespace System.Threading
             }
         }
 
-        static internal ContextCallback ccb = new ContextCallback(WaitCallback_Context);
+        internal static ContextCallback ccb = new ContextCallback(WaitCallback_Context);
 
-        static private void WaitCallback_Context(Object state)
+        private static void WaitCallback_Context(Object state)
         {
             QueueUserWorkItemCallback obj = (QueueUserWorkItemCallback)state;
             WaitCallback wc = obj.callback as WaitCallback;
@@ -944,9 +944,9 @@ namespace System.Threading
             }
         }
 
-        static internal ContextCallback ccb = new ContextCallback(WaitCallback_Context);
+        internal static ContextCallback ccb = new ContextCallback(WaitCallback_Context);
 
-        static private void WaitCallback_Context(Object state)
+        private static void WaitCallback_Context(Object state)
         {
             QueueUserWorkItemCallbackDefaultContext obj = (QueueUserWorkItemCallbackDefaultContext)state;
             WaitCallback wc = obj.callback as WaitCallback;

--- a/src/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -12,7 +12,7 @@ namespace System.Threading
     //
     // Methods for accessing memory with volatile semantics.
     //
-    public unsafe static class Volatile
+    public static unsafe class Volatile
     {
         #region Boolean
         private struct VolatileBoolean { public volatile Boolean Value; }

--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -713,7 +713,7 @@ namespace System
         //
         // Clears data from static members
         //
-        static internal void ClearCachedData()
+        internal static void ClearCachedData()
         {
             // Clear a fresh instance of cached data
             s_cachedData = new CachedData();
@@ -725,7 +725,7 @@ namespace System
         // Converts the value of the dateTime object from sourceTimeZone to destinationTimeZone
         //
 
-        static public DateTimeOffset ConvertTime(DateTimeOffset dateTimeOffset, TimeZoneInfo destinationTimeZone)
+        public static DateTimeOffset ConvertTime(DateTimeOffset dateTimeOffset, TimeZoneInfo destinationTimeZone)
         {
             if (destinationTimeZone == null)
             {
@@ -754,12 +754,12 @@ namespace System
             }
         }
 
-        static public DateTime ConvertTime(DateTime dateTime, TimeZoneInfo sourceTimeZone, TimeZoneInfo destinationTimeZone)
+        public static DateTime ConvertTime(DateTime dateTime, TimeZoneInfo sourceTimeZone, TimeZoneInfo destinationTimeZone)
         {
             return ConvertTime(dateTime, sourceTimeZone, destinationTimeZone, TimeZoneInfoOptions.None, s_cachedData);
         }
 
-        static public DateTime ConvertTime(DateTime dateTime, TimeZoneInfo destinationTimeZone)
+        public static DateTime ConvertTime(DateTime dateTime, TimeZoneInfo destinationTimeZone)
         {
             if (destinationTimeZone == null)
             {
@@ -784,12 +784,12 @@ namespace System
             }
         }
 
-        static internal DateTime ConvertTime(DateTime dateTime, TimeZoneInfo sourceTimeZone, TimeZoneInfo destinationTimeZone, TimeZoneInfoOptions flags)
+        internal static DateTime ConvertTime(DateTime dateTime, TimeZoneInfo sourceTimeZone, TimeZoneInfo destinationTimeZone, TimeZoneInfoOptions flags)
         {
             return ConvertTime(dateTime, sourceTimeZone, destinationTimeZone, flags, s_cachedData);
         }
 
-        static private DateTime ConvertTime(DateTime dateTime, TimeZoneInfo sourceTimeZone, TimeZoneInfo destinationTimeZone, TimeZoneInfoOptions flags, CachedData cachedData)
+        private static DateTime ConvertTime(DateTime dateTime, TimeZoneInfo sourceTimeZone, TimeZoneInfo destinationTimeZone, TimeZoneInfoOptions flags, CachedData cachedData)
         {
             if (sourceTimeZone == null)
             {
@@ -868,7 +868,7 @@ namespace System
         }
 
 
-        static internal DateTime ConvertTimeToUtc(DateTime dateTime, TimeZoneInfoOptions flags)
+        internal static DateTime ConvertTimeToUtc(DateTime dateTime, TimeZoneInfoOptions flags)
         {
             if (dateTime.Kind == DateTimeKind.Utc)
             {
@@ -1023,7 +1023,7 @@ namespace System
         // Accessing this property may throw InvalidTimeZoneException or COMException
         // if the machine is in an unstable or corrupt state.
         //
-        static public TimeZoneInfo Local
+        public static TimeZoneInfo Local
         {
             get
             {
@@ -1049,7 +1049,7 @@ namespace System
         //
         // returns a TimeZoneInfo instance that represents Universal Coordinated Time (UTC)
         //
-        static public TimeZoneInfo Utc
+        public static TimeZoneInfo Utc
         {
             get
             {
@@ -1128,7 +1128,7 @@ namespace System
         // returns a simple TimeZoneInfo instance that does
         // not support Daylight Saving Time
         //
-        static internal TimeZoneInfo CreateCustomTimeZone(
+        internal static TimeZoneInfo CreateCustomTimeZone(
                 String id,
                 TimeSpan baseUtcOffset,
                 String displayName,
@@ -1187,7 +1187,7 @@ namespace System
         // * returns DateTime.MaxValue when the converted value is too large
         // * returns DateTime.MinValue when the converted value is too small
         //
-        static private DateTime ConvertUtcToTimeZone(Int64 ticks, TimeZoneInfo destinationTimeZone, out Boolean isAmbiguousLocalDst)
+        private static DateTime ConvertUtcToTimeZone(Int64 ticks, TimeZoneInfo destinationTimeZone, out Boolean isAmbiguousLocalDst)
         {
             DateTime utcConverted;
             DateTime localConverted;
@@ -1231,7 +1231,7 @@ namespace System
         //
         // Converts TimeZoneInformation to an AdjustmentRule
         //
-        static internal AdjustmentRule CreateAdjustmentRuleFromTimeZoneInformation(TimeZoneInformation timeZoneInformation, DateTime startDate, DateTime endDate, int defaultBaseUtcOffset)
+        internal static AdjustmentRule CreateAdjustmentRuleFromTimeZoneInformation(TimeZoneInformation timeZoneInformation, DateTime startDate, DateTime endDate, int defaultBaseUtcOffset)
         {
             bool supportsDst = (timeZoneInformation.Dtzi.StandardDate.wMonth != 0);
 
@@ -1282,7 +1282,7 @@ namespace System
                 new TimeSpan(0, defaultBaseUtcOffset - timeZoneInformation.Dtzi.Bias, 0));
         }
 
-        static internal AdjustmentRule CreateAdjustmentRuleFromTimeZoneInformation(ref TIME_ZONE_INFORMATION timeZoneInformation, DateTime startDate, DateTime endDate, int defaultBaseUtcOffset)
+        internal static AdjustmentRule CreateAdjustmentRuleFromTimeZoneInformation(ref TIME_ZONE_INFORMATION timeZoneInformation, DateTime startDate, DateTime endDate, int defaultBaseUtcOffset)
         {
             bool supportsDst = (timeZoneInformation.StandardDate.wMonth != 0);
 
@@ -1338,7 +1338,7 @@ namespace System
         //
         // Helper function that returns a DaylightTimeStruct from a year and AdjustmentRule
         //
-        static private DaylightTimeStruct GetDaylightTime(Int32 year, AdjustmentRule rule)
+        private static DaylightTimeStruct GetDaylightTime(Int32 year, AdjustmentRule rule)
         {
             TimeSpan delta = rule.DaylightDelta;
             DateTime startTime = TransitionTimeToDateTime(year, rule.DaylightTransitionStart);
@@ -1354,7 +1354,7 @@ namespace System
         // Helper function that checks if a given dateTime is in Daylight Saving Time (DST)
         // This function assumes the dateTime and AdjustmentRule are both in the same time zone
         //
-        static private Boolean GetIsDaylightSavings(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime, TimeZoneInfoOptions flags)
+        private static Boolean GetIsDaylightSavings(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime, TimeZoneInfoOptions flags)
         {
             if (rule == null)
             {
@@ -1420,7 +1420,7 @@ namespace System
         // Helper function that checks if a given dateTime is in Daylight Saving Time (DST)
         // This function assumes the dateTime is in UTC and AdjustmentRule is in a different time zone
         //
-        static private Boolean GetIsDaylightSavingsFromUtc(DateTime time, Int32 Year, TimeSpan utc, AdjustmentRule rule, out Boolean isAmbiguousLocalDst, TimeZoneInfo zone)
+        private static Boolean GetIsDaylightSavingsFromUtc(DateTime time, Int32 Year, TimeSpan utc, AdjustmentRule rule, out Boolean isAmbiguousLocalDst, TimeZoneInfo zone)
         {
             isAmbiguousLocalDst = false;
 
@@ -1545,7 +1545,7 @@ namespace System
         }
 
 
-        static private Boolean CheckIsDst(DateTime startTime, DateTime time, DateTime endTime, bool ignoreYearAdjustment)
+        private static Boolean CheckIsDst(DateTime startTime, DateTime time, DateTime endTime, bool ignoreYearAdjustment)
         {
             Boolean isDst;
 
@@ -1593,7 +1593,7 @@ namespace System
         // In this example, any DateTime values that fall into the [1AM - 1:59:59AM] range
         // are ambiguous; as it is unclear if these times are in Daylight Saving Time.
         //
-        static private Boolean GetIsAmbiguousTime(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime)
+        private static Boolean GetIsAmbiguousTime(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime)
         {
             Boolean isAmbiguous = false;
             if (rule == null || rule.DaylightDelta == TimeSpan.Zero)
@@ -1669,7 +1669,7 @@ namespace System
         // A "time hole" is not limited to only occurring at the start of DST, and may occur at
         // the end of DST as well.
         //
-        static private Boolean GetIsInvalidTime(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime)
+        private static Boolean GetIsInvalidTime(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime)
         {
             Boolean isInvalid = false;
             if (rule == null || rule.DaylightDelta == TimeSpan.Zero)
@@ -1731,7 +1731,7 @@ namespace System
             return isInvalid;
         }
 
-        static private bool EqualStandardDates(TimeZoneInformation timeZone, ref TIME_DYNAMIC_ZONE_INFORMATION tdzi)
+        private static bool EqualStandardDates(TimeZoneInformation timeZone, ref TIME_DYNAMIC_ZONE_INFORMATION tdzi)
         {
             return timeZone.Dtzi.Bias == tdzi.Bias
                    && timeZone.Dtzi.StandardBias == tdzi.StandardBias
@@ -1745,7 +1745,7 @@ namespace System
                    && timeZone.Dtzi.StandardDate.wMilliseconds == tdzi.StandardDate.wMilliseconds;
         }
 
-        static private bool EqualDaylightDates(TimeZoneInformation timeZone, ref TIME_DYNAMIC_ZONE_INFORMATION tdzi)
+        private static bool EqualDaylightDates(TimeZoneInformation timeZone, ref TIME_DYNAMIC_ZONE_INFORMATION tdzi)
         {
             return timeZone.Dtzi.DaylightBias == tdzi.DaylightBias
                     && timeZone.Dtzi.DaylightDate.wYear == tdzi.DaylightDate.wYear
@@ -1758,7 +1758,7 @@ namespace System
                     && timeZone.Dtzi.DaylightDate.wMilliseconds == tdzi.DaylightDate.wMilliseconds;
         }
 
-        static private bool CheckDaylightSavingTimeNotSupported(TimeZoneInformation timeZone)
+        private static bool CheckDaylightSavingTimeNotSupported(TimeZoneInformation timeZone)
         {
             return (timeZone.Dtzi.DaylightDate.wYear == timeZone.Dtzi.StandardDate.wYear
                     && timeZone.Dtzi.DaylightDate.wMonth == timeZone.Dtzi.StandardDate.wMonth
@@ -1773,7 +1773,7 @@ namespace System
         //
         // enumerate all time zones till find a match and with valid key name
         //
-        static internal unsafe bool FindMatchToCurrentTimeZone(TimeZoneInformation timeZoneInformation)
+        internal static unsafe bool FindMatchToCurrentTimeZone(TimeZoneInformation timeZoneInformation)
         {
             uint index = 0;
             uint result = 0; // ERROR_SUCCESS
@@ -1815,7 +1815,7 @@ namespace System
         // assumes cachedData lock is taken
         //
 
-        static private TimeZoneInfo GetLocalTimeZone(CachedData cachedData)
+        private static TimeZoneInfo GetLocalTimeZone(CachedData cachedData)
         {
             ////
             //// Try using the "mincore!GetDynamicTimeZoneInformation" API to get the "id"
@@ -1851,7 +1851,7 @@ namespace System
         // try/catch logic for handling the TimeZoneInfo private constructor that takes
         // a Win32Native.TimeZoneInformation structure.
         //
-        static private TimeZoneInfo GetLocalTimeZoneFromWin32Data(TimeZoneInformation timeZoneInformation, Boolean dstDisabled)
+        private static TimeZoneInfo GetLocalTimeZoneFromWin32Data(TimeZoneInformation timeZoneInformation, Boolean dstDisabled)
         {
             // first try to create the TimeZoneInfo with the original 'dstDisabled' flag
             try
@@ -1883,7 +1883,7 @@ namespace System
         // Helper function that calculates the UTC offset for a dateTime in a timeZone.
         // This function assumes that the dateTime is already converted into the timeZone.
         //
-        static private TimeSpan GetUtcOffset(DateTime time, TimeZoneInfo zone, TimeZoneInfoOptions flags)
+        private static TimeSpan GetUtcOffset(DateTime time, TimeZoneInfo zone, TimeZoneInfoOptions flags)
         {
             TimeSpan baseOffset = zone.BaseUtcOffset;
             AdjustmentRule rule = zone.GetAdjustmentRuleForTime(time);
@@ -1909,20 +1909,20 @@ namespace System
         // This function assumes that the dateTime is represented in UTC and has *not*
         // already been converted into the timeZone.
         //
-        static private TimeSpan GetUtcOffsetFromUtc(DateTime time, TimeZoneInfo zone)
+        private static TimeSpan GetUtcOffsetFromUtc(DateTime time, TimeZoneInfo zone)
         {
             Boolean isDaylightSavings;
             return GetUtcOffsetFromUtc(time, zone, out isDaylightSavings);
         }
 
-        static private TimeSpan GetUtcOffsetFromUtc(DateTime time, TimeZoneInfo zone, out Boolean isDaylightSavings)
+        private static TimeSpan GetUtcOffsetFromUtc(DateTime time, TimeZoneInfo zone, out Boolean isDaylightSavings)
         {
             Boolean isAmbiguousLocalDst;
             return GetUtcOffsetFromUtc(time, zone, out isDaylightSavings, out isAmbiguousLocalDst);
         }
 
         // DateTime.Now fast path that avoids allocating an historically accurate TimeZoneInfo.Local and just creates a 1-year (current year) accurate time zone
-        static internal TimeSpan GetDateTimeNowUtcOffsetFromUtc(DateTime time, out Boolean isAmbiguousLocalDst)
+        internal static TimeSpan GetDateTimeNowUtcOffsetFromUtc(DateTime time, out Boolean isAmbiguousLocalDst)
         {
             Boolean isDaylightSavings = false;
             isAmbiguousLocalDst = false;
@@ -1944,7 +1944,7 @@ namespace System
             return baseOffset;
         }
 
-        static internal TimeSpan GetUtcOffsetFromUtc(DateTime time, TimeZoneInfo zone, out Boolean isDaylightSavings, out Boolean isAmbiguousLocalDst)
+        internal static TimeSpan GetUtcOffsetFromUtc(DateTime time, TimeZoneInfo zone, out Boolean isDaylightSavings, out Boolean isAmbiguousLocalDst)
         {
             isDaylightSavings = false;
             isAmbiguousLocalDst = false;
@@ -1997,7 +1997,7 @@ namespace System
         // * when the argument 'readStart' is true the corresponding daylightTransitionTimeStart field is read
         // * when the argument 'readStart' is false the corresponding dayightTransitionTimeEnd field is read
         //
-        static private bool TransitionTimeFromTimeZoneInformation(TIME_ZONE_INFORMATION timeZoneInformation, out TransitionTime transitionTime, bool readStartDate)
+        private static bool TransitionTimeFromTimeZoneInformation(TIME_ZONE_INFORMATION timeZoneInformation, out TransitionTime transitionTime, bool readStartDate)
         {
             //
             // SYSTEMTIME - 
@@ -2114,7 +2114,7 @@ namespace System
         // Overloaded method which take TimeZoneInformation
         //
 
-        static private bool TransitionTimeFromTimeZoneInformation(TimeZoneInformation timeZoneInformation, out TransitionTime transitionTime, bool readStartDate)
+        private static bool TransitionTimeFromTimeZoneInformation(TimeZoneInformation timeZoneInformation, out TransitionTime transitionTime, bool readStartDate)
         {
             bool supportsDst = (timeZoneInformation.Dtzi.StandardDate.wMonth != 0);
 
@@ -2199,7 +2199,7 @@ namespace System
         //
         // Helper function that converts a year and TransitionTime into a DateTime
         //
-        static private DateTime TransitionTimeToDateTime(Int32 year, TransitionTime transitionTime)
+        private static DateTime TransitionTimeToDateTime(Int32 year, TransitionTime transitionTime)
         {
             DateTime value;
             DateTime timeOfDay = transitionTime.TimeOfDay;
@@ -2391,7 +2391,7 @@ namespace System
         //
         // assumes cachedData lock is taken
         //
-        static private TimeZoneInfoResult TryGetTimeZone(ref TimeZoneInformation timeZoneInformation, Boolean dstDisabled, out TimeZoneInfo value, out Exception e, CachedData cachedData)
+        private static TimeZoneInfoResult TryGetTimeZone(ref TimeZoneInformation timeZoneInformation, Boolean dstDisabled, out TimeZoneInfo value, out Exception e, CachedData cachedData)
         {
             TimeZoneInfoResult result = TimeZoneInfoResult.Success;
             e = null;
@@ -2454,7 +2454,7 @@ namespace System
         // Helper function that validates the TimeSpan is within +/- 14.0 hours
         //
         [Pure]
-        static internal Boolean UtcOffsetOutOfRange(TimeSpan offset)
+        internal static Boolean UtcOffsetOutOfRange(TimeSpan offset)
         {
             return (offset.TotalHours < -14.0 || offset.TotalHours > 14.0);
         }
@@ -2468,7 +2468,7 @@ namespace System
         //
         // returns a Boolean indicating whether the AdjustmentRule[] supports DST
         //
-        static private void ValidateTimeZoneInfo(
+        private static void ValidateTimeZoneInfo(
                 String id,
                 TimeSpan baseUtcOffset,
                 AdjustmentRule[] adjustmentRules,
@@ -2657,7 +2657,7 @@ namespace System
 
             // -------- SECTION: factory methods -----------------*
 
-            static public AdjustmentRule CreateAdjustmentRule(
+            public static AdjustmentRule CreateAdjustmentRule(
                              DateTime dateStart,
                              DateTime dateEnd,
                              TimeSpan daylightDelta,
@@ -2680,7 +2680,7 @@ namespace System
                 return rule;
             }
 
-            static internal AdjustmentRule CreateAdjustmentRule(
+            internal static AdjustmentRule CreateAdjustmentRule(
                             DateTime dateStart,
                             DateTime dateEnd,
                             TimeSpan daylightDelta,
@@ -2723,7 +2723,7 @@ namespace System
             // Helper function that performs all of the validation checks for the 
             // factory methods and deserialization callback
             //
-            static private void ValidateAdjustmentRule(
+            private static void ValidateAdjustmentRule(
                              DateTime dateStart,
                              DateTime dateEnd,
                              TimeSpan daylightDelta,
@@ -2916,7 +2916,7 @@ namespace System
             // -------- SECTION: factory methods -----------------*
 
 
-            static public TransitionTime CreateFixedDateRule(
+            public static TransitionTime CreateFixedDateRule(
                     DateTime timeOfDay,
                     Int32 month,
                     Int32 day)
@@ -2925,7 +2925,7 @@ namespace System
             }
 
 
-            static public TransitionTime CreateFloatingDateRule(
+            public static TransitionTime CreateFloatingDateRule(
                     DateTime timeOfDay,
                     Int32 month,
                     Int32 week,
@@ -2935,7 +2935,7 @@ namespace System
             }
 
 
-            static private TransitionTime CreateTransitionTime(
+            private static TransitionTime CreateTransitionTime(
                     DateTime timeOfDay,
                     Int32 month,
                     Int32 week,
@@ -2964,7 +2964,7 @@ namespace System
             //
             // Helper function that validates a TransitionTime instance
             //
-            static private void ValidateTransitionTime(
+            private static void ValidateTransitionTime(
                     DateTime timeOfDay,
                     Int32 month,
                     Int32 week,

--- a/src/System.Private.CoreLib/src/System/UIntptr.cs
+++ b/src/System.Private.CoreLib/src/System/UIntptr.cs
@@ -109,7 +109,7 @@ namespace System
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static explicit operator uint (UIntPtr value)
+        public static unsafe explicit operator uint (UIntPtr value)
         {
 #if BIT64
             return checked((uint)value._value);
@@ -120,7 +120,7 @@ namespace System
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static explicit operator ulong (UIntPtr value)
+        public static unsafe explicit operator ulong (UIntPtr value)
         {
             return (ulong)value._value;
         }
@@ -132,14 +132,14 @@ namespace System
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static bool operator ==(UIntPtr value1, UIntPtr value2)
+        public static unsafe bool operator ==(UIntPtr value1, UIntPtr value2)
         {
             return value1._value == value2._value;
         }
 
         [Intrinsic]
         [NonVersionable]
-        public unsafe static bool operator !=(UIntPtr value1, UIntPtr value2)
+        public static unsafe bool operator !=(UIntPtr value1, UIntPtr value2)
         {
             return value1._value != value2._value;
         }

--- a/src/System.Private.Interop/src/Interop/Interop.COM.Windows.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.COM.Windows.cs
@@ -70,7 +70,7 @@ namespace System.Runtime.InteropServices
             Marshal.FreeBSTR(pBSTR);
         }
 
-        static internal void VariantClear(IntPtr pObject)
+        internal static void VariantClear(IntPtr pObject)
         {
             //Nop
         }     
@@ -87,13 +87,13 @@ namespace System.Runtime.InteropServices
 
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal extern IntPtr CoTaskMemRealloc(IntPtr pv, IntPtr size);
+        internal static extern IntPtr CoTaskMemRealloc(IntPtr pv, IntPtr size);
 
 
 
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe extern int CoCreateInstanceFromApp(
+        internal static extern unsafe int CoCreateInstanceFromApp(
             Guid* clsid,
             IntPtr pUnkOuter,
             int context,
@@ -134,7 +134,7 @@ namespace System.Runtime.InteropServices
 
         [DllImport(Libraries.CORE_COM_AUT)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal extern void VariantClear(IntPtr pObject);
+        internal static extern void VariantClear(IntPtr pObject);
         
 
 

--- a/src/System.Private.Interop/src/Interop/Interop.Common.Unix.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.Common.Unix.cs
@@ -13,7 +13,7 @@ namespace System.Runtime.InteropServices
 {
     public partial class ExternalInterop
     {
-        static internal int GetLastWin32Error()
+        internal static int GetLastWin32Error()
         {
             throw new PlatformNotSupportedException("GetLastWin32Error");
         }

--- a/src/System.Private.Interop/src/Interop/Interop.Common.Windows.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.Common.Windows.cs
@@ -36,7 +36,7 @@ namespace System.Runtime.InteropServices
         }
 #if CORECLR
         
-        static internal int GetLastWin32Error()
+        internal static int GetLastWin32Error()
         {
            return 0;
         }
@@ -44,7 +44,7 @@ namespace System.Runtime.InteropServices
 
         [DllImport(Libraries.CORE_DEBUG, EntryPoint = "OutputDebugStringW")]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe extern void OutputDebugString(char* lpOutputString);
+        internal static extern unsafe void OutputDebugString(char* lpOutputString);
 
         internal static unsafe void OutputDebugString(string outputString)
         {
@@ -58,12 +58,12 @@ namespace System.Runtime.InteropServices
         [DllImport(Libraries.CORE_ERRORHANDLING, EntryPoint = "GetLastError")]
         [McgGeneratedNativeCallCodeAttribute]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        static internal extern int GetLastWin32Error();
+        internal static extern int GetLastWin32Error();
 
         [DllImport(Libraries.CORE_ERRORHANDLING, EntryPoint = "SetLastError")]
         [McgGeneratedNativeCallCodeAttribute]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        static internal extern void SetLastWin32Error(int errorCode);
+        internal static extern void SetLastWin32Error(int errorCode);
 #endif 
     }
 }

--- a/src/System.Private.Interop/src/Interop/Interop.Localization.Windows.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.Localization.Windows.cs
@@ -60,7 +60,7 @@ namespace System.Runtime.InteropServices
 
         [DllImport(Libraries.CORE_LOCALIZATION, EntryPoint = "FormatMessageW")]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe extern int FormatMessage(
+        internal static extern unsafe int FormatMessage(
             int dwFlags,
             IntPtr lpSource,
             uint dwMessageId,
@@ -71,7 +71,7 @@ namespace System.Runtime.InteropServices
 
         [DllImport(Libraries.CORE_LOCALIZATION)]
         [McgGeneratedNativeCallCodeAttribute]
-        internal static unsafe extern int GetCPInfo(uint codePage, CPINFO* lpCpInfo);
+        internal static extern unsafe int GetCPInfo(uint codePage, CPINFO* lpCpInfo);
 
 
         internal const int FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
@@ -123,7 +123,7 @@ namespace System.Runtime.InteropServices
         /// </summary>
         /// <param name="errorCode">HRESULT</param>
         /// <returns></returns>
-        internal unsafe static String GetMessage(int errorCode)
+        internal static unsafe String GetMessage(int errorCode)
         {
             string errorMsg;
             int bufferSize = 1024;

--- a/src/System.Private.Interop/src/Interop/Interop.Sync.Windows.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.Sync.Windows.cs
@@ -44,19 +44,19 @@ namespace System.Runtime.InteropServices
 
         [DllImport(Libraries.CORE_SYNCH_L1)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe extern void InitializeCriticalSectionEx(CRITICAL_SECTION* lpCriticalSection, int dwSpinCount, int flags);
+        internal static extern unsafe void InitializeCriticalSectionEx(CRITICAL_SECTION* lpCriticalSection, int dwSpinCount, int flags);
 
         [DllImport(Libraries.CORE_SYNCH_L1)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe extern void EnterCriticalSection(CRITICAL_SECTION* lpCriticalSection);
+        internal static extern unsafe void EnterCriticalSection(CRITICAL_SECTION* lpCriticalSection);
 
         [DllImport(Libraries.CORE_SYNCH_L1)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe  extern void LeaveCriticalSection(CRITICAL_SECTION* lpCriticalSection);
+        internal static unsafe  extern void LeaveCriticalSection(CRITICAL_SECTION* lpCriticalSection);
 
         [DllImport(Libraries.CORE_SYNCH_L1)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe extern void DeleteCriticalSection(CRITICAL_SECTION* lpCriticalSection);
+        internal static extern unsafe void DeleteCriticalSection(CRITICAL_SECTION* lpCriticalSection);
 
     }
 }

--- a/src/System.Private.Interop/src/Interop/Interop.WinRT.Basic.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.WinRT.Basic.cs
@@ -76,14 +76,14 @@ namespace System.Runtime.InteropServices
         [DllImport(Libraries.CORE_WINRT_STRING)]
         [McgGeneratedNativeCallCodeAttribute]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        static internal extern unsafe int WindowsCreateStringReference(char* sourceString,
+        internal static extern unsafe int WindowsCreateStringReference(char* sourceString,
                                                                        uint length,
                                                                        HSTRING_HEADER* phstringHeader,
                                                                        void* hstring);
 
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe extern int CoCreateFreeThreadedMarshaler(void* pOuter, void** ppunkMarshal);
+        internal static extern unsafe int CoCreateFreeThreadedMarshaler(void* pOuter, void** ppunkMarshal);
 
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
@@ -92,34 +92,34 @@ namespace System.Runtime.InteropServices
 
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal unsafe extern int CoGetObjectContext(Guid* iid, void* ppv);
+        internal static extern unsafe int CoGetObjectContext(Guid* iid, void* ppv);
 
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
-        private static unsafe extern int CoGetMarshalSizeMax(ulong* pulSize, Guid* iid, IntPtr pUnk, 
+        private static extern unsafe int CoGetMarshalSizeMax(ulong* pulSize, Guid* iid, IntPtr pUnk, 
                                                              Interop.COM.MSHCTX dwDestContext, 
                                                              IntPtr pvDestContext, 
                                                              Interop.COM.MSHLFLAGS mshlflags);
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
-        private extern unsafe static int CoMarshalInterface(IntPtr pStream, Guid* iid, IntPtr pUnk, Interop.COM.MSHCTX dwDestContext, IntPtr pvDestContext, Interop.COM.MSHLFLAGS mshlflags);
+        private extern static unsafe int CoMarshalInterface(IntPtr pStream, Guid* iid, IntPtr pUnk, Interop.COM.MSHCTX dwDestContext, IntPtr pvDestContext, Interop.COM.MSHLFLAGS mshlflags);
 
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
-        private static unsafe extern int CoUnmarshalInterface(IntPtr pStream, Guid* iid, void** ppv);
+        private static extern unsafe int CoUnmarshalInterface(IntPtr pStream, Guid* iid, void** ppv);
 
 
         [DllImport(Libraries.CORE_COM)]
         [McgGeneratedNativeCallCodeAttribute]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        static internal extern int CoReleaseMarshalData(IntPtr pStream);
+        internal static extern int CoReleaseMarshalData(IntPtr pStream);
 
 
         /// <summary>
         /// Marshal IUnknown * into IStream*
         /// </summary>
         /// <returns>HResult</returns>
-        static internal unsafe int CoMarshalInterface(IntPtr pStream, ref Guid iid, IntPtr pUnk, Interop.COM.MSHCTX dwDestContext, IntPtr pvDestContext, Interop.COM.MSHLFLAGS mshlflags)
+        internal static unsafe int CoMarshalInterface(IntPtr pStream, ref Guid iid, IntPtr pUnk, Interop.COM.MSHCTX dwDestContext, IntPtr pvDestContext, Interop.COM.MSHLFLAGS mshlflags)
         {
             fixed (Guid* unsafe_iid = &iid)
             {
@@ -131,7 +131,7 @@ namespace System.Runtime.InteropServices
         /// Marshal IStream* into IUnknown*
         /// </summary>
         /// <returns>HResult</returns>
-        static internal unsafe int CoUnmarshalInterface(IntPtr pStream, ref Guid iid, out IntPtr ppv)
+        internal static unsafe int CoUnmarshalInterface(IntPtr pStream, ref Guid iid, out IntPtr ppv)
         {
             fixed (Guid* unsafe_iid = &iid)
             {
@@ -146,7 +146,7 @@ namespace System.Runtime.InteropServices
         /// Returns an upper bound on the number of bytes needed to marshal the specified interface pointer to the specified object.
         /// </summary>
         /// <returns>HResult</returns>
-        static internal unsafe int CoGetMarshalSizeMax(out ulong pulSize, ref Guid iid, IntPtr pUnk, Interop.COM.MSHCTX dwDestContext, IntPtr pvDestContext, Interop.COM.MSHLFLAGS mshlflags)
+        internal static unsafe int CoGetMarshalSizeMax(out ulong pulSize, ref Guid iid, IntPtr pUnk, Interop.COM.MSHCTX dwDestContext, IntPtr pvDestContext, Interop.COM.MSHLFLAGS mshlflags)
         {
             fixed (ulong* unsafe_pulSize = &pulSize)
             {
@@ -157,7 +157,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        static internal unsafe void RoGetActivationFactory(string className, ref Guid iid, out IntPtr ppv)
+        internal static unsafe void RoGetActivationFactory(string className, ref Guid iid, out IntPtr ppv)
         {
             fixed (char* unsafe_className = className)
             {
@@ -196,7 +196,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        static internal unsafe int CoGetObjectContext(ref Guid iid, out IntPtr ppv)
+        internal static unsafe int CoGetObjectContext(ref Guid iid, out IntPtr ppv)
         {
             fixed (void* unsafe_ppv = &ppv)
             {

--- a/src/System.Private.Interop/src/Interop/Interop.WinRT.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.WinRT.cs
@@ -63,7 +63,7 @@ namespace System.Runtime.InteropServices
 
         [DllImport(Libraries.CORE_WINRT_ERROR1, PreserveSig = true)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal extern int RoOriginateLanguageException(int hr, HSTRING message, IntPtr pLanguageException);
+        internal static extern int RoOriginateLanguageException(int hr, HSTRING message, IntPtr pLanguageException);
 
         [DllImport(Libraries.CORE_WINRT_ERROR1, PreserveSig = true)]
         [McgGeneratedNativeCallCodeAttribute]

--- a/src/System.Private.Interop/src/Shared/ComCallableObject.cs
+++ b/src/System.Private.Interop/src/Shared/ComCallableObject.cs
@@ -806,7 +806,7 @@ namespace System.Runtime.InteropServices
         /// </summary>
         static Lock s_ccwLookupMapLock;
 
-        static internal void InitializeStatics()
+        internal static void InitializeStatics()
         {
             const int CCWLookupMapDefaultSize = 101;
 
@@ -1081,7 +1081,7 @@ namespace System.Runtime.InteropServices
 
 #region RefCounted handle support
 
-        static internal void InitRefCountedHandleCallback()
+        internal static void InitRefCountedHandleCallback()
         {
             // TODO: <https://github.com/dotnet/corert/issues/1596>
 #if !CORERT

--- a/src/System.Private.Interop/src/Shared/DictionaryBase.cs
+++ b/src/System.Private.Interop/src/Shared/DictionaryBase.cs
@@ -13,19 +13,19 @@ namespace System.Collections.Generic.Internal
 {
     internal class SR
     {
-        static internal string ArgumentOutOfRange_NeedNonNegNum = "ArgumentOutOfRange_NeedNonNegNum";
-        static internal string Arg_WrongType = "Arg_WrongType";
-        static internal string Arg_ArrayPlusOffTooSmall = "Arg_ArrayPlusOffTooSmall";
-        static internal string Arg_RankMultiDimNotSupported = "Arg_RankMultiDimNotSupported";
-        static internal string Arg_NonZeroLowerBound = "Arg_NonZeroLowerBound";
-        static internal string Argument_InvalidArrayType = "Argument_InvalidArrayType";
-        static internal string Argument_AddingDuplicate = "Argument_AddingDuplicate";
-        static internal string InvalidOperation_EnumFailedVersion = "InvalidOperation_EnumFailedVersion";
-        static internal string InvalidOperation_EnumOpCantHappen = "InvalidOperation_EnumOpCantHappen";
-        static internal string NotSupported_KeyCollectionSet = "NotSupported_KeyCollectionSet";
-        static internal string NotSupported_ValueCollectionSet = "NotSupported_ValueCollectionSet";
-        static internal string ArgumentOutOfRange_SmallCapacity = "ArgumentOutOfRange_SmallCapacity";
-        static internal string Argument_InvalidOffLen = "Argument_InvalidOffLen";
+        internal static string ArgumentOutOfRange_NeedNonNegNum = "ArgumentOutOfRange_NeedNonNegNum";
+        internal static string Arg_WrongType = "Arg_WrongType";
+        internal static string Arg_ArrayPlusOffTooSmall = "Arg_ArrayPlusOffTooSmall";
+        internal static string Arg_RankMultiDimNotSupported = "Arg_RankMultiDimNotSupported";
+        internal static string Arg_NonZeroLowerBound = "Arg_NonZeroLowerBound";
+        internal static string Argument_InvalidArrayType = "Argument_InvalidArrayType";
+        internal static string Argument_AddingDuplicate = "Argument_AddingDuplicate";
+        internal static string InvalidOperation_EnumFailedVersion = "InvalidOperation_EnumFailedVersion";
+        internal static string InvalidOperation_EnumOpCantHappen = "InvalidOperation_EnumOpCantHappen";
+        internal static string NotSupported_KeyCollectionSet = "NotSupported_KeyCollectionSet";
+        internal static string NotSupported_ValueCollectionSet = "NotSupported_ValueCollectionSet";
+        internal static string ArgumentOutOfRange_SmallCapacity = "ArgumentOutOfRange_SmallCapacity";
+        internal static string Argument_InvalidOffLen = "Argument_InvalidOffLen";
     }
 
     internal class HashHelpers

--- a/src/System.Private.Interop/src/Shared/InternalModule.cs
+++ b/src/System.Private.Interop/src/Shared/InternalModule.cs
@@ -72,7 +72,7 @@ namespace System.Runtime.InteropServices
 #endif
         }
         // IUnknown
-        static internal McgInterfaceData s_IUnknown = new McgInterfaceData
+        internal static McgInterfaceData s_IUnknown = new McgInterfaceData
         {
             ItfType = InternalTypes.IUnknown,
             ItfGuid = Interop.COM.IID_IUnknown,
@@ -81,7 +81,7 @@ namespace System.Runtime.InteropServices
         };
 
         // IInspectable
-        static internal McgInterfaceData s_IInspectable = new McgInterfaceData
+        internal static McgInterfaceData s_IInspectable = new McgInterfaceData
         {
             ItfType = InternalTypes.IInspectable,
             ItfGuid = Interop.COM.IID_IInspectable,
@@ -91,7 +91,7 @@ namespace System.Runtime.InteropServices
 
 #if ENABLE_MIN_WINRT
         // IActivationFactoryInternal
-        static internal McgInterfaceData s_IActivationFactoryInternal = new McgInterfaceData
+        internal static McgInterfaceData s_IActivationFactoryInternal = new McgInterfaceData
         {
             ItfType = InternalTypes.IActivationFactoryInternal,
             ItfGuid = Interop.COM.IID_IActivationFactoryInternal,
@@ -102,7 +102,7 @@ namespace System.Runtime.InteropServices
 
 #if ENABLE_WINRT
         // ICustomPropertyProvider
-        static internal McgInterfaceData s_ICustomPropertyProvider = new McgInterfaceData
+        internal static McgInterfaceData s_ICustomPropertyProvider = new McgInterfaceData
         {
             ItfType = InternalTypes.ICustomPropertyProvider,
             ItfGuid = Interop.COM.IID_ICustomPropertyProvider,
@@ -111,7 +111,7 @@ namespace System.Runtime.InteropServices
         };
 
         // IWeakReferenceSource
-        static internal McgInterfaceData s_IWeakReferenceSource = new McgInterfaceData
+        internal static McgInterfaceData s_IWeakReferenceSource = new McgInterfaceData
         {
             ItfType = InternalTypes.IWeakReferenceSource,
             ItfGuid = Interop.COM.IID_IWeakReferenceSource,
@@ -120,7 +120,7 @@ namespace System.Runtime.InteropServices
         };
 
         // IWeakReference
-        static internal McgInterfaceData s_IWeakReference = new McgInterfaceData
+        internal static McgInterfaceData s_IWeakReference = new McgInterfaceData
         {
             ItfType = InternalTypes.IWeakReference,
             ItfGuid = Interop.COM.IID_IWeakReference,
@@ -129,7 +129,7 @@ namespace System.Runtime.InteropServices
         };
 #endif
         // ICCW
-        static internal McgInterfaceData s_ICCW = new McgInterfaceData
+        internal static McgInterfaceData s_ICCW = new McgInterfaceData
         {
             ItfType = InternalTypes.ICCW,
             ItfGuid = Interop.COM.IID_ICCW,
@@ -139,7 +139,7 @@ namespace System.Runtime.InteropServices
 
 #if ENABLE_WINRT
         // IJupiterObject
-        static internal McgInterfaceData s_IJupiterObject = new McgInterfaceData
+        internal static McgInterfaceData s_IJupiterObject = new McgInterfaceData
         {
             ItfType = InternalTypes.IJupiterObject,
             ItfGuid = Interop.COM.IID_IJupiterObject,
@@ -147,7 +147,7 @@ namespace System.Runtime.InteropServices
         };
 
         // IStringable
-        static internal McgInterfaceData s_IStringable = new McgInterfaceData
+        internal static McgInterfaceData s_IStringable = new McgInterfaceData
         {
             ItfType = InternalTypes.IStringable,
             ItfGuid = Interop.COM.IID_IStringable,
@@ -156,7 +156,7 @@ namespace System.Runtime.InteropServices
         };
 
         // IManagedActivationFactory
-        static internal McgInterfaceData s_IManagedActivationFactory = new McgInterfaceData
+        internal static McgInterfaceData s_IManagedActivationFactory = new McgInterfaceData
         {
             ItfType = InternalTypes.IManagedActivationFactory,
             ItfGuid = Interop.COM.IID_IManagedActivationFactory,
@@ -165,7 +165,7 @@ namespace System.Runtime.InteropServices
         };
 
         // IRestrictedErrorInfo
-        static internal McgInterfaceData s_IRestrictedErrorInfo = new McgInterfaceData
+        internal static McgInterfaceData s_IRestrictedErrorInfo = new McgInterfaceData
         {
             ItfType = InternalTypes.IRestrictedErrorInfo,
             ItfGuid = Interop.COM.IID_IRestrictedErrorInfo,
@@ -173,7 +173,7 @@ namespace System.Runtime.InteropServices
         };
 #endif
         // IMarshal
-        static internal McgInterfaceData s_IMarshal = new McgInterfaceData
+        internal static McgInterfaceData s_IMarshal = new McgInterfaceData
         {
             ItfType = InternalTypes.IMarshal,
             ItfGuid = Interop.COM.IID_IMarshal,
@@ -182,7 +182,7 @@ namespace System.Runtime.InteropServices
         };
 
         // IDispatch
-        static internal McgInterfaceData s_IDispatch = new McgInterfaceData
+        internal static McgInterfaceData s_IDispatch = new McgInterfaceData
         {
             ItfType = InternalTypes.IDispatch,
             ItfGuid = Interop.COM.IID_IDispatch,
@@ -191,7 +191,7 @@ namespace System.Runtime.InteropServices
         };
 #if ENABLE_WINRT
         // HSTRING, just needed for TypeHandle comparison
-        static internal McgInterfaceData s_HSTRING = new McgInterfaceData
+        internal static McgInterfaceData s_HSTRING = new McgInterfaceData
         {
             ItfType = InternalTypes.HSTRING
         };

--- a/src/System.Private.Interop/src/Shared/Interop.Manual.cs
+++ b/src/System.Private.Interop/src/Shared/Interop.Manual.cs
@@ -40,10 +40,10 @@ partial class Interop
 #if RHTESTCL
         [DllImport(CORE_SYNCH_L2)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal extern void Sleep(int milliseconds);
+        internal static extern void Sleep(int milliseconds);
 #else
         private static readonly System.Threading.WaitHandle s_sleepHandle = new System.Threading.ManualResetEvent(false);
-        static internal void Sleep(uint milliseconds)
+        internal static void Sleep(uint milliseconds)
         {
 #if CORECLR
             System.Threading.Thread.Sleep(0);

--- a/src/System.Private.Interop/src/Shared/McgComHelpers.cs
+++ b/src/System.Private.Interop/src/Shared/McgComHelpers.cs
@@ -203,7 +203,7 @@ namespace System.Runtime.InteropServices
 #if !RHTESTCL
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
 #endif
-        static internal void* CachedAlloc(int size, ref IntPtr cache)
+        internal static void* CachedAlloc(int size, ref IntPtr cache)
         {
             // Read cache, clear it
             void* pBlock = (void*)Interlocked.Exchange(ref cache, default(IntPtr));
@@ -222,7 +222,7 @@ namespace System.Runtime.InteropServices
 #if !RHTESTCL
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
 #endif
-        static internal void CachedFree(void* block, ref IntPtr cache)
+        internal static void CachedFree(void* block, ref IntPtr cache)
         {
             if ((void*)Interlocked.CompareExchange(ref cache, new IntPtr(block), default(IntPtr)) != null)
             {
@@ -745,7 +745,7 @@ namespace System.Runtime.InteropServices
         }
 
 
-        internal unsafe static IntPtr ObjectToComInterfaceInternal(Object obj, RuntimeTypeHandle typeHnd)
+        internal static unsafe IntPtr ObjectToComInterfaceInternal(Object obj, RuntimeTypeHandle typeHnd)
         {
             if (obj == null)
                 return default(IntPtr);

--- a/src/System.Private.Interop/src/Shared/McgHelpers.cs
+++ b/src/System.Private.Interop/src/Shared/McgHelpers.cs
@@ -376,7 +376,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        internal unsafe static int GetAt(IntPtr pComThis, uint index, IntPtr pItem)
+        internal static unsafe int GetAt(IntPtr pComThis, uint index, IntPtr pItem)
         {
             int hr = Interop.COM.S_OK;
 
@@ -407,7 +407,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        internal unsafe static int get_Size(System.IntPtr pComThis, System.IntPtr pSize)
+        internal static unsafe int get_Size(System.IntPtr pComThis, System.IntPtr pSize)
         {
             int hr = Interop.COM.S_OK;
 
@@ -433,7 +433,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        unsafe static int GetView(System.IntPtr pComThis, System.IntPtr pView)
+        static unsafe int GetView(System.IntPtr pComThis, System.IntPtr pView)
         {
             int hr = Interop.COM.S_OK;
 
@@ -462,7 +462,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        internal unsafe static int IndexOf(System.IntPtr pComThis, System.IntPtr _value, System.IntPtr pIndex, System.IntPtr pFound)
+        internal static unsafe int IndexOf(System.IntPtr pComThis, System.IntPtr _value, System.IntPtr pIndex, System.IntPtr pFound)
         {
             int hr = Interop.COM.S_OK;
 
@@ -501,7 +501,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        unsafe static int SetAt(System.IntPtr pComThis, uint index, IntPtr _value)
+        static unsafe int SetAt(System.IntPtr pComThis, uint index, IntPtr _value)
         {
             int hr = Interop.COM.S_OK;
 
@@ -539,7 +539,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        unsafe static int InsertAt(System.IntPtr pComThis, uint index, IntPtr _value)
+        static unsafe int InsertAt(System.IntPtr pComThis, uint index, IntPtr _value)
         {
             int hr = Interop.COM.S_OK;
 
@@ -578,7 +578,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        unsafe static int RemoveAt(System.IntPtr pComThis, uint index)
+        static unsafe int RemoveAt(System.IntPtr pComThis, uint index)
         {
             int hr = Interop.COM.S_OK;
 
@@ -614,7 +614,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        unsafe static int Append(System.IntPtr pComThis, IntPtr _value)
+        static unsafe int Append(System.IntPtr pComThis, IntPtr _value)
         {
             int hr = Interop.COM.S_OK;
 
@@ -641,7 +641,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        unsafe static int RemoveAtEnd(System.IntPtr pComThis)
+        static unsafe int RemoveAtEnd(System.IntPtr pComThis)
         {
             int hr = Interop.COM.S_OK;
 
@@ -681,7 +681,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        unsafe static int Clear(System.IntPtr pComThis)
+        static unsafe int Clear(System.IntPtr pComThis)
         {
             int hr = Interop.COM.S_OK;
 
@@ -708,7 +708,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        internal unsafe static int GetMany(System.IntPtr pComThis, uint startIndex, uint len, System.IntPtr pDest, System.IntPtr pCount)
+        internal static unsafe int GetMany(System.IntPtr pComThis, uint startIndex, uint len, System.IntPtr pDest, System.IntPtr pCount)
         {
             int hr = Interop.COM.S_OK;
 
@@ -763,7 +763,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        unsafe static int ReplaceAll(System.IntPtr pComThis, uint length, IntPtr pItems)
+        static unsafe int ReplaceAll(System.IntPtr pComThis, uint length, IntPtr pItems)
         {
             int hr = Interop.COM.S_OK;
 
@@ -853,7 +853,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        internal unsafe static int GetAt(IntPtr pComThis, uint _index, IntPtr pItem)
+        internal static unsafe int GetAt(IntPtr pComThis, uint _index, IntPtr pItem)
         {
             int hr = Interop.COM.S_OK;
 
@@ -883,7 +883,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        internal unsafe static int get_Size(System.IntPtr pComThis, System.IntPtr pSize)
+        internal static unsafe int get_Size(System.IntPtr pComThis, System.IntPtr pSize)
         {
             int hr = Interop.COM.S_OK;
 
@@ -910,7 +910,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        unsafe static int GetView(System.IntPtr pComThis, System.IntPtr pView)
+        static unsafe int GetView(System.IntPtr pComThis, System.IntPtr pView)
         {
             int hr = Interop.COM.S_OK;
 
@@ -938,7 +938,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        internal unsafe static int IndexOf(System.IntPtr pComThis, System.IntPtr _value, System.IntPtr pIndex, System.IntPtr pFound)
+        internal static unsafe int IndexOf(System.IntPtr pComThis, System.IntPtr _value, System.IntPtr pIndex, System.IntPtr pFound)
         {
             int hr = Interop.COM.S_OK;
 
@@ -976,7 +976,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        unsafe static int SetAt(System.IntPtr pComThis, uint _index, IntPtr _value)
+        static unsafe int SetAt(System.IntPtr pComThis, uint _index, IntPtr _value)
         {
             int hr = Interop.COM.S_OK;
 
@@ -1006,7 +1006,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        unsafe static int InsertAt(System.IntPtr pComThis, uint _index, IntPtr _value)
+        static unsafe int InsertAt(System.IntPtr pComThis, uint _index, IntPtr _value)
         {
             int hr = Interop.COM.S_OK;
 
@@ -1036,7 +1036,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        unsafe static int RemoveAt(System.IntPtr pComThis, uint _index)
+        static unsafe int RemoveAt(System.IntPtr pComThis, uint _index)
         {
             int hr = Interop.COM.S_OK;
 
@@ -1067,7 +1067,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        unsafe static int Append(System.IntPtr pComThis, IntPtr _value)
+        static unsafe int Append(System.IntPtr pComThis, IntPtr _value)
         {
             int hr = Interop.COM.S_OK;
 
@@ -1094,7 +1094,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        unsafe static int RemoveAtEnd(System.IntPtr pComThis)
+        static unsafe int RemoveAtEnd(System.IntPtr pComThis)
         {
             int hr = Interop.COM.S_OK;
 
@@ -1136,7 +1136,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        unsafe static int Clear(System.IntPtr pComThis)
+        static unsafe int Clear(System.IntPtr pComThis)
         {
             int hr = Interop.COM.S_OK;
 
@@ -1162,7 +1162,7 @@ namespace System.Runtime.InteropServices
 
 
         [NativeCallable]
-        internal unsafe static int GetMany(System.IntPtr pComThis, uint startIndex, uint len, System.IntPtr pDest, System.IntPtr pCount)
+        internal static unsafe int GetMany(System.IntPtr pComThis, uint startIndex, uint len, System.IntPtr pDest, System.IntPtr pCount)
         {
             int hr = Interop.COM.S_OK;
 
@@ -1213,7 +1213,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        unsafe static int ReplaceAll(System.IntPtr pComThis, uint length, IntPtr pItems)
+        static unsafe int ReplaceAll(System.IntPtr pComThis, uint length, IntPtr pItems)
         {
             int hr = Interop.COM.S_OK;
 

--- a/src/System.Private.Interop/src/Shared/McgMarshal.cs
+++ b/src/System.Private.Interop/src/Shared/McgMarshal.cs
@@ -178,7 +178,7 @@ namespace System.Runtime.InteropServices
 #endif
         }
 
-        public unsafe static void TypeToTypeName(
+        public static unsafe void TypeToTypeName(
             Type type,
             out HSTRING nativeTypeName,
             out int nativeTypeKind)
@@ -718,14 +718,14 @@ namespace System.Runtime.InteropServices
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public unsafe static int ComAddRef(IntPtr pComItf)
+        public static unsafe int ComAddRef(IntPtr pComItf)
         {
             return CalliIntrinsics.StdCall__AddRef(((__com_IUnknown*)(void*)pComItf)->pVtable->
                 pfnAddRef, pComItf);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal unsafe static int ComRelease_StdCall(IntPtr pComItf)
+        internal static unsafe int ComRelease_StdCall(IntPtr pComItf)
         {
             return CalliIntrinsics.StdCall__Release(((__com_IUnknown*)(void*)pComItf)->pVtable->
                 pfnRelease, pComItf);
@@ -735,7 +735,7 @@ namespace System.Runtime.InteropServices
         /// Inline version of ComRelease
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)] //reduces MCG-generated code size
-        public unsafe static int ComRelease(IntPtr pComItf)
+        public static unsafe int ComRelease(IntPtr pComItf)
         {
             IntPtr pRelease = ((__com_IUnknown*)(void*)pComItf)->pVtable->pfnRelease;
 
@@ -750,7 +750,7 @@ namespace System.Runtime.InteropServices
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public unsafe static int ComSafeRelease(IntPtr pComItf)
+        public static unsafe int ComSafeRelease(IntPtr pComItf)
         {
             if (pComItf != default(IntPtr))
             {
@@ -883,13 +883,13 @@ namespace System.Runtime.InteropServices
             return result;
         }
 
-        public unsafe static IntPtr ComQueryInterfaceNoThrow(IntPtr pComItf, ref Guid iid)
+        public static unsafe IntPtr ComQueryInterfaceNoThrow(IntPtr pComItf, ref Guid iid)
         {
             int hr = 0;
             return ComQueryInterfaceNoThrow(pComItf, ref iid, out hr);
         }
 
-        public unsafe static IntPtr ComQueryInterfaceNoThrow(IntPtr pComItf, ref Guid iid, out int hr)
+        public static unsafe IntPtr ComQueryInterfaceNoThrow(IntPtr pComItf, ref Guid iid, out int hr)
         {
             IntPtr pComIUnk;
             hr = ComQueryInterfaceWithHR(pComItf, ref iid, out pComIUnk);
@@ -897,7 +897,7 @@ namespace System.Runtime.InteropServices
             return pComIUnk;
         }
 
-        internal unsafe static int ComQueryInterfaceWithHR(IntPtr pComItf, ref Guid iid, out IntPtr ppv)
+        internal static unsafe int ComQueryInterfaceWithHR(IntPtr pComItf, ref Guid iid, out IntPtr ppv)
         {
             IntPtr pComIUnk;
             int hr;
@@ -1393,7 +1393,7 @@ namespace System.Runtime.InteropServices
         /// Return the stub to the pinvoke marshalling stub
         /// </summary>
         /// <param name="del">The delegate</param>
-        static internal IntPtr GetStubForPInvokeDelegate(Delegate del)
+        internal static IntPtr GetStubForPInvokeDelegate(Delegate del)
         {
             if (del == null)
                 return IntPtr.Zero;
@@ -1538,7 +1538,7 @@ namespace System.Runtime.InteropServices
         private static int s_numInteropThunksAllocatedSinceLastCleanup = 0;
 #endif
 
-        static private IntPtr GetOrAllocateThunk(Delegate del)
+        private static IntPtr GetOrAllocateThunk(Delegate del)
         {
 #if ENABLE_WINRT
             System.Collections.Generic.Internal.HashSet<EquatablePInvokeDelegateThunk> delegateHashSet = GetDelegateThunkHashSet();
@@ -1635,7 +1635,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Retrieve the corresponding P/invoke instance from the stub
         /// </summary>
-        static public Delegate GetPInvokeDelegateForStub(IntPtr pStub, RuntimeTypeHandle delegateType)
+        public static Delegate GetPInvokeDelegateForStub(IntPtr pStub, RuntimeTypeHandle delegateType)
         {
             if (pStub == IntPtr.Zero)
                 return null;
@@ -1693,7 +1693,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Retrieves the function pointer for the current open static delegate that is being called
         /// </summary>
-        static public IntPtr GetCurrentCalleeOpenStaticDelegateFunctionPointer()
+        public static IntPtr GetCurrentCalleeOpenStaticDelegateFunctionPointer()
         {
 #if RHTESTCL || CORECLR
             throw new NotSupportedException();
@@ -1721,7 +1721,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Retrieves the current delegate that is being called
         /// </summary>
-        static public T GetCurrentCalleeDelegate<T>() where T : class // constraint can't be System.Delegate
+        public static T GetCurrentCalleeDelegate<T>() where T : class // constraint can't be System.Delegate
         {
 #if RHTESTCL || CORECLR
             throw new NotSupportedException();

--- a/src/System.Private.Interop/src/Shared/McgModule.cs
+++ b/src/System.Private.Interop/src/Shared/McgModule.cs
@@ -1036,11 +1036,11 @@ namespace System.Runtime.InteropServices
             return (char)0;
         }
 
-        static public string ToHexStringUnsigned(uint u)
+        public static string ToHexStringUnsigned(uint u)
         {
             return ToHexStringUnsignedLong(u, true, 8);
         }
-        static public unsafe string ToHexStringUnsignedLong(ulong u, bool zeroPrepad, int numChars)
+        public static unsafe string ToHexStringUnsignedLong(ulong u, bool zeroPrepad, int numChars)
         {
             char[] chars = new char[numChars];
 
@@ -1062,7 +1062,7 @@ namespace System.Runtime.InteropServices
             }
             return str;
         }
-        static public unsafe string BasicToString(int num)
+        public static unsafe string BasicToString(int num)
         {
             char* pRevBuffer = stackalloc char[16];
             char* pFwdBuffer = stackalloc char[16];

--- a/src/System.Private.Interop/src/Shared/McgModuleManager.cs
+++ b/src/System.Private.Interop/src/Shared/McgModuleManager.cs
@@ -363,7 +363,7 @@ namespace System.Runtime.InteropServices
         internal class RuntimeTypeHandleComparer : IEqualityComparer<RuntimeTypeHandle>
         {
 
-            public readonly static RuntimeTypeHandleComparer Instance = new RuntimeTypeHandleComparer();
+            public static readonly RuntimeTypeHandleComparer Instance = new RuntimeTypeHandleComparer();
 
             bool IEqualityComparer<RuntimeTypeHandle>.Equals(RuntimeTypeHandle handle1, RuntimeTypeHandle handle2)
             {

--- a/src/System.Private.Interop/src/Shared/McgTypeHelpers.cs
+++ b/src/System.Private.Interop/src/Shared/McgTypeHelpers.cs
@@ -201,7 +201,7 @@ namespace System.Runtime.InteropServices
         }
 
 
-        internal unsafe static void TypeToTypeName(
+        internal static unsafe void TypeToTypeName(
             Type type,
             out HSTRING nativeTypeName,
             out int nativeTypeKind)
@@ -235,7 +235,7 @@ namespace System.Runtime.InteropServices
             }
         }
 #endif //!CORECLR
-        private unsafe static void TypeToTypeName(
+        private static unsafe void TypeToTypeName(
             RuntimeTypeHandle typeHandle,
             out string typeName,
             out TypeKind typeKind)
@@ -1165,7 +1165,7 @@ namespace System.Runtime.InteropServices
                     //
                     // The duplicates comes from duplicated interface declarations in the metadata across
                     // parent/child classes, as well as the "injected" override interfaces for protected
-                    // virtual methods (for example, if a derived class implements a IShapeInternal protected
+                    // virtual methods (for example, if a derived class implements a IShapeprotected internal
                     // method, it only implements a protected method and doesn't implement IShapeInternal
                     // directly, and we have to "inject" it in MCG
                     //

--- a/src/System.Private.Interop/src/Shared/RCWWalker.cs
+++ b/src/System.Private.Interop/src/Shared/RCWWalker.cs
@@ -569,7 +569,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Initialize RCWWalker
         /// </summary>
-        private unsafe static void Initialize(__com_IJupiterObject* pJupiterObject)
+        private static unsafe void Initialize(__com_IJupiterObject* pJupiterObject)
         {
             IntPtr pGCManager;
             int hr = CalliIntrinsics.StdCall<int>(pJupiterObject->pVtable->pfnGetJupiterGCManager, pJupiterObject, &pGCManager);

--- a/src/System.Private.Interop/src/Shared/StandardInterfaces.cs
+++ b/src/System.Private.Interop/src/Shared/StandardInterfaces.cs
@@ -1006,7 +1006,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        static private unsafe int GetWeakReference(
+        private static unsafe int GetWeakReference(
                                     IntPtr __IntPtr__pComThis,
                                     IntPtr __IntPtr__ppWeakReference)
         {
@@ -1070,7 +1070,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        static private unsafe int Resolve(
+        private static unsafe int Resolve(
                                     IntPtr __IntPtr__pComThis,
                                     IntPtr __IntPtr__piid,
                                     IntPtr __IntPtr__ppWeakReference)
@@ -1170,7 +1170,7 @@ namespace System.Runtime.InteropServices
         }
 
         [NativeCallable]
-        static private unsafe int ToString(
+        private static unsafe int ToString(
                                     IntPtr pComThis,
                                     IntPtr __IntPtr__pResult)
         {
@@ -1789,7 +1789,7 @@ namespace System.Runtime.InteropServices
         /// </remarks>
         /// <param name="lSize">Requested size</param>
         /// <returns>The IStream*</returns>
-        internal unsafe static IntPtr CreateMemStm(ulong lSize)
+        internal static unsafe IntPtr CreateMemStm(ulong lSize)
         {
 #if ENABLE_WINRT
             __com_IStream* pIStream = (__com_IStream*)ExternalInterop.CoTaskMemAlloc(new IntPtr(sizeof(__com_IStream)));
@@ -1805,7 +1805,7 @@ namespace System.Runtime.InteropServices
 #endif
         }
 
-        internal unsafe static void DestroyMemStm(__com_IStream* pIStream)
+        internal static unsafe void DestroyMemStm(__com_IStream* pIStream)
         {
             // Release memory allocated by CreateMemStm
             if (pIStream->m_pMem != null)

--- a/src/System.Private.Interop/src/Shared/__ComObject.cs
+++ b/src/System.Private.Interop/src/Shared/__ComObject.cs
@@ -2348,7 +2348,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Returns the default context cookie
         /// </summary>
-        static internal ContextCookie Default
+        internal static ContextCookie Default
         {
             get
             {
@@ -2392,7 +2392,7 @@ namespace System.Runtime.InteropServices
         /// NOTE: This does a P/Invoke so try to cache this whenever possible
         /// </summary>
         /// <returns>The current context cookie</returns>
-        static internal ContextCookie Current
+        internal static ContextCookie Current
         {
 
             [MethodImpl(MethodImplOptions.NoInlining)]
@@ -3136,7 +3136,7 @@ namespace System.Runtime.InteropServices
             /// </summary>
             static Lock s_contextEntryLock;
 
-            static internal void InitializeStatics()
+            internal static void InitializeStatics()
             {
                 s_contextEntryCache = new System.Collections.Generic.Internal.Dictionary<ContextCookie, ContextEntry>(new ContextCookieComparer());
 
@@ -3148,7 +3148,7 @@ namespace System.Runtime.InteropServices
         /// Retrieve current ContextEntry from cache
         /// </summary>
         /// <param name="currentCookie">Current context cookie. Passed in for better perf</param>
-        static internal ContextEntry GetCurrentContext(ContextCookie currentCookie)
+        internal static ContextEntry GetCurrentContext(ContextCookie currentCookie)
         {
             Debug.Assert(currentCookie.IsCurrent);
             return ContextEntryManager.GetContextEntry(currentCookie);
@@ -3541,7 +3541,7 @@ namespace System.Runtime.InteropServices
     /// </summary>
     internal class IStringableHelper
     {
-        internal unsafe static bool TryGetIStringableToString(object obj, out string toStringResult)
+        internal static unsafe bool TryGetIStringableToString(object obj, out string toStringResult)
         {
             bool isIStringableToString = false;
             toStringResult = String.Empty;
@@ -3894,7 +3894,7 @@ namespace System.Runtime.InteropServices
 
         private static volatile FactoryCache s_factoryCache;
 
-        static internal FactoryCache Get()
+        internal static FactoryCache Get()
         {
 #pragma warning disable 0420
             if (s_factoryCache == null)

--- a/src/System.Private.Interop/src/System/Reflection/DispatchProxy.cs
+++ b/src/System.Private.Interop/src/System/Reflection/DispatchProxy.cs
@@ -31,7 +31,7 @@ namespace System.Reflection
     ///
     ///   static class ChannelFactory<T>
     ///   {
-    ///       static public T CreateChannel()
+    ///       public static T CreateChannel()
     ///       {
     ///           return DispatchProxy.Create<T, WcfProxy>();
     ///       }

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
@@ -76,7 +76,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public unsafe static String PtrToStringAnsi(IntPtr ptr)
+        public static unsafe String PtrToStringAnsi(IntPtr ptr)
         {
             if (IntPtr.Zero == ptr)
             {
@@ -101,7 +101,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public unsafe static String PtrToStringAnsi(IntPtr ptr, int len)
+        public static unsafe String PtrToStringAnsi(IntPtr ptr, int len)
         {
             if (ptr == IntPtr.Zero)
                 throw new ArgumentNullException(nameof(ptr));
@@ -111,7 +111,7 @@ namespace System.Runtime.InteropServices
             return ConvertToUnicode(ptr, len);
         }
 
-        public unsafe static String PtrToStringUni(IntPtr ptr, int len)
+        public static unsafe String PtrToStringUni(IntPtr ptr, int len)
         {
             if (ptr == IntPtr.Zero)
                 throw new ArgumentNullException(nameof(ptr));
@@ -121,7 +121,7 @@ namespace System.Runtime.InteropServices
             return new String((char*)ptr, 0, len);
         }
 
-        public unsafe static String PtrToStringUni(IntPtr ptr)
+        public static unsafe String PtrToStringUni(IntPtr ptr)
         {
             if (IntPtr.Zero == ptr)
             {
@@ -666,12 +666,12 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public unsafe static IntPtr ReAllocHGlobal(IntPtr pv, IntPtr cb)
+        public static unsafe IntPtr ReAllocHGlobal(IntPtr pv, IntPtr cb)
         {
             return ExternalInterop.MemReAlloc(pv, cb);
         }
 
-        private unsafe static void ConvertToAnsi(string source, IntPtr pbNativeBuffer, int cbNativeBuffer)
+        private static unsafe void ConvertToAnsi(string source, IntPtr pbNativeBuffer, int cbNativeBuffer)
         {
             Debug.Assert(source != null);
             Debug.Assert(pbNativeBuffer != IntPtr.Zero);
@@ -685,7 +685,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        private unsafe static string ConvertToUnicode(IntPtr sourceBuffer, int cbSourceBuffer)
+        private static unsafe string ConvertToUnicode(IntPtr sourceBuffer, int cbSourceBuffer)
         {
             if (IsWin32Atom(sourceBuffer))
             {
@@ -766,7 +766,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         // String convertions.
         //====================================================================
-        public unsafe static IntPtr StringToHGlobalAnsi(String s)
+        public static unsafe IntPtr StringToHGlobalAnsi(String s)
         {
             if (s == null)
             {
@@ -786,7 +786,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public unsafe static IntPtr StringToHGlobalUni(String s)
+        public static unsafe IntPtr StringToHGlobalUni(String s)
         {
             if (s == null)
             {
@@ -856,7 +856,7 @@ namespace System.Runtime.InteropServices
             return pNewMem;
         }
 
-        public unsafe static IntPtr StringToCoTaskMemUni(String s)
+        public static unsafe IntPtr StringToCoTaskMemUni(String s)
         {
             if (s == null)
             {
@@ -887,7 +887,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public unsafe static IntPtr StringToCoTaskMemAnsi(String s)
+        public static unsafe IntPtr StringToCoTaskMemAnsi(String s)
         {
             if (s == null)
             {

--- a/src/System.Private.Interop/src/WinRT/ExceptionHelpers.cs
+++ b/src/System.Private.Interop/src/WinRT/ExceptionHelpers.cs
@@ -14,7 +14,7 @@ namespace System.Runtime.InteropServices
     /// <summary>
     /// This class has all the helpers which are needed to provide the Exception support for WinRT and ClassicCOM
     /// </summary>
-    public unsafe static partial class ExceptionHelpers
+    public static unsafe partial class ExceptionHelpers
     {
         /// <summary>
         ///  This class is a helper class to call into IRestrictedErrorInfo methods.

--- a/src/System.Private.Interop/src/WinRT/Interop.WinRT.cs
+++ b/src/System.Private.Interop/src/WinRT/Interop.WinRT.cs
@@ -28,7 +28,7 @@ partial class Interop
             return ret;
         }
 
-        static internal unsafe void RoGetActivationFactory(string className, ref Guid iid, out IntPtr ppv)
+        internal static unsafe void RoGetActivationFactory(string className, ref Guid iid, out IntPtr ppv)
         {
             fixed (char* unsafe_className = className)
             {
@@ -61,12 +61,12 @@ partial class Interop
         [DllImport(Interop.CORE_WINRT_STRING)]
         [McgGeneratedNativeCallCodeAttribute]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        static internal extern unsafe int WindowsCreateString(char* sourceString, uint length, void* hstring);
+        internal static extern unsafe int WindowsCreateString(char* sourceString, uint length, void* hstring);
 
         [DllImport(Interop.CORE_WINRT_STRING)]
         [McgGeneratedNativeCallCodeAttribute]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        static internal extern unsafe int WindowsCreateStringReference(
+        internal static extern unsafe int WindowsCreateStringReference(
             char* sourceString, uint length, HSTRING_HEADER* phstringHeader, void* hstring);
 
         [DllImport(Interop.CORE_WINRT_ERROR, PreserveSig = true)]
@@ -85,7 +85,7 @@ partial class Interop
 
         [DllImport(Interop.CORE_WINRT_ERROR1, PreserveSig = true)]
         [McgGeneratedNativeCallCodeAttribute]
-        static internal extern int RoOriginateLanguageException(int hr, HSTRING message, IntPtr pLanguageException);
+        internal static extern int RoOriginateLanguageException(int hr, HSTRING message, IntPtr pLanguageException);
 
         [DllImport(Interop.CORE_WINRT_ERROR1, PreserveSig = true)]
         [McgGeneratedNativeCallCodeAttribute]

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -18,7 +18,7 @@ namespace System.Reflection.Runtime.MethodInfos
 {
     internal abstract class RuntimeNamedMethodInfo : RuntimeMethodInfo
     {
-        internal protected abstract String ComputeToString(RuntimeMethodInfo contextMethod);
+        protected internal abstract String ComputeToString(RuntimeMethodInfo contextMethod);
         internal abstract MethodInvoker GetUncachedMethodInvoker(RuntimeTypeInfo[] methodArguments, MemberInfo exceptionPertainant);
     }
 
@@ -181,7 +181,7 @@ namespace System.Reflection.Runtime.MethodInfos
             return _common.GetHashCode();
         }
 
-        internal protected sealed override String ComputeToString(RuntimeMethodInfo contextMethod)
+        protected internal sealed override String ComputeToString(RuntimeMethodInfo contextMethod)
         {
             return RuntimeMethodHelpers.ComputeToString(ref _common, contextMethod, contextMethod.RuntimeGenericArgumentsOrParameters);
         }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -128,7 +128,7 @@ namespace Internal.Reflection.Execution
             return staticFieldAddress;
         }
 
-        private unsafe static NativeReader GetNativeReaderForBlob(IntPtr module, ReflectionMapBlob blob)
+        private static unsafe NativeReader GetNativeReaderForBlob(IntPtr module, ReflectionMapBlob blob)
         {
             NativeReader reader;
             if (TryGetNativeReaderForBlob(module, blob, out reader))
@@ -140,7 +140,7 @@ namespace Internal.Reflection.Execution
             return default(NativeReader);
         }
 
-        private unsafe static bool TryGetNativeReaderForBlob(IntPtr module, ReflectionMapBlob blob, out NativeReader reader)
+        private static unsafe bool TryGetNativeReaderForBlob(IntPtr module, ReflectionMapBlob blob, out NativeReader reader)
         {
             byte* pBlob;
             uint cbBlob;

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidatorSupport.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidatorSupport.cs
@@ -265,7 +265,7 @@ namespace Internal.Reflection.Execution
             return false;
         }
 
-        private unsafe static int NormalizedPrimitiveTypeSizeForIntegerTypes(this Type type)
+        private static unsafe int NormalizedPrimitiveTypeSizeForIntegerTypes(this Type type)
         {
             // Strip InstantiatedTypeInfo - IsEnum is not implemented on InstantiatedTypeInfo
             if (type is InstantiatedTypeInfo)

--- a/src/System.Private.Reflection.Metadata/tests/RoundTripTests.cs
+++ b/src/System.Private.Reflection.Metadata/tests/RoundTripTests.cs
@@ -135,7 +135,7 @@ namespace System.Private.Reflection.Metadata.Tests
         }
 
         [Fact]
-        public unsafe static void TestSimpleRoundTripping()
+        public static unsafe void TestSimpleRoundTripping()
         {
             var wr = new Writer.MetadataWriter();
             wr.ScopeDefinitions.Add(BuildSimpleTestData());
@@ -199,7 +199,7 @@ namespace System.Private.Reflection.Metadata.Tests
         }
 
         [Fact]
-        public unsafe static void TestCommonTailOptimization()
+        public static unsafe void TestCommonTailOptimization()
         {
             var wr = new Writer.MetadataWriter();
             wr.ScopeDefinitions.Add(BuildSimpleTestData());

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
@@ -99,7 +99,7 @@ namespace Internal.Runtime.TypeLoader
         internal static CallingConventionConverter_CommonCallingStub_PointerData s_commonStubData;
 
         [DllImport("*", ExactSpelling = true, EntryPoint = "CallingConventionConverter_GetStubs")]
-        private unsafe extern static void CallingConventionConverter_GetStubs(out IntPtr returnVoidStub,
+        private extern static unsafe void CallingConventionConverter_GetStubs(out IntPtr returnVoidStub,
                                                                       out IntPtr returnIntegerStub,
                                                                       out IntPtr commonStub
 #if CALLDESCR_FPARGREGSARERETURNREGS
@@ -111,7 +111,7 @@ namespace Internal.Runtime.TypeLoader
 
 #if _TARGET_ARM_
         [DllImport("*", ExactSpelling = true, EntryPoint = "CallingConventionConverter_SpecifyCommonStubData")]
-        private unsafe extern static void CallingConventionConverter_SpecifyCommonStubData(IntPtr commonStubData);
+        private extern static unsafe void CallingConventionConverter_SpecifyCommonStubData(IntPtr commonStubData);
 #endif
 
         static unsafe CallConverterThunk()
@@ -183,7 +183,7 @@ namespace Internal.Runtime.TypeLoader
         private const int ObjectArrayThunk = 7;
 
 
-        public unsafe static IntPtr MakeThunk(ThunkKind thunkKind,
+        public static unsafe IntPtr MakeThunk(ThunkKind thunkKind,
                                               IntPtr targetPointer,
                                               IntPtr instantiatingArg,
                                               bool hasThis, RuntimeTypeHandle[] parameters,
@@ -206,19 +206,19 @@ namespace Internal.Runtime.TypeLoader
             return FindExistingOrAllocateThunk(callConversionInfo);
         }
 
-        public unsafe static IntPtr MakeThunk(ThunkKind thunkKind, IntPtr targetPointer, RuntimeMethodSignature methodSignature, IntPtr instantiatingArg, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs)
+        public static unsafe IntPtr MakeThunk(ThunkKind thunkKind, IntPtr targetPointer, RuntimeMethodSignature methodSignature, IntPtr instantiatingArg, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs)
         {
             int callConversionInfo = CallConversionInfo.RegisterCallConversionInfo(thunkKind, targetPointer, methodSignature, instantiatingArg, typeArgs, methodArgs);
             return FindExistingOrAllocateThunk(callConversionInfo);
         }
 
-        internal unsafe static IntPtr MakeThunk(ThunkKind thunkKind, IntPtr targetPointer, IntPtr instantiatingArg, ArgIteratorData argIteratorData, bool[] paramsByRefForced)
+        internal static unsafe IntPtr MakeThunk(ThunkKind thunkKind, IntPtr targetPointer, IntPtr instantiatingArg, ArgIteratorData argIteratorData, bool[] paramsByRefForced)
         {
             int callConversionInfo = CallConversionInfo.RegisterCallConversionInfo(thunkKind, targetPointer, instantiatingArg, argIteratorData, paramsByRefForced);
             return FindExistingOrAllocateThunk(callConversionInfo);
         }
 
-        private unsafe static IntPtr FindExistingOrAllocateThunk(int callConversionInfo)
+        private static unsafe IntPtr FindExistingOrAllocateThunk(int callConversionInfo)
         {
             IntPtr thunk = IntPtr.Zero;
 
@@ -249,7 +249,7 @@ namespace Internal.Runtime.TypeLoader
             return thunk;
         }
 
-        public unsafe static IntPtr GetDelegateThunk(Delegate delegateObject, int thunkKind)
+        public static unsafe IntPtr GetDelegateThunk(Delegate delegateObject, int thunkKind)
         {
             if (thunkKind == ReversePinvokeThunk)
             {
@@ -306,7 +306,7 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        public unsafe static bool TryGetNonUnboxingFunctionPointerFromUnboxingAndInstantiatingStub(IntPtr potentialStub, RuntimeTypeHandle exactType, out IntPtr nonUnboxingMethod)
+        public static unsafe bool TryGetNonUnboxingFunctionPointerFromUnboxingAndInstantiatingStub(IntPtr potentialStub, RuntimeTypeHandle exactType, out IntPtr nonUnboxingMethod)
         {
             IntPtr callConversionId;
             IntPtr commonStubDataPtr;
@@ -1207,7 +1207,7 @@ namespace Internal.Runtime.TypeLoader
         }
 
 #if CALLINGCONVENTION_CALLEE_POPS
-        private unsafe static void SetupCallerPopArgument(byte* callerTransitionBlock, ArgIterator callerArgs)
+        private static unsafe void SetupCallerPopArgument(byte* callerTransitionBlock, ArgIterator callerArgs)
         {
             int argStackPopSize = callerArgs.CbStackPop();
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallInterceptor.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallInterceptor.cs
@@ -153,7 +153,7 @@ namespace Internal.Runtime.CallInterceptor
         }
 
         private unsafe delegate void SetupArbitraryLocalVariableSet_InnerDel<T>(IntPtr* localData, ref T context, ref SetupLocalVariableSetInfo<T> localVarSetInfo);
-        private unsafe static void SetupArbitraryLocalVariableSet_Inner<T>(IntPtr* localData, ref T context, ref SetupLocalVariableSetInfo<T> localVarSetInfo)
+        private static unsafe void SetupArbitraryLocalVariableSet_Inner<T>(IntPtr* localData, ref T context, ref SetupLocalVariableSetInfo<T> localVarSetInfo)
         {
             LocalVariableSet localVars = new LocalVariableSet(localData, localVarSetInfo.Types);
             DefaultInitializeLocalVariableSet(ref localVars);
@@ -182,7 +182,7 @@ namespace Internal.Runtime.CallInterceptor
         /// ComputeNecessaryMemoryForStackLocalVariableSet specifies. Used as part of pattern for manual construction
         /// of LocalVariableSet
         /// </summary>
-        public unsafe static void DefaultInitializeLocalVariableSet(ref LocalVariableSet localSet)
+        public static unsafe void DefaultInitializeLocalVariableSet(ref LocalVariableSet localSet)
         {
             int localRegionOffset = IntPtr.Size * localSet._types.Length;
             byte* baseAddress = (byte*)localSet._pbMemory;
@@ -728,7 +728,7 @@ namespace Internal.Runtime.CallInterceptor
         }
 
         private unsafe delegate void SetupBlockDelegate(void* pBuffer, ref CallConversionInterpreterLocals locals);
-        private unsafe static void SetupLocalsBlock1(void* pBuffer, ref CallConversionInterpreterLocals locals)
+        private static unsafe void SetupLocalsBlock1(void* pBuffer, ref CallConversionInterpreterLocals locals)
         {
 #if CCCONVERTER_TRACE
             CallingConventionConverterLogger.WriteLine("     -> Setup Locals Block 1 @ " + new IntPtr(pBuffer).LowLevelToString());
@@ -738,7 +738,7 @@ namespace Internal.Runtime.CallInterceptor
             Interpret(ref locals);
         }
 
-        private unsafe static void SetupLocalsBlock2(void* pBuffer, ref CallConversionInterpreterLocals locals)
+        private static unsafe void SetupLocalsBlock2(void* pBuffer, ref CallConversionInterpreterLocals locals)
         {
 #if CCCONVERTER_TRACE
             CallingConventionConverterLogger.WriteLine("     -> Setup Locals Block 2 @ " + new IntPtr(pBuffer).LowLevelToString());
@@ -748,7 +748,7 @@ namespace Internal.Runtime.CallInterceptor
             Interpret(ref locals);
         }
 
-        private unsafe static void SetupTransitionBlock(void* pBuffer, ref CallConversionInterpreterLocals locals)
+        private static unsafe void SetupTransitionBlock(void* pBuffer, ref CallConversionInterpreterLocals locals)
         {
 #if CCCONVERTER_TRACE
             CallingConventionConverterLogger.WriteLine("     -> Setup Transition Block @ " + new IntPtr(pBuffer).LowLevelToString());
@@ -758,7 +758,7 @@ namespace Internal.Runtime.CallInterceptor
             Interpret(ref locals);
         }
 
-        public unsafe static void Interpret(ref CallConversionInterpreterLocals locals)
+        public static unsafe void Interpret(ref CallConversionInterpreterLocals locals)
         {
             while (locals.Index < locals.Opcodes.Length)
             {
@@ -1175,7 +1175,7 @@ namespace Internal.Runtime.CallInterceptor
         /// <summary>
         /// Make a dynamic call to a function pointer passing arguments from arguments, using the signature described in callSignature
         /// </summary>
-        public unsafe static void MakeDynamicCall(IntPtr address, DynamicCallSignature callSignature, LocalVariableSet arguments)
+        public static unsafe void MakeDynamicCall(IntPtr address, DynamicCallSignature callSignature, LocalVariableSet arguments)
         {
 #if CCCONVERTER_TRACE
             CallingConventionConverterLogger.WriteLine("MakeDynamicCall executing... ");
@@ -1358,7 +1358,7 @@ namespace Internal.Runtime.CallInterceptor
             return callConversionOps.ToArray();
         }
 
-        private unsafe static IntPtr CallInterceptorThunk(IntPtr callerTransitionBlockParam, IntPtr thunkId)
+        private static unsafe IntPtr CallInterceptorThunk(IntPtr callerTransitionBlockParam, IntPtr thunkId)
         {
 #if CCCONVERTER_TRACE
             CallingConventionConverterLogger.WriteLine("CallInterceptorThunk executing... ID = " + thunkId.LowLevelToString());

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ConstrainedCallSupport.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ConstrainedCallSupport.cs
@@ -37,7 +37,7 @@ namespace Internal.Runtime.TypeLoader
         private delegate IntPtr RuntimeCacheFuncSignatureDel(IntPtr context, IntPtr callDescIntPtr, object contextObject, out IntPtr auxResult);
 
         [DllImport("*", ExactSpelling = true, EntryPoint = "ConstrainedCallSupport_GetStubs")]
-        private unsafe extern static void ConstrainedCallSupport_GetStubs(out IntPtr constrainedCallSupport_DerefThisAndCall_CommonCallingStub, out IntPtr constrainedCallSupport_DirectConstrainedCall_CommonCallingStub);
+        private extern static unsafe void ConstrainedCallSupport_GetStubs(out IntPtr constrainedCallSupport_DerefThisAndCall_CommonCallingStub, out IntPtr constrainedCallSupport_DirectConstrainedCall_CommonCallingStub);
 
         private static IntPtr s_constrainedCallSupport_DerefThisAndCall_CommonCallingStub;
         private static IntPtr s_constrainedCallSupport_DirectConstrainedCall_CommonCallingStub;
@@ -224,16 +224,16 @@ namespace Internal.Runtime.TypeLoader
             }
 
 #if ARM
-            private unsafe static IntPtr ResolveCallOnReferenceType(IntPtr unused1, ref object thisPtr, IntPtr callDescIntPtr)
+            private static unsafe IntPtr ResolveCallOnReferenceType(IntPtr unused1, ref object thisPtr, IntPtr callDescIntPtr)
 #else
-            private unsafe static IntPtr ResolveCallOnReferenceType(ref object thisPtr, IntPtr callDescIntPtr)
+            private static unsafe IntPtr ResolveCallOnReferenceType(ref object thisPtr, IntPtr callDescIntPtr)
 #endif
             {
                 IntPtr ignoredAuxResult;
                 return RuntimeAugments.RuntimeCacheLookup(thisPtr.GetType().TypeHandle.ToIntPtr(), callDescIntPtr, s_resolveCallOnReferenceTypeCacheMissFunc, thisPtr, out ignoredAuxResult);
             }
 
-            private unsafe static IntPtr ResolveCallOnReferenceTypeCacheMiss(IntPtr context, IntPtr callDescIntPtr, object contextObject, out IntPtr auxResult)
+            private static unsafe IntPtr ResolveCallOnReferenceTypeCacheMiss(IntPtr context, IntPtr callDescIntPtr, object contextObject, out IntPtr auxResult)
             {
                 auxResult = IntPtr.Zero;
                 NonGenericConstrainedCallDesc* callDesc = (NonGenericConstrainedCallDesc*)callDescIntPtr;
@@ -284,9 +284,9 @@ namespace Internal.Runtime.TypeLoader
             }
 
 #if ARM
-            private unsafe static IntPtr ResolveCallOnValueType(IntPtr unused1, IntPtr unused2, IntPtr callDescIntPtr)
+            private static unsafe IntPtr ResolveCallOnValueType(IntPtr unused1, IntPtr unused2, IntPtr callDescIntPtr)
 #else
-            private unsafe static IntPtr ResolveCallOnValueType(IntPtr unused, IntPtr callDescIntPtr)
+            private static unsafe IntPtr ResolveCallOnValueType(IntPtr unused, IntPtr callDescIntPtr)
 #endif
             {
                 NonGenericConstrainedCallDesc* callDesc = (NonGenericConstrainedCallDesc*)callDescIntPtr;
@@ -491,16 +491,16 @@ namespace Internal.Runtime.TypeLoader
             }
 
 #if ARM
-            private unsafe static IntPtr ResolveCallOnReferenceType(IntPtr unused1, ref object thisPtr, IntPtr callDescIntPtr)
+            private static unsafe IntPtr ResolveCallOnReferenceType(IntPtr unused1, ref object thisPtr, IntPtr callDescIntPtr)
 #else
-            private unsafe static IntPtr ResolveCallOnReferenceType(ref object thisPtr, IntPtr callDescIntPtr)
+            private static unsafe IntPtr ResolveCallOnReferenceType(ref object thisPtr, IntPtr callDescIntPtr)
 #endif
             {
                 IntPtr ignoredAuxResult;
                 return RuntimeAugments.RuntimeCacheLookup(thisPtr.GetType().TypeHandle.ToIntPtr(), callDescIntPtr, s_resolveCallOnReferenceTypeCacheMissFunc, thisPtr, out ignoredAuxResult);
             }
 
-            private unsafe static IntPtr ResolveCallOnReferenceTypeCacheMiss(IntPtr context, IntPtr callDescIntPtr, object contextObject, out IntPtr auxResult)
+            private static unsafe IntPtr ResolveCallOnReferenceTypeCacheMiss(IntPtr context, IntPtr callDescIntPtr, object contextObject, out IntPtr auxResult)
             {
                 auxResult = IntPtr.Zero;
 
@@ -522,9 +522,9 @@ namespace Internal.Runtime.TypeLoader
             }
 
 #if ARM
-            private unsafe static IntPtr ResolveCallOnValueType(IntPtr unused1, IntPtr unused2, IntPtr callDescIntPtr)
+            private static unsafe IntPtr ResolveCallOnValueType(IntPtr unused1, IntPtr unused2, IntPtr callDescIntPtr)
 #else
-            private unsafe static IntPtr ResolveCallOnValueType(IntPtr unused, IntPtr callDescIntPtr)
+            private static unsafe IntPtr ResolveCallOnValueType(IntPtr unused, IntPtr callDescIntPtr)
 #endif
             {
                 GenericConstrainedCallDesc* callDesc = (GenericConstrainedCallDesc*)callDescIntPtr;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EEType.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EEType.Runtime.cs
@@ -13,7 +13,7 @@ namespace Internal.Runtime
     // Supplies type loader specific extentions to EEType
     internal partial struct EEType
     {
-        private unsafe static EEType* GetArrayEEType()
+        private static unsafe EEType* GetArrayEEType()
         {
             return typeof(Array).TypeHandle.ToEETypePtr();
         }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -738,7 +738,7 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private unsafe static int GetInstanceGCDescSize(TypeBuilderState state, EEType* pTemplateEEType, bool isValueType, bool isArray)
+        private static unsafe int GetInstanceGCDescSize(TypeBuilderState state, EEType* pTemplateEEType, bool isValueType, bool isArray)
         {
             var gcBitfield = state.InstanceGCLayout;
             if (isArray)

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LazyVtableResolverThunk.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LazyVtableResolverThunk.cs
@@ -25,13 +25,13 @@ namespace Internal.Runtime.TypeLoader
         private static volatile IntPtr[] s_thunks = InitialThunks();
 
         [DllImport("*", ExactSpelling = true, EntryPoint = "VTableResolver_Init")]
-        private unsafe extern static int VTableResolver_Init(out IntPtr firstResolverThunk,
+        private extern static unsafe int VTableResolver_Init(out IntPtr firstResolverThunk,
                                                      IntPtr vtableResolveCallback,
                                                      IntPtr universalTransition,
                                                      out int pregeneratedThunkCount);
 
         [DllImport("*", ExactSpelling = true, EntryPoint = "VTableResolver_GetCommonCallingStub")]
-        private unsafe extern static IntPtr VTableResolver_GetCommonCallingStub();
+        private extern static unsafe IntPtr VTableResolver_GetCommonCallingStub();
 
         /// <summary>
         /// Build initial array of vtable thunks. These thunks are the ones directly embedded in 
@@ -316,7 +316,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="functionPointer">If there is no corresponding method defined in metadata, this is
         /// the function pointer that should be used for calls to this vtable slot</param>
         /// <returns>MethodDesc of function that defined the slot if possible.</returns>
-        private unsafe static MethodDesc ResolveVTableSlotIndexToMethodDescOrFunctionPointer(DefType type, int vtableSlotIndex, out IntPtr functionPointer)
+        private static unsafe MethodDesc ResolveVTableSlotIndexToMethodDescOrFunctionPointer(DefType type, int vtableSlotIndex, out IntPtr functionPointer)
         {
             Debug.Assert(type.RetrieveRuntimeTypeHandleIfPossible());
             Debug.Assert(type.RuntimeTypeHandle.ToEETypePtr()->NumVtableSlots > vtableSlotIndex);
@@ -778,7 +778,7 @@ namespace Internal.Runtime.TypeLoader
         /// Based on the structure of our code, these functions are always Instance, non-generic methods
         /// and therefore, we don't need to be concerned about an extra generic dictionary parameter
         /// </summary>
-        static private bool TryGetVTableCallableAddress(MethodDesc method, out IntPtr result)
+        private static bool TryGetVTableCallableAddress(MethodDesc method, out IntPtr result)
         {
             TypeLoaderEnvironment.MethodAddressType dummy;
             IntPtr methodAddressNonUnboxing;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -77,7 +77,7 @@ namespace Internal.Runtime.TypeLoader
         /// The StaticClassConstructionContext for a type is encoded in the negative space
         /// of the NonGCStatic fields of a type.
         /// </summary>
-        public unsafe static readonly int ClassConstructorOffset = -sizeof(System.Runtime.CompilerServices.StaticClassConstructionContext);
+        public static unsafe readonly int ClassConstructorOffset = -sizeof(System.Runtime.CompilerServices.StaticClassConstructionContext);
 
         private LowLevelList<TypeDesc> _typesThatNeedTypeHandles = new LowLevelList<TypeDesc>();
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.FieldAccess.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.FieldAccess.cs
@@ -298,7 +298,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="fieldAccessKind">type of static base to find</param>
         /// <param name="staticsRegionAddress">Output - statics region address info</param>
         /// <returns>true when found, false otherwise</returns>
-        private unsafe static bool TryGetStaticFieldBaseFromFieldAccessMap(
+        private static unsafe bool TryGetStaticFieldBaseFromFieldAccessMap(
             RuntimeTypeHandle declaringTypeHandle,
             FieldAccessStaticDataKind fieldAccessKind,
             out IntPtr staticsRegionAddress)

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
@@ -340,7 +340,7 @@ namespace Internal.Runtime.TypeLoader
         }
 #endif
 
-        public unsafe static bool IsPregeneratedOrTemplateRuntimeTypeHandle(RuntimeTypeHandle rtth)
+        public static unsafe bool IsPregeneratedOrTemplateRuntimeTypeHandle(RuntimeTypeHandle rtth)
         {
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
             if (!rtth.IsDynamicType())

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
@@ -76,7 +76,7 @@ namespace Internal.Runtime.TypeLoader
             return true;
         }
 
-        private unsafe static string GetStringFromMemoryInNativeFormat(IntPtr pointerToDataStream)
+        private static unsafe string GetStringFromMemoryInNativeFormat(IntPtr pointerToDataStream)
         {
             byte* dataStream = (byte*)pointerToDataStream.ToPointer();
             uint stringLen = NativePrimitiveDecoder.DecodeUnsigned(ref dataStream);

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
@@ -144,7 +144,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="module">Address of module to search for the blob</param>
         /// <param name="blob">Blob ID within blob map for the module</param>
         /// <returns>Native reader for the blob (asserts and returns an empty native reader when not found)</returns>
-        internal unsafe static NativeReader GetNativeReaderForBlob(IntPtr module, ReflectionMapBlob blob)
+        internal static unsafe NativeReader GetNativeReaderForBlob(IntPtr module, ReflectionMapBlob blob)
         {
             NativeReader reader;
             if (TryGetNativeReaderForBlob(module, blob, out reader))
@@ -168,7 +168,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="runtimeTypeHandle">EEType of the type in question</param>
         /// <param name="metadataReader">Metadata reader for the type</param>
         /// <param name="typeRefHandle">Located TypeRef handle</param>
-        public unsafe static bool TryGetTypeReferenceForNamedType(RuntimeTypeHandle runtimeTypeHandle, out MetadataReader metadataReader, out TypeReferenceHandle typeRefHandle)
+        public static unsafe bool TryGetTypeReferenceForNamedType(RuntimeTypeHandle runtimeTypeHandle, out MetadataReader metadataReader, out TypeReferenceHandle typeRefHandle)
         {
             int hashCode = runtimeTypeHandle.GetHashCode();
 
@@ -228,7 +228,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="metadataReader">Metadata reader for module containing the type reference</param>
         /// <param name="typeRefHandle">TypeRef handle to look up</param>
         /// <param name="runtimeTypeHandle">Resolved EEType for the type reference</param>
-        public unsafe static bool TryGetNamedTypeForTypeReference(MetadataReader metadataReader, TypeReferenceHandle typeRefHandle, out RuntimeTypeHandle runtimeTypeHandle, bool searchAllModules = false)
+        public static unsafe bool TryGetNamedTypeForTypeReference(MetadataReader metadataReader, TypeReferenceHandle typeRefHandle, out RuntimeTypeHandle runtimeTypeHandle, bool searchAllModules = false)
         {
             int hashCode = typeRefHandle.ComputeHashCode(metadataReader);
             IntPtr typeRefModuleHandle = ModuleList.Instance.GetModuleForMetadataReader(metadataReader);
@@ -250,7 +250,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="metadataReader">Metadata reader for module containing the type reference</param>
         /// <param name="typeRefHandle">TypeRef handle to look up</param>
         /// <param name="runtimeTypeHandle">Resolved EEType for the type reference</param>
-        public unsafe static bool TryResolveNamedTypeForTypeReference(MetadataReader metadataReader, TypeReferenceHandle typeRefHandle, out RuntimeTypeHandle runtimeTypeHandle)
+        public static unsafe bool TryResolveNamedTypeForTypeReference(MetadataReader metadataReader, TypeReferenceHandle typeRefHandle, out RuntimeTypeHandle runtimeTypeHandle)
         {
             int hashCode = typeRefHandle.ComputeHashCode(metadataReader);
             IntPtr typeRefModuleHandle = ModuleList.Instance.GetModuleForMetadataReader(metadataReader);
@@ -265,7 +265,7 @@ namespace Internal.Runtime.TypeLoader
             return false;
         }
 
-        private unsafe static bool TryGetNamedTypeForTypeReference_Inner(MetadataReader metadataReader,
+        private static unsafe bool TryGetNamedTypeForTypeReference_Inner(MetadataReader metadataReader,
             IntPtr typeRefModuleHandle,
             TypeReferenceHandle typeRefHandle,
             int hashCode,
@@ -336,7 +336,7 @@ namespace Internal.Runtime.TypeLoader
         /// </summary>
         /// <param name="elementTypeHandle">EEType of the array element type</param>
         /// <param name="arrayTypeHandle">Resolved EEType of the array type</param>
-        public unsafe static bool TryGetArrayTypeForNonDynamicElementType(RuntimeTypeHandle elementTypeHandle, out RuntimeTypeHandle arrayTypeHandle)
+        public static unsafe bool TryGetArrayTypeForNonDynamicElementType(RuntimeTypeHandle elementTypeHandle, out RuntimeTypeHandle arrayTypeHandle)
         {
             arrayTypeHandle = new RuntimeTypeHandle();
 
@@ -459,7 +459,7 @@ namespace Internal.Runtime.TypeLoader
         /// Locate the static constructor context given the runtime type handle (EEType) for the type in question.
         /// </summary>
         /// <param name="typeHandle">EEtype of the type to look up</param>
-        public unsafe static IntPtr TryGetStaticClassConstructionContext(RuntimeTypeHandle typeHandle)
+        public static unsafe IntPtr TryGetStaticClassConstructionContext(RuntimeTypeHandle typeHandle)
         {
             if (RuntimeAugments.HasCctor(typeHandle))
             {
@@ -522,7 +522,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="blob">Blob ID to fetch from the module</param>
         /// <param name="reader">Native reader created for the module blob</param>
         /// <returns>true when the blob was found in the module, false when not</returns>
-        private unsafe static bool TryGetNativeReaderForBlob(IntPtr module, ReflectionMapBlob blob, out NativeReader reader)
+        private static unsafe bool TryGetNativeReaderForBlob(IntPtr module, ReflectionMapBlob blob, out NativeReader reader)
         {
             byte* pBlob;
             uint cbBlob;
@@ -754,7 +754,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="vtableSlot">vtable slot index</param>
         /// <param name="methodNameAndSig">output name/sig of method</param>
         /// <returns></returns>
-        public unsafe static bool TryGetMethodMethodNameAndSigFromVTableSlotForPregeneratedOrTemplateType(TypeSystemContext context, RuntimeTypeHandle type, int vtableSlot, out MethodNameAndSignature methodNameAndSig)
+        public static unsafe bool TryGetMethodMethodNameAndSigFromVTableSlotForPregeneratedOrTemplateType(TypeSystemContext context, RuntimeTypeHandle type, int vtableSlot, out MethodNameAndSignature methodNameAndSig)
         {
             int logicalSlot = vtableSlot;
             EEType* ptrType = type.ToEETypePtr();
@@ -967,7 +967,7 @@ namespace Internal.Runtime.TypeLoader
         /// VTable slots reserved for dictionary pointers are ignored.</param>
         /// <param name="methodNameAndSig">The name and signature of the method</param>
         /// <returns>true if a definition is found, false if not</returns>
-        public unsafe static bool TryGetMethodNameAndSigFromVirtualResolveData(IntPtr moduleHandle,
+        public static unsafe bool TryGetMethodNameAndSigFromVirtualResolveData(IntPtr moduleHandle,
             RuntimeTypeHandle definitionType, int logicalSlot, out MethodNameAndSignature methodNameAndSig)
         {
             EEType* definitionEEType = definitionType.ToEETypePtr();

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.NamedTypeLookup.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.NamedTypeLookup.cs
@@ -37,7 +37,7 @@ namespace Internal.Runtime.TypeLoader
 
         private NamedTypeRuntimeTypeHandleToMetadataHashtable _runtimeTypeHandleToMetadataHashtable = new NamedTypeRuntimeTypeHandleToMetadataHashtable();
 
-        public readonly static IntPtr NoStaticsData = (IntPtr)1;
+        public static readonly IntPtr NoStaticsData = (IntPtr)1;
 
         private class NamedTypeRuntimeTypeHandleToMetadataHashtable : LockFreeReaderHashtable<RuntimeTypeHandle, NamedTypeLookupResult>
         {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
@@ -240,7 +240,7 @@ namespace Internal.Runtime.TypeLoader
         }
 
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
-        static private bool GetCallingConverterDataFromMethodSignature_MethodSignature(TypeSystem.MethodSignature methodSignature, NativeLayoutInfoLoadContext nativeLayoutContext, out bool hasThis, out TypeDesc[] parameters, out bool[] parametersWithGenericDependentLayout)
+        private static bool GetCallingConverterDataFromMethodSignature_MethodSignature(TypeSystem.MethodSignature methodSignature, NativeLayoutInfoLoadContext nativeLayoutContext, out bool hasThis, out TypeDesc[] parameters, out bool[] parametersWithGenericDependentLayout)
         {
             // Compute parameters dependent on generic instantiation for their layout
             parametersWithGenericDependentLayout = new bool[methodSignature.Length + 1];
@@ -298,7 +298,7 @@ namespace Internal.Runtime.TypeLoader
         /// StructNotDependentOnArgsForSize<GenStructDependencyOnArgsForSize<T>> -> true
         /// StructNotDependentOnArgsForSize<GenStructDependencyOnArgsForSize<List<T>>>> -> false
         /// </summary>
-        static private bool TypeHasLayoutDependentOnGenericInstantiation(TypeDesc type, HasVarsInvestigationLevel investigationLevel)
+        private static bool TypeHasLayoutDependentOnGenericInstantiation(TypeDesc type, HasVarsInvestigationLevel investigationLevel)
         {
             if (type is SignatureVariable)
             {
@@ -377,7 +377,7 @@ namespace Internal.Runtime.TypeLoader
             return false;
         }
 
-        static public bool MethodSignatureHasVarsNeedingCallingConventionConverter_MethodSignature(TypeSystem.MethodSignature methodSignature)
+        public static bool MethodSignatureHasVarsNeedingCallingConventionConverter_MethodSignature(TypeSystem.MethodSignature methodSignature)
         {
             if (TypeHasLayoutDependentOnGenericInstantiation(methodSignature.ReturnType, HasVarsInvestigationLevel.Parameter))
                 return true;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -481,7 +481,7 @@ namespace Internal.Runtime.TypeLoader
             return externalReferencesLookup.InitializeNativeReferences(moduleHandle);
         }
 
-        public unsafe static void GetFieldAlignmentAndSize(RuntimeTypeHandle fieldType, out int alignment, out int size)
+        public static unsafe void GetFieldAlignmentAndSize(RuntimeTypeHandle fieldType, out int alignment, out int size)
         {
             EEType* typePtr = fieldType.ToEETypePtr();
             if (typePtr->IsValueType)
@@ -503,7 +503,7 @@ namespace Internal.Runtime.TypeLoader
             public uint MethodRva;
         }
 
-        public unsafe static bool TryGetTargetOfUnboxingAndInstantiatingStub(IntPtr maybeInstantiatingAndUnboxingStub, out IntPtr targetMethod)
+        public static unsafe bool TryGetTargetOfUnboxingAndInstantiatingStub(IntPtr maybeInstantiatingAndUnboxingStub, out IntPtr targetMethod)
         {
             targetMethod = IntPtr.Zero;
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
@@ -21,7 +21,7 @@ namespace Internal.Runtime.TypeLoader
 
         private static Lock s_lock = new Lock();
 
-        static public TypeSystemContext Create()
+        public static TypeSystemContext Create()
         {
             using (LockHolder.Hold(s_lock))
             {
@@ -47,7 +47,7 @@ namespace Internal.Runtime.TypeLoader
             TargetOS.Windows));
         }
 
-        static public void Recycle(TypeSystemContext context)
+        public static void Recycle(TypeSystemContext context)
         {
             // Only cache a reasonably small context that is still in Gen0
             if (context.LoadFactor > 200 || GC.GetGeneration(context) > 0)

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemExtensions.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemExtensions.cs
@@ -34,7 +34,7 @@ namespace Internal.Runtime.TypeLoader
             return typeAsDefType != null && typeAsDefType.HasInstantiation;
         }
 
-        static public DefType GetClosestDefType(this TypeDesc type)
+        public static DefType GetClosestDefType(this TypeDesc type)
         {
             if (type is DefType)
                 return (DefType)type;
@@ -58,13 +58,13 @@ namespace Internal.Runtime.TypeLoader
             return RuntimeAugments.GetRuntimeTypeHandleRawValue(rtth) == IntPtr.Zero;
         }
 
-        public unsafe static bool IsDynamic(this RuntimeFieldHandle rtfh)
+        public static unsafe bool IsDynamic(this RuntimeFieldHandle rtfh)
         {
             IntPtr rtfhValue = *(IntPtr*)&rtfh;
             return (rtfhValue.ToInt64() & 0x1) == 0x1;
         }
 
-        public unsafe static bool IsDynamic(this RuntimeMethodHandle rtfh)
+        public static unsafe bool IsDynamic(this RuntimeMethodHandle rtfh)
         {
             IntPtr rtfhValue = *(IntPtr*)&rtfh;
             return (rtfhValue.ToInt64() & 0x1) == 0x1;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/genericdictionarycell.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/genericdictionarycell.cs
@@ -954,7 +954,7 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        internal unsafe static GenericDictionaryCell[] BuildDictionary(TypeBuilder typeBuilder, NativeLayoutInfoLoadContext nativeLayoutInfoLoadContext, NativeParser parser)
+        internal static unsafe GenericDictionaryCell[] BuildDictionary(TypeBuilder typeBuilder, NativeLayoutInfoLoadContext nativeLayoutInfoLoadContext, NativeParser parser)
         {
             uint parserStartOffset = parser.Offset;
 
@@ -980,7 +980,7 @@ namespace Internal.Runtime.TypeLoader
         /// Build an array of GenericDictionaryCell from a NativeParser stream that has the appropriate metadata
         /// Return null if there are no cells to describe
         /// </summary>
-        internal unsafe static GenericDictionaryCell[] BuildDictionaryFromMetadataTokensAndContext(TypeBuilder typeBuilder, NativeParser parser, NativeFormatMetadataUnit nativeMetadataUnit, FixupCellMetadataResolver resolver)
+        internal static unsafe GenericDictionaryCell[] BuildDictionaryFromMetadataTokensAndContext(TypeBuilder typeBuilder, NativeParser parser, NativeFormatMetadataUnit nativeMetadataUnit, FixupCellMetadataResolver resolver)
         {
             uint parserStartOffset = parser.Offset;
 

--- a/src/Test.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/Test.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -11,13 +11,13 @@ namespace System.Runtime.CompilerServices
     [McgIntrinsics]
     internal static class ClassConstructorRunner
     {
-        private unsafe static object CheckStaticClassConstructionReturnGCStaticBase(ref StaticClassConstructionContext context, object gcStaticBase)
+        private static unsafe object CheckStaticClassConstructionReturnGCStaticBase(ref StaticClassConstructionContext context, object gcStaticBase)
         {
             CheckStaticClassConstruction(ref context);
             return gcStaticBase;
         }
 
-        private unsafe static IntPtr CheckStaticClassConstructionReturnNonGCStaticBase(ref StaticClassConstructionContext context, IntPtr nonGcStaticBase)
+        private static unsafe IntPtr CheckStaticClassConstructionReturnNonGCStaticBase(ref StaticClassConstructionContext context, IntPtr nonGcStaticBase)
         {
             CheckStaticClassConstruction(ref context);
             return nonGcStaticBase;


### PR DESCRIPTION
- s/readonly static/static readonly/
- s/static internal/internal static/
- s/static private/private static/
- s/static public/public static/
- s/static protected/protected static/
- s/unsafe static/static unsafe/
- s/unsafe extern/extern unsafe/
- s/internal protected/protected internal/