### PR TITLE
Fix PInvoke CPPCodegen

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -406,14 +406,14 @@ namespace Internal.TypeSystem.Interop
                 TypeDesc resolvedType = ((ByRefType)managedType).ParameterType;
 
                 var nativeType = PInvokeMethodData.Context.GetWellKnownType(WellKnownType.IntPtr).MakeByRefType();
-                var vPinnedOutValue = emitter.NewLocal(nativeType, true);
+                var vOutValue = emitter.NewLocal(PInvokeMethodData.Context.GetWellKnownType(WellKnownType.IntPtr));
                 var vSafeHandle = emitter.NewLocal(resolvedType);
                 marshallingCodeStream.Emit(ILOpcode.newobj, emitter.NewToken(resolvedType.GetDefaultConstructor()));
                 marshallingCodeStream.EmitStLoc(vSafeHandle);
-                marshallingCodeStream.EmitLdLoca(vPinnedOutValue);
+                marshallingCodeStream.EmitLdLoca(vOutValue);
 
                 unmarshallingCodeStream.EmitLdLoc(vSafeHandle);
-                unmarshallingCodeStream.EmitLdLoc(vPinnedOutValue);
+                unmarshallingCodeStream.EmitLdLoc(vOutValue);
                 unmarshallingCodeStream.Emit(ILOpcode.call, emitter.NewToken(
                     PInvokeMethodData.SafeHandleType.GetKnownMethod("SetHandle", null)));
 

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -292,7 +292,7 @@ namespace Internal.IL
         private void AppendCastIfNecessary(TypeDesc destType, StackEntry srcEntry)
         {
             ConstantEntry constant = srcEntry as ConstantEntry;
-            if ((constant != null) && (constant.IsCastNecessary(destType)) || !destType.IsValueType)
+            if ((constant != null) && (constant.IsCastNecessary(destType)) || !destType.IsValueType || destType != srcEntry.Type)
             {
                 Append("(");
                 Append(GetSignatureTypeNameAndAddReference(destType));

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 // Name of namespace matches the name of the assembly on purpose to
 // ensure that we can handle this (mostly an issue for C++ code generation).
-namespace PInvoke
+namespace PInvokeTests
 {
     internal class Program
     {
@@ -54,14 +54,19 @@ namespace PInvoke
             return 100;
         }
 
-        public static void ThrowIfNotEquals<T>(T expected, T actual, string message)
+        public static void ThrowIfNotEquals(int expected, int actual, string message)
         {
-            if (!Object.Equals(expected, actual))
+            if (expected != actual)
             {
                 message += "\nExpected: " + expected + "\n";
                 message += "Actual: " + actual + "\n";
                 throw new Exception(message);
             }
+        }
+
+        public static void ThrowIfNotEquals(bool expected, bool actual, string message)
+        {
+           ThrowIfNotEquals(expected ? 1 : 0, actual ? 1 : 0, message);
         }
 
         private static void TestBlittableType()
@@ -123,9 +128,9 @@ namespace PInvoke
 
             Console.WriteLine("Testing marshalling out SafeHandle");
             SafeMemoryHandle hnd2;
-            val = SafeHandleOutTest(out hnd2);
-            int val2 = unchecked((int)hnd2.DangerousGetHandle().ToInt64());
-            ThrowIfNotEquals(val, val2, "SafeHandle out marshalling failed");
+            int actual = SafeHandleOutTest(out hnd2);
+            int expected = unchecked((int)hnd2.DangerousGetHandle().ToInt64());
+            ThrowIfNotEquals(actual, expected, "SafeHandle out marshalling failed");
         }
     }
 

--- a/tests/src/Simple/PInvoke/no_cpp
+++ b/tests/src/Simple/PInvoke/no_cpp
@@ -1,1 +1,0 @@
-Skip this test for cpp codegen mode


### PR DESCRIPTION
This change contains the following:

1. Fixed out SafeHandleMarshaller with CPP codegen as Sedar pointed out.
2. Also enable PInvoke test with CPP Codegen. The generic method
ThrowIfNotEquals doesn't work with CPPCodegen. So temporary created
overrides to address this.

@jkotas @sedarg @yizhang82 