### PR TITLE
Remove un-necessary ITuple constraint (CoreRT)

### DIFF
--- a/src/System.Private.CoreLib/src/System/TupleExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/TupleExtensions.cs
@@ -921,10 +921,10 @@ namespace System
         }
         #endregion
 
-        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct, ITuple =>
+        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
 
-        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : ITuple =>
+        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>
             new Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
     }
 }

--- a/src/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -1897,7 +1897,7 @@ namespace System
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
     : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IValueTupleInternal, ITuple
-    where TRest : struct, ITuple
+    where TRest : struct
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's first component.
@@ -2269,7 +2269,7 @@ namespace System
         {
             get
             {
-                return 7 + Rest.Length;
+                return 7 + ((IValueTupleInternal)Rest).Length;
             }
         }
 
@@ -2298,7 +2298,7 @@ namespace System
                         return Item7;
                 }
 
-                return Rest[index - 7];
+                return ((IValueTupleInternal)Rest)[index - 7];
             }
         }
     }


### PR DESCRIPTION
While working on type forwarding in CoreFx branch, I realized this constraint is actually creating some source-level back compatibility issue. Since it can be removed, I might as well.

Relates to CoreCLR PR https://github.com/dotnet/coreclr/pull/8787