### PR TITLE
NativeLayoutInfo, RuntimeMethodHandle

### DIFF
--- a/src/Common/src/Internal/NativeFormat/NativeFormat.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormat.cs
@@ -29,7 +29,12 @@ namespace Internal.NativeFormat
     // Bag is the key record type for extensibility. It is a list <id, data> pairs. Data is integer that 
     // is interpretted according to the id. It is typically relative offset of another record.
     //
-    internal enum BagElementKind : uint
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    enum BagElementKind : uint
     {
         End                         = 0x00,
         BaseType                    = 0x01,
@@ -61,6 +66,11 @@ namespace Internal.NativeFormat
     // FixupSignature signature describes indirection. It starts with integer describing the kind of data stored in the indirection,
     // followed by kind-specific signature.
     //
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum FixupSignatureKind : uint
     {
         Null                        = 0x00,
@@ -96,6 +106,11 @@ namespace Internal.NativeFormat
     // TypeSignature describes type. The low 4 bits of the integer that is starts with describe the kind. Upper 28 bits are kind 
     // specific data. The argument signatures immediately follow for nested types.
     //
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum TypeSignatureKind : uint
     {
         Null                        = 0x0,
@@ -110,6 +125,11 @@ namespace Internal.NativeFormat
         FunctionPointer             = 0xB, // Function pointer (data - calling convention, arg count, args)
     };
 
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum TypeModifierKind : uint
     {
         Array                       = 0x1,
@@ -117,12 +137,22 @@ namespace Internal.NativeFormat
         Pointer                     = 0x3,
     };
 
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum StaticDataKind : uint
     {
         Gc                          = 0x1,
         NonGc                       = 0x2,
     };
 
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum GenericContextKind : uint
     {
         FromThis                    = 0x00,
@@ -134,6 +164,11 @@ namespace Internal.NativeFormat
         NeedsUSGContext             = 0x08,
     };
 
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum CallingConventionConverterKind : uint
     {
         NoInstantiatingParam        = 0x00,   // The calling convention interpreter can assume that the calling convention of the target method has no instantiating parameter
@@ -142,6 +177,11 @@ namespace Internal.NativeFormat
     }
 
     [Flags]
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum TypeFlags : uint
     {
         HasClassConstructor             = 0x1,
@@ -149,6 +189,11 @@ namespace Internal.NativeFormat
     };
 
     [Flags]
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum MethodFlags : uint
     {
         HasInstantiation            = 0x1,
@@ -158,12 +203,22 @@ namespace Internal.NativeFormat
     };
 
     [Flags]
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum MethodCallingConvention : uint
     {
         Generic                     = 0x1,
         Static                      = 0x2,
     };
 
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
     enum FieldStorage : uint
     {
         Instance                    = 0x0,

--- a/src/Common/src/Internal/NativeFormat/NativeFormatReader.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormatReader.cs
@@ -249,7 +249,7 @@ namespace Internal.NativeFormat
 
         public IntPtr OffsetToAddress(uint offset)
         {
-            Debug.Assert(offset < _size);
+            Debug.Assert(offset <= _size);
 
             return new IntPtr(_base + offset);
         }
@@ -447,7 +447,7 @@ namespace Internal.NativeFormat
         }
     }
 
-    internal struct NativeHashtable
+    struct NativeHashtable
     {
         private NativeReader _reader;
         private uint _baseOffset;
@@ -480,9 +480,9 @@ namespace Internal.NativeFormat
         //
         public struct Enumerator
         {
-            private NativeParser _parser;
-            private uint _endOffset;
-            private byte _lowHashcode;
+            NativeParser _parser;
+            uint _endOffset;
+            byte _lowHashcode;
 
             internal Enumerator(NativeParser parser, uint endOffset, byte lowHashcode)
             {
@@ -518,10 +518,10 @@ namespace Internal.NativeFormat
 
         public struct AllEntriesEnumerator
         {
-            private NativeHashtable _table;
-            private NativeParser _parser;
-            private uint _currentBucket;
-            private uint _endOffset;
+            NativeHashtable _table;
+            NativeParser _parser;
+            uint _currentBucket;
+            uint _endOffset;
 
             internal AllEntriesEnumerator(NativeHashtable table)
             {

--- a/src/Common/src/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormatWriter.cs
@@ -357,10 +357,10 @@ namespace Internal.NativeFormat
 #if NATIVEFORMAT_COMPRESSION
         // TODO:
 #else
-        struct TypeSignatureCompressor
+        internal struct TypeSignatureCompressor
         {
-            TypeSignatureCompressor(NativeWriter pWriter) { }
-            void Pack(Vertex vertex) { }
+            internal TypeSignatureCompressor(NativeWriter pWriter) { }
+            internal void Pack(Vertex vertex) { }
         }
 #endif
 
@@ -393,6 +393,68 @@ namespace Internal.NativeFormat
         {
             Tuple vertex = new Tuple(item1, item2, item3);
             return Unify(vertex);
+        }
+
+        public Vertex GetMethodNameAndSigSignature(string name, Vertex signature)
+        {
+            MethodNameAndSigSignature sig = new MethodNameAndSigSignature(
+                GetStringConstant(name), 
+                GetRelativeOffsetSignature(signature));
+            return Unify(sig);
+        }
+
+        public Vertex GetStringConstant(string value)
+        {
+            StringConstant vertex = new StringConstant(value);
+            return Unify(vertex);
+        }
+
+        public Vertex GetRelativeOffsetSignature(Vertex item)
+        {
+            RelativeOffsetSignature sig = new RelativeOffsetSignature(item);
+            return Unify(sig);
+        }
+
+        public Vertex GetOffsetSignature(Vertex item)
+        {
+            OffsetSignature sig = new OffsetSignature(item);
+            return Unify(sig);
+        }
+
+        public Vertex GetExternalTypeSignature(uint externalTypeId)
+        {
+            ExternalTypeSignature sig = new ExternalTypeSignature(externalTypeId);
+            return Unify(sig);
+        }
+
+        public Vertex GetMethodSignature(uint flags, uint fptrReferenceId, Vertex containingType, Vertex methodNameAndSig, Vertex[] args)
+        {
+            MethodSignature sig = new MethodSignature(flags, fptrReferenceId, containingType, methodNameAndSig, args);
+            return Unify(sig);
+        }
+
+        public Vertex GetMethodSigSignature(uint callingConvention, uint genericArgCount, Vertex returnType, Vertex[] parameters)
+        {
+            MethodSigSignature sig = new MethodSigSignature(callingConvention, genericArgCount, returnType, parameters);
+            return Unify(sig);
+        }
+
+        public Vertex GetModifierTypeSignature(TypeModifierKind modifier, Vertex param)
+        {
+            ModifierTypeSignature sig = new ModifierTypeSignature(modifier, param);
+            return Unify(sig);
+        }
+
+        public Vertex GetVariableTypeSignature(uint index, bool method)
+        {
+            VariableTypeSignature sig = new VariableTypeSignature(index, method);
+            return Unify(sig);
+        }
+
+        public Vertex GetInstantiationTypeSignature(Vertex typeDef, Vertex[] arguments)
+        {
+            InstantiationTypeSignature sig = new InstantiationTypeSignature(typeDef, arguments);
+            return Unify(sig);
         }
     }
 
@@ -530,6 +592,478 @@ namespace Internal.NativeFormat
             }
 
             return hashCode;
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class MethodNameAndSigSignature : Vertex
+    {
+        Vertex _methodName;
+        Vertex _signature;
+
+        public MethodNameAndSigSignature(Vertex methodName, Vertex signature)
+        {
+            _methodName = methodName;
+            _signature = signature;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            _methodName.Save(writer);
+            _signature.Save(writer);
+        }
+
+        public override int GetHashCode()
+        {
+            return 509 * 197 + _methodName.GetHashCode() + 647 * _signature.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            MethodNameAndSigSignature other = obj as MethodNameAndSigSignature;
+            if (other == null)
+                return false;
+
+            return Object.Equals(_methodName, other._methodName) && Object.Equals(_signature, other._signature);
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class StringConstant : Vertex
+    {
+        string _value;
+
+        public StringConstant(string value)
+        {
+            _value = value;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            writer.WriteString(_value);
+        }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            StringConstant other = obj as StringConstant;
+            if (other == null)
+                return false;
+
+            return _value == other._value;
+        }
+    }
+
+    //
+    // Performs indirection to an existing native layout signature by writing out the
+    // relative offset.
+    //
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class RelativeOffsetSignature : Vertex
+    {
+        Vertex _item;
+
+        public RelativeOffsetSignature(Vertex item)
+        {
+            _item = item;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            writer.WriteRelativeOffset(_item);
+        }
+
+        public override int GetHashCode()
+        {
+            return _item.GetHashCode() >> 3;
+        }
+
+        public override bool Equals(object obj)
+        {
+            RelativeOffsetSignature other = obj as RelativeOffsetSignature;
+            if (other == null)
+                return false;
+
+            return Object.Equals(_item, other._item);
+        }
+    }
+
+    //
+    // Performs indirection to an existing native layout signature using offset from the
+    // beginning of the native format. This allows cross-native layout references. You must
+    // ensure that the native layout writer of the pointee is saved before that of the pointer
+    // so the offsets are locked down.
+    //
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class OffsetSignature : Vertex
+    {
+        Vertex _item;
+
+        public OffsetSignature(Vertex item)
+        {
+            _item = item;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            writer.WriteUnsigned((uint)_item.VertexOffset);
+        }
+
+        public override int GetHashCode()
+        {
+            return _item.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            OffsetSignature other = obj as OffsetSignature;
+            if (other == null)
+                return false;
+
+            return Object.Equals(_item, other._item);
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class ExternalTypeSignature : Vertex
+    {
+        uint _externalTypeId;
+
+        public ExternalTypeSignature(uint externalTypeId)
+        {
+            _externalTypeId = externalTypeId;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            NativeWriter.TypeSignatureCompressor compressor = new NativeWriter.TypeSignatureCompressor(writer);
+
+            writer.WriteUnsigned((uint)TypeSignatureKind.External | (_externalTypeId << 4));
+
+            compressor.Pack(this);
+        }
+
+        public override int GetHashCode()
+        {
+            return 32439 + 11 * (int)_externalTypeId;
+        }
+
+        public override bool Equals(object obj)
+        {
+            ExternalTypeSignature other = obj as ExternalTypeSignature;
+            if (other == null)
+                return false;
+
+            return _externalTypeId == other._externalTypeId;
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class MethodSignature : Vertex
+    {
+        uint _flags;
+        uint _fptrReferenceId;
+        Vertex _containingType;
+        Vertex _methodNameAndSig;
+        Vertex[] _args;
+
+        public MethodSignature(uint flags, uint fptrReferenceId, Vertex containingType, Vertex methodNameAndSig, Vertex[] args)
+        {
+            _flags = flags;
+            _fptrReferenceId = fptrReferenceId;
+            _containingType = containingType;
+            _methodNameAndSig = methodNameAndSig;
+            _args = args;
+
+            if ((flags & (uint)MethodFlags.HasInstantiation) != 0)
+                Debug.Assert(args != null && args.Length > 0);
+            if ((flags & (uint)MethodFlags.HasFunctionPointer) == 0)
+                Debug.Assert(fptrReferenceId == 0);
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            writer.WriteUnsigned(_flags);
+            if ((_flags & (uint)MethodFlags.HasFunctionPointer) != 0)
+                writer.WriteUnsigned(_fptrReferenceId);
+            _containingType.Save(writer);
+            _methodNameAndSig.Save(writer);
+            if ((_flags & (uint)MethodFlags.HasInstantiation) != 0)
+            {
+                writer.WriteUnsigned((uint)_args.Length);
+                for (uint iArg = 0; _args != null && iArg < _args.Length; iArg++)
+                    _args[iArg].Save(writer);
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = _args != null ? _args.Length : 0;
+            hash += (hash << 5) + (int)_flags * 23;
+            hash += (hash << 5) + (int)_fptrReferenceId * 119;
+            hash += (hash << 5) + _containingType.GetHashCode();
+            for (uint iArg = 0; _args != null && iArg < _args.Length; iArg++)
+                hash += (hash << 5) + _args[iArg].GetHashCode();
+            hash += (hash << 5) + _methodNameAndSig.GetHashCode();
+            return hash;
+        }
+
+        public override bool Equals(object obj)
+        {
+            MethodSignature other = obj as MethodSignature;
+            if (other == null)
+                return false;
+
+            if (!(
+                _flags == other._flags &&
+                _fptrReferenceId == other._fptrReferenceId &&
+                Object.Equals(_containingType, other._containingType) &&
+                Object.Equals(_methodNameAndSig, other._methodNameAndSig)))
+            {
+                return false;
+            }
+
+            if (_args != null)
+            {
+                if (other._args == null) return false;
+                if (other._args.Length != _args.Length) return false;
+                for (uint iArg = 0; _args != null && iArg < _args.Length; iArg++)
+                    if (!Object.Equals(_args[iArg], other._args[iArg]))
+                        return false;
+            }
+            else if (other._args != null)
+                return false;
+
+            return true;
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class MethodSigSignature : Vertex
+    {
+        uint _callingConvention;
+        uint _genericArgCount;
+        Vertex _returnType;
+        Vertex[] _parameters;
+
+        public MethodSigSignature(uint callingConvention, uint genericArgCount, Vertex returnType, Vertex[] parameters)
+        {
+            _callingConvention = callingConvention;
+            _returnType = returnType;
+            _genericArgCount = genericArgCount;
+            _parameters = parameters;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            writer.WriteUnsigned(_callingConvention);
+
+            // Signatures omit the generic type parameter count for non-generic methods
+            if (_genericArgCount > 0)
+                writer.WriteUnsigned(_genericArgCount);
+
+            writer.WriteUnsigned((uint)_parameters.Length);
+
+            _returnType.Save(writer);
+
+            foreach(var p in _parameters)
+                p.Save(writer);
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 317 + 709 * (int)_callingConvention + 953 * (int)_genericArgCount + 31 * _returnType.GetHashCode();
+            foreach (var p in _parameters)
+                hash += (hash << 5) + p.GetHashCode();
+            return hash;
+        }
+
+        public override bool Equals(object obj)
+        {
+            MethodSigSignature other = obj as MethodSigSignature;
+            if (other == null)
+                return false;
+
+            if (!(
+                _callingConvention == other._callingConvention &&
+                _genericArgCount == other._genericArgCount &&
+                _parameters.Length == other._parameters.Length &&
+                Object.Equals(_returnType, other._returnType)))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < _parameters.Length; i++)
+                if (!Object.Equals(_parameters[i], other._parameters[i]))
+                    return false;
+
+            return true;
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class ModifierTypeSignature : Vertex
+    {
+        TypeModifierKind _modifier;
+        Vertex _param;
+
+        public ModifierTypeSignature(TypeModifierKind modifier, Vertex param)
+        {
+            _modifier = modifier;
+            _param = param;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            NativeWriter.TypeSignatureCompressor compressor = new NativeWriter.TypeSignatureCompressor(writer);
+
+            writer.WriteUnsigned((uint)TypeSignatureKind.Modifier | ((uint)_modifier << 4));
+            _param.Save(writer);
+
+            compressor.Pack(this);
+        }
+
+        public override int GetHashCode()
+        {
+            return 432981 + 37 * (int)_modifier + _param.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            ModifierTypeSignature other = obj as ModifierTypeSignature;
+            if (other == null)
+                return false;
+
+            return _modifier == other._modifier && Object.Equals(_param, other._param);
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class VariableTypeSignature : Vertex
+    {
+        uint _variableId;
+
+        public VariableTypeSignature(uint index, bool method)
+        {
+            _variableId = (index << 1) | (method ? (uint)1 : 0);
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            NativeWriter.TypeSignatureCompressor compressor = new NativeWriter.TypeSignatureCompressor(writer);
+
+            writer.WriteUnsigned((uint)TypeSignatureKind.Variable | (_variableId << 4));
+
+            compressor.Pack(this);
+        }
+
+        public override int GetHashCode()
+        {
+            return 6093 + 7 * (int)_variableId;
+        }
+
+        public override bool Equals(object obj)
+        {
+            VariableTypeSignature other = obj as VariableTypeSignature;
+            if (other == null)
+                return false;
+
+            return _variableId == other._variableId;
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class InstantiationTypeSignature : Vertex
+    {
+        Vertex _typeDef;
+        Vertex[] _args;
+
+        public InstantiationTypeSignature(Vertex typeDef, Vertex[] args)
+        {
+            _typeDef = typeDef;
+            _args = args;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            NativeWriter.TypeSignatureCompressor compressor = new NativeWriter.TypeSignatureCompressor(writer);
+
+            writer.WriteUnsigned((uint)TypeSignatureKind.Instantiation | ((uint)_args.Length << 4));
+            _typeDef.Save(writer);
+            for (int iArg = 0; iArg < _args.Length; iArg++)
+                _args[iArg].Save(writer);
+
+            compressor.Pack(this);
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = _args.Length;
+
+            hash += (hash << 5) + _typeDef.GetHashCode();
+            for (int iArg = 0; iArg < _args.Length; iArg++)
+                hash += (hash << 5) + _args[iArg].GetHashCode();
+            return hash;
+        }
+
+        public override bool Equals(object obj)
+        {
+            InstantiationTypeSignature other = obj as InstantiationTypeSignature;
+            if (other == null)
+                return false;
+
+            if (_args.Length != other._args.Length || !Object.Equals(_typeDef, other._typeDef))
+                return false;
+
+            for (uint iArg = 0; iArg < _args.Length; iArg++)
+                if (!Object.Equals(_args[iArg], other._args[iArg]))
+                    return false;
+
+            return true;
         }
     }
 

--- a/src/Common/src/Internal/Runtime/MetadataBlob.cs
+++ b/src/Common/src/Internal/Runtime/MetadataBlob.cs
@@ -32,12 +32,12 @@ namespace Internal.Runtime
         DynamicInvokeTemplateData                   = 23,
 
         //Native layout blobs:
-        NativeLayoutInfo                            = 30, // Created by MDIL binder
-        NativeReferences                            = 31, // Created by MDIL binder
-        GenericsHashtable                           = 32, // Created by MDIL binder
-        NativeStatics                               = 33, // Created by MDIL binder
-        StaticsInfoHashtable                        = 34, // Created by MDIL binder
-        GenericMethodsHashtable                     = 35, // Created by MDIL binder
-        ExactMethodInstantiationsHashtable          = 36, // Created by MDIL binder
+        NativeLayoutInfo                            = 30,
+        NativeReferences                            = 31,
+        GenericsHashtable                           = 32,
+        NativeStatics                               = 33,
+        StaticsInfoHashtable                        = 34,
+        GenericMethodsHashtable                     = 35,
+        ExactMethodInstantiationsHashtable          = 36,
     }
 }

--- a/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -503,8 +503,12 @@ namespace Internal.TypeSystem
                 if (baseType == null)
                     return foundOnCurrentType;
 
-                if (foundOnCurrentType == null && (ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, baseType) == null))
+                if (foundOnCurrentType == null)
                 {
+                    MethodDesc foundOnBaseType = ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, baseType);
+                    if (foundOnBaseType != null)
+                        return foundOnBaseType;
+
                     // TODO! Does this handle the case where the base type explicitly implements the interface, but is abstract
                     // and doesn't actually have an implementation?
                     if (!IsInterfaceImplementedOnType(baseType, interfaceType))

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -422,6 +422,11 @@ namespace Internal.IL.Stubs
                         return EmitByRefMarshalling(byRefType);
                     }
                 }
+                else if (IsSafeHandle(byRefType.ParameterType))
+                {
+                    // HACK... This is incorrect
+                    return EmitSafeHandleMarshalling(byRefType.ParameterType);
+                }
             }
 
             if (type.IsString)

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatMethod.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatMethod.cs
@@ -414,7 +414,7 @@ namespace Internal.TypeSystem.NativeFormat
                 int handleAsToken = _handle.ToInt();
 
                 IntPtr moduleHandle = Internal.Runtime.TypeLoader.ModuleList.Instance.GetModuleForMetadataReader(MetadataReader);
-                return new MethodNameAndSignature(Name, RuntimeMethodSignature.CreateFromMethodHandle(moduleHandle, handleAsToken));
+                return new MethodNameAndSignature(Name, RuntimeSignature.CreateFromMethodHandle(moduleHandle, handleAsToken));
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -89,6 +89,12 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(factory.TypeNonGCStaticsSymbol((MetadataType)_type), "Class constructor");
             }
 
+            DependencyList gvmDependencies = ComputeGenericVirtualMethodEntries(factory);
+            if (gvmDependencies.Count > 0)
+            {
+                dependencyList.AddRange(gvmDependencies);
+            }
+
             return dependencyList;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between reflection metadata and generated method bodies.
+    /// </summary>
+    internal sealed class ExactMethodInstantiationsNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        private NativeWriter _nativeWriter;
+        private Section _nativeSection;
+        private VertexHashtable _hashtable;
+
+        private HashSet<MethodDesc> _exactMethodInsantiationsList;
+
+        public ExactMethodInstantiationsNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__exact_method_instantiations_End", true);
+            _externalReferences = externalReferences;
+
+            _nativeWriter = new NativeWriter();
+            _hashtable = new VertexHashtable();
+            _nativeSection = _nativeWriter.NewSection();
+            _nativeSection.Place(_hashtable);
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__exact_method_instantiations");
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            MemoryStream stream = new MemoryStream();
+            _nativeWriter.Save(stream);
+
+            byte[] streamBytes = stream.ToArray();
+
+            _endSymbol.SetSymbolOffset(streamBytes.Length);
+
+            return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+
+        public bool AddNativeLayoutExactMethodInstantiationHashTableEntry(NodeFactory factory, MethodDesc method)
+        {
+            _exactMethodInsantiationsList = _exactMethodInsantiationsList ?? new HashSet<MethodDesc>();
+
+            // Check if we already wrote this method to the hashtable
+            if (_exactMethodInsantiationsList.Contains(method))
+                return false;
+
+            _exactMethodInsantiationsList.Add(method);
+
+            // Nothing to add for interface methods because they have no implementations of their own...
+            if (method.OwningType.IsInterface)
+                return false;
+
+            if (method.IsRuntimeDeterminedExactMethod)
+                return false;
+
+            // This hashtable is only for method instantiations that don't use generic dictionaries,
+            // so check if the given method is shared before proceeding
+            if (method.IsSharedByGenericInstantiations || method.GetCanonMethodTarget(CanonicalFormKind.Specific) != method)
+                return false;
+
+            bool getUnboxingStub = (method.OwningType.IsValueType || method.OwningType.IsEnum) && !method.Signature.IsStatic;
+            IMethodNode methodEntryPointNode = factory.MethodEntrypoint(method, getUnboxingStub);
+
+            Vertex methodSignature = factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForMethod(factory, method, _nativeWriter);
+            Vertex methodPointer = _nativeWriter.GetUnsignedConstant(_externalReferences.GetIndex(methodEntryPointNode));
+
+            // Make the generic method entry vertex
+
+            Vertex entry = _nativeWriter.GetTuple(methodSignature, methodPointer);
+
+            // Add to the hash table, hashed by the containing type's hashcode
+            uint hashCode = (uint)method.OwningType.GetHashCode();
+            _hashtable.Append(hashCode, _nativeSection.Place(entry));
+
+            return true;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
@@ -15,20 +15,22 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class ExternalReferencesTableNode : ObjectNode, ISymbolNode
     {
         private ObjectAndOffsetSymbolNode _endSymbol;
+        private string _blobName;
 
         private Dictionary<SymbolAndDelta, uint> _insertedSymbolsDictionary = new Dictionary<SymbolAndDelta, uint>();
         private List<SymbolAndDelta> _insertedSymbols = new List<SymbolAndDelta>();
 
-        public ExternalReferencesTableNode()
+        public ExternalReferencesTableNode(string blobName)
         {
-            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__external_references_End", true);
+            _blobName = blobName;
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__external_" + blobName + "_references_End", true);
         }
 
         public ISymbolNode EndSymbol => _endSymbol;
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(nameMangler.CompilationUnitPrefix).Append("__external_references");
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__external_" + _blobName + "_references");
         }
         public int Offset => 0;
         public override bool IsShareable => false;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            return null;
+            return ComputeGenericVirtualMethodEntries(factory);
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between reflection metadata and generated method bodies.
+    /// </summary>
+    internal sealed class GenericVirtualMethodTableNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        private Dictionary<MethodDesc, Dictionary<TypeDesc, MethodDesc>> _gvmImplemenations;
+        private Dictionary<MethodDesc, NativeLayoutInfoTokenNode> _methodDescToNativeLayoutInfoToken;
+
+        public GenericVirtualMethodTableNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__gvm_table_End", true);
+            _externalReferences = externalReferences;
+
+            _gvmImplemenations = new Dictionary<MethodDesc, Dictionary<TypeDesc, MethodDesc>>();
+            _methodDescToNativeLayoutInfoToken = new Dictionary<MethodDesc, NativeLayoutInfoTokenNode>();
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__gvm_table");
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        public DependencyList AddGenericVirtualMethodImplementation(NodeFactory factory, MethodDesc callingMethod, TypeDesc implementationType, MethodDesc implementationMethod)
+        {
+            DependencyList dependencyNodes = null;
+
+            if (callingMethod.OwningType.IsInterface)
+                return dependencyNodes;
+
+            dependencyNodes = new DependencyList();
+
+            // Compute the open method signatures
+            MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
+            MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
+            TypeDesc openImplementationType = implementationType.GetTypeDefinition();
+
+            Vertex openCallingMethodSignature = factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForPlacedNameAndSignature(
+                factory,
+                openCallingMethod.Name,
+                factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForMethodSignature(factory, openCallingMethod));
+
+            Vertex openImplementationMethodSignature = factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForPlacedNameAndSignature(
+                factory,
+                openImplementationMethod.Name,
+                factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForMethodSignature(factory, openImplementationMethod));
+
+            _methodDescToNativeLayoutInfoToken[openCallingMethod] = factory.NativeLayoutInfoToken(openCallingMethodSignature);
+            _methodDescToNativeLayoutInfoToken[openImplementationMethod] = factory.NativeLayoutInfoToken(openImplementationMethodSignature);
+
+            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayoutInfoToken(openCallingMethodSignature), "gvm table needed signature"));
+            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayoutInfoToken(openImplementationMethodSignature), "gvm table needed signature"));
+
+            // Insert open method signatures into the GVM map
+            if (!_gvmImplemenations.ContainsKey(openCallingMethod))
+                _gvmImplemenations[openCallingMethod] = new Dictionary<TypeDesc, MethodDesc>();
+
+            _gvmImplemenations[openCallingMethod][openImplementationMethod.OwningType] = openImplementationMethod;
+
+            return dependencyNodes;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            NativeWriter nativeFormatWriter = new NativeWriter();
+            VertexHashtable gvmHashtable = new VertexHashtable();
+
+            Section gvmHashtableSection = nativeFormatWriter.NewSection();
+            gvmHashtableSection.Place(gvmHashtable);
+
+            // Emit the GVM target information entries
+            foreach (var gvm in _gvmImplemenations)
+            {
+                Debug.Assert(!gvm.Key.OwningType.IsInterface);
+
+                foreach (var targetMethod in gvm.Value)
+                {
+                    uint callingTypeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(gvm.Key.OwningType));
+                    Vertex vertex = nativeFormatWriter.GetUnsignedConstant(callingTypeId);
+
+                    uint targetTypeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(targetMethod.Key));
+                    vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant(targetTypeId));
+
+                    Debug.Assert(_methodDescToNativeLayoutInfoToken.ContainsKey(gvm.Key));
+                    Debug.Assert(_methodDescToNativeLayoutInfoToken.ContainsKey(targetMethod.Value));
+
+                    uint callingNameAndSigId = _externalReferences.GetIndex(_methodDescToNativeLayoutInfoToken[gvm.Key]);
+                    vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant(callingNameAndSigId));
+
+                    uint targetNameAndSigId = _externalReferences.GetIndex(_methodDescToNativeLayoutInfoToken[targetMethod.Value]);
+                    vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant(targetNameAndSigId));
+
+                    int hashCode = gvm.Key.OwningType.GetHashCode();
+                    hashCode = ((hashCode << 13) ^ hashCode) ^ targetMethod.Key.GetHashCode();
+
+                    gvmHashtable.Append((uint)hashCode, gvmHashtableSection.Place(vertex));
+                }
+            }
+
+            MemoryStream stream = new MemoryStream();
+            nativeFormatWriter.Save(stream);
+            byte[] streamBytes = stream.ToArray();
+
+            _endSymbol.SetSymbolOffset(streamBytes.Length);
+
+            return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericsHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericsHashtableNode.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a hashtable of all compiled generic type instantiations
+    /// </summary>
+    internal sealed class GenericsHashtableNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        private NativeWriter _writer;
+        private Section _tableSection;
+        private VertexHashtable _hashtable;
+
+        public GenericsHashtableNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__generics_hashtable_End", true);
+            _externalReferences = externalReferences;
+
+            _writer = new NativeWriter();
+            _hashtable = new VertexHashtable();
+            _tableSection = _writer.NewSection();
+            _tableSection.Place(_hashtable);
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__generics_hashtable");
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        public void AddInstantiatedTypeEntry(NodeFactory factory, TypeDesc type)
+        {
+            Debug.Assert(type.HasInstantiation && !type.IsGenericDefinition);
+
+            var typeSymbol = factory.NecessaryTypeSymbol(type);
+            uint instantiationId = _externalReferences.GetIndex(typeSymbol);
+            Vertex hashtableEntry = _writer.GetUnsignedConstant(instantiationId);
+
+            _hashtable.Append((uint)type.GetHashCode(), _tableSection.Place(hashtableEntry));
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            MemoryStream stream = new MemoryStream();
+            _writer.Save(stream);
+            byte[] streamBytes = stream.ToArray();
+
+            _endSymbol.SetSymbolOffset(streamBytes.Length);
+
+            return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
@@ -1,0 +1,209 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between reflection metadata and generated method bodies.
+    /// </summary>
+    internal sealed class InterfaceGenericVirtualMethodTableNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        private Dictionary<MethodDesc, HashSet<MethodDesc>> _interfaceGvmSlots;
+        private Dictionary<MethodDesc, Dictionary<TypeDesc, HashSet<int>>> _interfaceImpls;
+
+        private Dictionary<MethodDesc, NativeLayoutInfoTokenNode> _methodDescToNativeLayoutInfoToken;
+        private Dictionary<TypeDesc, NativeLayoutInfoTokenNode> _typeDescToNativeLayoutInfoToken;
+
+        public InterfaceGenericVirtualMethodTableNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__interface_gvm_table_End", true);
+            _externalReferences = externalReferences;
+
+            _interfaceGvmSlots = new Dictionary<MethodDesc, HashSet<MethodDesc>>();
+            _interfaceImpls = new Dictionary<MethodDesc, Dictionary<TypeDesc, HashSet<int>>>();
+            _methodDescToNativeLayoutInfoToken = new Dictionary<MethodDesc, NativeLayoutInfoTokenNode>();
+            _typeDescToNativeLayoutInfoToken = new Dictionary<TypeDesc, NativeLayoutInfoTokenNode>();
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__interface_gvm_table");
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        public DependencyList AddGenericVirtualMethodImplementation(NodeFactory factory, MethodDesc callingMethod, TypeDesc implementationType, MethodDesc implementationMethod)
+        {
+            DependencyList dependencyNodes = null;
+
+            if (!callingMethod.OwningType.IsInterface)
+                return dependencyNodes;
+
+            dependencyNodes = new DependencyList();
+
+            // Compute the open method signatures
+            MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
+            MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
+            TypeDesc openImplementationType = implementationType.GetTypeDefinition();
+
+            Vertex openCallingMethodSignature = factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForPlacedNameAndSignature(
+                factory,
+                openCallingMethod.Name,
+                factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForMethodSignature(factory, openCallingMethod));
+            
+            Vertex openImplementationMethodSignature = factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForPlacedNameAndSignature(
+                factory,
+                openImplementationMethod.Name,
+                factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForMethodSignature(factory, openImplementationMethod));
+
+            _methodDescToNativeLayoutInfoToken[openCallingMethod] = factory.NativeLayoutInfoToken(openCallingMethodSignature);
+            _methodDescToNativeLayoutInfoToken[openImplementationMethod] = factory.NativeLayoutInfoToken(openImplementationMethodSignature);
+
+            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayoutInfoToken(openCallingMethodSignature), "gvm table needed signature"));
+            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayoutInfoToken(openImplementationMethodSignature), "gvm table needed signature"));
+
+            // Add the entry to the interface GVM slots mapping table
+            {
+                if (!_interfaceGvmSlots.ContainsKey(openCallingMethod))
+                    _interfaceGvmSlots[openCallingMethod] = new HashSet<MethodDesc>();
+
+                _interfaceGvmSlots[openCallingMethod].Add(openImplementationMethod);
+            }
+
+            // If the implementation method is implementing some interface method, compute which
+            // interface explicitly implemented on the type that the current method implements an interface method for.
+            // We need this because at runtime, the interfaces explicitly implemented on the type will have 
+            // runtime-determined signatures that we can use to make generic substitutions and check for interface matching.
+            if (!openImplementationType.IsInterface)
+            {
+                if (!_interfaceImpls.ContainsKey(openImplementationMethod))
+                    _interfaceImpls[openImplementationMethod] = new Dictionary<TypeDesc, HashSet<int>>();
+                if (!_interfaceImpls[openImplementationMethod].ContainsKey(openImplementationType))
+                    _interfaceImpls[openImplementationMethod][openImplementationType] = new HashSet<int>();
+                
+                int index = 0;
+                int numIfacesAdded = 0;
+                foreach (var implementedInterfaces in implementationType.RuntimeInterfaces)
+                {
+                    if (implementedInterfaces == callingMethod.OwningType)
+                    {
+                        _interfaceImpls[openImplementationMethod][openImplementationType].Add(index);
+                        numIfacesAdded++;
+
+                        TypeDesc currentInterface = openImplementationType.RuntimeInterfaces[index];
+
+                        Vertex currentInterfaceSignature = factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForPlacedTypeSignature(
+                            factory, 
+                            currentInterface);
+
+                        _typeDescToNativeLayoutInfoToken[currentInterface] = factory.NativeLayoutInfoToken(currentInterfaceSignature);
+
+                        dependencyNodes.Add(new DependencyListEntry(factory.NativeLayoutInfoToken(currentInterfaceSignature), "gvm table needed signature"));
+                    }
+
+                    index++;
+                }
+
+                Debug.Assert(numIfacesAdded > 0);
+            }
+
+            return dependencyNodes;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            NativeWriter nativeFormatWriter = new NativeWriter();
+            VertexHashtable gvmHashtable = new VertexHashtable();
+
+            Section gvmHashtableSection = nativeFormatWriter.NewSection();
+            gvmHashtableSection.Place(gvmHashtable);
+
+            // Emit the interface slot resolution entries
+            foreach (var gvm in _interfaceGvmSlots)
+            {
+                Debug.Assert(gvm.Key.OwningType.IsInterface);
+
+                // Emit the method signature and containing type of the current interface method
+                uint typeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(gvm.Key.OwningType));
+                uint nameAndSigId = _externalReferences.GetIndex(_methodDescToNativeLayoutInfoToken[gvm.Key]);
+
+                Vertex vertex = nativeFormatWriter.GetTuple(
+                    nativeFormatWriter.GetUnsignedConstant(typeId),
+                    nativeFormatWriter.GetUnsignedConstant(nameAndSigId));
+
+                // Emit the method name / sig and containing type of each GVM target method for the current interface method entry
+                vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)gvm.Value.Count));
+                foreach (var targetSlot in gvm.Value)
+                {
+                    nameAndSigId = _externalReferences.GetIndex(_methodDescToNativeLayoutInfoToken[targetSlot]);
+                    typeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(targetSlot.OwningType));
+                    vertex = nativeFormatWriter.GetTuple(
+                        vertex,
+                        nativeFormatWriter.GetUnsignedConstant(nameAndSigId),
+                        nativeFormatWriter.GetUnsignedConstant(typeId));
+
+                    // Emit the interface GVM slot details for each type that implements the interface methods
+                    {
+                        Debug.Assert(_interfaceImpls.ContainsKey(targetSlot));
+
+                        var ifaceImpls = _interfaceImpls[targetSlot];
+                    
+                        // First, emit how many types have method implementations for this interface method entry
+                        vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)ifaceImpls.Count));
+                    
+                        // Emit each type that implements the interface method, and the interface signatures for the interfaces implemented by the type
+                        foreach (var currentImpl in ifaceImpls)
+                        {
+                            typeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(currentImpl.Key));
+                            vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant(typeId));
+                    
+                            // Emit information on which interfaces the current method entry provides implementations for
+                            vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)currentImpl.Value.Count));
+                            foreach (var ifaceId in currentImpl.Value)
+                            {
+                                // Emit the signature of the current interface implemented by the method
+                                Debug.Assert(((uint)ifaceId) < currentImpl.Key.RuntimeInterfaces.Length);
+                                TypeDesc currentInterface = currentImpl.Key.RuntimeInterfaces[ifaceId];
+                                uint sigId = _externalReferences.GetIndex(_typeDescToNativeLayoutInfoToken[currentInterface]);
+                                vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant(sigId));
+                            }
+                        }
+                    }
+                }
+
+                int hashCode = gvm.Key.OwningType.GetHashCode();
+                gvmHashtable.Append((uint)hashCode, gvmHashtableSection.Place(vertex));
+            }
+
+            MemoryStream stream = new MemoryStream();
+            nativeFormatWriter.Save(stream);
+            byte[] streamBytes = stream.ToArray();
+
+            _endSymbol.SetSymbolOffset(streamBytes.Length);
+
+            return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -99,6 +99,27 @@ namespace ILCompiler.DependencyAnalysis
                     dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke"));
             }
 
