### PR TITLE
Implement ldvirtftn in shared generic contexts

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -112,8 +112,8 @@ namespace ILCompiler.DependencyAnalysis
             // that use the same dictionary layout.
             foreach (var method in _owningType.GetAllMethods())
             {
-                // Static and generic methods have their own generic dictionaries
-                if (method.Signature.IsStatic || method.HasInstantiation)
+                // Generic methods have their own generic dictionaries
+                if (method.HasInstantiation)
                     continue;
 
                 // Abstract methods don't have a body

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -172,6 +172,9 @@ namespace ILCompiler.DependencyAnalysis
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
             MethodDesc instantiatedMethod = _method.InstantiateSignature(typeInstantiation, methodInstantiation);
+
+            // https://github.com/dotnet/corert/issues/2342 - we put a pointer to the virtual call helper into the dictionary
+            // but this should be something that will let us compute the target of the dipatch (e.g. interface dispatch cell).
             return factory.ReadyToRunHelper(ReadyToRunHelperId.VirtualCall, instantiatedMethod);
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -42,6 +42,11 @@ namespace ILCompiler.DependencyAnalysis
                     return new VirtualDispatchGenericLookupResult(method);
                 });
 
+                _virtualResolveHelpers = new NodeCache<MethodDesc, GenericLookupResult>(method =>
+                {
+                    return new VirtualResolveGenericLookupResult(method);
+                });
+
                 _typeGCStaticBaseSymbols = new NodeCache<TypeDesc, GenericLookupResult>(type =>
                 {
                     return new TypeGCStaticBaseGenericLookupResult(type);
@@ -86,6 +91,13 @@ namespace ILCompiler.DependencyAnalysis
             public GenericLookupResult VirtualCall(MethodDesc method)
             {
                 return _virtualCallHelpers.GetOrAdd(method);
+            }
+
+            private NodeCache<MethodDesc, GenericLookupResult> _virtualResolveHelpers;
+
+            public GenericLookupResult VirtualMethodAddress(MethodDesc method)
+            {
+                return _virtualResolveHelpers.GetOrAdd(method);
             }
 
             private NodeCache<MethodDesc, GenericLookupResult> _methodEntrypoints;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -40,6 +40,8 @@ namespace ILCompiler.DependencyAnalysis
                     return factory.GenericLookup.MethodDictionary((MethodDesc)target);
                 case ReadyToRunHelperId.VirtualCall:
                     return factory.GenericLookup.VirtualCall((MethodDesc)target);
+                case ReadyToRunHelperId.ResolveVirtualFunction:
+                    return factory.GenericLookup.VirtualMethodAddress((MethodDesc)target);
                 case ReadyToRunHelperId.MethodEntry:
                     return factory.GenericLookup.MethodEntry((MethodDesc)target);
                 default:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -103,6 +103,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.MethodDictionary:
                 case ReadyToRunHelperId.VirtualCall:
+                case ReadyToRunHelperId.ResolveVirtualFunction:
                 case ReadyToRunHelperId.MethodEntry:
                     {
                         EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2683,38 +2683,18 @@ namespace Internal.JitInterface
                     (void*)ObjectToHandle(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.ResolveGenericVirtualMethod, targetMethod));
                 pResult.nullInstanceCheck = false;
             }
-            else
+            else if((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) != 0)
             {
-                ReadyToRunHelperId helper;
-
-                if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) != 0)
-                {
-                    pResult.kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_LDVIRTFTN;
-                    helper = ReadyToRunHelperId.ResolveVirtualFunction;
-                }
-                else
-                {
-                    // CORINFO_CALL_CODE_POINTER tells the JIT that this is indirect
-                    // call that should not be inlined.
-                    pResult.kind = CORINFO_CALL_KIND.CORINFO_CALL_CODE_POINTER;
-                    helper = ReadyToRunHelperId.VirtualCall;
-                }
+                pResult.kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_LDVIRTFTN;
 
                 // If this is a non-interface/non-GVM call, we actually don't need a runtime lookup to find the target.
                 // We don't even need to keep track of the runtime-determined method being called because the system ensures
                 // that if e.g. Foo<__Canon>.GetHashCode is needed and we're generating a dictionary for Foo<string>,
                 // Foo<string>.GetHashCode is needed too.
                 if (pResult.exactContextNeedsRuntimeLookup &&
-                    !targetMethod.HasInstantiation &&
-                    !targetMethod.OwningType.IsInterface)
-                {
-                    pResult.exactContextNeedsRuntimeLookup = false;
-                }
-
-                if (pResult.exactContextNeedsRuntimeLookup)
+                    (targetMethod.HasInstantiation || targetMethod.OwningType.IsInterface))
                 {
                     pResult.codePointerOrStubLookup.lookupKind.needsRuntimeLookup = true;
-                    pResult.codePointerOrStubLookup.lookupKind.runtimeLookupFlags = 0;
                     pResult.codePointerOrStubLookup.runtimeLookup.indirections = CORINFO.USEHELPER;
 
                     // Do not bother computing the runtime lookup if we are inlining. The JIT is going
@@ -2726,14 +2706,55 @@ namespace Internal.JitInterface
                     }
 
                     pResult.codePointerOrStubLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(contextMethod);
