### PR TITLE
Remove un-necessary ITuple constraint

### DIFF
--- a/src/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -1897,7 +1897,7 @@ namespace System
     [StructLayout(LayoutKind.Auto)]
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
     : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IValueTupleInternal, ITuple
-    where TRest : struct, ITuple
+    where TRest : struct
     {
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's first component.
@@ -2269,7 +2269,8 @@ namespace System
         {
             get
             {
-                return 7 + Rest.Length;
+                IValueTupleInternal rest = Rest as IValueTupleInternal;
+                return rest == null ? 8 : 7 + rest.Length;
             }
         }
 
@@ -2298,7 +2299,16 @@ namespace System
                         return Item7;
                 }
 
-                return Rest[index - 7];
+                IValueTupleInternal rest = Rest as IValueTupleInternal;
+                if (rest == null)
+                {
+                    if (index == 7)
+                    {
+                        return Rest;
+                    }
+                    throw new IndexOutOfRangeException();
+                }
+                return rest[index - 7];
             }
         }
     }


### PR DESCRIPTION
While working on type forwarding in CoreFx branch, I realized this constraint is actually creating some source-level back compatibility issue. Since it can be removed, I might as well.

Relates to CoreCLR PR dotnet/coreclr#8787