### PR TITLE
Add compiler switches to enable optimizations and debug info generation

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -79,6 +79,8 @@ See the LICENSE file in the project root for more information.
       <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
       <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
+      <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
+      <IlcArg Condition="$(DebugSymbols) == 'true'" Include="-g" />
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -32,6 +32,8 @@ namespace ILCompiler
         internal Logger Logger => _logger;
         internal PInvokeILProvider PInvokeILProvider { get; }
 
+        protected abstract bool GenerateDebugInfo { get; }
+
         private readonly TypeGetTypeMethodThunkCache _typeGetTypeMethodThunks;
 
         protected Compilation(
@@ -118,6 +120,9 @@ namespace ILCompiler
 
         public MethodDebugInformation GetDebugInfo(MethodIL methodIL)
         {
+            if (!GenerateDebugInfo)
+                return MethodDebugInformation.None;
+
             // This method looks odd right now, but it's an extensibility point that lets us generate
             // fake debugging information for things that don't have physical symbols.
             return methodIL.GetDebugInfo();

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -107,10 +107,24 @@ namespace ILCompiler
     /// </summary>
     public enum OptimizationMode
     {
+        /// <summary>
+        /// Do not optimize.
+        /// </summary>
         None,
 
+        /// <summary>
+        /// Minimize code space.
+        /// </summary>
         PreferSize,
 
+        /// <summary>
+        /// Generate blended code. (E.g. favor size for rarely executed code such as class constructors.)
+        /// </summary>
+        Blended,
+
+        /// <summary>
+        /// Maximize execution speed.
+        /// </summary>
         PreferSpeed,
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -19,6 +19,8 @@ namespace ILCompiler
         protected Logger _logger = Logger.Null;
         private DependencyTrackingLevel _dependencyTrackingLevel = DependencyTrackingLevel.None;
         protected IEnumerable<ICompilationRootProvider> _compilationRoots = Array.Empty<ICompilationRootProvider>();
+        protected OptimizationMode _optimizationMode = OptimizationMode.None;
+        protected bool _generateDebugInfo = false;
 
         public CompilationBuilder(NodeFactory nodeFactory)
         {
@@ -40,6 +42,18 @@ namespace ILCompiler
         public CompilationBuilder UseCompilationRoots(IEnumerable<ICompilationRootProvider> compilationRoots)
         {
             _compilationRoots = compilationRoots;
+            return this;
+        }
+
+        public CompilationBuilder UseOptimizationMode(OptimizationMode mode)
+        {
+            _optimizationMode = mode;
+            return this;
+        }
+
+        public CompilationBuilder UseDebugInfo(bool generateDebugInfo)
+        {
+            _generateDebugInfo = generateDebugInfo;
             return this;
         }
 
@@ -86,5 +100,17 @@ namespace ILCompiler
         /// The graph keeps track of all dependencies.
         /// </summary>
         All
+    }
+
+    /// <summary>
+    /// Represents the level of optimizations performed by the compiler.
+    /// </summary>
+    public enum OptimizationMode
+    {
+        None,
+
+        PreferSize,
+
+        PreferSpeed,
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilation.cs
@@ -29,6 +29,15 @@ namespace ILCompiler
             Options = options;
         }
 
+        protected override bool GenerateDebugInfo
+        {
+            get
+            {
+                /// Some degree of control exposed by <see cref="CppCodegenConfigProvider.NoLineNumbersString"/>.
+                return true;
+            }
+        }
+
         private static IEnumerable<ICompilationRootProvider> GetCompilationRoots(IEnumerable<ICompilationRootProvider> existingRoots, NodeFactory factory)
         {
             yield return new CppCodegenCompilationRootProvider(factory.TypeSystemContext);

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
@@ -30,6 +30,14 @@ namespace ILCompiler
             _jitConfigProvider = configProvider;
         }
 
+        protected override bool GenerateDebugInfo
+        {
+            get
+            {
+                return _jitConfigProvider.HasFlag(CorJitFlag.CORJIT_FLAG_DEBUG_INFO);
+            }
+        }
+
         protected override void CompileInternal(string outputFile)
         {
             _corInfo = new CorInfoImpl(this, _jitConfigProvider);

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
@@ -61,8 +61,12 @@ namespace ILCompiler
                     jitFlagBuilder.Add(CorJitFlag.CORJIT_FLAG_SIZE_OPT);
                     break;
 
-                default:
+                case OptimizationMode.PreferSpeed:
                     jitFlagBuilder.Add(CorJitFlag.CORJIT_FLAG_SPEED_OPT);
+                    break;
+
+                default:
+                    // Not setting a flag results in BLENDED_CODE.
                     break;
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
@@ -15,7 +15,7 @@ namespace ILCompiler
     {
         // These need to provide reasonable defaults so that the user can optionally skip
         // calling the Use/Configure methods and still get something reasonable back.
-        private JitConfigProvider _jitConfig = new JitConfigProvider(Array.Empty<string>());
+        private KeyValuePair<string, string>[] _ryujitOptions = Array.Empty<KeyValuePair<string, string>>();
 
         public RyuJitCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group)
             : base(new RyuJitNodeFactory(context, group))
@@ -24,13 +24,53 @@ namespace ILCompiler
 
         public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
         {
-            _jitConfig = new JitConfigProvider(options);
+            var builder = new ArrayBuilder<KeyValuePair<string, string>>();
+
+            foreach (string param in options)
+            {
+                int indexOfEquals = param.IndexOf('=');
+
+                // We're skipping bad parameters without reporting.
+                // This is not a mainstream feature that would need to be friendly.
+                // Besides, to really validate this, we would also need to check that the config name is known.
+                if (indexOfEquals < 1)
+                    continue;
+
+                string name = param.Substring(0, indexOfEquals);
+                string value = param.Substring(indexOfEquals + 1);
+
+                builder.Add(new KeyValuePair<string, string>(name, value));
+            }
+
+            _ryujitOptions = builder.ToArray();
+
             return this;
         }
 
         public override ICompilation ToCompilation()
         {
-            return new RyuJitCompilation(CreateDependencyGraph(), _nodeFactory, _compilationRoots, _logger, _jitConfig);
+            ArrayBuilder<CorJitFlag> jitFlagBuilder = new ArrayBuilder<CorJitFlag>();
+
+            switch (_optimizationMode)
+            {
+                case OptimizationMode.None:
+                    jitFlagBuilder.Add(CorJitFlag.CORJIT_FLAG_DEBUG_CODE);
+                    break;
+
+                case OptimizationMode.PreferSize:
+                    jitFlagBuilder.Add(CorJitFlag.CORJIT_FLAG_SIZE_OPT);
+                    break;
+
+                default:
+                    jitFlagBuilder.Add(CorJitFlag.CORJIT_FLAG_SPEED_OPT);
+                    break;
+            }
+
+            if (_generateDebugInfo)
+                jitFlagBuilder.Add(CorJitFlag.CORJIT_FLAG_DEBUG_INFO);
+
+            var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);
+            return new RyuJitCompilation(CreateDependencyGraph(), _nodeFactory, _compilationRoots, _logger, jitConfig);
         }
     }
 }

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -142,7 +142,7 @@ namespace ILCompiler
                 Console.ReadLine();
             }
 
