### PR TITLE
Fix Unix thread shutdown

### DIFF
--- a/src/Native/Runtime/startup.cpp
+++ b/src/Native/Runtime/startup.cpp
@@ -268,12 +268,13 @@ void __stdcall RuntimeThreadShutdown(void* thread)
     // that is made for the single thread that runs the final stages of orderly process
     // shutdown (i.e., the thread that delivers the DLL_PROCESS_DETACH notifications when the
     // process is being torn down via an ExitProcess call).
-    UNREFERENCED_PARAMETER(thread);
+#ifndef PLATFORM_UNIX
+    // On UNIX, the ThreadStore::GetCurrentThread() is not valid at this point
     ASSERT((Thread*)thread == ThreadStore::GetCurrentThread());
-
+#endif
     if (!g_processShutdownHasStarted)
     {
-        ThreadStore::DetachCurrentThread();
+        ThreadStore::DetachCurrentThread((Thread*)thread);
     }
 }
 

--- a/src/Native/Runtime/threadstore.cpp
+++ b/src/Native/Runtime/threadstore.cpp
@@ -154,10 +154,13 @@ void ThreadStore::AttachCurrentThread()
     AttachCurrentThread(true);
 }
 
-void ThreadStore::DetachCurrentThread()
+void ThreadStore::DetachCurrentThread(Thread* pDetachingThread)
 {
-    // The thread may not have been initialized because it may never have run managed code before.
-    Thread * pDetachingThread = RawGetCurrentThread();
+    if (pDetachingThread == NULL)
+    {
+        // This thread has not run any managed code yet
+        return;
+    }
 
     // The thread was not initialized yet, so it was not attached
     if (!pDetachingThread->IsInitialized())

--- a/src/Native/Runtime/threadstore.h
+++ b/src/Native/Runtime/threadstore.h
@@ -39,7 +39,7 @@ public:
     static PTR_Thread       GetSuspendingThread();
     static void             AttachCurrentThread();
     static void             AttachCurrentThread(bool fAcquireThreadStoreLock);
-    static void             DetachCurrentThread();
+    static void             DetachCurrentThread(Thread* pDetachingThread);
 #ifndef DACCESS_COMPILE
     static void             SaveCurrentThreadOffsetForDAC();
 #else

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -414,11 +414,11 @@ public:
 typedef UnixHandle<UnixHandleType::Thread, pthread_t> ThreadUnixHandle;
 
 // Destructor of the thread local object represented by the g_threadKey,
-// called when a thread is shut down
+// called when a thread is shut down.
+// The parameter is the value that was set using the pthread_setspecific.
+// Please note that the pthread_getspecific now returns NULL!
 void TlsObjectDestructor(void* data)
 {
-    ASSERT(data == pthread_getspecific(g_threadKey));
-
     RuntimeThreadShutdown(data);
 }
 
@@ -491,26 +491,8 @@ extern "C" void PalAttachThread(void* thread)
 //  true if the thread was detached, false if there was no attached thread
 extern "C" bool PalDetachThread(void* thread)
 {
-    void* attachedThread = pthread_getspecific(g_threadKey);
-
-    if (attachedThread == thread)
-    {
-        int status = pthread_setspecific(g_threadKey, NULL);
-        if (status != 0)
-        {
-            ASSERT_UNCONDITIONALLY("PalDetachThread failed to clear thread pointer in thread local storage");
-            RhFailFast();
-        }
-        return true;
-    }
-
-    if (attachedThread != NULL)
-    {
-        ASSERT_UNCONDITIONALLY("PalDetachThread called with different thread pointer than PalAttachThread");
-        RhFailFast();
-    }
-
-    return false;
+    UNREFERENCED_PARAMETER(thread);
+    return true;
 }
 
 REDHAWK_PALEXPORT unsigned int REDHAWK_PALAPI PalGetCurrentProcessorNumber()


### PR DESCRIPTION
There was a problem with the secondary thread shutdown on Unix. First,
when the TlsObjectDestructor is called, it is passed the key that
was set using the pthread_setspecific before. But I was missing the fact
that before the TlsObjectDestructor is called, the key is set to NULL.
So we cannot use pthread_getspecific to get the key anymore and we can
only use the value passed as the TlsObjectDestructor parameter.

The second part of the problem was that the at the time the TlsObjectDestructor
is called, the tls_CurrentThread to which the key points was already removed
from the TLS and so an attempt to access tls_CurrentThread results in creation
of a fresh new tls_CurrentThread. And our checks that we have at a few places
that verify that the argument passed to the TlsObjectDestructor was actually
the current thread pointer cannot be done.