### PR TITLE
Port TimeZoneInfo cleanups from CoreCLR

### DIFF
--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -610,8 +610,7 @@ namespace System
             try
             {
                 using (RegistryKey dynamicKey = RegistryKey.GetBaseKey(RegistryKey.HKEY_LOCAL_MACHINE).OpenSubKey(
-                                   String.Format(CultureInfo.InvariantCulture, "{0}\\{1}\\Dynamic DST",
-                                       c_timeZonesRegistryHive, id),
+                                   c_timeZonesRegistryHive + "\\" + id + "\\Dynamic DST",
                                    false
                                    ))
                 {
@@ -788,8 +787,7 @@ namespace System
         {
             dstDisabled = false;
             using (RegistryKey key = RegistryKey.GetBaseKey(RegistryKey.HKEY_LOCAL_MACHINE).OpenSubKey(
-                              String.Format(CultureInfo.InvariantCulture, "{0}\\{1}",
-                                  c_timeZonesRegistryHive, id),
+                                  c_timeZonesRegistryHive + "\\" + id,
                                   false
                                   ))
             {
@@ -1063,8 +1061,7 @@ namespace System
             e = null;
 
             using (RegistryKey key = RegistryKey.GetBaseKey(RegistryKey.HKEY_LOCAL_MACHINE).OpenSubKey(
-                              String.Format(CultureInfo.InvariantCulture, "{0}\\{1}",
-                                  c_timeZonesRegistryHive, id),
+                                  c_timeZonesRegistryHive + "\\" + id,
                                   false
                                   ))
             {

--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -1137,7 +1137,7 @@ namespace System
                 String daylightDisplayName,
                 AdjustmentRule[] adjustmentRules)
         {
-            return new TimeZoneInfo(
+            return CreateCustomTimeZone(
                            id,
                            baseUtcOffset,
                            displayName,
@@ -1165,6 +1165,11 @@ namespace System
                 AdjustmentRule[] adjustmentRules,
                 Boolean disableDaylightSavingTime)
         {
+            if (!disableDaylightSavingTime && adjustmentRules?.Length > 0)
+            {
+                adjustmentRules = (AdjustmentRule[])adjustmentRules.Clone();
+            }
+
             return new TimeZoneInfo(
                             id,
                             baseUtcOffset,
@@ -2256,17 +2261,13 @@ namespace System
             Boolean adjustmentRulesSupportDst;
             ValidateTimeZoneInfo(id, baseUtcOffset, adjustmentRules, out adjustmentRulesSupportDst);
 
-            if (!disableDaylightSavingTime && adjustmentRules != null && adjustmentRules.Length > 0)
-            {
-                _adjustmentRules = (AdjustmentRule[])adjustmentRules.Clone();
-            }
-
             _id = id;
             _baseUtcOffset = baseUtcOffset;
             _displayName = displayName;
             _standardDisplayName = standardDisplayName;
             _daylightDisplayName = (disableDaylightSavingTime ? null : daylightDisplayName);
             _supportsDaylightSavingTime = adjustmentRulesSupportDst && !disableDaylightSavingTime;
+            _adjustmentRules = adjustmentRules;
         }
 
         //
@@ -3281,7 +3282,7 @@ namespace System
 
                 try
                 {
-                    return TimeZoneInfo.CreateCustomTimeZone(id, baseUtcOffset, displayName, standardName, daylightName, rules);
+                    return new TimeZoneInfo(id, baseUtcOffset, displayName, standardName, daylightName, rules, disableDaylightSavingTime: false);
                 }
                 catch (ArgumentException ex)
                 {

--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -2934,12 +2934,12 @@ namespace System
         public struct TransitionTime : IEquatable<TransitionTime>, ISerializable, IDeserializationCallback
         {
             // ---- SECTION:  members supporting exposed properties -------------*
-            private DateTime _timeOfDay;
-            private byte _month;
-            private byte _week;
-            private byte _day;
-            private DayOfWeek _dayOfWeek;
-            private Boolean _isFixedDateRule;
+            private readonly DateTime _timeOfDay;
+            private readonly byte _month;
+            private readonly byte _week;
+            private readonly byte _day;
+            private readonly DayOfWeek _dayOfWeek;
+            private readonly Boolean _isFixedDateRule;
 
 
             // ---- SECTION: public properties --------------*
@@ -3043,16 +3043,24 @@ namespace System
 
 
             // -------- SECTION: constructors -----------------*
-            /*
-                        private TransitionTime() {           
-                            _timeOfDay = new DateTime();
-                            _month = 0;
-                            _week  = 0;
-                            _day   = 0;
-                            _dayOfWeek = DayOfWeek.Sunday;
-                            _isFixedDateRule = false;
-                        }
-            */
+
+            private TransitionTime(
+                DateTime timeOfDay,
+                Int32 month,
+                Int32 week,
+                Int32 day,
+                DayOfWeek dayOfWeek,
+                Boolean isFixedDateRule)
+            {
+                ValidateTransitionTime(timeOfDay, month, week, day, dayOfWeek);
+
+                _timeOfDay = timeOfDay;
+                _month = (byte)month;
+                _week = (byte)week;
+                _day = (byte)day;
+                _dayOfWeek = dayOfWeek;
+                _isFixedDateRule = isFixedDateRule;
+            }
 
 
             // -------- SECTION: factory methods -----------------*
@@ -3063,7 +3071,7 @@ namespace System
                     Int32 month,
                     Int32 day)
             {
-                return CreateTransitionTime(timeOfDay, month, 1, day, DayOfWeek.Sunday, true);
+                return new TransitionTime(timeOfDay, month, 1, day, DayOfWeek.Sunday, true);
             }
 
 
@@ -3073,29 +3081,7 @@ namespace System
                     Int32 week,
                     DayOfWeek dayOfWeek)
             {
-                return CreateTransitionTime(timeOfDay, month, week, 1, dayOfWeek, false);
-            }
-
-
-            private static TransitionTime CreateTransitionTime(
-                    DateTime timeOfDay,
-                    Int32 month,
-                    Int32 week,
-                    Int32 day,
-                    DayOfWeek dayOfWeek,
-                    Boolean isFixedDateRule)
-            {
-                ValidateTransitionTime(timeOfDay, month, week, day, dayOfWeek);
-
-                TransitionTime t = new TransitionTime();
-                t._isFixedDateRule = isFixedDateRule;
-                t._timeOfDay = timeOfDay;
-                t._dayOfWeek = dayOfWeek;
-                t._day = (byte)day;
-                t._week = (byte)week;
-                t._month = (byte)month;
-
-                return t;
+                return new TransitionTime(timeOfDay, month, week, 1, dayOfWeek, false);
             }
 
 

--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -58,13 +58,13 @@ namespace System
         };
 
         // ---- SECTION:  members supporting exposed properties -------------*
-        private String _id;
-        private String _displayName;
-        private String _standardDisplayName;
-        private String _daylightDisplayName;
-        private TimeSpan _baseUtcOffset;
-        private Boolean _supportsDaylightSavingTime;
-        private AdjustmentRule[] _adjustmentRules;
+        private readonly String _id;
+        private readonly String _displayName;
+        private readonly String _standardDisplayName;
+        private readonly String _daylightDisplayName;
+        private readonly TimeSpan _baseUtcOffset;
+        private readonly Boolean _supportsDaylightSavingTime;
+        private readonly AdjustmentRule[] _adjustmentRules;
 
         // constants for TimeZoneInfo.Local and TimeZoneInfo.Utc
         private const string c_utcId = "UTC";

--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -2625,12 +2625,12 @@ namespace System
         sealed public class AdjustmentRule : IEquatable<AdjustmentRule>, ISerializable, IDeserializationCallback
         {
             // ---- SECTION:  members supporting exposed properties -------------*
-            private DateTime _dateStart;
-            private DateTime _dateEnd;
-            private TimeSpan _daylightDelta;
-            private TransitionTime _daylightTransitionStart;
-            private TransitionTime _daylightTransitionEnd;
-            private TimeSpan _baseUtcOffsetDelta;   // delta from the default Utc offset (utcOffset = defaultUtcOffset + _baseUtcOffsetDelta)
+            private readonly DateTime _dateStart;
+            private readonly DateTime _dateEnd;
+            private readonly TimeSpan _daylightDelta;
+            private readonly TransitionTime _daylightTransitionStart;
+            private readonly TransitionTime _daylightTransitionEnd;
+            private readonly TimeSpan _baseUtcOffsetDelta;   // delta from the default Utc offset (utcOffset = defaultUtcOffset + _baseUtcOffsetDelta)
 
 
             // ---- SECTION: public properties --------------*
@@ -2718,7 +2718,24 @@ namespace System
 
             // -------- SECTION: constructors -----------------*
 
-            private AdjustmentRule() { }
+            private AdjustmentRule(
+                DateTime dateStart,
+                DateTime dateEnd,
+                TimeSpan daylightDelta,
+                TransitionTime daylightTransitionStart,
+                TransitionTime daylightTransitionEnd,
+                TimeSpan baseUtcOffsetDelta)
+            {
+                ValidateAdjustmentRule(dateStart, dateEnd, daylightDelta,
+                                       daylightTransitionStart, daylightTransitionEnd);
+
+                _dateStart = dateStart;
+                _dateEnd = dateEnd;
+                _daylightDelta = daylightDelta;
+                _daylightTransitionStart = daylightTransitionStart;
+                _daylightTransitionEnd = daylightTransitionEnd;
+                _baseUtcOffsetDelta = baseUtcOffsetDelta;
+            }
 
 
             // -------- SECTION: factory methods -----------------*
@@ -2730,19 +2747,13 @@ namespace System
                              TransitionTime daylightTransitionStart,
                              TransitionTime daylightTransitionEnd)
             {
-                ValidateAdjustmentRule(dateStart, dateEnd, daylightDelta,
-                                       daylightTransitionStart, daylightTransitionEnd);
-
-                AdjustmentRule rule = new AdjustmentRule();
-
-                rule._dateStart = dateStart;
-                rule._dateEnd = dateEnd;
-                rule._daylightDelta = daylightDelta;
-                rule._daylightTransitionStart = daylightTransitionStart;
-                rule._daylightTransitionEnd = daylightTransitionEnd;
-                rule._baseUtcOffsetDelta = TimeSpan.Zero;
-
-                return rule;
+                return new AdjustmentRule(
+                    dateStart,
+                    dateEnd,
+                    daylightDelta,
+                    daylightTransitionStart,
+                    daylightTransitionEnd,
+                    baseUtcOffsetDelta: TimeSpan.Zero);
             }
 
             internal static AdjustmentRule CreateAdjustmentRule(
@@ -2753,9 +2764,13 @@ namespace System
                              TransitionTime daylightTransitionEnd,
                              TimeSpan baseUtcOffsetDelta)
             {
-                AdjustmentRule rule = CreateAdjustmentRule(dateStart, dateEnd, daylightDelta, daylightTransitionStart, daylightTransitionEnd);
-                rule._baseUtcOffsetDelta = baseUtcOffsetDelta;
-                return rule;
+                return new AdjustmentRule(
+                    dateStart,
+                    dateEnd,
+                    daylightDelta,
+                    daylightTransitionStart,
+                    daylightTransitionEnd,
+                    baseUtcOffsetDelta);
             }
 
             // ----- SECTION: internal utility methods ----------------*

--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -2699,16 +2699,13 @@ namespace System
             // IEquatable<AdjustmentRule>
             public bool Equals(AdjustmentRule other)
             {
-                bool equals = (other != null
+                return other != null
                      && _dateStart == other._dateStart
                      && _dateEnd == other._dateEnd
                      && _daylightDelta == other._daylightDelta
-                     && _baseUtcOffsetDelta == other._baseUtcOffsetDelta);
-
-                equals = equals && _daylightTransitionEnd.Equals(other._daylightTransitionEnd)
-                         && _daylightTransitionStart.Equals(other._daylightTransitionStart);
-
-                return equals;
+                     && _baseUtcOffsetDelta == other._baseUtcOffsetDelta
+                     && _daylightTransitionEnd.Equals(other._daylightTransitionEnd)
+                     && _daylightTransitionStart.Equals(other._daylightTransitionStart);
             }
 
 


### PR DESCRIPTION
Contributes to #2388

Ports the following:
~~https://github.com/dotnet/coreclr/pull/8513~~ (this change was already in CoreRT)
https://github.com/dotnet/coreclr/pull/8526
https://github.com/dotnet/coreclr/pull/8527
https://github.com/dotnet/coreclr/pull/8528
https://github.com/dotnet/coreclr/pull/8529
https://github.com/dotnet/coreclr/pull/8530
https://github.com/dotnet/coreclr/pull/8540
https://github.com/dotnet/coreclr/pull/8575

There's one more left to port (https://github.com/dotnet/coreclr/pull/8512) that I'll submit as a separate PR as it requires some minor refactoring in CoreRT to avoid having the Sort code in multiple places in CoreRT (it's only in one place in CoreCLR).

cc: @tarekgh, @DnlHarvey, @jkotas