+            if (_method.HasInstantiation)
+            {
+                if (factory.MetadataManager.GetExactMethodInstantiationsNode().AddNativeLayoutExactMethodInstantiationHashTableEntry(factory, _method))
+                {
+                    // Ensure dependency nodes used by the signature are added to the graph
+                    if (dependencies == null)
+                        dependencies = new DependencyList();
+
+                    dependencies.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(_method.OwningType), "Exact method instantiation signature"));
+
+                    foreach(var arg in _method.Instantiation)
+                        dependencies.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(arg), "Exact method instantiation signature"));
+
+                    dependencies.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(_method.Signature.ReturnType), "Exact method instantiation signature"));
+
+                    for(int i = 0; i < _method.Signature.Length; i++)
+                        dependencies.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(_method.Signature[i]), "Exact method instantiation signature"));
+                }
+            }
+
+
             return dependencies;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoNode.cs
@@ -1,0 +1,304 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between reflection metadata and generated method bodies.
+    /// </summary>
+    internal sealed class NativeLayoutInfoNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        private NativeWriter _writer;
+        private MemoryStream _writerStream;
+
+        private Section _signaturesSection;
+        private Section _ldTokenInfoSection;
+
+        public NativeLayoutInfoNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__native_info_layout_End", true);
+            _externalReferences = externalReferences;
+            _writer = new NativeWriter();
+            _signaturesSection = _writer.NewSection();
+            _ldTokenInfoSection = _writer.NewSection();
+        }
+
+        public ISymbolNode EndSymbol
+        {
+            get
+            {
+                return _endSymbol;
+            }
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__native_info_layout");
+        }
+        public int Offset => 0;
+        public override bool IsShareable => false;
+
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override string GetName() => this.GetMangledName();
+
+        public void SaveNativeLayoutInfoWriter()
+        {
+            if (_writerStream != null)
+            {
+#if DEBUG
+                // Sanity check... We should not write new items to the native layout after 
+                // we've already saved it.
+
+                MemoryStream debugStream = new MemoryStream();
+                _writer.Save(debugStream);
+                byte[] debugStreamBytes = debugStream.ToArray();
+                byte[] nativeLayoutInfoBytes = _writerStream.ToArray();
+                Debug.Assert(debugStreamBytes.Length == nativeLayoutInfoBytes.Length);
+                for (int i = 0; i < debugStreamBytes.Length; i++)
+                    Debug.Assert(debugStreamBytes[i] == nativeLayoutInfoBytes[i]);
+#endif
+                return;
+            }
+
+            _writerStream = new MemoryStream();
+            _writer.Save(_writerStream);
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            SaveNativeLayoutInfoWriter();
+
+            byte[] nativeLayoutInfoBytes = _writerStream.ToArray();
+
+            _endSymbol.SetSymbolOffset(nativeLayoutInfoBytes.Length);
+
+            return new ObjectData(nativeLayoutInfoBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+
+        #region Vertex Building Functions
+        public Vertex GetNativeLayoutInfoSignatureForLdToken<T>(NodeFactory factory, T methodDescOrFieldDesc)
+        {
+            // TODO: option to return the uninstantiated signature info. Current implementation will only encode 
+            // the instantiated signature (i.e. with containing type, return type, args, etc... encoded as external types)
+
+            MethodDesc method = methodDescOrFieldDesc as MethodDesc;
+            FieldDesc field = methodDescOrFieldDesc as FieldDesc;
+
+            Vertex signature = null;
+
+            if (method != null)
+            {
+                Vertex containingType = GetNativeLayoutInfoSignatureForEEType(factory, method.OwningType);
+                Vertex nameAndSig = _writer.GetMethodNameAndSigSignature(
+                    method.Name, 
+                    GetNativeLayoutInfoSignatureForMethodSignature(factory, method.GetTypicalMethodDefinition()));
+                Vertex[] args = null;
+                MethodFlags flags = 0;
+
+                if (method.HasInstantiation)
+                {
+                    flags |= MethodFlags.HasInstantiation;
+                    args = new Vertex[method.Instantiation.Length];
+                    for (int i = 0; i < args.Length; i++)
+                        args[i] = GetNativeLayoutInfoSignatureForEEType(factory, method.Instantiation[i]);
+                }
+
+                signature = _writer.GetMethodSignature((uint)flags, 0, containingType, nameAndSig, args);
+            }
+            else if (field != null)
+            {
+                // TODO
+            }
+
+            Debug.Assert(signature != null);
+
+            signature = _ldTokenInfoSection.Place(signature);
+            return signature;
+        }
+
+        public Vertex GetNativeLayoutInfoSignatureForEEType(NodeFactory factory, TypeDesc type)
+        {
+            IEETypeNode typeSymbol = factory.NecessaryTypeSymbol(type);
+            uint typeIndex = _externalReferences.GetIndex(typeSymbol);
+            return _writer.GetExternalTypeSignature(typeIndex);
+        }
+
+        public Vertex GetNativeLayoutInfoSignatureForMethodSignature(NodeFactory factory, MethodDesc method)
+        {
+            MethodCallingConvention methodCallingConvention = default(MethodCallingConvention);
+
+            if (method.Signature.GenericParameterCount > 0)
+                methodCallingConvention |= MethodCallingConvention.Generic;
+            if (method.Signature.IsStatic)
+                methodCallingConvention |= MethodCallingConvention.Static;
+
+            int parameterCount = method.Signature.Length;
+            Vertex returnType = GetNativeLayoutInfoSignatureForTypeSignature(factory, method.Signature.ReturnType);
+            Vertex[] parameters = new Vertex[parameterCount];
+            for (int i = 0; i < parameterCount; i++)
+            {
+                parameters[i] = GetNativeLayoutInfoSignatureForTypeSignature(factory, method.Signature[i]);
+            }
+
+            return _signaturesSection.Place(_writer.GetMethodSigSignature((uint)methodCallingConvention, (uint)method.Signature.GenericParameterCount, returnType, parameters));
+        }
+
+        public Vertex GetNativeLayoutInfoSignatureForMethod(NodeFactory factory, MethodDesc method, NativeWriter writerToUse = null)
+        {
+            if (writerToUse == null)
+                writerToUse = _writer;
+
+            // Get native layout vertices for the declaring type
+
+            ISymbolNode declaringTypeNode = factory.NecessaryTypeSymbol(method.OwningType);
+            Debug.Assert(declaringTypeNode != null);
+            Vertex declaringType = writerToUse.GetUnsignedConstant(_externalReferences.GetIndex(declaringTypeNode));
+
+            // Get a vertex sequence for the method instantiation args if any
+
+            VertexSequence arguments = new VertexSequence();
+            if (method.HasInstantiation)
+            {
+                foreach (var arg in method.Instantiation)
+                {
+                    ISymbolNode argNode = factory.NecessaryTypeSymbol(arg);
+                    Debug.Assert(argNode != null);
+                    arguments.Append(writerToUse.GetUnsignedConstant(_externalReferences.GetIndex(argNode)));
+                }
+            }
+
+            // Get the name and sig of the method
+
+            Vertex nameAndSig = GetNativeLayoutInfoSignatureForPlacedNameAndSignature(
+                factory,
+                method.Name,
+                GetNativeLayoutInfoSignatureForMethodSignature(factory, method.GetTypicalMethodDefinition()),
+                writerToUse);
+
+            return writerToUse.GetTuple(declaringType, nameAndSig, arguments);
+        }
+
+        public Vertex GetNativeLayoutInfoSignatureForPlacedNameAndSignature(NodeFactory factory, string name, Vertex signature, NativeWriter writerToUse = null)
+        {
+            if (writerToUse == null)
+                writerToUse = _writer;
+
+            // Always use the nativeLayoutInfoWriter for names and sigs, even when writerToUse is one of the hash tables. This saves space,
+            // since we can Unify more signatures, allows optimizations in comparing sigs in the same module, and prevents the dynamic
+            // type loader having to know about other native layout sections (since sigs contain types). If we are using a non-native
+            // layout info writer, write the sig to the native layout info, and refer to it by offset in its own section.  At runtime,
+            // we will assume all names and sigs are in the native layout and find it.
+            Vertex nameAndSig = _writer.GetMethodNameAndSigSignature(name, signature);
+            nameAndSig = _signaturesSection.Place(nameAndSig);
+            if (writerToUse != _writer)
+            {
+                nameAndSig = writerToUse.GetOffsetSignature(nameAndSig);
+            }
+            return nameAndSig;
+        }
+
+        public Vertex GetNativeLayoutInfoSignatureForPlacedTypeSignature(NodeFactory factory, TypeDesc type)
+        {
+            Vertex typeSignature = GetNativeLayoutInfoSignatureForTypeSignature(factory, type);
+            return _signaturesSection.Place(typeSignature);
+        }
+
+
+        public Vertex GetNativeLayoutInfoSignatureForTypeSignature(NodeFactory factory, TypeDesc type)
+        {
+            Vertex signature = null;
+
+            switch (type.Category)
+            {
+                case Internal.TypeSystem.TypeFlags.SzArray:
+                    signature = _writer.GetModifierTypeSignature(TypeModifierKind.Array, GetNativeLayoutInfoSignatureForTypeSignature(factory, ((ArrayType)type).ElementType));
+                    break;
+
+                case Internal.TypeSystem.TypeFlags.Pointer:
+                    signature = _writer.GetModifierTypeSignature(TypeModifierKind.Pointer, GetNativeLayoutInfoSignatureForTypeSignature(factory, ((PointerType)type).ParameterType));
+                    break;
+
+                case Internal.TypeSystem.TypeFlags.ByRef:
+                    signature = _writer.GetModifierTypeSignature(TypeModifierKind.ByRef, GetNativeLayoutInfoSignatureForTypeSignature(factory, ((ByRefType)type).ParameterType));
+                    break;
+
+                case Internal.TypeSystem.TypeFlags.SignatureTypeVariable:
+                    signature = _writer.GetVariableTypeSignature((uint)((SignatureVariable)type).Index, false);
+                    break;
+
+                case Internal.TypeSystem.TypeFlags.SignatureMethodVariable:
+                    signature = _writer.GetVariableTypeSignature((uint)((SignatureMethodVariable)type).Index, true);
+                    break;
+
+                case Internal.TypeSystem.TypeFlags.Void:
+                case Internal.TypeSystem.TypeFlags.Boolean:
+                case Internal.TypeSystem.TypeFlags.Char:
+                case Internal.TypeSystem.TypeFlags.SByte:
+                case Internal.TypeSystem.TypeFlags.Byte:
+                case Internal.TypeSystem.TypeFlags.Int16:
+                case Internal.TypeSystem.TypeFlags.UInt16:
+                case Internal.TypeSystem.TypeFlags.Int32:
+                case Internal.TypeSystem.TypeFlags.UInt32:
+                case Internal.TypeSystem.TypeFlags.Int64:
+                case Internal.TypeSystem.TypeFlags.UInt64:
+                case Internal.TypeSystem.TypeFlags.Single:
+                case Internal.TypeSystem.TypeFlags.Double:
+                case Internal.TypeSystem.TypeFlags.IntPtr:
+                case Internal.TypeSystem.TypeFlags.UIntPtr:
+                case Internal.TypeSystem.TypeFlags.Enum:
+                    signature = GetNativeLayoutInfoSignatureForEEType(factory, type);
+                    break;
+
+                case Internal.TypeSystem.TypeFlags.Class:
+                case Internal.TypeSystem.TypeFlags.ValueType:
+                case Internal.TypeSystem.TypeFlags.Interface:
+                    if (type.HasInstantiation && !type.IsGenericDefinition)
+                    {
+                        TypeDesc typeDef = type.GetTypeDefinition();
+
+                        Vertex typeDefVertex = GetNativeLayoutInfoSignatureForTypeSignature(factory, typeDef);
+                        Vertex[] args = new Vertex[type.Instantiation.Length];
+                        for (int i = 0; i < args.Length; i++)
+                            args[i] = GetNativeLayoutInfoSignatureForTypeSignature(factory, type.Instantiation[i]);
+
+                        signature = _writer.GetInstantiationTypeSignature(typeDefVertex, args);
+                    }
+                    else
+                    {
+                        signature = GetNativeLayoutInfoSignatureForEEType(factory, type);
+                    }
+                    break;
+
+                // TODO case Internal.TypeSystem.TypeFlags.Array:
+                // TODO case Internal.TypeSystem.TypeFlags.FunctionPointer:
+
+                default:
+                    throw new NotImplementedException("NYI");
+            }
+
+            Debug.Assert(signature != null);
+            return signature;
+        }
+        #endregion
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoSignatureNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoSignatureNode.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    class NativeLayoutInfoSignatureNode : ObjectNode, ISymbolNode
+    {
+        private static int s_counter = 0;
+
+        private int _id;
+        private Vertex _nativeSignature;
+
+        public NativeLayoutInfoSignatureNode(Vertex nativeSignature)
+        {
+            _nativeSignature = nativeSignature;
+            _id = s_counter++;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__NativeLayoutInfoSignature_" + _id);
+        }
+        public int Offset => 0;
+
+        protected override string GetName() => this.GetMangledName();
+
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+
+        public override bool IsShareable => false;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            factory.MetadataManager.GetNativeLayoutInfoNode().SaveNativeLayoutInfoWriter();
+
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory);
+
+            objData.Alignment = objData.TargetPointerSize;
+            objData.DefinedSymbols.Add(this);
+
+            objData.EmitPointerReloc(factory.TypeManagerIndirection);
+            objData.EmitNaturalInt(_nativeSignature.VertexOffset);
+
+            return objData.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoTokenNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoTokenNode.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents an offset into the native layout info blob.
+    /// </summary>
+    internal sealed class NativeLayoutInfoTokenNode : ObjectNode, ISymbolNode
+    {
+        private static int s_counter = 0;
+
+        private int _id;
+        private Vertex _nativeVertex;
+
+        public NativeLayoutInfoTokenNode(Vertex nativeVertex)
+        {
+            _nativeVertex = nativeVertex;
+            _id = s_counter++;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__NativeLayoutInfoToken_" + _id);
+        }
+
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            factory.MetadataManager.GetNativeLayoutInfoNode().SaveNativeLayoutInfoWriter();
+
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory);
+
+            objData.Alignment = sizeof(uint);
+            objData.DefinedSymbols.Add(this);
+
+            objData.EmitInt(_nativeVertex.VertexOffset);
+
+            return objData.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -13,6 +13,7 @@ using Internal.Text;
 using Internal.TypeSystem;
 using Internal.Runtime;
 using Internal.IL;
+using Internal.NativeFormat;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -230,6 +231,21 @@ namespace ILCompiler.DependencyAnalysis
                 return new InterfaceDispatchCellNode(method);
             });
 
