### PR TITLE
Generic Method Templates

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalDefinitionEETypeNode.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    internal sealed class CanonicalDefinitionEETypeNode : EETypeNode
+    {
+        public CanonicalDefinitionEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
+        {
+            Debug.Assert(type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
+        }
+
+        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory) => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override bool IsShareable => IsTypeNodeShareable(_type);
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory) => null;
+        protected override int GCDescSize => 0;
+
+        protected override void ComputeOptionalEETypeFields(NodeFactory factory)
+        {
+            // TODO: handle the __UniversalCanon case (valuetype padding optional field...)
+            Debug.Assert(_type.IsCanonicalDefinitionType(CanonicalFormKind.Specific));
+        }
+
+        protected override void OutputBaseSize(ref ObjectDataBuilder objData)
+        {
+            // Canonical definition types will have their base size set to the minimum
+            objData.EmitInt(MinimumObjectSize);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.TypeSystem;
+using Internal.Runtime;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Canonical type instantiations are emitted, not because they are used directly by the user code, but because
+    /// they are used by the dynamic type loader when dynamically instantiating types at runtime.
+    /// The data that we emit on canonical type instantiations should just be the minimum that is needed by the template 
+    /// type loader. 
+    /// Similarly, the dependencies that we track for canonicl type instantiations are minimal, and are just the ones used
+    /// by the dynamic type loader
+    /// </summary>
+    internal sealed class CanonicalEETypeNode : EETypeNode
+    {
+        public CanonicalEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
+        {
+            Debug.Assert(!type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
+            Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
+            Debug.Assert(type == type.ConvertToCanonForm(CanonicalFormKind.Specific));
+
+            // TODO: needs a closer look when we enable USG
+            Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Universal));
+        }
+
+        public override bool StaticDependenciesAreComputed => true;
+        public override bool IsShareable => IsTypeNodeShareable(_type);
+        public override bool HasConditionalStaticDependencies => false;
+        protected override bool EmitVirtualSlotsAndInterfaces => true;
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+
+            DefType closestDefType = _type.GetClosestDefType();
+
+            DependencyList dependencyList = new DependencyList();
+
+            if (_type.RuntimeInterfaces.Length > 0)
+                dependencyList.Add(factory.InterfaceDispatchMap(_type), "Canonical interface dispatch map");
+
+            dependencyList.Add(factory.VTable(_type), "VTable");
+
+            // TODO: native layout dependencies (template type entries)
+
+            // TODO: other dependencies needed by the dynamic type loader?
+
+            return dependencyList;
+        }
+
+        protected override int GCDescSize
+        {
+            get
+            {
+                // No GCDescs for universal canonical types
+                if (_type.IsCanonicalSubtype(CanonicalFormKind.Universal))
+                    return 0;
+
+                Debug.Assert(_type.IsCanonicalSubtype(CanonicalFormKind.Specific));
+                return GCDescEncoder.GetGCDescSize(_type);
+            }
+        }
+
+        protected override void OutputGCDesc(ref ObjectDataBuilder builder)
+        {
+            // No GCDescs for universal canonical types
+            if (_type.IsCanonicalSubtype(CanonicalFormKind.Universal))
+                return;
+
+            Debug.Assert(_type.IsCanonicalSubtype(CanonicalFormKind.Specific));
+            GCDescEncoder.EncodeGCDesc(ref builder, _type);
+        }
+
+        protected override void OutputInterfaceMap(NodeFactory factory, ref ObjectDataBuilder objData)
+        {
+            foreach (var itf in _type.RuntimeInterfaces)
+            {
+                // Interface omitted for canonical instantiations (constructed at runtime for dynamic types from the native layout info)
+                objData.EmitZeroPointer();
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
@@ -1,0 +1,121 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Hashtable of all generic method templates used by the TypeLoader at runtime
+    /// </summary>
+    internal sealed class GenericMethodsTemplateMap : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        public GenericMethodsTemplateMap(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__GenericMethodsTemplateMap_End", true);
+            _externalReferences = externalReferences;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__GenericMethodsTemplateMap");
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName() => this.GetMangledName();
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // Dependencies for this node are tracked by the method code nodes
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            // Ensure the native layout data has been saved, in order to get valid Vertex offsets for the signature Vertices
+            factory.MetadataManager.NativeLayoutInfo.SaveNativeLayoutInfoWriter(factory);
+
+            NativeWriter nativeWriter = new NativeWriter();
+            VertexHashtable hashtable = new VertexHashtable();
+            Section nativeSection = nativeWriter.NewSection();
+            nativeSection.Place(hashtable);
+
+
+            foreach (MethodDesc method in factory.MetadataManager.GetCompiledMethods())
+            {
+                if (!IsEligibleToBeATemplate(method))
+                    continue;
+
+                // Method entry
+                Vertex methodEntry = factory.NativeLayout.TemplateMethodEntry(method).SavedVertex;
+
+                // Method's native layout info
+                Vertex nativeLayout = factory.NativeLayout.TemplateMethodLayout(method).SavedVertex;
+
+                // Hashtable Entry
+                Vertex entry = nativeWriter.GetTuple(
+                    nativeWriter.GetUnsignedConstant((uint)methodEntry.VertexOffset),
+                    nativeWriter.GetUnsignedConstant((uint)nativeLayout.VertexOffset));
+
+                // Add to the hash table, hashed by the containing type's hashcode
+                uint hashCode = (uint)method.GetHashCode();
+                hashtable.Append(hashCode, nativeSection.Place(entry));
+            }
+
+            MemoryStream stream = new MemoryStream();
+            nativeWriter.Save(stream);
+
+            byte[] streamBytes = stream.ToArray();
+
+            _endSymbol.SetSymbolOffset(streamBytes.Length);
+
+            return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+
+        public static DependencyList GetTemplateMethodDependencies(NodeFactory factory, MethodDesc method)
+        {
+            if (!IsEligibleToBeATemplate(method))
+                return null;
+
+            DependencyList dependencies = new DependencyList();
+
+            dependencies.Add(new DependencyListEntry(factory.NativeLayout.TemplateMethodEntry(method), "Template Method Entry"));
+            dependencies.Add(new DependencyListEntry(factory.NativeLayout.TemplateMethodLayout(method), "Template Method Layout"));
+
+            return dependencies;
+        }
+
+        private static bool IsEligibleToBeATemplate(MethodDesc method)
+        {
+            if (!method.HasInstantiation)
+                return false;
+
+            if (method.IsCanonicalMethod(CanonicalFormKind.Specific))
+            {
+                // Must be fully canonical
+                Debug.Assert(method == method.GetCanonMethodTarget(CanonicalFormKind.Specific));
+                return true;
+            }
+            else if (method.IsCanonicalMethod(CanonicalFormKind.Universal))
+            {
+                // Must be fully canonical
+                if (method == method.GetCanonMethodTarget(CanonicalFormKind.Universal))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -119,6 +119,13 @@ namespace ILCompiler.DependencyAnalysis
                     dependencies = dependencies ?? new DependencyList();
                     dependencies.Add(new DependencyListEntry(factory.GVMDependencies(_method), "GVM Dependencies Support"));
                 }
+
+                var templateMethodDependencies = GenericMethodsTemplateMap.GetTemplateMethodDependencies(factory, _method);
+                if (templateMethodDependencies != null)
+                {
+                    dependencies = dependencies ?? new DependencyList();
+                    dependencies.AddRange(templateMethodDependencies);
+                }
             }
 
             return dependencies;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoNode.cs
@@ -26,6 +26,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private Section _signaturesSection;
         private Section _ldTokenInfoSection;
+        private Section _templatesSection;
 
         private List<NativeLayoutVertexNode> _vertexNodesToWrite;
 
@@ -37,6 +38,7 @@ namespace ILCompiler.DependencyAnalysis
             _writer = new NativeWriter();
             _signaturesSection = _writer.NewSection();
             _ldTokenInfoSection = _writer.NewSection();
+            _templatesSection = _writer.NewSection();
 
             _vertexNodesToWrite = new List<NativeLayoutVertexNode>();
         }
@@ -54,6 +56,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public Section LdTokenInfoSection => _ldTokenInfoSection;
         public Section SignaturesSection => _signaturesSection;
+        public Section TemplatesSection => _templatesSection;
         public ExternalReferencesTableNode ExternalReferences => _externalReferences;
         public NativeWriter Writer => _writer;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
@@ -53,6 +53,16 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     return new NativeLayoutSignatureNode(signature);
                 });
