### PR TITLE
Adding ValueTuple and ITuple to corlib in CoreRT

### DIFF
--- a/src/Common/src/System/Numerics/Hashing/HashHelpers.cs
+++ b/src/Common/src/System/Numerics/Hashing/HashHelpers.cs
@@ -8,7 +8,7 @@ namespace System.Numerics.Hashing
 
     internal static class HashHelpers
     {
-        public static readonly int RandomSeed = Guid.NewGuid().GetHashCode();
+        public static readonly int RandomSeed = new Random().Next(Int32.MinValue, Int32.MaxValue);
 
         public static int Combine(int h1, int h2)
         {

--- a/src/Common/src/System/Numerics/Hashing/HashHelpers.cs
+++ b/src/Common/src/System/Numerics/Hashing/HashHelpers.cs
@@ -8,11 +8,14 @@ namespace System.Numerics.Hashing
 
     internal static class HashHelpers
     {
+        public static readonly int RandomSeed = Guid.NewGuid().GetHashCode();
+
         public static int Combine(int h1, int h2)
         {
-            // This should get optimized to use a single ROL instruction.
-            uint shift5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
-            return ((int)shift5 + h1) ^ h2;
+            // RyuJIT optimizes this to use the ROL instruction
+            // Related GitHub pull request: dotnet/coreclr#1830
+            uint rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
+            return ((int)rol5 + h1) ^ h2;
         }
     }
 }

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -741,6 +741,12 @@
   <data name="ArgumentException_TupleLastArgumentNotATuple" xml:space="preserve">
     <value>The last element of an eight element tuple must be a Tuple.</value>
   </data>
+  <data name="ArgumentException_ValueTupleIncorrectType" xml:space="preserve">
+    <value>Argument must be of type {0}.</value>
+  </data>
+  <data name="ArgumentException_ValueTupleLastArgumentNotATuple" xml:space="preserve">
+    <value>The TRest type argument of ValueTuple`8 must be a ValueTuple.</value>
+  </data>
   <data name="ArgumentNull_Array" xml:space="preserve">
     <value>Array cannot be null.</value>
   </data>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -135,8 +135,6 @@
     <Compile Include="System\IO\SeekOrigin.cs" />
     <Compile Include="System\IO\Stream.cs" />
     <Compile Include="System\IO\StreamHelpers.CopyValidation.cs" />
-    <Compile Include="System\Runtime\CompilerServices\ITuple.cs" />
-    <Compile Include="System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\CastableObject.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\AssemblyNameHelpers.StrongName.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\AssemblyNameHelpers.cs" />
@@ -200,8 +198,6 @@
     <Compile Include="System\Reflection\TypeInfo.cs" />
     <Compile Include="System\Reflection\TypeInfo.Workaround.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimeImplementedCustomAttributeData.cs" />
-    <Compile Include="System\TupleExtensions.cs" />
-    <Compile Include="System\ValueTuple.cs" />
     <Compile Include="System\__Canon.cs" />
     <Compile Include="System\AccessViolationException.cs" />
     <Compile Include="System\Action.cs" />
@@ -432,6 +428,7 @@
     <Compile Include="System\Runtime\CompilerServices\ForceDictionaryLookupsAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\ILTransformInjectedAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\ICastable.cs" />
+    <Compile Include="System\Runtime\CompilerServices\ITuple.cs" />
     <Compile Include="System\Runtime\CompilerServices\IndexerNameAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\InitializedDataAttributes.cs" />
     <Compile Include="System\Runtime\CompilerServices\InternalCompilerAttributes.cs" />
@@ -444,6 +441,7 @@
     <Compile Include="System\Runtime\CompilerServices\StateMachineAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\StaticClassConstructionContext.cs" />
     <Compile Include="System\Runtime\CompilerServices\EagerOrderedStaticConstructorAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\TypeForwardedFromAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\TypeForwardedToAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\Unsafe.cs" />
@@ -616,6 +614,7 @@
     <Compile Include="System\TimeZoneInfo.cs" />
     <Compile Include="System\TimeZoneNotFoundException.cs" />
     <Compile Include="System\Tuple.cs" />
+    <Compile Include="System\TupleExtensions.cs" />
     <Compile Include="System\Type.cs" />
     <Compile Include="System\Type.Helpers.cs" />
     <Compile Include="System\TypeUnificationKey.cs" />
@@ -630,6 +629,7 @@
     <Compile Include="System\UnauthorizedAccessException.cs" />
     <Compile Include="System\UnhandledExceptionEventArgs.cs" />
     <Compile Include="System\UnhandledExceptionEventHandler.cs" />
+    <Compile Include="System\ValueTuple.cs" />
     <Compile Include="System\ValueType.cs" />
     <Compile Include="System\Version.cs" />
     <Compile Include="System\Void.cs" />

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -135,6 +135,7 @@
     <Compile Include="System\IO\SeekOrigin.cs" />
     <Compile Include="System\IO\Stream.cs" />
     <Compile Include="System\IO\StreamHelpers.CopyValidation.cs" />
+    <Compile Include="System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\CastableObject.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\AssemblyNameHelpers.StrongName.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\AssemblyNameHelpers.cs" />
@@ -198,6 +199,8 @@
     <Compile Include="System\Reflection\TypeInfo.cs" />
     <Compile Include="System\Reflection\TypeInfo.Workaround.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimeImplementedCustomAttributeData.cs" />
+    <Compile Include="System\TupleExtensions.cs" />
+    <Compile Include="System\ValueTuple.cs" />
     <Compile Include="System\__Canon.cs" />
     <Compile Include="System\AccessViolationException.cs" />
     <Compile Include="System\Action.cs" />

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -135,6 +135,7 @@
     <Compile Include="System\IO\SeekOrigin.cs" />
     <Compile Include="System\IO\Stream.cs" />
     <Compile Include="System\IO\StreamHelpers.CopyValidation.cs" />
+    <Compile Include="System\Runtime\CompilerServices\ITuple.cs" />
     <Compile Include="System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\CastableObject.cs" />
     <Compile Include="System\Reflection\Runtime\Assemblies\AssemblyNameHelpers.StrongName.cs" />

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.sln
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.CoreLib", "System.Private.CoreLib.csproj", "{BE95C560-B508-4588-8907-F9FC5BC1A0CF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|arm = Debug|arm
+		Debug|arm64 = Debug|arm64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|arm = Release|arm
+		Release|arm64 = Release|arm64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|arm.ActiveCfg = Debug|arm
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|arm.Build.0 = Debug|arm
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|arm64.ActiveCfg = Debug|arm64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|arm64.Build.0 = Debug|arm64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x64.ActiveCfg = Debug|x64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x64.Build.0 = Debug|x64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x86.ActiveCfg = Debug|x86
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x86.Build.0 = Debug|x86
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|arm.ActiveCfg = Release|arm
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|arm.Build.0 = Release|arm
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|arm64.ActiveCfg = Release|arm64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|arm64.Build.0 = Release|arm64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x64.ActiveCfg = Release|x64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x64.Build.0 = Release|x64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x86.ActiveCfg = Release|x86
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ITuple.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ITuple.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// This interface is required for types that want to be indexed into by dynamic patterns.
+    /// </summary>
+    public interface ITuple
+    {
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int Length { get; }
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object this[int index] { get; }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that the use of <see cref="System.ValueTuple"/> on a member is meant to be treated as a tuple with element names.
+    /// </summary>
+    [CLSCompliant(false)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Event)]
+    public sealed class TupleElementNamesAttribute : Attribute
+    {
+        private readonly string[] _transformNames;
+
+        /// <summary>
+        /// Initializes a new instance of the <see
+        /// cref="TupleElementNamesAttribute"/> class.
+        /// </summary>
+        /// <param name="transformNames">
+        /// Specifies, in a pre-order depth-first traversal of a type's
+        /// construction, which <see cref="System.ValueType"/> occurrences are
+        /// meant to carry element names.
+        /// </param>
+        /// <remarks>
+        /// This constructor is meant to be used on types that contain an
+        /// instantiation of <see cref="System.ValueType"/> that contains
+        /// element names.  For instance, if <c>C</c> is a generic type with
+        /// two type parameters, then a use of the constructed type <c>C{<see
+        /// cref="System.ValueTuple{T1, T2}"/>, <see
+        /// cref="System.ValueTuple{T1, T2, T3}"/></c> might be intended to
+        /// treat the first type argument as a tuple with element names and the
+        /// second as a tuple without element names. In which case, the
+        /// appropriate attribute specification should use a
+        /// <c>transformNames</c> value of <c>{ "name1", "name2", null, null,
+        /// null }</c>.
+        /// </remarks>
+        public TupleElementNamesAttribute(string[] transformNames)
+        {
+            if (transformNames == null)
+            {
+                throw new ArgumentNullException(nameof(transformNames));
+            }
+
+            _transformNames = transformNames;
+        }
+
+        /// <summary>
+        /// Specifies, in a pre-order depth-first traversal of a type's
+        /// construction, which <see cref="System.ValueTuple"/> elements are
+        /// meant to carry element names.
+        /// </summary>
+        public IList<string> TransformNames => _transformNames;
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Tuple.cs
+++ b/src/System.Private.CoreLib/src/System/Tuple.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 //
@@ -13,14 +13,14 @@ using System.Text;
 
 namespace System
 {
+
     /// <summary>
     /// Helper so we can call some tuple methods recursively without knowing the underlying types.
     /// </summary>
-    internal interface ITuple
+    internal interface ITupleInternal : ITuple
     {
         string ToString(StringBuilder sb);
         int GetHashCode(IEqualityComparer comparer);
-        int Size { get; }
     }
 
     public static class Tuple
@@ -102,7 +102,7 @@ namespace System
         }
     }
 
-    public class Tuple<T1> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple
+    public class Tuple<T1> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
 
@@ -161,34 +161,46 @@ namespace System
             return comparer.GetHashCode(m_Item1);
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer)
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('(');
-            return ((ITuple)this).ToString(sb);
+            sb.Append("(");
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb)
+        string ITupleInternal.ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(')');
             return sb.ToString();
         }
 
-        int ITuple.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 1;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
         {
             get
             {
-                return 1;
+                if (index != 0)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+                return Item1;
             }
         }
     }
 
-    public class Tuple<T1, T2> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple
+    public class Tuple<T1, T2> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
         private readonly T2 m_Item2;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
@@ -256,18 +268,18 @@ namespace System
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer)
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('(');
-            return ((ITuple)this).ToString(sb);
+            sb.Append("(");
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb)
+        string ITupleInternal.ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -276,16 +288,32 @@ namespace System
             return sb.ToString();
         }
 
-        int ITuple.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 2;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
         {
             get
             {
-                return 2;
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
-    public class Tuple<T1, T2, T3> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple
+    public class Tuple<T1, T2, T3> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
         private readonly T2 m_Item2;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
@@ -360,18 +388,18 @@ namespace System
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer)
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('(');
-            return ((ITuple)this).ToString(sb);
+            sb.Append("(");
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb)
+        string ITupleInternal.ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -382,16 +410,34 @@ namespace System
             return sb.ToString();
         }
 
-        int ITuple.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 3;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
         {
             get
             {
-                return 3;
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
-    public class Tuple<T1, T2, T3, T4> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple
+    public class Tuple<T1, T2, T3, T4> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
         private readonly T2 m_Item2;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
@@ -473,18 +519,18 @@ namespace System
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer)
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('(');
-            return ((ITuple)this).ToString(sb);
+            sb.Append("(");
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb)
+        string ITupleInternal.ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -497,16 +543,36 @@ namespace System
             return sb.ToString();
         }
 
-        int ITuple.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 4;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
         {
             get
             {
-                return 4;
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
-    public class Tuple<T1, T2, T3, T4, T5> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple
+    public class Tuple<T1, T2, T3, T4, T5> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
         private readonly T2 m_Item2;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
@@ -595,18 +661,18 @@ namespace System
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer)
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('(');
-            return ((ITuple)this).ToString(sb);
+            sb.Append("(");
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb)
+        string ITupleInternal.ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -621,16 +687,38 @@ namespace System
             return sb.ToString();
         }
 
-        int ITuple.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 5;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
         {
             get
             {
-                return 5;
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
-    public class Tuple<T1, T2, T3, T4, T5, T6> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple
+    public class Tuple<T1, T2, T3, T4, T5, T6> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
         private readonly T2 m_Item2;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
@@ -726,18 +814,18 @@ namespace System
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer)
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('(');
-            return ((ITuple)this).ToString(sb);
+            sb.Append("(");
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb)
+        string ITupleInternal.ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -754,16 +842,40 @@ namespace System
             return sb.ToString();
         }
 
-        int ITuple.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 6;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
         {
             get
             {
-                return 6;
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
-    public class Tuple<T1, T2, T3, T4, T5, T6, T7> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple
+    public class Tuple<T1, T2, T3, T4, T5, T6, T7> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
         private readonly T2 m_Item2;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
@@ -866,18 +978,18 @@ namespace System
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer)
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('(');
-            return ((ITuple)this).ToString(sb);
+            sb.Append("(");
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb)
+        string ITupleInternal.ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -896,16 +1008,42 @@ namespace System
             return sb.ToString();
         }
 
-        int ITuple.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 7;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
         {
             get
             {
-                return 7;
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    case 6:
+                        return Item7;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
-    public class Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple
+    public class Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
         private readonly T2 m_Item2;    // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
@@ -927,7 +1065,7 @@ namespace System
 
         public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
         {
-            if (!(rest is ITuple))
+            if (!(rest is ITupleInternal))
             {
                 throw new ArgumentException(SR.ArgumentException_TupleLastArgumentNotATuple);
             }
@@ -1018,11 +1156,11 @@ namespace System
         Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
-            ITuple t = (ITuple)m_Rest;
-            if (t.Size >= 8) { return t.GetHashCode(comparer); }
+            ITupleInternal t = (ITupleInternal)m_Rest;
+            if (t.Length >= 8) { return t.GetHashCode(comparer); }
 
             // In this case, the rest memeber has less than 8 elements so we need to combine some our elements with the elements in rest
-            int k = 8 - t.Size;
+            int k = 8 - t.Length;
             switch (k)
             {
                 case 1:
@@ -1044,18 +1182,18 @@ namespace System
             return -1;
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer)
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('(');
-            return ((ITuple)this).ToString(sb);
+            sb.Append("(");
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb)
+        string ITupleInternal.ToString(StringBuilder sb)
         {
             sb.Append(m_Item1);
             sb.Append(", ");
@@ -1071,14 +1209,46 @@ namespace System
             sb.Append(", ");
             sb.Append(m_Item7);
             sb.Append(", ");
-            return ((ITuple)m_Rest).ToString(sb);
+            return ((ITupleInternal)m_Rest).ToString(sb);
         }
 
-        int ITuple.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length
         {
             get
             {
-                return 7 + ((ITuple)m_Rest).Size;
+                return 7 + ((ITupleInternal)Rest).Length;
+            }
+        }
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    case 6:
+                        return Item7;
+                }
+
+                return ((ITupleInternal)Rest)[index - 7];
             }
         }
     }

--- a/src/System.Private.CoreLib/src/System/TupleExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/TupleExtensions.cs
@@ -1,0 +1,929 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="Tuple"/> instances to interop with C# tuples features (deconstruction syntax, converting from and to <see cref="ValueTuple"/>).
+    /// </summary>
+    public static class TupleExtensions
+    {
+        #region Deconstruct
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 1 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1>(
+            this Tuple<T1> value,
+            out T1 item1)
+        {
+            item1 = value.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 2 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2>(
+            this Tuple<T1, T2> value,
+            out T1 item1, out T2 item2)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 3 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3>(
+            this Tuple<T1, T2, T3> value,
+            out T1 item1, out T2 item2, out T3 item3)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 4 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4>(
+            this Tuple<T1, T2, T3, T4> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 5 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5>(
+            this Tuple<T1, T2, T3, T4, T5> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 6 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6>(
+            this Tuple<T1, T2, T3, T4, T5, T6> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 7 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 8 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 9 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 10 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 11 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 12 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 13 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 14 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 15 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 16 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 17 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 18 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 19 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 20 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+            item20 = value.Rest.Rest.Item6;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 21 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+            item20 = value.Rest.Rest.Item6;
+            item21 = value.Rest.Rest.Item7;
+        }
+        #endregion
+
+        #region ToValueTuple
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 1 element.
+        /// </summary>
+        public static ValueTuple<T1>
+            ToValueTuple<T1>(
+                this Tuple<T1> value)
+        {
+            return ValueTuple.Create(value.Item1);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 2 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2>
+            ToValueTuple<T1, T2>(
+                this Tuple<T1, T2> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 3 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3>
+            ToValueTuple<T1, T2, T3>(
+                this Tuple<T1, T2, T3> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 4 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4>
+            ToValueTuple<T1, T2, T3, T4>(
+                this Tuple<T1, T2, T3, T4> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 5 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5>
+            ToValueTuple<T1, T2, T3, T4, T5>(
+                this Tuple<T1, T2, T3, T4, T5> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 6 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6>
+            ToValueTuple<T1, T2, T3, T4, T5, T6>(
+                this Tuple<T1, T2, T3, T4, T5, T6> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 7 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 8 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 9 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 10 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 11 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 12 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 13 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 14 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 15 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 16 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 17 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 18 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 19 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 20 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 21 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6, value.Rest.Rest.Item7)));
+        }
+        #endregion
+
+        #region ToTuple
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 1 element.
+        /// </summary>
+        public static Tuple<T1>
+            ToTuple<T1>(
+                this ValueTuple<T1> value)
+        {
+            return Tuple.Create(value.Item1);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 2 elements.
+        /// </summary>
+        public static Tuple<T1, T2>
+            ToTuple<T1, T2>(
+                this ValueTuple<T1, T2> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 3 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3>
+            ToTuple<T1, T2, T3>(
+                this ValueTuple<T1, T2, T3> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 4 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4>
+            ToTuple<T1, T2, T3, T4>(
+                this ValueTuple<T1, T2, T3, T4> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 5 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5>
+            ToTuple<T1, T2, T3, T4, T5>(
+                this ValueTuple<T1, T2, T3, T4, T5> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 6 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6>
+            ToTuple<T1, T2, T3, T4, T5, T6>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 7 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 8 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 9 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 10 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 11 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 12 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 13 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 14 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 15 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 16 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 17 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 18 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 19 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 20 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 21 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6, value.Rest.Rest.Item7)));
+        }
+        #endregion
+
+        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
+
+        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>
+            new Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
+    }
+}

--- a/src/System.Private.CoreLib/src/System/TupleExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/TupleExtensions.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
+// Note: EditorBrowsable can be un-commented once https://github.com/dotnet/corefx/issues/14447 is resolved
+//using System.ComponentModel;
+
+using System.Runtime.CompilerServices;
 
 namespace System
 {
@@ -15,7 +18,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 1 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1>(
             this Tuple<T1> value,
             out T1 item1)
@@ -26,7 +29,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 2 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2>(
             this Tuple<T1, T2> value,
             out T1 item1, out T2 item2)
@@ -38,7 +41,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 3 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3>(
             this Tuple<T1, T2, T3> value,
             out T1 item1, out T2 item2, out T3 item3)
@@ -51,7 +54,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 4 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4>(
             this Tuple<T1, T2, T3, T4> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4)
@@ -65,7 +68,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 5 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5>(
             this Tuple<T1, T2, T3, T4, T5> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5)
@@ -80,7 +83,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 6 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6>(
             this Tuple<T1, T2, T3, T4, T5, T6> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6)
@@ -96,7 +99,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 7 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7)
@@ -113,7 +116,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 8 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8)
@@ -131,7 +134,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 9 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9)
@@ -150,7 +153,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 10 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10)
@@ -170,7 +173,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 11 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11)
@@ -191,7 +194,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 12 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12)
@@ -213,7 +216,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 13 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13)
@@ -236,7 +239,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 14 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14)
@@ -260,7 +263,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 15 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15)
@@ -285,7 +288,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 16 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16)
@@ -311,7 +314,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 17 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17)
@@ -338,7 +341,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 18 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18)
@@ -366,7 +369,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 19 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19)
@@ -395,7 +398,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 20 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20)
@@ -425,7 +428,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 21 elements.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21)
@@ -920,10 +923,10 @@ namespace System
         }
         #endregion
 
-        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
+        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct, ITuple =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
 
-        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>
+        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : ITuple =>
             new Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
     }
 }

--- a/src/System.Private.CoreLib/src/System/TupleExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/TupleExtensions.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Note: EditorBrowsable can be un-commented once https://github.com/dotnet/corefx/issues/14447 is resolved
-//using System.ComponentModel;
-
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace System
@@ -18,7 +16,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 1 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1>(
             this Tuple<T1> value,
             out T1 item1)
@@ -29,7 +27,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 2 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2>(
             this Tuple<T1, T2> value,
             out T1 item1, out T2 item2)
@@ -41,7 +39,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 3 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3>(
             this Tuple<T1, T2, T3> value,
             out T1 item1, out T2 item2, out T3 item3)
@@ -54,7 +52,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 4 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4>(
             this Tuple<T1, T2, T3, T4> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4)
@@ -68,7 +66,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 5 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5>(
             this Tuple<T1, T2, T3, T4, T5> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5)
@@ -83,7 +81,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 6 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6>(
             this Tuple<T1, T2, T3, T4, T5, T6> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6)
@@ -99,7 +97,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 7 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7)
@@ -116,7 +114,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 8 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8)
@@ -134,7 +132,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 9 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9)
@@ -153,7 +151,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 10 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10)
@@ -173,7 +171,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 11 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11)
@@ -194,7 +192,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 12 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12)
@@ -216,7 +214,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 13 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13)
@@ -239,7 +237,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 14 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14)
@@ -263,7 +261,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 15 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15)
@@ -288,7 +286,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 16 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16)
@@ -314,7 +312,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 17 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17)
@@ -341,7 +339,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 18 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18)
@@ -369,7 +367,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 19 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19)
@@ -398,7 +396,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 20 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20)
@@ -428,7 +426,7 @@ namespace System
         /// <summary>
         /// Deconstruct a properly nested <see cref="Tuple"/> with 21 elements.
         /// </summary>
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
             this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value,
             out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21)

--- a/src/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -1,0 +1,2080 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Numerics.Hashing;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    /// <summary>
+    /// Helper so we can call some tuple methods recursively without knowing the underlying types.
+    /// </summary>
+    internal interface ITupleInternal
+    {
+        int GetHashCode(IEqualityComparer comparer);
+        int Size { get; }
+        string ToStringEnd();
+    }
+
+    /// <summary>
+    /// The ValueTuple types (from arity 0 to 8) comprise the runtime implementation that underlies tuples in C# and struct tuples in F#.
+    /// Aside from created via language syntax, they are most easily created via the ValueTuple.Create factory methods.
+    /// The System.ValueTuple types differ from the System.Tuple types in that:
+    /// - they are structs rather than classes,
+    /// - they are mutable rather than readonly, and
+    /// - their members (such as Item1, Item2, etc) are fields rather than properties.
+    /// </summary>
+    public struct ValueTuple
+        : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
+    {
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if <paramref name="obj"/> is a <see cref="ValueTuple"/>.</returns>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple;
+        }
+
+        /// <summary>Returns a value indicating whether this instance is equal to a specified value.</summary>
+        /// <param name="other">An instance to compare to this instance.</param>
+        /// <returns>true if <paramref name="other"/> has the same value as this instance; otherwise, false.</returns>
+        public bool Equals(ValueTuple other)
+        {
+            return true;
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            return other is ValueTuple;
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return 0;
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple other)
+        {
+            return 0;
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return 0;
+        }
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return 0;
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return 0;
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return 0;
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>()</c>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "()";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return ")";
+        }
+
+        int ITupleInternal.Size => 0;
+
+        /// <summary>Creates a new struct 0-tuple.</summary>
+        /// <returns>A 0-tuple.</returns>
+        public static ValueTuple Create() =>
+            new ValueTuple();
+
+        /// <summary>Creates a new struct 1-tuple, or singleton.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <returns>A 1-tuple (singleton) whose value is (item1).</returns>
+        public static ValueTuple<T1> Create<T1>(T1 item1) =>
+            new ValueTuple<T1>(item1);
+
+        /// <summary>Creates a new struct 2-tuple, or pair.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <returns>A 2-tuple (pair) whose value is (item1, item2).</returns>
+        public static ValueTuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) =>
+            new ValueTuple<T1, T2>(item1, item2);
+
+        /// <summary>Creates a new struct 3-tuple, or triple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <returns>A 3-tuple (triple) whose value is (item1, item2, item3).</returns>
+        public static ValueTuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3) =>
+            new ValueTuple<T1, T2, T3>(item1, item2, item3);
+
+        /// <summary>Creates a new struct 4-tuple, or quadruple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <returns>A 4-tuple (quadruple) whose value is (item1, item2, item3, item4).</returns>
+        public static ValueTuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4) =>
+            new ValueTuple<T1, T2, T3, T4>(item1, item2, item3, item4);
+
+        /// <summary>Creates a new struct 5-tuple, or quintuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <returns>A 5-tuple (quintuple) whose value is (item1, item2, item3, item4, item5).</returns>
+        public static ValueTuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) =>
+            new ValueTuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
+
+        /// <summary>Creates a new struct 6-tuple, or sextuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <returns>A 6-tuple (sextuple) whose value is (item1, item2, item3, item4, item5, item6).</returns>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
+
+        /// <summary>Creates a new struct 7-tuple, or septuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <typeparam name="T7">The type of the seventh component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <param name="item7">The value of the seventh component of the tuple.</param>
+        /// <returns>A 7-tuple (septuple) whose value is (item1, item2, item3, item4, item5, item6, item7).</returns>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
+
+        /// <summary>Creates a new struct 8-tuple, or octuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <typeparam name="T7">The type of the seventh component of the tuple.</typeparam>
+        /// <typeparam name="T8">The type of the eighth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <param name="item7">The value of the seventh component of the tuple.</param>
+        /// <param name="item8">The value of the eighth component of the tuple.</param>
+        /// <returns>An 8-tuple (octuple) whose value is (item1, item2, item3, item4, item5, item6, item7, item8).</returns>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>(item1, item2, item3, item4, item5, item6, item7, ValueTuple.Create(item8));
+
+        internal static int CombineHashCodes(int h1, int h2)
+        {
+            return HashHelpers.Combine(HashHelpers.Combine(HashHelpers.RandomSeed, h1), h2);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2), h3);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3), h4);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4), h5);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5), h6);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
+        }
+    }
+
+    /// <summary>Represents a 1-tuple, or singleton, as a value type.</summary>
+    /// <typeparam name="T1">The type of the tuple's only component.</typeparam>
+    public struct ValueTuple<T1>
+        : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        public ValueTuple(T1 item1)
+        {
+            Item1 = item1;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1> && Equals((ValueTuple<T1>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its field
+        /// is equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1>)) return false;
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return Comparer<T1>.Default.Compare(Item1, objTuple.Item1);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1> other)
+        {
+            return Comparer<T1>.Default.Compare(Item1, other.Item1);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return comparer.Compare(Item1, objTuple.Item1);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return EqualityComparer<T1>.Default.GetHashCode(Item1);
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return comparer.GetHashCode(Item1);
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return comparer.GetHashCode(Item1);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1)</c>,
+        /// where <c>Item1</c> represents the value of <see cref="Item1"/>. If the field is <see langword="null"/>,
+        /// it is represented as <see cref="string.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 1;
+    }
+
+    /// <summary>
+    /// Represents a 2-tuple, or pair, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2>
+        : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// </summary>
+        public T2 Item2;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            Item1 = item1;
+            Item2 = item2;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        ///
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2> && Equals((ValueTuple<T1, T2>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified <see cref="ValueTuple{T1, T2}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified object based on a specified comparison method.
+        /// </summary>
+        /// <param name="other">The object to compare with this instance.</param>
+        /// <param name="comparer">An object that defines the method to use to evaluate whether the two objects are equal.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        ///
+        /// <remarks>
+        /// This member is an explicit interface member implementation. It can be used only when the
+        ///  <see cref="ValueTuple{T1, T2}"/> instance is cast to an <see cref="IStructuralEquatable"/> interface.
+        ///
+        /// The <see cref="IEqualityComparer.Equals"/> implementation is called only if <c>other</c> is not <see langword="null"/>,
+        ///  and if it can be successfully cast (in C#) or converted (in Visual Basic) to a <see cref="ValueTuple{T1, T2}"/>
+        ///  whose components are of the same types as those of the current instance. The IStructuralEquatable.Equals(Object, IEqualityComparer) method
+        ///  first passes the <see cref="Item1"/> values of the <see cref="ValueTuple{T1, T2}"/> objects to be compared to the
+        ///  <see cref="IEqualityComparer.Equals"/> implementation. If this method call returns <see langword="true"/>, the method is
+        ///  called again and passed the <see cref="Item2"/> values of the two <see cref="ValueTuple{T1, T2}"/> instances.
+        /// </remarks>
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            return Comparer<T2>.Default.Compare(Item2, other.Item2);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item2, objTuple.Item2);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2)</c>,
+        /// where <c>Item1</c> and <c>Item2</c> represent the values of the <see cref="Item1"/>
+        /// and <see cref="Item2"/> fields. If either field value is <see langword="null"/>,
+        /// it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 2;
+    }
+
+    /// <summary>
+    /// Represents a 3-tuple, or triple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3>
+        : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3> && Equals((ValueTuple<T1, T2, T3>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            return Comparer<T3>.Default.Compare(Item3, other.Item3);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item3, objTuple.Item3);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 3;
+    }
+
+    /// <summary>
+    /// Represents a 4-tuple, or quadruple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4>
+        : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4> && Equals((ValueTuple<T1, T2, T3, T4>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            return Comparer<T4>.Default.Compare(Item4, other.Item4);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item4, objTuple.Item4);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 4;
+    }
+
+    /// <summary>
+    /// Represents a 5-tuple, or quintuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4, T5>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's fifth component.
+        /// </summary>
+        public T5 Item5;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5> && Equals((ValueTuple<T1, T2, T3, T4, T5>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            return Comparer<T5>.Default.Compare(Item5, other.Item5);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item5, objTuple.Item5);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 5;
+    }
+
+    /// <summary>
+    /// Represents a 6-tuple, or sixtuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's fifth component.
+        /// </summary>
+        public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's sixth component.
+        /// </summary>
+        public T6 Item6;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            return Comparer<T6>.Default.Compare(Item6, other.Item6);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item6, objTuple.Item6);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                               EqualityComparer<T6>.Default.GetHashCode(Item6));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5),
+                                               comparer.GetHashCode(Item6));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 6;
+    }
+
+    /// <summary>
+    /// Represents a 7-tuple, or sentuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
+    /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's fifth component.
+        /// </summary>
+        public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's sixth component.
+        /// </summary>
+        public T6 Item6;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's seventh component.
+        /// </summary>
+        public T7 Item7;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
+        /// <param name="item7">The value of the tuple's seventh component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6)
+                && EqualityComparer<T7>.Default.Equals(Item7, other.Item7);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6)
+                && comparer.Equals(Item7, objTuple.Item7);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            c = Comparer<T6>.Default.Compare(Item6, other.Item6);
+            if (c != 0) return c;
+
+            return Comparer<T7>.Default.Compare(Item7, other.Item7);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item6, objTuple.Item6);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item7, objTuple.Item7);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                               EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                               EqualityComparer<T7>.Default.GetHashCode(Item7));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5),
+                                               comparer.GetHashCode(Item6),
+                                               comparer.GetHashCode(Item7));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6, Item7)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 7;
+    }
+
+    /// <summary>
+    /// Represents an 8-tuple, or octuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
+    /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
+    /// <typeparam name="TRest">The type of the tuple's eighth component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal
+        where TRest : struct
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's fifth component.
+        /// </summary>
+        public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's sixth component.
+        /// </summary>
+        public T6 Item6;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's seventh component.
+        /// </summary>
+        public T7 Item7;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's eighth component.
+        /// </summary>
+        public TRest Rest;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
+        /// <param name="item7">The value of the tuple's seventh component.</param>
+        /// <param name="rest">The value of the tuple's eight component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
+        {
+            if (!(rest is ITupleInternal))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleLastArgumentNotAValueTuple);
+            }
+
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+            Rest = rest;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6)
+                && EqualityComparer<T7>.Default.Equals(Item7, other.Item7)
+                && EqualityComparer<TRest>.Default.Equals(Rest, other.Rest);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6)
+                && comparer.Equals(Item7, objTuple.Item7)
+                && comparer.Equals(Rest, objTuple.Rest);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            c = Comparer<T6>.Default.Compare(Item6, other.Item6);
+            if (c != 0) return c;
+
+            c = Comparer<T7>.Default.Compare(Item7, other.Item7);
+            if (c != 0) return c;
+
+            return Comparer<TRest>.Default.Compare(Rest, other.Rest);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item6, objTuple.Item6);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item7, objTuple.Item7);
+            if (c != 0) return c;
+
+            return comparer.Compare(Rest, objTuple.Rest);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                   EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                   EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                   EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                   EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                   EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                   EqualityComparer<T7>.Default.GetHashCode(Item7));
+            }
+
+            int size = rest.Size;
+            if (size >= 8) { return rest.GetHashCode(); }
+
+            // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
+            int k = 8 - size;
+            switch (k)
+            {
+                case 1:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 2:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 3:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 4:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 5:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 6:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 7:
+                case 8:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                       EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+            }
+
+            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            return -1;
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1), comparer.GetHashCode(Item2), comparer.GetHashCode(Item3),
+                                                   comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                   comparer.GetHashCode(Item7));
+            }
+
+            int size = rest.Size;
+            if (size >= 8) { return rest.GetHashCode(comparer); }
+
+            // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
+            int k = 8 - size;
+            switch (k)
+            {
+                case 1:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 2:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item6), comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 3:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item5), comparer.GetHashCode(Item6), comparer.GetHashCode(Item7),
+                                                       rest.GetHashCode(comparer));
+                case 4:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                       comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 5:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item3), comparer.GetHashCode(Item4), comparer.GetHashCode(Item5),
+                                                       comparer.GetHashCode(Item6), comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 6:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item2), comparer.GetHashCode(Item3), comparer.GetHashCode(Item4),
+                                                       comparer.GetHashCode(Item5), comparer.GetHashCode(Item6), comparer.GetHashCode(Item7),
+                                                       rest.GetHashCode(comparer));
+                case 7:
+                case 8:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1), comparer.GetHashCode(Item2), comparer.GetHashCode(Item3),
+                                                       comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                       comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+            }
+
+            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            return -1;
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6, Item7, Rest)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
+            }
+            else
+            {
+                return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + rest.ToStringEnd();
+            }
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
+            }
+            else
+            {
+                return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + rest.ToStringEnd();
+            }
+        }
+
+        int ITupleInternal.Size
+        {
+            get
+            {
+                ITupleInternal rest = Rest as ITupleInternal;
+                return rest == null ? 8 : 7 + rest.Size;
+            }
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using HashHelpers = System.Numerics.Hashing.HashHelpers;
 
 namespace System
 {
@@ -259,40 +260,37 @@ namespace System
 
         internal static int CombineHashCodes(int h1, int h2)
         {
-            // Forward to helper class in Common for this
-            // We keep the actual hashing logic there, so
-            // other classes can use it for hashing
-            return System.Numerics.Hashing.HashHelpers.Combine(h1, h2);
+            return HashHelpers.Combine(HashHelpers.Combine(HashHelpers.RandomSeed, h1), h2);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2), h3);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3), h4);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3), h4);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4), h5);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5), h6);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5), h6);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
         }
     }
 
@@ -1949,7 +1947,7 @@ namespace System
         {
             if (!(rest is IValueTupleInternal))
             {
-                throw new ArgumentException(SR.ArgumentException_TupleLastArgumentNotATuple);
+                throw new ArgumentException(SR.ArgumentException_ValueTupleLastArgumentNotATuple);
             }
 
             Item1 = item1;

--- a/src/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -4,19 +4,18 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Numerics.Hashing;
+using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
     /// <summary>
     /// Helper so we can call some tuple methods recursively without knowing the underlying types.
     /// </summary>
-    internal interface ITupleInternal
+    internal interface IValueTupleInternal : ITuple
     {
         int GetHashCode(IEqualityComparer comparer);
-        int Size { get; }
         string ToStringEnd();
     }
 
@@ -29,7 +28,7 @@ namespace System
     /// - their members (such as Item1, Item2, etc) are fields rather than properties.
     /// </summary>
     public struct ValueTuple
-        : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
+        : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, IValueTupleInternal, ITuple
     {
         /// <summary>
         /// Returns a value that indicates whether the current <see cref="ValueTuple"/> instance is equal to a specified object.
@@ -60,7 +59,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return 0;
@@ -85,7 +84,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return 0;
@@ -103,7 +102,7 @@ namespace System
             return 0;
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return 0;
         }
@@ -120,12 +119,26 @@ namespace System
             return "()";
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
             return ")";
         }
 
-        int ITupleInternal.Size => 0;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 0;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                throw new IndexOutOfRangeException();
+            }
+        }
 
         /// <summary>Creates a new struct 0-tuple.</summary>
         /// <returns>A 0-tuple.</returns>
@@ -246,44 +259,47 @@ namespace System
 
         internal static int CombineHashCodes(int h1, int h2)
         {
-            return HashHelpers.Combine(HashHelpers.Combine(HashHelpers.RandomSeed, h1), h2);
+            // Forward to helper class in Common for this
+            // We keep the actual hashing logic there, so
+            // other classes can use it for hashing
+            return System.Numerics.Hashing.HashHelpers.Combine(h1, h2);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3)
         {
-            return HashHelpers.Combine(CombineHashCodes(h1, h2), h3);
+            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
         {
-            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3), h4);
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3), h4);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
         {
-            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4), h5);
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
         {
-            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5), h6);
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5), h6);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
         {
-            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
         {
-            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
+            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
         }
     }
 
     /// <summary>Represents a 1-tuple, or singleton, as a value type.</summary>
     /// <typeparam name="T1">The type of the tuple's only component.</typeparam>
     public struct ValueTuple<T1>
-        : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, ITupleInternal
+        : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, IValueTupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1}"/> instance's first component.
@@ -347,7 +363,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -374,7 +390,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -388,7 +404,7 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return EqualityComparer<T1>.Default.GetHashCode(Item1);
+            return Item1?.GetHashCode() ?? 0;
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -396,7 +412,7 @@ namespace System
             return comparer.GetHashCode(Item1);
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return comparer.GetHashCode(Item1);
         }
@@ -415,12 +431,30 @@ namespace System
             return "(" + Item1?.ToString() + ")";
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 1;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 1;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                if (index != 0)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+                return Item1;
+            }
+        }
     }
 
     /// <summary>
@@ -430,7 +464,7 @@ namespace System
     /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2>
-        : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, IValueTupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
@@ -521,7 +555,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2>)other);
@@ -549,7 +583,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2>)other;
@@ -566,8 +600,8 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -581,7 +615,7 @@ namespace System
                                                comparer.GetHashCode(Item2));
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -601,12 +635,34 @@ namespace System
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ")";
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 2;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 2;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -617,7 +673,7 @@ namespace System
     /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2, T3>
-        : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, IValueTupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's first component.
@@ -697,7 +753,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3>)other);
@@ -728,7 +784,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3>)other;
@@ -748,9 +804,9 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -765,7 +821,7 @@ namespace System
                                                comparer.GetHashCode(Item3));
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -783,12 +839,36 @@ namespace System
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 3;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 3;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -800,7 +880,7 @@ namespace System
     /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2, T3, T4>
-        : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, IValueTupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's first component.
@@ -888,7 +968,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
@@ -922,7 +1002,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
@@ -945,10 +1025,10 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0,
+                                               Item4?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -964,7 +1044,7 @@ namespace System
                                                comparer.GetHashCode(Item4));
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -982,12 +1062,38 @@ namespace System
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 4;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 4;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -1000,7 +1106,7 @@ namespace System
     /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2, T3, T4, T5>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, IValueTupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's first component.
@@ -1096,7 +1202,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
@@ -1133,7 +1239,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
@@ -1159,11 +1265,11 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                               EqualityComparer<T5>.Default.GetHashCode(Item5));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0,
+                                               Item4?.GetHashCode() ?? 0,
+                                               Item5?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1180,7 +1286,7 @@ namespace System
                                                comparer.GetHashCode(Item5));
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -1198,12 +1304,40 @@ namespace System
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 5;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 5;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -1217,7 +1351,7 @@ namespace System
     /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2, T3, T4, T5, T6>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IValueTupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's first component.
@@ -1321,7 +1455,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
@@ -1361,7 +1495,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
@@ -1390,12 +1524,12 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                               EqualityComparer<T6>.Default.GetHashCode(Item6));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0,
+                                               Item4?.GetHashCode() ?? 0,
+                                               Item5?.GetHashCode() ?? 0,
+                                               Item6?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1413,7 +1547,7 @@ namespace System
                                                comparer.GetHashCode(Item6));
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -1431,12 +1565,42 @@ namespace System
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 6;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 6;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -1451,7 +1615,7 @@ namespace System
     /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ITupleInternal
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IValueTupleInternal, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's first component.
@@ -1563,7 +1727,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
@@ -1606,7 +1770,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
@@ -1638,13 +1802,13 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                               EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                               EqualityComparer<T7>.Default.GetHashCode(Item7));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                Item2?.GetHashCode() ?? 0,
+                                                Item3?.GetHashCode() ?? 0,
+                                                Item4?.GetHashCode() ?? 0,
+                                                Item5?.GetHashCode() ?? 0,
+                                                Item6?.GetHashCode() ?? 0,
+                                                Item7?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1663,7 +1827,7 @@ namespace System
                                                comparer.GetHashCode(Item7));
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -1681,12 +1845,44 @@ namespace System
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
         }
 
-        int ITupleInternal.Size => 7;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 7;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    case 6:
+                        return Item7;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -1702,8 +1898,8 @@ namespace System
     /// <typeparam name="TRest">The type of the tuple's eighth component.</typeparam>
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
-        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal
-        where TRest : struct
+    : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IValueTupleInternal, ITuple
+    where TRest : struct, ITuple
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's first component.
@@ -1751,9 +1947,9 @@ namespace System
         /// <param name="rest">The value of the tuple's eight component.</param>
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
         {
-            if (!(rest is ITupleInternal))
+            if (!(rest is IValueTupleInternal))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleLastArgumentNotAValueTuple);
+                throw new ArgumentException(SR.ArgumentException_TupleLastArgumentNotATuple);
             }
 
             Item1 = item1;
@@ -1828,7 +2024,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
@@ -1874,7 +2070,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;
@@ -1910,19 +2106,19 @@ namespace System
         public override int GetHashCode()
         {
             // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
-            ITupleInternal rest = Rest as ITupleInternal;
+            IValueTupleInternal rest = Rest as IValueTupleInternal;
             if (rest == null)
             {
-                return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                   EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                   EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                   EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                   EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                   EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                   EqualityComparer<T7>.Default.GetHashCode(Item7));
+                return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                 Item2?.GetHashCode() ?? 0,
+                                                 Item3?.GetHashCode() ?? 0,
+                                                 Item4?.GetHashCode() ?? 0,
+                                                 Item5?.GetHashCode() ?? 0,
+                                                 Item6?.GetHashCode() ?? 0,
+                                                 Item7?.GetHashCode() ?? 0);
             }
 
-            int size = rest.Size;
+            int size = rest.Length;
             if (size >= 8) { return rest.GetHashCode(); }
 
             // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
@@ -1930,51 +2126,51 @@ namespace System
             switch (k)
             {
                 case 1:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 2:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 3:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 4:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 5:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 6:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item2?.GetHashCode() ?? 0,
+                                                       Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 7:
                 case 8:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                       EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                       Item2?.GetHashCode() ?? 0,
+                                                       Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
             }
 
-            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            Contract.Assert(false, "Missed all cases for computing ValueTuple hash code");
             return -1;
         }
 
@@ -1986,7 +2182,7 @@ namespace System
         private int GetHashCodeCore(IEqualityComparer comparer)
         {
             // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
-            ITupleInternal rest = Rest as ITupleInternal;
+            IValueTupleInternal rest = Rest as IValueTupleInternal;
             if (rest == null)
             {
                 return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1), comparer.GetHashCode(Item2), comparer.GetHashCode(Item3),
@@ -1994,7 +2190,7 @@ namespace System
                                                    comparer.GetHashCode(Item7));
             }
 
-            int size = rest.Size;
+            int size = rest.Length;
             if (size >= 8) { return rest.GetHashCode(comparer); }
 
             // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
@@ -2025,11 +2221,11 @@ namespace System
                                                        comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
             }
 
-            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            Contract.Assert(false, "Missed all cases for computing ValueTuple hash code");
             return -1;
         }
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        int IValueTupleInternal.GetHashCode(IEqualityComparer comparer)
         {
             return GetHashCodeCore(comparer);
         }
@@ -2044,7 +2240,7 @@ namespace System
         /// </remarks>
         public override string ToString()
         {
-            ITupleInternal rest = Rest as ITupleInternal;
+            IValueTupleInternal rest = Rest as IValueTupleInternal;
             if (rest == null)
             {
                 return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
@@ -2055,9 +2251,9 @@ namespace System
             }
         }
 
-        string ITupleInternal.ToStringEnd()
+        string IValueTupleInternal.ToStringEnd()
         {
-            ITupleInternal rest = Rest as ITupleInternal;
+            IValueTupleInternal rest = Rest as IValueTupleInternal;
             if (rest == null)
             {
                 return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
@@ -2068,12 +2264,43 @@ namespace System
             }
         }
 
-        int ITupleInternal.Size
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length
         {
             get
             {
-                ITupleInternal rest = Rest as ITupleInternal;
-                return rest == null ? 8 : 7 + rest.Size;
+                return 7 + Rest.Length;
+            }
+        }
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    case 6:
+                        return Item7;
+                }
+
+                return Rest[index - 7];
             }
         }
     }

--- a/src/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -402,7 +402,7 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return Item1?.GetHashCode() ?? 0;
+            return EqualityComparer<T1>.Default.GetHashCode(Item1);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -598,8 +598,8 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
-                                               Item2?.GetHashCode() ?? 0);
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                EqualityComparer<T2>.Default.GetHashCode(Item2));
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -802,9 +802,9 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
-                                               Item2?.GetHashCode() ?? 0,
-                                               Item3?.GetHashCode() ?? 0);
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                EqualityComparer<T3>.Default.GetHashCode(Item3));
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1023,10 +1023,10 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
-                                               Item2?.GetHashCode() ?? 0,
-                                               Item3?.GetHashCode() ?? 0,
-                                               Item4?.GetHashCode() ?? 0);
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                EqualityComparer<T4>.Default.GetHashCode(Item4));
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1263,11 +1263,11 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
-                                               Item2?.GetHashCode() ?? 0,
-                                               Item3?.GetHashCode() ?? 0,
-                                               Item4?.GetHashCode() ?? 0,
-                                               Item5?.GetHashCode() ?? 0);
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5));
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1522,12 +1522,12 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
-                                               Item2?.GetHashCode() ?? 0,
-                                               Item3?.GetHashCode() ?? 0,
-                                               Item4?.GetHashCode() ?? 0,
-                                               Item5?.GetHashCode() ?? 0,
-                                               Item6?.GetHashCode() ?? 0);
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                EqualityComparer<T6>.Default.GetHashCode(Item6));
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1800,13 +1800,13 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
-                                                Item2?.GetHashCode() ?? 0,
-                                                Item3?.GetHashCode() ?? 0,
-                                                Item4?.GetHashCode() ?? 0,
-                                                Item5?.GetHashCode() ?? 0,
-                                                Item6?.GetHashCode() ?? 0,
-                                                Item7?.GetHashCode() ?? 0);
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                EqualityComparer<T7>.Default.GetHashCode(Item7));
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -2107,13 +2107,13 @@ namespace System
             IValueTupleInternal rest = Rest as IValueTupleInternal;
             if (rest == null)
             {
-                return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
-                                                 Item2?.GetHashCode() ?? 0,
-                                                 Item3?.GetHashCode() ?? 0,
-                                                 Item4?.GetHashCode() ?? 0,
-                                                 Item5?.GetHashCode() ?? 0,
-                                                 Item6?.GetHashCode() ?? 0,
-                                                 Item7?.GetHashCode() ?? 0);
+                return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                    EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                    EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                    EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                    EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                    EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                    EqualityComparer<T7>.Default.GetHashCode(Item7));
             }
 
             int size = rest.Length;
@@ -2124,47 +2124,47 @@ namespace System
             switch (k)
             {
                 case 1:
-                    return ValueTuple.CombineHashCodes(Item7?.GetHashCode() ?? 0,
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T7>.Default.GetHashCode(Item7),
                                                        rest.GetHashCode());
                 case 2:
-                    return ValueTuple.CombineHashCodes(Item6?.GetHashCode() ?? 0,
-                                                       Item7?.GetHashCode() ?? 0,
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
                                                        rest.GetHashCode());
                 case 3:
-                    return ValueTuple.CombineHashCodes(Item5?.GetHashCode() ?? 0,
-                                                       Item6?.GetHashCode() ?? 0,
-                                                       Item7?.GetHashCode() ?? 0,
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
                                                        rest.GetHashCode());
                 case 4:
-                    return ValueTuple.CombineHashCodes(Item4?.GetHashCode() ?? 0,
-                                                       Item5?.GetHashCode() ?? 0,
-                                                       Item6?.GetHashCode() ?? 0,
-                                                       Item7?.GetHashCode() ?? 0,
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
                                                        rest.GetHashCode());
                 case 5:
-                    return ValueTuple.CombineHashCodes(Item3?.GetHashCode() ?? 0,
-                                                       Item4?.GetHashCode() ?? 0,
-                                                       Item5?.GetHashCode() ?? 0,
-                                                       Item6?.GetHashCode() ?? 0,
-                                                       Item7?.GetHashCode() ?? 0,
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
                                                        rest.GetHashCode());
                 case 6:
-                    return ValueTuple.CombineHashCodes(Item2?.GetHashCode() ?? 0,
-                                                       Item3?.GetHashCode() ?? 0,
-                                                       Item4?.GetHashCode() ?? 0,
-                                                       Item5?.GetHashCode() ?? 0,
-                                                       Item6?.GetHashCode() ?? 0,
-                                                       Item7?.GetHashCode() ?? 0,
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
                                                        rest.GetHashCode());
                 case 7:
                 case 8:
-                    return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
-                                                       Item2?.GetHashCode() ?? 0,
-                                                       Item3?.GetHashCode() ?? 0,
-                                                       Item4?.GetHashCode() ?? 0,
-                                                       Item5?.GetHashCode() ?? 0,
-                                                       Item6?.GetHashCode() ?? 0,
-                                                       Item7?.GetHashCode() ?? 0,
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                       EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
                                                        rest.GetHashCode());
             }
 


### PR DESCRIPTION
ValueTuple types are supporting the C#7.0 tuples feature. They have been implemented as a standalone CoreFx package, but should be moved down into the various corlibs (mscorlib/desktop and mscorlib/mono are already done) to be consistent with `System.Tuple` and can be used by other APIs.

This PR does not contain `ITuple` yet, but I will add it shortly. It is an interface in `CompilerServices` namespace used for dynamic pattern matching (in a future version of C#). It applies to `System.Tuple` and `System.ValueTuple` types. It was implemented in mscorlib/desktop, and I'm in the process of implementing it in other corlibs.

The main purpose for opening this PR at this point is to raise two questions: 
1. where should test code for `ValueTuple` go?
2. where is the existing test code for `System.Tuple`? I could not find it.

FYI @tarekgh @VSadov 