### PR TITLE
Add a few EEType validation rules

### DIFF
--- a/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
+++ b/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
@@ -15,6 +15,7 @@ namespace Internal.TypeSystem
         ClassLoadBadFormat,
         ClassLoadExplicitLayout,
         ClassLoadValueClassTooLarge,
+        ClassLoadRankTooLarge,
 
         // MissingMethodException
         MissingMethod,

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -572,20 +572,6 @@ namespace ILCompiler.DependencyAnalysis
 
                 // Check the type doesn't have bogus MethodImpls or overrides and we can get the finalizer.
                 defType.GetFinalizer();
-
-                const int FieldOffsetMax = (1 << 27) - 1; // FIELD_OFFSET_MAX in CoreCLR
-                const int FieldOffsetLastRealOffset = FieldOffsetMax - 6; // FIELD_OFFSET_LAST_REAL_OFFSET in CoreCLR
-                // No need to look at individual fields if the class is smaller.
-                if (defType.InstanceByteCount > FieldOffsetLastRealOffset)
-                {
-                    // CoreCLR requires the top 5 bits of the field offset to be zero. This means we can have a class
-                    // larger than FieldOffsetMax, but no field can have an offset bigger than that.
-                    foreach (var field in defType.GetFields())
-                    {
-                        if (!field.IsStatic && field.Offset > FieldOffsetLastRealOffset)
-                            throw new TypeSystemException.TypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
-                    }
-                }
             }
 
             // Validate parameterized types

--- a/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
@@ -63,6 +63,8 @@ namespace Internal.Runtime
                     return SR.ClassLoad_ValueClassTooLarge;
                 case ExceptionStringID.ClassLoadExplicitLayout:
                     return SR.ClassLoad_ExplicitLayout;
+                case ExceptionStringID.ClassLoadRankTooLarge:
+                    return SR.ClassLoad_RankTooLarge;
                 case ExceptionStringID.InvalidProgramSpecific:
                     return SR.InvalidProgram_Specific;
                 case ExceptionStringID.InvalidProgramVararg:

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1819,6 +1819,9 @@
   <data name="ClassLoad_General" xml:space="preserve">
     <value>Could not load type '{0}' from assembly '{1}'.</value>
   </data>
+  <data name="ClassLoad_RankTooLarge" xml:space="preserve">
+    <value>'{0}' from assembly '{1}' has too many dimensions.</value>
+  </data>
   <data name="ClassLoad_ExplicitGeneric" xml:space="preserve">
     <value>Could not load type '{0}' from assembly '{1}' because generic types cannot have explicit layout.</value>
   </data>


### PR DESCRIPTION
* Pre-emptively check we can get a finalizer
* Apply same limit on field offsets that CoreCLR has
* Limit array rank to 32