### PR TITLE
Split pipeline build to match CoreFX's model.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <Import Project="$(ToolsDir)CodeCoverage.targets" Condition="Exists('$(ToolsDir)CodeCoverage.targets')" />
   <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets') and '$(Performance)' == 'true'"/>
+  <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
 
   <ItemGroup>
     <Project Include="src\dirs.proj" />

--- a/buildpipeline/DotNet-CoreRT-Linux.json
+++ b/buildpipeline/DotNet-CoreRT-Linux.json
@@ -449,7 +449,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Remove container",
@@ -462,6 +462,42 @@
       "inputs": {
         "filename": "docker",
         "arguments": "rm $(DockerContainerName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish packages",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run -w=\"$(GitDirectory)\" --name $(DockerContainerName) $(DockerModifiedImageName) $(GitDirectory)/buildscripts/publish-packages.sh -AzureAccount $(CloudDropAccountName) -AzureToken $(CloudDropAccessToken) -Container $(Label)",
+        "workingFolder": "$(SourceFolder)",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Commit changes",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "commit $(DockerContainerName) $(DockerModifiedImageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -533,60 +569,6 @@
         "filename": "docker",
         "arguments": "rm $(DockerContainerName)",
         "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Download nuget",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "curl",
-        "arguments": "-L -k -o $(SourceFolder)/nuget.zip https://dotnet.myget.org/F/dotnet-buildtools/api/v2/package/NuGet.CommandLine/3.5.0-rc-1256",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Unzip nuget",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "unzip",
-        "arguments": "$(SourceFolder)/nuget.zip -d $(SourceFolder)/nuget",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": false,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Publish packages",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "mono",
-        "arguments": "nuget/tools/NuGet.exe push bin/Product/pkg/*.nupkg $(MyGetApiKey) -Source $(MyGetFeedUrl) -Timeout 3600",
-        "workingFolder": "$(SourceFolder)",
         "failOnStandardError": "false"
       }
     },
@@ -721,7 +703,7 @@
       "allowOverride": true
     },
     "Label": {
-      "value": "$(Build.BuildNumber)",
+      "value": "corert-alpha-$(Build.BuildNumber)",
       "allowOverride": true
     },
     "SourceVersion": {
@@ -770,6 +752,25 @@
     "MyGetApiKey": {
       "value": null,
       "isSecret": true,
+      "allowOverride": true
+    },
+    "CloudDropAccountName": {
+      "value": "dotnetbuildoutput"
+    },
+    "CloudDropAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "UpdatePublishedVersions.AuthToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VersionsRepoOwner": {
+      "value": "crummel",
+      "allowOverride": true
+    },
+    "VersionsRepo": {
+      "value": "dotnet_versions",
       "allowOverride": true
     }
   },

--- a/buildpipeline/DotNet-CoreRT-Linux.json
+++ b/buildpipeline/DotNet-CoreRT-Linux.json
@@ -702,8 +702,12 @@
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
+    "BuildTag": {
+      "value": "corert-alpha",
+      "allowOverride": true
+    },
     "Label": {
-      "value": "corert-alpha-$(Build.BuildNumber)",
+      "value": "$(BuildTag)-$(Build.BuildNumber)",
       "allowOverride": true
     },
     "SourceVersion": {

--- a/buildpipeline/DotNet-CoreRT-Mac.json
+++ b/buildpipeline/DotNet-CoreRT-Mac.json
@@ -256,8 +256,12 @@
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
+    "BuildTag": {
+      "value": "corert-alpha",
+      "allowOverride": true
+    },
     "Label": {
-      "value": "corert-alpha-$(Build.BuildNumber)",
+      "value": "$(BuildTag)-$(Build.BuildNumber)",
       "allowOverride": true
     },
     "SourceVersion": {

--- a/buildpipeline/DotNet-CoreRT-Mac.json
+++ b/buildpipeline/DotNet-CoreRT-Mac.json
@@ -130,53 +130,17 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Download nuget",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "curl",
-        "arguments": "-L -k -o $(SourceFolder)/nuget.zip https://dotnet.myget.org/F/dotnet-buildtools/api/v2/package/NuGet.CommandLine/3.5.0-rc-1256",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Unzip nuget",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "unzip",
-        "arguments": "$(SourceFolder)/nuget.zip -d $(SourceFolder)/nuget",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Publish packages",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "*",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "mono",
-        "arguments": "nuget/tools/NuGet.exe push bin/Product/pkg/*.nupkg $(MyGetApiKey) -Source $(MyGetFeedUrl) -Timeout 3600",
-        "workingFolder": "$(SourceFolder)",
+        "filename": "$(Build.SourcesDirectory)/$(SourceFolder)/buildscripts/publish-packages.sh",
+        "arguments": "-AzureAccount $(CloudDropAccountName) -AzureToken $(CloudDropAccessToken) -Container $(Label)",
+        "workingFolder": "$(Build.SourcesDirectory)/$(SourceFolder)",
         "failOnStandardError": "false"
       }
     },
