### PR TITLE
Change stackwalking to always use unadjusted IP

### DIFF
--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -498,9 +498,10 @@ typedef enum _EXCEPTION_DISPOSITION {
     ExceptionCollidedUnwind
 } EXCEPTION_DISPOSITION;
 
-#define STATUS_ACCESS_VIOLATION          ((UInt32   )0xC0000005L)    
-#define STATUS_STACK_OVERFLOW            ((UInt32   )0xC00000FDL)    
-#define STATUS_REDHAWK_NULL_REFERENCE    ((UInt32   )0x00000000L)    
+#define STATUS_ACCESS_VIOLATION                     ((UInt32   )0xC0000005L)
+#define STATUS_STACK_OVERFLOW                       ((UInt32   )0xC00000FDL)
+#define STATUS_REDHAWK_NULL_REFERENCE               ((UInt32   )0x00000000L)
+#define STATUS_REDHAWK_WRITE_BARRIER_NULL_REFERENCE ((UInt32   )0x00000042L)
 
 #ifdef PLATFORM_UNIX
 #define NULL_AREA_SIZE                   (4*1024)

--- a/src/Native/Runtime/PalRedhawkCommon.h
+++ b/src/Native/Runtime/PalRedhawkCommon.h
@@ -61,13 +61,14 @@ struct PAL_LIMITED_CONTEXT
     UIntNative GetIp() const { return IP; }
     UIntNative GetSp() const { return SP; }
     UIntNative GetFp() const { return R7; }
+    UIntNative GetLr() const { return LR; }
 #elif defined(_TARGET_ARM64_)
     // @TODO: Add ARM64 registers
     UIntNative IP;
     UIntNative GetIp() const { PORTABILITY_ASSERT("@TODO: FIXME:ARM64"); }
     UIntNative GetSp() const { PORTABILITY_ASSERT("@TODO: FIXME:ARM64"); }
     UIntNative GetFp() const { PORTABILITY_ASSERT("@TODO: FIXME:ARM64"); }
-
+    UIntNative GetLr() const { PORTABILITY_ASSERT("@TODO: FIXME:ARM64"); }
 #elif defined(UNIX_AMD64_ABI)
     // Param regs: rdi, rsi, rdx, rcx, r8, r9, scratch: rax, rdx (both return val), preserved: rbp, rbx, r12-r15
     UIntNative  IP;

--- a/src/Native/Runtime/StackFrameIterator.cpp
+++ b/src/Native/Runtime/StackFrameIterator.cpp
@@ -441,7 +441,7 @@ PTR_VOID StackFrameIterator::HandleExCollide(PTR_ExInfo pExInfo)
         CalculateCurrentMethodState();
         ASSERT(IsValid());
 
-        if ((pExInfo->m_kind == EK_HardwareFault) && (curFlags & RemapHardwareFaultsToSafePoint))
+        if ((pExInfo->m_kind & EK_HardwareFault) && (curFlags & RemapHardwareFaultsToSafePoint))
             m_effectiveSafePointAddress = GetCodeManager()->RemapHardwareFaultToGCSafePoint(&m_methodInfo, m_ControlPC);
     }
     else

