### PR TITLE
Fix Exception.ToString() incompatibility.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -175,21 +175,8 @@ namespace System
 
         private string GetClassName()
         {
-            Type thisType = this.GetType();
-            ReflectionExecutionDomainCallbacks callbacks = RuntimeAugments.CallbacksIfAvailable;
-            if (callbacks != null)
-            {
-                String preferredString = callbacks.GetBetterDiagnosticInfoIfAvailable(thisType.TypeHandle);
-                if (preferredString != null)
-                    return preferredString;
-            }
-
-            // If all else fails, fall back to the classic GetType().ToString() behavior (which will likely
-            // provide an unfriendly-looking string on Project N.)
-            return thisType.ToString();
+            return GetType().ToString();
         }
-
-
 
         // Retrieves the lowest exception (inner most) for the given Exception.
         // This will traverse exceptions using the innerException property.


### PR DESCRIPTION
Fix https://github.com/dotnet/corert/issues/2290

GetClassName() tries to get the nicer debug-mode type name
first, but Type.ToString() will get that same info anyway.

This change makes GetClassName() a simple wrap of
Type.ToString() for compat reasons.

(With this change, it looks silly to even have a helper
function but keeping it makes the code more diffable
with the desktop source code.)