### PR TITLE
Add ResourceManager to CoreLib

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2053,4 +2053,46 @@
   <data name="IndexOutOfRange_IORaceCondition" xml:space="preserve">
     <value>Probable I/O race condition detected while copying memory. The I/O package is not thread safe by default. In multithreaded applications, a stream must be accessed in a thread-safe way, such as a thread-safe wrapper returned by TextReader's or TextWriter's Synchronized methods. This also applies to classes like StreamWriter and StreamReader.</value>
   </data>
+  <data name="Argument_StreamNotSeekable" xml:space="preserve">
+    <value>Stream was not seekable.</value>
+  </data>
+  <data name="Arg_ResourceFileUnsupportedVersion" xml:space="preserve">
+    <value>The ResourceReader class does not know how to read this version of .resources files.</value>
+  </data>
+  <data name="Resources_StreamNotValid" xml:space="preserve">
+    <value>Stream is not a valid resource file.</value>
+  </data>
+  <data name="BadImageFormat_ResourcesHeaderCorrupted" xml:space="preserve">
+    <value>Corrupt .resources file. Unable to read resources from this file because of invalid header information. Try regenerating the .resources file.</value>
+  </data>
+  <data name="Argument_StreamNotReadable" xml:space="preserve">
+    <value>Stream was not readable.</value>
+  </data>
+  <data name="BadImageFormat_NegativeStringLength" xml:space="preserve">
+    <value>Corrupt .resources file. String length must be non-negative.</value>
+  </data>
+  <data name="BadImageFormat_ResourcesNameInvalidOffset" xml:space="preserve">
+    <value>Corrupt .resources file. The Invalid offset into name section is .</value>
+  </data>
+  <data name="BadImageFormat_TypeMismatch" xml:space="preserve">
+    <value>Corrupt .resources file.  The specified type doesn't match the available data in the stream.</value>
+  </data>
+  <data name="BadImageFormat_ResourceNameCorrupted_NameIndex" xml:space="preserve">
+    <value>Corrupt .resources file. The resource name for name index that extends past the end of the stream is </value>
+  </data>
+  <data name="BadImageFormat_ResourcesDataInvalidOffset" xml:space="preserve">
+    <value>Corrupt .resources file. Invalid offset  into data section is </value>
+  </data>
+  <data name="Format_Bad7BitInt32" xml:space="preserve">
+    <value>Too many bytes in what should have been a 7 bit encoded Int32.</value>
+  </data>
+  <data name="BadImageFormat_InvalidType" xml:space="preserve">
+    <value>Corrupt .resources file.  The specified type doesn't exist.</value>
+  </data>
+  <data name="ResourceReaderIsClosed" xml:space="preserve">
+    <value>ResourceReader is closed.</value>
+  </data>
+  <data name="Arg_MissingManifestResourceException" xml:space="preserve">
+    <value>Unable to find manifest resource.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -17,7 +17,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|arm'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|arm'" />
   <PropertyGroup>
-    <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
+    <SkipCommonResourcesIncludes Condition="'$(IsProjectNLibrary)' == 'true'">true</SkipCommonResourcesIncludes>
     <ExcludeMscorlibFacade>true</ExcludeMscorlibFacade>
     <ExcludeAssemblyInfoPartialFile>true</ExcludeAssemblyInfoPartialFile>
     <UseSyncTable>true</UseSyncTable>
@@ -50,7 +50,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\ExceptionStringID.cs">
       <Link>ExceptionStringID.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\System\SR.Core.cs">
+    <Compile Include="..\..\Common\src\System\SR.Core.cs" Condition="'$(IsProjectNLibrary)' == 'true'">
       <Link>Resources\Common</Link>
     </Compile>
     <Compile Include="..\..\Common\src\System\Threading\Tasks\TaskToApm.cs">
@@ -196,6 +196,12 @@
     <Compile Include="System\Reflection\TypeInfo.cs" />
     <Compile Include="System\Reflection\TypeInfo.Workaround.cs" />
     <Compile Include="System\Reflection\Runtime\CustomAttributes\RuntimeImplementedCustomAttributeData.cs" />
