### PR TITLE
TimeZoneInfo Cleanup

### DIFF
--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -15,9 +15,11 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System
 {
@@ -142,11 +144,10 @@ namespace System
             throw new NotImplementedException();
         }
 
-        public static ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones()
+        private static void PopulateAllSystemTimeZones(CachedData cachedData)
         {
+            Debug.Assert(Monitor.IsEntered(cachedData));
             // UNIXTODO
-            if (s_cachedData._allSystemTimeZonesRead)
-                s_cachedData._allSystemTimeZonesRead = true;
             throw new NotImplementedException();
         }
 


### PR DESCRIPTION
Some cleanup in CoreRT's TimeZoneInfo implementation:

- The `CachedData` locking is currently inconsistent. Some code is using a private `Lock` object with `LockHolder.Hold`, while other code is locking against the `CachedData` instance (via `Monitor.Enter/Exit`). This change removes the private `Lock` object and just locks against the `CachedData` instance throughout, which is consistent with the CoreCLR implementation.

- `TimeZoneInfoComparer` is being used in two places in CoreRT to sort the list of system time zones, whereas it's only used in one place in CoreCLR. This change refactors the code to have a shared implementation of `GetSystemTimeZones` in CoreRT that handles the sorting in one place, allowing a single `Comparison<T>` lambda to be used, which matches the CoreCLR implementation. Now the  single shared `GetSystemTimeZones` implementation calls a private static `PopulateAllSystemTimeZones` method, which has separate implementations for Win32/WinRT/Unix. This addresses porting https://github.com/dotnet/coreclr/pull/8512.

- The WinRT implementation of `FindSystemTimeZoneById` was accessing the cached data without any locking. Added locking.

cc: @tarekgh, @jkotas

Fixes #2388 