### PR TITLE
Refactor PInvokeILEmitter for external configuration

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -17,8 +17,11 @@ namespace Internal.IL
 {
     internal sealed class ILProvider : LockFreeReaderHashtable<MethodDesc, ILProvider.MethodILData>
     {
-        public ILProvider()
+        private PInvokeILProvider _pinvokeILProvider;
+
+        public ILProvider(PInvokeILProvider pinvokeILProvider)
         {
+            _pinvokeILProvider = pinvokeILProvider;
         }
 
         private MethodIL TryGetRuntimeImplementedMethodIL(MethodDesc method)
@@ -106,7 +109,7 @@ namespace Internal.IL
                 {
                     var pregenerated = McgInteropSupport.TryGetPregeneratedPInvoke(method);
                     if (pregenerated == null)
-                        return PInvokeILEmitter.EmitIL(method);
+                        return _pinvokeILProvider.EmitIL(method);
                     method = pregenerated;
                 }
 

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -30,6 +30,7 @@ namespace ILCompiler
         internal NodeFactory NodeFactory => _nodeFactory;
         internal CompilerTypeSystemContext TypeSystemContext => NodeFactory.TypeSystemContext;
         internal Logger Logger => _logger;
+        internal PInvokeILProvider PInvokeILProvider { get; }
 
         private readonly TypeGetTypeMethodThunkCache _typeGetTypeMethodThunks;
 
@@ -56,15 +57,18 @@ namespace ILCompiler
                 rootProvider.AddCompilationRoots(rootingService);
 
             _typeGetTypeMethodThunks = new TypeGetTypeMethodThunkCache(nodeFactory.CompilationModuleGroup.GeneratedAssembly.GetGlobalModuleType());
+
+            PInvokeILProvider = new PInvokeILProvider(new PInvokeILEmitterConfiguration(!nodeFactory.CompilationModuleGroup.IsSingleFileCompilation));
+            _methodILCache = new ILProvider(PInvokeILProvider);
         }
 
-        private ILProvider _methodILCache = new ILProvider();
-
+        private ILProvider _methodILCache;
+        
         internal MethodIL GetMethodIL(MethodDesc method)
         {
             // Flush the cache when it grows too big
             if (_methodILCache.Count > 1000)
-                _methodILCache = new ILProvider();
+                _methodILCache = new ILProvider(PInvokeILProvider);
 
             return _methodILCache.GetMethodIL(method);
         }

--- a/src/ILCompiler.Compiler/src/IL/PInvokeILEmitterConfiguration.cs
+++ b/src/ILCompiler.Compiler/src/IL/PInvokeILEmitterConfiguration.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Internal.IL
+{
+    public class PInvokeILEmitterConfiguration
+    {
+        private int _nativeMethodIdCounter = 0;
+        public bool ForceLazyResolution { get; private set; }
+
+        public PInvokeILEmitterConfiguration(bool forceLazyResolution)
+        {
+            ForceLazyResolution = forceLazyResolution;
+        }
+
+        /// <summary>
+        /// Provides a unique numeric identifier to disambiguate PInvoke method names where there
+        /// might otherwise be a naming conflict 
+        /// </summary>
+        public int GetNextNativeMethodId()
+        {
+            return System.Threading.Interlocked.Increment(ref _nativeMethodIdCounter);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/IL/Stubs/PInvokeILProvider.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/PInvokeILProvider.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+
+using Internal.IL.Stubs;
+
+namespace Internal.IL
+{
+    /// <summary>
+    /// Wraps the API and configuration for a particular PInvoke IL emitter. Eventually this will
+    /// allow ILProvider to switch out its PInvoke IL generator with another, such as MCG.
+    /// </summary>
+    class PInvokeILProvider
+    {
+        private readonly PInvokeILEmitterConfiguration _pInvokeILEmitterConfiguration;
+
+        public PInvokeILProvider(PInvokeILEmitterConfiguration pInvokeILEmitterConfiguration)
+        {
+            _pInvokeILEmitterConfiguration = pInvokeILEmitterConfiguration;
+        }
+
+        public MethodIL EmitIL(MethodDesc method)
+        {
+            return PInvokeILEmitter.EmitIL(method, _pInvokeILEmitterConfiguration);
+        }
+
+        public bool IsStubRequired(MethodDesc method)
+        {
+            return PInvokeILEmitter.IsStubRequired(method, _pInvokeILEmitterConfiguration);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -191,6 +191,8 @@
     <Compile Include="CppCodeGen\CppGenerationBuffer.cs" />
     <Compile Include="CppCodeGen\CppWriter.cs" />
     <Compile Include="CppCodeGen\NodeDataSection.cs" />
+    <Compile Include="IL\PInvokeILEmitterConfiguration.cs" />
+    <Compile Include="IL\Stubs\PInvokeILProvider.cs" />
     <Compile Include="IL\Stubs\StartupCode\StartupCodeMainMethod.cs" />
     <Compile Include="Logger.cs" />
   </ItemGroup>

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -810,7 +810,7 @@ namespace Internal.JitInterface
             // transitions in inlined methods today (impCheckForPInvokeCall is not called for inlinees and number of other places
             // depend on it). To get a decent code with this limitation, we mirror CoreCLR behavior: Check
             // whether PInvoke stub is required here, and disable inlining of PInvoke methods in getMethodAttribsInternal.
-            return Internal.IL.Stubs.PInvokeILEmitter.IsStubRequired(method);
+            return _compilation.PInvokeILProvider.IsStubRequired(method);
         }
 
         [return: MarshalAs(UnmanagedType.Bool)]


### PR DESCRIPTION
The main motivation for this change is to allow multi-module builds to
demand lazy pinvokes when building libraries that would otherwise
generate eager pinvokes to OS-specific APIs. For example
`RoActivateInstance` only exists on Windows.

Add `PInvokeILEmitterConfiguration` class to capture externally
specified configuration, in this case to force lazy pinvokes when
compiling all code in an assembly into a library.  Move the static
native method counter out into `PInvokeILEmitterConfiguration` so its
lifetime is tied to the compilation.

Add `PInvokeILProvider` class which abstracts the `PInvokeILEmitter` and
`PInvokeILEmitterConfiguration` from `ILProvider`.  A
`PInvokeILProvider` instance is provided to `ILProvider` and will
eventually be switchable with something more functional than the current
PInvoke IL emitter.