+    <!-- TODO: Enable ResourceManager in ProjectN TFS build -->
+    <Compile Include="System\Resources\MissingManifestResourceException.cs" Condition="'$(IsProjectNLibrary)' != 'true'" />
+    <Compile Include="System\Resources\NeutralResourcesLanguageAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'" />
+    <Compile Include="System\Resources\ResourceManager.cs" Condition="'$(IsProjectNLibrary)' != 'true'" />
+    <Compile Include="System\Resources\ResourceReader.cs" Condition="'$(IsProjectNLibrary)' != 'true'" />
+    <Compile Include="System\Resources\StreamExtensions.cs" Condition="'$(IsProjectNLibrary)' != 'true'" />
     <Compile Include="System\__Canon.cs" />
     <Compile Include="System\AccessViolationException.cs" />
     <Compile Include="System\Action.cs" />

--- a/src/System.Private.CoreLib/src/System/Resources/MissingManifestResourceException.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/MissingManifestResourceException.cs
@@ -12,19 +12,19 @@ namespace System.Resources
         public MissingManifestResourceException()
             : base(SR.Arg_MissingManifestResourceException)
         {
-            HResult = HResults.COR_E_MISSINGMANIFESTRESOURCE;
+            HResult = __HResults.COR_E_MISSINGMANIFESTRESOURCE;
         }
 
         public MissingManifestResourceException(string message)
             : base(message)
         {
-            HResult = HResults.COR_E_MISSINGMANIFESTRESOURCE;
+            HResult = __HResults.COR_E_MISSINGMANIFESTRESOURCE;
         }
 
         public MissingManifestResourceException(string message, Exception inner)
             : base(message, inner)
         {
-            HResult = HResults.COR_E_MISSINGMANIFESTRESOURCE;
+            HResult = __HResults.COR_E_MISSINGMANIFESTRESOURCE;
         }
 
         protected MissingManifestResourceException(SerializationInfo info, StreamingContext context) : base(info, context)