+
+                _templateMethodEntries = new NodeCache<MethodDesc, NativeLayoutTemplateMethodSignatureVertexNode>(method =>
+                {
+                    return new NativeLayoutTemplateMethodSignatureVertexNode(_factory, method);
+                });
+
+                _templateMethodLayouts = new NodeCache<MethodDesc, NativeLayoutTemplateMethodLayoutVertexNode>(method =>
+                {
+                    return new NativeLayoutTemplateMethodLayoutVertexNode(_factory, method);
+                });
             }
 
             private NodeCache<TypeDesc, NativeLayoutTypeSignatureVertexNode> _typeSignatures;
@@ -89,6 +99,18 @@ namespace ILCompiler.DependencyAnalysis
             internal NativeLayoutSignatureNode NativeLayoutSignature(NativeLayoutSavedVertexNode signature)
             {
                 return _nativeLayoutSignatureNodes.GetOrAdd(signature);
+            }
+
+            private NodeCache<MethodDesc, NativeLayoutTemplateMethodSignatureVertexNode> _templateMethodEntries;
+            internal NativeLayoutTemplateMethodSignatureVertexNode TemplateMethodEntry(MethodDesc method)
+            {
+                return _templateMethodEntries.GetOrAdd(method);
+            }
+
+            private NodeCache<MethodDesc, NativeLayoutTemplateMethodLayoutVertexNode> _templateMethodLayouts;
+            internal NativeLayoutTemplateMethodLayoutVertexNode TemplateMethodLayout(MethodDesc method)
+            {
+                return _templateMethodLayouts.GetOrAdd(method);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -101,6 +101,14 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         return new GenericDefinitionEETypeNode(this, type);
                     }
