### PR TITLE
Use ExecutionPolicy ByPass to execute probe-win.ps1 script during the build

### DIFF
--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -99,7 +99,7 @@ exit /b 1
 
 :EvaluatePS
 :: Eval the output from probe-win1.ps1
-for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& ""%__SourceDir%\Native\probe-win.ps1"""') do %%a
+for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& ""%__SourceDir%\Native\probe-win.ps1"""') do %%a
 
 
 set __VSProductVersion=

--- a/src/Native/gen-buildsys-win.bat
+++ b/src/Native/gen-buildsys-win.bat
@@ -22,7 +22,7 @@ if /i "%3" == "x64" (set __VSString=%__VSString% Win64)
 if defined CMakePath goto DoGen
 
 :: Eval the output from probe-win1.ps1
-for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& .\probe-win.ps1"') do %%a
+for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& .\probe-win.ps1"') do %%a
 
 :DoGen
 "%CMakePath%" "-DCLR_CMAKE_TARGET_ARCH=%3" -G "Visual Studio %__VSString%" %1


### PR DESCRIPTION
Fixes #2377