-                    pResult.codePointerOrStubLookup.lookupKind.runtimeLookupFlags = (ushort)helper;
+                    pResult.codePointerOrStubLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.ResolveVirtualFunction;
                 }
                 else
                 {
+                    pResult.exactContextNeedsRuntimeLookup = false;
                     pResult.codePointerOrStubLookup.constLookup.accessType = InfoAccessType.IAT_VALUE;
 
                     pResult.codePointerOrStubLookup.constLookup.addr =
-                            (void*)ObjectToHandle(_compilation.NodeFactory.ReadyToRunHelper(helper, targetMethod));
+                            (void*)ObjectToHandle(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.ResolveVirtualFunction, targetMethod));
+                }
+
+                // The current CoreRT ReadyToRun helpers do not handle null thisptr - ask the JIT to emit explicit null checks
+                // TODO: Optimize this
+                pResult.nullInstanceCheck = true;
+            }
+            else
+            {
+                // CORINFO_CALL_CODE_POINTER tells the JIT that this is indirect
+                // call that should not be inlined.
+                pResult.kind = CORINFO_CALL_KIND.CORINFO_CALL_CODE_POINTER;
+
+                // If this is a non-interface/non-GVM call, we actually don't need a runtime lookup to find the target.
+                // We don't even need to keep track of the runtime-determined method being called because the system ensures
+                // that if e.g. Foo<__Canon>.GetHashCode is needed and we're generating a dictionary for Foo<string>,
+                // Foo<string>.GetHashCode is needed too.
+                if (pResult.exactContextNeedsRuntimeLookup &&
+                    (targetMethod.HasInstantiation || targetMethod.OwningType.IsInterface))
+                {
+                    pResult.codePointerOrStubLookup.lookupKind.needsRuntimeLookup = true;
+                    pResult.codePointerOrStubLookup.runtimeLookup.indirections = CORINFO.USEHELPER;
+
+                    // Do not bother computing the runtime lookup if we are inlining. The JIT is going
+                    // to abort the inlining attempt anyway.
+                    MethodDesc contextMethod = methodFromContext(pResolvedToken.tokenContext);
+                    if (contextMethod != MethodBeingCompiled)
+                    {
+                        return;
+                    }
+
+                    pResult.codePointerOrStubLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(contextMethod);
+                    pResult.codePointerOrStubLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.VirtualCall;
+                }
+                else
+                {
+                    pResult.exactContextNeedsRuntimeLookup = false;
+                    pResult.codePointerOrStubLookup.constLookup.accessType = InfoAccessType.IAT_VALUE;
+
+                    pResult.codePointerOrStubLookup.constLookup.addr =
+                            (void*)ObjectToHandle(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.VirtualCall, targetMethod));
                 }
 
                 // The current CoreRT ReadyToRun helpers do not handle null thisptr - ask the JIT to emit explicit null checks

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -14,6 +14,8 @@ class Program
         TestDelegateFatFunctionPointers.Run();
         TestVirtualMethodUseTracking.Run();
         TestSlotsInHierarchy.Run();
+        TestDelegateVirtualMethod.Run();
+        TestDelegateInterfaceMethod.Run();
         TestNameManglingCollisionRegression.Run();
         TestUnusedGVMsDoNotCrashCompiler.Run();
 
@@ -139,6 +141,63 @@ class Program
             string roundtrip = new TestDelegateFatFunctionPointers().Generic<string>(hw);
             if (roundtrip != hw)
                 throw new Exception();
+        }
+    }
+
+    class TestDelegateVirtualMethod
+    {
+        static void Generic<T>()
+        {
+            Base<T> o = new Derived<T>();
+            Func<string> f = o.Do;
+            if (f() != "Derived")
+                throw new Exception();
+
+            o = new Base<T>();
+            f = o.Do;
+            if (f() != "Base")
+                throw new Exception();
+        }
+
+        public static void Run()
+        {
+            Generic<string>();
+        }
+
+        class Base<T>
+        {
+            public virtual string Do() => "Base";
+        }
+
+        class Derived<T> : Base<T>
+        {
+            public override string Do() => "Derived";
+        }
+    }
+
+    class TestDelegateInterfaceMethod
+    {
+        static void Generic<T>()
+        {
+            IFoo<T> o = new Foo<T>();
+            Func<string> f = o.Do;
+            if (f() != "Foo")
+                throw new Exception();
+        }
+
+        public static void Run()
+        {
+            Generic<string>();
+        }
+
+        interface IFoo<T>
+        {
+            string Do();
+        }
+
+        class Foo<T> : IFoo<T>
+        {
+            public string Do() => "Foo";
         }
     }
 


### PR DESCRIPTION
This is to unblock #2308.
Requires JIT changes from dotnet/coreclr#8608.

This is two commits: first one is a bugfix uncovered by #2308. The second implements a missing feature required to support ldvirtftn in shared generic context.

I'm also restricting the number of cases when we actually need a generic lookup to calls/ldftn of interfaces and generic virtual methods. Normal virtual method calls/ldvirtfn go through the vtable slots that are the same between various canonically equivalent instantiations and don't need a runtime lookup.

On Project N, generic dictionaries point to the interface dispatch cell. The process of invoking/loading-the-address-of an interface method consists of a generic lookup for the interface dispatch cell, followed by a call to RhpResolveInterfaceMethod. This doesn't map great to what RyuJIT does (generic lookup followed by "mov rcx, this / call resultOfGenericLookup"). I'm making the dictionary point to a stub to do the dispatch for now. This has obvious delegate equivalency problems. I'll be filing an issue for the feature work to fix this.