### PR TITLE
Make threadstatics multifile friendly

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -196,20 +196,13 @@ namespace ILCompiler
 
             public void AddCompilationRoot(TypeDesc type, string reason)
             {
-                if (type.IsGenericDefinition)
+                if (!ConstructedEETypeNode.CreationAllowed(type))
                 {
                     _graph.AddRoot(_factory.NecessaryTypeSymbol(type), reason);
                 }
                 else
                 {
                     _graph.AddRoot(_factory.ConstructedTypeSymbol(type), reason);
-
-                    // If the type has a thread static field then we should eagerly create a helper
-                    // to access such fields at runtime. This is required for multi-module compilation.
-                    if (type.IsDefType && (((DefType)type).ThreadStaticFieldSize > 0))
-                    {
-                        _graph.AddRoot(_factory.ReadyToRunHelper(ReadyToRunHelperId.GetThreadStaticBase, (MetadataType)type), reason);
-                    }
                 }
             }
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -236,14 +236,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
             var instantiatedType = (MetadataType)_type.InstantiateSignature(typeInstantiation, methodInstantiation);
-            return factory.TypeThreadStaticsSymbol(instantiatedType);
-        }
-
-        public override void EmitDictionaryEntry(ref ObjectDataBuilder builder, NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
-        {
-            ThreadStaticsNode targetNode = (ThreadStaticsNode)GetTarget(factory, typeInstantiation, methodInstantiation);
-            int typeTlsIndex = factory.ThreadStaticsRegion.IndexOfEmbeddedObject(targetNode);
-            builder.EmitNaturalInt(typeTlsIndex);
+            return factory.TypeThreadStaticIndex(instantiatedType);
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -156,12 +156,6 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Address Load");
                 return dependencyList;
             }
-            else if (_id == ReadyToRunHelperId.GetThreadStaticBase)
-            {
-                DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(factory.TypeThreadStaticsSymbol((MetadataType)_target), "ReadyToRun Thread Static Storage");
-                return dependencyList;
-            }
             else
             {
                 return null;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -49,19 +49,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode CreateReadyToRunHelperNode(Tuple<ReadyToRunHelperId, object> helperCall)
         {
-            ReadyToRunHelperNode node = new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
-
-            if ((node.Id != ReadyToRunHelperId.GetThreadStaticBase) ||
-                CompilationModuleGroup.ContainsType((TypeDesc)node.Target))
-            {
-                return node;
-            }
-            else
-            {
-                // The ReadyToRun helper for a type with thread static fields resides in the same module as the target type.
-                // Other modules should use an extern symbol node to access it.
-                return ExternSymbol(node.GetMangledName());
-            }
+            return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a node containing information necessary at runtime to locate type's thread static base.
+    /// </summary>
+    internal class TypeThreadStaticIndexNode : ObjectNode, ISymbolNode
+    {
+        private MetadataType _type;
+
+        public TypeThreadStaticIndexNode(MetadataType type)
+        {
+            _type = type;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("__TypeThreadStaticIndex_")
+              .Append(NodeFactory.NameMangler.GetMangledTypeName(_type));
+        }
+        public int Offset => 0;
+        protected override string GetName() => this.GetMangledName();
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+        public override bool IsShareable => true;
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            return new DependencyList
+            {
+                new DependencyListEntry(factory.TypeThreadStaticsSymbol(_type), "Thread static storage")
+            };
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory);
+
+            objData.Alignment = objData.TargetPointerSize;
+            objData.DefinedSymbols.Add(this);
+
+            int typeTlsIndex = 0;
+            if (!relocsOnly)
+            {
+                var node = factory.TypeThreadStaticsSymbol(_type);
+                typeTlsIndex = factory.ThreadStaticsRegion.IndexOfEmbeddedObject(node);
+            }
+
+            objData.EmitPointerReloc(factory.TypeManagerIndirection);
+            objData.EmitNaturalInt(typeTlsIndex);
+
+            return objData.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\TargetRegisterMap.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64UnboxingStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ThreadStaticsNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\TypeThreadStaticIndexNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\TypeMetadataMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\UnboxingStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\VirtualMethodUseNode.cs" />


### PR DESCRIPTION
Adding a COMDAT-foldable cell that encapsulates the type's thread static
index and the associated type manager indirection.

In multifile mode, threadstatic index for a generic type will
potentially get generated in multiple modules, but we will end up using
just one of them at runtime. If we had multiple nodes hardcoding the
index, we would need to set up complex section dependencies to make sure
they fold together and agree after linking.

I chose not to special case generic types and use the indirection node
for non-generic types as well. This removed 3 places where we needed to
special case the R2R threadstatic base helper in the compiler (and there
was probably one more place we needed to special case to fix a TODO I'm
just deleting).

I don't think the tiny overhead is worth the complexity in the compiler,
especially considering we're talking about the non-optimized mode
(single file with no R2R will always be the optimized one).

Fixes #2482.