--- a/src/System.Private.CoreLib/src/System/Resources/MissingManifestResourceException.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/MissingManifestResourceException.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Resources
+{
+    [Serializable]
+    public class MissingManifestResourceException : SystemException
+    {
+        public MissingManifestResourceException()
+            : base(SR.Arg_MissingManifestResourceException)
+        {
+            HResult = HResults.COR_E_MISSINGMANIFESTRESOURCE;
+        }
+
+        public MissingManifestResourceException(string message)
+            : base(message)
+        {
+            HResult = HResults.COR_E_MISSINGMANIFESTRESOURCE;
+        }
+
+        public MissingManifestResourceException(string message, Exception inner)
+            : base(message, inner)
+        {
+            HResult = HResults.COR_E_MISSINGMANIFESTRESOURCE;
+        }
+
+        protected MissingManifestResourceException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Resources/NeutralResourcesLanguageAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/NeutralResourcesLanguageAttribute.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Resources
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public sealed class NeutralResourcesLanguageAttribute : Attribute
+    {
+        private readonly string _culture;
+
+        public NeutralResourcesLanguageAttribute(string cultureName)
+        {
+            if (cultureName == null)
+            {
+                throw new ArgumentNullException(nameof(cultureName));
+            }
+
+            _culture = cultureName;
+        }
+
+        public string CultureName
+        {
+            get { return _culture; }
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Reflection;
+
+namespace System.Resources
+{
+    public class ResourceManager
+    {
+        protected Assembly MainAssembly;
+
+        public ResourceManager(Type resourceSource)
+        {
+            if (null == resourceSource)
+            {
+                throw new ArgumentNullException(nameof(resourceSource));
+            }
+
+            // TODO: NS2.0 ResourceManager
+        }
+
+        public ResourceManager(string baseName, Assembly assembly)
+        {
+            if (null == baseName)
+            {
+                throw new ArgumentNullException(nameof(baseName));
+            }
+            if (null == assembly)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            MainAssembly = assembly;
+
+            // TODO: NS2.0 ResourceManager
+        }
+
+        public ResourceManager(string resourcesName)
+        {
+            // TODO: NS2.0 ResourceManager
+        }
+
+        public string GetString(string name)
+        {
+            return GetString(name, null);
+        }
+
+        // Looks up a resource value for a particular name.  Looks in the
+        // specified CultureInfo, and if not found, all parent CultureInfos.
+        // Returns null if the resource wasn't found.
+        //
+        public virtual string GetString(string name, CultureInfo culture)
+        {
+            if (null == name)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            // TODO: NS2.0 ResourceManager
+            return name;
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
@@ -1,0 +1,435 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Collections;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace System.Resources
+{
+    public sealed class ResourceReader : IDisposable
+    {
+        private const int ResSetVersion = 2;
+        private const int ResourceTypeCodeString = 1;
+        private const int ResourceManagerMagicNumber = unchecked((int)0xBEEFCACE);
+        private const int ResourceManagerHeaderVersionNumber = 1;
+
+        private Stream _stream;    // backing store we're reading from.
+        private long _nameSectionOffset;  // Offset to name section of file.
+        private long _dataSectionOffset;  // Offset to Data section of file.
+        private long _resourceStreamStart;  // beginning of the resource stream, which could be part of a longer file stream
+
+        private int[] _namePositions; // relative locations of names
+        private int _stringTypeIndex;
+        private int _numOfTypes;
+        private int _numResources;    // Num of resources files, in case arrays aren't allocated.      
+        private int _version;
+
+        // "System.String, mscorlib" representation in resources stream
+        private readonly static byte[] s_SystemStringName = EncodeStringName();
+
+        public ResourceReader(Stream stream)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+            if (!stream.CanRead)
+                throw new ArgumentException(SR.Argument_StreamNotReadable);
+            if (!stream.CanSeek)
+                throw new ArgumentException(SR.Argument_StreamNotSeekable);
+
+            _stream = stream;
+
+            ReadResources();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private unsafe void Dispose(bool disposing)
+        {
+            if (_stream != null) {
+                if (disposing) {
+                    Stream stream = _stream;
+                    _stream = null;
+                    if (stream != null) {
+                        stream.Dispose();
+                    }
+                    _namePositions = null;
+                }
+            }
+        }
+
+        private void SkipString()
+        {
+            int stringLength;
+            if (!_stream.TryReadInt327BitEncoded(out stringLength) || stringLength < 0)
+            {
+                throw new BadImageFormatException(SR.BadImageFormat_NegativeStringLength);
+            }
+            _stream.Seek(stringLength, SeekOrigin.Current);
+        }
+
+        private unsafe int GetNamePosition(int index)
+        {
+            Debug.Assert(index >= 0 && index < _numResources, "Bad index into name position array.  index: " + index);
+
+            int r;
+
+            r = _namePositions[index];
+            if (r < 0 || r > _dataSectionOffset - _nameSectionOffset)
+            {
+                throw new FormatException(SR.BadImageFormat_ResourcesNameInvalidOffset + ":" + r);
+            }
+            return r;
+        }
+        public IDictionaryEnumerator GetEnumerator()
+        {
+            if (_stream == null)
+                throw new InvalidOperationException(SR.ResourceReaderIsClosed);
+            return new ResourceEnumerator(this);
+        }
+
+        private void SuccessElseEosException(bool condition)
+        {
+            if (!condition) {
+                throw new EndOfStreamException();
+            }
+        }
+
+        private string GetKeyForNameIndex(int index)
+        {
+            Debug.Assert(_stream != null, "ResourceReader is closed!");
+            long nameVA = GetNamePosition(index);
+            lock (this)
+            {
+                _stream.Seek(_resourceStreamStart + nameVA + _nameSectionOffset, SeekOrigin.Begin);
+                var result = _stream.ReadString(utf16: true);
+
+                int dataOffset;
+                SuccessElseEosException(_stream.TryReadInt32(out dataOffset));
+                if (dataOffset < 0 || dataOffset >= _stream.Length - _dataSectionOffset)
+                {
+                    throw new FormatException(SR.BadImageFormat_ResourcesDataInvalidOffset + " offset :" + dataOffset);
+                }
+                return result;
+            }
+        }
+
+        private string GetValueForNameIndex(int index)
+        {
+            Debug.Assert(_stream != null, "ResourceReader is closed!");
+            long nameVA = GetNamePosition(index);
+            lock (this)
+            {
+                _stream.Seek(_resourceStreamStart + nameVA + _nameSectionOffset, SeekOrigin.Begin);
+                SkipString();
+
+                int dataPos;
+                SuccessElseEosException(_stream.TryReadInt32(out dataPos));
+                if (dataPos < 0 || dataPos >= _stream.Length - _dataSectionOffset)
+                {
+                    throw new FormatException(SR.BadImageFormat_ResourcesDataInvalidOffset + dataPos);
+                }
+
+                try
+                {
+                    return ReadStringElseNull(dataPos);
+                }
+                catch (EndOfStreamException eof)
+                {
+                    throw new BadImageFormatException(SR.BadImageFormat_TypeMismatch, eof);
+                }
+                catch (ArgumentOutOfRangeException e)
+                {
+                    throw new BadImageFormatException(SR.BadImageFormat_TypeMismatch, e);
+                }
+            }
+        }
+        
+        //returns null if the resource is not a string
+        private string ReadStringElseNull(int pos)
+        {
+            _stream.Seek(_dataSectionOffset + pos, SeekOrigin.Begin);
+
+            int typeIndex;       
+            if(!_stream.TryReadInt327BitEncoded(out typeIndex)) {
+                throw new BadImageFormatException(SR.BadImageFormat_TypeMismatch);
+            }
+
+            if (_version == 1) {
+                if (typeIndex == -1 || !IsString(typeIndex)) {
+                    return null;
+                }
+            }
+            else
+            {
+                if (ResourceTypeCodeString != typeIndex) {
+                    return null;
+                }
+            }
+
+            return _stream.ReadString(utf16 : false);
+        }
+
+        private void ReadResources()
+        {
+            Debug.Assert(_stream != null, "ResourceReader is closed!");
+
+            try
+            {
+                // mega try-catch performs exceptionally bad on x64; factored out body into 
+                // _ReadResources and wrap here.
+                _ReadResources();
+            }
+            catch (EndOfStreamException eof)
+            {
+                throw new BadImageFormatException(SR.BadImageFormat_ResourcesHeaderCorrupted, eof);
+            }
+            catch (IndexOutOfRangeException e)
+            {
+                throw new BadImageFormatException(SR.BadImageFormat_ResourcesHeaderCorrupted, e);
+            }
+        }
+
+        private void _ReadResources()
+        {
+            _resourceStreamStart = _stream.Position;
+
+            // Read out the ResourceManager header
+            // Read out magic number
+            int magicNum;
+            SuccessElseEosException(_stream.TryReadInt32(out magicNum));
+
+            if (magicNum != ResourceManagerMagicNumber)
+                throw new ArgumentException(SR.Resources_StreamNotValid);
+
+            // Assuming this is ResourceManager header V1 or greater, hopefully
+            // after the version number there is a number of bytes to skip
+            // to bypass the rest of the ResMgr header. For V2 or greater, we
+            // use this to skip to the end of the header
+
+            int resMgrHeaderVersion;
+            SuccessElseEosException(_stream.TryReadInt32(out resMgrHeaderVersion));
+
+            //number of bytes to skip over to get past ResMgr header
+            int numBytesToSkip;
+            SuccessElseEosException(_stream.TryReadInt32(out numBytesToSkip));
+
+            if (numBytesToSkip < 0 || resMgrHeaderVersion < 0) {
+                throw new BadImageFormatException(SR.BadImageFormat_ResourcesHeaderCorrupted);
+            }
+
+            if (resMgrHeaderVersion > 1) {
+                _stream.Seek(numBytesToSkip, SeekOrigin.Current);
+            }
+            else {
+                // We don't care about numBytesToSkip; read the rest of the header
+                //Due to legacy : this field is always a variant of  System.Resources.ResourceReader, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+                //So we Skip the type name for resourcereader unlike Desktop
+                SkipString();
+
+                // Skip over type name for a suitable ResourceSet
+                SkipString();
+            }
+
+            // Read RuntimeResourceSet header
+            // Do file version check
+            SuccessElseEosException(_stream.TryReadInt32(out _version));
+            if (_version != ResSetVersion && _version != 1) {
+                throw new ArgumentException(SR.Arg_ResourceFileUnsupportedVersion + "Expected:" + ResSetVersion + "but got:" + _version);
+            }
+
+            // number of resources
+            SuccessElseEosException(_stream.TryReadInt32(out _numResources));
+            if (_numResources < 0) {
+                throw new BadImageFormatException(SR.BadImageFormat_ResourcesHeaderCorrupted);
+            }
+
+            SuccessElseEosException(_stream.TryReadInt32(out _numOfTypes));
+            if (_numOfTypes < 0) {
+                throw new BadImageFormatException(SR.BadImageFormat_ResourcesHeaderCorrupted);
+            }
+
+            // find index of System.String
+            for (int i = 0; i < _numOfTypes; i++)
+            {
+                if(_stream.StartsWith(s_SystemStringName, advance : true)){
+                    _stringTypeIndex = i;
+                }
+            }
+
+            // Prepare to read in the array of name hashes
+            //  Note that the name hashes array is aligned to 8 bytes so 
+            //  we can use pointers into it on 64 bit machines. (4 bytes 
+            //  may be sufficient, but let's plan for the future)
+            //  Skip over alignment stuff.  All public .resources files
+            //  should be aligned   No need to verify the byte values.
+            long pos = _stream.Position;
+            int alignBytes = ((int)pos) & 7;
+            if (alignBytes != 0)
+            {
+                for (int i = 0; i < 8 - alignBytes; i++)
+                {
+                    _stream.ReadByte();
+                }
+            }
+
+            //Skip over the  array of name hashes
+
+            for (int i = 0; i < _numResources; i++)
+            {
+                int hash;
+                SuccessElseEosException(_stream.TryReadInt32(out hash));
+            }
+
+            // Read in the array of relative positions for all the names.
+            _namePositions = new int[_numResources];
+            for (int i = 0; i < _numResources; i++)
+            {
+                int namePosition;
+                SuccessElseEosException(_stream.TryReadInt32(out namePosition));
+                if (namePosition < 0)
+                {
+                    throw new BadImageFormatException(SR.BadImageFormat_ResourcesHeaderCorrupted);
+                }
+
+                _namePositions[i] = namePosition;
+            }
+
+            // Read location of data section.
+            int dataSectionOffset;
+            SuccessElseEosException(_stream.TryReadInt32(out dataSectionOffset));
+            if (dataSectionOffset < 0)
+            {
+                throw new BadImageFormatException(SR.BadImageFormat_ResourcesHeaderCorrupted);
+            }
+            _dataSectionOffset = dataSectionOffset;
+
+            // Store current location as start of name section
+            _nameSectionOffset = _stream.Position - _resourceStreamStart;
+
+            // _nameSectionOffset should be <= _dataSectionOffset; if not, it's corrupt
+            if (_dataSectionOffset < _nameSectionOffset)
+            {
+                throw new BadImageFormatException(SR.BadImageFormat_ResourcesHeaderCorrupted);
+            }
+        }
+       
+        private bool IsString(int typeIndex)
+        {
+            if (typeIndex < 0 || typeIndex >= _numOfTypes)
+            {
+                throw new BadImageFormatException(SR.BadImageFormat_InvalidType);
+            }
+
+            return typeIndex == _stringTypeIndex;
+        }
+
+        private static byte[] EncodeStringName()
+        {
+            // ResourceWriter always write the resources with legacy core library name (i.e. mscorlib).
+            // Ensure that when we read the type name, we update the library name to be the same.
+            var name = "System.String, mscorlib";
+            int length = name.Length;
+
+            var buffer = new byte[length + 1];
+            var encoded = Encoding.UTF8.GetBytes(name, 0, length, buffer, 1);
+
+            // all characters should be single byte encoded and the type name shorter than 128 bytes
+            // this restriction is needed to encode without multiple allocations of the buffer
+            if (encoded > 127 || encoded != length)
+            {
+                throw new NotSupportedException();
+            }
+
+            checked { buffer[0] = (byte)encoded; }
+            return buffer;
+        }
+
+        internal sealed class ResourceEnumerator : IDictionaryEnumerator
+        {
+            private const int ENUM_DONE = int.MinValue;
+            private const int ENUM_NOT_STARTED = -1;
+
+            private ResourceReader _reader;
+            private bool _currentIsValid;
+            private int _currentName;
+            
+            internal ResourceEnumerator(ResourceReader reader)
+            {
+                _currentName = ENUM_NOT_STARTED;
+                _reader = reader;
+               
+            }
+
+            public bool MoveNext()
+            {
+                if (_currentName == _reader._numResources - 1 || _currentName == ENUM_DONE)
+                {
+                    _currentIsValid = false;
+                    _currentName = ENUM_DONE;
+                    return false;
+                }
+                _currentIsValid = true;
+                _currentName++;
+                return true;
+            }
+
+            public Object Key
+            {
+                [System.Security.SecuritySafeCritical]  // auto-generated
+                get
+                {
+                    if (_currentName == ENUM_DONE) throw new InvalidOperationException(SR.InvalidOperation_EnumEnded);
+                    if (!_currentIsValid) throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
+                    return _reader.GetKeyForNameIndex(_currentName);
+                }
+            }
+
+            public Object Current
+            {
+                get
+                {
+                    return Entry;
+                }
+            }
+
+            public DictionaryEntry Entry
+            {
+                [System.Security.SecuritySafeCritical]  // auto-generated
+                get
+                {
+                    if (_currentName == ENUM_DONE) throw new InvalidOperationException(SR.InvalidOperation_EnumEnded);
+                    if (!_currentIsValid) throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
+
+                    string key = _reader.GetKeyForNameIndex(_currentName);
+                    string value = _reader.GetValueForNameIndex(_currentName);
+
+                    return new DictionaryEntry(key, value);
+                }
+            }
+
+            public Object Value
+            {
+                get
+                {
+                    if (_currentName == ENUM_DONE) throw new InvalidOperationException(SR.InvalidOperation_EnumEnded);
+                    if (!_currentIsValid) throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
+
+                    return _reader.GetValueForNameIndex(_currentName);
+                }
+            }
+
+            public void Reset()
+            {
+                if (_reader._stream == null) throw new InvalidOperationException(SR.ResourceReaderIsClosed);
+                _currentIsValid = false;
+                _currentName = ENUM_NOT_STARTED;
+            }
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Resources/StreamExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/StreamExtensions.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace System.Resources
+{
+    internal static class BinaryStreamExtensions
+    {
+        public static bool TryReadInt32(this Stream stream, out int result)
+        {
+            result = 0;
+            var b0 = stream.ReadByte();
+            if (b0 < 0) return false;
+            var b1 = stream.ReadByte();
+            if (b1 < 0) return false;
+            var b2 = stream.ReadByte();
+            if (b2 < 0) return false;
+            var b3 = stream.ReadByte();
+            if (b3 < 0) return false;
+
+            result = b3;
+            result <<= 8;
+            result |= b2;
+            result <<= 8;
+            result |= b1;
+            result <<= 8;
+            result |= b0;
+
+            return true;
+        }
+
+        //blatantly copied over from BinaryReader
+        public static bool TryReadInt327BitEncoded(this Stream stream, out int result)
+        {
+            // Read out an int 7 bits at a time.  The high bit
+            // of the byte when on means to continue reading more bytes.
+            result = 0;
+            int shift = 0;
+            byte b;
+            do
+            {
+                // Check for a corrupted stream.  Read a max of 5 bytes.
+                // In a future version, add a DataFormatException.
+                if (shift == 5 * 7)  // 5 bytes max per int, shift += 7
+                    throw new FormatException(SR.Format_Bad7BitInt32);
+
+                // ReadByte handles end of stream cases for us.
+                int readByte = stream.ReadByte();
+                if (readByte < 0)
+                {
+                    result = default(int);
+                    return false;
+                }
+                b = (byte)readByte;
+                result |= (b & 0x7F) << shift;
+                shift += 7;
+            } while ((b & 0x80) != 0);
+
+            return true;
+        }
+
+        // reads length (7-bit encoded int) + UTF8 buffer
+        public static string ReadString(this Stream stream, bool utf16 = false)
+        {
+            var position = stream.Position;
+            int stringLength;
+            if (!stream.TryReadInt327BitEncoded(out stringLength))
+            {
+                throw new BadImageFormatException(SR.Resources_StreamNotValid);
+            }
+
+            if(stringLength == 0) { return string.Empty; }
+
+            byte[] buffer = new byte[stringLength];
+            int totalRead = 0;
+
+            do
+            {
+                int justRead = stream.Read(buffer, totalRead, stringLength - totalRead);
+                if(justRead == 0)
+                {
+                    throw new EndOfStreamException(SR.BadImageFormat_ResourceNameCorrupted_NameIndex + position);
+                }
+                totalRead += justRead;
+            }
+            while (totalRead != stringLength);
+
+            if (utf16) {
+                return Encoding.Unicode.GetString(buffer, 0, buffer.Length);
+            }
+            else {
+                return Encoding.UTF8.GetString(buffer, 0, buffer.Length);
+            }
+        }
+
+        internal static bool StartsWith(this Stream stream, byte[] value, bool advance = false)
+        {
+            long originalPosition = stream.Position;
+            foreach(var b in value)
+            {
+                int read = stream.ReadByte();
+                if(b != read) {
+                    if (!advance) {
+                        stream.Position = originalPosition;
+                    }
+                    return false;
+                }
+            }
+            if (!advance) {
+                stream.Position = originalPosition;
+            }
+            return true;
+        }
+    }
+}

--- a/src/System.Private.DeveloperExperience.Console/src/System.Private.DeveloperExperience.Console.csproj
+++ b/src/System.Private.DeveloperExperience.Console/src/System.Private.DeveloperExperience.Console.csproj
@@ -25,7 +25,7 @@
     <ReferencePath Include="$(AotPackageReferencePath)\System.Collections.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Console.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.IO.dll" />
-    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" />
+    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" Condition="'$(IsProjectNLibrary)' == 'true'" />
     
     <ProjectReference Include="..\..\System.Private.StackTraceGenerator\src\System.Private.StackTraceGenerator.csproj" />
   </ItemGroup>

--- a/src/System.Private.Interop/src/System.Private.Interop.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.csproj
@@ -32,7 +32,7 @@
     <ReferencePath Include="$(AotPackageReferencePath)\System.Collections.dll" >
       <Aliases>CoreFX_Collections</Aliases>
     </ReferencePath>
-    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" />
+    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" Condition="'$(IsProjectNLibrary)' == 'true'" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Reflection.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Diagnostics.Tracing.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Diagnostics.Contracts.dll" />

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -24,7 +24,7 @@
     </ProjectReference>
     <ReferencePath Include="$(AotPackageReferencePath)\System.Runtime.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Diagnostics.Tracing.dll" />
-    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" />
+    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" Condition="'$(IsProjectNLibrary)' == 'true'" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Collections.Immutable.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Reflection.Metadata.dll" />
   </ItemGroup>

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -25,7 +25,7 @@
 
     <ReferencePath Include="$(AotPackageReferencePath)\System.Runtime.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Runtime.Extensions.dll" Condition="'$(IsProjectNLibrary)' == 'true'" />
-    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" />
+    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" Condition="'$(IsProjectNLibrary)' == 'true'" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Reflection.dll" Condition="'$(IsProjectNLibrary)' == 'true'" />  
   </ItemGroup>
 

--- a/src/System.Private.Reflection/src/System.Private.Reflection.csproj
+++ b/src/System.Private.Reflection/src/System.Private.Reflection.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\..\System.Private.CoreLib\src\System.Private.CoreLib.csproj" />
   </ItemGroup>
   <PropertyGroup>
-    <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
+    <SkipCommonResourcesIncludes Condition="'$(IsProjectNLibrary)' == 'true'">true</SkipCommonResourcesIncludes>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Internal\Reflection\Augments\TypeForwarders.cs" />

--- a/src/System.Private.Threading/src/System.Private.Threading.csproj
+++ b/src/System.Private.Threading/src/System.Private.Threading.csproj
@@ -23,7 +23,7 @@
     <ReferencePath Include="$(AotPackageReferencePath)\System.Runtime.Extensions.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Diagnostics.Tracing.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Collections.dll" />
-    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" />
+    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" Condition="'$(IsProjectNLibrary)' == 'true'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Internal\Threading\SpinLockTraceCallbacksImplementation.cs" />

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -23,7 +23,7 @@
     </ProjectReference>
     <ReferencePath Include="$(AotPackageReferencePath)\System.Runtime.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Runtime.Extensions.dll" />
-    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" />
+    <ReferencePath Include="$(AotPackageReferencePath)\System.Resources.ResourceManager.dll" Condition="'$(IsProjectNLibrary)' == 'true'" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Collections.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Collections.Immutable.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Reflection.Metadata.dll" />


### PR DESCRIPTION
Partial port of https://github.com/dotnet/corefx/pull/12468 and https://github.com/dotnet/coreclr/pull/7402 to CoreRT. The console and NS2.0 runtime-specific parts remain to be implemented. This is necessary to unblock building CoreRT specific framework libraries in corefx repo.