### PR TITLE
Make two System.Type methods virtual to conform with 4.2.0.0.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -105,7 +105,7 @@ namespace System
         public bool IsContextful => IsContextfulImpl();
         protected virtual bool IsContextfulImpl() => typeof(ContextBoundObject).IsAssignableFrom(this);
 
-        public bool IsEnum => IsSubclassOf(typeof(Enum));
+        public virtual bool IsEnum => IsSubclassOf(typeof(Enum));
         public bool IsMarshalByRef => IsMarshalByRefImpl();
         protected virtual bool IsMarshalByRefImpl() => typeof(MarshalByRefObject).IsAssignableFrom(this);
         public bool IsPrimitive => IsPrimitiveImpl();
@@ -351,7 +351,7 @@ namespace System
                 return systemType.GetHashCode();
             return base.GetHashCode();
         }
-        public bool Equals(Type o) => o == null ? false : object.ReferenceEquals(this.UnderlyingSystemType, o.UnderlyingSystemType);
+        public virtual bool Equals(Type o) => o == null ? false : object.ReferenceEquals(this.UnderlyingSystemType, o.UnderlyingSystemType);
 
         public static bool operator ==(Type left, Type right)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -141,6 +141,11 @@ namespace System.Reflection.Runtime.TypeInfos
             return object.ReferenceEquals(this, obj);
         }
 
+        public sealed override bool Equals(Type o)
+        {
+            return object.ReferenceEquals(this, o);
+        }
+
         public sealed override int GetHashCode()
         {
             return InternalGetHashCode();
@@ -299,6 +304,14 @@ namespace System.Reflection.Runtime.TypeInfos
             get
             {
                 return false;
+            }
+        }
+
+        public sealed override bool IsEnum
+        {
+            get
+            {
+                return 0 != (Classification & TypeClassification.IsEnum);
             }
         }
 


### PR DESCRIPTION
System.Runtime 4.2.0.0 finally brings IsEnum in line with
the other "Is" predicates....