--- a/src/Native/Runtime/StackFrameIterator.cpp
+++ b/src/Native/Runtime/StackFrameIterator.cpp
@@ -271,10 +271,18 @@ void StackFrameIterator::InternalInit(Thread * pThreadToWalk, PTR_PInvokeTransit
 
 #ifndef DACCESS_COMPILE
 
-void StackFrameIterator::InternalInitForEH(Thread * pThreadToWalk, PAL_LIMITED_CONTEXT * pCtx)
+void StackFrameIterator::InternalInitForEH(Thread * pThreadToWalk, PAL_LIMITED_CONTEXT * pCtx, bool instructionFault)
 {
     STRESS_LOG0(LF_STACKWALK, LL_INFO10000, "----Init---- [ EH ]\n");
     InternalInit(pThreadToWalk, pCtx, EHStackWalkFlags);
+
+    // Counteract m_ControlPC adjustment that will be done by PrepareToYieldFrame
+    // We treat the IP as a return-address and adjust backward when doing EH-related things.  The faulting
+    // instruction IP here will be the start of the faulting instruction and so we have the right IP for
+    // EH-related things already.
+    if (instructionFault)
+        m_ControlPC = AdjustReturnAddressForward(m_ControlPC);
+
     PrepareToYieldFrame();
     STRESS_LOG1(LF_STACKWALK, LL_INFO10000, "   %p\n", m_ControlPC);
 }
@@ -1505,7 +1513,7 @@ PTR_VOID StackFrameIterator::AdjustReturnAddressForward(PTR_VOID controlPC)
 #ifdef _TARGET_ARM_
     return (PTR_VOID)(((PTR_UInt8)controlPC) + 2);
 #elif defined(_TARGET_ARM64_)
-    PORTABILITY_ASSERT("@TODO: FIXME:ARM64");
+    return (PTR_VOID)(((PTR_UInt8)controlPC) + 4);
 #else
     return (PTR_VOID)(((PTR_UInt8)controlPC) + 1);
 #endif
@@ -1515,7 +1523,7 @@ PTR_VOID StackFrameIterator::AdjustReturnAddressBackward(PTR_VOID controlPC)
 #ifdef _TARGET_ARM_
     return (PTR_VOID)(((PTR_UInt8)controlPC) - 2);
 #elif defined(_TARGET_ARM64_)
-    PORTABILITY_ASSERT("@TODO: FIXME:ARM64");
+    return (PTR_VOID)(((PTR_UInt8)controlPC) - 4);
 #else
     return (PTR_VOID)(((PTR_UInt8)controlPC) - 1);
 #endif
@@ -1572,7 +1580,7 @@ StackFrameIterator::ReturnAddressCategory StackFrameIterator::CategorizeUnadjust
 
 #ifndef DACCESS_COMPILE
 
-COOP_PINVOKE_HELPER(Boolean, RhpSfiInit, (StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx))
+COOP_PINVOKE_HELPER(Boolean, RhpSfiInit, (StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx, Boolean instructionFault))
 {
     Thread * pCurThread = ThreadStore::GetCurrentThread();
 
@@ -1586,7 +1594,7 @@ COOP_PINVOKE_HELPER(Boolean, RhpSfiInit, (StackFrameIterator* pThis, PAL_LIMITED
     if (pStackwalkCtx == NULL)
         pThis->InternalInitForStackTrace();
     else
-        pThis->InternalInitForEH(pCurThread, pStackwalkCtx);
+        pThis->InternalInitForEH(pCurThread, pStackwalkCtx, instructionFault);
 
     bool isValid = pThis->IsValid();
     if (isValid)

--- a/src/Native/Runtime/StackFrameIterator.h
+++ b/src/Native/Runtime/StackFrameIterator.h
@@ -17,7 +17,7 @@ struct EHEnum
     EHEnumState m_state;
 };
 
-EXTERN_C Boolean FASTCALL RhpSfiInit(StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx);
+EXTERN_C Boolean FASTCALL RhpSfiInit(StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx, Boolean instructionFault);
 EXTERN_C Boolean FASTCALL RhpSfiNext(StackFrameIterator* pThis, UInt32* puExCollideClauseIdx, Boolean* pfUnwoundReversePInvoke);
 
 struct PInvokeTransitionFrame;
@@ -27,7 +27,7 @@ typedef DPTR(PAL_LIMITED_CONTEXT) PTR_PAL_LIMITED_CONTEXT;
 class StackFrameIterator
 {
     friend class AsmOffsets;
-    friend Boolean FASTCALL RhpSfiInit(StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx);
+    friend Boolean FASTCALL RhpSfiInit(StackFrameIterator* pThis, PAL_LIMITED_CONTEXT* pStackwalkCtx, Boolean instructionFault);
     friend Boolean FASTCALL RhpSfiNext(StackFrameIterator* pThis, UInt32* puExCollideClauseIdx, Boolean* pfUnwoundReversePInvoke);
 
 public:
@@ -76,7 +76,7 @@ private:
 
     void InternalInit(Thread * pThreadToWalk, PTR_PInvokeTransitionFrame pFrame, UInt32 dwFlags); // GC stackwalk
     void InternalInit(Thread * pThreadToWalk, PTR_PAL_LIMITED_CONTEXT pCtx, UInt32 dwFlags);  // EH and hijack stackwalk, and collided unwind
-    void InternalInitForEH(Thread * pThreadToWalk, PAL_LIMITED_CONTEXT * pCtx);             // EH stackwalk
+    void InternalInitForEH(Thread * pThreadToWalk, PAL_LIMITED_CONTEXT * pCtx, bool instructionFault); // EH stackwalk
     void InternalInitForStackTrace();  // Environment.StackTrace
 
     PTR_VOID HandleExCollide(PTR_ExInfo pExInfo);

--- a/src/Native/Runtime/amd64/ExceptionHandling.S
+++ b/src/Native/Runtime/amd64/ExceptionHandling.S
@@ -26,14 +26,6 @@ NESTED_ENTRY RhpThrowHwEx, _TEXT, NoHandler
         // Align the stack towards zero
         and     rsp, -16
 
-        add     rsi, 1  // 'faulting IP' += 1, we do this because everywhere else we treat the faulting IP as
-                        // a return-address and optionally subtract one when doing EH-related things (but not
-                        // subtracting 1 when doing GC-related things).  The fault IP here will be the start
-                        // of the faulting instruction, so +1 will point to either the next instruction or the
-                        // middle of this instruction.  Either way, when the dispatch / stackwalk code deals
-                        // with this address it'll apply a -1 for EH range checks and the GC-related operations
-                        // don't need to be precise here because the fault location isn't a GC safe point 
-
         xor     rdx, rdx
 
 //  struct PAL_LIMITED_CONTEXT

--- a/src/Native/Runtime/amd64/ExceptionHandling.asm
+++ b/src/Native/Runtime/amd64/ExceptionHandling.asm
@@ -40,14 +40,6 @@ NESTED_ENTRY RhpThrowHwEx, _TEXT
         ; Tell the unwinder that the frame is there now
         .pushframe
 
-        add     rdx, 1  ;; 'faulting IP' += 1, we do this because everywhere else we treat the faulting IP as
-                        ;; a return-address and optionally subtract one when doing EH-related things (but not
-                        ;; subtracting 1 when doing GC-related things).  The fault IP here will be the start
-                        ;; of the faulting instruction, so +1 will point to either the next instruction or the
-                        ;; middle of this instruction.  Either way, when the dispatch / stackwalk code deals
-                        ;; with this address it'll apply a -1 for EH range checks and the GC-related operations
-                        ;; don't need to be precise here because the fault location isn't a GC safe point 
-
         alloc_stack     SIZEOF_XmmSaves + 8h    ;; reserve stack for the xmm saves (+8h to realign stack)
         push_vol_reg    r8                      ;; padding
         push_nonvol_reg r15

--- a/src/Native/Runtime/arm/ExceptionHandling.asm
+++ b/src/Native/Runtime/arm/ExceptionHandling.asm
@@ -26,15 +26,7 @@
         PROLOG_NOP mov r2, r0       ;; save exception code into r2
         PROLOG_NOP mov r0, sp       ;; get SP of fault site
 
-        PROLOG_NOP add lr, r1, #2   ;; 'faulting IP' += 2, we do this because everywhere else we treat the 
-                                    ;; faulting IP as a return-address and optionally subtract one when doing 
-                                    ;; EH-related things (but not subtracting 2 when doing GC-related things).
-                                    ;; The fault IP here will be the start of the faulting instruction, so +2 
-                                    ;; will point to either the next instruction or the middle of this 
-                                    ;; instruction.  Either way, when the dispatch / stackwalk code deals with
-                                    ;; this address it'll apply a -2 for EH range checks and the GC-related 
-                                    ;; operations don't need to be precise here because the fault location 
-                                    ;; isn't a GC safe point 
+        PROLOG_NOP mov lr, r1       ;; set IP of fault size
 
         ;; Setup a PAL_LIMITED_CONTEXT on the stack {
         PROLOG_NOP vpush {d8-d15}

--- a/src/Native/Runtime/i386/ExceptionHandling.asm
+++ b/src/Native/Runtime/i386/ExceptionHandling.asm
@@ -29,15 +29,6 @@ FASTCALL_FUNC  RhpThrowHwEx, 0
         esp_offsetof_ExInfo     textequ %0
         esp_offsetof_Context    textequ %SIZEOF__ExInfo
 
-
-        add     edx, 1  ;; 'faulting IP' += 1, we do this because everywhere else we treat the faulting IP as
-                        ;; a return-address and optionally subtract one when doing EH-related things (but not
-                        ;; subtracting 1 when doing GC-related things).  The fault IP here will be the start
-                        ;; of the faulting instruction, so +1 will point to either the next instruction or the
-                        ;; middle of this instruction.  Either way, when the dispatch / stackwalk code deals
-                        ;; with this address it'll apply a -1 for EH range checks and the GC-related operations
-                        ;; don't need to be precise here because the fault location isn't a GC safe point 
-
         push    edx         ; make it look like we were called by pushing the faulting IP like a return address
         push    ebp
         mov     ebp, esp

--- a/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -198,12 +198,6 @@ namespace System.Runtime
         {
         }
 
-#if ARM
-        private const int c_IPAdjustForHardwareFault = 2;
-#else
-        private const int c_IPAdjustForHardwareFault = 1;
-#endif
-
         internal static unsafe void* PointerAlign(void* ptr, int alignmentInBytes)
         {
             int alignMask = alignmentInBytes - 1;
@@ -234,13 +228,6 @@ namespace System.Runtime
             const int contextAlignment = 16;
             byte* pbBuffer = stackalloc byte[sizeof(OSCONTEXT) + contextAlignment];
             void* pContext = PointerAlign(pbBuffer, contextAlignment);
-
-            // We 'normalized' the faulting IP of hardware faults to behave like return addresses.  Undo this
-            // normalization here so that we report the correct thing in the exception context record.
-            if ((exInfo._kind & ExKind.KindMask) == ExKind.HardwareFault)
-            {
-                exInfo._pExContext->IP = (IntPtr)(((byte*)exInfo._pExContext->IP) - c_IPAdjustForHardwareFault);
-            }
 
             InternalCalls.RhpCopyContextFromExInfo(pContext, sizeof(OSCONTEXT), exInfo._pExContext);
 
@@ -387,6 +374,7 @@ namespace System.Runtime
         private enum HwExceptionCode : uint
         {
             STATUS_REDHAWK_NULL_REFERENCE = 0x00000000u,
+            STATUS_REDHAWK_WRITE_BARRIER_NULL_REFERENCE = 0x00000042u,
 
             STATUS_DATATYPE_MISALIGNMENT = 0x80000002u,
             STATUS_ACCESS_VIOLATION = 0xC0000005u,
@@ -410,19 +398,20 @@ namespace System.Runtime
             None = 0,
             Throw = 1,
             HardwareFault = 2,
-            // unused: 3
             KindMask = 3,
 
             RethrowFlag = 4,
-            Rethrow = 5,        // RethrowFlag | Throw
-            RethrowFault = 6,   // RethrowFlag | HardwareFault
+
+            SuperscededFlag = 8,
+
+            InstructionFaultFlag = 0x10
         }
 
         [StackOnly]
         [StructLayout(LayoutKind.Explicit)]
         public struct ExInfo
         {
-            internal void Init(object exceptionObj)
+            internal void Init(object exceptionObj, bool instructionFault = false)
             {
                 // _pPrevExInfo    -- set by asm helper
                 // _pExContext     -- set by asm helper
@@ -432,6 +421,8 @@ namespace System.Runtime
                 // _frameIter      -- initialized explicitly during dispatch
 
                 _exception = exceptionObj;
+                if (instructionFault)
+                    _kind |= ExKind.InstructionFaultFlag;
                 _notifyDebuggerSP = UIntPtr.Zero;
             }
 
@@ -496,11 +487,20 @@ namespace System.Runtime
             InternalCalls.RhpValidateExInfoStack();
 
             IntPtr faultingCodeAddress = exInfo._pExContext->IP;
+            bool instructionFault = true;
 
             ExceptionIDs exceptionId;
             switch (exceptionCode)
             {
                 case (uint)HwExceptionCode.STATUS_REDHAWK_NULL_REFERENCE:
+                    exceptionId = ExceptionIDs.NullReference;
+                    break;
+
+                case (uint)HwExceptionCode.STATUS_REDHAWK_WRITE_BARRIER_NULL_REFERENCE:
+                    // The write barrier where the actual fault happened has been unwound already.
+                    // The IP of this fault needs to be treated as return address, not as IP of 
+                    // faulting instruction.
+                    instructionFault = false;
                     exceptionId = ExceptionIDs.NullReference;
                     break;
 
@@ -533,7 +533,7 @@ namespace System.Runtime
 
             Exception exceptionToThrow = GetClasslibException(exceptionId, faultingCodeAddress);
 
-            exInfo.Init(exceptionToThrow);
+            exInfo.Init(exceptionToThrow, instructionFault);
             DispatchEx(ref exInfo._frameIter, ref exInfo, MaxTryRegionIdx);
             FallbackFailFast(RhFailFastReason.InternalError, null);
         }
@@ -598,7 +598,7 @@ namespace System.Runtime
             UIntPtr prevFramePtr = UIntPtr.Zero;
             bool unwoundReversePInvoke = false;
 
-            bool isValid = frameIter.Init(exInfo._pExContext);
+            bool isValid = frameIter.Init(exInfo._pExContext, (exInfo._kind & ExKind.InstructionFaultFlag) != 0);
             Debug.Assert(isValid, "RhThrowEx called with an unexpected context");
             DebuggerNotify.BeginFirstPass(exceptionObj, frameIter.ControlPC, frameIter.SP);
             for (; isValid; isValid = frameIter.Next(out startIdx, out unwoundReversePInvoke))

--- a/src/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -229,7 +229,7 @@ namespace System.Runtime
         [RuntimeImport(Redhawk.BaseName, "RhpSfiInit")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [ManuallyManaged(GcPollPolicy.Never)]
-        internal static extern unsafe bool RhpSfiInit(ref StackFrameIterator pThis, void* pStackwalkCtx);
+        internal static extern unsafe bool RhpSfiInit(ref StackFrameIterator pThis, void* pStackwalkCtx, bool instructionFault);
 
         [RuntimeImport(Redhawk.BaseName, "RhpSfiNext")]
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/Runtime.Base/src/System/Runtime/StackFrameIterator.cs
+++ b/src/Runtime.Base/src/System/Runtime/StackFrameIterator.cs
@@ -28,9 +28,9 @@ namespace System.Runtime
         internal UIntPtr SP { get { return _regDisplay.SP; } }
         internal UIntPtr FramePointer { get { return _framePointer; } }
 
-        internal bool Init(EH.PAL_LIMITED_CONTEXT* pStackwalkCtx)
+        internal bool Init(EH.PAL_LIMITED_CONTEXT* pStackwalkCtx, bool instructionFault = false)
         {
-            return InternalCalls.RhpSfiInit(ref this, pStackwalkCtx);
+            return InternalCalls.RhpSfiInit(ref this, pStackwalkCtx, instructionFault);
         }
 
         internal bool Next()

--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -929,11 +929,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfilter_d\throwinfilter_d.*" />
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfilter_r\throwinfilter_r.*" />
 
-    <!-- Windows x64 unwinder gets consused by IP in the middle of instruction -->
-    <!-- https://github.com/dotnet/corert/issues/2535 -->
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30126\b30126\b30126.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30128\b30128\b30128.*" />
-
     <!-- Arrays with non-zero lower bounds -->
     <!-- https://github.com/dotnet/corert/issues/2245 -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_dbghuge_b\_il_dbghuge_b.*" />


### PR DESCRIPTION
Handling of hardware exceptions had a hack to add +1 to the actual instruction IP. Windows x64 unwinder
is disassembling instructions at the IP passed in to detect method epilogs. If the bytes at IP + 1
happened to match the epilog pattern, the unwind is done as if we were in the middle of the epilog that
lead to spectacular crash.

This change is moving this adjustment to be done later for EH related things only, and not interfere
with stackwalking.

Fixes #2535