### PR TITLE
Run ordered class constructors explicitly

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -657,7 +657,7 @@ namespace ILCompiler.DependencyAnalysis
         public ArrayOfEmbeddedPointersNode<IMethodNode> EagerCctorTable = new ArrayOfEmbeddedPointersNode<IMethodNode>(
             "__EagerCctorStart",
             "__EagerCctorEnd",
-            new EagerConstructorComparer());
+            null);
 
         public ArrayOfEmbeddedPointersNode<InterfaceDispatchMapNode> DispatchMapTable = new ArrayOfEmbeddedPointersNode<InterfaceDispatchMapNode>(
             "__DispatchMapTableStart",

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+
+using AssemblyName = System.Reflection.AssemblyName;
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Encapsulates a list of class constructors that must be run in a prescribed order during start-up
+    /// </summary>
+    public sealed class LibraryInitializers
+    {
+        private const string ClassLibraryPlaceHolderString = "*ClassLibrary*";
+        private const string LibraryInitializerContainerNamespaceName = "Internal.Runtime.CompilerHelpers";
+        private const string LibraryInitializerContainerTypeName = "LibraryInitializer";
+        private const string LibraryInitializerMethodName = "InitializeLibrary";
+
+        private static readonly LibraryInitializerInfo[] s_assembliesWithLibraryInitializers =
+            {
+                new LibraryInitializerInfo(ClassLibraryPlaceHolderString),
+                new LibraryInitializerInfo("System.Private.TypeLoader", false),
+                new LibraryInitializerInfo("System.Private.Reflection.Execution", false),
+                new LibraryInitializerInfo("System.Private.DeveloperExperience.Console"),
+            };
+
+        private List<MethodDesc> _libraryInitializerMethods;
+
+        private readonly TypeSystemContext _context;
+        private readonly bool _isCppCodeGen;
+
+        public LibraryInitializers(TypeSystemContext context, bool isCppCodeGen)
+        {
+            _context = context;
+            //
+            // We should not care which code-gen is being used, however currently CppCodeGen cannot
+            // handle code pulled in by all explicit cctors.
+            //
+            // See https://github.com/dotnet/corert/issues/2486
+            //
+            _isCppCodeGen = isCppCodeGen;
+        }
+        
+        public IList<MethodDesc> LibraryInitializerMethods
+        {
+            get
+            {
+                if (_libraryInitializerMethods == null)
+                    InitLibraryInitializers();
+
+                return _libraryInitializerMethods;
+            }
+        }
+
+        private void InitLibraryInitializers()
+        {
+            Debug.Assert(_libraryInitializerMethods == null);
+            
+            _libraryInitializerMethods = new List<MethodDesc>();
+
+            foreach (var entry in s_assembliesWithLibraryInitializers)
+            {
+                if (_isCppCodeGen && !entry.UseWithCppCodeGen)
+                    continue;
+
+                ModuleDesc assembly = entry.Assembly == ClassLibraryPlaceHolderString
+                    ? _context.SystemModule
+                    : _context.ResolveAssembly(new AssemblyName(entry.Assembly), false);
+
+                if (assembly == null)
+                    continue;
+
+                TypeDesc containingType = assembly.GetType(LibraryInitializerContainerNamespaceName, LibraryInitializerContainerTypeName, false);
+                if (containingType == null)
+                    continue;
+
+                MethodDesc initializerMethod = containingType.GetMethod(LibraryInitializerMethodName, null);
+                if (initializerMethod == null)
+                    continue;
+
+                _libraryInitializerMethods.Add(initializerMethod);
+            }
+        }
+
+        private sealed class LibraryInitializerInfo
+        {
+            public string Assembly { get; }
+            public bool UseWithCppCodeGen { get; }
+
+            public LibraryInitializerInfo(string assembly, bool useWithCppCodeGen = true)
+            {
+                Assembly = assembly;
+                UseWithCppCodeGen = useWithCppCodeGen;
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/MainMethodRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MainMethodRootProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -21,10 +22,12 @@ namespace ILCompiler
         public const string ManagedEntryPointMethodName = "__managed__Main";
 
         private EcmaModule _module;
+        private IList<MethodDesc> _libraryInitializers;
 
-        public MainMethodRootProvider(EcmaModule module)
+        public MainMethodRootProvider(EcmaModule module, IList<MethodDesc> libraryInitializers)
         {
             _module = module;
+            _libraryInitializers = libraryInitializers;
         }
 
         public void AddCompilationRoots(IRootingServiceProvider rootProvider)
@@ -34,7 +37,7 @@ namespace ILCompiler
                 throw new Exception("No managed entrypoint defined for executable module");
 
             TypeDesc owningType = _module.GetGlobalModuleType();
-            var startupCodeMain = new StartupCodeMainMethod(owningType, mainMethod);
+            var startupCodeMain = new StartupCodeMainMethod(owningType, mainMethod, _libraryInitializers);
 
             rootProvider.AddCompilationRoot(startupCodeMain, "Startup Code Main Method", ManagedEntryPointMethodName);
         }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -378,20 +378,6 @@ namespace ILCompiler.CppCodeGen
             if (methodIL == null)
                 return;
 
-            // TODO: Remove this code once CppCodegen is able to generate code for the reflection startup path.
-            //       The startup path runs before any user code is executed.
-            //       For now we replace the startup path with a simple "ret". Reflection won't work, but
-            //       programs not using reflection will.
-            if (method.Name == ".cctor")
-            {
-                MetadataType owningType = method.OwningType as MetadataType;
-                if (owningType != null &&
-                    owningType.Name == "ReflectionExecution" && owningType.Namespace == "Internal.Reflection.Execution")
-                {
-                    methodIL = new Internal.IL.Stubs.ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
-                }
-            }
-
             try
             {
                 // TODO: hacky special-case

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -90,6 +90,7 @@
       <Link>JitInterface\JitConfigProvider.cs</Link>
     </Compile>
     <Compile Include="Compiler\CompilerGeneratedType.cs" />
+    <Compile Include="Compiler\LibraryInitializers.cs" />
     <Compile Include="Compiler\ICompilationRootProvider.cs" />
     <Compile Include="Compiler\Compilation.cs" />
     <Compile Include="Compiler\CompilationBuilder.cs" />
@@ -266,7 +267,7 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\IL\PInvokeMethodData.cs">
       <Link>TypeSystem\Interop\IL\PInvokeMethodData.cs</Link>
-    </Compile>	
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\UnsafeIntrinsics.cs">
       <Link>IL\Stubs\UnsafeIntrinsics.cs</Link>
     </Compile>

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    /// <summary>
+    /// Container class to run specific class constructors in a defined order. Since we can't
+    /// directly invoke class constructors in C#, they're renamed Initialize.
+    /// </summary>
+    internal class LibraryInitializer
+    {
+        public static void InitializeLibrary()
+        {
+            PreallocatedOutOfMemoryException.Initialize();
+            ClassConstructorRunner.Initialize();
+            TypeLoaderExports.Initialize();
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <Compile Include="Internal\Diagnostics\ExceptionExtensions.cs" />
     <Compile Include="Internal\Diagnostics\StackTraceHelper.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\ReflectionHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\ThreadingHelpers.cs" />
   </ItemGroup>

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -13,7 +13,7 @@ using Internal.Runtime.CompilerHelpers;
 
 namespace System.Runtime.CompilerServices
 {
-    // Marked [EagerStaticClassConstruction] because Cctor.GetCctor
+    // Marked [EagerOrderedStaticConstructor] because Cctor.GetCctor
     // uses _cctorGlobalLock
     [EagerOrderedStaticConstructor(EagerStaticConstructorOrder.CompilerServicesClassConstructorRunner)]
     internal static partial class ClassConstructorRunner
@@ -262,10 +262,8 @@ namespace System.Runtime.CompilerServices
         //==============================================================================================================
         // These structs are allocated on demand whenever the runtime tries to run a class constructor. Once the
         // the class constructor has been successfully initialized, we reclaim this structure. The structure is long-
-        // lived only if the class constructor threw an exception. This must be marked [EagerStaticClassConstruction] to 
-        // avoid infinite mutual recursion in GetCctor.
+        // lived only if the class constructor threw an exception.
         //==============================================================================================================
-        [EagerOrderedStaticConstructor(EagerStaticConstructorOrder.CompilerServicesClassConstructorRunnerCctor)]
         private unsafe struct Cctor
         {
             public Lock Lock;
@@ -273,14 +271,7 @@ namespace System.Runtime.CompilerServices
             public int HoldingThread;
             private int _refCount;
             private StaticClassConstructionContext* _pContext;
-
-            // Because Cctor's are mutable structs, we have to give our callers raw references to the underlying arrays 
-            // for this collection to be usable.  This also means once we place a Cctor in an array, we can't grow or 
-            // reallocate the array.
-            private static Cctor[][] s_cctorArrays = new Cctor[10][];
-            private static int s_cctorArraysCount = 0;
-            private static int s_count;
-
+            
             //==========================================================================================================
             // Gets the Cctor entry associated with a specific class constructor context (creating it if necessary.)
             //==========================================================================================================
@@ -479,8 +470,35 @@ namespace System.Runtime.CompilerServices
             private static int s_nextBlockingRecordIndex;
         }
 
-        private static Lock s_cctorGlobalLock = new Lock();
+        private static Lock s_cctorGlobalLock;
 
+        // These three  statics are used by ClassConstructorRunner.Cctor but moved out to avoid an unnecessary 
+        // extra class constructor call.
+        //
+        // Because Cctor's are mutable structs, we have to give our callers raw references to the underlying arrays 
+        // for this collection to be usable.  This also means once we place a Cctor in an array, we can't grow or 
+        // reallocate the array.
+        private static Cctor[][] s_cctorArrays;
+        private static int s_cctorArraysCount;
+        private static int s_count;
+
+        //
+        // CoreRT calls Initialize directly for all types its needs that typically have EagerOrderedStaticConstructor
+        // attributes. To retain compatibility, please ensure static initialization is not done inline, and instead
+        // added to Initialize.
+        //
+#if !CORERT
+        static ClassConstructorRunner()
+        {
+            Initialize();
+        }
+#endif
+        internal static void Initialize()
+        {
+            s_cctorArrays = new Cctor[10][];
+            s_cctorGlobalLock = new Lock();
+        }
+        
         [Conditional("ENABLE_NOISY_CCTOR_LOG")]
         private static void NoisyLog(string format, IntPtr cctorMethod, int threadId)
         {

--- a/src/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -73,12 +73,31 @@ namespace System.Runtime
         // Initialize the cache eagerly to avoid null checks.
         // Use array with just single element to make this pay-for-play. The actual cache will be allocated only 
         // once the lazy lookups are actually needed.
-        private static Entry[] s_cache = new Entry[1];
+        private static Entry[] s_cache;
 
         private static Lock s_lock;
         private static GCHandle s_previousCache;
-        private volatile static IntPtr[] s_resolutionFunctionPointers = new IntPtr[4];
-        private static int s_nextResolutionFunctionPointerIndex = (int)SignatureKind.Count;
+        private volatile static IntPtr[] s_resolutionFunctionPointers;
+        private static int s_nextResolutionFunctionPointerIndex;
+
+        //
+        // CoreRT calls Initialize directly for all types its needs that typically have EagerOrderedStaticConstructor
+        // attributes. To retain compatibility, please ensure static initialization is not done inline, and instead
+        // added to Initialize.
+        //
+#if !CORERT
+        static TypeLoaderExports()
+        {
+            Initialize();
+        }
+#endif
+
+        internal static void Initialize()
+        {
+            s_cache = new Entry[1];
+            s_resolutionFunctionPointers = new IntPtr[4];
+            s_nextResolutionFunctionPointerIndex = (int)SignatureKind.Count;
+        }
 
         [RuntimeExport("GenericLookup")]
         public static IntPtr GenericLookup(IntPtr context, IntPtr signature)

--- a/src/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -17,7 +17,24 @@ namespace System
     [EagerOrderedStaticConstructor(EagerStaticConstructorOrder.SystemPreallocatedOutOfMemoryException)]
     internal class PreallocatedOutOfMemoryException
     {
-        public static readonly OutOfMemoryException Instance = new OutOfMemoryException(message: null);  // Cannot call the nullary constructor as that triggers non-trivial resource manager logic.
+        public static OutOfMemoryException Instance { get; private set; }
+
+        //
+        // CoreRT calls Initialize directly for all types its needs that typically have EagerOrderedStaticConstructor
+        // attributes. To retain compatibility, please ensure static initialization is not done inline, and instead
+        // added to Initialize.
+        //
+#if !CORERT
+        static PreallocatedOutOfMemoryException()
+        {
+            Initialize();
+        }
+#endif
+
+        internal static void Initialize()
+        {
+             Instance = new OutOfMemoryException(message: null);  // Cannot call the nullary constructor as that triggers non-trivial resource manager logic.
+        }
     }
 
     public class RuntimeExceptionHelpers

--- a/src/System.Private.DeveloperExperience.Console/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/System.Private.DeveloperExperience.Console/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.DeveloperExperience;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    public class LibraryInitializer
+    {
+        public static void InitializeLibrary()
+        {
+            DeveloperExperienceConnectorConsole.Initialize();
+        }
+    }
+}

--- a/src/System.Private.DeveloperExperience.Console/src/System.Private.DeveloperExperience.Console.csproj
+++ b/src/System.Private.DeveloperExperience.Console/src/System.Private.DeveloperExperience.Console.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Compile Include="Internal\DeveloperExperience\DeveloperExperienceConnector.cs" />
     <Compile Include="Internal\DeveloperExperience\DeveloperExperienceConsole.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
@@ -38,12 +38,24 @@ namespace Internal.Reflection.Execution
     [EagerOrderedStaticConstructor(EagerStaticConstructorOrder.ReflectionExecution)]
     public static class ReflectionExecution
     {
+        //
+        // CoreRT calls Initialize directly for all types its needs that typically have EagerOrderedStaticConstructor
+        // attributes. To retain compatibility, please ensure static initialization is not done inline, and instead
+        // added to Initialize.
+        //
+#if !CORERT
         /// <summary>
         /// This eager constructor initializes runtime reflection support. As part of ExecutionEnvironmentImplementation
         /// initialization it enumerates the modules and registers the ones containing EmbeddedMetadata reflection blobs
         /// in its _moduleToMetadataReader map.
         /// </summary>
         static ReflectionExecution()
+        {
+            Initialize();
+        }
+#endif
+
+        internal static void Initialize()
         {
             // Initialize Reflection.Core's one and only ExecutionDomain.
             ExecutionEnvironmentImplementation executionEnvironment = new ExecutionEnvironmentImplementation();
@@ -85,7 +97,7 @@ namespace Internal.Reflection.Execution
             return ReflectionCoreExecution.ExecutionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, defaultAssemblies);
         }
 
-        internal static ExecutionEnvironmentImplementation ExecutionEnvironment { get; }
+        internal static ExecutionEnvironmentImplementation ExecutionEnvironment { get; private set; }
 
         internal static IList<string> DefaultAssemblyNamesForGetType;
     }

--- a/src/System.Private.Reflection.Execution/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.Reflection.Execution;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    public class LibraryInitializer
+    {
+        public static void InitializeLibrary()
+        {
+            ReflectionExecution.Initialize();
+        }
+    }
+}

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Internal\Reflection\Execution\PayForPlayExperience\MissingMetadataExceptionCreator.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\CustomAttributeInstantiator.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\DelegateMethodInfoRetriever.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
     <Compile Include="System\Reflection\MissingRuntimeArtifactException.cs" />
 
   </ItemGroup>

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.Runtime.TypeLoader;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    public class LibraryInitializer
+    {
+        public static void InitializeLibrary()
+        {
+            TypeLoaderEnvironment.Initialize();
+        }
+    }
+}

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
@@ -83,7 +83,7 @@ namespace Internal.Runtime.TypeLoader
             return Encoding.UTF8.GetString(dataStream, checked((int)stringLen));
         }
 
-        private static LowLevelDictionary<string, IntPtr> s_nativeFormatStrings = new LowLevelDictionary<string, IntPtr>();
+        private static LowLevelDictionary<string, IntPtr> s_nativeFormatStrings;
 
         /// <summary>
         /// From a string, get a pointer to an allocated memory location that holds a NativeFormat encoded string.

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.NamedTypeLookup.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.NamedTypeLookup.cs
@@ -37,7 +37,7 @@ namespace Internal.Runtime.TypeLoader
 
         private NamedTypeRuntimeTypeHandleToMetadataHashtable _runtimeTypeHandleToMetadataHashtable = new NamedTypeRuntimeTypeHandleToMetadataHashtable();
 
-        public static readonly IntPtr NoStaticsData = (IntPtr)1;
+        public static IntPtr NoStaticsData { get; private set; }
 
         private class NamedTypeRuntimeTypeHandleToMetadataHashtable : LockFreeReaderHashtable<RuntimeTypeHandle, NamedTypeLookupResult>
         {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -92,7 +92,7 @@ namespace Internal.Runtime.TypeLoader
         [ThreadStatic]
         private static bool t_isReentrant;
 
-        public static readonly TypeLoaderEnvironment Instance;
+        public static TypeLoaderEnvironment Instance { get; private set; }
 
         /// <summary>
         /// List of loaded binary modules is typically used to locate / process various metadata blobs
@@ -107,10 +107,24 @@ namespace Internal.Runtime.TypeLoader
         [ThreadStatic]
         private static LowLevelDictionary<IntPtr, NativeReader> t_moduleNativeReaders;
 
+        //
+        // CoreRT calls Initialize directly for all types its needs that typically have EagerOrderedStaticConstructor
+        // attributes. To retain compatibility, please ensure static initialization is not done inline, and instead
+        // added to Initialize.
+        //
+#if !CORERT
         static TypeLoaderEnvironment()
+        {
+            Initialize();
+        }
+#endif
+
+        internal static void Initialize()
         {
             Instance = new TypeLoaderEnvironment();
             RuntimeAugments.InitializeLookups(new Callbacks());
+            s_nativeFormatStrings = new LowLevelDictionary<string, IntPtr>();
+            NoStaticsData = (IntPtr)1;
         }
 
         public TypeLoaderEnvironment()

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -27,7 +27,6 @@
     <ReferencePath Include="$(AotPackageReferencePath)\System.Collections.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Collections.Immutable.dll" />
     <ReferencePath Include="$(AotPackageReferencePath)\System.Reflection.Metadata.dll" />
-
     <ProjectReference Include="..\..\System.Private.CoreLib\src\System.Private.CoreLib.csproj" />
     <ProjectReference Include="..\..\System.Private.Reflection.Metadata\src\System.Private.Reflection.Metadata.csproj" />
   </ItemGroup>
@@ -264,6 +263,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\WellKnownType.cs">
       <Link>Internal\TypeSystem\WellKnownType.cs</Link>
     </Compile>
+    <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\CallConverterThunk.CallConversionInfo.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\CallConverterThunk.CallConversionParameters.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\CallConverterThunk.cs" />


### PR DESCRIPTION
Previously, order-dependent class constructors were run by looking at the EagerOrderedClassConstructorAttribute and sorting them accordingly. That mechanism is not ideal for scenarios where separately compiled assembly object files are linked together since we would then have to sort all class constructors from modules on startup. Replace the attribute mechanism with a simple list of class constructors to run. The startup code injects calls to these at runtime after module tables are initialized.

Internal.Runtime.TypeLoaderEnvironment..cctor is disabled for C++ code generation due to issue #2486.