### PR TITLE
Fix CharSet for new interop methods

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.DynamicLoad.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.DynamicLoad.cs
@@ -20,7 +20,7 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll")]
         internal static extern bool FreeLibrary(IntPtr hModule);
 
-        [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", EntryPoint = "LoadStringW")]
+        [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", EntryPoint = "LoadStringW", CharSet = CharSet.Unicode)]
         internal static extern int LoadString(SafeLibraryHandle handle, int id, StringBuilder buffer, int bufferLength);
 
         internal const int LOAD_LIBRARY_AS_DATAFILE = 0x00000002;

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetSystemDirectory.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetSystemDirectory.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class mincore
     {
-        [DllImport("api-ms-win-core-sysinfo-l1-2-1", EntryPoint = "GetSystemDirectoryW")]
+        [DllImport("api-ms-win-core-sysinfo-l1-2-1", EntryPoint = "GetSystemDirectoryW", CharSet = CharSet.Unicode)]
         internal static extern int GetSystemDirectory([Out]StringBuilder sb, int length);
     }
 }


### PR DESCRIPTION
Default CharSet is Ansi, but we're importing the `W` variants that are Unicode.