### PR TITLE
Compile BuildFrameworkNativeObjects test libraries in parallel

### DIFF
--- a/src/BuildIntegration/BuildFrameworkNativeObjects.proj
+++ b/src/BuildIntegration/BuildFrameworkNativeObjects.proj
@@ -1,10 +1,27 @@
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="BuildAllFrameworkLibraries" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <IlcCompileDependsOn>IlcFramework</IlcCompileDependsOn>
+    <IlcCompileDependsOn>BuildOneFrameworkLibrary</IlcCompileDependsOn>
     <IlcMultiModule>true</IlcMultiModule>
   </PropertyGroup>
   
   <Import Project="Microsoft.NETCore.Native.targets" />
+
+  <Target Name="BuildAllFrameworkLibraries">
+    <ItemGroup>
+      <ProjectToBuild Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>
+          LibraryToCompile=%(IlcReference.Identity)
+        </AdditionalProperties>
+      </ProjectToBuild>
+    </ItemGroup>
+    <MSBuild Projects="@(ProjectToBuild)" Targets="IlcCompile" BuildInParallel="true" />
+  </Target>
+
+  <Target Name="BuildOneFrameworkLibrary">
+    <ItemGroup>
+        <ManagedBinary Include="$(LibraryToCompile)" />
+    </ItemGroup>
+  </Target>
   
 </Project>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -85,7 +85,7 @@ See the LICENSE file in the project root for more information.
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />
-    <WriteLinesToFile File="$(NativeIntermediateOutputPath)ilc.rsp" Lines="@(IlcArg)" Overwrite="true" />
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp" Lines="@(IlcArg)" Overwrite="true" />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeObject)))" />
 
@@ -94,7 +94,7 @@ See the LICENSE file in the project root for more information.
       <TestHost Condition="'$(OS)' != 'Windows_NT'">corerun</TestHost>
     </PropertyGroup>
 
-    <Exec Command="&quot;$(IlcPath)\$(TestHost)&quot; &quot;$(IlcPath)\ilc.exe&quot; @&quot;$(NativeIntermediateOutputPath)ilc.rsp&quot;">
+    <Exec Command="&quot;$(IlcPath)\$(TestHost)&quot; &quot;$(IlcPath)\ilc.exe&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;">
     </Exec>
 
   </Target>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -181,9 +181,9 @@ goto :eof
         )
     )
 
-    echo msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" !extraArgs! !__SourceFile!.csproj
+    echo msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" !extraArgs! !__SourceFile!.csproj
     echo.
-    msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" !extraArgs! !__SourceFile!.csproj
+    msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" !extraArgs! !__SourceFile!.csproj
     endlocal
 
     set __SavedErrorLevel=%ErrorLevel%

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -34,8 +34,8 @@ run_test_dir()
     rm -rf ${__dir_path}/bin ${__dir_path}/obj
 
     local __msbuild_dir=${CoreRT_TestRoot}/../Tools
-    echo ${__msbuild_dir}/msbuild.sh /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} ${__extra_args} ${__dir_path}/${__filename}.csproj
-    ${__msbuild_dir}/msbuild.sh /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} ${__extra_args} ${__dir_path}/${__filename}.csproj
+    echo ${__msbuild_dir}/msbuild.sh /m /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} ${__extra_args} ${__dir_path}/${__filename}.csproj
+    ${__msbuild_dir}/msbuild.sh /m /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} ${__extra_args} ${__dir_path}/${__filename}.csproj
 
     runtest ${__dir_path} ${__filename}
     local __exitcode=$?

--- a/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.csproj
+++ b/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" DefaultTargets="IlcCompile" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="BuildAllFrameworkLibraries" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <NativeIntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\native\</NativeIntermediateOutputPath>


### PR DESCRIPTION
MSBuild parallelizes at the project level (though there are third party
extensions that allow parallelism at the task level). Build each of the
framework assemblies by batching on `@(IlcReference)` with a custom
target that invokes the `<MSBuild>` task.

On a hyper-threaded i7-6700 it reduced `BuildFrameworkNativeObjects` run time from 67s to 17s.