### PR TITLE
Fix build of native components on Alpine

### DIFF
--- a/src/Native/System.Private.CoreLib.Native/pal_datetime.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_datetime.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include <stdlib.h>
+#include <stdint.h>
 #include <sys/time.h>
 
 static const int64_t SECS_TO_100NS = 10000000; /* 10^7 */


### PR DESCRIPTION
This tiny change enables successful build of the native
components on x64 Alpine Linux.