### PR TITLE
Add version increment and size check

### DIFF
--- a/src/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -1090,7 +1090,10 @@ namespace System.Collections.Generic
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             Contract.EndContractBlock();
 
-            Array.Sort<T>(_items, index, count, comparer);
+            if (count > 1)
+            {
+                Array.Sort<T>(_items, index, count, comparer);
+            }
             _version++;
         }
 
@@ -1102,10 +1105,11 @@ namespace System.Collections.Generic
             }
             Contract.EndContractBlock();
 
-            if (_size > 0)
+            if (_size > 1)
             {
                 ArraySortHelper<T>.Sort(_items, 0, _size, comparison);
             }
+            _version++;
         }
 
         // ToArray returns a new Object array containing the contents of the List.


### PR DESCRIPTION
Add missing version increment in the `Sort(Comparison<T>)` method.
Add new or modify existing condition in the `Sort` methods to skip an operation if the collection size is less than 2.

Fix #8071