+                    else if (type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
+                    {
+                        return new CanonicalDefinitionEETypeNode(this, type);
+                    }
+                    else if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
+                    {
+                        return new CanonicalEETypeNode(this, type);
+                    }
                     else
                     {
                         return new EETypeNode(this, type);
@@ -116,7 +124,14 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (_compilationModuleGroup.ContainsType(type))
                 {
-                    return new ConstructedEETypeNode(this, type);
+                    if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
+                    {
+                        return new CanonicalEETypeNode(this, type);
+                    }
+                    else
+                    {
+                        return new ConstructedEETypeNode(this, type);
+                    }
                 }
                 else
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -115,6 +115,9 @@ namespace ILCompiler
             var interfaceGenericVirtualMethodTableNode = new InterfaceGenericVirtualMethodTableNode(commonFixupsTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.InterfaceGenericVirtualMethodTable), interfaceGenericVirtualMethodTableNode, interfaceGenericVirtualMethodTableNode, interfaceGenericVirtualMethodTableNode.EndSymbol);
 
+            var genericMethodsTemplatesMapNode = new GenericMethodsTemplateMap(commonFixupsTableNode);
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.GenericMethodsTemplateMap), genericMethodsTemplatesMapNode, genericMethodsTemplatesMapNode, genericMethodsTemplatesMapNode.EndSymbol);
+
             // The external references tables should go last
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.CommonFixupsTable), commonFixupsTableNode, commonFixupsTableNode, commonFixupsTableNode.EndSymbol);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.NativeReferences), nativeReferencesTableNode, nativeReferencesTableNode, nativeReferencesTableNode.EndSymbol);
@@ -137,11 +140,6 @@ namespace ILCompiler
             if (methodNode != null)
             {
                 MethodDesc method = methodNode.Method;
-                if (method.IsCanonicalMethod(CanonicalFormKind.Specific))
-                {
-                    // Canonical methods are not interesting.
-                    return;
-                }
 
                 AddGeneratedType(method.OwningType);
                 _methodDefinitionsGenerated.Add(method.GetTypicalMethodDefinition());
@@ -339,6 +337,12 @@ namespace ILCompiler
 
             foreach (var method in _methodsGenerated)
             {
+                if (method.IsCanonicalMethod(CanonicalFormKind.Specific))
+                {
+                    // Canonical methods are not interesting.
+                    continue;
+                }
+
                 MetadataRecord record = transformed.GetTransformedMethodDefinition(method.GetTypicalMethodDefinition());
 
                 if (record != null)

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -99,5 +99,13 @@ namespace ILCompiler
 
             return false;
         }
+
+        /// <summary>
+        /// Wrapper helper function around the IsCanonicalDefinitionType API on the TypeSystemContext
+        /// </summary>
+        public static bool IsCanonicalDefinitionType(this TypeDesc type, CanonicalFormKind kind)
+        {
+            return type.Context.IsCanonicalDefinitionType(type, kind);
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
@@ -83,7 +83,7 @@ namespace ILCompiler
         /// </summary>
         public static bool HasGenericDictionarySlot(this TypeDesc type)
         {
-            return !type.IsInterface &&
+            return !type.IsInterface && type.HasInstantiation &&
                 (type.ConvertToCanonForm(CanonicalFormKind.Specific) != type || type.IsCanonicalSubtype(CanonicalFormKind.Any));
         }
     }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Compiler\DependencyAnalysis\GenericTypesHashtableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericMethodsHashtableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExactMethodInstantiationsNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericMethodsTemplateMap.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeMethodHandleNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunGenericHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfFrozenObjectsNode.cs" />
@@ -165,6 +166,8 @@
     <Compile Include="Compiler\DependencyAnalysis\AssemblyStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\BlobNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EETypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\CanonicalDefinitionEETypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\CanonicalEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsNode.cs" />


### PR DESCRIPTION
New node to generate the hashtable of generic method templates.

As discussed, we will be generating canonical EEType structures in CoreRT, and all template types and methods will be fully canonical, unlike ProjectN. The changes in this PR enable the compilation of canonical EETypes.

Note: The dictionary layout for template methods is empty for now. Dynamic instantiations using the TypeLoader at runtime will not work yet.