### PR TITLE
Calling convention conversion

### DIFF
--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -136,6 +136,8 @@ endif()
 
 list(APPEND RUNTIME_SOURCES_ARCH_ASM
   ${ARCH_SOURCES_DIR}/AllocFast.${ASM_SUFFIX}
+  ${ARCH_SOURCES_DIR}/CallDescrWorker.${ASM_SUFFIX}
+  ${ARCH_SOURCES_DIR}/CallingConventionConverterHelpers.${ASM_SUFFIX}
   ${ARCH_SOURCES_DIR}/ExceptionHandling.${ASM_SUFFIX}
   ${ARCH_SOURCES_DIR}/Interlocked.${ASM_SUFFIX}
   ${ARCH_SOURCES_DIR}/PInvoke.${ASM_SUFFIX}

--- a/src/Native/Runtime/amd64/CallDescrWorker.S
+++ b/src/Native/Runtime/amd64/CallDescrWorker.S
@@ -1,0 +1,3 @@
+// Licensed to the .NET Foundation under one or more agreements.// The .NET Foundation licenses this file to you under the MIT license.// See the LICENSE file in the project root for more information.
+.intel_syntax noprefix#include <unixasmmacros.inc>
+NESTED_ENTRY RhCallDescrWorker, _TEXT, NoHandlerALTERNATE_ENTRY ReturnFromCallDescrThunk    // UNIXTODO: Implement this function    int 3NESTED_END RhCallDescrWorker, _TEXT

--- a/src/Native/Runtime/amd64/CallDescrWorker.S
+++ b/src/Native/Runtime/amd64/CallDescrWorker.S
@@ -1,3 +1,12 @@
-// Licensed to the .NET Foundation under one or more agreements.// The .NET Foundation licenses this file to you under the MIT license.// See the LICENSE file in the project root for more information.
-.intel_syntax noprefix#include <unixasmmacros.inc>
-NESTED_ENTRY RhCallDescrWorker, _TEXT, NoHandlerALTERNATE_ENTRY ReturnFromCallDescrThunk    // UNIXTODO: Implement this function    int 3NESTED_END RhCallDescrWorker, _TEXT
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.intel_syntax noprefix
+#include <unixasmmacros.inc>
+
+NESTED_ENTRY RhCallDescrWorker, _TEXT, NoHandler
+ALTERNATE_ENTRY ReturnFromCallDescrThunk
+    // UNIXTODO: Implement this function
+    int 3
+NESTED_END RhCallDescrWorker, _TEXT

--- a/src/Native/Runtime/amd64/CallingConventionConverterHelpers.S
+++ b/src/Native/Runtime/amd64/CallingConventionConverterHelpers.S
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.intel_syntax noprefix
+#include <unixasmmacros.inc>
+
+//
+// void CallingConventionConverter_ReturnVoidReturnThunk()
+//
+LEAF_ENTRY CallingConventionConverter_ReturnVoidReturnThunk, _TEXT
+        ret
+LEAF_END CallingConventionConverter_ReturnVoidReturnThunk, _TEXT
+
+//
+// int CallingConventionConverter_ReturnIntegerReturnThunk(int)
+//
+LEAF_ENTRY CallingConventionConverter_ReturnIntegerReturnThunk, _TEXT
+        // UNIXTODO: Implement this function
+        int 3
+LEAF_END CallingConventionConverter_ReturnIntegerReturnThunk, _TEXT
+
+//
+// Note: The "__jmpstub__" prefix is used to indicate to debugger
+// that it must step-through this stub when it encounters it while
+// stepping.
+//
+
+// __jmpstub__CallingConventionConverter_CommonCallingStub
+//
+//
+// struct CallingConventionConverter_CommonCallingStub_PointerData
+// {
+//     void *ManagedCallConverterThunk;
+//     void *UniversalThunk;
+// }
+//
+// struct CommonCallingStubInputData
+// {
+//     ULONG_PTR CallingConventionId;
+//     CallingConventionConverter_CommonCallingStub_PointerData *commonData;
+// }
+//
+// r10 - Points at CommonCallingStubInputData
+//  
+//
+LEAF_ENTRY __jmpstub__CallingConventionConverter_CommonCallingStub, _TEXT
+        // UNIXTODO: Implement this function
+        int 3
+LEAF_END __jmpstub__CallingConventionConverter_CommonCallingStub, _TEXT
+
+//
+// void CallingConventionConverter_GetStubs(IntPtr *returnVoidStub, IntPtr *returnIntegerStub, IntPtr *commonStub)
+//
+LEAF_ENTRY CallingConventionConverter_GetStubs, _TEXT
+        // UNIXTODO: Implement this function
+        int 3
+LEAF_END CallingConventionConverter_GetStubs, _TEXT

--- a/src/Native/Runtime/amd64/CallingConventionConverterHelpers.asm
+++ b/src/Native/Runtime/amd64/CallingConventionConverterHelpers.asm
@@ -1,8 +1,6 @@
-;; ==++==
-;;
-;;   Copyright (c) Microsoft Corporation.  All rights reserved.
-;;
-;; ==--==
+;; Licensed to the .NET Foundation under one or more agreements.
+;; The .NET Foundation licenses this file to you under the MIT license.
+;; See the LICENSE file in the project root for more information.
 
 ;; -----------------------------------------------------------------------------------------------------------
 ;; #include "asmmacros.inc"

--- a/src/Native/Runtime/amd64/CallingConventionConverterHelpers.asm
+++ b/src/Native/Runtime/amd64/CallingConventionConverterHelpers.asm
@@ -1,0 +1,88 @@
+;; ==++==
+;;
+;;   Copyright (c) Microsoft Corporation.  All rights reserved.
+;;
+;; ==--==
+
+;; -----------------------------------------------------------------------------------------------------------
+;; #include "asmmacros.inc"
+;; -----------------------------------------------------------------------------------------------------------
+
+LEAF_ENTRY macro Name, Section
+    Section segment para 'CODE'
+    align   16
+    public  Name
+    Name    proc
+endm
+
+LEAF_END macro Name, Section
+    Name    endp
+    Section ends
+endm
+
+;  - TAILCALL_RAX: ("jmp rax") should be used for tailcalls, this emits an instruction 
+;            sequence which is recognized by the unwinder as a valid epilogue terminator
+TAILJMP_RAX TEXTEQU <DB 048h, 0FFh, 0E0h>
+POINTER_SIZE                        equ 08h
+
+;;
+;; void CallingConventionConverter_ReturnVoidReturnThunk()
+;;
+LEAF_ENTRY CallingConventionConverter_ReturnVoidReturnThunk, _TEXT
+        ret
+LEAF_END CallingConventionConverter_ReturnVoidReturnThunk, _TEXT
+
+;;
+;; int CallingConventionConverter_ReturnIntegerReturnThunk(int)
+;;
+LEAF_ENTRY CallingConventionConverter_ReturnIntegerReturnThunk, _TEXT
+        mov rax, rcx
+        ret
+LEAF_END CallingConventionConverter_ReturnIntegerReturnThunk, _TEXT
+
+;;
+;; Note: The "__jmpstub__" prefix is used to indicate to debugger
+;; that it must step-through this stub when it encounters it while
+;; stepping.
+;;
+
+;; __jmpstub__CallingConventionConverter_CommonCallingStub
+;;
+;;
+;; struct CallingConventionConverter_CommonCallingStub_PointerData
+;; {
+;;     void *ManagedCallConverterThunk;
+;;     void *UniversalThunk;
+;; }
+;;
+;; struct CommonCallingStubInputData
+;; {
+;;     ULONG_PTR CallingConventionId;
+;;     CallingConventionConverter_CommonCallingStub_PointerData *commonData;
+;; }
+;;
+;; r10 - Points at CommonCallingStubInputData
+;;  
+;;
+LEAF_ENTRY __jmpstub__CallingConventionConverter_CommonCallingStub, _TEXT
+        mov     r11, [r10]                ; put CallingConventionId into r11 as "parameter" to universal transition thunk
+        mov     r10, [r10 + POINTER_SIZE] ; get pointer to CallingConventionConverter_CommonCallingStub_PointerData into r10
+        mov     rax, [r10 + POINTER_SIZE] ; get address of UniversalTransitionThunk
+        mov     r10, [r10]                ; get address of ManagedCallConverterThunk
+        TAILJMP_RAX
+LEAF_END __jmpstub__CallingConventionConverter_CommonCallingStub, _TEXT
+
+;;
+;; void CallingConventionConverter_GetStubs(IntPtr *returnVoidStub, IntPtr *returnIntegerStub, IntPtr *commonStub)
+;;
+LEAF_ENTRY CallingConventionConverter_GetStubs, _TEXT
+        lea     rax, [CallingConventionConverter_ReturnVoidReturnThunk]
+        mov    [rcx], rax
+        lea     rax, [CallingConventionConverter_ReturnIntegerReturnThunk]
+        mov    [rdx], rax
+        lea     rax, [__jmpstub__CallingConventionConverter_CommonCallingStub]
+        mov    [r8], rax
+        ret
+LEAF_END CallingConventionConverter_GetStubs, _TEXT
+
+end

--- a/src/Native/Runtime/arm/CallingConventionConverterHelpers.asm
+++ b/src/Native/Runtime/arm/CallingConventionConverterHelpers.asm
@@ -1,8 +1,6 @@
-;; ==++==
-;;
-;;   Copyright (c) Microsoft Corporation.  All rights reserved.
-;;
-;; ==--==
+;; Licensed to the .NET Foundation under one or more agreements.
+;; The .NET Foundation licenses this file to you under the MIT license.
+;; See the LICENSE file in the project root for more information.
 
 #include "kxarm.h"
 

--- a/src/Native/Runtime/arm/CallingConventionConverterHelpers.asm
+++ b/src/Native/Runtime/arm/CallingConventionConverterHelpers.asm
@@ -1,0 +1,91 @@
+;; ==++==
+;;
+;;   Copyright (c) Microsoft Corporation.  All rights reserved.
+;;
+;; ==--==
+
+#include "kxarm.h"
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  DATA SECTIONS  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+    DATAAREA
+UniversalThunkPointer % 4
+    TEXTAREA
+
+OFFSETOF_CallingConventionId EQU 0
+OFFSETOF_commonData EQU 4
+OFFSETOF_ManagedCallConverterThunk EQU 0
+OFFSETOF_UniversalThunk EQU 4
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CallingConventionCoverter Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;
+;; Note: The "__jmpstub__" prefix is used to indicate to debugger
+;; that it must step-through this stub when it encounters it while
+;; stepping.
+;;
+
+    ;;
+    ;; void CallingConventionConverter_ReturnThunk()
+    ;;
+    LEAF_ENTRY CallingConventionConverter_ReturnThunk
+        bx          lr
+    LEAF_END CallingConventionConverter_ReturnThunk
+
+    ;;
+    ;; __jmpstub__CallingConventionConverter_CommonCallingStub
+    ;;
+    ;; struct CallingConventionConverter_CommonCallingStub_PointerData
+    ;; {
+    ;;     void *ManagedCallConverterThunk;
+    ;;     void *UniversalThunk;
+    ;; }
+    ;;
+    ;; struct CommonCallingStubInputData
+    ;; {
+    ;;     ULONG_PTR CallingConventionId;
+    ;;     CallingConventionConverter_CommonCallingStub_PointerData *commonData; // Only the ManagedCallConverterThunk field is used
+    ;;                                                                           // However, it is specified just like other platforms, so the behavior of the common
+    ;;                                                                           // calling stub is easier to debug
+    ;; }
+    ;;
+    ;; sp-4 - Points at CommonCallingStubInputData
+    ;;  
+    ;;
+    LEAF_ENTRY __jmpstub__CallingConventionConverter_CommonCallingStub
+        ldr     r12, [sp, #-4]
+        ldr     r12, [r12, #OFFSETOF_CallingConventionId] ; Get CallingConventionId into r12
+        str     r12, [sp, #-8] ; Put calling convention id into red zone
+        ldr     r12, [sp, #-4]
+        ldr     r12, [r12, #OFFSETOF_commonData] ; Get pointer to common data
+        ldr     r12, [r12, #OFFSETOF_ManagedCallConverterThunk] ; Get pointer to managed call converter thunk
+        str     r12, [sp, #-4] ; Put managed calling convention thunk pointer into red zone (overwrites pointer to CommonCallingStubInputData)
+        ldr     r12, =UniversalThunkPointer
+        ldr     r12, [r12]
+        bx      r12
+    LEAF_END __jmpstub__CallingConventionConverter_CommonCallingStub
+
+    ;;
+    ;; void CallingConventionConverter_SpecifyCommonStubData(CallingConventionConverter_CommonCallingStub_PointerData *commonData);
+    ;;
+    LEAF_ENTRY CallingConventionConverter_SpecifyCommonStubData
+        ldr     r1, [r0, #OFFSETOF_ManagedCallConverterThunk]     ; Load ManagedCallConverterThunk into r1 {r1 = (CallingConventionConverter_CommonCallingStub_PointerData*)r0->ManagedCallConverterThunk }
+        ldr     r2, [r0, #OFFSETOF_UniversalThunk]                ; Load UniversalThunk into r2 {r2 = (CallingConventionConverter_CommonCallingStub_PointerData*)r0->UniversalThunk }
+        ldr     r12, =UniversalThunkPointer
+        str     r2, [r12]
+        bx      lr
+    LEAF_END CallingConventionConverter_SpecifyCommonStubData
+
+    ;;
+    ;; void CallingConventionConverter_GetStubs(IntPtr *returnVoidStub, IntPtr *returnIntegerStub, IntPtr *commonCallingStub)
+    ;;
+    LEAF_ENTRY CallingConventionConverter_GetStubs
+        ldr     r12, =CallingConventionConverter_ReturnThunk
+        str     r12, [r0] ;; ARM doesn't need different return thunks.
+        str     r12, [r1]
+        ldr     r12, =__jmpstub__CallingConventionConverter_CommonCallingStub
+        str     r12, [r2]
+        bx      lr
+    LEAF_END CallingConventionConverter_GetStubs
+
+    END

--- a/src/Native/Runtime/arm64/CallingConventionConverterHelpers.asm
+++ b/src/Native/Runtime/arm64/CallingConventionConverterHelpers.asm
@@ -1,0 +1,5 @@
+;; Licensed to the .NET Foundation under one or more agreements.
+;; The .NET Foundation licenses this file to you under the MIT license.
+;; See the LICENSE file in the project root for more information.
+
+;; TODO

--- a/src/Native/Runtime/i386/CallingConventionConverterHelpers.asm
+++ b/src/Native/Runtime/i386/CallingConventionConverterHelpers.asm
@@ -1,8 +1,6 @@
-;; ==++==
-;;
-;;   Copyright (c) Microsoft Corporation.  All rights reserved.
-;;
-;; ==--==
+;; Licensed to the .NET Foundation under one or more agreements.
+;; The .NET Foundation licenses this file to you under the MIT license.
+;; See the LICENSE file in the project root for more information.
 
 .586
 .model  flat

--- a/src/Native/Runtime/i386/CallingConventionConverterHelpers.asm
+++ b/src/Native/Runtime/i386/CallingConventionConverterHelpers.asm
@@ -1,0 +1,129 @@
+;; ==++==
+;;
+;;   Copyright (c) Microsoft Corporation.  All rights reserved.
+;;
+;; ==--==
+
+.586
+.model  flat
+option  casemap:none
+.code
+
+;; -----------------------------------------------------------------------------------------------------------
+;; standard macros
+;; -----------------------------------------------------------------------------------------------------------
+LEAF_ENTRY macro Name, Section
+    Section segment para 'CODE'
+    public  Name
+    Name    proc
+endm
+
+LEAF_END macro Name, Section
+    Name    endp
+    Section ends
+endm
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  DATA SECTIONS  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;
+;; struct ReturnBlock
+;; {
+;;   8 bytes of space
+;;   Used to hold return information.
+;;   eax, and 32bit float returns use the first 4 bytes, 
+;;   eax,edx and 64bit float returns use the full 8 bytes
+;; };
+;;
+
+ReturnInformation__ReturnData EQU 4h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Interop Thunks Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; ? CallingConventionConverter_ReturnVoidReturnThunk(int cbBytesOfStackToPop)
+;;
+LEAF_ENTRY CallingConventionConverter_ReturnVoidReturnThunk, _TEXT
+        pop edx     ; pop return address into edx
+        add esp,ecx ; remove ecx bytes from the call stack
+        push edx    ; put the return address back on the stack
+        ret         ; return to it (use a push/ret pair here so that the return stack buffer still works)
+LEAF_END CallingConventionConverter_ReturnVoidReturnThunk, _TEXT
+
+;;
+;; int CallingConventionConverter_ReturnIntegerReturnThunk(int cbBytesOfStackToPop, ReturnBlock*)
+;;
+LEAF_ENTRY CallingConventionConverter_ReturnIntegerReturnThunk, _TEXT
+        pop eax           ; pop return address into edx
+        add esp,ecx       ; remove ecx bytes from the call stack
+        push eax          ; put the return address back on the stack
+        mov eax, [edx]    ; setup eax and edx to hold the return value
+        mov edx, [edx + 4]
+        ret               ; return  (use a push/ret pair here so that the return stack buffer still works)
+LEAF_END CallingConventionConverter_ReturnIntegerReturnThunk, _TEXT
+
+;;
+;; float CallingConventionConverter_Return4ByteFloatReturnThunk(int cbBytesOfStackToPop, ReturnBlock*)
+;;
+LEAF_ENTRY CallingConventionConverter_Return4ByteFloatReturnThunk, _TEXT
+        pop eax            ; pop return address into edx
+        add esp,ecx        ; remove ecx bytes from the call stack
+        push eax           ; put the return address back on the stack
+        fld dword ptr [edx]; fill in the return value
+        ret                ; return (use a push/ret pair here so that the return stack buffer still works)
+LEAF_END CallingConventionConverter_Return4ByteFloatReturnThunk, _TEXT
+
+;;
+;; double CallingConventionConverter_Return4ByteFloatReturnThunk(int cbBytesOfStackToPop, ReturnBlock*)
+;;
+LEAF_ENTRY CallingConventionConverter_Return8ByteFloatReturnThunk, _TEXT
+        pop eax            ; pop return address into edx
+        add esp,ecx        ; remove ecx bytes from the call stack
+        push eax           ; put the return address back on the stack
+        fld qword ptr [edx]; fill in the return value
+        ret                ; return (use a push/ret pair here so that the return stack buffer still works)
+LEAF_END CallingConventionConverter_Return8ByteFloatReturnThunk, _TEXT
+
+;;
+;; Note: The "__jmpstub__" prefix is used to indicate to debugger
+;; that it must step-through this stub when it encounters it while
+;; stepping.
+;;
+
+;;
+;; __jmpstub__CallingConventionConverter_CommonCallingStub(?)
+;;
+LEAF_ENTRY __jmpstub__CallingConventionConverter_CommonCallingStub, _TEXT
+        ;; rax <- stub info
+        push        ebp
+        mov         ebp, esp
+        push        [eax]   ; First argument
+        mov         eax,[eax+4] ; 
+        push        [eax]   ; Pointer to CallingConventionConverter Managed thunk
+        mov         eax,[eax+4] ; Pointer to UniversalTransitionThunk
+        jmp         eax
+LEAF_END __jmpstub__CallingConventionConverter_CommonCallingStub, _TEXT
+
+    ;;
+    ;; void CallingConventionConverter_GetStubs(IntPtr *returnVoidStub, IntPtr *returnIntegerStub, IntPtr* commonCallingStub, IntPtr *return4ByteFloat, IntPtr *return8ByteFloat)
+    ;;
+LEAF_ENTRY CallingConventionConverter_GetStubs, _TEXT
+        lea     eax, [CallingConventionConverter_ReturnVoidReturnThunk]
+        mov     ecx, [esp+04h]
+        mov     [ecx], eax
+        lea     eax, [CallingConventionConverter_ReturnIntegerReturnThunk]
+        mov     ecx, [esp+08h]
+        mov     [ecx], eax
+        lea     eax, [__jmpstub__CallingConventionConverter_CommonCallingStub]
+        mov     ecx, [esp+0Ch]
+        mov     [ecx], eax
+        lea     eax, [CallingConventionConverter_Return4ByteFloatReturnThunk]
+        mov     ecx, [esp+10h]
+        mov     [ecx], eax
+        lea     eax, [CallingConventionConverter_Return8ByteFloatReturnThunk]
+        mov     ecx, [esp+14h]
+        mov     [ecx], eax
+        retn 14h
+LEAF_END CallingConventionConverter_GetStubs, _TEXT
+
+
+end

--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -261,8 +261,9 @@ void * ReturnFromUniversalTransition_DebugStepTailCall;
 
 // @TODO Implement CallDescrThunk
 EXTERN_C void * ReturnFromCallDescrThunk;
+#ifdef USE_PORTABLE_HELPERS
 void * ReturnFromCallDescrThunk;
-
+#endif
 // 
 // Return address hijacking
 //
@@ -383,12 +384,21 @@ COOP_PINVOKE_HELPER(void*, RhpGetNextThunkStubsBlockAddress, (void* pCurrentThun
     ASSERT_UNCONDITIONALLY("NYI");
     return NULL;
 }
-#endif
 
 COOP_PINVOKE_HELPER(void, RhCallDescrWorker, (void * callDescr))
 {
     ASSERT_UNCONDITIONALLY("NYI");
 }
+
+#ifdef CALLDESCR_FPARGREGSARERETURNREGS
+COOP_PINVOKE_HELPER(void, CallingConventionConverter_GetStubs, (UIntNative* pReturnVoidStub, UIntNative* pReturnIntegerStub, UIntNative* pCommonStub))
+#else
+COOP_PINVOKE_HELPER(void, CallingConventionConverter_GetStubs, (UIntNative* pReturnVoidStub, UIntNative* pReturnIntegerStub, UIntNative* pCommonStub, UIntNative* pReturnFloatingPointReturn4Thunk, UIntNative* pReturnFloatingPointReturn8Thunk))
+#endif
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+}
+#endif
 
 COOP_PINVOKE_HELPER(void, RhpETWLogLiveCom, (Int32 eventType, void * ccwHandle, void * objectId, void * typeRawValue, void * iUnknown, void * vTable, Int32 comRefCount, Int32 jupiterRefCount, Int32 flags))
 {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.cs
@@ -116,8 +116,6 @@ namespace Internal.Runtime.TypeLoader
 
         static unsafe CallConverterThunk()
         {
-            // TODO: export CallingConventionConverter_GetStubs on CoreRT
-#if !CORERT
             CallingConventionConverter_GetStubs(out ReturnVoidReturnThunk, out ReturnIntegerPointReturnThunk, out CommonInputThunkStub
 #if CALLDESCR_FPARGREGSARERETURNREGS
 #else
@@ -131,8 +129,6 @@ namespace Internal.Runtime.TypeLoader
             {
                 CallingConventionConverter_SpecifyCommonStubData((IntPtr)commonStubData);
             }
-#endif
-
 #endif
         }
 


### PR DESCRIPTION
Enabling the calling convention conversion functionality in the non-portable CoreRT, and adding all the conversion helper stubs