### PR TITLE
Adding support for RuntimeMethodHandle nodes.

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutSignatureNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutSignatureNode.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a native layout signature. A signature is a pair where the first item is a pointer
+    /// to the TypeManager that contains the native layout info blob of interest, and the second item
+    /// is an offset into that native layout info blob
+    /// </summary>
+    class NativeLayoutSignatureNode : ObjectNode, ISymbolNode
+    {
+        private static int s_counter = 0;
+
+        private int _id;
+        private NativeLayoutSavedVertexNode _nativeSignature;
+
+        public NativeLayoutSignatureNode(NativeLayoutSavedVertexNode nativeSignature)
+        {
+            _nativeSignature = nativeSignature;
+            _id = s_counter++;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__NativeLayoutSignature_" + _id);
+        }
+        public int Offset => 0;
+        protected override string GetName() => this.GetMangledName();
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+        public override bool IsShareable => false;
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            DependencyList dependencies = new DependencyList();
+            dependencies.Add(new DependencyListEntry(_nativeSignature, "NativeLayoutSignatureNode target vertex"));
+            return dependencies;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            // Ensure native layout is saved to get valid Vertex offsets
+            factory.MetadataManager.NativeLayoutInfo.SaveNativeLayoutInfoWriter(factory);
+
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory);
+
+            objData.Alignment = objData.TargetPointerSize;
+            objData.DefinedSymbols.Add(this);
+
+            objData.EmitPointerReloc(factory.TypeManagerIndirection);
+            objData.EmitNaturalInt(_nativeSignature.SavedVertex.VertexOffset);
+
+            return objData.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
@@ -48,6 +48,11 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     return new NativeLayoutMethodLdTokenVertexNode(_factory, method);
                 });
+
+                _nativeLayoutSignatureNodes = new NodeCache<NativeLayoutSavedVertexNode, NativeLayoutSignatureNode>(signature =>
+                {
+                    return new NativeLayoutSignatureNode(signature);
+                });
             }
 
             private NodeCache<TypeDesc, NativeLayoutTypeSignatureVertexNode> _typeSignatures;
@@ -80,6 +85,11 @@ namespace ILCompiler.DependencyAnalysis
                 return _methodLdTokenSignatures.GetOrAdd(method);
             }
 
+            private NodeCache<NativeLayoutSavedVertexNode, NativeLayoutSignatureNode> _nativeLayoutSignatureNodes;
+            internal NativeLayoutSignatureNode NativeLayoutSignature(NativeLayoutSavedVertexNode signature)
+            {
+                return _nativeLayoutSignatureNodes.GetOrAdd(signature);
+            }
         }
 
         public NativeLayoutHelper NativeLayout;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -13,6 +13,7 @@ using Internal.Text;
 using Internal.TypeSystem;
 using Internal.Runtime;
 using Internal.IL;
+using Internal.NativeFormat;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -235,6 +236,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new InterfaceDispatchMapNode(type);
             });
 
+            _runtimeMethodHandles = new NodeCache<MethodDesc, RuntimeMethodHandleNode>((MethodDesc method) =>
+            {
+                return new RuntimeMethodHandleNode(this, method);
+            });
+
             _interfaceDispatchMapIndirectionNodes = new NodeCache<TypeDesc, EmbeddedObjectNode>((TypeDesc type) =>
             {
                 var dispatchMap = InterfaceDispatchMap(type);
@@ -368,6 +374,13 @@ namespace ILCompiler.DependencyAnalysis
         internal InterfaceDispatchCellNode InterfaceDispatchCell(MethodDesc method)
         {
             return _interfaceDispatchCells.GetOrAdd(method);
+        }
+
+        private NodeCache<MethodDesc, RuntimeMethodHandleNode> _runtimeMethodHandles;
+
+        internal RuntimeMethodHandleNode RuntimeMethodHandle(MethodDesc method)
+        {
+            return _runtimeMethodHandles.GetOrAdd(method);
         }
 
         private class BlobTupleEqualityComparer : IEqualityComparer<Tuple<Utf8String, byte[], int>>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    class RuntimeMethodHandleNode : ObjectNode, ISymbolNode
+    {
+        MethodDesc _targetMethod;
+
+        public RuntimeMethodHandleNode(NodeFactory factory, MethodDesc targetMethod)
+        {
+            Debug.Assert(!targetMethod.IsSharedByGenericInstantiations);
+            _targetMethod = targetMethod;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix)
+              .Append("__RuntimeMethodHandle_")
+              .Append(NodeFactory.NameMangler.GetMangledMethodName(_targetMethod));
+        }
+        public int Offset => 0;
+        protected override string GetName() => this.GetMangledName();
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+        public override bool IsShareable => false;
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory);
+
+            objData.Alignment = objData.TargetPointerSize;
+            objData.DefinedSymbols.Add(this);
+
+            NativeLayoutMethodLdTokenVertexNode ldtokenSigNode = factory.NativeLayout.MethodLdTokenVertex(_targetMethod);
+            objData.EmitPointerReloc(factory.NativeLayout.NativeLayoutSignature(ldtokenSigNode));
+
+            return objData.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -106,6 +106,8 @@
     <Compile Include="Compiler\DependencyAnalysis\NativeLayoutVertexNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericsHashtableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExactMethodInstantiationsNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\RuntimeMethodHandleNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NativeLayoutSignatureNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunGenericHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfFrozenObjectsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ClassConstructorContextMap.cs" />


### PR DESCRIPTION
This is again part of the larger GVM work, which I'm splitting into multiple PRs.

This change just enables the RMH support, but won't emit any RMH structures yet.