### PR TITLE
Implement canSkipMethodVerification

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -822,8 +822,11 @@ namespace Internal.JitInterface
         { throw new NotImplementedException("isInstantiationOfVerifiedGeneric"); }
         private void initConstraintsForVerification(CORINFO_METHOD_STRUCT_* method, ref bool pfHasCircularClassConstraints, ref bool pfHasCircularMethodConstraint)
         { throw new NotImplementedException("isInstantiationOfVerifiedGeneric"); }
+
         private CorInfoCanSkipVerificationResult canSkipMethodVerification(CORINFO_METHOD_STRUCT_* ftnHandle)
-        { throw new NotImplementedException("canSkipMethodVerification"); }
+        {
+            return CorInfoCanSkipVerificationResult.CORINFO_VERIFICATION_CAN_SKIP;
+        }
 
         private void methodMustBeLoadedBeforeCodeIsRun(CORINFO_METHOD_STRUCT_* method)
         {
@@ -963,7 +966,10 @@ namespace Internal.JitInterface
         }
 
         private CorInfoCanSkipVerificationResult canSkipVerification(CORINFO_MODULE_STRUCT_* module)
-        { throw new NotImplementedException("canSkipVerification"); }
+        {
+            return CorInfoCanSkipVerificationResult.CORINFO_VERIFICATION_CAN_SKIP;
+        }
+
         private bool isValidToken(CORINFO_MODULE_STRUCT_* module, uint metaTOK)
         { throw new NotImplementedException("isValidToken"); }
         private bool isValidStringRef(CORINFO_MODULE_STRUCT_* module, uint metaTOK)

--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -1119,10 +1119,6 @@
     <!-- https://github.com/dotnet/corert/issues/2355 -->
     <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Pinning\PinningOther\PinnedObject\PinnedObject.*" />
 
-    <!-- System.NotImplementedException: canSkipMethodVerification -->
-    <!-- https://github.com/dotnet/corert/issues/2462 -->
-    <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\AboveStackLimit\AboveStackLimit.*" />
-
     <!-- Main method missing in textual stacktrace -->
     <!-- https://github.com/dotnet/corert/issues/2463 -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowexcept_d\trythrowexcept_d.*" />


### PR DESCRIPTION
The JIT calls this when it hits internal limitations to decide whether to retry with optimizations off; or whether to stay on the safe side and give up in partial trust environments.

Fixes #2462