@@ -293,7 +257,7 @@
       "allowOverride": true
     },
     "Label": {
-      "value": "$(Build.BuildNumber)",
+      "value": "corert-alpha-$(Build.BuildNumber)",
       "allowOverride": true
     },
     "SourceVersion": {
@@ -321,6 +285,25 @@
     "MyGetApiKey": {
       "value": null,
       "isSecret": true,
+      "allowOverride": true
+    },
+    "CloudDropAccountName": {
+      "value": "dotnetbuildoutput"
+    },
+    "CloudDropAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "UpdatePublishedVersions.AuthToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VersionsRepoOwner": {
+      "value": "crummel",
+      "allowOverride": true
+    },
+    "VersionsRepo": {
+      "value": "dotnet_versions",
       "allowOverride": true
     }
   },

--- a/buildpipeline/DotNet-CoreRT-Publish.json
+++ b/buildpipeline/DotNet-CoreRT-Publish.json
@@ -1,0 +1,452 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run script $(VS140COMNTOOLS)\\VsDevCmd.bat",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(VS140COMNTOOLS)\\VsDevCmd.bat",
+        "arguments": "",
+        "modifyEnvironment": "true",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Fetch custom tooling (NuGet, EmbedIndex)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "scripts/DotNet-Trusted-Publish/Fetch-Tools.ps1",
+        "arguments": "$(Build.StagingDirectory)\\ToolingDownload",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Set up pipeline-specific git repository",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-gitUrl $(GitUrl) -root $(Pipeline.SourcesDirectory)",
+        "inlineScript": "param($gitUrl, $root)\n\nif (Test-Path $root)\n{\n  Remove-Item -Recurse -Force $root\n}\ngit clone --no-checkout $gitUrl $root 2>&1 | Write-Host\ncd $root\ngit checkout $env:SourceVersion 2>&1 | Write-Host\n\nWrite-Host (\"##vso[task.setvariable variable=Pipeline.SourcesDirectory;]$root\")",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download packages",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(CloudDropAccountName) $(CloudDropAccessToken) $(Label)",
+        "inlineScript": "param($account, $token, $container)\nif ($env:UseLegacyBuildScripts -eq \"true\")\n{\n  .\\sync.cmd /ab /p:CloudDropAccountName=$account /p:CloudDropAccessToken=$token /p:ContainerName=$container\n}\nelse\n{\n  .\\init-tools.cmd\n  msbuild buildscripts\\syncAzure.proj /p:CloudDropAccountName=$account /p:CloudDropAccessToken=$token /p:ContainerName=$container /fl \"/flp:v=diag;logfile=package-download.log\"\n}",
+        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Index symbol packages",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "inlineScript": "if ($env:Configuration -ne \"Release\") { exit }\n\n& $env:Build_SourcesDirectory\\scripts\\DotNet-Trusted-Publish\\Embed-Index.ps1 `\n  $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\Microsoft.TargetingPack.Private.CoreRT\\$env:AzureContainerSymbolPackageGlob `\n  $env:Build_StagingDirectory\\IndexedSymbolPackages",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Generate Version Assets",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "inlineScript": "msbuild build.proj /t:CreateOrUpdateCurrentVersionFile /p:OfficialBuildId=$env:OfficialBuildId /p:BuildVersionFile=bin\\obj\\BuildVersion-$env:OfficialBuildId.props",
+        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Log Native Version Assets Files",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "dir",
+        "arguments": "$(Pipeline.SourcesDirectory)\\bin\\obj\\BuildVersion*",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "packages -> dotnet.myget.org",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(MyGetApiKey)",
+        "inlineScript": "param($ApiKey)\nif ($env:Configuration -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\Microsoft.TargetingPack.Private.CoreRT\\$env:AzureContainerPackageGlob $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "symbol packages -> dotnet.myget.org",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(MyGetApiKey)",
+        "inlineScript": "param($ApiKey)\nif ($env:Configuration -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Build_StagingDirectory\\IndexedSymbolPackages\\*.nupkg $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Update versions repository",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-gitHubAuthToken $(UpdatePublishedVersions.AuthToken) -root $(Pipeline.SourcesDirectory)",
+        "inlineScript": "param($gitHubAuthToken, $root)\nif ($env:Configuration -ne \"Release\") { exit }\ncd $root\n. $root\\buildscripts\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo $env:VersionsRepo `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\Microsoft.TargetingPack.Private.CoreRT\\$env:AzureContainerPackageGlob",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Get Build Number",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(OfficialBuildId) $(Pipeline.SourcesDirectory)",
+        "inlineScript": "param(\n  [string]$OfficialBuildId,\n  [string]$SourcesDir\n)\n$VersionPropsFile=$SourcesDir + \"\\bin\\obj\\BuildVersion-\" + $OfficialBuildId + \".props\"\n[xml]$versionXml=Get-Content $VersionPropsFile\n$env:BuildNumber=$versionXml.Project.PropertyGroup.BuildNumberMajor.InnerText + \".\" + $versionXml.Project.PropertyGroup.BuildNumberMinor.InnerText\nWrite-Host (\"##vso[task.setvariable variable=BuildNumber;]$env:BuildNumber\")",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Publish to Artifact Services Drop (BuildNumber)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "f9d96d25-0c81-4e77-8282-1ad1f785cbb4",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "dropServiceURI": "https://devdiv.artifacts.visualstudio.com/DefaultCollection",
+        "buildNumber": "dotnet/$(GitHubRepositoryName)/$(SourceBranch)/$(BuildNumber)/packages/$(Configuration)",
+        "sourcePath": "$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer",
+        "dropExePath": "",
+        "toLowerCase": "true",
+        "detailedLog": "false",
+        "usePat": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Publish to Artifact Services Drop (OfficialBuildId)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "f9d96d25-0c81-4e77-8282-1ad1f785cbb4",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "dropServiceURI": "https://devdiv.artifacts.visualstudio.com/DefaultCollection",
+        "buildNumber": "dotnet/$(GitHubRepositoryName)/$(SourceBranch)/$(OfficialBuildId)/packages/$(Configuration)",
+        "sourcePath": "$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer",
+        "dropExePath": "",
+        "toLowerCase": "true",
+        "detailedLog": "false",
+        "usePat": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": true,
+      "displayName": "Copy Publish Artifact: PublishLogs",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "1d341bb0-2106-458c-8422-d00bcea6512a",
+        "versionSpec": "*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "CopyRoot": "",
+        "Contents": "**\\*.log",
+        "ArtifactName": "PublishLogs",
+        "ArtifactType": "Container",
+        "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "Configuration": {
+      "value": "Debug",
+      "allowOverride": true
+    },
+    "TeamName": {
+      "value": "DotNetCore"
+    },
+    "CloudDropAccountName": {
+      "value": "dotnetbuildoutput"
+    },
+    "CloudDropAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "OfficialBuildId": {
+      "value": "$(Build.BuildNumber)",
+      "allowOverride": true
+    },
+    "Label": {
+      "value": "corert-alpha-$(Build.BuildNumber)",
+      "allowOverride": true
+    },
+    "MyGetFeedUrl": {
+      "value": "https://dotnet.myget.org/F/dotnet-core-test/api/v2/package",
+      "allowOverride": true
+    },
+    "MyGetApiKey": {
+      "value": null,
+      "isSecret": true
+    },
+    "VstsPat": {
+      "value": null,
+      "isSecret": true
+    },
+    "DevDivPat": {
+      "value": null,
+      "isSecret": true
+    },
+    "UpdatePublishedVersions.AuthToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VersionsRepoOwner": {
+      "value": "crummel",
+      "allowOverride": true
+    },
+    "VersionsRepo": {
+      "value": "dotnet_versions",
+      "allowOverride": true
+    },
+    "Pipeline.SourcesDirectory": {
+      "value": "$(Build.BinariesDirectory)\\pipelineRepository"
+    },
+    "SourceVersion": {
+      "value": "master",
+      "allowOverride": true
+    },
+    "SourceBranch": {
+      "value": "master",
+      "allowOverride": true
+    },
+    "AzureContainerPackageGlob": {
+      "value": "*.nupkg",
+      "allowOverride": true
+    },
+    "AzureContainerSymbolPackageGlob": {
+      "value": "symbols\\*.nupkg",
+      "allowOverride": true
+    },
+    "GitHubRepositoryName": {
+      "value": "corert"
+    },
+    "UseLegacyBuildScripts": {
+      "value": "false",
+      "allowOverride": true
+    }
+  },
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 180,
+  "repository": {
+    "properties": {
+      "labelSources": "0",
+      "reportBuildStatus": "false"
+    },
+    "id": "0a2b2664-c1be-429c-9b40-8a24dee27a4a",
+    "type": "TfsGit",
+    "name": "DotNet-BuildPipeline",
+    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline",
+    "defaultBranch": "refs/heads/master",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "defaultBranch": "refs/heads/master",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 2943,
+  "name": "DotNet-CoreRT-Publish",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097399
+  }
+}

