### PR TITLE
Fix native build warnings

### DIFF
--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -217,12 +217,9 @@ void* RtRHeaderWrapper();
 extern "C" void __fail_fast()
 {
     // TODO: FailFast
-    throw "__fail_fast";
-}
-
-extern "C" void RhpEtwExceptionThrown()
-{
-    throw "RhpEtwExceptionThrown";
+    printf("Call to an unimplemented runtime method; execution cannot continue.\n");
+    printf("Method: __fail_fast\n");
+    exit(-1);
 }
 
 extern "C" bool REDHAWK_PALAPI PalInit();


### PR DESCRIPTION
* `RhpEtwExceptionThrown` - we don't need.
* Doing a C++ throw out of an `extern "C"` method will likely unwind in
a weird way. Exit instead.