### PR TITLE
Add support for thread static base dictionary lookups

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -69,11 +69,17 @@ namespace ILCompiler.DependencyAnalysis
             Instantiation typeInst = this.TypeInstantiation;
             Instantiation methodInst = this.MethodInstantiation;
 
-            foreach (var entry in layout.Entries)
+            foreach (GenericLookupResult lookupResult in layout.Entries)
             {
-                ISymbolNode targetNode = entry.GetTarget(factory, typeInst, methodInst);
-                int targetDelta = entry.TargetDelta;
-                builder.EmitPointerReloc(targetNode, targetDelta);
+#if DEBUG
+                int offsetBefore = builder.CountBytes;
+#endif
+
+                lookupResult.EmitDictionaryEntry(ref builder, factory, typeInst, methodInst);
+
+#if DEBUG
+                Debug.Assert(builder.CountBytes - offsetBefore == factory.Target.PointerSize);
+#endif
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -47,6 +47,11 @@ namespace ILCompiler.DependencyAnalysis
                     return new VirtualResolveGenericLookupResult(method);
                 });
 
+                _typeThreadStaticBaseIndexSymbols = new NodeCache<TypeDesc, GenericLookupResult>(type =>
+                {
+                    return new TypeThreadStaticBaseIndexGenericLookupResult(type);
+                });
+
                 _typeGCStaticBaseSymbols = new NodeCache<TypeDesc, GenericLookupResult>(type =>
                 {
                     return new TypeGCStaticBaseGenericLookupResult(type);
@@ -63,6 +68,13 @@ namespace ILCompiler.DependencyAnalysis
             public GenericLookupResult Type(TypeDesc type)
             {
                 return _typeSymbols.GetOrAdd(type);
+            }
+
+            private NodeCache<TypeDesc, GenericLookupResult> _typeThreadStaticBaseIndexSymbols;
+
+            public GenericLookupResult TypeThreadStaticBaseIndex(TypeDesc type)
+            {
+                return _typeThreadStaticBaseIndexSymbols.GetOrAdd(type);
             }
 
             private NodeCache<TypeDesc, GenericLookupResult> _typeGCStaticBaseSymbols;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -36,6 +36,8 @@ namespace ILCompiler.DependencyAnalysis
                     return factory.GenericLookup.TypeGCStaticBase((TypeDesc)target);
                 case ReadyToRunHelperId.GetNonGCStaticBase:
                     return factory.GenericLookup.TypeNonGCStaticBase((TypeDesc)target);
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    return factory.GenericLookup.TypeThreadStaticBaseIndex((TypeDesc)target);
                 case ReadyToRunHelperId.MethodDictionary:
                     return factory.GenericLookup.MethodDictionary((MethodDesc)target);
                 case ReadyToRunHelperId.VirtualCall:

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1673,7 +1673,7 @@ namespace Internal.JitInterface
                         // Find out what kind of base do we need to look up.
                         if (field.IsThreadStatic)
                         {
-                            throw new NotImplementedException();
+                            helperId = ReadyToRunHelperId.GetThreadStaticBase;
                         }
                         else if (field.HasGCStaticBase)
                         {

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 class Program
 {
@@ -16,6 +17,7 @@ class Program
         TestSlotsInHierarchy.Run();
         TestDelegateVirtualMethod.Run();
         TestDelegateInterfaceMethod.Run();
+        TestThreadStaticFieldAccess.Run();
         TestNameManglingCollisionRegression.Run();
         TestUnusedGVMsDoNotCrashCompiler.Run();
 
@@ -319,6 +321,64 @@ class Program
                 throw new Exception();
 
             if (derived.Cast("Hello") != "Hello")
+                throw new Exception();
+        }
+    }
+
+    class TestThreadStaticFieldAccess
+    {
+        class TypeWithThreadStaticField<T>
+        {
+            [ThreadStatic]
+            public static int X;
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static int Read()
+            {
+                return X;
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static void Write(int x)
+            {
+                X = x;
+            }
+        }
+
+        class BeforeFieldInitType<T>
+        {
+            [ThreadStatic]
+            public static int X = 1985;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int ReadFromBeforeFieldInitType<T>()
+        {
+            return BeforeFieldInitType<T>.X;
+        }
+
+        public static void Run()
+        {
+            // This will set the field to a value from non-shared code
+            TypeWithThreadStaticField<object>.X = 42;
+
+            // Now read the value from shared code
+            if (TypeWithThreadStaticField<object>.Read() != 42)
+                throw new Exception();
+
+            // Set the value from shared code
+            TypeWithThreadStaticField<string>.Write(112);
+
+            // Now read the value from non-shared code
+            if (TypeWithThreadStaticField<string>.X != 112)
+                throw new Exception();
+
+            // Check that the storage locations for string and object instantiations differ
+            if (TypeWithThreadStaticField<object>.Read() != 42)
+                throw new Exception();
+
+            // Make sure we run the cctor
+            if (ReadFromBeforeFieldInitType<object>() != 1985)
                 throw new Exception();
         }
     }


### PR DESCRIPTION
This adds support for generating helpers and dictionary entries to
support thread static base lookups for generic types in shared generic
context.

I slightly tweaked how dictionary slots get emitted because the "every
slot is an `ISymbolNode`" paradigm wasn't very flexible.