--- a/buildpipeline/DotNet-CoreRT-Publish.json
+++ b/buildpipeline/DotNet-CoreRT-Publish.json
@@ -336,8 +336,12 @@
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
+    "BuildTag": {
+      "value": "corert-alpha",
+      "allowOverride": true
+    },
     "Label": {
-      "value": "corert-alpha-$(Build.BuildNumber)",
+      "value": "$(BuildTag)-$(Build.BuildNumber)",
       "allowOverride": true
     },
     "MyGetFeedUrl": {

--- a/buildpipeline/DotNet-CoreRT-Windows.json
+++ b/buildpipeline/DotNet-CoreRT-Windows.json
@@ -148,27 +148,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Download nuget",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "https://dotnet.myget.org/F/dotnet-buildtools/api/v2/package/NuGet.CommandLine/3.5.0-rc-1256 $(CustomNuGetDownloadPath) $(CustomNuGetPath)",
-        "inlineScript": "param($packageUrl, $packageDestDir, $nugetDestPath)\n$downloadPath=\"$packageDestDir\\NuGet.CommandLine.nupkg\"\n$extract = \"$packageDestDir\\extracted\"\n$t = mkdir $packageDestDir -ea Ignore\n(New-Object Net.WebClient).DownloadFile($packageUrl, $downloadPath)\nAdd-Type -Assembly 'System.IO.Compression.FileSystem'\nRemove-Item $extract -Recurse -ea Ignore\n[System.IO.Compression.ZipFile]::ExtractToDirectory($downloadPath, $extract)\nCopy-Item $packageDestDir\\extracted\\tools\\NuGet.exe $nugetDestPath",
-        "workingFolder": "",
-        "failOnStandardError": "true"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Publish packages to MyGet",
+      "displayName": "Publish packages",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -176,8 +156,8 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(CustomNuGetPath)",
-        "arguments": "push bin\\Product\\pkg\\*.nupkg $(MyGetApiKey) -Source $(MyGetFeedUrl) -Timeout 3600",
+        "filename": "$(Build.SourcesDirectory)\\$(SourceFolder)\\buildscripts\\publish-packages.cmd",
+        "arguments": "-AzureAccount=$(CloudDropAccountName) -AzureToken=\"$(CloudDropAccessToken)\" -Container=$(Label)",
         "workingFolder": "$(SourceFolder)",
         "failOnStandardError": "false"
       }