+            _runtimeMethodHandles = new NodeCache<MethodDesc, RuntimeMethodHandleNode>((MethodDesc method) =>
+            {
+                return new RuntimeMethodHandleNode(this, method);
+            });
+
+            _nativeLayoutInfoSignatureNodes = new NodeCache<Vertex, NativeLayoutInfoSignatureNode>((Vertex signature) =>
+            {
+                return new NativeLayoutInfoSignatureNode(signature);
+            });
+            
+            _nativeLayoutInfoTokenNodes = new NodeCache<Vertex, NativeLayoutInfoTokenNode>((Vertex nativeVertex) =>
+            {
+                return new NativeLayoutInfoTokenNode(nativeVertex);
+            });
+
             _interfaceDispatchMaps = new NodeCache<TypeDesc, InterfaceDispatchMapNode>((TypeDesc type) =>
             {
                 return new InterfaceDispatchMapNode(type);
@@ -366,6 +382,27 @@ namespace ILCompiler.DependencyAnalysis
         internal InterfaceDispatchCellNode InterfaceDispatchCell(MethodDesc method)
         {
             return _interfaceDispatchCells.GetOrAdd(method);
+        }
+
+        private NodeCache<MethodDesc, RuntimeMethodHandleNode> _runtimeMethodHandles;
+
+        internal RuntimeMethodHandleNode RuntimeMethodHandle(MethodDesc method)
+        {
+            return _runtimeMethodHandles.GetOrAdd(method);
+        }
+
+        private NodeCache<Vertex, NativeLayoutInfoSignatureNode> _nativeLayoutInfoSignatureNodes;
+        
+        internal NativeLayoutInfoSignatureNode NativeLayoutInfoSignature(Vertex signature)
+        {
+            return _nativeLayoutInfoSignatureNodes.GetOrAdd(signature);
+        }
+        
+        private NodeCache<Vertex, NativeLayoutInfoTokenNode> _nativeLayoutInfoTokenNodes;
+        
+        internal NativeLayoutInfoTokenNode NativeLayoutInfoToken(Vertex nativeVertex)
+        {
+            return _nativeLayoutInfoTokenNodes.GetOrAdd(nativeVertex);
         }
 
         private class BlobTupleEqualityComparer : IEqualityComparer<Tuple<Utf8String, byte[], int>>
@@ -506,7 +543,8 @@ namespace ILCompiler.DependencyAnalysis
             new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnGCStaticBase" },
             new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnNonGCStaticBase" },
             new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnThreadStaticBase" },
-            new string[] { "Internal.Runtime", "ThreadStatics", "GetThreadStaticBaseForType" }
+            new string[] { "Internal.Runtime", "ThreadStatics", "GetThreadStaticBaseForType" },
+            new string[] { "System.Runtime", "TypeLoaderExports", "GVMLookupForSlot" }
         };
 
         private ISymbolNode[] _helperEntrypointSymbols;
@@ -720,5 +758,7 @@ namespace ILCompiler.DependencyAnalysis
         EnsureClassConstructorRunAndReturnNonGCStaticBase,
         EnsureClassConstructorRunAndReturnThreadStaticBase,
         GetThreadStaticBaseForType,
+        GVMLookupForSlot,
+
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -162,6 +162,35 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(factory.TypeThreadStaticsSymbol((MetadataType)_target), "ReadyToRun Thread Static Storage");
                 return dependencyList;
             }
