### PR TITLE
Add missing cast to intptr_t

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -1944,6 +1944,7 @@ namespace Internal.IL
 
             PushTemp(GetStackValueKind(type), type);
 
+            AppendCastIfNecessary(GetStackValueKind(type), type);
             Append("*(");
             Append(_writer.GetCppSignatureTypeName(type));
             Append("*)");


### PR DESCRIPTION
`ldobj` import casts the stack value to the token type but then wants to store the result as `intptr_t` again so another cast is needed.

Fixes #2466