### PR TITLE
Implement SetLastError DllImport flag functionality

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.ErrNo.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.ErrNo.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal unsafe partial class Sys
+    {
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(Interop.Libraries.CoreLibNative, "CoreLibNative_GetLastErrNo")]
+        internal static extern int GetLastErrNo();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(Interop.Libraries.CoreLibNative, "CoreLibNative_SetLastErrNo")]
+        internal static extern void SetLastErrNo(int error);
+    }
+}

--- a/src/Common/src/Interop/Windows/mincore/Interop.GetLastError.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.GetLastError.cs
@@ -2,13 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport("api-ms-win-core-errorhandling-l1-1-0.dll")]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(Interop.Libraries.ErrorHandling, "GetLastError")]
         internal extern static int GetLastError();
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.SetLastError.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.SetLastError.cs
@@ -2,13 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class mincore
     {
-        [DllImport("api-ms-win-core-errorhandling-l1-1-0.dll")]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(Interop.Libraries.ErrorHandling, "SetLastError")]
         internal extern static void SetLastError(uint dwErrCode);
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -413,6 +413,7 @@ namespace Internal.TypeSystem.Ecma
             Debug.Assert((int)MethodImportAttributes.CallingConventionStdCall == (int)PInvokeAttributes.CallingConventionStdCall);
             Debug.Assert((int)MethodImportAttributes.CharSetAuto == (int)PInvokeAttributes.CharSetAuto);
             Debug.Assert((int)MethodImportAttributes.CharSetUnicode == (int)PInvokeAttributes.CharSetUnicode);
+            Debug.Assert((int)MethodImportAttributes.SetLastError == (int)PInvokeAttributes.SetLastError);
 
             return new PInvokeMetadata(moduleName, name, (PInvokeAttributes)import.Attributes);
         }
@@ -422,11 +423,11 @@ namespace Internal.TypeSystem.Ecma
             MetadataReader metadataReader = MetadataReader;
             
             // Spot check the enums match
-            Debug.Assert((int)ParameterAttributes.In == (int)ParameterAttributes.In);
-            Debug.Assert((int)ParameterAttributes.Out == (int)ParameterAttributes.Out);
-            Debug.Assert((int)ParameterAttributes.Optional == (int)ParameterAttributes.Optional);
-            Debug.Assert((int)ParameterAttributes.HasDefault == (int)ParameterAttributes.HasDefault);
-            Debug.Assert((int)ParameterAttributes.HasFieldMarshal == (int)ParameterAttributes.HasFieldMarshal);
+            Debug.Assert((int)ParameterAttributes.In == (int)ParameterMetadataAttributes.In);
+            Debug.Assert((int)ParameterAttributes.Out == (int)ParameterMetadataAttributes.Out);
+            Debug.Assert((int)ParameterAttributes.Optional == (int)ParameterMetadataAttributes.Optional);
+            Debug.Assert((int)ParameterAttributes.HasDefault == (int)ParameterMetadataAttributes.HasDefault);
+            Debug.Assert((int)ParameterAttributes.HasFieldMarshal == (int)ParameterMetadataAttributes.HasFieldMarshal);
 
 
             ParameterHandleCollection parameterHandles = metadataReader.GetMethodDefinition(_handle).GetParameters();
@@ -436,7 +437,7 @@ namespace Internal.TypeSystem.Ecma
             {
                 Parameter parameter = metadataReader.GetParameter(parameterHandle);
                 TypeDesc marshalAs = null; // TODO: read marshalAs argument;
-                ParameterMetadata data = new ParameterMetadata(parameter.SequenceNumber, (ParameterAttributes)parameter.Attributes, marshalAs);
+                ParameterMetadata data = new ParameterMetadata(parameter.SequenceNumber, (ParameterMetadataAttributes)parameter.Attributes, marshalAs);
                 parameterMetadataArray[index++] = data;
             }
             return parameterMetadataArray;

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -67,7 +67,6 @@ namespace Internal.TypeSystem.Interop
             Debug.Assert(method.IsPInvoke);
 
             // TODO: true if there are any custom marshalling rules on the parameters