+            else if (_id == ReadyToRunHelperId.ResolveGenericVirtualMethod)
+            {
+                MethodDesc method = _target as MethodDesc;
+                Debug.Assert(method != null && method.HasInstantiation);
+
+                DependencyList dependencyList = new DependencyList();
+
+                if (factory.MetadataManager.GetExactMethodInstantiationsNode().AddNativeLayoutExactMethodInstantiationHashTableEntry(factory, method))
+                {
+                    // Ensure dependency nodes used by the signature are added to the graph
+                    if (dependencyList == null)
+                        dependencyList = new DependencyList();
+
+                    bool getUnboxingStub = (method.OwningType.IsValueType || method.OwningType.IsEnum) && !method.Signature.IsStatic;
+                    dependencyList.Add(new DependencyListEntry(factory.MethodEntrypoint(method, getUnboxingStub), "Exact method instantiation signature"));
+
+                    dependencyList.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(method.OwningType), "Exact method instantiation signature"));
+
+                    foreach (var arg in method.Instantiation)
+                        dependencyList.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(arg), "Exact method instantiation signature"));
+
+                    dependencyList.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(method.Signature.ReturnType), "Exact method instantiation signature"));
+
+                    for (int i = 0; i < method.Signature.Length; i++)
+                        dependencyList.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(method.Signature[i]), "Exact method instantiation signature"));
+                }
+
+                return dependencyList;
+            }
             else
             {
                 return null;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    class RuntimeMethodHandleNode : ObjectNode, ISymbolNode
+    {
+        MethodDesc _targetMethod;
+        NativeLayoutInfoSignatureNode _nativeSignatureNode;
+
+        public RuntimeMethodHandleNode(NodeFactory factory, MethodDesc targetMethod)
+        {
+            Debug.Assert(!targetMethod.IsSharedByGenericInstantiations);
+
+            Vertex nativeSignature = factory.MetadataManager.GetNativeLayoutInfoNode().GetNativeLayoutInfoSignatureForLdToken(factory, targetMethod);
+
+            _targetMethod = targetMethod;
+            _nativeSignatureNode = factory.NativeLayoutInfoSignature(nativeSignature);
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("__RuntimeMethodHandle_");
+            sb.Append(NodeFactory.NameMangler.GetMangledMethodName(_targetMethod));
+        }
+        public int Offset => 0;
+
+        protected override string GetName() => this.GetMangledName();
+
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+
+        public override bool IsShareable => false;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory);
+
+            objData.Alignment = objData.TargetPointerSize;
+            objData.DefinedSymbols.Add(this);
+
+            objData.EmitPointerReloc(_nativeSignatureNode);
+
+            return objData.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -220,7 +220,11 @@ namespace ILCompiler.DependencyAnalysis
                     break;
 
                 case ReadyToRunHelperId.ResolveGenericVirtualMethod:
-                    encoder.EmitINT3();
+                    {
+                        encoder.EmitLEAQ(Register.RDX, factory.RuntimeMethodHandle((MethodDesc)Target));
+                        encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.GVMLookupForSlot));
+                        encoder.EmitRET();
+                    }
                     break;
 
                 default:

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -90,6 +90,12 @@
     </Compile>
     <Compile Include="Compiler\CompilerGeneratedType.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayMapNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ExactMethodInstantiationsNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericsHashtableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericVirtualMethodTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\InterfaceGenericVirtualMethodTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NativeLayoutInfoNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NativeLayoutInfoTokenNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionFieldMapNode.cs" />
     <Compile Include="Compiler\ICompilationRootProvider.cs" />
     <Compile Include="Compiler\Compilation.cs" />
@@ -172,6 +178,8 @@
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64Emitter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchMapNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\RuntimeMethodHandleNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NativeLayoutInfoSignatureNode.cs" />
     <Compile Include="Compiler\ExportedMethodsRootProvider.cs" />
     <Compile Include="Compiler\IRootingServiceProvider.cs" />
     <Compile Include="Compiler\JitHelper.cs" />

--- a/src/ILCompiler/ILCompiler.sln
+++ b/src/ILCompiler/ILCompiler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "desktop", "desktop\desktop.csproj", "{B2C35178-5E42-4010-A72A-938711D7F8F0}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -24,48 +24,102 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.MetadataWriter",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILCompiler.MetadataTransform", "..\ILCompiler.MetadataTransform\src\ILCompiler.MetadataTransform.csproj", "{A965EA82-219D-48F7-AD51-BC030C16CC6F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.TypeLoader", "..\System.Private.TypeLoader\src\System.Private.TypeLoader.csproj", "{F36495F7-8CF5-474D-A92D-40317AE2439C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Private.Reflection.Execution", "..\System.Private.Reflection.Execution\src\System.Private.Reflection.Execution.csproj", "{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|x64.ActiveCfg = Debug|x64
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Debug|x64.Build.0 = Debug|x64
+		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|Any CPU.ActiveCfg = Release|x64
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.ActiveCfg = Release|x64
 		{B2C35178-5E42-4010-A72A-938711D7F8F0}.Release|x64.Build.0 = Release|x64
+		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Debug|x64.Build.0 = Debug|Any CPU
+		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Release|x64.ActiveCfg = Release|Any CPU
 		{DD5B6BAA-D41A-4A6E-9E7D-83060F394B10}.Release|x64.Build.0 = Release|Any CPU
+		{FBA029C3-B184-4457-AEEC-38D0C2523067}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBA029C3-B184-4457-AEEC-38D0C2523067}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBA029C3-B184-4457-AEEC-38D0C2523067}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{FBA029C3-B184-4457-AEEC-38D0C2523067}.Debug|x64.Build.0 = Debug|Any CPU
+		{FBA029C3-B184-4457-AEEC-38D0C2523067}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBA029C3-B184-4457-AEEC-38D0C2523067}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FBA029C3-B184-4457-AEEC-38D0C2523067}.Release|x64.ActiveCfg = Release|Any CPU
 		{FBA029C3-B184-4457-AEEC-38D0C2523067}.Release|x64.Build.0 = Release|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Debug|x64.Build.0 = Debug|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|x64.ActiveCfg = Release|Any CPU
 		{1A9DF196-43A9-44BB-B2C6-D62AA56B0E49}.Release|x64.Build.0 = Release|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Debug|x64.Build.0 = Debug|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|x64.ActiveCfg = Release|Any CPU
 		{DAC23E9F-F826-4577-AE7A-0849FF83280C}.Release|x64.Build.0 = Release|Any CPU
+		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Debug|x64.Build.0 = Debug|Any CPU
+		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Release|Any CPU.Build.0 = Release|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Release|x64.ActiveCfg = Release|Any CPU
 		{13BB3788-C3EB-4046-8105-A95F8AE49404}.Release|x64.Build.0 = Release|Any CPU
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x64.ActiveCfg = Debug|x64
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Debug|x64.Build.0 = Debug|x64
+		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|Any CPU.ActiveCfg = Release|x86
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x64.ActiveCfg = Release|x64
 		{BE95C560-B508-4588-8907-F9FC5BC1A0CF}.Release|x64.Build.0 = Release|x64
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Debug|x64.Build.0 = Debug|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Release|x64.ActiveCfg = Release|Any CPU
 		{D66338D4-F9E4-4051-B302-232C6BFB6EF6}.Release|x64.Build.0 = Release|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Debug|x64.Build.0 = Debug|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Release|x64.ActiveCfg = Release|Any CPU
 		{A965EA82-219D-48F7-AD51-BC030C16CC6F}.Release|x64.Build.0 = Release|Any CPU
+		{F36495F7-8CF5-474D-A92D-40317AE2439C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F36495F7-8CF5-474D-A92D-40317AE2439C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F36495F7-8CF5-474D-A92D-40317AE2439C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F36495F7-8CF5-474D-A92D-40317AE2439C}.Debug|x64.Build.0 = Debug|Any CPU
+		{F36495F7-8CF5-474D-A92D-40317AE2439C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F36495F7-8CF5-474D-A92D-40317AE2439C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F36495F7-8CF5-474D-A92D-40317AE2439C}.Release|x64.ActiveCfg = Release|Any CPU
+		{F36495F7-8CF5-474D-A92D-40317AE2439C}.Release|x64.Build.0 = Release|Any CPU
+		{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}.Debug|x64.Build.0 = Debug|Any CPU
+		{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}.Release|x64.ActiveCfg = Release|Any CPU
+		{306A4D48-0ACF-41C4-BBA0-BCDAD9253E2D}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ILCompiler/repro/Program.cs
+++ b/src/ILCompiler/repro/Program.cs
@@ -4,10 +4,65 @@
 
 using System;
 