-            _optimizationMode = optimize ? OptimizationMode.PreferSpeed : OptimizationMode.None;
+            _optimizationMode = optimize ? OptimizationMode.Blended : OptimizationMode.None;
 
             foreach (var input in inputFiles)
                 Helpers.AppendExpandedPaths(_inputFilePaths, input, true);

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -3140,10 +3140,14 @@ namespace Internal.JitInterface
 
         private uint getJitFlags(ref CORJIT_FLAGS flags, uint sizeInBytes)
         {
+            // Read the user-defined configuration options.
+            foreach (var flag in _jitConfig.Flags)
+                flags.Set(flag);
+
+            // Set the rest of the flags that don't make sense to expose publically.
             flags.Set(CorJitFlag.CORJIT_FLAG_SKIP_VERIFICATION);
             flags.Set(CorJitFlag.CORJIT_FLAG_READYTORUN);
             flags.Set(CorJitFlag.CORJIT_FLAG_RELOC);
-            flags.Set(CorJitFlag.CORJIT_FLAG_DEBUG_INFO);
             flags.Set(CorJitFlag.CORJIT_FLAG_PREJIT);
             flags.Set(CorJitFlag.CORJIT_FLAG_USE_PINVOKE_HELPERS);
 


### PR DESCRIPTION
By default, both options will be `false` (as opposed to `true` before this change). This is a breaking change that makes us behave the same as pretty much every other major compiler in the world. Make sure to run `build clean` to regenerate rsp files for the repro project.

After #2403 got fixed there's nothing preventing us from finally
implementing this.

Includes piping in the driver EXE, Compilation and RyuJIT compilation,
and build integration.

Fixes #696. Fixes #383.