### PR TITLE
Generic Virtual Methods Hashtables

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -301,5 +301,25 @@ namespace Internal.TypeSystem
 
             return method;
         }
+
+        /// <summary>
+        /// Scan the type and its base types for an implementation of an interface method. Returns null if no 
+        /// implementation is found.
+        /// </summary>
+        public static MethodDesc ResolveInterfaceMethodTarget(this TypeDesc thisType, MethodDesc interfaceMethodToResolve)
+        {
+            Debug.Assert(interfaceMethodToResolve.OwningType.IsInterface);
+
+            MethodDesc result = null;
+            TypeDesc currentType = thisType;
+            do
+            {
+                result = currentType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethodToResolve);
+                currentType = currentType.BaseType;
+            }
+            while (result == null && currentType != null);
+
+            return result;
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -26,6 +26,14 @@ namespace ILCompiler.DependencyAnalysis
             return false;
         }
 
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                return _type.IsDefType && _type.HasGenericVirtualMethod();
+            }
+        }
+
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DefType closestDefType = _type.GetClosestDefType();
@@ -87,6 +95,12 @@ namespace ILCompiler.DependencyAnalysis
             if (factory.TypeSystemContext.HasLazyStaticConstructor(_type))
             {
                 dependencyList.Add(factory.TypeNonGCStaticsSymbol((MetadataType)_type), "Class constructor");
+            }
+
+            // Generated type contains generic virtual methods that will get added to the GVM tables
+            if (TypeGVMEntriesNode.TypeNeedsGVMTableEntries(_type))
+            {
+                dependencyList.Add(new DependencyListEntry(factory.TypeGVMEntries(_type), "Type with generic virtual methods"));
             }
 
             return dependencyList;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -1,0 +1,182 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// This analysis node is used for computing GVM dependencies for the following cases:
