### PR TITLE
Set larger timeout for push job

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -64,6 +64,8 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
                 Utilities.addGithubPRTriggerForBranch(newJob, branch, prJobDescription)
             }
             else {
+                // Set a large timeout since the default (2 hours) is insufficient
+                Utilities.setJobTimeout(newJob, 1440)
                 Utilities.addGithubPushTrigger(newJob)
             }
         }


### PR DESCRIPTION
The CoreCLR tests need more than the standard 2 hours allowed by CI.