@@ -236,7 +216,7 @@
       "inputs": {
         "symbolServiceURI": "https://devdiv.artifacts.visualstudio.com/DefaultCollection",
         "requestName": "$(system.teamProject)/$(Build.BuildNumber)/$(Build.BuildId)",
-        "sourcePath": "$(Build.SourcesDirectory)\\corefx\\bin",
+        "sourcePath": "$(Build.SourcesDirectory)\\corert\\bin",
         "assemblyPath": "",
         "toLowerCase": "true",
         "detailedLog": "true",
@@ -409,7 +389,7 @@
       "allowOverride": true
     },
     "Label": {
-      "value": "$(Build.BuildNumber)",
+      "value": "corert-alpha-$(Build.BuildNumber)",
       "allowOverride": true
     },
     "SourceVersion": {
@@ -444,6 +424,25 @@
     "SourceFolder": {
       "value": "corert_$(Build.BuildId)",
       "allowOverride": false
+    },
+    "CloudDropAccountName": {
+      "value": "dotnetbuildoutput"
+    },
+    "CloudDropAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "UpdatePublishedVersions.AuthToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VersionsRepoOwner": {
+      "value": "crummel",
+      "allowOverride": true
+    },
+    "VersionsRepo": {
+      "value": "dotnet_versions",
+      "allowOverride": true
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreRT-Windows.json
+++ b/buildpipeline/DotNet-CoreRT-Windows.json
@@ -388,8 +388,12 @@
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
+    "BuildTag": {
+      "value": "corert-alpha",
+      "allowOverride": true
+    },
     "Label": {
-      "value": "corert-alpha-$(Build.BuildNumber)",
+      "value": "$(BuildTag)-$(Build.BuildNumber)",
       "allowOverride": true
     },
     "SourceVersion": {

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -7,42 +7,147 @@
   },
   "Pipelines": [
     {
-      "Name": "All-Release-x64",
+      "Name": "All-Release",
       "Parameters": {
         "TreatWarningsAsErrors": "false"
       },
       "BuildParameters": {
-        "Platform": "x64",
         "Configuration": "Release"
       },
       "Definitions": [
         {
           "Name": "DotNet-CoreRT-Linux",
+          "Parameters": {
+            "Platform": "x64"
+          },
           "ReportingParameters": {
             "OperatingSystem": "Debian 8.2",
-            "SubType": "native",
             "Type": "build/product/",
-            "ConfigurationGroup": "Release"
+            "ConfigurationGroup": "Release",
+            "Platform": "x64"
           }
         },
         {
           "Name": "DotNet-CoreRT-Mac",
+          "Parameters": {
+            "Platform": "x64"
+          },
           "ReportingParameters": {
-            "SubType": "native",
             "OperatingSystem": "OSX",
             "Type": "build/product/",
-            "ConfigurationGroup": "Release"
+            "ConfigurationGroup": "Release",
+            "Platform": "x64"
           }
         },
         {
           "Name": "DotNet-CoreRT-Windows",
+          "Parameters": {
+            "Platform": "x64"
+          },
           "ReportingParameters": {
-            "SubType": "managed",
-            "OperatingSystem": "All (Managed)",
+            "OperatingSystem": "Windows",
             "Type": "build/product/",
-            "ConfigurationGroup": "Release"
+            "ConfigurationGroup": "Release",
+            "Platform": "x64"
           }
         }
+      ]
+    },
+    {
+      "Name": "All-Debug",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "Configuration": "Debug"
+      },
+      "Definitions": [
+        {
+          "Name": "DotNet-CoreRT-Linux",
+          "Parameters": {
+            "Platform": "x64"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Debian 8.2",
+            "Type": "build/product/",
+            "ConfigurationGroup": "Debug",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CoreRT-Mac",
+          "Parameters": {
+            "Platform": "x64"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "OSX",
+            "Type": "build/product/",
+            "ConfigurationGroup": "Debug",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CoreRT-Windows",
+          "Parameters": {
+            "Platform": "x64"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "ConfigurationGroup": "Debug",
+            "Platform": "x64"
+          }
+        }
+      ]
+    },
+    {
+      "Name": "Publish-Release",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "Configuration": "Release"
+      },
+      "Definitions": [
+        {
+          "Name": "DotNet-CoreRT-Publish",
+          "Parameters": {
+            "GitHubRepositoryName": "corert"
+          },
+          "ReportingParameters": {
+            "TaskName": "Package Publish",
+            "Type": "build/publish/",
+            "ConfigurationGroup": "Release - Push to MyGet Feed"
+          }
+        }
+      ],
+      "DependsOn": [
+        "All-Release"
+      ]
+    },
+    {
+      "Name": "Publish-Debug",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "ConfigurationGroup": "Debug"
+      },
+      "Definitions": [
+        {
+          "Name": "DotNet-CoreRT-Publish",
+          "Parameters": {
+            "GitHubRepositoryName": "corert"
+          },
+          "ReportingParameters": {
+            "TaskName": "Package Publish",
+            "Type": "build/publish/",
+            "ConfigurationGroup": "Debug - Push to Azure Storage"
+          }
+        }
+      ],
+      "DependsOn": [
+        "All-Debug"
       ]
     }
   ]