-            // TODO: true if SetLastError is true
 
             TypeDesc returnType = method.Signature.ReturnType;
             if (!MarshalHelpers.IsBlittableType(returnType) && !returnType.IsVoid)
@@ -81,7 +80,12 @@ namespace Internal.TypeSystem.Interop
                 }
             }
 
-            if (UseLazyResolution(method, method.GetPInvokeMethodMetadata().Module, configuration))
+            PInvokeMetadata methodData = method.GetPInvokeMethodMetadata();    
+            if (UseLazyResolution(method, methodData.Module, configuration))
+            {
+                return true;
+            }
+            if ((methodData.Attributes & PInvokeAttributes.SetLastError) == PInvokeAttributes.SetLastError)
             {
                 return true;
             }

--- a/src/Common/src/TypeSystem/Interop/IL/PInvokeMethodData.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/PInvokeMethodData.cs
@@ -32,7 +32,15 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public  bool IsSafeHandle(TypeDesc type)
+        public MetadataType PInvokeMarshal
+        {
+            get
+            {
+                return Context.SystemModule.GetKnownType("System.Runtime.InteropServices", "PInvokeMarshal");
+            }
+        }
+
+        public bool IsSafeHandle(TypeDesc type)
         {
             var safeHandleType = this.SafeHandleType;
             while (type != null)

--- a/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
@@ -39,7 +39,7 @@ namespace Internal.TypeSystem
     }
 
     [Flags]
