### PR TITLE
Add custom attribute to force static PInvoke resolution

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.DynamicLoad.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.DynamicLoad.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Win32;
@@ -14,6 +15,7 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll")]
         internal static extern IntPtr GetProcAddress(IntPtr hModule, byte* lpProcName);
 
+        [PInvokeStaticResolution]
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", EntryPoint = "LoadLibraryExW")]
         internal static extern IntPtr LoadLibraryEx(char* lpFileName, IntPtr hFile, int dwFlags);
 

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -131,6 +131,12 @@ namespace Internal.IL.Stubs
             // TODO: Test and make this work on non-Windows
             if (!method.Context.Target.IsWindows)
                 return false;
+            
+            // Some PInvokes must resolved statically if they're called as part of startup and we can't reflect on types yet
+            if (method.HasCustomAttribute("System.Runtime.CompilerServices", "PInvokeStaticResolutionAttribute"))
+            {
+                return false;
+            }
 
             if (configuration.ForceLazyResolution)
                 return true;

--- a/src/Runtime.Base/src/Runtime.Base.csproj
+++ b/src/Runtime.Base/src/Runtime.Base.csproj
@@ -98,6 +98,7 @@
     <Compile Include="System\Runtime\CompilerServices\IsVolatile.cs" />
     <Compile Include="System\Runtime\CompilerServices\ManuallyManagedAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\MethodImplAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\PInvokeStaticResolutionAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpers.cs" />
     <Compile Include="System\Runtime\CompilerServices\Unsafe.cs" />
     <Compile Include="System\Runtime\CompilerServices\UnsafeValueTypeAttribute.cs" />

--- a/src/Runtime.Base/src/System/Runtime/CompilerServices/PInvokeStaticResolutionAttribute.cs
+++ b/src/Runtime.Base/src/System/Runtime/CompilerServices/PInvokeStaticResolutionAttribute.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates a PInvoke is resolved statically at compile time
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class PInvokeStaticResolutionAttribute : Attribute { }
+}

--- a/src/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -397,12 +397,15 @@ namespace System.Runtime
         [DllImport(Redhawk.BaseName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void RhpSignalFinalizationComplete();
 
+        [PInvokeStaticResolution]
         [DllImport(Redhawk.BaseName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void RhpAcquireCastCacheLock();
 
+        [PInvokeStaticResolution]
         [DllImport(Redhawk.BaseName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void RhpReleaseCastCacheLock();
 
+        [PInvokeStaticResolution]
         [DllImport(Redhawk.BaseName, CallingConvention = CallingConvention.Cdecl)]
         internal extern static long PalGetTickCount64();
 

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -1151,6 +1151,9 @@
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\CompilerServices\ManuallyManagedAttribute.cs">
       <Link>Runtime.Base\src\System\Runtime\CompilerServices\ManuallyManagedAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\..\Runtime.Base\src\System\Runtime\CompilerServices\PInvokeStaticResolutionAttribute.cs">
+      <Link>Runtime.Base\src\System\Runtime\CompilerServices\PInvokeStaticResolutionAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\InteropServices\UnsafeGCHandle.cs">
       <Link>Runtime.Base\src\System\Runtime\InteropServices\UnsafeGCHandle.cs</Link>
     </Compile>

--- a/src/Test.CoreLib/src/Test.CoreLib.csproj
+++ b/src/Test.CoreLib/src/Test.CoreLib.csproj
@@ -92,6 +92,9 @@
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\CompilerServices\ManuallyManagedAttribute.cs">
       <Link>Runtime.Base\src\System\Runtime\CompilerServices\ManuallyManagedAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\..\Runtime.Base\src\System\Runtime\CompilerServices\PInvokeStaticResolutionAttribute.cs">
+      <Link>Runtime.Base\src\System\Runtime\CompilerServices\PInvokeStaticResolutionAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\InteropServices\UnsafeGCHandle.cs">
       <Link>Runtime.Base\src\System\Runtime\InteropServices\UnsafeGCHandle.cs</Link>
     </Compile>


### PR DESCRIPTION
Add `PInvokeStaticResolutionAttribute` which overrides the logic that
decides whether the PInvoke will be resolved by the compiler or lazily
at runtime. For multi-module compilation it is preferable to have
PInvokes all resolved lazily since we compile everything and there may
be unresolvable (but un-used) PInvokes.  However some PInvokes occur
early enough on the startup path that we can't do lazy resolution yet.
For example, calling LoadLibraryEx causes an infinite loop.