### PR TITLE
Don't fall through endfinally and others

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -778,7 +778,7 @@ namespace Internal.IL
                         break;
                     case ILOpcode.endfinally:
                         ImportEndFinally();
-                        break;
+                        return;
                     case ILOpcode.leave:
                         {
                             int delta = (int)ReadILUInt32();
@@ -837,7 +837,7 @@ namespace Internal.IL
                         break;
                     case ILOpcode.endfilter:
                         ImportEndFilter();
-                        break;
+                        return;
                     case ILOpcode.unaligned:
                         ImportUnalignedPrefix(ReadILByte());
                         continue;
@@ -864,7 +864,7 @@ namespace Internal.IL
                         continue;
                     case ILOpcode.rethrow:
                         ImportRethrow();
-                        break;
+                        return;
                     case ILOpcode.sizeof_:
                         ImportSizeOf(ReadILToken());
                         break;

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
@@ -25,8 +25,8 @@ namespace ILCompiler
         private static readonly LibraryInitializerInfo[] s_assembliesWithLibraryInitializers =
             {
                 new LibraryInitializerInfo(ClassLibraryPlaceHolderString),
-                new LibraryInitializerInfo("System.Private.TypeLoader", false),
-                new LibraryInitializerInfo("System.Private.Reflection.Execution", false),
+                new LibraryInitializerInfo("System.Private.TypeLoader"),
+                new LibraryInitializerInfo("System.Private.Reflection.Execution"),
                 new LibraryInitializerInfo("System.Private.DeveloperExperience.Console"),
             };
 
@@ -39,10 +39,8 @@ namespace ILCompiler
         {
             _context = context;
             //
-            // We should not care which code-gen is being used, however currently CppCodeGen cannot
-            // handle code pulled in by all explicit cctors.
-            //
-            // See https://github.com/dotnet/corert/issues/2518
+            // We should not care which code-gen is being used but for the time being
+            // this can be useful to workaround CppCodeGen bugs.
             //
             _isCppCodeGen = isCppCodeGen;
         }

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -2164,6 +2164,8 @@ namespace Internal.IL
 
         private void ImportEndFinally()
         {
+            _stack.Clear();
+
             int finallyIndex = FindNearestFinally(_currentOffset - 1);
 
             AppendLine();


### PR DESCRIPTION
`endfinally`, `endfilter` and `rethrow` were treated as fallthrough capable when they are not. `endfinally` was also failing to clear the stack.

Fixes #2518