+    ///    1) Derived types where the GVM is overridden
+    ///    2) Variant-interfaces GVMs
+    /// This analysis node will ensure that the proper GVM instantiations are compiled on types.
+    /// </summary>
+    internal class GVMDependenciesNode : DependencyNodeCore<NodeFactory>
+    {
+        private MethodDesc _method;
+
+        public GVMDependenciesNode(MethodDesc method)
+        {
+            Debug.Assert(!method.IsRuntimeDeterminedExactMethod);
+            Debug.Assert(method.IsVirtual && method.HasInstantiation);
+            _method = method;
+        }
+
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => "__GVMDependenciesNode_" + NodeFactory.NameMangler.GetMangledMethodName(_method);
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return Array.Empty<DependencyListEntry>();
+        }
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        {
+            return Array.Empty<CombinedDependencyListEntry>();
+        }
+
+        public override bool HasDynamicDependencies
+        {
+            get
+            {
+                if (_method.IsCanonicalMethod(CanonicalFormKind.Specific))
+                    return false;
+
+                if (_method.OwningType.IsCanonicalSubtype(CanonicalFormKind.Universal) &&
+                    _method.OwningType != _method.OwningType.ConvertToCanonForm(CanonicalFormKind.Universal))
+                    return false;
+
+                return true;
+            }
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
+        {
+            Debug.Assert(_method.IsVirtual && _method.HasInstantiation);
+
+            List<CombinedDependencyListEntry> dynamicDependencies = new List<CombinedDependencyListEntry>();
+
+            for (int i = firstNode; i < markedNodes.Count; i++)
+            {
+                DependencyNodeCore<NodeFactory> entry = markedNodes[i];
+                EETypeNode entryAsEETypeNode = entry as EETypeNode;
+
+                if (entryAsEETypeNode == null)
+                    continue;
+
+                TypeDesc potentialOverrideType = entryAsEETypeNode.Type;
+                if (!(potentialOverrideType is DefType))
+                    continue;
+
+                Debug.Assert(!potentialOverrideType.IsRuntimeDeterminedSubtype);
+
+                if (_method.OwningType.HasSameTypeDefinition(potentialOverrideType) && potentialOverrideType.IsInterface && (potentialOverrideType != _method.OwningType))
+                {
+                    if (_method.OwningType.CanCastTo(potentialOverrideType))
+                    {
+                        // Variance expansion
+                        MethodDesc matchingMethodOnRelatedVariantMethod = potentialOverrideType.GetMethod(_method.Name, _method.GetTypicalMethodDefinition().Signature);
+                        matchingMethodOnRelatedVariantMethod = _method.Context.GetInstantiatedMethod(matchingMethodOnRelatedVariantMethod, _method.Instantiation);
+                        dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(matchingMethodOnRelatedVariantMethod), null, "GVM Variant Interface dependency"));
+                    }
+                }
+
+                // If this is an interface gvm, look for types that implement the interface
+                // and other instantantiations that have the same canonical form.
+                // This ensure the various slot numbers remain equivalent across all types where there is an equivalence
+                // relationship in the vtable.
+                if (_method.OwningType.IsInterface)
+                {
+                    if (potentialOverrideType.IsInterface)
+                        continue;
+
+                    foreach (DefType interfaceImpl in potentialOverrideType.RuntimeInterfaces)
+                    {
+                        if (interfaceImpl.ConvertToCanonForm(CanonicalFormKind.Specific) == _method.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific))
+                        {
+                            // Find if the type implements this method. (Note, do this comparision against the generic definition of the method, not the
+                            // specific method instantiation that is "method"
+                            MethodDesc genericDefinition = interfaceImpl.GetMethod(_method.Name, _method.GetTypicalMethodDefinition().Signature);
+                            MethodDesc slotDecl = potentialOverrideType.ResolveInterfaceMethodTarget(genericDefinition);
+                            if (slotDecl != null)
+                                CreateDependencyForMethodSlotAndInstantiation(slotDecl, dynamicDependencies, factory);
+                        }
+                    }
+                }
+                else
+                {
+                    // TODO: Ensure GVM Canon Target
+
+                    TypeDesc overrideTypeCanonCur = potentialOverrideType;
+                    TypeDesc methodCanonContainingType = _method.OwningType;
+                    while (overrideTypeCanonCur != null)
+                    {
+                        if (overrideTypeCanonCur.ConvertToCanonForm(CanonicalFormKind.Specific) == methodCanonContainingType.ConvertToCanonForm(CanonicalFormKind.Specific))
+                        {
+                            MethodDesc methodDefInDerivedType = potentialOverrideType.GetMethod(_method.Name, _method.GetTypicalMethodDefinition().Signature);
+                            if(methodDefInDerivedType != null)
+                                CreateDependencyForMethodSlotAndInstantiation(methodDefInDerivedType, dynamicDependencies, factory);
+
+                            MethodDesc slotDecl = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(_method);
+                            if (slotDecl != null)
+                                CreateDependencyForMethodSlotAndInstantiation(slotDecl.GetMethodDefinition(), dynamicDependencies, factory);
+                        }
+
+                        overrideTypeCanonCur = overrideTypeCanonCur.BaseType;
+                    }
+                }
+            }
+            return dynamicDependencies;
+        }
+
+        private void CreateDependencyForMethodSlotAndInstantiation(MethodDesc methodDef, List<CombinedDependencyListEntry> dynamicDependencies, NodeFactory factory)
+        {
+            Debug.Assert(methodDef != null);
+            Debug.Assert(!methodDef.Signature.IsStatic);
+
+            if (methodDef.IsAbstract)
+                return;
+
+            MethodDesc derivedMethodInstantiation = _method.Context.GetInstantiatedMethod(methodDef, _method.Instantiation);
+
+            // Universal canonical instantiations should be entirely universal canon
+            if (derivedMethodInstantiation.IsCanonicalMethod(CanonicalFormKind.Universal))
+            {
+                derivedMethodInstantiation = derivedMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Universal);
+            }
+
+            // TODO: verify for invalid instantiations, like List<void>?
+            bool validInstantiation = 
+                derivedMethodInstantiation.IsSharedByGenericInstantiations ||       // Non-exact methods are always valid instantiations (always pass constraints check)
+                derivedMethodInstantiation.CheckConstraints();                      // Verify that the instantiation does not violate constraints
+
+            if (validInstantiation)
+            {
+                MethodDesc canonMethodTarget = derivedMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
+                bool getUnboxingStub = (derivedMethodInstantiation.OwningType.IsValueType || derivedMethodInstantiation.OwningType.IsEnum);
+                dynamicDependencies.Add(new CombinedDependencyListEntry(factory.MethodEntrypoint(canonMethodTarget, getUnboxingStub), null, "DerivedMethodInstantiation"));
+
+                if (canonMethodTarget != derivedMethodInstantiation)
+                {
+                    // Dependency includes the generic method dictionary of the instantiation
+                    // TODO: detect large recursive generics and fallback to USG templates
+                    Debug.Assert(!derivedMethodInstantiation.IsCanonicalMethod(CanonicalFormKind.Any));
+                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.MethodGenericDictionary(derivedMethodInstantiation), null, "DerivedMethodInstantiation dictionary"));
+                }
+            }
+            else
+            {
+                // TODO: universal generics
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
@@ -1,0 +1,151 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between reflection metadata and generated method bodies.
+    /// </summary>
+    internal sealed class GenericVirtualMethodTableNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+        private Dictionary<MethodDesc, Dictionary<TypeDesc, MethodDesc>> _gvmImplemenations;
+
+        public GenericVirtualMethodTableNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__gvm_table_End", true);
+            _externalReferences = externalReferences;
+            _gvmImplemenations = new Dictionary<MethodDesc, Dictionary<TypeDesc, MethodDesc>>();
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__gvm_table");
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        /// <summary>
+        /// Helper method to compute the dependencies that would be needed by a hashtable entry for a GVM call.
+        /// This helper is used by the TypeGVMEntriesNode, which is used by the dependency analysis to compute the 
+        /// GVM hashtable entries for the compiled types.
+        /// The dependencies returned from this function will be reported as static dependencies of the TypeGVMEntriesNode,
+        /// which we create for each type that has generic virtual methods.
+        /// </summary>
+        public static DependencyList GetGenericVirtualMethodImplementationDependencies(NodeFactory factory, MethodDesc callingMethod, MethodDesc implementationMethod)
+        {
+            Debug.Assert(!callingMethod.OwningType.IsInterface);
+
+            DependencyList dependencyNodes = new DependencyList();
+
+            // Compute the open method signatures
+            MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
+            MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
+
+            var openCallingMethodNameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(openCallingMethod);
+            var openImplementationMethodNameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(openImplementationMethod);
+
+            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openCallingMethodNameAndSig), "gvm table calling method signature"));
+            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openImplementationMethodNameAndSig), "gvm table implementation method signature"));
+
+            return dependencyNodes;
+        }
+
+        private void AddGenericVirtualMethodImplementation(NodeFactory factory, MethodDesc callingMethod, MethodDesc implementationMethod)
+        {
+            Debug.Assert(!callingMethod.OwningType.IsInterface);
+
+            // Compute the open method signatures
+            MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
+            MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
+
+            // Insert open method signatures into the GVM map
+            if (!_gvmImplemenations.ContainsKey(openCallingMethod))
+                _gvmImplemenations[openCallingMethod] = new Dictionary<TypeDesc, MethodDesc>();
+
+            _gvmImplemenations[openCallingMethod][openImplementationMethod.OwningType] = openImplementationMethod;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            // Build the GVM table entries from the list of interesting GVMTableEntryNodes
+            foreach (var interestingEntry in factory.MetadataManager.GetTypeGVMEntries())
+            {
+                foreach (var typeGVMEntryInfo in interestingEntry.ScanForGenericVirtualMethodEntries())
+                {
+                    AddGenericVirtualMethodImplementation(factory, typeGVMEntryInfo.CallingMethod, typeGVMEntryInfo.ImplementationMethod);
+                }
+            }
+
+            // Ensure the native layout blob has been saved
+            factory.MetadataManager.NativeLayoutInfo.SaveNativeLayoutInfoWriter(factory);
+
+            NativeWriter nativeFormatWriter = new NativeWriter();
+            VertexHashtable gvmHashtable = new VertexHashtable();
+
+            Section gvmHashtableSection = nativeFormatWriter.NewSection();
+            gvmHashtableSection.Place(gvmHashtable);
+
+            // Emit the GVM target information entries
+            foreach (var gvmEntry in _gvmImplemenations)
+            {
+                Debug.Assert(!gvmEntry.Key.OwningType.IsInterface);
+
+                foreach (var implementationEntry in gvmEntry.Value)
+                {
+                    MethodDesc callingMethod = gvmEntry.Key;
+                    TypeDesc implementationType = implementationEntry.Key;
+                    MethodDesc implementationMethod = implementationEntry.Value;
+
+                    uint callingTypeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(callingMethod.OwningType));
+                    Vertex vertex = nativeFormatWriter.GetUnsignedConstant(callingTypeId);
+
+                    uint targetTypeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(implementationType));
+                    vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant(targetTypeId));
+
+                    var nameAndSig = factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.MethodNameAndSignatureVertex(callingMethod));
+                    vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)nameAndSig.SavedVertex.VertexOffset));
+
+                    nameAndSig = factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.MethodNameAndSignatureVertex(implementationMethod));
+                    vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)nameAndSig.SavedVertex.VertexOffset));
+
+                    int hashCode = callingMethod.OwningType.GetHashCode();
+                    hashCode = ((hashCode << 13) ^ hashCode) ^ implementationType.GetHashCode();
+
+                    gvmHashtable.Append((uint)hashCode, gvmHashtableSection.Place(vertex));
+                }
+            }
+
+            // Zero out the dictionary so that we AV if someone tries to insert after we're done.
+            _gvmImplemenations = null;
+
+            MemoryStream stream = new MemoryStream();
+            nativeFormatWriter.Save(stream);
+            byte[] streamBytes = stream.ToArray();
+
+            _endSymbol.SetSymbolOffset(streamBytes.Length);
+
+            return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
@@ -1,0 +1,220 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map between reflection metadata and generated method bodies.
+    /// </summary>
+    internal sealed class InterfaceGenericVirtualMethodTableNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+        private Dictionary<MethodDesc, HashSet<MethodDesc>> _interfaceGvmSlots;
+        private Dictionary<MethodDesc, Dictionary<TypeDesc, HashSet<int>>> _interfaceImpls;
+
+        public InterfaceGenericVirtualMethodTableNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__interface_gvm_table_End", true);
+            _externalReferences = externalReferences;
+            _interfaceGvmSlots = new Dictionary<MethodDesc, HashSet<MethodDesc>>();
+            _interfaceImpls = new Dictionary<MethodDesc, Dictionary<TypeDesc, HashSet<int>>>();
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__interface_gvm_table");
+        }
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        /// <summary>
+        /// Helper method to compute the dependencies that would be needed by a hashtable entry for an interface GVM call.
+        /// This helper is used by the TypeGVMEntriesNode, which is used by the dependency analysis to compute the 
+        /// GVM hashtable entries for the compiled types.
+        /// The dependencies returned from this function will be reported as static dependencies of the TypeGVMEntriesNode,
+        /// which we create for each type that has generic virtual methods.
+        /// </summary>
+        public static DependencyList GetGenericVirtualMethodImplementationDependencies(NodeFactory factory, MethodDesc callingMethod, TypeDesc implementationType, MethodDesc implementationMethod)
+        {
+            Debug.Assert(callingMethod.OwningType.IsInterface);
+
+            DependencyList dependencyNodes = new DependencyList();
+
+            // Compute the open method signatures
+            MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
+            MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
+            TypeDesc openImplementationType = implementationType.GetTypeDefinition();
+
+            var openCallingMethodNameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(openCallingMethod);
+            var openImplementationMethodNameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(openImplementationMethod);
+
+            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openCallingMethodNameAndSig), "interface gvm table calling method signature"));
+            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openImplementationMethodNameAndSig), "interface gvm table implementation method signature"));
+
+            if (!openImplementationType.IsInterface)
+            {
+                for(int index = 0; index < implementationType.RuntimeInterfaces.Length; index++)
+                {
+                    if (implementationType.RuntimeInterfaces[index] == callingMethod.OwningType)
+                    {
+                        TypeDesc currentInterface = openImplementationType.RuntimeInterfaces[index];
+                        var currentInterfaceSignature = factory.NativeLayout.TypeSignatureVertex(currentInterface);
+                        dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(currentInterfaceSignature), "interface gvm table interface signature"));
+                    }
+                }
+            }
+
+            return dependencyNodes;
+        }
+
+        private void AddGenericVirtualMethodImplementation(NodeFactory factory, MethodDesc callingMethod, TypeDesc implementationType, MethodDesc implementationMethod)
+        {
+            Debug.Assert(callingMethod.OwningType.IsInterface);
+
+            // Compute the open method signatures
+            MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
+            MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
+            TypeDesc openImplementationType = implementationType.GetTypeDefinition();
+
+            // Add the entry to the interface GVM slots mapping table
+            if (!_interfaceGvmSlots.ContainsKey(openCallingMethod))
+                _interfaceGvmSlots[openCallingMethod] = new HashSet<MethodDesc>();
+            _interfaceGvmSlots[openCallingMethod].Add(openImplementationMethod);
+
+            // If the implementation method is implementing some interface method, compute which
+            // interface explicitly implemented on the type that the current method implements an interface method for.
+            // We need this because at runtime, the interfaces explicitly implemented on the type will have 
+            // runtime-determined signatures that we can use to make generic substitutions and check for interface matching.
+            if (!openImplementationType.IsInterface)
+            {
+                if (!_interfaceImpls.ContainsKey(openImplementationMethod))
+                    _interfaceImpls[openImplementationMethod] = new Dictionary<TypeDesc, HashSet<int>>();
+                if (!_interfaceImpls[openImplementationMethod].ContainsKey(openImplementationType))
+                    _interfaceImpls[openImplementationMethod][openImplementationType] = new HashSet<int>();
+                
+                int numIfacesAdded = 0;
+                for (int index = 0; index < implementationType.RuntimeInterfaces.Length; index++)
+                {
+                    if (implementationType.RuntimeInterfaces[index] == callingMethod.OwningType)
+                    {
+                        _interfaceImpls[openImplementationMethod][openImplementationType].Add(index);
+                        numIfacesAdded++;
+                    }
+                }
+
+                Debug.Assert(numIfacesAdded > 0);
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            // Build the GVM table entries from the list of interesting GVMTableEntryNodes
+            foreach (var interestingEntry in factory.MetadataManager.GetTypeGVMEntries())
+            {
+                foreach (var typeGVMEntryInfo in interestingEntry.ScanForInterfaceGenericVirtualMethodEntries())
+                {
+                    AddGenericVirtualMethodImplementation(factory, typeGVMEntryInfo.CallingMethod, typeGVMEntryInfo.ImplementationType, typeGVMEntryInfo.ImplementationMethod);
+                }
+            }
+
+            // Ensure the native layout blob has been saved
+            factory.MetadataManager.NativeLayoutInfo.SaveNativeLayoutInfoWriter(factory);
+
+            NativeWriter nativeFormatWriter = new NativeWriter();
+            VertexHashtable gvmHashtable = new VertexHashtable();
+
+            Section gvmHashtableSection = nativeFormatWriter.NewSection();
+            gvmHashtableSection.Place(gvmHashtable);
+
+            // Emit the interface slot resolution entries
+            foreach (var gvmEntry in _interfaceGvmSlots)
+            {
+                Debug.Assert(gvmEntry.Key.OwningType.IsInterface);
+
+                MethodDesc callingMethod = gvmEntry.Key;
+
+                // Emit the method signature and containing type of the current interface method
+                uint typeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(callingMethod.OwningType));
+                var nameAndSig = factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.MethodNameAndSignatureVertex(callingMethod));
+                Vertex vertex = nativeFormatWriter.GetTuple(
+                    nativeFormatWriter.GetUnsignedConstant(typeId),
+                    nativeFormatWriter.GetUnsignedConstant((uint)nameAndSig.SavedVertex.VertexOffset));
+
+                // Emit the method name / sig and containing type of each GVM target method for the current interface method entry
+                vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)gvmEntry.Value.Count));
+                foreach (MethodDesc implementationMethod in gvmEntry.Value)
+                {
+                    nameAndSig = factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.MethodNameAndSignatureVertex(implementationMethod));
+                    typeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(implementationMethod.OwningType));
+                    vertex = nativeFormatWriter.GetTuple(
+                        vertex,
+                        nativeFormatWriter.GetUnsignedConstant((uint)nameAndSig.SavedVertex.VertexOffset),
+                        nativeFormatWriter.GetUnsignedConstant(typeId));
+
+                    // Emit the interface GVM slot details for each type that implements the interface methods
+                    {
+                        Debug.Assert(_interfaceImpls.ContainsKey(implementationMethod));
+
+                        var ifaceImpls = _interfaceImpls[implementationMethod];
+                    
+                        // First, emit how many types have method implementations for this interface method entry
+                        vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)ifaceImpls.Count));
+                    
+                        // Emit each type that implements the interface method, and the interface signatures for the interfaces implemented by the type
+                        foreach (var currentImpl in ifaceImpls)
+                        {
+                            TypeDesc implementationType = currentImpl.Key;
+
+                            typeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(implementationType));
+                            vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant(typeId));
+                    
+                            // Emit information on which interfaces the current method entry provides implementations for
+                            vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)currentImpl.Value.Count));
+                            foreach (var ifaceId in currentImpl.Value)
+                            {
+                                // Emit the signature of the current interface implemented by the method
+                                Debug.Assert(((uint)ifaceId) < implementationType.RuntimeInterfaces.Length);
+                                TypeDesc currentInterface = implementationType.RuntimeInterfaces[ifaceId];
+                                var typeSig = factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.TypeSignatureVertex(currentInterface));
+                                vertex = nativeFormatWriter.GetTuple(vertex, nativeFormatWriter.GetUnsignedConstant((uint)typeSig.SavedVertex.VertexOffset));
+                            }
+                        }
+                    }
+                }
+
+                int hashCode = callingMethod.OwningType.GetHashCode();
+                gvmHashtable.Append((uint)hashCode, gvmHashtableSection.Place(vertex));
+            }
+
+            // Zero out the dictionary so that we AV if someone tries to insert after we're done.
+            _interfaceGvmSlots = null;
+
+            MemoryStream stream = new MemoryStream();
+            nativeFormatWriter.Save(stream);
+            byte[] streamBytes = stream.ToArray();
+
+            _endSymbol.SetSymbolOffset(streamBytes.Length);
+
+            return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -107,6 +107,13 @@ namespace ILCompiler.DependencyAnalysis
                     dependencies = dependencies ?? new DependencyList();
                     dependencies.AddRange(exactMethodInstantiationDependencies);
                 }