-    public enum ParameterAttributes
+    public enum ParameterMetadataAttributes
     {
         None = 0,
         In = 1,
@@ -51,19 +51,19 @@ namespace Internal.TypeSystem
 
     public struct ParameterMetadata
     {
-        private  readonly ParameterAttributes _attributes;
+        private  readonly ParameterMetadataAttributes _attributes;
         public readonly TypeDesc MarshalAs;
         public readonly int Index;
 
-        public bool In { get { return (_attributes & ParameterAttributes.In) == ParameterAttributes.In; } }
-        public bool Out { get { return (_attributes & ParameterAttributes.Out) == ParameterAttributes.Out; } }
+        public bool In { get { return (_attributes & ParameterMetadataAttributes.In) == ParameterMetadataAttributes.In; } }
+        public bool Out { get { return (_attributes & ParameterMetadataAttributes.Out) == ParameterMetadataAttributes.Out; } }
         public bool Return { get { return Index == 0;  } }
-        public bool Optional { get { return (_attributes & ParameterAttributes.Optional) == ParameterAttributes.Optional;  } }
-        public bool HasDefault { get { return (_attributes & ParameterAttributes.HasDefault) == ParameterAttributes.HasDefault; } }
-        public bool HasFieldMarshal { get { return (_attributes & ParameterAttributes.HasFieldMarshal) == ParameterAttributes.HasFieldMarshal; } }
+        public bool Optional { get { return (_attributes & ParameterMetadataAttributes.Optional) == ParameterMetadataAttributes.Optional;  } }
+        public bool HasDefault { get { return (_attributes & ParameterMetadataAttributes.HasDefault) == ParameterMetadataAttributes.HasDefault; } }
+        public bool HasFieldMarshal { get { return (_attributes & ParameterMetadataAttributes.HasFieldMarshal) == ParameterMetadataAttributes.HasFieldMarshal; } }
 
 
-        public ParameterMetadata(int index, ParameterAttributes attributes, TypeDesc marshalAs)
+        public ParameterMetadata(int index, ParameterMetadataAttributes attributes, TypeDesc marshalAs)
         {
             Index = index;
             _attributes = attributes;

--- a/src/Native/Bootstrap/platform.unix.cpp
+++ b/src/Native/Bootstrap/platform.unix.cpp
@@ -36,9 +36,12 @@ extern "C"
 
 extern "C"
 {
+    // TODO: Remove this when when we replace the references of
+    // Interop.mincore.GetLastError with Marsha.GetLastWin32Error
+    // CoreLib System.Text and System.Threading in CoreLib
     uint32_t GetLastError()
     {
-        return 1;
+       throw "GetLastError";
     }
 
     uint32_t WaitForMultipleObjectsEx(uint32_t, void*, uint32_t, uint32_t, uint32_t)

--- a/src/Native/Runtime/PalRedhawkFunctions.h
+++ b/src/Native/Runtime/PalRedhawkFunctions.h
@@ -94,12 +94,6 @@ inline UInt32 PalGetEnvironmentVariable(__in_z_opt LPCSTR arg1, __out_z_opt LPST
 }
 #endif
 
-extern "C" UInt32 __stdcall GetLastError();
-inline UInt32 PalGetLastError()
-{
-    return GetLastError();
-}
-
 extern "C" void * __stdcall GetProcAddress(HANDLE, const char *);
 inline void * PalGetProcAddress(HANDLE arg1, const char * arg2)
 {

--- a/src/Native/Runtime/unix/PalRedhawkInline.h
+++ b/src/Native/Runtime/unix/PalRedhawkInline.h
@@ -4,6 +4,8 @@
 
 // Implementation of Redhawk PAL inline functions
 
+#include <errno.h>
+
 FORCEINLINE Int32 PalInterlockedIncrement(_Inout_ _Interlocked_operand_ Int32 volatile *pDst)
 {
     return __sync_add_and_fetch(pDst, 1);
@@ -89,3 +91,13 @@ FORCEINLINE void PalMemoryBarrier()
 }
 
 #define PalDebugBreak() __builtin_trap()
+
+FORCEINLINE Int32 PalGetLastError()
+{
+    return errno;
+}
+
+FORCEINLINE void PalSetLastError(Int32 error)
+{
+    errno = error;
+}

--- a/src/Native/Runtime/windows/PalRedhawkInline.h
+++ b/src/Native/Runtime/windows/PalRedhawkInline.h
@@ -88,7 +88,20 @@ FORCEINLINE void * PalInterlockedCompareExchangePointer(_Inout_ _Interlocked_ope
 
 #endif // BIT64
 
-#if defined(_X86_) || defined(_AMD64_)
+EXTERN_C __declspec(dllimport) unsigned long __stdcall GetLastError();
+FORCEINLINE int PalGetLastError()
+{
+    return (int)GetLastError();
+}
+
+EXTERN_C __declspec(dllimport) void  __stdcall SetLastError(unsigned long error);
+FORCEINLINE void PalSetLastError(int error)
+{
+    SetLastError((unsigned long)error);
+}
+
+
+#if defined(_X86_) || defined(_AMD64_)	
 
 // fxsave/fxrstor instruction support, CpuIdEx Function: 1, EDX:24
 #define X86_FXSR    (1<<24)

--- a/src/Native/System.Private.CoreLib.Native/CMakeLists.txt
+++ b/src/Native/System.Private.CoreLib.Native/CMakeLists.txt
@@ -7,6 +7,7 @@ set(NATIVE_SOURCES
     pal_datetime.cpp
     pal_dynamicload.cpp
     pal_random.cpp
+    pal_errno.cpp
 )
 
 add_library(System.Private.CoreLib.Native

--- a/src/Native/System.Private.CoreLib.Native/pal_errno.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_errno.cpp
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <stdint.h>
+#include <errno.h>
+
+extern "C" int32_t CoreLibNative_GetLastErrNo()
+{
+    return errno;
+}
+
+extern "C" void CoreLibNative_SetLastErrNo(int32_t error)
+{
+    errno = error;
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -735,6 +735,7 @@
     <Compile Include="System\Text\Normalization.Windows.cs" />
     <Compile Include="System\DateTime.Windows.cs" />
     <Compile Include="System\Globalization\FormatProvider.FormatAndParse.Windows.cs" />
+    <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Windows.cs" />
     <Compile Include="..\..\Common\src\Interop\Windows\Interop.BOOL.cs">
       <Link>Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
@@ -933,6 +934,7 @@
     <Compile Include="System\IO\PathInternal.Unix.cs" />
     <Compile Include="System\Threading\ThreadPool.Unix.cs" />
     <Compile Include="System\Threading\Timer.Unix.cs" />
+    <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Unix.cs" />
     <Compile Include="..\..\Common\src\Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
@@ -971,6 +973,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.SysConf.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.SysConf.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.ErrNo.cs">
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.ErrNo.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Interop\Unix\System.Native\Interop.Close.cs</Link>

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/PInvokeMarshal.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/PInvokeMarshal.Unix.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// This PInvokeMarshal class should provide full public Marshal 
+    /// implementation for all things related to P/Invoke marshalling
+    /// </summary>
+    public partial class PInvokeMarshal
+    {
+        public static void SaveLastWin32Error()
+        {
+            s_lastWin32Error = Interop.Sys.GetLastErrNo();
+        }
+
+        internal static void ClearLastWin32Error()
+        {
+            Interop.Sys.SetLastErrNo(0);
+        }
+
+        public static unsafe String PtrToStringAnsi(IntPtr ptr)
+        {
+            if (IntPtr.Zero == ptr)
+            {
+                return null;
+            }
+
+            int len = Internal.Runtime.CompilerHelpers.InteropHelpers.strlen((byte*)ptr);
+            if (len == 0)
+            {
+                return string.Empty;
+            }
+
+            return System.Text.Encoding.UTF8.GetString((byte*)ptr, len);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/PInvokeMarshal.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/PInvokeMarshal.Windows.cs
@@ -12,17 +12,14 @@ namespace System.Runtime.InteropServices
     /// </summary>
     public partial class PInvokeMarshal
     {
-        [ThreadStatic]
-        internal static int s_lastWin32Error;
-
-        public static int GetLastWin32Error()
+        public static void SaveLastWin32Error()
         {
-            return s_lastWin32Error;
+            s_lastWin32Error = Interop.mincore.GetLastError();
         }
 
-        public static void SetLastWin32Error(int errorCode)
+        internal static void ClearLastWin32Error()
         {
-            s_lastWin32Error = errorCode;
+            Interop.mincore.SetLastError(0);
         }
     }
 }

--- a/tests/src/Simple/PInvoke/PInvoke.csproj
+++ b/tests/src/Simple/PInvoke/PInvoke.csproj
@@ -13,6 +13,8 @@
     <NativeObjectExt Condition="'$(OS)' == 'Windows_NT'">.obj</NativeObjectExt>
     <NativeObjectExt Condition="'$(OS)' != 'Windows_NT'">.o</NativeObjectExt>
     <PInvokeNativeObject>$(IntermediateOutputPath)$(OutputName)$(NativeObjectExt)</PInvokeNativeObject>
+    <DefineConstants>$(DefineConstants);$(OS)</DefineConstants>
+    <UseDebugCrt Condition="'$(Configuration)' == 'Debug'">true</UseDebugCrt>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +32,7 @@
       <PInvokeCompilerArg Include="/Fo$(PInvokeNativeObject)" Condition="'$(OS)' == 'Windows_NT'" />
       <PInvokeCompilerArg Include="-o $(PInvokeNativeObject)" Condition="'$(OS)' != 'Windows_NT'" />
       <PInvokeCompilerArg Include="@(CppCompilerAndLinkerArg)" />
+      <PInvokeCompilerArg Include="-D $(OS)" />
     </ItemGroup>
 
     <MakeDir Directories="$(IntermediateOutputPath)" />

--- a/tests/src/Simple/PInvoke/no_unix
+++ b/tests/src/Simple/PInvoke/no_unix
@@ -1,1 +1,0 @@
-Doesn't work on OSX.


### PR DESCRIPTION
Call PInvokeMarshal.SaveLastWin32Error after the P/Invoke call to ensure
the last error is saved in thread local variable which can be later
accessed through PInvokeMarshal.GetLastWin32Error.

Additionally, I have rename ParameterAttributes to
ParameterMetadataAttributes to avoid the confusion with
System.Reflection.ParameterAttributes.

This change also makes sure PInvoke works on Unix and also get rids of
build warning on windows.

@jkotas @yizhang82 @MichalStrehovsky 