### PR TITLE
Virtual Method Resolution Fix

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -503,8 +503,12 @@ namespace Internal.TypeSystem
                 if (baseType == null)
                     return foundOnCurrentType;
 
-                if (foundOnCurrentType == null && (ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, baseType) == null))
+                if (foundOnCurrentType == null)
                 {
+                    MethodDesc foundOnBaseType = ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod, baseType);
+                    if (foundOnBaseType != null)
+                        return foundOnBaseType;
+
                     // TODO! Does this handle the case where the base type explicitly implements the interface, but is abstract
                     // and doesn't actually have an implementation?
                     if (!IsInterfaceImplementedOnType(baseType, interfaceType))


### PR DESCRIPTION
Virtual methods implemented only on the basetype were not being resolved correctly.

Example:
interface IFoo { void Method<T>(); }
class Base : IFoo { void IFoo.Method<T>() { ... } }
class Devied : Base, IFoo { }

IFoo o = new Derived();
o.Method<int>();

With this repro, ResolveInterfaceMethodToVirtualMethodOnType was incorrectly returning null, and wasn't finding the method on the base type.