--- a/buildscripts/build-managed.cmd
+++ b/buildscripts/build-managed.cmd
@@ -45,7 +45,7 @@ dir /b "%__DotNetCliPath%\sdk"
 call "!VS%__VSProductVersion%COMNTOOLS!\VsDevCmd.bat"
 echo Commencing build of managed components for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
-%_msbuildexe% /ConsoleLoggerParameters:ForceNoAlign "%__ProjectDir%\build.proj" %__MSBCleanBuildArgs% %__ExtraMsBuildParams% /p:RepoPath="%__ProjectDir%" /p:RepoLocalBuild="true" /p:RelativeProductBinDir="%__RelativeProductBinDir%" /p:NuPkgRid=win7-x64 /p:ToolchainMilestone=%__ToolchainMilestone% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__BuildLog%"
+%_msbuildexe% /ConsoleLoggerParameters:ForceNoAlign "%__ProjectDir%\build.proj" %__MSBCleanBuildArgs% %__ExtraMsBuildParams% /p:RepoPath="%__ProjectDir%" /p:RepoLocalBuild="true" /p:RelativeProductBinDir="%__RelativeProductBinDir%" /p:NuPkgRid=win7-x64 /p:ToolchainMilestone=%__ToolchainMilestone% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%__BuildLog%"
 IF NOT ERRORLEVEL 1 (
   findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%__BuildLog%"
   goto AfterILCompilerBuild

--- a/buildscripts/build-managed.cmd
+++ b/buildscripts/build-managed.cmd
@@ -45,7 +45,7 @@ dir /b "%__DotNetCliPath%\sdk"
 call "!VS%__VSProductVersion%COMNTOOLS!\VsDevCmd.bat"
 echo Commencing build of managed components for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
-%_msbuildexe% /ConsoleLoggerParameters:ForceNoAlign "%__ProjectDir%\build.proj" %__MSBCleanBuildArgs% %__ExtraMsBuildParams% /p:RepoPath="%__ProjectDir%" /p:RepoLocalBuild="true" /p:RelativeProductBinDir="%__RelativeProductBinDir%" /p:NuPkgRid=win7-x64 /p:ToolchainMilestone=%__ToolchainMilestone% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%__BuildLog%"
+%_msbuildexe% /ConsoleLoggerParameters:ForceNoAlign "%__ProjectDir%\build.proj" %__MSBCleanBuildArgs% %__ExtraMsBuildParams% /p:RepoPath="%__ProjectDir%" /p:RepoLocalBuild="true" /p:RelativeProductBinDir="%__RelativeProductBinDir%" /p:NuPkgRid=win7-x64 /p:ToolchainMilestone=%__ToolchainMilestone% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__BuildLog%"
 IF NOT ERRORLEVEL 1 (
   findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%__BuildLog%"
   goto AfterILCompilerBuild

--- a/buildscripts/publish-packages.cmd
+++ b/buildscripts/publish-packages.cmd
@@ -1,0 +1,40 @@
+@echo off
+REM don't pass args to buildvars-setup, just get defaults
+call %~dp0buildvars-setup.cmd
+
+set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+if not exist %_msbuildexe% (set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe")
+REM hopefully it's on the path
+if not exist %_msbuildexe% set _msbuildexe=msbuild
+
+set AzureAccount=
+set AzureToken=
+set Container=
+
+:Arg_Loop
+if "%1" == "" goto ArgsDone
+
+if /i "%1" == "-AzureAccount" (set AzureAccount=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "-AzureToken" (set AzureToken=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "-Container" (set Container=%2&shift&shift&goto Arg_Loop)
+
+echo Invalid command line argument: %1
+exit /b 1
+:ArgsDone
+
+set AzureToken=%AzureToken:"=%
+
+if "%AzureAccount%" == "" (
+    echo Azure account not specified.
+    exit /b 1
+)
+if "%AzureToken%" == "" (
+    echo Azure token not specified.
+    exit /b 1
+)
+if "%Container%" == "" (
+    echo Azure container not specified.
+    exit /b 1
+)
+
+%_msbuildexe% %__ProjectDir%\buildscripts\publish.proj /p:CloudDropAccountName=%AzureAccount% /p:CloudDropAccessToken=%AzureToken% /p:ContainerName=%Container% /flp:v=diag;LogFile=publish-packages.log

--- a/buildscripts/publish-packages.sh
+++ b/buildscripts/publish-packages.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+export AzureAccount=
+export AzureToken=
+export Container=
+
+while [ "$1" != "" ]; do
+        lowerI="$(echo $1 | awk '{print tolower($0)}')"
+        case $lowerI in
+        -azureaccount)
+            shift
+            export AzureAccount=$1
+            ;;
+        -azuretoken)
+            shift
+            export AzureToken=$1
+            ;;
+        -container)
+            shift
+            export Container=$1
+            ;;
+        *)
+          echo Bad argument $1
+          exit 1
+    esac
+    shift
+done
+
+# don't pass args to buildvars-setup, just get defaults
+scriptRoot="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. $scriptRoot/buildvars-setup.sh
+
+$__ProjectRoot/Tools/msbuild.sh $scriptRoot/publish.proj /p:CloudDropAccountName=$AzureAccount /p:CloudDropAccessToken=$AzureToken /p:ContainerName=$Container "/flp:v=diag;LogFile=publish-packages.log"

--- a/buildscripts/publish.proj
+++ b/buildscripts/publish.proj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$(ToolsDir)PublishContent.targets" />
+  <Import Project="$(ToolsDir)versioning.targets" />
+
+  <PropertyGroup>
+    <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)**\*.nupkg</PublishPattern>
+  </PropertyGroup>
+
+  <Target Name="CreateContainerName"
+          DependsOnTargets="CreateVersionFileDuringBuild"
+          Condition="'$(ContainerName)' == ''">
+    <PropertyGroup>
+      <ContainerName>corert-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="CreateContainerName;UploadToAzure" />
+</Project>

