### PR TITLE
Support lazy pinvoke resolution in OSX/linux and add library extension probing

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.DynamicLoad.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.DynamicLoad.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     internal unsafe partial class Sys
     {
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_LoadLibrary")]
-        internal static extern IntPtr LoadLibrary(byte* filename);
+        internal static extern IntPtr LoadLibrary(string filename);
 
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetProcAddress")]
         internal static extern IntPtr GetProcAddress(IntPtr handle, byte* symbol);

--- a/src/Common/src/Interop/Windows/mincore/Interop.DynamicLoad.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.DynamicLoad.cs
@@ -14,8 +14,8 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll")]
         internal static extern IntPtr GetProcAddress(IntPtr hModule, byte* lpProcName);
 
-        [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", EntryPoint = "LoadLibraryExW")]
-        internal static extern IntPtr LoadLibraryEx(char* lpFileName, IntPtr hFile, int dwFlags);
+        [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", EntryPoint = "LoadLibraryExW", CharSet = CharSet.Unicode)]
+        internal static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hFile, int dwFlags);
 
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll")]
         internal static extern bool FreeLibrary(IntPtr hModule);

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -99,10 +99,6 @@ namespace Internal.TypeSystem.Interop
         /// </summary>
         public static bool UseLazyResolution(MethodDesc method, string importModule, PInvokeILEmitterConfiguration configuration)
         {
-            // TODO: Test and make this work on non-Windows
-            if (!method.Context.Target.IsWindows)
-                return false;
-
             bool? forceLazyResolution = configuration.ForceLazyResolution;
             if (forceLazyResolution.HasValue)
                 return forceLazyResolution.Value;
@@ -113,9 +109,14 @@ namespace Internal.TypeSystem.Interop
                 return false;
 
             if (method.Context.Target.IsWindows)
+            {
                 return !importModule.StartsWith("api-ms-win-");
-            else
-                return !importModule.StartsWith("System.Private.");
+            }
+            else 
+            {
+                // Account for System.Private.CoreLib.Native / System.Globalization.Native / System.Native / etc
+                return !importModule.StartsWith("System.");
+            }
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -633,17 +633,6 @@ namespace ILCompiler.DependencyAnalysis
             return ReadOnlyDataBlob(symbolName, stringBytes, 1);
         }
 
-        public ISymbolNode ConstantUtf16String(string str)
-        {
-            int stringBytesCount = Encoding.Unicode.GetByteCount(str);
-            byte[] stringBytes = new byte[stringBytesCount + 2];
-            Encoding.Unicode.GetBytes(str, 0, str.Length, stringBytes, 0);
-
-            string symbolName = "__utf16str_" + NameMangler.GetMangledStringName(str);
-
-            return ReadOnlyDataBlob(symbolName, stringBytes, 2);
-        }
-
         /// <summary>
         /// Returns alternative symbol name that object writer should produce for given symbols
         /// in addition to the regular one.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
@@ -37,9 +37,7 @@ namespace ILCompiler.DependencyAnalysis
             ObjectDataBuilder builder = new ObjectDataBuilder(factory);
             builder.DefinedSymbols.Add(this);
 
-            ISymbolNode nameSymbol = factory.Target.IsWindows ?
-                factory.ConstantUtf16String(_moduleName) :
-                factory.ConstantUtf8String(_moduleName);
+            ISymbolNode nameSymbol = factory.ConstantUtf8String(_moduleName);
 
             //
             // Emit a ModuleFixupCell struct

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -682,7 +682,6 @@
     <Compile Include="System\Runtime\InteropServices\StructLayoutAttribute.cs" />
     <Compile Include="System\WeakReference.cs" />
     <Compile Include="System\WeakReferenceOfT.cs" />
-    <Compile Include="..\..\Common\src\Internal\Text\UTF8String.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true' and '$(EnableWinRT)'!='true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs" />
@@ -727,7 +726,7 @@
     <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-   </ItemGroup>
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeThreadPoolIOHandle.cs" />

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -31,6 +31,9 @@
   <PropertyGroup Condition="'$(TargetsUnix)'=='true'">
     <DefineConstants>PLATFORM_UNIX;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsOSX)'=='true'">
+    <DefineConstants>PLATFORM_OSX;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <DefineConstants>AMD64;BIT64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
@@ -679,6 +682,7 @@
     <Compile Include="System\Runtime\InteropServices\StructLayoutAttribute.cs" />
     <Compile Include="System\WeakReference.cs" />
     <Compile Include="System\WeakReferenceOfT.cs" />
+    <Compile Include="..\..\Common\src\Internal\Text\UTF8String.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true' and '$(EnableWinRT)'!='true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs" />
@@ -723,7 +727,7 @@
     <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-  </ItemGroup>
+   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeThreadPoolIOHandle.cs" />

--- a/src/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -14,8 +14,6 @@ namespace System.IO
 
         public static char[] GetInvalidPathChars() => new char[] { '\0' };
 
-        private static readonly bool s_isMac = Interop.Sys.GetUnixName() == "OSX";
-
         // Expands the given path to a fully qualified path. 
         public static string GetFullPath(string path)
         {
@@ -200,6 +198,17 @@ namespace System.IO
         }
 
         /// <summary>Gets whether the system is case-sensitive.</summary>
-        internal static bool IsCaseSensitive { get { return !s_isMac; } }
+        internal static bool IsCaseSensitive
+        {
+            get
+            {
+#if PLATFORM_OSX
+                // Mac is case-preserving but case-insensitive by default
+                return false;
+#else
+                return true;
+#endif
+            }
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -900,26 +900,24 @@ namespace System
         //
         static unsafe private string TryGetLocalizedNameByNativeResource(string filePath, int resource)
         {
-            fixed (char* file = filePath.ToCharArray())
+            using (SafeLibraryHandle handle =
+                       new SafeLibraryHandle(Interop.mincore.LoadLibraryEx(filePath, IntPtr.Zero, Interop.mincore.LOAD_LIBRARY_AS_DATAFILE)))
             {
-                using (SafeLibraryHandle handle =
-                           new SafeLibraryHandle(Interop.mincore.LoadLibraryEx(file, IntPtr.Zero, Interop.mincore.LOAD_LIBRARY_AS_DATAFILE)))
+                if (!handle.IsInvalid)
                 {
-                    if (!handle.IsInvalid)
+                    StringBuilder localizedResource = StringBuilderCache.Acquire(Interop.mincore.LOAD_STRING_MAX_LENGTH);
+                    localizedResource.Length = Interop.mincore.LOAD_STRING_MAX_LENGTH;
+
+                    int result = Interop.mincore.LoadString(handle, resource,
+                                     localizedResource, localizedResource.Length);
+
+                    if (result != 0)
                     {
-                        StringBuilder localizedResource = StringBuilderCache.Acquire(Interop.mincore.LOAD_STRING_MAX_LENGTH);
-                        localizedResource.Length = Interop.mincore.LOAD_STRING_MAX_LENGTH;
-
-                        int result = Interop.mincore.LoadString(handle, resource,
-                                         localizedResource, localizedResource.Length);
-
-                        if (result != 0)
-                        {
-                            return StringBuilderCache.GetStringAndRelease(localizedResource);
-                        }
+                        return StringBuilderCache.GetStringAndRelease(localizedResource);
                     }
                 }
             }
+
             return String.Empty;
         }
 


### PR DESCRIPTION
@jkotas @MichalStrehovsky @shrah PTAL
The lazy resolution mostly already works - just need to enable it and test it, and add the proper extension probing. The UTF-8 conversion back and forth is a bit unfortunate but I doubt that'll show up in perf benchmark anytime soon. I've also converged the cell to always use UTF-8 but not sure if that's a good idea. Perhaps follow platform specific convention would be a more efficient choice?