### PR TITLE
Fix handling of parametrized types in CppCodeGen

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio-2015.md
@@ -52,7 +52,7 @@ _Note: The size of NuGet packages is approximately 2.75 GB, so download might ta
   - Set startup command line to:
 `@c:\corert\bin\obj\Windows_NT.x64.Debug\cpp.rsp`
 
-    - `--nolinenumbers` command line option can be used to suppress generation of line number mappings in C++ files - useful for debugging
+    - `--codegenopt:nolinenumbers` command line option can be used to suppress generation of line number mappings in C++ files - useful for debugging
 
   - Build & run using **F5**
     - This will run the compiler. The output is `c:\corert\bin\obj\Windows_NT.x64.Debug\repro\native\repro.cpp` file.

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -25,7 +25,7 @@ See the LICENSE file in the project root for more information.
     <CppCompilerAndLinkerArg Include="/I$(IlcPath)\inc" />
     <CppCompilerAndLinkerArg Condition="'$(Configuration)' == 'Debug'" Include="/Od" />
     <CppCompilerAndLinkerArg Condition="'$(Configuration)' != 'Debug'" Include="/O2" />
-    <CppCompilerAndLinkerArg Include="/c /nologo /W3 /GS /DCPPCODEGEN /EHs /Zi" />
+    <CppCompilerAndLinkerArg Include="/c /nologo /W3 /GS /DCPPCODEGEN /EHs /Zi /bigobj" />
     <CppCompilerAndLinkerArg Condition="'$(UseDebugCrt)' == 'true'" Include="/MTd" />
     <CppCompilerAndLinkerArg Condition="'$(UseDebugCrt)' != 'true'" Include="/MT" />
     <CppCompilerAndLinkerArg Include="$(AdditionalCppCompilerFlags)" />

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
@@ -42,11 +42,11 @@ namespace ILCompiler
             // We should not care which code-gen is being used, however currently CppCodeGen cannot
             // handle code pulled in by all explicit cctors.
             //
-            // See https://github.com/dotnet/corert/issues/2486
+            // See https://github.com/dotnet/corert/issues/2518
             //
             _isCppCodeGen = isCppCodeGen;
         }
-        
+
         public IList<MethodDesc> LibraryInitializerMethods
         {
             get

--- a/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NameMangler.cs
@@ -87,14 +87,14 @@ namespace ILCompiler
                 sb.Append("_");
             }
 
-            string santizedName = (sb != null) ? sb.ToString() : s;
+            string sanitizedName = (sb != null) ? sb.ToString() : s;
 
             // The character sequences denoting generic instantiations, arrays, byrefs, or pointers must be
             // restricted to that use only. Replace them if they happened to be used in any identifiers in 
             // the compilation input.
             return _mangleForCplusPlus
-                ? santizedName.Replace(EnterNameScopeSequence, "_AA_").Replace(ExitNameScopeSequence, "_VV_")
-                : santizedName;
+                ? sanitizedName.Replace(EnterNameScopeSequence, "_AA_").Replace(ExitNameScopeSequence, "_VV_")
+                : sanitizedName;
         }
 
         /// <summary>

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -149,10 +149,10 @@ namespace Internal.IL
                 var localSlotToInfoMap = new Dictionary<int, ILLocalVariable>();
                 foreach (var v in localVariables)
                 {
-                    string sanitizedName = _compilation.NameMangler.SanitizeName(v.Name);
-                    if (!names.Add(v.Name))
+                    string sanitizedName = _writer.SanitizeCppVarName(v.Name);
+                    if (!names.Add(sanitizedName))
                     {
-                        sanitizedName = string.Format("{0}_local{1}", v.Name, v.Slot);
+                        sanitizedName = string.Format("{0}_local{1}", sanitizedName, v.Slot);
                         names.Add(sanitizedName);
                     }
 
@@ -172,7 +172,7 @@ namespace Internal.IL
             int index = 0;
             foreach (var p in parameters)
             {
-                parameterIndexToNameMap[index] = p;
+                parameterIndexToNameMap[index] = _writer.SanitizeCppVarName(p);
                 ++index;
             }
 
@@ -422,7 +422,7 @@ namespace Internal.IL
 
             if (_parameterIndexToNameMap != null && argument && _parameterIndexToNameMap.ContainsKey(index))
             {
-                return _writer.SanitizeCppVarName(_parameterIndexToNameMap[index]);
+                return _parameterIndexToNameMap[index];
             }
 
             return (argument ? "_a" : "_l") + index.ToStringInvariant();
@@ -2417,7 +2417,7 @@ namespace Internal.IL
                     "::",
                     _writer.GetCppMethodName(helper),
                     "((intptr_t)",
-                    _writer.GetCppTypeName((TypeDesc)ldtokenValue),
+                    _compilation.NameMangler.GetMangledTypeName((TypeDesc)ldtokenValue),
                     "::__getMethodTable())");
 
                 value = new LdTokenEntry<TypeDesc>(StackValueKind.ValueType, name, (TypeDesc)ldtokenValue, GetWellKnownType(ldtokenKind));
@@ -2493,7 +2493,7 @@ namespace Internal.IL
 
             GetSignatureTypeNameAndAddReference(type);
 
-            PushExpression(StackValueKind.Int32, "sizeof(" + _writer.GetCppTypeName(type) + ")");
+            PushExpression(StackValueKind.Int32, "(int32_t)sizeof(" + _writer.GetCppTypeName(type) + ")");
         }
 
         private void ImportRefAnyType()
@@ -2575,9 +2575,12 @@ namespace Internal.IL
 
             AddTypeDependency(type, constructed);
 
-            foreach (var field in type.GetFields())
+            if (!type.IsGenericDefinition)
             {
-                AddTypeDependency(field.FieldType, false);
+                foreach (var field in type.GetFields())
+                {
+                    AddTypeDependency(field.FieldType, false);
+                }
             }
         }
         private void AddTypeDependency(TypeDesc type, bool constructed)
@@ -2586,14 +2589,8 @@ namespace Internal.IL
             {
                 return;
             }
-            else if (type.IsPointer || type.IsByRef)
-            {
-                Debug.Assert(type is ParameterizedType);
-                AddTypeDependency((type as ParameterizedType).ParameterType, constructed);
-                return;
-            }
-            Object node;
 
+            Object node;
             if (constructed)
                 node = _nodeFactory.ConstructedTypeSymbol(type);
             else

--- a/src/ILCompiler/reproNative/reproNativeCpp.vcxproj
+++ b/src/ILCompiler/reproNative/reproNativeCpp.vcxproj
@@ -59,6 +59,7 @@
       <AdditionalIncludeDirectories>..\..\Native\gc;..\..\Native\gc\env;..\..\Native\Bootstrap</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4477</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalOptions>/bigobj</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -79,6 +80,7 @@
       <AdditionalIncludeDirectories>..\..\Native\gc;..\..\Native\gc\env</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4477</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalOptions>/bigobj</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
- Use NameMangler.GetMangledTypeName directly to get the EEType name
- Delete filtering of IsPointer and IsByRef during type emission since it works fine now

Fix #2486