### PR TITLE
Unix CoreCLR tests CI authoring

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -30,7 +30,10 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
             def newJobName = Utilities.getFullJobName(project, lowercaseConfiguration + '_' + os.toLowerCase(), isPR)
             def buildString = "";
             def prJobDescription = "${os} ${configuration}";
-
+            if (configuration == 'Debug') {
+                prJobDescription += " and CoreCLR tests"
+            }
+            
             // Calculate the build commands
             if (os == 'Windows_NT') {
                 buildString = "build.cmd ${lowercaseConfiguration}"
@@ -38,6 +41,7 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
             }
             else {
                 buildString = "./build.sh ${lowercaseConfiguration}"
+                testScriptString = "tests/runtest.sh -coreclr "
             }
 
             // Create a new job with the specified name.  The brace opens a new closure
@@ -51,7 +55,6 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
 
                         if (configuration == 'Debug') {
                             if (isPR) {
-                                prJobDescription += " and CoreCLR tests"
                                 // Run a small set of BVTs during PR validation
                                 batchFile(testScriptString + "Top200")
                             }
@@ -63,6 +66,20 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
                     }
                     else {
                         shell(buildString)
+
+                        if (configuration == 'Debug') {
+                            if (isPR) {
+                                prJobDescription += " and CoreCLR tests"
+                                // Run a small set of BVTs during PR validation
+                                shell(testScriptString + "top200")
+                            }
+                            else {
+                                // Run the full set of known passing tests in the post-commit job
+
+                                // Todo: Enable push test jobs once we establish a reasonable passing set of tests
+                                // shell(testScriptString + "KnownGood")
+                            }
+                        }
                     }
                 }
             }

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -105,6 +105,11 @@ while [ "$1" != "" ]; do
             shift
             CoreRT_CliBinDir=$1
             ;;
+        -coreclr)
+            shift
+            echo "Tests will run here. For now, early out."
+            exit 0
+            ;;
         *)
             ;;
     esac


### PR DESCRIPTION
Author the CI netci.groovy changes along with a stubbed out `runtest.sh
-coreclr top200` implementation so that the actual PR containing the
test changes will run. This is needed to ensure we don’t break the
build since netci.groovy changes aren’t picked up in a PR (CI takes
netci.groovy from HEAD).