### PR TITLE
Removing dependency on managedthreadid.cs on Windows

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Environment.cs
@@ -16,6 +16,10 @@ internal static partial class Interop
 
         [DllImport(Libraries.Kernel32, EntryPoint = "ExitProcess")]
         internal static extern void ExitProcess(int exitCode);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(Interop.Libraries.Kernel32, "GetCurrentThreadId")]
+        internal static extern int GetCurrentThreadId();
     }
 
     internal static void ExitProcess(int exitCode)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
@@ -12,7 +12,7 @@ namespace Internal.Runtime.Augments
     /// <summary>For internal use only.  Exposes runtime functionality to the Environments implementation in corefx.</summary>
     public static class EnvironmentAugments
     {
-        public static int CurrentManagedThreadId => System.Threading.ManagedThreadId.Current;
+        public static int CurrentManagedThreadId => System.Environment.CurrentManagedThreadId;
         public static void FailFast(string message, Exception error) => RuntimeExceptionHelpers.FailFast(message, error);
 
         public static void Exit(int exitCode)

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -585,7 +585,8 @@
     <Compile Include="System\Threading\CancellationToken.cs" />
     <Compile Include="System\Threading\CancellationTokenRegistration.cs" />
     <Compile Include="System\Threading\CancellationTokenSource.cs" />
-    <Compile Include="System\Threading\ManagedThreadId.cs" />
+    <!--In ProjectN, 32 bit native thread id is used-->
+    <Compile Include="System\Threading\ManagedThreadId.cs" Condition="'$(IsProjectNLibrary)' != 'true'" />
     <Compile Include="System\Threading\LowLevelThread.cs" />
     <Compile Include="System\Threading\Lock.cs" />
     <Compile Include="System\Threading\Condition.cs" />

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -585,8 +585,6 @@
     <Compile Include="System\Threading\CancellationToken.cs" />
     <Compile Include="System\Threading\CancellationTokenRegistration.cs" />
     <Compile Include="System\Threading\CancellationTokenSource.cs" />
-    <!--In ProjectN, 32 bit native thread id is used-->
-    <Compile Include="System\Threading\ManagedThreadId.cs" Condition="'$(IsProjectNLibrary)' != 'true'" />
     <Compile Include="System\Threading\LowLevelThread.cs" />
     <Compile Include="System\Threading\Lock.cs" />
     <Compile Include="System\Threading\Condition.cs" />
@@ -940,6 +938,7 @@
     <Compile Include="System\DateTime.Unix.cs" />
     <Compile Include="System\Globalization\FormatProvider.FormatAndParse.Unix.cs" />
     <Compile Include="System\Environment.Unix.cs" />
+    <Compile Include="System\Threading\ManagedThreadId.cs" />
     <Compile Include="System\IO\FileStream.Unix.cs" />
     <Compile Include="System\IO\Path.Unix.cs" />
     <Compile Include="System\IO\PathInternal.Unix.cs" />

--- a/src/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -9,6 +9,14 @@ namespace System
 {
     public static partial class Environment
     {
+        public static int CurrentManagedThreadId
+        {
+            get
+            {
+                return ManagedThreadId.Current;
+            }
+        }
+
         internal static long TickCount64
         {
             get

--- a/src/System.Private.CoreLib/src/System/Environment.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Windows.cs
@@ -6,6 +6,14 @@ namespace System
 {
     public static partial class Environment
     {
+        public static int CurrentManagedThreadId
+        {
+            get
+            {
+                return unchecked((int)Interop.mincore.GetCurrentThreadId());
+            }
+        }
+
         internal static long TickCount64 => (long)Interop.mincore.GetTickCount64();
 
         public static int ProcessorCount

--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -76,7 +76,11 @@ namespace System
         {
             get
             {
+#if CORERT
                 return ManagedThreadId.Current;
+#else
+                return unchecked((int)Interop.mincore.GetCurrentThreadId());
+#endif
             }
         }
 

--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -72,18 +72,6 @@ namespace System
             RuntimeExceptionHelpers.FailFast(message, exception);
         }
 
-        public static int CurrentManagedThreadId
-        {
-            get
-            {
-#if CORERT
-                return ManagedThreadId.Current;
-#else
-                return unchecked((int)Interop.mincore.GetCurrentThreadId());
-#endif
-            }
-        }
-
         // The upper bits of t_executionIdCache are the executionId. The lower bits of
         // the t_executionIdCache are counting down to get it periodically refreshed.
         // TODO: Consider flushing the executionIdCache on Wait operations or similar 

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.NonPortable.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.NonPortable.cs
@@ -31,10 +31,10 @@ namespace System.Runtime.CompilerServices
         {
             get
             {
-                return ManagedThreadId.Current;
+                return Environment.CurrentManagedThreadId;
             }
         }
 
-        private const int ManagedThreadIdNone = ManagedThreadId.ManagedThreadIdNone;
+        private const int ManagedThreadIdNone =0;
     }
 }

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.NonPortable.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.NonPortable.cs
@@ -35,6 +35,6 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        private const int ManagedThreadIdNone =0;
+        private const int ManagedThreadIdNone = 0;
     }
 }


### PR DESCRIPTION
Removing dependency on ManagedThreadId.cs on windows. On windows, ProjectN will identify Environment.GetCurrentManagedThreadID as intrinsic and generate windows thread id. Non ProjectN environments will use it as runtime import, hence will not hit by Pinvoke performance degradation. Unix environment will still use simulated managed thread ids.