--- a/buildscripts/syncAzure.proj
+++ b/buildscripts/syncAzure.proj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <ContainerNamePrefix Condition="'$(ContainerNamePrefix)' == ''">corert-$(PreReleaseLabel)</ContainerNamePrefix>
+    <ContainerName Condition="'$(ContainerNamePrefix)' != '' and '$(BuildNumberMajor)' != '' and '$(BuildNumberMinor)' != ''">$(ContainerNamePrefix)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
+    <DownloadDirectory>$(PackagesDir)AzureTransfer</DownloadDirectory>
+  </PropertyGroup>
+
+  <Import Project="$(ToolsDir)SyncCloudContent.targets" />
+
+  <Target Name="ValidateRequiredProperties">
+    <Error Condition="'$(CloudDropAccountName)' == ''" Text="Missing property CloudDropAccountName." />
+    <Error Condition="'$(CloudDropAccessToken)' == ''" Text="Missing property CloudDropAccessToken." />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="ValidateRequiredProperties;DownloadBlobsFromAzureTargets" />
+</Project>

--- a/buildscripts/updatePublishedVersions.ps1
+++ b/buildscripts/updatePublishedVersions.ps1
@@ -1,0 +1,26 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# This script updates the dotnet/versions repository based on a set of packages. It directly
+# commits the changes using GitHub APIs.
+
+param(
+    [Parameter(Mandatory=$true)][string]$gitHubUser,
+    [Parameter(Mandatory=$true)][string]$gitHubEmail,
+    [Parameter(Mandatory=$true)][string]$gitHubAuthToken,
+    [Parameter(Mandatory=$true)][string]$versionsRepoOwner,
+    [Parameter(Mandatory=$true)][string]$versionsRepo,
+    [Parameter(Mandatory=$true)][string]$versionsRepoPath,
+    # A pattern matching all packages in the set that the versions repository should be set to.
+    [Parameter(Mandatory=$true)][string]$nupkgPath)
+
+msbuild /t:UpdatePublishedVersions `
+    /p:GitHubUser="$gitHubUser" `
+    /p:GitHubEmail="$gitHubEmail" `
+    /p:GitHubAuthToken="$gitHubAuthToken" `
+    /p:VersionsRepoOwner="$versionsRepoOwner" `
+    /p:VersionsRepo="$versionsRepo" `
+    /p:VersionsRepoPath="$versionsRepoPath" `
+    /p:ShippedNuGetPackageGlobPath="$nupkgPath"

--- a/dir.props
+++ b/dir.props
@@ -68,6 +68,8 @@
     <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
     <ProductBinDir Condition="'$(ProductBinDir)'==''">$(BinDir)Product/</ProductBinDir>
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests/</TestWorkingDir>
+    <PackageOutputRoot Condition="'$(PackageOutputRoot)'=='' and '$(NonShippingPackage)' == 'true'">$(BinDir)packages_noship/</PackageOutputRoot>
+    <PackageOutputRoot Condition="'$(PackageOutputRoot)'==''">$(ProductBinDir)pkg/</PackageOutputRoot>
 
     <!-- Folder where restored Nuget packages will go -->
     <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(BinDir)packages/</PackagesOutDir>
@@ -92,7 +94,9 @@
     <OSPlatformConfig>$(BinDirOSGroup).$(BinDirPlatform).$(BinDirConfiguration)</OSPlatformConfig>
 
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(ProductBinDir)</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/</OutputPath>
+    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(BaseOutputPath)pkg/$(OSPlatformConfig)/$(MSBuildProjectName)/</PackageOutputPath>
+    <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
+    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
 
     <!-- Folder where we will drop the Nuget package for the toolchain -->
     <ProductPackageDir Condition="'$(ProductPackageDir)'==''">$(BaseOutputPath)$(OSPlatformConfig)/packaging/</ProductPackageDir>

--- a/dir.props
+++ b/dir.props
@@ -69,7 +69,7 @@
     <ProductBinDir Condition="'$(ProductBinDir)'==''">$(BinDir)Product/</ProductBinDir>
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests/</TestWorkingDir>
     <PackageOutputRoot Condition="'$(PackageOutputRoot)'=='' and '$(NonShippingPackage)' == 'true'">$(BinDir)packages_noship/</PackageOutputRoot>
-    <PackageOutputRoot Condition="'$(PackageOutputRoot)'==''">$(ProductBinDir)pkg/</PackageOutputRoot>
+    <PackageOutputRoot Condition="'$(PackageOutputRoot)'=='' and '$(NonShippingPackage)' != 'true'">$(ProductBinDir)pkg/</PackageOutputRoot>
 
     <!-- Folder where restored Nuget packages will go -->
     <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(BinDir)packages/</PackagesOutDir>
@@ -94,9 +94,9 @@
     <OSPlatformConfig>$(BinDirOSGroup).$(BinDirPlatform).$(BinDirConfiguration)</OSPlatformConfig>
 
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(ProductBinDir)</BaseOutputPath>
-    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(BaseOutputPath)pkg/$(OSPlatformConfig)/$(MSBuildProjectName)/</PackageOutputPath>
+    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(OSPlatformConfig)/$(MSBuildProjectName)/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
-    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)</OutputPath>
 
     <!-- Folder where we will drop the Nuget package for the toolchain -->
     <ProductPackageDir Condition="'$(ProductPackageDir)'==''">$(BaseOutputPath)$(OSPlatformConfig)/packaging/</ProductPackageDir>


### PR DESCRIPTION
- OS-specific legs no longer publish to MyGet, they just upload to Azure.
- New publish leg downloads from Azure and publishes to MyGet.
- Only includes Microsoft.TargetingPack.Private.CoreRT for now, will add ILCompiler
  after we sort out what OS-specific packages should be named.