### PR TITLE
Replace MRE with call to Sleep on mincore

### DIFF
--- a/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
+++ b/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
@@ -124,6 +124,9 @@ internal partial class Interop
         [DllImport("api-ms-win-core-synch-l1-1-0.dll")]
         internal extern static uint WaitForMultipleObjectsEx(uint nCount, IntPtr lpHandles, bool bWaitAll, uint dwMilliseconds, bool bAlertable);
 
+        [DllImport("api-ms-win-core-synch-l1-2-0.dll", EntryPoint = "Sleep")]
+        internal extern static void _Sleep(uint milliseconds);
+
         //
         // Wrapper for calling RaiseFailFastException
         //
@@ -169,13 +172,12 @@ internal partial class Interop
                     IntPtr pContextRecord,
                     uint dwFlags);
 
-        private static readonly System.Threading.WaitHandle s_sleepHandle = new System.Threading.ManualResetEvent(false);
         internal static void Sleep(uint milliseconds)
         {
             if (milliseconds == 0)
                 System.Threading.SpinWait.Yield();
             else
-                s_sleepHandle.WaitOne((int)milliseconds);
+                _Sleep(milliseconds);
         }
     }
     internal unsafe partial class WinRT


### PR DESCRIPTION
Use the system `Sleep` API instead of a static `WaitHandle`. The current
MRE ends up calling `WaitForMultipleObjectsEx` after about 8 levels of
abstraction. An additional benefit is the removal of Interop.mincore
needing a static class constructor.