### PR TITLE
Generic Methods Hashtable

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -99,10 +99,11 @@ namespace ILCompiler.DependencyAnalysis
         }
         public override int Offset => 0;
         public override bool IsShareable => false;
-
         protected override Instantiation TypeInstantiation => _owningType.Instantiation;
         protected override Instantiation MethodInstantiation => new Instantiation();
         protected override TypeSystemContext Context => _owningType.Context;
+
+        public TypeDesc OwningType => _owningType;
 
         protected override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)
         {
@@ -155,10 +156,16 @@ namespace ILCompiler.DependencyAnalysis
         }
         public override int Offset => _owningMethod.Context.Target.PointerSize;
         public override bool IsShareable => false;
-
         protected override Instantiation TypeInstantiation => _owningMethod.OwningType.Instantiation;
         protected override Instantiation MethodInstantiation => _owningMethod.Instantiation;
         protected override TypeSystemContext Context => _owningMethod.Context;
+
+        public MethodDesc OwningMethod => _owningMethod;
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            return GenericMethodsHashtableNode.GetGenericMethodsHashtableDependenciesForMethod(factory, _owningMethod);
+        }
 
         protected override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsHashtableNode.cs
@@ -1,0 +1,129 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a hashtable of all compiled generic method instantiations
+    /// </summary>
+    internal sealed class GenericMethodsHashtableNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        public GenericMethodsHashtableNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__generic_methods_hashtable_End", true);
+            _externalReferences = externalReferences;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__generic_methods_hashtable");
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            NativeWriter nativeWriter = new NativeWriter();
+            VertexHashtable hashtable = new VertexHashtable();
+            Section nativeSection = nativeWriter.NewSection();
+            nativeSection.Place(hashtable);
+
+            foreach (var dictionaryNode in factory.MetadataManager.GetCompiledGenericDictionaries())
+            {
+                MethodGenericDictionaryNode methodDictionary = dictionaryNode as MethodGenericDictionaryNode;
+                if (methodDictionary == null)
+                    continue;
+
+                MethodDesc method = methodDictionary.OwningMethod;
+
+                Debug.Assert(method.HasInstantiation && !method.IsCanonicalMethod(CanonicalFormKind.Any));
+
+                Vertex fullMethodSignature;
+                {
+                    // Method's containing type
+                    IEETypeNode containingTypeNode = factory.NecessaryTypeSymbol(method.OwningType);
+                    Vertex containingType = nativeWriter.GetUnsignedConstant(_externalReferences.GetIndex(containingTypeNode));
+
+                    // Method's instantiation arguments
+                    VertexSequence arguments = new VertexSequence();
+                    for (int i = 0; i < method.Instantiation.Length; i++)
+                    {
+                        IEETypeNode argNode = factory.NecessaryTypeSymbol(method.Instantiation[i]);
+                        arguments.Append(nativeWriter.GetUnsignedConstant(_externalReferences.GetIndex(argNode)));
+                    }
+
+                    // Method name and signature
+                    NativeLayoutVertexNode nameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(method.GetTypicalMethodDefinition());
+                    NativeLayoutSavedVertexNode placedNameAndSig = factory.NativeLayout.PlacedSignatureVertex(nameAndSig);
+                    Vertex placedNameAndSigVertexOffset = nativeWriter.GetUnsignedConstant((uint)placedNameAndSig.SavedVertex.VertexOffset);
+
+                    fullMethodSignature = nativeWriter.GetTuple(containingType, placedNameAndSigVertexOffset, arguments);
+                }
+
+                // Method's dictionary pointer
+                Vertex dictionaryVertex = nativeWriter.GetUnsignedConstant(_externalReferences.GetIndex(dictionaryNode));
+
+                Vertex entry = nativeWriter.GetTuple(dictionaryVertex, fullMethodSignature);
+
+                hashtable.Append((uint)method.GetHashCode(), nativeSection.Place(entry));
+            }
+
+            MemoryStream stream = new MemoryStream();
+            nativeWriter.Save(stream);
+            byte[] streamBytes = stream.ToArray();
+
+            _endSymbol.SetSymbolOffset(streamBytes.Length);
+
+            return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+
+        public static DependencyList GetGenericMethodsHashtableDependenciesForMethod(NodeFactory factory, MethodDesc method)
+        {
+            Debug.Assert(method.HasInstantiation && !method.IsCanonicalMethod(CanonicalFormKind.Any));
+
+            DependencyList dependencies = new DependencyList();
+
+            // Method's containing type
+            IEETypeNode containingTypeNode = factory.NecessaryTypeSymbol(method.OwningType);
+            dependencies.Add(new DependencyListEntry(containingTypeNode, "GenericMethodsHashtable entry containing type"));
+
+            // Method's instantiation arguments
+            for (int i = 0; i < method.Instantiation.Length; i++)
+            {
+                IEETypeNode argNode = factory.NecessaryTypeSymbol(method.Instantiation[i]);
+                dependencies.Add(new DependencyListEntry(argNode, "GenericMethodsHashtable entry instantiation argument"));
+            }
+
+            // Method name and signature
+            NativeLayoutVertexNode nameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(method.GetTypicalMethodDefinition());
+            NativeLayoutSavedVertexNode placedNameAndSig = factory.NativeLayout.PlacedSignatureVertex(nameAndSig);
+            dependencies.Add(new DependencyListEntry(placedNameAndSig, "GenericMethodsHashtable entry signature"));
+
+            GenericDictionaryNode dictionaryNode = factory.MethodGenericDictionary(method);
+            dependencies.Add(new DependencyListEntry(dictionaryNode, "GenericMethodsHashtable entry dictionary"));
+
+            return dependencies;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesHashtableNode.cs
@@ -14,20 +14,20 @@ namespace ILCompiler.DependencyAnalysis
     /// <summary>
     /// Represents a hashtable of all compiled generic type instantiations
     /// </summary>
-    internal sealed class GenericsHashtableNode : ObjectNode, ISymbolNode
+    internal sealed class GenericTypesHashtableNode : ObjectNode, ISymbolNode
     {
         private ObjectAndOffsetSymbolNode _endSymbol;
         private ExternalReferencesTableNode _externalReferences;
 
-        public GenericsHashtableNode(ExternalReferencesTableNode externalReferences)
+        public GenericTypesHashtableNode(ExternalReferencesTableNode externalReferences)
         {
-            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__generics_hashtable_End", true);
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__generic_types_hashtable_End", true);
             _externalReferences = externalReferences;
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(nameMangler.CompilationUnitPrefix).Append("__generics_hashtable");
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__generic_types_hashtable");
         }
 
         public ISymbolNode EndSymbol => _endSymbol;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -88,6 +88,9 @@ namespace ILCompiler.DependencyAnalysis
                 else
                     yield return new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke");
             }
+
+            if (Method.HasInstantiation && Method.IsVirtual)
+                yield return new DependencyListEntry(factory.GVMDependencies(Method), "GVM Dependencies Support for method dictinoary");
         }
 
         protected override string GetName() => $"{Method.ToString()} backed by {CanonicalMethodNode.GetMangledName()}";

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -43,6 +43,7 @@ namespace ILCompiler
         private HashSet<TypeDesc> _typesWithEETypesGenerated = new HashSet<TypeDesc>();
         private HashSet<MethodDesc> _methodDefinitionsGenerated = new HashSet<MethodDesc>();
         private HashSet<MethodDesc> _methodsGenerated = new HashSet<MethodDesc>();
