### PR TITLE
Adding ISerializable to System.Delegate/System.MulticastDelegate

### DIFF
--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -5,6 +5,7 @@
 using System.Text;
 using System.Runtime;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
@@ -19,7 +20,7 @@ namespace System
     // sequential layout directive so that Bartok matches it.
     [StructLayout(LayoutKind.Sequential)]
     [DebuggerDisplay("Target method(s) = {GetTargetMethodsDescriptionForDebugger()}")]
-    public abstract partial class Delegate : ICloneable
+    public abstract partial class Delegate : ICloneable, ISerializable
     {
         // This ctor exists solely to prevent C# from generating a protected .ctor that violates the surface area. I really want this to be a
         // "protected-and-internal" rather than "internal" but C# has no keyword for the former.
@@ -705,6 +706,11 @@ namespace System
         public virtual object Clone()
         {
             return MemberwiseClone();
+        }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            throw new NotSupportedException();
         }
 
         internal bool IsOpenStatic

--- a/src/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -3,13 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 
 using Internal.Runtime.CompilerServices;
 
 namespace System
 {
-    public abstract class MulticastDelegate : Delegate
+    public abstract class MulticastDelegate : Delegate, ISerializable
     {
         // This ctor exists solely to prevent C# from generating a protected .ctor that violates the surface area. I really want this to be a
         // "protected-and-internal" rather than "internal" but C# has no keyword for the former.
@@ -113,6 +114,11 @@ namespace System
         public override sealed Delegate[] GetInvocationList()
         {
             return base.GetInvocationList();
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Doing this now because the lack of it is forcing us to
spam apicompat baselines with exemptions for every
delegate type in the framework.

System.Delegate.GetObjectData() just throws
NotSupportedException so that's easy to implement now.

System.MulticastDelegate.GetObjectData() is more
complicated and probably needs MethodInfo
serialization to work first. So this is a stub.