+interface IFoo<U>
+{
+    string IMethod1<T>(T t);
+}
+
+class Base : IFoo<int>, IFoo<string>
+{
+    public virtual string GMethod1<T>(T t)
+    {
+        return "Base.GMethod1<" + t.ToString() + ">";
+    }
+
+    public virtual string IMethod1<T>(T t)
+    {
+        return "Base.IMethod1<" + t.ToString() + ">";
+    }
+}
+
+class Derived : Base, IFoo<int>, IFoo<string>
+{
+    public override string GMethod1<T>(T t)
+    {
+        return "Derived.GMethod1<" + t.ToString() + ">";
+    }
+
+    string IFoo<int>.IMethod1<T>(T t)
+    {
+        return "IFoo<int>.IMethod1<" + t.ToString() + ">";
+    }
+}
+
 internal class Program
 {
     private static void Main(string[] args)
     {
         Console.WriteLine("Hello world");
+
+        Base b = new Base();
+        Test(b);
+
+        Base c = new Derived();
+        Test(c);
+    }
+
+    private static void Test(object o)
+    {
+        Base b = o as Base;
+        var res = b.GMethod1<int>(123);
+        Console.WriteLine(res);
+
+        res = b.IMethod1<int>(123);
+        Console.WriteLine(res);
+
+        IFoo<int> ifoo1 = o as IFoo<int>;
+        res = ifoo1.IMethod1<int>(456);
+        Console.WriteLine(res);
+
+        IFoo<string> ifoo2 = o as IFoo<string>;
+        res = ifoo2.IMethod1<int>(789);
+        Console.WriteLine(res);
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
@@ -14,10 +14,10 @@ namespace Internal.Runtime.Augments
         public abstract int GetThreadStaticsSizeForDynamicType(int index, out int numTlsCells);
         public abstract IntPtr GenericLookupFromContextAndSignature(IntPtr context, IntPtr signature, out IntPtr auxResult);
         public abstract bool GetRuntimeMethodHandleComponents(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodArgs);
-        public abstract bool CompareMethodSignatures(RuntimeMethodSignature signature1, RuntimeMethodSignature signature2);
+        public abstract bool CompareMethodSignatures(RuntimeSignature signature1, RuntimeSignature signature2);
         public abstract IntPtr GetDelegateThunk(Delegate delegateObject, int thunkKind);
         public abstract IntPtr TryGetDefaultConstructorForType(RuntimeTypeHandle runtimeTypeHandle);
-        public abstract bool TryGetGenericVirtualTargetForTypeAndSlot(RuntimeTypeHandle targetHandle, ref RuntimeTypeHandle declaringType, RuntimeTypeHandle[] genericArguments, ref string methodName, ref RuntimeMethodSignature methodSignature, out IntPtr methodPointer, out IntPtr dictionaryPointer, out bool slotUpdated);
+        public abstract bool TryGetGenericVirtualTargetForTypeAndSlot(RuntimeTypeHandle targetHandle, ref RuntimeTypeHandle declaringType, RuntimeTypeHandle[] genericArguments, ref string methodName, ref RuntimeSignature methodSignature, out IntPtr methodPointer, out IntPtr dictionaryPointer, out bool slotUpdated);
 
         /// <summary>
         /// Register a new runtime-allocated code thunk in the diagnostic stream.

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/GenericVirtualMethodSupport.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/GenericVirtualMethodSupport.cs
@@ -28,7 +28,7 @@ namespace Internal.Runtime.CompilerServices
             {
                 RuntimeTypeHandle handle = new RuntimeTypeHandle(eetype);
                 string methodName = methodNameAndSignature.Name;
-                RuntimeMethodSignature methodSignature = methodNameAndSignature.Signature;
+                RuntimeSignature methodSignature = methodNameAndSignature.Signature;
                 if (RuntimeAugments.TypeLoaderCallbacks.TryGetGenericVirtualTargetForTypeAndSlot(handle, ref declaringType, genericArguments, ref methodName, ref methodSignature, out functionPointer, out genericDictionary, out slotChanged))
                 {
                     methodNameAndSignature = new MethodNameAndSignature(methodName, methodSignature);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/RuntimeMethodHandleInfo.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/RuntimeMethodHandleInfo.cs
@@ -10,114 +10,13 @@ using System.Diagnostics;
 
 namespace Internal.Runtime.CompilerServices
 {
-    public struct RuntimeMethodSignature
-    {
-        private IntPtr _ptrField;
-        private bool _isNativeLayoutSignature;
-        private int _intField;
-
-        public static RuntimeMethodSignature CreateFromNativeLayoutSignature(IntPtr signature)
-        {
-            return new RuntimeMethodSignature
-            {
-                _ptrField = signature,
-                _isNativeLayoutSignature = true
-            };
-        }
-
-        public static RuntimeMethodSignature CreateFromMethodHandle(IntPtr moduleHandle, int token)
-        {
-            return new RuntimeMethodSignature
-            {
-                _ptrField = moduleHandle,
-                _isNativeLayoutSignature = false,
-                _intField = token
-            };
-        }
-
-        public bool IsNativeLayoutSignature
-        {
-            get
-            {
-                return _isNativeLayoutSignature;
-            }
-        }
-
-        public IntPtr NativeLayoutSignature
-        {
-            get
-            {
-                if (_isNativeLayoutSignature)
-                    return _ptrField;
-                else
-                    return IntPtr.Zero;
-            }
-        }
-
-        public int Token
-        {
-            get
-            {
-                if (!_isNativeLayoutSignature)
-                    return _intField;
-                else
-                    return 0;
-            }
-        }
-
-        public IntPtr ModuleHandle
-        {
-            get
-            {
-                if (!_isNativeLayoutSignature)
-                    return _ptrField;
-                else
-                    return IntPtr.Zero;
-            }
-        }
-
-        public bool Equals(RuntimeMethodSignature other)
-        {
-            if (IsNativeLayoutSignature && other.IsNativeLayoutSignature)
-            {
-                if (NativeLayoutSignature == other.NativeLayoutSignature)
-                    return true;
-            }
-            else if (!IsNativeLayoutSignature && !other.IsNativeLayoutSignature)
-            {
-                if ((ModuleHandle == other.ModuleHandle) && (Token == other.Token))
-                    return true;
-            }
-
-            // Walk both signatures to check for equality the slow way
-            return RuntimeAugments.TypeLoaderCallbacks.CompareMethodSignatures(this, other);
-        }
-
-        /// <summary>
-        /// Fast equality check
-        /// </summary>
-        public bool StructuralEquals(RuntimeMethodSignature other)
-        {
-            if (_ptrField != other._ptrField)
-                return false;
-
-            if (_intField != other._intField)
-                return false;
-
-            if (_isNativeLayoutSignature != other._isNativeLayoutSignature)
-                return false;
-
-            return true;
-        }
-    }
-
     [System.Runtime.CompilerServices.DependencyReductionRoot]
     public class MethodNameAndSignature
     {
         public string Name { get; private set; }
-        public RuntimeMethodSignature Signature { get; private set; }
+        public RuntimeSignature Signature { get; private set; }
 
-        public MethodNameAndSignature(string name, RuntimeMethodSignature signature)
+        public MethodNameAndSignature(string name, RuntimeSignature signature)
         {
             Name = name;
             Signature = signature;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/RuntimeSignature.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/RuntimeSignature.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using Internal.Runtime.Augments;
+
+namespace Internal.Runtime.CompilerServices
+{
+    public struct RuntimeSignature
+    {
+        private IntPtr _ptrField;
+        private int _intField;
+        private bool _isNativeLayoutSignature;
+
+        public static RuntimeSignature CreateFromNativeLayoutSignature(IntPtr moduleHandle, int token)
+        {
+            return new RuntimeSignature
+            {
+                _ptrField = moduleHandle,
+                _intField = token,
+                _isNativeLayoutSignature = true,
+            };
+        }
+
+        public static RuntimeSignature CreateFromMethodHandle(IntPtr moduleHandle, int token)
+        {
+            return new RuntimeSignature
+            {
+                _ptrField = moduleHandle,
+                _intField = token,
+                _isNativeLayoutSignature = false,
+            };
+        }
+
+        public bool IsNativeLayoutSignature
+        {
+            get
+            {
+                return _isNativeLayoutSignature;
+            }
+        }
+
+        public int Token
+        {
+            get
+            {
+                return _intField;
+            }
+        }
+
+        public IntPtr ModuleHandle
+        {
+            get
+            {
+                return _ptrField;
+            }
+        }
+
+        public bool Equals(RuntimeSignature other)
+        {
+            if (IsNativeLayoutSignature == other.IsNativeLayoutSignature)
+            {
+                if ((ModuleHandle == other.ModuleHandle) && (Token == other.Token))
+                    return true;
+            }
+
+            // Walk both signatures to check for equality the slow way
+            return RuntimeAugments.TypeLoaderCallbacks.CompareMethodSignatures(this, other);
+        }
+
+        /// <summary>
+        /// Fast equality check
+        /// </summary>
+        public bool StructuralEquals(RuntimeSignature other)
+        {
+            if (_ptrField != other._ptrField)
+                return false;
+
+            if (_intField != other._intField)
+                return false;
+
+            if (_isNativeLayoutSignature != other._isNativeLayoutSignature)
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Internal\Runtime\CompilerServices\GenericVirtualMethodSupport.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\RuntimeFieldHandleInfo.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\RuntimeMethodHandleInfo.cs" />
+    <Compile Include="Internal\Runtime\CompilerServices\RuntimeSignature.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\OpenMethodResolver.cs" />
     <Compile Include="Internal\Runtime\TypeLoaderExceptionHelper.cs" />
     <Compile Include="Internal\Threading\Tracing\SpinLockTrace.cs" />

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -516,7 +516,7 @@ namespace Internal.Reflection.Execution
                 uint index = cookie >> 1;
 
                 MethodNameAndSignature nameAndSignature;
-                IntPtr nameAndSigSignature = (IntPtr)(pNativeLayoutInfoBlob + pBlob[index]);
+                RuntimeSignature nameAndSigSignature = RuntimeSignature.CreateFromNativeLayoutSignature(moduleHandle, (int)pBlob[index]);
                 success = TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignatureFromNativeLayoutSignature(ref nameAndSigSignature, out nameAndSignature);
                 Debug.Assert(success);
 
@@ -1075,7 +1075,7 @@ namespace Internal.Reflection.Execution
             }
             else
             {
-                uint nameAndSigOffset = externalReferences.GetRvaFromIndex(entryMethodHandleOrNameAndSigRaw);
+                uint nameAndSigOffset = externalReferences.GetNativeLayoutInfoTokenFromIndex(entryMethodHandleOrNameAndSigRaw);
                 MethodNameAndSignature nameAndSig;
                 if (!TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignatureFromNativeLayoutOffset(mappingTableModule, nameAndSigOffset, out nameAndSig))
                 {
@@ -1195,7 +1195,7 @@ namespace Internal.Reflection.Execution
             TypeDefinition typeDefinition = typeDefinitionHandle.GetTypeDefinition(reader);
 
             Debug.Assert(nameAndSignature.Signature.IsNativeLayoutSignature);
-            IntPtr nativeLayoutSignature = nameAndSignature.Signature.NativeLayoutSignature;
+            RuntimeSignature nativeLayoutSignature = nameAndSignature.Signature;
 
             foreach (MethodHandle mh in typeDefinition.Methods)
             {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.CallConversionInfo.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.CallConversionInfo.cs
@@ -51,7 +51,7 @@ namespace Internal.Runtime.TypeLoader
         //
         // Method signature and generic context info. Signatures are parsed lazily when they are really needed
         //
-        private RuntimeMethodSignature _methodSignature;
+        private RuntimeSignature _methodSignature;
         private volatile bool _signatureParsed;
         private RuntimeTypeHandle[] _typeArgs;
         private RuntimeTypeHandle[] _methodArgs;
@@ -179,11 +179,7 @@ namespace Internal.Runtime.TypeLoader
                 {
                     NativeLayoutInfoLoadContext nativeLayoutContext = new NativeLayoutInfoLoadContext();
 
-                    if (_methodSignature.IsNativeLayoutSignature)
-                        nativeLayoutContext._moduleHandle = RuntimeAugments.GetModuleFromPointer(_methodSignature.NativeLayoutSignature);
-                    else
-                        nativeLayoutContext._moduleHandle = _methodSignature.ModuleHandle;
-
+                    nativeLayoutContext._moduleHandle = _methodSignature.ModuleHandle;
                     nativeLayoutContext._typeSystemContext = context;
                     nativeLayoutContext._typeArgumentHandles = Instantiation.Empty;
                     nativeLayoutContext._methodArgumentHandles = Instantiation.Empty;
@@ -252,7 +248,7 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        public static int RegisterCallConversionInfo(ThunkKind thunkKind, IntPtr targetPointer, RuntimeMethodSignature methodSignature, IntPtr instantiatingArg, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs)
+        public static int RegisterCallConversionInfo(ThunkKind thunkKind, IntPtr targetPointer, RuntimeSignature methodSignature, IntPtr instantiatingArg, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs)
         {
             CallConversionInfo newConversionInfo = new CallConversionInfo();
             newConversionInfo._registrationKind = CallConversionInfoRegistrationKind.UsesMethodSignatureAndGenericArgs;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
@@ -206,7 +206,7 @@ namespace Internal.Runtime.TypeLoader
             return FindExistingOrAllocateThunk(callConversionInfo);
         }
 
-        public static unsafe IntPtr MakeThunk(ThunkKind thunkKind, IntPtr targetPointer, RuntimeMethodSignature methodSignature, IntPtr instantiatingArg, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs)
+        public static unsafe IntPtr MakeThunk(ThunkKind thunkKind, IntPtr targetPointer, RuntimeSignature methodSignature, IntPtr instantiatingArg, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs)
         {
             int callConversionInfo = CallConversionInfo.RegisterCallConversionInfo(thunkKind, targetPointer, methodSignature, instantiatingArg, typeArgs, methodArgs);
             return FindExistingOrAllocateThunk(callConversionInfo);
@@ -267,7 +267,7 @@ namespace Internal.Runtime.TypeLoader
             genericTypeDefHandle = RuntimeAugments.GetGenericInstantiation(delegateType, out typeArgs);
             Debug.Assert(typeArgs != null && typeArgs.Length > 0);
 
-            RuntimeMethodSignature invokeMethodSignature;
+            RuntimeSignature invokeMethodSignature;
             bool gotInvokeMethodSignature = TypeBuilder.TryGetDelegateInvokeMethodSignature(delegateType, out invokeMethodSignature);
 
             if (!gotInvokeMethodSignature)

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
@@ -137,5 +137,17 @@ namespace Internal.Runtime.TypeLoader
         {
             return RuntimeAugments.CreateRuntimeTypeHandle(GetIntPtrFromIndex(index));
         }
+
+        unsafe public uint GetNativeLayoutInfoTokenFromIndex(uint index)
+        {
+            if (index >= _elementsCount)
+                throw new BadImageFormatException();
+
+#if CORERT
+            return *(uint*)(((IntPtr*)_elements)[index]);
+#else
+            return ((TableElement*)_elements)[index];
+#endif
+        }
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/FixupCellMetadataResolver.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/FixupCellMetadataResolver.cs
@@ -81,7 +81,7 @@ namespace Internal.Runtime.TypeLoader
             return instantiatedField;
         }
 
-        public RuntimeMethodSignature GetSignature(Internal.Metadata.NativeFormat.Handle token)
+        public RuntimeSignature GetSignature(Internal.Metadata.NativeFormat.Handle token)
         {
             switch (token.HandleType)
             {
@@ -97,7 +97,7 @@ namespace Internal.Runtime.TypeLoader
                     Environment.FailFast("Unknown and invalid handle type");
                     break;
             }
-            return RuntimeMethodSignature.CreateFromMethodHandle(_metadataUnit.RuntimeModule, token.ToInt());
+            return RuntimeSignature.CreateFromMethodHandle(_metadataUnit.RuntimeModule, token.ToInt());
         }
 
         public Instantiation TypeInstantiation

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LazyVtableResolverThunk.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LazyVtableResolverThunk.cs
@@ -490,7 +490,7 @@ namespace Internal.Runtime.TypeLoader
                     continue;
 
                 MethodSignatureComparer sigComparer = new MethodSignatureComparer(method.MetadataReader, method.Handle);
-                if (!sigComparer.IsMatchingNativeLayoutMethodNameAndSignature(methodNameAndSig.Name, methodNameAndSig.Signature.NativeLayoutSignature))
+                if (!sigComparer.IsMatchingNativeLayoutMethodNameAndSignature(methodNameAndSig.Name, methodNameAndSig.Signature.NativeLayoutSignature()))
                     continue;
 
                 // At this point we've matched

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutFieldAlgorithm.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutFieldAlgorithm.cs
@@ -232,7 +232,8 @@ namespace Internal.Runtime.TypeLoader
             // Look up the universal template for this type.  Only the universal template has field layout
             // information, so we have to use it to parse the field layout.
             NativeLayoutInfoLoadContext universalLayoutLoadContext;
-            NativeParser typeInfoParser = type.GetOrCreateTypeBuilderState().GetParserForUniversalNativeLayoutInfo(out universalLayoutLoadContext);
+            NativeLayoutInfo universalLayoutInfo;
+            NativeParser typeInfoParser = type.GetOrCreateTypeBuilderState().GetParserForUniversalNativeLayoutInfo(out universalLayoutLoadContext, out universalLayoutInfo);
 
             if (typeInfoParser.IsNull)
                 throw new TypeBuilder.MissingTemplateException();

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutInfoLoadContext.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutInfoLoadContext.cs
@@ -152,7 +152,7 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        internal MethodDesc GetMethod(ref NativeParser parser, out IntPtr methodNameSigPtr, out IntPtr methodSigPtr)
+        internal MethodDesc GetMethod(ref NativeParser parser, out RuntimeSignature methodNameSigPtr, out RuntimeSignature methodSigPtr)
         {
             MethodFlags flags = (MethodFlags)parser.GetUnsigned();
 
@@ -161,7 +161,7 @@ namespace Internal.Runtime.TypeLoader
                 functionPointer = GetExternalReferencePointer(parser.GetUnsigned());
 
             DefType containingType = (DefType)GetType(ref parser);
-            MethodNameAndSignature nameAndSignature = TypeLoaderEnvironment.Instance.GetMethodNameAndSignature(ref parser, out methodNameSigPtr, out methodSigPtr);
+            MethodNameAndSignature nameAndSignature = TypeLoaderEnvironment.Instance.GetMethodNameAndSignature(ref parser, _moduleHandle, out methodNameSigPtr, out methodSigPtr);
 
             bool unboxingStub = (flags & MethodFlags.IsUnboxingStub) != 0;
 
@@ -189,8 +189,8 @@ namespace Internal.Runtime.TypeLoader
 
         internal MethodDesc GetMethod(ref NativeParser parser)
         {
-            IntPtr methodSigPtr;
-            IntPtr methodNameSigPtr;
+            RuntimeSignature methodSigPtr;
+            RuntimeSignature methodNameSigPtr;
             return GetMethod(ref parser, out methodNameSigPtr, out methodSigPtr);
         }
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TemplateLocator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TemplateLocator.cs
@@ -92,7 +92,7 @@ namespace Internal.Runtime.TypeLoader
                     if (typeDesc == canonForm)
                     {
                         TypeLoaderLogger.WriteLine("Found metadata template for type " + concreteType.ToString() + ": " + typeDesc.ToString());
-                        nativeLayoutInfoToken = (uint)externalFixupsTable.GetRvaFromIndex(entryParser.GetUnsigned());
+                        nativeLayoutInfoToken = (uint)externalFixupsTable.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
                         if (nativeLayoutInfoToken == BadTokenFixupValue)
                         {
                             throw new BadImageFormatException();
@@ -150,7 +150,7 @@ namespace Internal.Runtime.TypeLoader
                     if (methodDesc == canonForm)
                     {
                         TypeLoaderLogger.WriteLine("Found metadata template for method " + concreteMethod.ToString() + ": " + methodDesc.ToString());
-                        nativeLayoutInfoToken = (uint)externalFixupsTable.GetRvaFromIndex(entryParser.GetUnsigned());
+                        nativeLayoutInfoToken = (uint)externalFixupsTable.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
                         if (nativeLayoutInfoToken == BadTokenFixupValue)
                         {
                             throw new BadImageFormatException();
@@ -197,7 +197,7 @@ namespace Internal.Runtime.TypeLoader
                     if (canonForm == candidateTemplate.ConvertToCanonForm(kind))
                     {
                         TypeLoaderLogger.WriteLine("Found template for type " + concreteType.ToString() + ": " + candidateTemplate.ToString());
-                        nativeLayoutInfoToken = (uint)externalFixupsTable.GetRvaFromIndex(entryParser.GetUnsigned());
+                        nativeLayoutInfoToken = (uint)externalFixupsTable.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
                         if (nativeLayoutInfoToken == BadTokenFixupValue)
                         {
                             // TODO: once multifile gets fixed up, make this throw a BadImageFormatException
@@ -269,7 +269,7 @@ namespace Internal.Runtime.TypeLoader
                 NativeParser entryParser;
                 while (!(entryParser = enumerator.GetNext()).IsNull)
                 {
-                    var methodSignatureParser = new NativeParser(nativeLayoutReader, externalFixupsTable.GetRvaFromIndex(entryParser.GetUnsigned()));
+                    var methodSignatureParser = new NativeParser(nativeLayoutReader, externalFixupsTable.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned()));
 
                     // Get the unified generic method holder and convert it to its canonical form
                     var candidateTemplate = (InstantiatedMethod)context.GetMethod(ref methodSignatureParser);
@@ -279,7 +279,7 @@ namespace Internal.Runtime.TypeLoader
                     {
                         TypeLoaderLogger.WriteLine("Found template for generic method " + concreteMethod.ToString() + ": " + candidateTemplate.ToString());
                         nativeLayoutInfoModule = moduleHandle;
-                        nativeLayoutInfoToken = (uint)externalFixupsTable.GetRvaFromIndex(entryParser.GetUnsigned());
+                        nativeLayoutInfoToken = (uint)externalFixupsTable.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
                         if (nativeLayoutInfoToken == BadTokenFixupValue)
                         {
                             // TODO: once multifile gets fixed up, make this throw a BadImageFormatException

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -36,7 +36,7 @@ namespace Internal.Runtime.TypeLoader
         internal class VTableLayoutInfo
         {
             public uint VTableSlot;
-            public IntPtr MethodSignature;
+            public RuntimeSignature MethodSignature;
             public bool IsSealedVTableSlot;
         }
 
@@ -238,9 +238,9 @@ namespace Internal.Runtime.TypeLoader
                 return default(NativeParser);
         }
 
-        public NativeParser GetParserForUniversalNativeLayoutInfo(out NativeLayoutInfoLoadContext universalLayoutLoadContext)
+        public NativeParser GetParserForUniversalNativeLayoutInfo(out NativeLayoutInfoLoadContext universalLayoutLoadContext, out NativeLayoutInfo universalLayoutInfo)
         {
-            NativeLayoutInfo universalLayoutInfo = new NativeLayoutInfo();
+            universalLayoutInfo = new NativeLayoutInfo();
             universalLayoutLoadContext = null;
             TypeDesc universalTemplate = TypeBeingBuilt.Context.TemplateLookup.TryGetUniversalTypeTemplate(TypeBeingBuilt, ref universalLayoutInfo);
             if (universalTemplate == null)

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
@@ -21,12 +21,51 @@ namespace Internal.Runtime.TypeLoader
 {
     public sealed partial class TypeLoaderEnvironment
     {
-        public bool TryGetGenericVirtualTargetForTypeAndSlot(RuntimeTypeHandle targetHandle, ref RuntimeTypeHandle declaringType, RuntimeTypeHandle[] genericArguments, ref string methodName, ref RuntimeMethodSignature methodSignature, out IntPtr methodPointer, out IntPtr dictionaryPointer, out bool slotUpdated)
+#if GVM_RESOLUTION_TRACE
+        private string GetTypeNameDebug(RuntimeTypeHandle rtth)
+        {
+            string result;
+
+            if (RuntimeAugments.IsGenericType(rtth))
+            {
+                RuntimeTypeHandle[] typeArgumentsHandles;
+                RuntimeTypeHandle openTypeDef = RuntimeAugments.GetGenericInstantiation(rtth, out typeArgumentsHandles); ;
+                result = GetTypeNameDebug(openTypeDef) + "<";
+                for (int i = 0; i < typeArgumentsHandles.Length; i++)
+                    result += (i == 0 ? "" : ",") + GetTypeNameDebug(typeArgumentsHandles[i]);
+                return result + ">";
+            }
+            else
+            {
+                Metadata.NativeFormat.MetadataReader reader;
+                Metadata.NativeFormat.TypeDefinitionHandle typeDefHandle;
+
+                // Check if we have metadata.
+                if (Instance.TryGetMetadataForNamedType(rtth, out reader, out typeDefHandle))
+                    return typeDefHandle.GetFullName(reader);
+            }
+
+            result = "EEType:0x";
+            ulong num = (ulong)RuntimeAugments.GetPointerFromTypeHandle(rtth);
+
+            int shift = IntPtr.Size * 8;
+            const string HexDigits = "0123456789ABCDEF";
+            while (shift > 0)
+            {
+                shift -= 4;
+                int digit = (int)((num >> shift) & 0xF);
+                result += HexDigits[digit];
+            }
+            return result;
+        }
+#endif
+
+        public bool TryGetGenericVirtualTargetForTypeAndSlot(RuntimeTypeHandle targetHandle, ref RuntimeTypeHandle declaringType, RuntimeTypeHandle[] genericArguments, ref string methodName, ref RuntimeSignature methodSignature, out IntPtr methodPointer, out IntPtr dictionaryPointer, out bool slotUpdated)
         {
             MethodNameAndSignature methodNameAndSignature = new MethodNameAndSignature(methodName, methodSignature);
 
-#if REFLECTION_EXECUTION_TRACE
-            ReflectionExecutionLogger.WriteLine("GVM resolution starting for " + GetTypeNameDebug(declaringType) + "." + methodNameAndSignature.Name + "(...)  on a target of type " + GetTypeNameDebug(targetHandle) + " ...");
+#if GVM_RESOLUTION_TRACE
+            Debug.WriteLine("GVM resolution starting for " + GetTypeNameDebug(declaringType) + "." + methodNameAndSignature.Name + "(...)  on a target of type " + GetTypeNameDebug(targetHandle) + " ...");
 #endif
 
             if (RuntimeAugments.IsInterface(declaringType))
@@ -47,7 +86,7 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private MethodNameAndSignature GetMethodNameAndSignatureFromNativeReader(NativeReader nativeLayoutReader, uint nativeLayoutOffset)
+        private MethodNameAndSignature GetMethodNameAndSignatureFromNativeReader(NativeReader nativeLayoutReader, IntPtr moduleHandle, uint nativeLayoutOffset)
         {
             NativeParser parser = new NativeParser(nativeLayoutReader, nativeLayoutOffset);
 
@@ -57,9 +96,9 @@ namespace Internal.Runtime.TypeLoader
             // when not comparing signatures (parsing them requires resolving types and is tremendously 
             // expensive).
             NativeParser sigParser = parser.GetParserFromRelativeOffset();
-            IntPtr methodSigPtr = sigParser.Reader.OffsetToAddress(sigParser.Offset);
+            RuntimeSignature methodSigPtr = RuntimeSignature.CreateFromNativeLayoutSignature(moduleHandle, (int)sigParser.Offset);
 
-            return new MethodNameAndSignature(methodName, RuntimeMethodSignature.CreateFromNativeLayoutSignature(methodSigPtr));
+            return new MethodNameAndSignature(methodName, methodSigPtr);
         }
 
         private RuntimeTypeHandle GetOpenTypeDefinition(RuntimeTypeHandle typeHandle, out RuntimeTypeHandle[] typeArgumentsHandles)
@@ -83,14 +122,19 @@ namespace Internal.Runtime.TypeLoader
         {
             uint numTargetImplementations = entryParser.GetUnsigned();
 
+#if GVM_RESOLUTION_TRACE
+            Debug.WriteLine(" :: Declaring type = " + GetTypeNameDebug(declaringType));
+            Debug.WriteLine(" :: Target type = " + GetTypeNameDebug(openTargetTypeHandle));
+#endif
+
             for (uint j = 0; j < numTargetImplementations; j++)
             {
-                uint nameAndSigToken = extRefs.GetRvaFromIndex(entryParser.GetUnsigned());
-                MethodNameAndSignature targetMethodNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, nameAndSigToken);
+                uint nameAndSigToken = extRefs.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
+                MethodNameAndSignature targetMethodNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, moduleHandle, nameAndSigToken);
                 RuntimeTypeHandle targetTypeHandle = extRefs.GetRuntimeTypeHandleFromIndex(entryParser.GetUnsigned());
 
-#if REFLECTION_EXECUTION_TRACE
-                ReflectionExecutionLogger.WriteLine("    Searching for GVM implementation on targe type = " + GetTypeNameDebug(targetTypeHandle));
+#if GVM_RESOLUTION_TRACE
+                Debug.WriteLine("    Searching for GVM implementation on targe type = " + GetTypeNameDebug(targetTypeHandle));
 #endif
 
                 uint numIfaceImpls = entryParser.GetUnsigned();
@@ -98,6 +142,10 @@ namespace Internal.Runtime.TypeLoader
                 for (uint k = 0; k < numIfaceImpls; k++)
                 {
                     RuntimeTypeHandle implementingTypeHandle = extRefs.GetRuntimeTypeHandleFromIndex(entryParser.GetUnsigned());
+
+#if GVM_RESOLUTION_TRACE
+                    Debug.WriteLine("      -> Current implementing type = " + GetTypeNameDebug(implementingTypeHandle));
+#endif
 
                     uint numIfaceSigs = entryParser.GetUnsigned();
 
@@ -114,18 +162,20 @@ namespace Internal.Runtime.TypeLoader
                     {
                         RuntimeTypeHandle currentIfaceTypeHandle = default(RuntimeTypeHandle);
 
-                        NativeParser ifaceSigParser = new NativeParser(nativeLayoutReader, extRefs.GetRvaFromIndex(entryParser.GetUnsigned()));
-                        IntPtr currentIfaceSigPtr = ifaceSigParser.Reader.OffsetToAddress(ifaceSigParser.Offset);
+                        NativeParser ifaceSigParser = new NativeParser(nativeLayoutReader, extRefs.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned()));
 
-                        if (TypeLoaderEnvironment.Instance.GetTypeFromSignatureAndContext(currentIfaceSigPtr, targetTypeInstantiation, null, out currentIfaceTypeHandle, out currentIfaceSigPtr))
+                        if (TypeLoaderEnvironment.Instance.GetTypeFromSignatureAndContext(ref ifaceSigParser, moduleHandle, targetTypeInstantiation, null, out currentIfaceTypeHandle))
                         {
+#if GVM_RESOLUTION_TRACE
+                            Debug.WriteLine("         -> Current interface on type = " + GetTypeNameDebug(currentIfaceTypeHandle));
+#endif
                             Debug.Assert(!currentIfaceTypeHandle.IsNull());
 
                             if ((!variantDispatch && declaringType.Equals(currentIfaceTypeHandle)) ||
                                 (variantDispatch && RuntimeAugments.IsAssignableFrom(declaringType, currentIfaceTypeHandle)))
                             {
-#if REFLECTION_EXECUTION_TRACE
-                                ReflectionExecutionLogger.WriteLine("    " + (declaringType.Equals(currentIfaceTypeHandle) ? "Exact" : "Variant-compatible") + " match found on this target type!");
+#if GVM_RESOLUTION_TRACE
+                                Debug.WriteLine("    " + (declaringType.Equals(currentIfaceTypeHandle) ? "Exact" : "Variant-compatible") + " match found on this target type!");
 #endif
                                 // We found the GVM slot target for the input interface GVM call, so let's update the interface GVM slot and return success to the caller
                                 declaringType = targetTypeHandle;
@@ -198,8 +248,8 @@ namespace Internal.Runtime.TypeLoader
             RuntimeTypeHandle[] targetTypeInstantiation;
             openTargetTypeHandle = GetOpenTypeDefinition(targetTypeHandle, out targetTypeInstantiation);
 
-#if REFLECTION_EXECUTION_TRACE
-            ReflectionExecutionLogger.WriteLine("INTERFACE GVM call = " + GetTypeNameDebug(declaringType) + "." + methodNameAndSignature.Name);
+#if GVM_RESOLUTION_TRACE
+            Debug.WriteLine("INTERFACE GVM call = " + GetTypeNameDebug(declaringType) + "." + methodNameAndSignature.Name);
 #endif
 
             foreach (IntPtr moduleHandle in ModuleList.Enumerate(RuntimeAugments.GetModuleFromTypeHandle(openTargetTypeHandle)))
@@ -227,8 +277,8 @@ namespace Internal.Runtime.TypeLoader
                     if (!openCallingTypeHandle.Equals(interfaceTypeHandle))
                         continue;
 
-                    uint nameAndSigToken = extRefs.GetRvaFromIndex(entryParser.GetUnsigned());
-                    MethodNameAndSignature interfaceMethodNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, nameAndSigToken);
+                    uint nameAndSigToken = extRefs.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
+                    MethodNameAndSignature interfaceMethodNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, moduleHandle, nameAndSigToken);
 
                     if (!interfaceMethodNameAndSignature.Equals(methodNameAndSignature))
                         continue;
@@ -428,8 +478,8 @@ namespace Internal.Runtime.TypeLoader
             int hashCode = openCallingTypeHandle.GetHashCode();
             hashCode = ((hashCode << 13) ^ hashCode) ^ openTargetTypeHandle.GetHashCode();
 
-#if REFLECTION_EXECUTION_TRACE
-            ReflectionExecutionLogger.WriteLine("GVM Target Resolution = " + GetTypeNameDebug(targetTypeHandle) + "." + callingMethodNameAndSignature.Name);
+#if GVM_RESOLUTION_TRACE
+            Debug.WriteLine("GVM Target Resolution = " + GetTypeNameDebug(targetTypeHandle) + "." + callingMethodNameAndSignature.Name);
 #endif
 
             foreach (IntPtr moduleHandle in ModuleList.Enumerate(RuntimeAugments.GetModuleFromTypeHandle(openTargetTypeHandle)))
@@ -460,14 +510,14 @@ namespace Internal.Runtime.TypeLoader
                     if (!parsedTargetTypeHandle.Equals(openTargetTypeHandle))
                         continue;
 
-                    uint parsedCallingNameAndSigToken = extRefs.GetRvaFromIndex(entryParser.GetUnsigned());
-                    MethodNameAndSignature parsedCallingNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, parsedCallingNameAndSigToken);
+                    uint parsedCallingNameAndSigToken = extRefs.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
+                    MethodNameAndSignature parsedCallingNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, moduleHandle, parsedCallingNameAndSigToken);
 
                     if (!parsedCallingNameAndSignature.Equals(callingMethodNameAndSignature))
                         continue;
 
-                    uint parsedTargetMethodNameAndSigToken = extRefs.GetRvaFromIndex(entryParser.GetUnsigned());
-                    MethodNameAndSignature targetMethodNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, parsedTargetMethodNameAndSigToken);
+                    uint parsedTargetMethodNameAndSigToken = extRefs.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
+                    MethodNameAndSignature targetMethodNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, moduleHandle, parsedTargetMethodNameAndSigToken);
 
                     Debug.Assert(targetMethodNameAndSignature != null);
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
@@ -852,7 +852,7 @@ namespace Internal.Runtime.TypeLoader
                 if (!entryType.Equals(definitionType))
                     continue;
 
-                uint nameAndSigPointerToken = externalReferences.GetRvaFromIndex(entryParser.GetUnsigned());
+                uint nameAndSigPointerToken = externalReferences.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
 
                 MethodNameAndSignature nameAndSig;
                 if (!TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignatureFromNativeLayoutOffset(moduleHandle, nameAndSigPointerToken, out nameAndSig))
@@ -861,7 +861,7 @@ namespace Internal.Runtime.TypeLoader
                     continue;
                 }
 
-                if (!methodSignatureComparer.IsMatchingNativeLayoutMethodNameAndSignature(nameAndSig.Name, nameAndSig.Signature.NativeLayoutSignature))
+                if (!methodSignatureComparer.IsMatchingNativeLayoutMethodNameAndSignature(nameAndSig.Name, nameAndSig.Signature))
                 {
                     continue;
                 }
@@ -885,8 +885,8 @@ namespace Internal.Runtime.TypeLoader
 
                 if (isGenericVirtualMethod)
                 {
-                    IntPtr methodName;
-                    IntPtr methodSignature;
+                    RuntimeSignature methodName;
+                    RuntimeSignature methodSignature;
 
                     if (!TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignaturePointersFromNativeLayoutSignature(moduleHandle, nameAndSigPointerToken, out methodName, out methodSignature))
                     {
@@ -895,7 +895,7 @@ namespace Internal.Runtime.TypeLoader
                     }
 
                     RuntimeMethodHandle gvmSlot;
-                    if (!TypeLoaderEnvironment.Instance.TryGetRuntimeMethodHandleForComponents(declaringTypeOfVirtualInvoke, methodName, RuntimeMethodSignature.CreateFromNativeLayoutSignature(methodSignature), genericArgs, out gvmSlot))
+                    if (!TypeLoaderEnvironment.Instance.TryGetRuntimeMethodHandleForComponents(declaringTypeOfVirtualInvoke, methodName.NativeLayoutSignature(), methodSignature, genericArgs, out gvmSlot))
                     {
                         return false;
                     }
@@ -995,7 +995,7 @@ namespace Internal.Runtime.TypeLoader
                 if (!entryType.Equals(definitionType))
                     continue;
 
-                uint nameAndSigPointerToken = externalReferences.GetRvaFromIndex(entryParser.GetUnsigned());
+                uint nameAndSigPointerToken = externalReferences.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
 
                 uint parentHierarchyAndFlag = entryParser.GetUnsigned();
                 bool isGenericVirtualMethod = ((parentHierarchyAndFlag & VirtualInvokeTableEntry.FlagsMask) == VirtualInvokeTableEntry.GenericVirtualMethod);
@@ -1576,7 +1576,7 @@ namespace Internal.Runtime.TypeLoader
                 }
                 else
                 {
-                    uint nameAndSigToken = extRefTable.GetRvaFromIndex(entryParser.GetUnsigned());
+                    uint nameAndSigToken = extRefTable.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
                     MethodNameAndSignature nameAndSig;
                     if (!TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignatureFromNativeLayoutOffset(_moduleHandle, nameAndSigToken, out nameAndSig))
                     {
@@ -1584,7 +1584,7 @@ namespace Internal.Runtime.TypeLoader
                         return;
                     }
                     Debug.Assert(nameAndSig.Signature.IsNativeLayoutSignature);
-                    if (!methodSignatureComparer.IsMatchingNativeLayoutMethodNameAndSignature(nameAndSig.Name, nameAndSig.Signature.NativeLayoutSignature))
+                    if (!methodSignatureComparer.IsMatchingNativeLayoutMethodNameAndSignature(nameAndSig.Name, nameAndSig.Signature))
                         return;
                 }
 
@@ -1608,7 +1608,7 @@ namespace Internal.Runtime.TypeLoader
                 {
                     Debug.Assert((_hasEntryPoint || ((_flags & InvokeTableFlags.HasVirtualInvoke) != 0)) && ((_flags & InvokeTableFlags.RequiresInstArg) != 0));
 
-                    uint nameAndSigPointerToken = extRefTable.GetRvaFromIndex(entryParser.GetUnsigned());
+                    uint nameAndSigPointerToken = extRefTable.GetNativeLayoutInfoTokenFromIndex(entryParser.GetUnsigned());
                     if (!TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignatureFromNativeLayoutOffset(_moduleHandle, nameAndSigPointerToken, out _nameAndSignature))
                     {
                         Debug.Assert(false);    //Error

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.MetadataSignatureParsing.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.MetadataSignatureParsing.cs
@@ -5,10 +5,12 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+
+using global::Internal.Runtime.CompilerServices;
 using global::Internal.Metadata.NativeFormat;
 using global::Internal.NativeFormat;
 using global::Internal.Runtime.TypeLoader;
-using Internal.Runtime.Augments;
+using global::Internal.Runtime.Augments;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -16,16 +18,12 @@ namespace Internal.Runtime.TypeLoader
 {
     internal static class SigParsing
     {
-        public static RuntimeTypeHandle GetTypeFromNativeLayoutSignature(ref NativeParser parser, uint offset)
+        public static RuntimeTypeHandle GetTypeFromNativeLayoutSignature(ref NativeParser parser, IntPtr moduleHandle, uint offset)
         {
-            IntPtr remainingSignature;
             RuntimeTypeHandle typeHandle;
 
-            IntPtr signatureAddress = parser.Reader.OffsetToAddress(offset);
-            bool success = TypeLoaderEnvironment.Instance.GetTypeFromSignatureAndContext(signatureAddress, null, null, out typeHandle, out remainingSignature);
-
-            // Reset the parser to after the type
-            parser = new NativeParser(parser.Reader, parser.Reader.AddressToOffset(remainingSignature));
+            parser.Offset = offset;
+            TypeLoaderEnvironment.Instance.GetTypeFromSignatureAndContext(ref parser, moduleHandle, null, null, out typeHandle);
 
             return typeHandle;
         }
@@ -84,13 +82,13 @@ namespace Internal.Runtime.TypeLoader
             _isStatic = (_method.Flags & MethodAttributes.Static) != 0;
         }
 
-        public bool IsMatchingNativeLayoutMethodNameAndSignature(string name, IntPtr signature)
+        public bool IsMatchingNativeLayoutMethodNameAndSignature(string name, RuntimeSignature signature)
         {
             return _method.Name.StringEquals(name, _metadataReader) &&
                 IsMatchingNativeLayoutMethodSignature(signature);
         }
 
-        public bool IsMatchingNativeLayoutMethodSignature(IntPtr signature)
+        public bool IsMatchingNativeLayoutMethodSignature(RuntimeSignature signature)
         {
             NativeParser parser = GetNativeParserForSignature(signature);
 
@@ -108,7 +106,7 @@ namespace Internal.Runtime.TypeLoader
 
             uint parameterCount = parser.GetUnsigned();
 
-            if (!CompareTypeSigWithType(ref parser, _methodSignature.ReturnType))
+            if (!CompareTypeSigWithType(ref parser, signature.ModuleHandle, _methodSignature.ReturnType))
             {
                 return false;
             }
@@ -121,7 +119,7 @@ namespace Internal.Runtime.TypeLoader
                     // The metadata-defined _method has more parameters than the native layout
                     return false;
                 }
-                if (!CompareTypeSigWithType(ref parser, parameterSignature))
+                if (!CompareTypeSigWithType(ref parser, signature.ModuleHandle, parameterSignature))
                     return false;
                 parameterIndexToMatch++;
             }
@@ -135,14 +133,15 @@ namespace Internal.Runtime.TypeLoader
         /// </summary>
         /// <param name="signature">Signature to look up</param>
         /// <returns>Native parser for the signature</param>
-        internal static NativeParser GetNativeParserForSignature(IntPtr signature)
+        internal static NativeParser GetNativeParserForSignature(RuntimeSignature signature)
         {
-            IntPtr moduleHandle = RuntimeAugments.GetModuleFromPointer(signature);
-            NativeReader reader = TypeLoaderEnvironment.GetNativeReaderForBlob(moduleHandle, ReflectionMapBlob.NativeLayoutInfo);
-            return new NativeParser(reader, reader.AddressToOffset(signature));
+            Debug.Assert(signature.IsNativeLayoutSignature);
+
+            NativeReader reader = TypeLoaderEnvironment.GetNativeReaderForBlob(signature.ModuleHandle, ReflectionMapBlob.NativeLayoutInfo);
+            return new NativeParser(reader, (uint)signature.Token);
         }
 
-        private bool CompareTypeSigWithType(ref NativeParser parser, Handle typeHandle)
+        private bool CompareTypeSigWithType(ref NativeParser parser, IntPtr moduleHandle, Handle typeHandle)
         {
             while (typeHandle.HandleType == HandleType.TypeSpecification)
             {
@@ -164,7 +163,7 @@ namespace Internal.Runtime.TypeLoader
                 case TypeSignatureKind.Lookback:
                     {
                         NativeParser lookbackParser = parser.GetLookbackParser(data);
-                        return CompareTypeSigWithType(ref lookbackParser, typeHandle);
+                        return CompareTypeSigWithType(ref lookbackParser, moduleHandle, typeHandle);
                     }
 
                 case TypeSignatureKind.Modifier:
@@ -176,7 +175,7 @@ namespace Internal.Runtime.TypeLoader
                             case TypeModifierKind.Array:
                                 if (typeHandle.HandleType == HandleType.SZArraySignature)
                                 {
-                                    return CompareTypeSigWithType(ref parser, typeHandle
+                                    return CompareTypeSigWithType(ref parser, moduleHandle, typeHandle
                                         .ToSZArraySignatureHandle(_metadataReader)
                                         .GetSZArraySignature(_metadataReader)
                                         .ElementType);
@@ -186,7 +185,7 @@ namespace Internal.Runtime.TypeLoader
                             case TypeModifierKind.ByRef:
                                 if (typeHandle.HandleType == HandleType.ByReferenceSignature)
                                 {
-                                    return CompareTypeSigWithType(ref parser, typeHandle
+                                    return CompareTypeSigWithType(ref parser, moduleHandle, typeHandle
                                         .ToByReferenceSignatureHandle(_metadataReader)
                                         .GetByReferenceSignature(_metadataReader)
                                         .Type);
@@ -196,7 +195,7 @@ namespace Internal.Runtime.TypeLoader
                             case TypeModifierKind.Pointer:
                                 if (typeHandle.HandleType == HandleType.PointerSignature)
                                 {
-                                    return CompareTypeSigWithType(ref parser, typeHandle
+                                    return CompareTypeSigWithType(ref parser, moduleHandle, typeHandle
                                         .ToPointerSignatureHandle(_metadataReader)
                                         .GetPointerSignature(_metadataReader)
                                         .Type);
@@ -252,7 +251,7 @@ namespace Internal.Runtime.TypeLoader
                         if (data != sig.Rank)
                             return false;
 
-                        if (!CompareTypeSigWithType(ref parser, sig.ElementType))
+                        if (!CompareTypeSigWithType(ref parser, moduleHandle, sig.ElementType))
                             return false;
 
                         uint boundCount1 = parser.GetUnsigned();
@@ -277,7 +276,7 @@ namespace Internal.Runtime.TypeLoader
 
                         for (uint i = 0; i < argCount1; i++)
                         {
-                            if (!CompareTypeSigWithType(ref parser, typeHandle))
+                            if (!CompareTypeSigWithType(ref parser, moduleHandle, typeHandle))
                                 return false;
                         }
                         return false;
@@ -294,7 +293,7 @@ namespace Internal.Runtime.TypeLoader
                             .ToTypeInstantiationSignatureHandle(_metadataReader)
                             .GetTypeInstantiationSignature(_metadataReader);
 
-                        if (!CompareTypeSigWithType(ref parser, sig.GenericType))
+                        if (!CompareTypeSigWithType(ref parser, moduleHandle, sig.GenericType))
                         {
                             return false;
                         }
@@ -307,7 +306,7 @@ namespace Internal.Runtime.TypeLoader
                                 // The metadata generic has more parameters than the native layour
                                 return false;
                             }
-                            if (!CompareTypeSigWithType(ref parser, genericArgumentTypeHandle))
+                            if (!CompareTypeSigWithType(ref parser, moduleHandle, genericArgumentTypeHandle))
                             {
                                 return false;
                             }
@@ -342,7 +341,7 @@ namespace Internal.Runtime.TypeLoader
                                 return false;
                         }
 
-                        RuntimeTypeHandle type1 = SigParsing.GetTypeFromNativeLayoutSignature(ref parser, startOffset);
+                        RuntimeTypeHandle type1 = SigParsing.GetTypeFromNativeLayoutSignature(ref parser, moduleHandle, startOffset);
                         return type1.Equals(type2);
                     }
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
@@ -21,43 +21,40 @@ namespace Internal.Runtime.TypeLoader
 {
     public sealed partial class TypeLoaderEnvironment
     {
-        public bool CompareMethodSignatures(RuntimeMethodSignature signature1, RuntimeMethodSignature signature2)
+        public bool CompareMethodSignatures(RuntimeSignature signature1, RuntimeSignature signature2)
         {
-            IntPtr nativeLayoutSignature1 = signature1.NativeLayoutSignature;
-            IntPtr nativeLayoutSignature2 = signature2.NativeLayoutSignature;
-
-            if ((nativeLayoutSignature1 != IntPtr.Zero) && (nativeLayoutSignature2 != IntPtr.Zero))
+            if (signature1.IsNativeLayoutSignature && signature2.IsNativeLayoutSignature)
             {
-                if (nativeLayoutSignature1 == nativeLayoutSignature2)
+                if(signature1.StructuralEquals(signature2))
                     return true;
 
-                NativeReader reader1 = GetNativeLayoutInfoReader(RuntimeAugments.GetModuleFromPointer(nativeLayoutSignature1));
-                NativeParser parser1 = new NativeParser(reader1, reader1.AddressToOffset(nativeLayoutSignature1));
+                NativeReader reader1 = GetNativeLayoutInfoReader(signature1.ModuleHandle);
+                NativeParser parser1 = new NativeParser(reader1, (uint)signature1.Token);
 
-                NativeReader reader2 = GetNativeLayoutInfoReader(RuntimeAugments.GetModuleFromPointer(nativeLayoutSignature2));
-                NativeParser parser2 = new NativeParser(reader2, reader2.AddressToOffset(nativeLayoutSignature2));
+                NativeReader reader2 = GetNativeLayoutInfoReader(signature2.ModuleHandle);
+                NativeParser parser2 = new NativeParser(reader2, (uint)signature2.Token);
 
-                return CompareMethodSigs(parser1, parser2);
+                return CompareMethodSigs(parser1, parser2, signature1.ModuleHandle, signature2.ModuleHandle);
             }
-            else if (nativeLayoutSignature1 != IntPtr.Zero)
+            else if (signature1.IsNativeLayoutSignature)
             {
                 int token = signature2.Token;
                 MetadataReader metadataReader = ModuleList.Instance.GetMetadataReaderForModule(signature2.ModuleHandle);
 
                 MethodSignatureComparer comparer = new MethodSignatureComparer(metadataReader, token.AsHandle().ToMethodHandle(metadataReader));
-                return comparer.IsMatchingNativeLayoutMethodSignature(nativeLayoutSignature1);
+                return comparer.IsMatchingNativeLayoutMethodSignature(signature1);
             }
-            else if (nativeLayoutSignature2 != IntPtr.Zero)
+            else if (signature2.IsNativeLayoutSignature)
             {
                 int token = signature1.Token;
                 MetadataReader metadataReader = ModuleList.Instance.GetMetadataReaderForModule(signature1.ModuleHandle);
 
                 MethodSignatureComparer comparer = new MethodSignatureComparer(metadataReader, token.AsHandle().ToMethodHandle(metadataReader));
-                return comparer.IsMatchingNativeLayoutMethodSignature(nativeLayoutSignature2);
+                return comparer.IsMatchingNativeLayoutMethodSignature(signature2);
             }
             else
             {
-                // For now, RuntimeMethodSignatures are only used to compare for method signature equality (along with their Name)
+                // For now, RuntimeSignatures are only used to compare for method signature equality (along with their Name)
                 // So we can implement this with the simple equals check
                 if (signature1.Token != signature2.Token)
                     return false;
@@ -73,9 +70,8 @@ namespace Internal.Runtime.TypeLoader
         {
             if (signature.Signature.IsNativeLayoutSignature)
             {
-                IntPtr sigPtr = signature.Signature.NativeLayoutSignature;
-                NativeReader reader = GetNativeLayoutInfoReader(RuntimeAugments.GetModuleFromPointer(sigPtr));
-                NativeParser parser = new NativeParser(reader, reader.AddressToOffset(sigPtr));
+                NativeReader reader = GetNativeLayoutInfoReader(signature.Signature.ModuleHandle);
+                NativeParser parser = new NativeParser(reader, (uint)signature.Signature.Token);
 
                 return GetGenericArgCountFromSig(parser);
             }
@@ -90,27 +86,29 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        public bool TryGetMethodNameAndSignatureFromNativeLayoutSignature(ref IntPtr signature, out MethodNameAndSignature nameAndSignature)
+        public bool TryGetMethodNameAndSignatureFromNativeLayoutSignature(ref RuntimeSignature signature, out MethodNameAndSignature nameAndSignature)
         {
             nameAndSignature = null;
 
-            NativeReader reader = GetNativeLayoutInfoReader(RuntimeAugments.GetModuleFromPointer(signature));
-            uint offset = reader.AddressToOffset(signature);
+            NativeReader reader = GetNativeLayoutInfoReader(signature.ModuleHandle);
+            uint offset = (uint)signature.Token;
             NativeParser parser = new NativeParser(reader, offset);
             if (parser.IsNull)
                 return false;
 
-            IntPtr methodSigPtr;
-            IntPtr methodNameSigPtr;
-            nameAndSignature = GetMethodNameAndSignature(ref parser, out methodNameSigPtr, out methodSigPtr);
-            signature = (IntPtr)((long)signature + (parser.Offset - offset));
+            RuntimeSignature methodSigPtr;
+            RuntimeSignature methodNameSigPtr;
+            nameAndSignature = GetMethodNameAndSignature(ref parser, signature.ModuleHandle, out methodNameSigPtr, out methodSigPtr);
+
+            signature = RuntimeSignature.CreateFromNativeLayoutSignature(signature.ModuleHandle, (int)(parser.Offset - offset));
+
             return true;
         }
 
-        public bool TryGetMethodNameAndSignaturePointersFromNativeLayoutSignature(IntPtr module, uint methodNameAndSigToken, out IntPtr methodNameSigPtr, out IntPtr methodSigPtr)
+        public bool TryGetMethodNameAndSignaturePointersFromNativeLayoutSignature(IntPtr module, uint methodNameAndSigToken, out RuntimeSignature methodNameSigPtr, out RuntimeSignature methodSigPtr)
         {
-            methodNameSigPtr = default(IntPtr);
-            methodSigPtr = default(IntPtr);
+            methodNameSigPtr = default(RuntimeSignature);
+            methodSigPtr = default(RuntimeSignature);
 
             NativeReader reader = GetNativeLayoutInfoReader(module);
             uint offset = methodNameAndSigToken;
@@ -118,14 +116,14 @@ namespace Internal.Runtime.TypeLoader
             if (parser.IsNull)
                 return false;
 
-            methodNameSigPtr = parser.Reader.OffsetToAddress(parser.Offset);
+            methodNameSigPtr = RuntimeSignature.CreateFromNativeLayoutSignature(module, (int)parser.Offset);
             string methodName = parser.GetString();
 
             // Signatures are indirected to through a relative offset so that we don't have to parse them
             // when not comparing signatures (parsing them requires resolving types and is tremendously 
             // expensive).
             NativeParser sigParser = parser.GetParserFromRelativeOffset();
-            methodSigPtr = sigParser.Reader.OffsetToAddress(sigParser.Offset);
+            methodSigPtr = RuntimeSignature.CreateFromNativeLayoutSignature(module, (int)sigParser.Offset);
 
             return true;
         }
@@ -139,33 +137,32 @@ namespace Internal.Runtime.TypeLoader
             if (parser.IsNull)
                 return false;
 
-            IntPtr methodSigPtr;
-            IntPtr methodNameSigPtr;
-            nameAndSignature = GetMethodNameAndSignature(ref parser, out methodNameSigPtr, out methodSigPtr);
+            RuntimeSignature methodSigPtr;
+            RuntimeSignature methodNameSigPtr;
+            nameAndSignature = GetMethodNameAndSignature(ref parser, moduleHandle, out methodNameSigPtr, out methodSigPtr);
             return true;
         }
 
-        internal MethodNameAndSignature GetMethodNameAndSignature(ref NativeParser parser, out IntPtr methodNameSigPtr, out IntPtr methodSigPtr)
+        internal MethodNameAndSignature GetMethodNameAndSignature(ref NativeParser parser, IntPtr moduleHandle, out RuntimeSignature methodNameSigPtr, out RuntimeSignature methodSigPtr)
         {
-            methodNameSigPtr = parser.Reader.OffsetToAddress(parser.Offset);
+            methodNameSigPtr = RuntimeSignature.CreateFromNativeLayoutSignature(moduleHandle, (int)parser.Offset);
             string methodName = parser.GetString();
 
             // Signatures are indirected to through a relative offset so that we don't have to parse them
             // when not comparing signatures (parsing them requires resolving types and is tremendously 
             // expensive).
             NativeParser sigParser = parser.GetParserFromRelativeOffset();
-            methodSigPtr = sigParser.Reader.OffsetToAddress(sigParser.Offset);
+            methodSigPtr = RuntimeSignature.CreateFromNativeLayoutSignature(moduleHandle, (int)sigParser.Offset);
 
-            return new MethodNameAndSignature(methodName, RuntimeMethodSignature.CreateFromNativeLayoutSignature(methodSigPtr));
+            return new MethodNameAndSignature(methodName, methodSigPtr);
         }
 
-        internal bool IsStaticMethodSignature(RuntimeMethodSignature methodSig)
+        internal bool IsStaticMethodSignature(RuntimeSignature methodSig)
         {
             if (methodSig.IsNativeLayoutSignature)
             {
-                IntPtr moduleHandle = RuntimeAugments.GetModuleFromPointer(methodSig.NativeLayoutSignature);
-                NativeReader reader = GetNativeLayoutInfoReader(moduleHandle);
-                NativeParser parser = new NativeParser(reader, reader.AddressToOffset(methodSig.NativeLayoutSignature));
+                NativeReader reader = GetNativeLayoutInfoReader(methodSig.ModuleHandle);
+                NativeParser parser = new NativeParser(reader, (uint)methodSig.Token);
 
                 MethodCallingConvention callingConvention = (MethodCallingConvention)parser.GetUnsigned();
                 return callingConvention.HasFlag(MethodCallingConvention.Static);
@@ -180,10 +177,10 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        internal bool GetCallingConverterDataFromMethodSignature(TypeSystemContext context, RuntimeMethodSignature methodSig, NativeLayoutInfoLoadContext nativeLayoutContext, out bool hasThis, out TypeDesc[] parameters, out bool[] parametersWithGenericDependentLayout)
+        internal bool GetCallingConverterDataFromMethodSignature(TypeSystemContext context, RuntimeSignature methodSig, NativeLayoutInfoLoadContext nativeLayoutContext, out bool hasThis, out TypeDesc[] parameters, out bool[] parametersWithGenericDependentLayout)
         {
             if (methodSig.IsNativeLayoutSignature)
-                return GetCallingConverterDataFromMethodSignature_NativeLayout(context, methodSig.NativeLayoutSignature, nativeLayoutContext, out hasThis, out parameters, out parametersWithGenericDependentLayout);
+                return GetCallingConverterDataFromMethodSignature_NativeLayout(context, methodSig, nativeLayoutContext, out hasThis, out parameters, out parametersWithGenericDependentLayout);
             else
             {
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
@@ -203,14 +200,13 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        internal bool GetCallingConverterDataFromMethodSignature_NativeLayout(TypeSystemContext context, IntPtr methodSig, NativeLayoutInfoLoadContext nativeLayoutContext, out bool hasThis, out TypeDesc[] parameters, out bool[] parametersWithGenericDependentLayout)
+        internal bool GetCallingConverterDataFromMethodSignature_NativeLayout(TypeSystemContext context, RuntimeSignature methodSig, NativeLayoutInfoLoadContext nativeLayoutContext, out bool hasThis, out TypeDesc[] parameters, out bool[] parametersWithGenericDependentLayout)
         {
             hasThis = false;
             parameters = null;
 
-            IntPtr moduleHandle = RuntimeAugments.GetModuleFromPointer(methodSig);
-            NativeReader reader = GetNativeLayoutInfoReader(moduleHandle);
-            NativeParser parser = new NativeParser(reader, reader.AddressToOffset(methodSig));
+            NativeReader reader = GetNativeLayoutInfoReader(methodSig.ModuleHandle);
+            NativeParser parser = new NativeParser(reader, (uint)methodSig.Token);
 
             MethodCallingConvention callingConvention = (MethodCallingConvention)parser.GetUnsigned();
             hasThis = !callingConvention.HasFlag(MethodCallingConvention.Static);
@@ -231,7 +227,7 @@ namespace Internal.Runtime.TypeLoader
                 // The second time to identify if the parameter loaded via the signature should be forced to be
                 // passed byref as part of the universal generic calling convention.
                 parameters[i] = GetConstructedTypeFromParserAndNativeLayoutContext(ref parser, nativeLayoutContext);
-                parametersWithGenericDependentLayout[i] = TypeSignatureHasVarsNeedingCallingConventionConverter(ref parserCopy, context, HasVarsInvestigationLevel.Parameter);
+                parametersWithGenericDependentLayout[i] = TypeSignatureHasVarsNeedingCallingConventionConverter(ref parserCopy, methodSig.ModuleHandle, context, HasVarsInvestigationLevel.Parameter);
                 if (parameters[i] == null)
                     return false;
             }
@@ -332,10 +328,10 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        internal bool MethodSignatureHasVarsNeedingCallingConventionConverter(TypeSystemContext context, RuntimeMethodSignature methodSig)
+        internal bool MethodSignatureHasVarsNeedingCallingConventionConverter(TypeSystemContext context, RuntimeSignature methodSig)
         {
             if (methodSig.IsNativeLayoutSignature)
-                return MethodSignatureHasVarsNeedingCallingConventionConverter_NativeLayout(context, methodSig.NativeLayoutSignature);
+                return MethodSignatureHasVarsNeedingCallingConventionConverter_NativeLayout(context, methodSig);
             else
             {
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
@@ -353,24 +349,23 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private bool MethodSignatureHasVarsNeedingCallingConventionConverter_NativeLayout(TypeSystemContext context, IntPtr methodSig)
+        private bool MethodSignatureHasVarsNeedingCallingConventionConverter_NativeLayout(TypeSystemContext context, RuntimeSignature methodSig)
         {
-            IntPtr moduleHandle = RuntimeAugments.GetModuleFromPointer(methodSig);
-            NativeReader reader = GetNativeLayoutInfoReader(moduleHandle);
-            NativeParser parser = new NativeParser(reader, reader.AddressToOffset(methodSig));
+            NativeReader reader = GetNativeLayoutInfoReader(methodSig.ModuleHandle);
+            NativeParser parser = new NativeParser(reader, (uint)methodSig.Token);
 
             MethodCallingConvention callingConvention = (MethodCallingConvention)parser.GetUnsigned();
             uint numGenArgs = callingConvention.HasFlag(MethodCallingConvention.Generic) ? parser.GetUnsigned() : 0;
             uint parameterCount = parser.GetUnsigned();
 
             // Check the return type of the method
-            if (TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, context, HasVarsInvestigationLevel.Parameter))
+            if (TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, methodSig.ModuleHandle, context, HasVarsInvestigationLevel.Parameter))
                 return true;
 
             // Check the parameters of the method
             for (uint i = 0; i < parameterCount; i++)
             {
-                if (TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, context, HasVarsInvestigationLevel.Parameter))
+                if (TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, methodSig.ModuleHandle, context, HasVarsInvestigationLevel.Parameter))
                     return true;
             }
 
@@ -429,7 +424,7 @@ namespace Internal.Runtime.TypeLoader
         /// StructNotDependentOnArgsForSize<GenStructDependencyOnArgsForSize<T>> -> true
         /// StructNotDependentOnArgsForSize<GenStructDependencyOnArgsForSize<List<T>>>> -> false
         /// </summary>
-        private bool TypeSignatureHasVarsNeedingCallingConventionConverter(ref NativeParser parser, TypeSystemContext context, HasVarsInvestigationLevel investigationLevel)
+        private bool TypeSignatureHasVarsNeedingCallingConventionConverter(ref NativeParser parser, IntPtr moduleHandle, TypeSystemContext context, HasVarsInvestigationLevel investigationLevel)
         {
             uint data;
             var kind = parser.GetTypeSignatureKind(out data);
@@ -442,13 +437,13 @@ namespace Internal.Runtime.TypeLoader
                 case TypeSignatureKind.Lookback:
                     {
                         var lookbackParser = parser.GetLookbackParser(data);
-                        return TypeSignatureHasVarsNeedingCallingConventionConverter(ref lookbackParser, context, investigationLevel);
+                        return TypeSignatureHasVarsNeedingCallingConventionConverter(ref lookbackParser, moduleHandle, context, investigationLevel);
                     }
 
                 case TypeSignatureKind.Instantiation:
                     {
                         RuntimeTypeHandle genericTypeDef;
-                        if (!TryGetTypeFromSimpleTypeSignature(ref parser, out genericTypeDef))
+                        if (!TryGetTypeFromSimpleTypeSignature(ref parser, moduleHandle, out genericTypeDef))
                         {
                             Debug.Assert(false);
                             return true;    // Returning true will prevent further reading from the native parser
@@ -458,14 +453,14 @@ namespace Internal.Runtime.TypeLoader
                         {
                             // Reference types are treated like pointers. No calling convention conversion needed. Just consume the rest of the signature.
                             for (uint i = 0; i < data; i++)
-                                TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, context, HasVarsInvestigationLevel.Ignore);
+                                TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, moduleHandle, context, HasVarsInvestigationLevel.Ignore);
                             return false;
                         }
                         else
                         {
                             bool result = false;
                             for (uint i = 0; i < data; i++)
-                                result = TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, context, HasVarsInvestigationLevel.NotParameter) || result;
+                                result = TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, moduleHandle, context, HasVarsInvestigationLevel.NotParameter) || result;
 
                             if ((result == true) && (investigationLevel == HasVarsInvestigationLevel.Parameter))
                             {
@@ -483,7 +478,7 @@ namespace Internal.Runtime.TypeLoader
                     {
                         // Arrays, pointers and byref types signatures are treated as pointers, not requiring calling convention conversion.
                         // Just consume the parameter type from the stream and return false;
-                        TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, context, HasVarsInvestigationLevel.Ignore);
+                        TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, moduleHandle, context, HasVarsInvestigationLevel.Ignore);
                         return false;
                     }
 
@@ -491,7 +486,7 @@ namespace Internal.Runtime.TypeLoader
                     {
                         // No need for a calling convention converter for this case. Just consume the signature from the stream.
 
-                        TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, context, HasVarsInvestigationLevel.Ignore);
+                        TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, moduleHandle, context, HasVarsInvestigationLevel.Ignore);
 
                         uint boundCount = parser.GetUnsigned();
                         for (uint i = 0; i < boundCount; i++)
@@ -509,7 +504,7 @@ namespace Internal.Runtime.TypeLoader
 
                         uint argCount = parser.GetUnsigned();
                         for (uint i = 0; i < argCount; i++)
-                            TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, context, HasVarsInvestigationLevel.Ignore);
+                            TypeSignatureHasVarsNeedingCallingConventionConverter(ref parser, moduleHandle, context, HasVarsInvestigationLevel.Ignore);
                     }
                     return false;
 
@@ -519,7 +514,7 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private bool TryGetTypeFromSimpleTypeSignature(ref NativeParser parser, out RuntimeTypeHandle typeHandle)
+        private bool TryGetTypeFromSimpleTypeSignature(ref NativeParser parser, IntPtr moduleHandle, out RuntimeTypeHandle typeHandle)
         {
             uint data;
             TypeSignatureKind kind = parser.GetTypeSignatureKind(out data);
@@ -527,11 +522,11 @@ namespace Internal.Runtime.TypeLoader
             if (kind == TypeSignatureKind.Lookback)
             {
                 var lookbackParser = parser.GetLookbackParser(data);
-                return TryGetTypeFromSimpleTypeSignature(ref lookbackParser, out typeHandle);
+                return TryGetTypeFromSimpleTypeSignature(ref lookbackParser, moduleHandle, out typeHandle);
             }
             else if (kind == TypeSignatureKind.External)
             {
-                typeHandle = GetExternalTypeHandle(ref parser, data);
+                typeHandle = GetExternalTypeHandle(moduleHandle, data);
                 return true;
             }
 
@@ -540,9 +535,8 @@ namespace Internal.Runtime.TypeLoader
             return false;
         }
 
-        private RuntimeTypeHandle GetExternalTypeHandle(ref NativeParser parser, uint typeIndex)
+        private RuntimeTypeHandle GetExternalTypeHandle(IntPtr moduleHandle, uint typeIndex)
         {
-            IntPtr moduleHandle = RuntimeAugments.GetModuleFromPointer(parser.Reader.OffsetToAddress(parser.Offset));
             Debug.Assert(moduleHandle != IntPtr.Zero);
 
             RuntimeTypeHandle result;
@@ -576,7 +570,7 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private bool CompareMethodSigs(NativeParser parser1, NativeParser parser2)
+        private bool CompareMethodSigs(NativeParser parser1, NativeParser parser2, IntPtr moduleHandle1, IntPtr moduleHandle2)
         {
             MethodCallingConvention callingConvention1 = (MethodCallingConvention)parser1.GetUnsigned();
             MethodCallingConvention callingConvention2 = (MethodCallingConvention)parser2.GetUnsigned();
@@ -598,14 +592,14 @@ namespace Internal.Runtime.TypeLoader
             // Compare one extra parameter to account for the return type
             for (uint i = 0; i <= parameterCount1; i++)
             {
-                if (!CompareTypeSigs(ref parser1, ref parser2))
+                if (!CompareTypeSigs(ref parser1, ref parser2, moduleHandle1, moduleHandle2))
                     return false;
             }
 
             return true;
         }
 
-        private bool CompareTypeSigs(ref NativeParser parser1, ref NativeParser parser2)
+        private bool CompareTypeSigs(ref NativeParser parser1, ref NativeParser parser2, IntPtr moduleHandle1, IntPtr moduleHandle2)
         {
             // startOffset lets us backtrack to the TypeSignatureKind for external types since the TypeLoader
             // expects to read it in.
@@ -618,7 +612,7 @@ namespace Internal.Runtime.TypeLoader
             if (typeSignatureKind1 == TypeSignatureKind.Lookback)
             {
                 NativeParser lookbackParser1 = parser1.GetLookbackParser(data1);
-                return CompareTypeSigs(ref lookbackParser1, ref parser2);
+                return CompareTypeSigs(ref lookbackParser1, ref parser2, moduleHandle1, moduleHandle2);
             }
 
             uint data2;
@@ -631,7 +625,7 @@ namespace Internal.Runtime.TypeLoader
             {
                 NativeParser lookbackParser2 = parser2.GetLookbackParser(data2);
                 parser1 = new NativeParser(parser1.Reader, startOffset1);
-                return CompareTypeSigs(ref parser1, ref lookbackParser2);
+                return CompareTypeSigs(ref parser1, ref lookbackParser2, moduleHandle1, moduleHandle2);
             }
 
             if (typeSignatureKind1 != typeSignatureKind2)
@@ -651,7 +645,7 @@ namespace Internal.Runtime.TypeLoader
                         // Ensure the modifier kind (vector, pointer, byref) is the same
                         if (data1 != data2)
                             return false;
-                        return CompareTypeSigs(ref parser1, ref parser2);
+                        return CompareTypeSigs(ref parser1, ref parser2, moduleHandle1, moduleHandle2);
                     }
 
                 case TypeSignatureKind.Variable:
@@ -668,7 +662,7 @@ namespace Internal.Runtime.TypeLoader
                         if (data1 != data2)
                             return false;
 
-                        if (!CompareTypeSigs(ref parser1, ref parser2))
+                        if (!CompareTypeSigs(ref parser1, ref parser2, moduleHandle1, moduleHandle2))
                             return false;
 
                         uint boundCount1 = parser1.GetUnsigned();
@@ -706,7 +700,7 @@ namespace Internal.Runtime.TypeLoader
                             return false;
                         for (uint i = 0; i < argCount1; i++)
                         {
-                            if (!CompareTypeSigs(ref parser1, ref parser2))
+                            if (!CompareTypeSigs(ref parser1, ref parser2, moduleHandle1, moduleHandle2))
                                 return false;
                         }
                         break;
@@ -718,12 +712,12 @@ namespace Internal.Runtime.TypeLoader
                         if (data1 != data2)
                             return false;
 
-                        if (!CompareTypeSigs(ref parser1, ref parser2))
+                        if (!CompareTypeSigs(ref parser1, ref parser2, moduleHandle1, moduleHandle2))
                             return false;
 
                         for (uint i = 0; i < data1; i++)
                         {
-                            if (!CompareTypeSigs(ref parser1, ref parser2))
+                            if (!CompareTypeSigs(ref parser1, ref parser2, moduleHandle1, moduleHandle2))
                                 return false;
                         }
                         break;
@@ -731,8 +725,8 @@ namespace Internal.Runtime.TypeLoader
 
                 case TypeSignatureKind.External:
                     {
-                        RuntimeTypeHandle typeHandle1 = GetExternalTypeHandle(ref parser1, data1);
-                        RuntimeTypeHandle typeHandle2 = GetExternalTypeHandle(ref parser2, data2);
+                        RuntimeTypeHandle typeHandle1 = GetExternalTypeHandle(moduleHandle1, data1);
+                        RuntimeTypeHandle typeHandle2 = GetExternalTypeHandle(moduleHandle2, data2);
                         if (!typeHandle1.Equals(typeHandle2))
                             return false;
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/genericdictionarycell.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/genericdictionarycell.cs
@@ -165,7 +165,7 @@ namespace Internal.Runtime.TypeLoader
             internal TypeDesc ConstraintType;
             internal MethodDesc ConstrainedMethod;
             internal IntPtr MethodName;
-            internal RuntimeMethodSignature MethodSignature;
+            internal RuntimeSignature MethodSignature;
 
             override internal void Prepare(TypeBuilder builder)
             {
@@ -304,7 +304,7 @@ namespace Internal.Runtime.TypeLoader
         {
             internal MethodDesc Method;
             internal IntPtr MethodName;
-            internal RuntimeMethodSignature MethodSignature;
+            internal RuntimeSignature MethodSignature;
 
             internal unsafe override void Prepare(TypeBuilder builder)
             {
@@ -503,7 +503,7 @@ namespace Internal.Runtime.TypeLoader
         private class MethodCell : GenericDictionaryCell
         {
             internal MethodDesc Method;
-            internal RuntimeMethodSignature MethodSignature;
+            internal RuntimeSignature MethodSignature;
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
             internal bool ExactCallableAddressNeeded;
 #endif
@@ -774,7 +774,7 @@ namespace Internal.Runtime.TypeLoader
 
                 methodArgs = builder.GetRuntimeTypeHandles(_methodToUseForInstantiatingParameters.Instantiation);
 
-                Debug.Assert(!MethodSignature.IsNativeLayoutSignature || (MethodSignature.NativeLayoutSignature != IntPtr.Zero));
+                Debug.Assert(!MethodSignature.IsNativeLayoutSignature || (MethodSignature.NativeLayoutSignature() != IntPtr.Zero));
 
                 CallConverterThunk.ThunkKind thunkKind;
                 if (usgConverter)
@@ -890,7 +890,7 @@ namespace Internal.Runtime.TypeLoader
         private class CallingConventionConverterCell : GenericDictionaryCell
         {
             internal NativeFormat.CallingConventionConverterKind Flags;
-            internal RuntimeMethodSignature Signature;
+            internal RuntimeSignature Signature;
             internal Instantiation MethodArgs;
             internal Instantiation TypeArgs;
 
@@ -1064,7 +1064,7 @@ namespace Internal.Runtime.TypeLoader
             {
                 ExactCallableAddressNeeded = exactCallableAddressNeeded,
                 Method = method,
-                MethodSignature = RuntimeMethodSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
+                MethodSignature = RuntimeSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
             };
 #else
             Environment.FailFast("Creating a methodcell from a MethodDesc only supported in the presence of metadata based type loading.");
@@ -1205,7 +1205,7 @@ namespace Internal.Runtime.TypeLoader
                         {
                             Method = method,
                             MethodName = IntPtr.Zero,
-                            MethodSignature = RuntimeMethodSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
+                            MethodSignature = RuntimeSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
                         };
                     }
                     break;
@@ -1279,7 +1279,7 @@ namespace Internal.Runtime.TypeLoader
                         cell = new MethodCell
                         {
                             Method = method,
-                            MethodSignature = RuntimeMethodSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
+                            MethodSignature = RuntimeSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
                         };
                     }
                     break;
@@ -1293,7 +1293,7 @@ namespace Internal.Runtime.TypeLoader
                         cell = new MethodCell
                         {
                             Method = method,
-                            MethodSignature = RuntimeMethodSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
+                            MethodSignature = RuntimeSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
                         };
                     }
                     break;
@@ -1308,7 +1308,7 @@ namespace Internal.Runtime.TypeLoader
                         {
                             ExactCallableAddressNeeded = true,
                             Method = method,
-                            MethodSignature = RuntimeMethodSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
+                            MethodSignature = RuntimeSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
                         };
                     }
                     break;
@@ -1363,7 +1363,7 @@ namespace Internal.Runtime.TypeLoader
                             ConstraintType = constraintType,
                             ConstrainedMethod = method,
                             MethodName = IntPtr.Zero,
-                            MethodSignature = RuntimeMethodSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
+                            MethodSignature = RuntimeSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt())
                         };
                     }
                     break;
@@ -1521,16 +1521,16 @@ namespace Internal.Runtime.TypeLoader
                     {
                         NativeParser ldtokenSigParser = parser.GetParserFromRelativeOffset();
 
-                        IntPtr methodNameSigPtr;
-                        IntPtr methodSigPtr;
+                        RuntimeSignature methodNameSigPtr;
+                        RuntimeSignature methodSigPtr;
                         var method = nativeLayoutInfoLoadContext.GetMethod(ref ldtokenSigParser, out methodNameSigPtr, out methodSigPtr);
                         TypeLoaderLogger.WriteLine("LdToken on: " + method.OwningType.ToString() + "::" + method.NameAndSignature.Name);
 
                         cell = new MethodLdTokenCell
                         {
                             Method = method,
-                            MethodName = methodNameSigPtr,
-                            MethodSignature = RuntimeMethodSignature.CreateFromNativeLayoutSignature(methodSigPtr)
+                            MethodName = methodNameSigPtr.NativeLayoutSignature(),
+                            MethodSignature = methodSigPtr
                         };
                     }
                     break;
@@ -1602,15 +1602,15 @@ namespace Internal.Runtime.TypeLoader
 
                 case FixupSignatureKind.Method:
                     {
-                        IntPtr methodSigPtr;
-                        IntPtr methodNameSigPtr;
+                        RuntimeSignature methodSigPtr;
+                        RuntimeSignature methodNameSigPtr;
                         var method = nativeLayoutInfoLoadContext.GetMethod(ref parser, out methodNameSigPtr, out methodSigPtr);
                         TypeLoaderLogger.WriteLine("Method: " + method.ToString());
 
                         cell = new MethodCell
                         {
                             Method = method,
-                            MethodSignature = RuntimeMethodSignature.CreateFromNativeLayoutSignature(methodSigPtr)
+                            MethodSignature = methodSigPtr
                         };
                     }
                     break;
@@ -1652,8 +1652,8 @@ namespace Internal.Runtime.TypeLoader
                         var constraintType = nativeLayoutInfoLoadContext.GetType(ref parser);
 
                         NativeParser ldtokenSigParser = parser.GetParserFromRelativeOffset();
-                        IntPtr methodNameSigPtr;
-                        IntPtr methodSigPtr;
+                        RuntimeSignature methodNameSigPtr;
+                        RuntimeSignature methodSigPtr;
                         var method = nativeLayoutInfoLoadContext.GetMethod(ref ldtokenSigParser, out methodNameSigPtr, out methodSigPtr);
 
                         TypeLoaderLogger.WriteLine("GenericConstrainedMethod: " + constraintType.ToString() + " Method " + method.OwningType.ToString() + "::" + method.NameAndSignature.Name);
@@ -1662,8 +1662,8 @@ namespace Internal.Runtime.TypeLoader
                         {
                             ConstraintType = constraintType,
                             ConstrainedMethod = method,
-                            MethodName = methodNameSigPtr,
-                            MethodSignature = RuntimeMethodSignature.CreateFromNativeLayoutSignature(methodSigPtr)
+                            MethodName = methodNameSigPtr.NativeLayoutSignature(),
+                            MethodSignature = methodSigPtr
                         };
                     }
                     break;
@@ -1701,14 +1701,14 @@ namespace Internal.Runtime.TypeLoader
 
                 case FixupSignatureKind.CallingConventionConverter:
                     {
-                        NativeFormat.CallingConventionConverterKind flags = (NativeFormat.CallingConventionConverterKind)parser.GetUnsigned();
+                        CallingConventionConverterKind flags = (CallingConventionConverterKind)parser.GetUnsigned();
                         NativeParser sigParser = parser.GetParserFromRelativeOffset();
-                        IntPtr signature = sigParser.Reader.OffsetToAddress(sigParser.Offset);
+                        RuntimeSignature signature = RuntimeSignature.CreateFromNativeLayoutSignature(nativeLayoutInfoLoadContext._moduleHandle, (int)sigParser.Offset);
 
 #if TYPE_LOADER_TRACE
                         TypeLoaderLogger.WriteLine("CallingConventionConverter on: ");
                         TypeLoaderLogger.WriteLine("     -> Flags: " + ((int)flags).LowLevelToString());
-                        TypeLoaderLogger.WriteLine("     -> Signature: " + signature.LowLevelToString());
+                        TypeLoaderLogger.WriteLine("     -> Signature: " + signature.NativeLayoutSignature().LowLevelToString());
                         for (int i = 0; !nativeLayoutInfoLoadContext._typeArgumentHandles.IsNull && i < nativeLayoutInfoLoadContext._typeArgumentHandles.Length; i++)
                             TypeLoaderLogger.WriteLine("     -> TypeArg[" + i.LowLevelToString() + "]: " + nativeLayoutInfoLoadContext._typeArgumentHandles[i]);
                         for (int i = 0; !nativeLayoutInfoLoadContext._methodArgumentHandles.IsNull && i < nativeLayoutInfoLoadContext._methodArgumentHandles.Length; i++)
@@ -1718,7 +1718,7 @@ namespace Internal.Runtime.TypeLoader
                         cell = new CallingConventionConverterCell
                         {
                             Flags = flags,
-                            Signature = RuntimeMethodSignature.CreateFromNativeLayoutSignature(signature),
+                            Signature = signature,
                             MethodArgs = nativeLayoutInfoLoadContext._methodArgumentHandles,
                             TypeArgs = nativeLayoutInfoLoadContext._typeArgumentHandles
                         };

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{F36495F7-8CF5-474D-A92D-40317AE2439C}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
-    <DefineConstants>TYPE_LOADER_IMPLEMENTATION;$(DefineConstants)</DefineConstants>
+    <DefineConstants>GVM_RESOLUTION_TRACE;TYPE_LOADER_IMPLEMENTATION;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />


### PR DESCRIPTION
Exact method instantiations table, GVM tables.
Bug: unable to find exact method instantiation at runtime. hashcode issue?

Debugging hack

Parsing refactoring from PN.
Simple GVM test working (if exact method instantiation found)

Fixed native layout token placement bugs
Fixed issue with interface implementation on base Type
Added generic type instantiations hashtable
Fixed interface GVM entries
Fixed unplaced vertexes in native layout token nodes
Fixed and enabled GVM resolution tracing