### PR TITLE
Update default clang version to 3.9 and require xcode 8

### DIFF
--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -12,12 +12,19 @@ PowerShell also needs to be available from the PATH environment variable (it's t
 
 Install basic dependency packages:
 
-```
-sudo apt-get install cmake llvm-3.5 clang-3.5 lldb-3.6 lldb-3.6-dev liblttng-ust liblttng-ust-dev uuid uuid-dev
+First add a new package source to be able to install clang-3.9:
+```sh
+echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo apt-get update
 ```
 
-# Mac OSX (10.10+)
+```sh
+sudo apt-get install cmake clang-3.9 libicu52 libunwind8
+```
 
-1. Install [Command Line Tools for XCode 6.3.1](https://developer.apple.com/xcode/download/) or higher. 
+# Mac OSX (10.11.5+)
+
+1. Install [Command Line Tools for XCode 8](https://developer.apple.com/xcode/download/) or higher. 
 2. Install [CMake](https://cmake.org/download/). Launch `/Applications/CMake.app/Contents/MacOS/CMake` GUI. Goto "OSX App Menu -> Tools -> Install For Command Line Use" and follow the steps. CMake < 3.6 has [a bug](https://cmake.org/Bug/view.php?id=16064) that can make `--install` fail. Do `sudo mkdir /usr/local/bin` to work around.
 3. Install OpenSSL. Build tools have a dependency on OpenSSL. You can use [Homebrew](http://brew.sh/) to install it: with Homebrew installed, run `brew install openssl` followed by `ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/`, followed by `ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/`.

--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -149,7 +149,7 @@ export __UnprocessedBuildArgs=
 export __CleanBuild=0
 export __VerboseBuild=0
 export __ClangMajorVersion=3
-export __ClangMinorVersion=5
+export __ClangMinorVersion=9
 export __CrossBuild=0
 
 
@@ -201,6 +201,14 @@ while [ "$1" != "" ]; do
         clang3.7)
             export __ClangMajorVersion=3
             export __ClangMinorVersion=7
+            ;;
+        clang3.8)
+            export __ClangMajorVersion=3
+            export __ClangMinorVersion=8
+            ;;
+        clang3.9)
+            export __ClangMajorVersion=3
+            export __ClangMinorVersion=9
             ;;
         cross)
             export __CrossBuild=1

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -17,7 +17,7 @@ See the LICENSE file in the project root for more information.
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == '' and '$(TargetOS)' == 'OSX'">clang</CppCompilerAndLinker>
-    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang-3.5</CppCompilerAndLinker>
+    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang-3.9</CppCompilerAndLinker>
     <CppCompiler>$(CppCompilerAndLinker)</CppCompiler>
     <CppLinker>$(CppCompilerAndLinker)</CppLinker>
   </PropertyGroup>


### PR DESCRIPTION
This change updates the default clang version used to build CoreRT to the
latest stable version 3.9. It also removes the version 3.5 from the supported
ones. The 3.5 has a bug preventing us from using thread_local C++ feature.

Due to the same reason, the minimum supported xcode version on OSX is 8, so
the prerequisities document is updated accordingly.
The minimum required OSX version is also raised based on the xcode 8 requirement.