### PR TITLE
Hide a garbage Tools item from Solution Explorer

### DIFF
--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageDestination Include="Tools">
+      <InProject>false</InProject>
       <TargetFramework>.NetCoreApp,Version=1.2</TargetFramework>
     </PackageDestination>
   </ItemGroup>

--- a/src/ILCompiler.DependencyAnalysisFramework/src/ILCompiler.DependencyAnalysisFramework.csproj
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/ILCompiler.DependencyAnalysisFramework.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageDestination Include="Tools">
+      <InProject>false</InProject>
       <TargetFramework>.NetCoreApp,Version=1.2</TargetFramework>
     </PackageDestination>
   </ItemGroup>

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageDestination Include="Tools">
+      <InProject>false</InProject>
       <TargetFramework>.NetCoreApp,Version=1.2</TargetFramework>
     </PackageDestination>
   </ItemGroup>

--- a/src/ILCompiler.MetadataWriter/src/ILCompiler.MetadataWriter.csproj
+++ b/src/ILCompiler.MetadataWriter/src/ILCompiler.MetadataWriter.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageDestination Include="Tools">
+      <InProject>false</InProject>
       <TargetFramework>.NetCoreApp,Version=1.2</TargetFramework>
     </PackageDestination>
   </ItemGroup>

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageDestination Include="Tools">
+      <InProject>false</InProject>
       <TargetFramework>.NetCoreApp,Version=1.2</TargetFramework>
     </PackageDestination>
   </ItemGroup>

--- a/src/ILCompiler/src/ILCompiler.csproj
+++ b/src/ILCompiler/src/ILCompiler.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageDestination Include="Tools">
+      <InProject>false</InProject>
       <TargetFramework>.NetCoreApp,Version=1.2</TargetFramework>
     </PackageDestination>
   </ItemGroup>


### PR DESCRIPTION
This thing is useless in the VS Solution Explorer and has an annoying
warning sign.

![capture](https://cloud.githubusercontent.com/assets/13110571/21731786/fdd35a62-d40a-11e6-9a1f-092060514293.PNG)