+        private HashSet<GenericDictionaryNode> _genericDictionariesGenerated = new HashSet<GenericDictionaryNode>();
         private List<TypeGVMEntriesNode> _typeGVMEntries = new List<TypeGVMEntriesNode>();
 
         private Dictionary<DynamicInvokeMethodSignature, MethodDesc> _dynamicInvokeThunks = new Dictionary<DynamicInvokeMethodSignature, MethodDesc>();
@@ -102,8 +103,11 @@ namespace ILCompiler
             var exactMethodInstantiations = new ExactMethodInstantiationsNode(nativeReferencesTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.ExactMethodInstantiationsHashtable), exactMethodInstantiations, exactMethodInstantiations, exactMethodInstantiations.EndSymbol);
 
-            var genericsHashtable = new GenericsHashtableNode(nativeReferencesTableNode);
-            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.GenericsHashtable), genericsHashtable, genericsHashtable, genericsHashtable.EndSymbol);
+            var genericsTypesHashtableNode = new GenericTypesHashtableNode(nativeReferencesTableNode);
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.GenericsHashtable), genericsTypesHashtableNode, genericsTypesHashtableNode, genericsTypesHashtableNode.EndSymbol);
+
+            var genericMethodsHashtableNode = new GenericMethodsHashtableNode(nativeReferencesTableNode);
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.GenericMethodsHashtable), genericMethodsHashtableNode, genericMethodsHashtableNode, genericMethodsHashtableNode.EndSymbol);
 
             var genericVirtualMethodTableNode = new GenericVirtualMethodTableNode(commonFixupsTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.GenericVirtualMethodTable), genericVirtualMethodTableNode, genericVirtualMethodTableNode, genericVirtualMethodTableNode.EndSymbol);
@@ -155,6 +159,12 @@ namespace ILCompiler
             if (gvmEntryNode != null)
             {
                 _typeGVMEntries.Add(gvmEntryNode);
+            }
+
+            var dictionaryNode = obj as GenericDictionaryNode;
+            if (dictionaryNode != null)
+            {
+                _genericDictionariesGenerated.Add(dictionaryNode);
             }
         }
 
@@ -400,6 +410,11 @@ namespace ILCompiler
         internal IEnumerable<TypeGVMEntriesNode> GetTypeGVMEntries()
         {
             return _typeGVMEntries;
+        }
+
+        internal IEnumerable<GenericDictionaryNode> GetCompiledGenericDictionaries()
+        {
+            return _genericDictionariesGenerated;
         }
 
         internal IEnumerable<MethodDesc> GetCompiledMethods()

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -110,7 +110,8 @@
     <Compile Include="Compiler\DependencyAnalysis\NativeLayoutInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\NativeLayoutVertexNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\NativeLayoutSignatureNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\GenericsHashtableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericTypesHashtableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericMethodsHashtableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExactMethodInstantiationsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeMethodHandleNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunGenericHelperNode.cs" />


### PR DESCRIPTION
1) Hashtable of all the compiled generic method instantiations that have a dictionary.
2) Hookup compiled method dictionaries to GVM dependencies analysis
3) Renaming of the hashtable of compiled generic types from GenericsHashtableNode to GenericTypesHashtableNode.