+
+                if (_method.IsVirtual)
+                {
+                    // Generic virtual methods dependency tracking
+                    dependencies = dependencies ?? new DependencyList();
+                    dependencies.Add(new DependencyListEntry(factory.GVMDependencies(_method), "GVM Dependencies Support"));
+                }
             }
 
             return dependencies;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -192,6 +192,16 @@ namespace ILCompiler.DependencyAnalysis
                 return new FatFunctionPointerNode(method);
             });
 
+            _gvmDependenciesNode = new NodeCache<MethodDesc, GVMDependenciesNode>(method =>
+            {
+                return new GVMDependenciesNode(method);
+            });
+
+            _gvmTableEntries = new NodeCache<TypeDesc, TypeGVMEntriesNode>(type =>
+            {
+                return new TypeGVMEntriesNode(type);
+            });
+
             _shadowConcreteMethods = new NodeCache<MethodDesc, IMethodNode>(method =>
             {
                 return new ShadowConcreteMethodNode<MethodCodeNode>(method,
@@ -518,6 +528,18 @@ namespace ILCompiler.DependencyAnalysis
         public IMethodNode FatFunctionPointer(MethodDesc method)
         {
             return _fatFunctionPointers.GetOrAdd(method);
+        }
+
+        private NodeCache<MethodDesc, GVMDependenciesNode> _gvmDependenciesNode;
+        internal GVMDependenciesNode GVMDependencies(MethodDesc method)
+        {
+            return _gvmDependenciesNode.GetOrAdd(method);
+        }
+
+        private NodeCache<TypeDesc, TypeGVMEntriesNode> _gvmTableEntries;
+        internal TypeGVMEntriesNode TypeGVMEntries(TypeDesc type)
+        {
+            return _gvmTableEntries.GetOrAdd(type);
         }
 
         private NodeCache<MethodDesc, IMethodNode> _shadowConcreteMethods;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -156,6 +156,16 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Address Load");
                 return dependencyList;
             }
+            else if (_id == ReadyToRunHelperId.ResolveGenericVirtualMethod)
+            {
+                MethodDesc method = _target as MethodDesc;
+                Debug.Assert(method != null && method.HasInstantiation && method.IsVirtual);
+
+                // GVM dependency tracking
+                DependencyList dependencyList = new DependencyList();
+                dependencyList.Add(new DependencyListEntry(factory.GVMDependencies(method), "R2R GVM dependency tracking"));
+                return dependencyList;
+            }
             else
             {
                 return null;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.TypeSystem;
+using ILCompiler.DependencyAnalysisFramework;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// This node is used for GVM dependency analysis and GVM tables building. Given an input
+    /// type, this node can scan the type for a list of GVM table entries, and compute their dependencies.
+    /// </summary>
+    internal sealed class TypeGVMEntriesNode : DependencyNodeCore<NodeFactory>
+    {
+        internal class TypeGVMEntryInfo
+        {
+            public TypeGVMEntryInfo(MethodDesc callingMethod, MethodDesc implementationMethod, TypeDesc implementationType)
+            {
+                CallingMethod = callingMethod;
+                ImplementationMethod = implementationMethod;
+                ImplementationType = implementationType;
+            }
+            public MethodDesc CallingMethod { get; private set; }
+            public MethodDesc ImplementationMethod { get; private set; }
+            public TypeDesc ImplementationType { get; private set; }
+        }
+         
+        private TypeDesc _associatedType;
+        private DependencyList _staticDependencies;
+
+        public TypeGVMEntriesNode(TypeDesc associatedType)
+        {
+            Debug.Assert(!associatedType.IsRuntimeDeterminedSubtype);
+            Debug.Assert(TypeNeedsGVMTableEntries(associatedType));
+            _associatedType = associatedType;
+        }
+
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => "__TypeGVMEntriesNode_" + NodeFactory.NameMangler.GetMangledTypeName(_associatedType);
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
+        {
+            return Array.Empty<CombinedDependencyListEntry>();
+        }
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context)
+        {
+            return Array.Empty<CombinedDependencyListEntry>();
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            if (_staticDependencies == null)
+            {
+                _staticDependencies = new DependencyList();
+
+                foreach(var entry in ScanForGenericVirtualMethodEntries())
+                    _staticDependencies.AddRange(GenericVirtualMethodTableNode.GetGenericVirtualMethodImplementationDependencies(context, entry.CallingMethod, entry.ImplementationMethod));
+
+                foreach (var entry in ScanForInterfaceGenericVirtualMethodEntries())
+                    _staticDependencies.AddRange(InterfaceGenericVirtualMethodTableNode.GetGenericVirtualMethodImplementationDependencies(context, entry.CallingMethod, entry.ImplementationType, entry.ImplementationMethod));
+            }
+
+            return _staticDependencies;
+        }
+
+        public static bool TypeNeedsGVMTableEntries(TypeDesc type)
+        {
+            // Only non-interface deftypes can have entries for their GVMs in the GVM hashtables.
+            // Interface GVM entries are computed for types that implemenent the interface (not for the interface on its own)
+            if(!type.IsDefType || type.IsInterface)
+                return false;
+
+            return type.HasGenericVirtualMethod();
+        }
+
+        public IEnumerable<TypeGVMEntryInfo> ScanForGenericVirtualMethodEntries()
+        {
+            foreach (var method in _associatedType.GetMethods())
+            {
+                if (!method.IsVirtual || !method.HasInstantiation)
+                    continue;
+
+                MethodDesc slotDecl = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                Debug.Assert(slotDecl != null);
+                yield return new TypeGVMEntryInfo(slotDecl, method, null);
+            }
+        }
+
+        public IEnumerable<TypeGVMEntryInfo> ScanForInterfaceGenericVirtualMethodEntries()
+        {
+            foreach (var iface in _associatedType.RuntimeInterfaces)
+            {
+                foreach (var method in iface.GetMethods())
+                {
+                    if (!method.HasInstantiation || method.Signature.IsStatic)
+                        continue;
+
+                    MethodDesc slotDecl = _associatedType.ResolveInterfaceMethodTarget(method);
+                    if (slotDecl != null)
+                        yield return new TypeGVMEntryInfo(method, slotDecl, _associatedType);
+                }
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -60,6 +60,10 @@ namespace ILCompiler.DependencyAnalysis
                 if (!method.IsVirtual)
                     continue;
 
+                // GVMs are not emitted in the type's vtable.
+                if (method.HasInstantiation)
+                    continue;
+
                 slots.Add(method);
             }
 
@@ -121,6 +125,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AddEntry(NodeFactory factory, MethodDesc virtualMethod)
         {
+            // GVMs are not emitted in the type's vtable.
+            Debug.Assert(!virtualMethod.HasInstantiation);
             Debug.Assert(virtualMethod.IsVirtual);
 #if DEBUG
             Debug.Assert(!_slotsCommitted);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.DependencyAnalysis
             // If the VTable slice is getting built on demand, the fact that the virtual method is used means
             // that the slot is used.
             var lazyVTableSlice = factory.VTable(_decl.OwningType) as LazilyBuiltVTableSliceNode;
-            if (lazyVTableSlice != null)
+            if (lazyVTableSlice != null && !_decl.HasInstantiation)
                 lazyVTableSlice.AddEntry(factory, _decl);
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -84,5 +84,20 @@ namespace ILCompiler
                 !method.Signature.IsStatic &&
                 !method.ImplementationType.IsValueType;
         }
+
+
+        /// <summary>
+        /// Gets a value indicating whether this type has any generic virtual methods.
+        /// </summary>
+        public static bool HasGenericVirtualMethod(this TypeDesc type)
+        {
+            foreach (var method in type.GetAllMethods())
+            {
+                if (method.IsVirtual && method.HasInstantiation)
+                    return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -102,13 +102,17 @@
     <Compile Include="Compiler\DelegateCreationInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayMapNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericVirtualMethodTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\InterfaceGenericVirtualMethodTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\TypeGVMEntriesNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GVMDependenciesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionFieldMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\NativeLayoutInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\NativeLayoutVertexNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NativeLayoutSignatureNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericsHashtableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExactMethodInstantiationsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeMethodHandleNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\NativeLayoutSignatureNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunGenericHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfFrozenObjectsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ClassConstructorContextMap.cs" />
@@ -131,7 +135,7 @@
     <Compile Include="Compiler\DependencyAnalysis\IEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\INodeWithRuntimeDeterminedDependencies.cs" />
     <Compile Include="Compiler\DependencyAnalysis\PInvokeMethodFixupNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\PInvokeModuleFixupNode.cs" />    
+    <Compile Include="Compiler\DependencyAnalysis\PInvokeModuleFixupNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ResourceDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ResourceIndexNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RyuJitNodeFactory.cs" />

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/InterfaceArrangements.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/InterfaceArrangements.cs
@@ -7,32 +7,39 @@ using System.Runtime.InteropServices;
 
 namespace InterfaceArrangements
 {
-    interface I1
-    {
-    }
+    interface I1 { }
 
-    interface I2 : I1
-    {
-    }
+    interface I2 : I1 { }
     
-    interface IGen1<T>
-    {
+    interface IGen1<T> { }
 
+    class NoInterfaces { }
+
+    class OneInterface : I1 { }
+
+    class Base<T> : IGen1<T>, I1 { }
+
+    class Mid<U,V> : Base<U>, IGen1<V> { }
+
+    class DerivedFromMid : Mid<string, string>, IGen1<string> { }
+
+    interface IFoo<out U>
+    {
+        void IMethod();
     }
 
-    class NoInterfaces
-    {}
-
-    class OneInterface : I1
-    { }
-
-    class Base<T> : IGen1<T>, I1
+    class Foo : IFoo<string>, IFoo<int>
     {
+        public virtual void IMethod() { }
     }
 
-    class Mid<U,V> : Base<U>, IGen1<V>
-    { }
+    class DerivedFromFoo : Foo, IFoo<string>, IFoo<int>
+    {
+        void IFoo<string>.IMethod() { }
+    }
 
-    class DerivedFromMid : Mid<string, string>, IGen1<string>
-    { }
+    class SuperDerivedFromFoo : DerivedFromFoo, IFoo<string>, IFoo<int>
+    {
+        void IFoo<int>.IMethod() { }
+    }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
@@ -91,8 +91,7 @@ namespace Internal.Runtime.TypeLoader
             nameAndSignature = null;
 
             NativeReader reader = GetNativeLayoutInfoReader(signature.ModuleHandle);
-            uint offset = signature.NativeLayoutOffset;
-            NativeParser parser = new NativeParser(reader, offset);
+            NativeParser parser = new NativeParser(reader, signature.NativeLayoutOffset);
             if (parser.IsNull)
                 return false;
 
@@ -109,8 +108,7 @@ namespace Internal.Runtime.TypeLoader
             methodSig = default(RuntimeSignature);
 
             NativeReader reader = GetNativeLayoutInfoReader(module);
-            uint offset = methodNameAndSigToken;
-            NativeParser parser = new NativeParser(reader, offset);
+            NativeParser parser = new NativeParser(reader, methodNameAndSigToken);
             if (parser.IsNull)
                 return false;
 


### PR DESCRIPTION
GVM dependency tracking analysis and GVM table building logic:
    1) GenericVirtualMethodTableNode: Node that builds the GVM hashtable blob for GVMs on classes
    2) InterfaceGenericVirtualMethodTableNode: Node that builds the GVM hashtable blob for GVMs on interfaces
    3) MethodLdTokenNode: Analysis node that tracks dependencies of GVMs for derived types and variant interfaces
    4) TypeGVMEntriesNode: Analysis node that scans an input type and computes the list of GVM entries that would be added to the hashtables. Also used to track dependencies of GVM table entries (ex: native layout signatures of methods).

Couple of additions to the typesystem:
    1) New helper method to compute whether a type has generic virtual methods
    2) Concrete constraints validation for types and methods.