### PR TITLE
Refactor for metadata flexibility

### DIFF
--- a/src/Common/src/TypeSystem/NativeFormat/MetadataExtensions.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/MetadataExtensions.cs
@@ -196,7 +196,7 @@ namespace Internal.TypeSystem.NativeFormat
             byte[] array = new byte[collection.Count];
             int i = 0;
             foreach (byte b in collection)
-                array[i] = b;
+                array[i++] = b;
 
             return array;
         }

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatModule.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatModule.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Internal.Metadata.NativeFormat;
+using AssemblyFlags = Internal.Metadata.NativeFormat.AssemblyFlags;
 
 using Internal.TypeSystem;
 
@@ -185,14 +186,21 @@ namespace Internal.TypeSystem.NativeFormat
                         return (MetadataType)namespaceDefinition.MetadataUnit.GetType((Handle)typeDefinitionHandle);
                     }
                 }
+            }
 
+            foreach (QualifiedNamespaceDefinition namespaceDefinition in namespaceDefinitions)
+            {
+                // At least the namespace was found.
+                MetadataReader metadataReader = namespaceDefinition.MetadataReader;
+                
                 // Now scan the type forwarders on this namespace
                 foreach (var typeForwarderHandle in namespaceDefinition.Definition.TypeForwarders)
                 {
                     var typeForwarder = metadataReader.GetTypeForwarder(typeForwarderHandle);
                     if (typeForwarder.Name.StringEquals(name, metadataReader))
                     {
-                        return (MetadataType)namespaceDefinition.MetadataUnit.GetType((Handle)typeForwarderHandle);
+                        ModuleDesc forwardTargetModule = namespaceDefinition.MetadataUnit.GetModule(typeForwarder.Scope);
+                        return forwardTargetModule.GetType(nameSpace, name, throwIfNotFound);
                     }
                 }
             }

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -114,6 +114,7 @@ namespace Internal.Reflection.Augments
     public abstract class ReflectionCoreCallbacks
     {
         public abstract Assembly Load(AssemblyName refName);
+        public abstract Assembly Load(byte[] rawAssembly, byte[] pdbSymbolStore);
 
         public abstract MethodBase GetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle);
         public abstract MethodBase GetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle, RuntimeTypeHandle declaringTypeHandle);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
@@ -24,32 +24,36 @@ namespace Internal.Runtime.CompilerServices
         public const short OpenNonVirtualResolve = 2;
 
         private readonly short _resolveType;
+        private readonly GCHandle _readerGCHandle;
         private readonly int _handle;
         private readonly IntPtr _methodHandleOrSlotOrCodePointer;
         private readonly EETypePtr _declaringType;
 
-        public OpenMethodResolver(RuntimeTypeHandle declaringTypeOfSlot, int slot, int handle)
+        public OpenMethodResolver(RuntimeTypeHandle declaringTypeOfSlot, int slot, GCHandle readerGCHandle, int handle)
         {
             _resolveType = DispatchResolve;
             _declaringType = declaringTypeOfSlot.ToEETypePtr();
             _methodHandleOrSlotOrCodePointer = new IntPtr(slot);
             _handle = handle;
+            _readerGCHandle = readerGCHandle;
         }
 
-        public unsafe OpenMethodResolver(RuntimeTypeHandle declaringTypeOfSlot, RuntimeMethodHandle gvmSlot, int handle)
+        public unsafe OpenMethodResolver(RuntimeTypeHandle declaringTypeOfSlot, RuntimeMethodHandle gvmSlot, GCHandle readerGCHandle, int handle)
         {
             _resolveType = GVMResolve;
             _methodHandleOrSlotOrCodePointer = *(IntPtr*)&gvmSlot;
             _declaringType = declaringTypeOfSlot.ToEETypePtr();
             _handle = handle;
+            _readerGCHandle = readerGCHandle;
         }
 
-        public OpenMethodResolver(RuntimeTypeHandle declaringType, IntPtr codePointer, int handle)
+        public OpenMethodResolver(RuntimeTypeHandle declaringType, IntPtr codePointer, GCHandle readerGCHandle, int handle)
         {
             _resolveType = OpenNonVirtualResolve;
             _methodHandleOrSlotOrCodePointer = codePointer;
             _declaringType = declaringType.ToEETypePtr();
             _handle = handle;
+            _readerGCHandle = readerGCHandle;
         }
 
         public short ResolverType
@@ -86,6 +90,14 @@ namespace Internal.Runtime.CompilerServices
             }
         }
 
+        public object Reader
+        {
+            get
+            {
+                return _readerGCHandle.Target;
+            }
+        }
+        
         public int Handle
         {
             get

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -242,7 +242,7 @@ namespace System
             // This sort of delegate is invoked by calling the thunk function pointer with the arguments to the delegate + a reference to the delegate object itself.
             m_firstParameter = this;
             m_functionPointer = functionPointerThunk;
-            OpenMethodResolver instanceMethodResolver = new OpenMethodResolver(default(RuntimeTypeHandle), functionPointer, 0);
+            OpenMethodResolver instanceMethodResolver = new OpenMethodResolver(default(RuntimeTypeHandle), functionPointer, default(GCHandle), 0);
             m_extraFunctionPointerOrData = instanceMethodResolver.ToIntPtr();
         }
 
@@ -252,7 +252,7 @@ namespace System
             // This sort of delegate is invoked by calling the thunk function pointer with the arguments to the delegate + a reference to the delegate object itself.
             m_firstParameter = this;
             m_functionPointer = GetThunk(OpenInstanceThunk);
-            OpenMethodResolver instanceMethodResolver = new OpenMethodResolver(default(RuntimeTypeHandle), functionPointer, 0);
+            OpenMethodResolver instanceMethodResolver = new OpenMethodResolver(default(RuntimeTypeHandle), functionPointer, default(GCHandle), 0);
             m_extraFunctionPointerOrData = instanceMethodResolver.ToIntPtr();
         }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -180,7 +180,7 @@ namespace System.Reflection
 
         public static Assembly Load(AssemblyName assemblyRef) => ReflectionAugments.ReflectionCoreCallbacks.Load(assemblyRef);
         public static Assembly Load(byte[] rawAssembly) => Load(rawAssembly, rawSymbolStore: null);
-        public static Assembly Load(byte[] rawAssembly, byte[] rawSymbolStore) { throw new PlatformNotSupportedException(); }
+        public static Assembly Load(byte[] rawAssembly, byte[] rawSymbolStore) => ReflectionAugments.ReflectionCoreCallbacks.Load(rawAssembly, rawSymbolStore);
 
         public static Assembly Load(string assemblyString)
         {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -11,6 +11,10 @@ using System.Reflection.Runtime.TypeInfos.NativeFormat;
 using System.Reflection.Runtime.Assemblies;
 using System.Reflection.Runtime.MethodInfos;
 using System.Reflection.Runtime.MethodInfos.NativeFormat;
+#if ECMA_METADATA_SUPPORT            
+using System.Reflection.Runtime.TypeInfos.EcmaFormat;
+using System.Reflection.Runtime.MethodInfos.EcmaFormat;
+#endif
 using System.Reflection.Runtime.TypeParsing;
 using System.Reflection.Runtime.CustomAttributes;
 using Internal.Metadata.NativeFormat;
@@ -116,33 +120,58 @@ namespace Internal.Reflection.Core.Execution
         //
         // Retrieves the MethodBase for a given method handle. Helper to implement Delegate.GetMethodInfo()
         //
-        public MethodBase GetMethod(RuntimeTypeHandle declaringTypeHandle, MethodHandle methodHandle, RuntimeTypeHandle[] genericMethodTypeArgumentHandles)
+        public MethodBase GetMethod(RuntimeTypeHandle declaringTypeHandle, QMethodDefinition methodHandle, RuntimeTypeHandle[] genericMethodTypeArgumentHandles)
         {
             RuntimeTypeInfo contextTypeInfo = declaringTypeHandle.GetTypeForRuntimeTypeHandle();
-            NativeFormatRuntimeNamedTypeInfo definingTypeInfo = contextTypeInfo.AnchoringTypeDefinitionForDeclaredMembers.CastToNativeFormatRuntimeNamedTypeInfo();
-            MetadataReader reader = definingTypeInfo.Reader;
-            if (methodHandle.IsConstructor(reader))
+            RuntimeNamedMethodInfo runtimeNamedMethodInfo = null;
+
+            if (methodHandle.IsNativeFormatMetadataBased)
             {
-                return RuntimePlainConstructorInfo<NativeFormatMethodCommon>.GetRuntimePlainConstructorInfo(new NativeFormatMethodCommon(methodHandle, definingTypeInfo, contextTypeInfo));
-            }
-            else
-            {
-                // RuntimeMethodHandles always yield methods whose ReflectedType is the DeclaringType.
-                RuntimeTypeInfo reflectedType = contextTypeInfo;
-                RuntimeNamedMethodInfo<NativeFormatMethodCommon> runtimeNamedMethodInfo = RuntimeNamedMethodInfo<NativeFormatMethodCommon>.GetRuntimeNamedMethodInfo(new NativeFormatMethodCommon(methodHandle, definingTypeInfo, contextTypeInfo), reflectedType);
-                if (!runtimeNamedMethodInfo.IsGenericMethod)
+                var nativeFormatMethodHandle = methodHandle.NativeFormatHandle;
+                NativeFormatRuntimeNamedTypeInfo definingTypeInfo = contextTypeInfo.AnchoringTypeDefinitionForDeclaredMembers.CastToNativeFormatRuntimeNamedTypeInfo();
+                MetadataReader reader = definingTypeInfo.Reader;
+                if (nativeFormatMethodHandle.IsConstructor(reader))
                 {
-                    return runtimeNamedMethodInfo;
+                    return RuntimePlainConstructorInfo<NativeFormatMethodCommon>.GetRuntimePlainConstructorInfo(new NativeFormatMethodCommon(nativeFormatMethodHandle, definingTypeInfo, contextTypeInfo));
                 }
                 else
                 {
-                    RuntimeTypeInfo[] genericTypeArguments = new RuntimeTypeInfo[genericMethodTypeArgumentHandles.Length];
-                    for (int i = 0; i < genericMethodTypeArgumentHandles.Length; i++)
-                    {
-                        genericTypeArguments[i] = genericMethodTypeArgumentHandles[i].GetTypeForRuntimeTypeHandle();
-                    }
-                    return RuntimeConstructedGenericMethodInfo.GetRuntimeConstructedGenericMethodInfo(runtimeNamedMethodInfo, genericTypeArguments);
+                    // RuntimeMethodHandles always yield methods whose ReflectedType is the DeclaringType.
+                    RuntimeTypeInfo reflectedType = contextTypeInfo;
+                    runtimeNamedMethodInfo = RuntimeNamedMethodInfo<NativeFormatMethodCommon>.GetRuntimeNamedMethodInfo(new NativeFormatMethodCommon(nativeFormatMethodHandle, definingTypeInfo, contextTypeInfo), reflectedType);
                 }
+            }
+#if ECMA_METADATA_SUPPORT            
+            else
+            {
+                var ecmaFormatMethodHandle = methodHandle.EcmaFormatHandle;
+                var definingEcmaTypeInfo = contextTypeInfo.AnchoringTypeDefinitionForDeclaredMembers.CastToEcmaFormatRuntimeNamedTypeInfo();
+                var reader = definingEcmaTypeInfo.Reader;
+                if (ecmaFormatMethodHandle.IsConstructor(reader))
+                {
+                    return RuntimePlainConstructorInfo<EcmaFormatMethodCommon>.GetRuntimePlainConstructorInfo(new EcmaFormatMethodCommon(ecmaFormatMethodHandle, definingEcmaTypeInfo, contextTypeInfo));
+                }
+                else
+                {
+                    // RuntimeMethodHandles always yield methods whose ReflectedType is the DeclaringType.
+                    RuntimeTypeInfo reflectedType = contextTypeInfo;
+                    runtimeNamedMethodInfo = RuntimeNamedMethodInfo<EcmaFormatMethodCommon>.GetRuntimeNamedMethodInfo(new EcmaFormatMethodCommon(ecmaFormatMethodHandle, definingEcmaTypeInfo, contextTypeInfo), reflectedType);
+                }
+            }
+#endif
+
+            if (!runtimeNamedMethodInfo.IsGenericMethod)
+            {
+                return runtimeNamedMethodInfo;
+            }
+            else
+            {
+                RuntimeTypeInfo[] genericTypeArguments = new RuntimeTypeInfo[genericMethodTypeArgumentHandles.Length];
+                for (int i = 0; i < genericMethodTypeArgumentHandles.Length; i++)
+                {
+                    genericTypeArguments[i] = genericMethodTypeArgumentHandles[i].GetTypeForRuntimeTypeHandle();
+                }
+                return RuntimeConstructedGenericMethodInfo.GetRuntimeConstructedGenericMethodInfo(runtimeNamedMethodInfo, genericTypeArguments);
             }
         }
 
@@ -163,11 +192,24 @@ namespace Internal.Reflection.Core.Execution
         //=======================================================================================
         public Type GetNamedTypeForHandle(RuntimeTypeHandle typeHandle, bool isGenericTypeDefinition)
         {
-            MetadataReader reader;
-            TypeDefinitionHandle typeDefinitionHandle;
-            if (ExecutionEnvironment.TryGetMetadataForNamedType(typeHandle, out reader, out typeDefinitionHandle))
+            QTypeDefinition qTypeDefinition;
+
+            if (ExecutionEnvironment.TryGetMetadataForNamedType(typeHandle, out qTypeDefinition))
             {
-                return typeDefinitionHandle.GetNamedType(reader, typeHandle);
+#if ECMA_METADATA_SUPPORT
+                if (qTypeDefinition.IsNativeFormatMetadataBased)
+#endif
+                {
+                    return qTypeDefinition.NativeFormatHandle.GetNamedType(qTypeDefinition.NativeFormatReader, typeHandle);
+                }
+#if ECMA_METADATA_SUPPORT
+                else
+                {
+                    return System.Reflection.Runtime.TypeInfos.EcmaFormat.EcmaFormatRuntimeNamedTypeInfo.GetRuntimeNamedTypeInfo(qTypeDefinition.EcmaFormatReader, 
+                        qTypeDefinition.EcmaFormatHandle, 
+                        typeHandle);
+                }
+#endif
             }
             else
             {

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -127,7 +127,7 @@ namespace Internal.Reflection.Core.Execution
 
             if (methodHandle.IsNativeFormatMetadataBased)
             {
-                var nativeFormatMethodHandle = methodHandle.NativeFormatHandle;
+                MethodHandle nativeFormatMethodHandle = methodHandle.NativeFormatHandle;
                 NativeFormatRuntimeNamedTypeInfo definingTypeInfo = contextTypeInfo.AnchoringTypeDefinitionForDeclaredMembers.CastToNativeFormatRuntimeNamedTypeInfo();
                 MetadataReader reader = definingTypeInfo.Reader;
                 if (nativeFormatMethodHandle.IsConstructor(reader))
@@ -144,9 +144,9 @@ namespace Internal.Reflection.Core.Execution
 #if ECMA_METADATA_SUPPORT            
             else
             {
-                var ecmaFormatMethodHandle = methodHandle.EcmaFormatHandle;
-                var definingEcmaTypeInfo = contextTypeInfo.AnchoringTypeDefinitionForDeclaredMembers.CastToEcmaFormatRuntimeNamedTypeInfo();
-                var reader = definingEcmaTypeInfo.Reader;
+                System.Reflection.Metadata.MethodDefinitionHandle ecmaFormatMethodHandle = methodHandle.EcmaFormatHandle;
+                EcmaFormatRuntimeNamedTypeInfo definingEcmaTypeInfo = contextTypeInfo.AnchoringTypeDefinitionForDeclaredMembers.CastToEcmaFormatRuntimeNamedTypeInfo();
+                System.Reflection.Metadata.MetadataReader reader = definingEcmaTypeInfo.Reader;
                 if (ecmaFormatMethodHandle.IsConstructor(reader))
                 {
                     return RuntimePlainConstructorInfo<EcmaFormatMethodCommon>.GetRuntimePlainConstructorInfo(new EcmaFormatMethodCommon(ecmaFormatMethodHandle, definingEcmaTypeInfo, contextTypeInfo));

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -53,8 +53,8 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         // Reflection Mapping Tables
         //==============================================================================================
-        public abstract bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out MetadataReader metadataReader, out TypeDefinitionHandle typeDefHandle);
-        public abstract bool TryGetNamedTypeForMetadata(MetadataReader metadataReader, TypeDefinitionHandle typeDefHandle, out RuntimeTypeHandle runtimeTypeHandle);
+        public abstract bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out QTypeDefinition qTypeDefinition);
+        public abstract bool TryGetNamedTypeForMetadata(QTypeDefinition qTypeDefinition, out RuntimeTypeHandle runtimeTypeHandle);
 
         public abstract bool TryGetTypeReferenceForNamedType(RuntimeTypeHandle runtimeTypeHandle, out MetadataReader metadataReader, out TypeReferenceHandle typeRefHandle);
         public abstract bool TryGetNamedTypeForTypeReference(MetadataReader metadataReader, TypeReferenceHandle typeRefHandle, out RuntimeTypeHandle runtimeTypeHandle);
@@ -75,7 +75,7 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         // Invoke and field access support.
         //==============================================================================================
-        public abstract MethodInvoker TryGetMethodInvoker(MetadataReader reader, RuntimeTypeHandle declaringTypeHandle, MethodHandle methodHandle, RuntimeTypeHandle[] genericMethodTypeArgumentHandles);
+        public abstract MethodInvoker TryGetMethodInvoker(RuntimeTypeHandle declaringTypeHandle, QMethodDefinition methodHandle, RuntimeTypeHandle[] genericMethodTypeArgumentHandles);
         public abstract FieldAccessor TryGetFieldAccessor(MetadataReader reader, RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle, FieldHandle fieldHandle);
 
         //==============================================================================================
@@ -92,8 +92,8 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         // RuntimeMethodHandle and RuntimeFieldHandle support.
         //==============================================================================================
-        public abstract bool TryGetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out MethodHandle methodHandle, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles);
-        public abstract bool TryGetMethodFromHandleAndType(RuntimeMethodHandle runtimeMethodHandle, RuntimeTypeHandle declaringTypeHandle, out MethodHandle methodHandle, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles);
+        public abstract bool TryGetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out QMethodDefinition methodHandle, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles);
+        public abstract bool TryGetMethodFromHandleAndType(RuntimeMethodHandle runtimeMethodHandle, RuntimeTypeHandle declaringTypeHandle, out QMethodDefinition methodHandle, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles);
         public abstract bool TryGetFieldFromHandle(RuntimeFieldHandle runtimeFieldHandle, out RuntimeTypeHandle declaringTypeHandle, out FieldHandle fieldHandle);
         public abstract bool TryGetFieldFromHandleAndType(RuntimeFieldHandle runtimeFieldHandle, RuntimeTypeHandle declaringTypeHandle, out FieldHandle fieldHandle);
 
@@ -114,7 +114,7 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         // Non-public methods
         //==============================================================================================
-        internal MethodInvoker GetMethodInvoker(MetadataReader reader, RuntimeTypeInfo declaringType, MethodHandle methodHandle, RuntimeTypeInfo[] genericMethodTypeArguments, MemberInfo exceptionPertainant)
+        internal MethodInvoker GetMethodInvoker(RuntimeTypeInfo declaringType, QMethodDefinition methodHandle, RuntimeTypeInfo[] genericMethodTypeArguments, MemberInfo exceptionPertainant)
         {
             if (declaringType.ContainsGenericParameters)
                 return new OpenMethodInvoker();
@@ -131,7 +131,7 @@ namespace Internal.Reflection.Core.Execution
             {
                 genericMethodTypeArgumentHandles[i] = genericMethodTypeArguments[i].TypeHandle;
             }
-            MethodInvoker methodInvoker = TryGetMethodInvoker(reader, typeDefinitionHandle, methodHandle, genericMethodTypeArgumentHandles);
+            MethodInvoker methodInvoker = TryGetMethodInvoker(typeDefinitionHandle, methodHandle, genericMethodTypeArgumentHandles);
             if (methodInvoker == null)
                 throw ReflectionCoreExecution.ExecutionDomain.CreateNonInvokabilityException(exceptionPertainant);
             return methodInvoker;

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -105,6 +105,8 @@
     <Compile Include="System\Reflection\Runtime\General\TypeResolver.NativeFormat.cs" />
     <Compile Include="System\Reflection\Runtime\General\TypeUnifier.cs" />
     <Compile Include="System\Reflection\Runtime\General\TypeUnifier.NativeFormat.cs" />
+    <Compile Include="System\Reflection\Runtime\General\QSignatureTypeHandle.cs" />
+    <Compile Include="System\Reflection\Runtime\General\QSignatureTypeHandle.NativeFormat.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\NativeFormat\NativeFormatMethodCommon.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\OpenMethodInvoker.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\RuntimeConstructedGenericMethodInfo.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/NativeFormat/NativeFormatCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/NativeFormat/NativeFormatCustomAttributeData.cs
@@ -241,44 +241,6 @@ namespace System.Reflection.Runtime.CustomAttributes.NativeFormat
             return WrapInCustomAttributeTypedArgument(value, argumentType);
         }
 
-        //
-        // Wrap a custom attribute argument (or an element of an array-typed custom attribute argument) in a CustomAttributeTypeArgument structure
-        // for insertion into a CustomAttributeData value.
-        //
-        private CustomAttributeTypedArgument WrapInCustomAttributeTypedArgument(Object value, Type argumentType)
-        {
-            if (argumentType.Equals(CommonRuntimeTypes.Object))
-            {
-                // If the declared attribute type is System.Object, we must report the type based on the runtime value.
-                if (value == null)
-                    argumentType = CommonRuntimeTypes.String;  // Why is null reported as System.String? Because that's what the desktop CLR does.
-                else if (value is Type)
-                    argumentType = CommonRuntimeTypes.Type;    // value.GetType() will not actually be System.Type - rather it will be some internal implementation type. We only want to report it as System.Type.
-                else
-                    argumentType = value.GetType();
-            }
-
-            // Handle the array case
-            IEnumerable enumerableValue = value as IEnumerable;
-            if (enumerableValue != null && !(value is String))
-            {
-                if (!argumentType.IsArray)
-                    throw new BadImageFormatException();
-                Type reportedElementType = argumentType.GetElementType();
-                LowLevelListWithIList<CustomAttributeTypedArgument> elementTypedArguments = new LowLevelListWithIList<CustomAttributeTypedArgument>();
-                foreach (Object elementValue in enumerableValue)
-                {
-                    CustomAttributeTypedArgument elementTypedArgument = WrapInCustomAttributeTypedArgument(elementValue, reportedElementType);
-                    elementTypedArguments.Add(elementTypedArgument);
-                }
-                return new CustomAttributeTypedArgument(argumentType, new ReadOnlyCollection<CustomAttributeTypedArgument>(elementTypedArguments));
-            }
-            else
-            {
-                return new CustomAttributeTypedArgument(argumentType, value);
-            }
-        }
-
         private readonly MetadataReader _reader;
         private readonly CustomAttribute _customAttribute;
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -164,6 +165,44 @@ namespace System.Reflection.Runtime.CustomAttributes
             {
                 // This emulates Object.ToString() for consistency with prior .Net Native implementations. 
                 return GetType().ToString();
+            }
+        }
+
+        //
+        // Wrap a custom attribute argument (or an element of an array-typed custom attribute argument) in a CustomAttributeTypeArgument structure
+        // for insertion into a CustomAttributeData value.
+        //
+        protected CustomAttributeTypedArgument WrapInCustomAttributeTypedArgument(Object value, Type argumentType)
+        {
+            if (argumentType.Equals(CommonRuntimeTypes.Object))
+            {
+                // If the declared attribute type is System.Object, we must report the type based on the runtime value.
+                if (value == null)
+                    argumentType = CommonRuntimeTypes.String;  // Why is null reported as System.String? Because that's what the desktop CLR does.
+                else if (value is Type)
+                    argumentType = CommonRuntimeTypes.Type;    // value.GetType() will not actually be System.Type - rather it will be some internal implementation type. We only want to report it as System.Type.
+                else
+                    argumentType = value.GetType();
+            }
+
+            // Handle the array case
+            IEnumerable enumerableValue = value as IEnumerable;
+            if (enumerableValue != null && !(value is String))
+            {
+                if (!argumentType.IsArray)
+                    throw new BadImageFormatException();
+                Type reportedElementType = argumentType.GetElementType();
+                LowLevelListWithIList<CustomAttributeTypedArgument> elementTypedArguments = new LowLevelListWithIList<CustomAttributeTypedArgument>();
+                foreach (Object elementValue in enumerableValue)
+                {
+                    CustomAttributeTypedArgument elementTypedArgument = WrapInCustomAttributeTypedArgument(elementValue, reportedElementType);
+                    elementTypedArguments.Add(elementTypedArgument);
+                }
+                return new CustomAttributeTypedArgument(argumentType, new ReadOnlyCollection<CustomAttributeTypedArgument>(elementTypedArguments));
+            }
+            else
+            {
+                return new CustomAttributeTypedArgument(argumentType, value);
             }
         }
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Runtime.Assemblies
     internal partial class RuntimeAssembly
     {
         public sealed override object CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes) { throw new NotImplementedException(); }
-//        public sealed override MethodInfo EntryPoint { get { throw new NotImplementedException(); } }
+        public sealed override MethodInfo EntryPoint { get { throw new NotImplementedException(); } }
         public sealed override void GetObjectData(SerializationInfo info, StreamingContext context) { throw new NotImplementedException(); }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Runtime.Assemblies
     internal partial class RuntimeAssembly
     {
         public sealed override object CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes) { throw new NotImplementedException(); }
-        public sealed override MethodInfo EntryPoint { get { throw new NotImplementedException(); } }
+//        public sealed override MethodInfo EntryPoint { get { throw new NotImplementedException(); } }
         public sealed override void GetObjectData(SerializationInfo info, StreamingContext context) { throw new NotImplementedException(); }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.NativeFormat.cs
@@ -163,7 +163,7 @@ namespace System.Reflection.Runtime.ParameterInfos.NativeFormat
     //-----------------------------------------------------------------------------------------------------------
     internal sealed partial class NativeFormatMethodParameterInfo : RuntimeMethodParameterInfo
     {
-        internal static NativeFormatMethodParameterInfo GetNativeFormatMethodParameterInfo(MethodBase member, MethodHandle methodHandle, int position, ParameterHandle parameterHandle, QTypeDefRefOrSpec qualifiedParameterType, TypeContext typeContext)
+        internal static NativeFormatMethodParameterInfo GetNativeFormatMethodParameterInfo(MethodBase member, MethodHandle methodHandle, int position, ParameterHandle parameterHandle, QSignatureTypeHandle qualifiedParameterType, TypeContext typeContext)
         {
             return new NativeFormatMethodParameterInfo(member, methodHandle, position, parameterHandle, qualifiedParameterType, typeContext);
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -43,6 +43,30 @@ namespace System.Reflection.Runtime.Assemblies
         }
 
         /// <summary>
+        /// Returns non-null or throws.
+        /// </summary>
+        internal static RuntimeAssembly GetRuntimeAssemblyFromByteArray(byte[] rawAssembly, byte[] pdbSymbolStore)
+        {
+            AssemblyBinder binder = ReflectionCoreExecution.ExecutionDomain.ReflectionDomainSetup.AssemblyBinder;
+            AssemblyBindResult bindResult;
+            Exception exception;
+            if (!binder.Bind(rawAssembly, pdbSymbolStore, out bindResult, out exception))
+            {
+                if (exception != null)
+                    throw exception;
+                else
+                    throw new BadImageFormatException();
+            }
+
+            RuntimeAssembly result = null;
+            GetEcmaRuntimeAssembly(bindResult, ref result);
+            if (result != null)
+                return result;
+            else
+                throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>
         /// Returns null if no assembly matches the assemblyRefName. Throws for other error cases.
         /// </summary>
         internal static RuntimeAssembly GetRuntimeAssemblyIfExists(RuntimeAssemblyName assemblyRefName)
@@ -172,7 +196,7 @@ namespace System.Reflection.Runtime.ParameterInfos
     //-----------------------------------------------------------------------------------------------------------
     internal sealed partial class RuntimeThinMethodParameterInfo : RuntimeMethodParameterInfo
     {
-        internal static RuntimeThinMethodParameterInfo GetRuntimeThinMethodParameterInfo(MethodBase member, int position, QTypeDefRefOrSpec qualifiedParameterType, TypeContext typeContext)
+        internal static RuntimeThinMethodParameterInfo GetRuntimeThinMethodParameterInfo(MethodBase member, int position, QSignatureTypeHandle qualifiedParameterType, TypeContext typeContext)
         {
             return new RuntimeThinMethodParameterInfo(member, position, qualifiedParameterType, typeContext);
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -59,6 +59,11 @@ namespace System.Reflection.Runtime.Assemblies
             }
 
             RuntimeAssembly result = null;
+
+            GetNativeFormatRuntimeAssembly(bindResult, ref result);
+            if (result != null)
+                return result;
+
             GetEcmaRuntimeAssembly(bindResult, ref result);
             if (result != null)
                 return result;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.NativeFormat.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// Collection of "qualified handle" tuples.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.Metadata.NativeFormat;
+using Internal.Runtime.TypeLoader;
+
+namespace System.Reflection.Runtime.General
+{
+    public partial struct QSignatureTypeHandle
+    {
+        public QSignatureTypeHandle(MetadataReader reader, Handle handle, bool skipCheck = false)
+        {
+            if (!skipCheck)
+            {
+                if (!handle.IsTypeDefRefOrSpecHandle(reader))
+                    throw new BadImageFormatException();
+            }
+            
+            Debug.Assert(handle.IsTypeDefRefOrSpecHandle(reader));
+            _reader = reader;
+            _handle = handle;
+
+#if ECMA_METADATA_SUPPORT
+            _blobReader = default(global::System.Reflection.Metadata.BlobReader);
+#endif
+        }
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.Runtime.General
         public object Reader { get { return _reader; } }
         private object _reader;
 #if ECMA_METADATA_SUPPORT
-        readonly private global::System.Reflection.Metadata.BlobReader _blobReader;
+        private readonly global::System.Reflection.Metadata.BlobReader _blobReader;
 #endif
         private global::Internal.Metadata.NativeFormat.Handle _handle;
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// Collection of "qualified handle" tuples.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection.Runtime.TypeInfos;
+
+namespace System.Reflection.Runtime.General
+{
+    public partial struct QSignatureTypeHandle
+    {
+        public object Reader { get { return _reader; } }
+        private object _reader;
+#if ECMA_METADATA_SUPPORT
+        readonly private global::System.Reflection.Metadata.BlobReader _blobReader;
+#endif
+        private global::Internal.Metadata.NativeFormat.Handle _handle;
+
+        internal RuntimeTypeInfo Resolve(TypeContext typeContext)
+        {
+            Exception exception = null;
+            RuntimeTypeInfo runtimeType = TryResolve(typeContext, ref exception);
+            if (runtimeType == null)
+                throw exception;
+            return runtimeType;
+        }
+
+        internal RuntimeTypeInfo TryResolve(TypeContext typeContext, ref Exception exception)
+        {
+            if (Reader is global::Internal.Metadata.NativeFormat.MetadataReader)
+            {
+                return _handle.TryResolve((global::Internal.Metadata.NativeFormat.MetadataReader)Reader, typeContext, ref exception);
+            }
+            
+#if ECMA_METADATA_SUPPORT
+            global::System.Reflection.Metadata.MetadataReader ecmaReader = Reader as global::System.Reflection.Metadata.MetadataReader;
+            if (ecmaReader != null)
+            {
+                return TryResolveSignature(typeContext, ref exception);
+            }
+#endif
+
+            throw new BadImageFormatException();  // Expected TypeRef, Def or Spec with MetadataReader
+        }
+        
+        // 
+        // This is a port of the desktop CLR's RuntimeType.FormatTypeName() routine. This routine is used by various Reflection ToString() methods
+        // to display the name of a type. Do not use for any other purpose as it inherits some pretty quirky desktop behavior.
+        //        
+        internal String FormatTypeName(TypeContext typeContext)
+        {
+            try
+            {
+                // Though we wrap this in a try-catch as a failsafe, this code must still strive to avoid triggering MissingMetadata exceptions
+                // (non-error exceptions are very annoying when debugging.)
+
+                Exception exception = null;
+                RuntimeTypeInfo runtimeType = TryResolve(typeContext, ref exception);
+                if (runtimeType == null)
+                    return ToStringUtils.UnavailableType;
+
+                // Because this runtimeType came from a successful TryResolve() call, it is safe to querying the TypeInfo's of the type and its component parts.
+                // If we're wrong, we do have the safety net of a try-catch.
+                return runtimeType.FormatTypeName();
+            }
+            catch (Exception)
+            {
+                return ToStringUtils.UnavailableType;
+            }
+        }        
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -37,7 +37,7 @@ namespace System.Reflection.Runtime.General
         public sealed override Assembly Load(byte[] rawAssembly, byte[] pdbSymbolStore)
         {
             if (rawAssembly == null)
-                throw new ArgumentNullException("rawAssembly");
+                throw new ArgumentNullException(nameof(rawAssembly));
 
             return RuntimeAssembly.GetRuntimeAssemblyFromByteArray(rawAssembly, pdbSymbolStore);
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -34,6 +34,14 @@ namespace System.Reflection.Runtime.General
             return RuntimeAssembly.GetRuntimeAssembly(refName.ToRuntimeAssemblyName());
         }
 
+        public sealed override Assembly Load(byte[] rawAssembly, byte[] pdbSymbolStore)
+        {
+            if (rawAssembly == null)
+                throw new ArgumentNullException("rawAssembly");
+
+            return RuntimeAssembly.GetRuntimeAssemblyFromByteArray(rawAssembly, pdbSymbolStore);
+        }
+
         //
         // This overload of GetMethodForHandle only accepts handles for methods declared on non-generic types (the method, however,
         // can be an instance of a generic method.) To resolve handles for methods declared on generic types, you must pass
@@ -44,7 +52,7 @@ namespace System.Reflection.Runtime.General
         public sealed override MethodBase GetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle)
         {
             ExecutionEnvironment executionEnvironment = ReflectionCoreExecution.ExecutionEnvironment;
-            MethodHandle methodHandle;
+            QMethodDefinition methodHandle;
             RuntimeTypeHandle declaringTypeHandle;
             RuntimeTypeHandle[] genericMethodTypeArgumentHandles;
             if (!executionEnvironment.TryGetMethodFromHandle(runtimeMethodHandle, out declaringTypeHandle, out methodHandle, out genericMethodTypeArgumentHandles))
@@ -62,7 +70,7 @@ namespace System.Reflection.Runtime.General
         public sealed override MethodBase GetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle, RuntimeTypeHandle declaringTypeHandle)
         {
             ExecutionEnvironment executionEnvironment = ReflectionCoreExecution.ExecutionEnvironment;
-            MethodHandle methodHandle;
+            QMethodDefinition methodHandle;
             RuntimeTypeHandle[] genericMethodTypeArgumentHandles;
             if (!executionEnvironment.TryGetMethodFromHandleAndType(runtimeMethodHandle, declaringTypeHandle, out methodHandle, out genericMethodTypeArgumentHandles))
             {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.NativeFormat.cs
@@ -70,7 +70,7 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
             RuntimeTypeHandle typeHandle = precomputedTypeHandle;
             if (typeHandle.IsNull())
             {
-                if (!ReflectionCoreExecution.ExecutionEnvironment.TryGetNamedTypeForMetadata(metadataReader, typeDefHandle, out typeHandle))
+                if (!ReflectionCoreExecution.ExecutionEnvironment.TryGetNamedTypeForMetadata(new QTypeDefinition(metadataReader, typeDefHandle), out typeHandle))
                     typeHandle = default(RuntimeTypeHandle);
             }
             UnificationKey key = new UnificationKey(metadataReader, typeDefHandle, typeHandle);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/IRuntimeMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/IRuntimeMethodCommon.cs
@@ -35,14 +35,14 @@ namespace System.Reflection.Runtime.MethodInfos
         /// <summary>
         /// Return an array of the types of the return value and parameter types.
         /// </summary>
-        QTypeDefRefOrSpec[] QualifiedMethodSignature { get; }
+        QSignatureTypeHandle[] QualifiedMethodSignature { get; }
 
         /// <summary>
         /// Parse the metadata that describes parameters, and for each parameter for which there is specific metadata
         /// construct a RuntimeParameterInfo and fill in the VirtualRuntimeParamterInfoArray. Do remember to use contextMethod
         /// instead of using the one internal to the RuntimeMethodCommon, as the runtime may pass in a subtly different context.
         /// </summary>
-        void FillInMetadataDescribedParameters(ref VirtualRuntimeParameterInfoArray result, QTypeDefRefOrSpec[] parameterTypes, MethodBase contextMethod, TypeContext typeContext);
+        void FillInMetadataDescribedParameters(ref VirtualRuntimeParameterInfoArray result, QSignatureTypeHandle[] parameterTypes, MethodBase contextMethod, TypeContext typeContext);
 
         String Name { get; }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
@@ -37,21 +37,21 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
 
         public MethodInvoker GetUncachedMethodInvoker(RuntimeTypeInfo[] methodArguments, MemberInfo exceptionPertainant)
         {
-            return ReflectionCoreExecution.ExecutionEnvironment.GetMethodInvoker(Reader, DeclaringType, MethodHandle, methodArguments, exceptionPertainant);
+            return ReflectionCoreExecution.ExecutionEnvironment.GetMethodInvoker(DeclaringType, new QMethodDefinition(Reader, MethodHandle), methodArguments, exceptionPertainant);
         }
 
-        public QTypeDefRefOrSpec[] QualifiedMethodSignature
+        public QSignatureTypeHandle[] QualifiedMethodSignature
         {
             get
             {
                 MethodSignature methodSignature = this.MethodSignature;
 
-                QTypeDefRefOrSpec[] typeSignatures = new QTypeDefRefOrSpec[methodSignature.Parameters.Count + 1];
-                typeSignatures[0] = new QTypeDefRefOrSpec(_reader, methodSignature.ReturnType, true);
+                QSignatureTypeHandle[] typeSignatures = new QSignatureTypeHandle[methodSignature.Parameters.Count + 1];
+                typeSignatures[0] = new QSignatureTypeHandle(_reader, methodSignature.ReturnType, true);
                 int paramIndex = 1;
                 foreach (Handle parameterTypeSignatureHandle in methodSignature.Parameters)
                 {
-                    typeSignatures[paramIndex++] = new QTypeDefRefOrSpec(_reader, parameterTypeSignatureHandle, true);
+                    typeSignatures[paramIndex++] = new QSignatureTypeHandle(_reader, parameterTypeSignatureHandle, true);
                 }
 
                 return typeSignatures;
@@ -67,7 +67,7 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
             }
         }
 
-        public void FillInMetadataDescribedParameters(ref VirtualRuntimeParameterInfoArray result, QTypeDefRefOrSpec[] typeSignatures, MethodBase contextMethod, TypeContext typeContext)
+        public void FillInMetadataDescribedParameters(ref VirtualRuntimeParameterInfoArray result, QSignatureTypeHandle[] typeSignatures, MethodBase contextMethod, TypeContext typeContext)
         {
             foreach (ParameterHandle parameterHandle in _method.Parameters)
             {
@@ -233,7 +233,7 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
                         _methodHandle,
                         index - 1,
                         parameterHandle,
-                        new QTypeDefRefOrSpec(reader, typeSignatures[index]),
+                        new QSignatureTypeHandle(reader, typeSignatures[index]),
                         typeContext);
             }
             for (int i = 0; i < count; i++)
@@ -244,7 +244,7 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
                         RuntimeThinMethodParameterInfo.GetRuntimeThinMethodParameterInfo(
                             contextMethod,
                             i - 1,
-                            new QTypeDefRefOrSpec(reader, typeSignatures[i]),
+                            new QSignatureTypeHandle(reader, typeSignatures[i]),
                             typeContext);
                 }
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodHelpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodHelpers.cs
@@ -33,7 +33,7 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             TypeContext typeContext = contextMethod.DeclaringType.CastToRuntimeTypeInfo().TypeContext;
             typeContext = new TypeContext(typeContext.GenericTypeArguments, methodTypeArguments);
-            QTypeDefRefOrSpec[] typeSignatures = runtimeMethodCommon.QualifiedMethodSignature;
+            QSignatureTypeHandle[] typeSignatures = runtimeMethodCommon.QualifiedMethodSignature;
             int count = typeSignatures.Length;
 
             VirtualRuntimeParameterInfoArray result = new VirtualRuntimeParameterInfoArray(count);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/NativeFormat/NativeFormatMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/NativeFormat/NativeFormatMethodParameterInfo.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Runtime.ParameterInfos.NativeFormat
     //
     internal sealed partial class NativeFormatMethodParameterInfo : RuntimeMethodParameterInfo
     {
-        private NativeFormatMethodParameterInfo(MethodBase member, MethodHandle methodHandle, int position, ParameterHandle parameterHandle, QTypeDefRefOrSpec qualifiedParameterTypeHandle, TypeContext typeContext)
+        private NativeFormatMethodParameterInfo(MethodBase member, MethodHandle methodHandle, int position, ParameterHandle parameterHandle, QSignatureTypeHandle qualifiedParameterTypeHandle, TypeContext typeContext)
             : base(member, position, qualifiedParameterTypeHandle, typeContext)
         {
             _methodHandle = methodHandle;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
@@ -18,7 +18,7 @@ namespace System.Reflection.Runtime.ParameterInfos
     //
     internal abstract class RuntimeMethodParameterInfo : RuntimeParameterInfo
     {
-        protected RuntimeMethodParameterInfo(MethodBase member, int position, QTypeDefRefOrSpec qualifiedParameterTypeHandle, TypeContext typeContext)
+        protected RuntimeMethodParameterInfo(MethodBase member, int position, QSignatureTypeHandle qualifiedParameterTypeHandle, TypeContext typeContext)
             : base(member, position)
         {
             QualifiedParameterTypeHandle = qualifiedParameterTypeHandle;
@@ -41,7 +41,7 @@ namespace System.Reflection.Runtime.ParameterInfos
             }
         }
 
-        protected readonly QTypeDefRefOrSpec QualifiedParameterTypeHandle;
+        protected readonly QSignatureTypeHandle QualifiedParameterTypeHandle;
         private readonly TypeContext _typeContext;
         private volatile Type _lazyParameterType;
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeThinMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeThinMethodParameterInfo.cs
@@ -18,7 +18,7 @@ namespace System.Reflection.Runtime.ParameterInfos
     //
     internal sealed partial class RuntimeThinMethodParameterInfo : RuntimeMethodParameterInfo
     {
-        private RuntimeThinMethodParameterInfo(MethodBase member, int position, QTypeDefRefOrSpec qualifiedParameterTypeHandle, TypeContext typeContext)
+        private RuntimeThinMethodParameterInfo(MethodBase member, int position, QSignatureTypeHandle qualifiedParameterTypeHandle, TypeContext typeContext)
             : base(member, position, qualifiedParameterTypeHandle, typeContext)
         {
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/NativeFormat/NativeFormatRuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/NativeFormat/NativeFormatRuntimePropertyInfo.cs
@@ -134,11 +134,11 @@ namespace System.Reflection.Runtime.PropertyInfos.NativeFormat
             }
         }
 
-        protected sealed override QTypeDefRefOrSpec PropertyTypeHandle
+        protected sealed override QSignatureTypeHandle PropertyTypeHandle
         {
             get
             {
-                return new QTypeDefRefOrSpec(_reader, _property.Signature.GetPropertySignature(_reader).Type);
+                return new QSignatureTypeHandle(_reader, _property.Signature.GetPropertySignature(_reader).Type);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -345,7 +345,7 @@ namespace System.Reflection.Runtime.PropertyInfos
         /// <summary>
         /// Return a qualified handle that can be used to get the type of the property.
         /// </summary>
-        protected abstract QTypeDefRefOrSpec PropertyTypeHandle { get; }
+        protected abstract QSignatureTypeHandle PropertyTypeHandle { get; }
 
         protected enum PropertyMethodSemantics
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -833,7 +833,7 @@ namespace System.Reflection.Runtime.TypeInfos
             {
                 QTypeDefRefOrSpec baseTypeDefRefOrSpec = TypeRefDefOrSpecForBaseType;
                 RuntimeTypeInfo baseType = null;
-                if (!baseTypeDefRefOrSpec.IsNull)
+                if (!baseTypeDefRefOrSpec.IsValid)
                 {
                     baseType = baseTypeDefRefOrSpec.Resolve(this.TypeContext);
                 }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -168,10 +168,10 @@ namespace Internal.Reflection.Execution
         /// <param name="runtimeTypeHandle">Runtime handle of the type in question</param>
         /// <param name="metadataReader">Metadata reader located for the type</param>
         /// <param name="typeDefHandle">TypeDef handle for the type</param>
-        public unsafe sealed override bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out QTypeDefinition qtypedefinition)
+        public unsafe sealed override bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out QTypeDefinition qTypeDefinition)
         {
             Debug.Assert(!RuntimeAugments.IsGenericType(runtimeTypeHandle));
-            return TypeLoaderEnvironment.Instance.TryGetMetadataForNamedType(runtimeTypeHandle, out qtypedefinition);
+            return TypeLoaderEnvironment.Instance.TryGetMetadataForNamedType(runtimeTypeHandle, out qTypeDefinition);
         }
 
         //

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MetadataTable.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MetadataTable.cs
@@ -12,8 +12,6 @@ using global::Internal.Reflection.Core;
 using global::Internal.Reflection.Core.Execution;
 using global::Internal.Reflection.Execution.MethodInvokers;
 
-using global::Internal.Metadata.NativeFormat;
-
 using global::System.Runtime.CompilerServices;
 using global::System.Runtime.InteropServices;
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MetadataReaderExtensions.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MetadataReaderExtensions.cs
@@ -69,6 +69,15 @@ namespace Internal.Reflection.Execution
             }
         }
 
+        public static TypeDefinitionHandle AsTypeDefinitionHandle(this int i)
+        {
+            unsafe
+            {
+                Debug.Assert((HandleType)((uint)i >> 24) == HandleType.TypeDefinition);
+                return *(TypeDefinitionHandle*)&i;
+            }
+        }
+
         public static int WithoutHandleType(this int constantStringValueHandle)
         {
             unsafe

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/InstanceMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/InstanceMethodInvoker.cs
@@ -5,6 +5,7 @@
 using global::System;
 using global::System.Threading;
 using global::System.Reflection;
+using System.Runtime.InteropServices;
 using global::System.Diagnostics;
 using global::System.Collections.Generic;
 
@@ -52,7 +53,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
             {
                 return RuntimeAugments.CreateDelegate(
                     delegateType,
-                    new OpenMethodResolver(_declaringTypeHandle, MethodInvokeInfo.LdFtnResult, 0).ToIntPtr(),
+                    new OpenMethodResolver(_declaringTypeHandle, MethodInvokeInfo.LdFtnResult, default(GCHandle), 0).ToIntPtr(),
                     target,
                     isStatic: isStatic,
                     isOpen: isOpen);

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/MethodInvokerWithMethodInvokeInfo.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/MethodInvokerWithMethodInvokeInfo.cs
@@ -55,7 +55,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 var method = reader.GetMethodDefinition(methodHandle.EcmaFormatHandle);
                 var blobReader = reader.GetBlobReader(method.Signature);
                 byte sigByte = blobReader.ReadByte();
-                if ((sigByte & 0x20) == 0)
+                if ((sigByte & SignatureAttributes.Instance) == 0)
                     isStatic = true;
             }
 #endif

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/MethodInvokerWithMethodInvokeInfo.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/MethodInvokerWithMethodInvokeInfo.cs
@@ -13,6 +13,7 @@ using global::Internal.Reflection.Execution;
 using global::Internal.Reflection.Core.Execution;
 
 using global::Internal.Metadata.NativeFormat;
+using System.Reflection.Runtime.General;
 
 namespace Internal.Reflection.Execution.MethodInvokers
 {
@@ -36,11 +37,30 @@ namespace Internal.Reflection.Execution.MethodInvokers
         //
         // Creates the appropriate flavor of Invoker depending on the calling convention "shape" (static, instance or virtual.)
         //
-        internal static MethodInvoker CreateMethodInvoker(MetadataReader reader, RuntimeTypeHandle declaringTypeHandle, MethodHandle methodHandle, MethodInvokeInfo methodInvokeInfo)
+        internal static MethodInvoker CreateMethodInvoker(RuntimeTypeHandle declaringTypeHandle, QMethodDefinition methodHandle, MethodInvokeInfo methodInvokeInfo)
         {
-            Method method = methodHandle.GetMethod(reader);
-            MethodAttributes methodAttributes = method.Flags;
-            if (0 != (methodAttributes & MethodAttributes.Static))
+            bool isStatic = false;
+            
+            if (methodHandle.IsNativeFormatMetadataBased)
+            {
+                Method method = methodHandle.NativeFormatHandle.GetMethod(methodHandle.NativeFormatReader);
+                MethodAttributes methodAttributes = method.Flags;
+                if (0 != (methodAttributes & MethodAttributes.Static))
+                    isStatic = true;
+            }
+#if ECMA_METADATA_SUPPORT
+            if (methodHandle.IsEcmaFormatMetadataBased)
+            {
+                var reader = methodHandle.EcmaFormatReader;
+                var method = reader.GetMethodDefinition(methodHandle.EcmaFormatHandle);
+                var blobReader = reader.GetBlobReader(method.Signature);
+                byte sigByte = blobReader.ReadByte();
+                if ((sigByte & 0x20) == 0)
+                    isStatic = true;
+            }
+#endif
+
+            if (isStatic)
                 return new StaticMethodInvoker(methodInvokeInfo);
             else if (methodInvokeInfo.VirtualResolveData != IntPtr.Zero)
                 return new VirtualMethodInvoker(methodInvokeInfo, declaringTypeHandle);

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfoImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfoImplementation.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using global::System;
+using global::System.Reflection;
+using global::System.Collections.Generic;
+
+using global::Internal.Runtime.Augments;
+
+using global::Internal.Reflection.Core;
+using global::Internal.Reflection.Core.Execution;
+
+using global::Internal.Metadata.NativeFormat;
+
+namespace Internal.Reflection.Execution
+{
+    internal sealed class NativeFormatEnumInfoImplementation : EnumInfoImplementation
+    {
+        public NativeFormatEnumInfoImplementation(Type enumType, MetadataReader reader, TypeDefinitionHandle typeDefinitionHandle) : base(enumType)
+        {
+            _reader = reader;
+            _typeDefinition = typeDefinitionHandle.GetTypeDefinition(reader);
+        }
+
+        protected override KeyValuePair<String, ulong>[] ReadNamesAndValues()
+        {
+            LowLevelList<KeyValuePair<String, ulong>> namesAndUnboxedValues = new LowLevelList<KeyValuePair<String, ulong>>();
+            MetadataReader reader = _reader;
+            foreach (FieldHandle fieldHandle in _typeDefinition.Fields)
+            {
+                Field field = fieldHandle.GetField(reader);
+                if (0 != (field.Flags & FieldAttributes.Static))
+                {
+                    String name = field.Name.GetString(reader);
+                    Handle valueHandle = field.DefaultValue;
+                    ulong lValue = ReadUnboxedEnumValue(reader, valueHandle);
+                    namesAndUnboxedValues.Add(new KeyValuePair<String, ulong>(name, lValue));
+                }
+            }
+
+            return namesAndUnboxedValues.ToArray();
+        }
+
+        //
+        // This returns the underlying enum values as "ulong" regardless of the actual underlying type. Signed integral types 
+        // get sign-extended into the 64-bit value, unsigned types get zero-extended.
+        //
+        private static ulong ReadUnboxedEnumValue(MetadataReader reader, Handle valueHandle)
+        {
+            HandleType handleType = valueHandle.HandleType;
+            switch (handleType)
+            {
+                case HandleType.ConstantBooleanValue:
+                    {
+                        bool v = valueHandle.ToConstantBooleanValueHandle(reader).GetConstantBooleanValue(reader).Value;
+                        return v ? 1UL : 0UL;
+                    }
+
+                case HandleType.ConstantCharValue:
+                    {
+                        char v = valueHandle.ToConstantCharValueHandle(reader).GetConstantCharValue(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                case HandleType.ConstantByteValue:
+                    {
+                        byte v = valueHandle.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                case HandleType.ConstantSByteValue:
+                    {
+                        sbyte v = valueHandle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                case HandleType.ConstantUInt16Value:
+                    {
+                        UInt16 v = valueHandle.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                case HandleType.ConstantInt16Value:
+                    {
+                        Int16 v = valueHandle.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                case HandleType.ConstantUInt32Value:
+                    {
+                        UInt32 v = valueHandle.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                case HandleType.ConstantInt32Value:
+                    {
+                        Int32 v = valueHandle.ToConstantInt32ValueHandle(reader).GetConstantInt32Value(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                case HandleType.ConstantUInt64Value:
+                    {
+                        UInt64 v = valueHandle.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                case HandleType.ConstantInt64Value:
+                    {
+                        Int64 v = valueHandle.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value;
+                        return (ulong)(long)v;
+                    }
+
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
+        private MetadataReader _reader;
+        private TypeDefinition _typeDefinition;
+    }
+}

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfoImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfoImplementation.cs
@@ -23,7 +23,7 @@ namespace Internal.Reflection.Execution
             _typeDefinition = typeDefinitionHandle.GetTypeDefinition(reader);
         }
 
-        protected override KeyValuePair<String, ulong>[] ReadNamesAndValues()
+        protected sealed override KeyValuePair<String, ulong>[] ReadNamesAndValues()
         {
             LowLevelList<KeyValuePair<String, ulong>> namesAndUnboxedValues = new LowLevelList<KeyValuePair<String, ulong>>();
             MetadataReader reader = _reader;

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -110,8 +110,7 @@ namespace Internal.Reflection.Execution
 
             if (qTypeDefinition.IsNativeFormatMetadataBased)
             {
-                TypeDefinitionHandle typeDefinitionHandle = qTypeDefinition.NativeFormatHandle;
-                return new NativeFormatEnumInfoImplementation(enumType, qTypeDefinition.NativeFormatReader, typeDefinitionHandle);
+                return new NativeFormatEnumInfoImplementation(enumType, qTypeDefinition.NativeFormatReader, qTypeDefinition.NativeFormatHandle);
             }
 #if ECMA_METADATA_SUPPORT
             if (qTypeDefinition.IsEcmaFormatMetadataBased)

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -16,6 +16,8 @@ using Internal.Reflection.Core.Execution;
 using Internal.Reflection.Execution.PayForPlayExperience;
 using Internal.Reflection.Extensions.NonPortable;
 
+using System.Reflection.Runtime.General;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.Reflection.Execution
@@ -102,12 +104,22 @@ namespace Internal.Reflection.Execution
                 enumType = enumType.GetGenericTypeDefinition();
             }
 
-            MetadataReader reader;
-            TypeDefinitionHandle typeDefinitionHandle;
-            if (!ReflectionExecution.ExecutionEnvironment.TryGetMetadataForNamedType(enumType.TypeHandle, out reader, out typeDefinitionHandle))
+            QTypeDefinition qTypeDefinition;
+            if (!ReflectionExecution.ExecutionEnvironment.TryGetMetadataForNamedType(enumType.TypeHandle, out qTypeDefinition))
                 return null;
 
-            return new EnumInfoImplementation(enumType, reader, typeDefinitionHandle);
+            if (qTypeDefinition.IsNativeFormatMetadataBased)
+            {
+                TypeDefinitionHandle typeDefinitionHandle = qTypeDefinition.NativeFormatHandle;
+                return new NativeFormatEnumInfoImplementation(enumType, qTypeDefinition.NativeFormatReader, typeDefinitionHandle);
+            }
+#if ECMA_METADATA_SUPPORT
+            if (qTypeDefinition.IsEcmaFormatMetadataBased)
+            {
+                return new EcmaFormatEnumInfoImplementation(enumType, qTypeDefinition.EcmaFormatReader, qTypeDefinition.EcmaFormatHandle);
+            }
+#endif
+            return null;
         }
 
         // This is called from the ToString() helper of a RuntimeType that does not have full metadata.
@@ -120,7 +132,7 @@ namespace Internal.Reflection.Execution
         public sealed override String GetMethodNameFromStartAddressIfAvailable(IntPtr methodStartAddress)
         {
             RuntimeTypeHandle declaringTypeHandle = default(RuntimeTypeHandle);
-            MethodHandle methodHandle;
+            QMethodDefinition methodHandle;
             RuntimeTypeHandle[] genericMethodTypeArgumentHandles;
             if (!ReflectionExecution.ExecutionEnvironment.TryGetMethodForOriginalLdFtnResult(methodStartAddress,
                 ref declaringTypeHandle, out methodHandle, out genericMethodTypeArgumentHandles))

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Extensions/NonPortable/DelegateMethodInfoRetriever.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Extensions/NonPortable/DelegateMethodInfoRetriever.cs
@@ -12,6 +12,7 @@ using global::Internal.Reflection.Execution;
 using global::Internal.Reflection.Core.Execution;
 
 using global::Internal.Metadata.NativeFormat;
+using System.Reflection.Runtime.General;
 
 namespace Internal.Reflection.Extensions.NonPortable
 {
@@ -29,7 +30,7 @@ namespace Internal.Reflection.Extensions.NonPortable
             if (originalLdFtnResult == (IntPtr)0)
                 return null;
 
-            MethodHandle methodHandle = default(MethodHandle);
+            QMethodDefinition methodHandle = default(QMethodDefinition);
             RuntimeTypeHandle[] genericMethodTypeArgumentHandles = null;
 
             bool callTryGetMethod = true;
@@ -47,7 +48,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                     else if (resolver->ResolverType == OpenMethodResolver.DispatchResolve)
                     {
                         callTryGetMethod = false;
-                        methodHandle = resolver->Handle.AsMethodHandle();
+                        methodHandle = QMethodDefinition.FromObjectAndInt(resolver->Reader, resolver->Handle);
                         genericMethodTypeArgumentHandles = null;
                     }
                     else
@@ -55,7 +56,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                         System.Diagnostics.Debug.Assert(resolver->ResolverType == OpenMethodResolver.GVMResolve);
 
                         callTryGetMethod = false;
-                        methodHandle = resolver->Handle.AsMethodHandle();
+                        methodHandle = QMethodDefinition.FromObjectAndInt(resolver->Reader, resolver->Handle);
 
                         RuntimeTypeHandle declaringTypeHandleIgnored;
                         MethodNameAndSignature nameAndSignatureIgnored;

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Internal\Reflection\Execution\ReflectionExecutionDomainCallbacksImplementation.cs" />
     <Compile Include="Internal\Reflection\Execution\MetadataReaderExtensions.cs" />
     <Compile Include="Internal\Reflection\Execution\EnumInfoImplementation.cs" />
+    <Compile Include="Internal\Reflection\Execution\NativeFormatEnumInfoImplementation.cs" />
     <Compile Include="Internal\Reflection\Execution\DefaultValueParser.cs" />
     <Compile Include="Internal\Reflection\Execution\MethodInvokeInfo.cs" />
     <Compile Include="Internal\Reflection\Execution\RuntimeHandlesExtensions.cs" />

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -33,6 +33,8 @@ namespace Internal.Reflection.Core
 
         public abstract bool Bind(AssemblyName refName, out AssemblyBindResult result, out Exception exception);
 
+        public abstract bool Bind(byte[] rawAssembly, byte[] rawSymbolStore, out AssemblyBindResult result, out Exception exception);
+
         // This helper is a concession to the fact that third-party binders running on top of the Win8P surface area have no sensible way
         // to perform this task due to the lack of a SetCulture() api on the AssemblyName class. Reflection.Core *is* able to do this 
         // thanks to the Internal.Reflection.Augment contract so we will expose this helper for the convenience of binders. 

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
@@ -26,7 +26,7 @@ namespace Internal.Reflection.Execution
     // native process. There is no support for probing for assemblies in directories, user-supplied files, GACs, NICs or any
     // other repository.
     //=============================================================================================================================
-    public sealed class AssemblyBinderImplementation : AssemblyBinder
+    public sealed partial class AssemblyBinderImplementation : AssemblyBinder
     {
         private sealed class AssemblyNameKey : IEquatable<AssemblyNameKey>
         {
@@ -76,6 +76,24 @@ namespace Internal.Reflection.Execution
 
         public static AssemblyBinderImplementation Instance { get; } = new AssemblyBinderImplementation();
 
+        partial void BindEcmaByteArray(byte[] rawAssembly, byte[] rawSymbolStore, ref AssemblyBindResult bindResult, ref Exception exception, ref bool? result);
+        partial void BindEcmaAssemblyName(AssemblyName refName, ref AssemblyBindResult result, ref Exception exception, ref bool resultBoolean);
+
+        public sealed override bool Bind(byte[] rawAssembly, byte[] rawSymbolStore, out AssemblyBindResult bindResult, out Exception exception)
+        {
+            bool? result = null;
+            exception = null;
+            bindResult = default(AssemblyBindResult);
+
+            BindEcmaByteArray(rawAssembly, rawSymbolStore, ref bindResult, ref exception, ref result);
+
+            // If the Ecma assembly binder isn't linked in, simply throw PlatformNotSupportedException
+            if (!result.HasValue)
+                throw new PlatformNotSupportedException();
+            else
+                return result.Value;
+        }
+
         public sealed override bool Bind(AssemblyName refName, out AssemblyBindResult result, out Exception exception)
         {
             bool foundMatch = false;
@@ -120,6 +138,10 @@ namespace Internal.Reflection.Execution
                     result.OverflowScopes = scopeDefinitionGroup.OverflowScopes;
                 }
             }
+
+            BindEcmaAssemblyName(refName, ref result, ref exception, ref foundMatch);
+            if (exception != null)
+                return false;
 
             if (!foundMatch)
             {

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
@@ -236,7 +236,9 @@ namespace Internal.Reflection.Execution
         /// <param name="moduleInfo">Module to register</param>
         private void RegisterModule(ModuleInfo moduleInfo)
         {
-            if (moduleInfo.MetadataReader == null)
+            NativeFormatModuleInfo nativeFormatModuleInfo = moduleInfo as NativeFormatModuleInfo;
+
+            if (nativeFormatModuleInfo == null)
             {
                 return;
             }
@@ -246,7 +248,7 @@ namespace Internal.Reflection.Execution
             {
                 scopeGroups.Add(oldGroup.Key, oldGroup.Value);
             }
-            AddScopesFromReaderToGroups(scopeGroups, moduleInfo.MetadataReader);
+            AddScopesFromReaderToGroups(scopeGroups, nativeFormatModuleInfo.MetadataReader);
 
             // Update reader and scope list
             KeyValuePair<AssemblyNameKey, ScopeDefinitionGroup>[] scopeGroupsArray = new KeyValuePair<AssemblyNameKey, ScopeDefinitionGroup>[scopeGroups.Count];

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.CallConversionInfo.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallConverterThunk.CallConversionInfo.cs
@@ -179,7 +179,7 @@ namespace Internal.Runtime.TypeLoader
                 {
                     NativeLayoutInfoLoadContext nativeLayoutContext = new NativeLayoutInfoLoadContext();
 
-                    nativeLayoutContext._moduleHandle = _methodSignature.ModuleHandle;
+                    nativeLayoutContext._module = _methodSignature.GetModuleInfo();
                     nativeLayoutContext._typeSystemContext = context;
                     nativeLayoutContext._typeArgumentHandles = Instantiation.Empty;
                     nativeLayoutContext._methodArgumentHandles = Instantiation.Empty;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/DispatchCellInfo.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/DispatchCellInfo.cs
@@ -22,7 +22,7 @@ namespace Internal.Runtime.TypeLoader
         VTableOffset = 0x2,
     }
 
-#pragma warning disable 0649 // Disable warning about unused field. Some fields in struct below are only manipulated from native code
+    [StructLayout(StructLayoutKind.Sequential)]
     internal struct DispatchCellInfo
     {
         public DispatchCellType CellType;
@@ -32,5 +32,4 @@ namespace Internal.Runtime.TypeLoader
         public uint MetadataToken;
         public uint VTableOffset;
     }
-#endif
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/DispatchCellInfo.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/DispatchCellInfo.cs
@@ -32,4 +32,5 @@ namespace Internal.Runtime.TypeLoader
         public uint MetadataToken;
         public uint VTableOffset;
     }
+#endif
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/DispatchCellInfo.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/DispatchCellInfo.cs
@@ -22,6 +22,7 @@ namespace Internal.Runtime.TypeLoader
         VTableOffset = 0x2,
     }
 
+#pragma warning disable 0649 // Disable warning about unused field. Some fields in struct below are only manipulated from native code
     internal struct DispatchCellInfo
     {
         public DispatchCellType CellType;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -15,7 +15,6 @@ using System.Threading;
 
 using Internal.Metadata.NativeFormat;
 using Internal.TypeSystem;
-using Internal.TypeSystem.NativeFormat;
 
 namespace Internal.Runtime.TypeLoader
 {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LazyVtableResolverThunk.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LazyVtableResolverThunk.cs
@@ -490,7 +490,7 @@ namespace Internal.Runtime.TypeLoader
                     continue;
 
                 MethodSignatureComparer sigComparer = new MethodSignatureComparer(method.MetadataReader, method.Handle);
-                if (!sigComparer.IsMatchingNativeLayoutMethodNameAndSignature(methodNameAndSig.Name, methodNameAndSig.Signature.NativeLayoutSignature()))
+                if (!sigComparer.IsMatchingNativeLayoutMethodNameAndSignature(methodNameAndSig.Name, methodNameAndSig.Signature))
                     continue;
 
                 // At this point we've matched

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LockFreeObjectInterner.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LockFreeObjectInterner.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Internal.TypeSystem
+{
+    public class LockFreeObjectInterner : LockFreeReaderHashtableOfPointers<object, GCHandle>
+    {
+        static LockFreeObjectInterner s_interner = new LockFreeObjectInterner();
+        public static GCHandle GetInternedObjectHandle(object obj)
+        {
+            return s_interner.GetOrCreateValue(obj);
+        }
+
+        /// <summary>
+        /// Given a key, compute a hash code. This function must be thread safe.
+        /// </summary>
+        protected override int GetKeyHashCode(object key)
+        {
+            return key.GetHashCode();
+        }
+
+        /// <summary>
+        /// Given a value, compute a hash code which would be identical to the hash code
+        /// for a key which should look up this value. This function must be thread safe.
+        /// </summary>
+        protected override int GetValueHashCode(GCHandle value)
+        {
+            return value.Target.GetHashCode();
+        }
+
+        /// <summary>
+        /// Compare a key and value. If the key refers to this value, return true.
+        /// This function must be thread safe.
+        /// </summary>
+        protected override bool CompareKeyToValue(object key, GCHandle value)
+        {
+            return key == value.Target;
+        }
+
+        /// <summary>
+        /// Compare a value with another value. Return true if values are equal.
+        /// This function must be thread safe.
+        /// </summary>
+        protected override bool CompareValueToValue(GCHandle value1, GCHandle value2)
+        {
+            return value1.Target == value2.Target;
+        }
+
+        /// <summary>
+        /// Create a new value from a key. Must be threadsafe. Value may or may not be added
+        /// to collection. Return value must not be null.
+        /// </summary>
+        protected override GCHandle CreateValueFromKey(object key)
+        {
+            return GCHandle.Alloc(key);
+        }
+
+        /// <summary>
+        /// Convert a value to an IntPtr for storage into the hashtable
+        /// </summary>
+        protected override IntPtr ConvertValueToIntPtr(GCHandle value)
+        {
+            return GCHandle.ToIntPtr(value);
+        }
+
+        /// <summary>
+        /// Convert an IntPtr into a value for comparisions, or for returning.
+        /// </summary>
+        protected override GCHandle ConvertIntPtrToValue(IntPtr pointer)
+        {
+            return GCHandle.FromIntPtr(pointer);
+        }
+    }
+}

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/MetadataReaderHelpers.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/MetadataReaderHelpers.cs
@@ -206,19 +206,9 @@ namespace Internal.Runtime.TypeLoader
             return true;
         }
 
-        private static byte[] ConvertByteCollectionToArray(ByteCollection collection)
-        {
-            byte[] array = new byte[collection.Count];
-            int i = 0;
-            foreach (byte b in collection)
-                array[i++] = b;
-
-            return array;
-        }
-
         private static byte[] ConvertByteCollectionOfPublicKeyToByteArrayOfPublicKeyToken(ByteCollection publicKeyCollection)
         {
-            byte[] publicKey = ConvertByteCollectionToArray(publicKeyCollection);
+            byte[] publicKey = Internal.TypeSystem.NativeFormat.MetadataExtensions.ConvertByteCollectionToArray(publicKeyCollection);
             return AssemblyNameHelpers.ComputePublicKeyToken(publicKey);
         }
 
@@ -227,7 +217,7 @@ namespace Internal.Runtime.TypeLoader
             if (isKey)
                 return ConvertByteCollectionOfPublicKeyToByteArrayOfPublicKeyToken(publicKeyOrToken);
             else
-                return ConvertByteCollectionToArray(publicKeyOrToken);
+                return Internal.TypeSystem.NativeFormat.MetadataExtensions.ConvertByteCollectionToArray(publicKeyOrToken);
         }
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/MetadataReaderHelpers.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/MetadataReaderHelpers.cs
@@ -211,7 +211,7 @@ namespace Internal.Runtime.TypeLoader
             byte[] array = new byte[collection.Count];
             int i = 0;
             foreach (byte b in collection)
-                array[i] = b;
+                array[i++] = b;
 
             return array;
         }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ModuleList.Ecma.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ModuleList.Ecma.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime;
+using System.Text;
+using System.Threading;
+using Internal.Runtime.Augments;
+using Internal.Reflection.Execution;
+
+namespace Internal.Runtime.TypeLoader
+{
+    public sealed class EcmaModuleInfo : ModuleInfo
+    {
+        /// <summary>
+        /// Ecma PE data for this module.
+        /// </summary>
+        public PEInfo EcmaPEInfo { get; private set; }
+
+        /// <summary>
+        /// Initialize module info and construct per-module metadata reader.
+        /// </summary>
+        /// <param name="moduleHandle">Handle (address) of module to initialize</param>
+        internal EcmaModuleInfo(IntPtr moduleHandle, PEInfo peinfo)
+            : base(moduleHandle, ModuleType.Ecma)
+        {
+            EcmaPEInfo = peinfo;
+        }
+    }
+
+    public static class EcmaModuleList
+    {
+        /// <summary>
+        /// Locate the containing module for a given metadata reader. Assert when not found.
+        /// </summary>
+        /// <param name="reader">Metadata reader to look up</param>
+        /// <returns>Module handle of the module containing the given reader</returns>
+        public static ModuleInfo GetModuleInfoForMetadataReader(this ModuleList moduleList, MetadataReader reader)
+        {
+            foreach (ModuleInfo moduleInfo in moduleList.GetLoadedModuleMapInternal().Modules)
+            {
+                EcmaModuleInfo ecmaModuleInfo = moduleInfo as EcmaModuleInfo;
+                if (ecmaModuleInfo == null)
+                    continue;
+                
+                if (ecmaModuleInfo.EcmaPEInfo.Reader == reader)
+                {
+                    return moduleInfo;
+                }
+            }
+
+            // We should never have a reader that is not associated with a module (where does it come from?!)
+            Debug.Assert(false);
+            return null;
+        }
+    }
+}

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ModuleList.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ModuleList.cs
@@ -11,13 +11,15 @@ using System.Text;
 using System.Threading;
 using Internal.Runtime.Augments;
 using Internal.Metadata.NativeFormat;
+using Internal.Reflection.Execution;
 
 namespace Internal.Runtime.TypeLoader
 {
     public enum ModuleType
     {
         Eager,
-        ReadyToRun
+        ReadyToRun,
+        Ecma
     }
 
     /// <summary>
@@ -33,7 +35,7 @@ namespace Internal.Runtime.TypeLoader
         public IntPtr Handle { get; private set; }
 
         /// <summary>
-        /// Module metadata reader.
+        /// Module metadata reader for NativeFormat metadata
         /// </summary>
         public MetadataReader MetadataReader { get; private set; }
 
@@ -47,11 +49,18 @@ namespace Internal.Runtime.TypeLoader
         /// </summary>
         internal ModuleType ModuleType { get; private set; }
 
+#if ECMA_METADATA_SUPPORT
+        /// <summary>
+        /// Ecma PE data for this module.
+        /// </summary>
+        public PEInfo EcmaPEInfo { get; private set; }
+#endif
+
         /// <summary>
         /// Initialize module info and construct per-module metadata reader.
         /// </summary>
         /// <param name="moduleHandle">Handle (address) of module to initialize</param>
-        internal ModuleInfo(IntPtr moduleHandle, ModuleType moduleType)
+        internal ModuleInfo(IntPtr moduleHandle, ModuleType moduleType, object peinfo)
         {
             Handle = moduleHandle;
             ModuleType = moduleType;
@@ -59,24 +68,31 @@ namespace Internal.Runtime.TypeLoader
             byte* pBlob;
             uint cbBlob;
 
-            if (RuntimeAugments.FindBlob(moduleHandle, (int)ReflectionMapBlob.EmbeddedMetadata, new IntPtr(&pBlob), new IntPtr(&cbBlob)))
+            if (moduleType != ModuleType.Ecma)
             {
-                MetadataReader = new MetadataReader((IntPtr)pBlob, (int)cbBlob);
+                if (RuntimeAugments.FindBlob(moduleHandle, (int)ReflectionMapBlob.EmbeddedMetadata, new IntPtr(&pBlob), new IntPtr(&cbBlob)))
+                {
+                    MetadataReader = new MetadataReader((IntPtr)pBlob, (int)cbBlob);
+                }
             }
+#if ECMA_METADATA_SUPPORT
+            else
+            {
+                EcmaPEInfo = (PEInfo)peinfo;
+            }
+#endif
 
             DynamicModule* dynamicModulePtr = (DynamicModule*)MemoryHelpers.AllocateMemory(sizeof(DynamicModule));
             dynamicModulePtr->CbSize = DynamicModule.DynamicModuleSize;
             Debug.Assert(sizeof(DynamicModule) >= dynamicModulePtr->CbSize);
 
-#if SUPPORTS_R2R_LOADING                
-            if (moduleType == ModuleType.ReadyToRun)
+            if ((moduleType == ModuleType.ReadyToRun) || (moduleType == ModuleType.Ecma))
             {
-                // ReadyToRun modules utilize dynamic type resolution
+                // Dynamic type load modules utilize dynamic type resolution
                 dynamicModulePtr->DynamicTypeSlotDispatchResolve = Intrinsics.AddrOf(
-                    (Func<IntPtr, IntPtr, ushort, IntPtr>)ReadyToRunCallbacks.ResolveTypeSlotDispatch);
+                    (Func<IntPtr, IntPtr, ushort, IntPtr>)ResolveTypeSlotDispatch);
             }
             else
-#endif
             {
                 Debug.Assert(moduleType == ModuleType.Eager);
                 // Pre-generated modules do not
@@ -88,6 +104,16 @@ namespace Internal.Runtime.TypeLoader
 
             DynamicModulePtr = dynamicModulePtr;
         }
+
+        internal unsafe static IntPtr ResolveTypeSlotDispatch(IntPtr targetTypeAsIntPtr, IntPtr interfaceTypeAsIntPtr, ushort slot)
+        {
+            IntPtr methodAddress;
+            if (!TypeLoaderEnvironment.Instance.TryResolveTypeSlotDispatch(targetTypeAsIntPtr, interfaceTypeAsIntPtr, slot, out methodAddress))
+            {
+                throw new BadImageFormatException();
+            }
+            return methodAddress;
+        }        
     }
 
     /// <summary>
@@ -114,7 +140,9 @@ namespace Internal.Runtime.TypeLoader
             HandleToModuleIndex = new LowLevelDictionary<IntPtr, int>();
             for (int moduleIndex = 0; moduleIndex < Modules.Length; moduleIndex++)
             {
-                HandleToModuleIndex.Add(Modules[moduleIndex].Handle, moduleIndex);
+                // Ecma modules don't go in the reverse lookup hash because they share a module index with the system module
+                if (Modules[moduleIndex].ModuleType != ModuleType.Ecma)
+                    HandleToModuleIndex.Add(Modules[moduleIndex].Handle, moduleIndex);
             }
         }
     }
@@ -307,7 +335,18 @@ namespace Internal.Runtime.TypeLoader
         /// </summary>
         public bool MoveNext()
         {
-            return _moduleInfoEnumerator.MoveNext();
+            bool result;
+            do
+            {
+                result = _moduleInfoEnumerator.MoveNext();
+                // Ecma module shouldn't be reported as they should not be enumerated by ModuleHandle (as its always the System module)
+                if (!result || (_moduleInfoEnumerator.Current.ModuleType != ModuleType.Ecma))
+                {
+                    break;
+                }
+            } while(true);
+
+            return result;
         }
 
         /// <summary>
@@ -516,7 +555,7 @@ namespace Internal.Runtime.TypeLoader
 
                 for (int newModuleIndex = 0; newModuleIndex < newModuleHandles.Count; newModuleIndex++)
                 {
-                    ModuleInfo newModuleInfo = new ModuleInfo(newModuleHandles[newModuleIndex], moduleType);
+                    ModuleInfo newModuleInfo = new ModuleInfo(newModuleHandles[newModuleIndex], moduleType, null);
 
                     updatedModules[oldModuleCount + newModuleIndex] = newModuleInfo;
 
@@ -524,6 +563,29 @@ namespace Internal.Runtime.TypeLoader
                     {
                         _moduleRegistrationCallbacks(newModuleInfo);
                     }
+                }
+
+                // Atomically update the module map
+                _loadedModuleMap = new ModuleMap(updatedModules);
+            }
+        }
+
+        public void RegisterModule(ModuleInfo newModuleInfo)
+        {
+            // prevent multiple threads from registering modules concurrently
+            using (LockHolder.Hold(_moduleRegistrationLock))
+            {
+                // Copy existing modules to new dictionary
+                int oldModuleCount = _loadedModuleMap.Modules.Length;
+                ModuleInfo[] updatedModules = new ModuleInfo[oldModuleCount + 1];
+                if (oldModuleCount > 0)
+                {
+                    Array.Copy(_loadedModuleMap.Modules, 0, updatedModules, 0, oldModuleCount);
+                }
+                updatedModules[oldModuleCount] = newModuleInfo;
+                if (_moduleRegistrationCallbacks != null)
+                {
+                    _moduleRegistrationCallbacks(newModuleInfo);
                 }
 
                 // Atomically update the module map
@@ -575,6 +637,70 @@ namespace Internal.Runtime.TypeLoader
             }
             return null;
         }
+
+        /// <summary>
+        /// Given dynamic module handle, locate the moduleinfo
+        /// </summary>
+        /// <param name="moduleHandle">Handle of module to look up</param>
+        /// <returns>fails if not found</returns>
+        public unsafe ModuleInfo GetModuleInfoForDynamicModule(IntPtr dynamicModuleHandle)
+        {
+            foreach (ModuleInfo moduleInfo in _loadedModuleMap.Modules)
+            {
+                if (new IntPtr(moduleInfo.DynamicModulePtr) == dynamicModuleHandle)
+                    return moduleInfo;
+            }
+
+            // We should never have a dynamic module that is not associated with a module (where does it come from?!)
+            Debug.Assert(false);
+            return null;
+        }        
+
+
+        /// <summary>
+        /// Locate the containing module for a given metadata reader. Assert when not found.
+        /// </summary>
+        /// <param name="reader">Metadata reader to look up</param>
+        /// <returns>Module handle of the module containing the given reader</returns>
+        public ModuleInfo GetModuleInfoForMetadataReader(MetadataReader reader)
+        {
+            foreach (ModuleInfo moduleInfo in _loadedModuleMap.Modules)
+            {
+                if (moduleInfo.MetadataReader == reader)
+                {
+                    return moduleInfo;
+                }
+            }
+
+            // We should never have a reader that is not associated with a module (where does it come from?!)
+            Debug.Assert(false);
+            return null;
+        }
+
+#if ECMA_METADATA_SUPPORT
+        /// <summary>
+        /// Locate the containing module for a given metadata reader. Assert when not found.
+        /// </summary>
+        /// <param name="reader">Metadata reader to look up</param>
+        /// <returns>Module handle of the module containing the given reader</returns>
+        public ModuleInfo GetModuleInfoForMetadataReader(System.Reflection.Metadata.MetadataReader reader)
+        {
+            foreach (ModuleInfo moduleInfo in _loadedModuleMap.Modules)
+            {
+                if (moduleInfo.EcmaPEInfo == null)
+                    continue;
+                
+                if (moduleInfo.EcmaPEInfo.Reader == reader)
+                {
+                    return moduleInfo;
+                }
+            }
+
+            // We should never have a reader that is not associated with a module (where does it come from?!)
+            Debug.Assert(false);
+            return null;
+        }
+#endif
 
         /// <summary>
         /// Locate the containing module for a given metadata reader. Assert when not found.
@@ -635,6 +761,26 @@ namespace Internal.Runtime.TypeLoader
         public static ModuleHandleEnumerable Enumerate(IntPtr preferredModule = default(IntPtr))
         {
             return new ModuleHandleEnumerable(Instance._loadedModuleMap, preferredModule);
+        }
+    }
+
+    public static partial class RuntimeSignatureHelper
+    {
+        public static ModuleInfo GetModuleInfo(this Internal.Runtime.CompilerServices.RuntimeSignature methodSignature)
+        {
+            if (methodSignature.IsNativeLayoutSignature)
+            {
+                return ModuleList.Instance.GetModuleInfoByHandle(methodSignature.ModuleHandle);
+            }
+            else
+            {
+                ModuleInfo moduleInfo;
+                if (!ModuleList.Instance.TryGetModuleInfoByHandle(methodSignature.ModuleHandle, out moduleInfo))
+                {
+                    moduleInfo = ModuleList.Instance.GetModuleInfoForDynamicModule(methodSignature.ModuleHandle);
+                }
+                return moduleInfo;
+            }
         }
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutInfoLoadContext.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutInfoLoadContext.cs
@@ -24,7 +24,7 @@ namespace Internal.Runtime.TypeLoader
     internal class NativeLayoutInfoLoadContext
     {
         public TypeSystemContext _typeSystemContext;
-        public IntPtr _moduleHandle;
+        public ModuleInfo _module;
         private ExternalReferencesTable _staticInfoLookup;
         private ExternalReferencesTable _externalReferencesLookup;
         public Instantiation _typeArgumentHandles;
@@ -66,7 +66,7 @@ namespace Internal.Runtime.TypeLoader
         {
             if (!_externalReferencesLookup.IsInitialized())
             {
-                bool success = _externalReferencesLookup.InitializeNativeReferences(_moduleHandle);
+                bool success = _externalReferencesLookup.InitializeNativeReferences(_module.Handle);
                 Debug.Assert(success);
             }
         }
@@ -88,7 +88,7 @@ namespace Internal.Runtime.TypeLoader
         {
             if (!_staticInfoLookup.IsInitialized())
             {
-                bool success = _staticInfoLookup.InitializeNativeStatics(_moduleHandle);
+                bool success = _staticInfoLookup.InitializeNativeStatics(_module.Handle);
                 Debug.Assert(success);
             }
 
@@ -167,7 +167,7 @@ namespace Internal.Runtime.TypeLoader
                 functionPointer = GetExternalReferencePointer(parser.GetUnsigned());
 
             DefType containingType = (DefType)GetType(ref parser);
-            MethodNameAndSignature nameAndSignature = TypeLoaderEnvironment.Instance.GetMethodNameAndSignature(ref parser, _moduleHandle, out methodNameSig, out methodSig);
+            MethodNameAndSignature nameAndSignature = TypeLoaderEnvironment.Instance.GetMethodNameAndSignature(ref parser, _module.Handle, out methodNameSig, out methodSig);
 
             bool unboxingStub = (flags & MethodFlags.IsUnboxingStub) != 0;
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TemplateLocator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TemplateLocator.cs
@@ -169,9 +169,10 @@ namespace Internal.Runtime.TypeLoader
             var canonForm = concreteType.ConvertToCanonForm(kind);
             var hashCode = canonForm.GetHashCode();
 
-            foreach (var moduleInfo in ModuleList.EnumerateModules())
+            foreach (ModuleInfo unknownModuleInfo in ModuleList.EnumerateModules())
             {
-                if (moduleInfo.MetadataReader == null)
+                NativeFormatModuleInfo moduleInfo = unknownModuleInfo as NativeFormatModuleInfo;
+                if (moduleInfo == null)
                     continue;
 
                 ExternalReferencesTable externalFixupsTable;
@@ -234,9 +235,11 @@ namespace Internal.Runtime.TypeLoader
             var canonForm = concreteMethod.GetCanonMethodTarget(kind);
             var hashCode = canonForm.GetHashCode();
 
-            foreach (var moduleInfo in ModuleList.EnumerateModules())
+            foreach (ModuleInfo unknownModuleInfo in ModuleList.EnumerateModules())
             {
-                if (moduleInfo.MetadataReader == null)
+                NativeFormatModuleInfo moduleInfo = unknownModuleInfo as NativeFormatModuleInfo;
+
+                if (moduleInfo == null)
                     continue;
 
                 NativeReader nativeLayoutReader = TypeLoaderEnvironment.Instance.GetNativeLayoutInfoReader(moduleInfo.Handle);

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -23,7 +23,7 @@ namespace Internal.Runtime.TypeLoader
     internal struct NativeLayoutInfo
     {
         public uint Offset;
-        public IntPtr Module;
+        public ModuleInfo Module;
         public NativeReader Reader;
         public NativeLayoutInfoLoadContext LoadContext;
     }
@@ -151,18 +151,18 @@ namespace Internal.Runtime.TypeLoader
                     {
                         TypeBeingBuilt.Context.TemplateLookup.TryGetMetadataNativeLayout(TypeBeingBuilt, out _r2rnativeLayoutInfo.Module, out _r2rnativeLayoutInfo.Offset);
 
-                        if (_r2rnativeLayoutInfo.Module != IntPtr.Zero)
+                        if (_r2rnativeLayoutInfo.Module != null)
                             _readyToRunNativeLayout = true;
                     }
                     _nativeLayoutTokenComputed = true;
                 }
 
-                if (_nativeLayoutInfo.Module != IntPtr.Zero)
+                if (_nativeLayoutInfo.Module != null)
                 {
                     FinishInitNativeLayoutInfo(TypeBeingBuilt, ref _nativeLayoutInfo);
                 }
 
-                if (_r2rnativeLayoutInfo.Module != IntPtr.Zero)
+                if (_r2rnativeLayoutInfo.Module != null)
                 {
                     FinishInitNativeLayoutInfo(TypeBeingBuilt, ref _r2rnativeLayoutInfo);
                 }
@@ -181,7 +181,7 @@ namespace Internal.Runtime.TypeLoader
             var nativeLayoutInfoLoadContext = new NativeLayoutInfoLoadContext();
 
             nativeLayoutInfoLoadContext._typeSystemContext = type.Context;
-            nativeLayoutInfoLoadContext._moduleHandle = nativeLayoutInfo.Module;
+            nativeLayoutInfoLoadContext._module = nativeLayoutInfo.Module;
 
             if (type is DefType)
             {
@@ -198,7 +198,7 @@ namespace Internal.Runtime.TypeLoader
 
             nativeLayoutInfoLoadContext._methodArgumentHandles = new Instantiation(null);
 
-            nativeLayoutInfo.Reader = TypeLoaderEnvironment.Instance.GetNativeLayoutInfoReader(nativeLayoutInfo.Module);
+            nativeLayoutInfo.Reader = TypeLoaderEnvironment.Instance.GetNativeLayoutInfoReader(nativeLayoutInfo.Module.Handle);
             nativeLayoutInfo.LoadContext = nativeLayoutInfoLoadContext;
         }
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericsRegistration.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericsRegistration.cs
@@ -16,6 +16,7 @@ using Internal.Runtime.CompilerServices;
 
 using Internal.NativeFormat;
 using Internal.TypeSystem;
+using System.Reflection.Runtime.General;
 
 namespace Internal.Runtime.TypeLoader
 {
@@ -96,12 +97,26 @@ namespace Internal.Runtime.TypeLoader
                                 }
 #endif
 
-                                TypeSystem.NativeFormat.NativeFormatType nativeFormatType = (TypeSystem.NativeFormat.NativeFormatType)metadataType;
-                                RegisterNewNamedTypeRuntimeTypeHandle(nativeFormatType.MetadataReader,
-                                    nativeFormatType.Handle,
-                                    nativeFormatType.GetTypeBuilderState().HalfBakedRuntimeTypeHandle,
-                                    nonGcStaticFields,
-                                    gcStaticFields);
+                                TypeSystem.NativeFormat.NativeFormatType nativeFormatType = metadataType as TypeSystem.NativeFormat.NativeFormatType;
+                                if (nativeFormatType != null)
+                                {
+                                    RegisterNewNamedTypeRuntimeTypeHandle(new QTypeDefinition(nativeFormatType.MetadataReader,
+                                                                                nativeFormatType.Handle),
+                                        nativeFormatType.GetTypeBuilderState().HalfBakedRuntimeTypeHandle,
+                                        nonGcStaticFields,
+                                        gcStaticFields);
+                                }
+#if ECMA_METADATA_SUPPORT
+                                TypeSystem.Ecma.EcmaType ecmaFormatType = metadataType as TypeSystem.Ecma.EcmaType;
+                                if (ecmaFormatType != null)
+                                {
+                                    RegisterNewNamedTypeRuntimeTypeHandle(new QTypeDefinition(ecmaFormatType.MetadataReader,
+                                                                                ecmaFormatType.Handle),
+                                        ecmaFormatType.GetTypeBuilderState().HalfBakedRuntimeTypeHandle,
+                                        nonGcStaticFields,
+                                        gcStaticFields);
+                                }
+#endif
 
                                 nativeFormatTypesRegisteredCount++;
 #else
@@ -162,8 +177,22 @@ namespace Internal.Runtime.TypeLoader
                             else
                             {
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
-                                TypeSystem.NativeFormat.NativeFormatType nativeFormatType = (TypeSystem.NativeFormat.NativeFormatType)typeEntry.MetadataDefinitionType;
-                                UnregisterNewNamedTypeRuntimeTypeHandle(nativeFormatType.MetadataReader, nativeFormatType.Handle, nativeFormatType.GetTypeBuilderState().HalfBakedRuntimeTypeHandle);
+                                TypeSystem.NativeFormat.NativeFormatType nativeFormatType = typeEntry.MetadataDefinitionType as TypeSystem.NativeFormat.NativeFormatType;
+                                if (nativeFormatType != null)
+                                {
+                                    UnregisterNewNamedTypeRuntimeTypeHandle(new QTypeDefinition(nativeFormatType.MetadataReader, 
+                                                                                nativeFormatType.Handle),
+                                                                            nativeFormatType.GetTypeBuilderState().HalfBakedRuntimeTypeHandle);
+                                }
+#if ECMA_METADATA_SUPPORT
+                                TypeSystem.Ecma.EcmaType ecmaFormatType = typeEntry.MetadataDefinitionType as TypeSystem.Ecma.EcmaType;
+                                if (ecmaFormatType != null)
+                                {
+                                    UnregisterNewNamedTypeRuntimeTypeHandle(new QTypeDefinition(ecmaFormatType.MetadataReader, 
+                                                                                ecmaFormatType.Handle),
+                                                                            ecmaFormatType.GetTypeBuilderState().HalfBakedRuntimeTypeHandle);
+                                }
+#endif
 #else
                                 Environment.FailFast("Ready to Run module type?");
 #endif

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.FieldAccess.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.FieldAccess.cs
@@ -10,6 +10,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
+using System.Reflection.Runtime.General;
+
 using Internal.Runtime;
 using Internal.Runtime.Augments;
 using Internal.Runtime.CompilerServices;
@@ -164,15 +166,16 @@ namespace Internal.Runtime.TypeLoader
                     {
                         if (fieldName == null)
                         {
-                            MetadataReader mdReader;
-                            TypeDefinitionHandle typeDefHandleUnused;
+                            QTypeDefinition qTypeDefinition;
+
                             bool success = Instance.TryGetMetadataForNamedType(
                                 declaringTypeHandleDefinition,
-                                out mdReader,
-                                out typeDefHandleUnused);
+                                out qTypeDefinition);
                             Debug.Assert(success);
 
-                            fieldName = mdReader.GetString(fieldHandle.GetField(mdReader).Name);
+                            MetadataReader nativeFormatMetadataReader = qTypeDefinition.NativeFormatReader;
+
+                            fieldName = nativeFormatMetadataReader.GetString(fieldHandle.GetField(nativeFormatMetadataReader).Name);
                         }
 
                         string entryFieldName = entryParser.GetString();

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
@@ -244,7 +244,7 @@ namespace Internal.Runtime.TypeLoader
                 if (moduleInfo.MetadataReader != null)
 #endif            
                 {
-                    var metadataReader = moduleInfo.MetadataReader;
+                    var metadataReader = ((NativeFormatModuleInfo)moduleInfo).MetadataReader;
                     var methodHandle = methodData->MethodSignature.Token.AsHandle().ToMethodHandle(metadataReader);
                     var method = methodHandle.GetMethod(metadataReader);
                     name = metadataReader.GetConstantStringValue(method.Name).Value;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
@@ -252,7 +252,7 @@ namespace Internal.Runtime.TypeLoader
 #if ECMA_METADATA_SUPPORT
                 else
                 {
-                    var ecmaReader = moduleInfo.EcmaPEInfo.Reader;
+                    var ecmaReader = ((EcmaModuleInfo)moduleInfo).EcmaPEInfo.Reader;
                     var ecmaHandle = System.Reflection.Metadata.Ecma335.MetadataTokens.Handle(methodData->MethodSignature.Token);
                     var ecmaMethodHandle = (System.Reflection.Metadata.MethodDefinitionHandle)ecmaHandle;
                     var ecmaMethod = ecmaReader.GetMethodDefinition(ecmaMethodHandle);

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
@@ -1793,7 +1793,7 @@ namespace Internal.Runtime.TypeLoader
                 if (moduleInfo.MetadataReader != null)
 #endif
                 {
-                    methodHandle = new QMethodDefinition(moduleInfo.MetadataReader, nameAndSignature.Signature.Token.AsHandle().ToMethodHandle(null));
+                    methodHandle = new QMethodDefinition(((NativeFormatModuleInfo)moduleInfo).MetadataReader, nameAndSignature.Signature.Token.AsHandle().ToMethodHandle(null));
                 }
 #if ECMA_METADATA_SUPPORT
                 else

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
@@ -10,6 +10,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
+using System.Reflection.Runtime.General;
+
 using Internal.Runtime;
 using Internal.Runtime.Augments;
 using Internal.Runtime.CompilerServices;
@@ -18,6 +20,9 @@ using Internal.Metadata.NativeFormat;
 using Internal.NativeFormat;
 using Internal.TypeSystem;
 using Internal.TypeSystem.NativeFormat;
+#if ECMA_METADATA_SUPPORT
+using Internal.TypeSystem.Ecma;
+#endif
 
 namespace Internal.Runtime.TypeLoader
 {
@@ -1033,30 +1038,31 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="methodInvokeMetadata">Output - metadata information for method invoker construction</param>
         /// <returns>true when found, false otherwise</returns>
         public static bool TryGetMethodInvokeMetadata(
-            MetadataReader metadataReader,
             RuntimeTypeHandle declaringTypeHandle,
-            MethodHandle methodHandle,
+            QMethodDefinition methodHandle,
             RuntimeTypeHandle[] genericMethodTypeArgumentHandles,
             ref MethodSignatureComparer methodSignatureComparer,
             CanonicalFormKind canonFormKind,
             out MethodInvokeMetadata methodInvokeMetadata)
         {
-            if (TryGetMethodInvokeMetadataFromInvokeMap(
-                metadataReader,
-                declaringTypeHandle,
-                methodHandle,
-                genericMethodTypeArgumentHandles,
-                ref methodSignatureComparer,
-                canonFormKind,
-                out methodInvokeMetadata))
+            if (methodHandle.IsNativeFormatMetadataBased)
             {
-                return true;
+                if (TryGetMethodInvokeMetadataFromInvokeMap(
+                    methodHandle.NativeFormatReader,
+                    declaringTypeHandle,
+                    methodHandle.NativeFormatHandle,
+                    genericMethodTypeArgumentHandles,
+                    ref methodSignatureComparer,
+                    canonFormKind,
+                    out methodInvokeMetadata))
+                {
+                    return true;
+                }
             }
 
             TypeSystemContext context = TypeSystemContextFactory.Create();
 
             bool success = TryGetMethodInvokeMetadataFromNativeFormatMetadata(
-                metadataReader,
                 declaringTypeHandle,
                 methodHandle,
                 genericMethodTypeArgumentHandles,
@@ -1257,9 +1263,8 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="methodInvokeMetadata">Output - metadata information for method invoker construction</param>
         /// <returns>true when found, false otherwise</returns>
         private static bool TryGetMethodInvokeMetadataFromNativeFormatMetadata(
-            MetadataReader metadataReader,
             RuntimeTypeHandle declaringTypeHandle,
-            MethodHandle methodHandle,
+            QMethodDefinition methodHandle,
             RuntimeTypeHandle[] genericMethodTypeArgumentHandles,
             ref MethodSignatureComparer methodSignatureComparer,
             TypeSystemContext typeSystemContext,
@@ -1270,20 +1275,33 @@ namespace Internal.Runtime.TypeLoader
 
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
             TypeDesc declaringType = typeSystemContext.ResolveRuntimeTypeHandle(declaringTypeHandle);
-            NativeFormatType nativeFormatType = declaringType.GetTypeDefinition() as NativeFormatType;
+            TypeDesc declaringTypeDefinition = declaringType.GetTypeDefinition();
 
-            if (nativeFormatType == null)
+            if (declaringTypeDefinition == null)
                 return false;
 
-            Debug.Assert(metadataReader == nativeFormatType.MetadataReader);
 
-            MethodDesc methodOnType = nativeFormatType.MetadataUnit.GetMethod(methodHandle, nativeFormatType);
+            MethodDesc methodOnType = null;
+            
+            if (declaringTypeDefinition is NativeFormatType)
+            {
+                NativeFormatType nativeFormatType = ((NativeFormatType)declaringTypeDefinition);
+                Debug.Assert(methodHandle.NativeFormatReader == nativeFormatType.MetadataReader);
+                methodOnType = nativeFormatType.MetadataUnit.GetMethod(methodHandle.NativeFormatHandle, nativeFormatType);
+            }
+            else
+            {
+                EcmaType ecmaType = ((EcmaType)declaringTypeDefinition);
+                Debug.Assert(methodHandle.EcmaFormatReader == ecmaType.MetadataReader);
+                methodOnType = ecmaType.EcmaModule.GetMethod(methodHandle.EcmaFormatHandle);
+            }
+
             if (methodOnType == null)
             {
                 return false;
             }
 
-            if (nativeFormatType != declaringType)
+            if (declaringTypeDefinition != declaringType)
             {
                 // If we reach here, then the method is on a generic type, and we just found the uninstantiated form
                 // Get the method on the instantiated type and continue
@@ -1300,10 +1318,11 @@ namespace Internal.Runtime.TypeLoader
             IntPtr unboxingStubAddress = IntPtr.Zero;
             MethodAddressType foundAddressType = MethodAddressType.None;
 #if SUPPORTS_R2R_LOADING
-            if (!TryGetCodeTableEntry(methodOnType, out entryPoint, out unboxingStubAddress, out foundAddressType))
-            {
-                return false;
-            }
+            TryGetCodeTableEntry(methodOnType, out entryPoint, out unboxingStubAddress, out foundAddressType);
+#endif
+#if SUPPORT_JIT
+            if (foundAddressType == MethodAddressType.None)
+                MethodEntrypointStubs.TryGetMethodEntrypoint(methodOnType, out entryPoint, out unboxingStubAddress, out foundAddressType);
 #endif
             if (foundAddressType == MethodAddressType.None)
                 return false;
@@ -1318,7 +1337,10 @@ namespace Internal.Runtime.TypeLoader
             // TODO: This will probably require additional work to smoothly use unboxing stubs
             // in vtables - for plain reflection invoke everything seems to work
             // without additional changes thanks to the "NeedsParameterInterpretation" flag.
-            methodInvokeMetadata.MappingTableModule = nativeFormatType.MetadataUnit.RuntimeModule;
+            if (methodHandle.IsNativeFormatMetadataBased)
+                methodInvokeMetadata.MappingTableModule = ((NativeFormatType)declaringTypeDefinition).MetadataUnit.RuntimeModule;
+            else
+                methodInvokeMetadata.MappingTableModule = IntPtr.Zero; // MappingTableModule is only used if NeedsParameterInterpretation isn't set
             methodInvokeMetadata.MethodEntryPoint = entryPoint;
             methodInvokeMetadata.RawMethodEntryPoint = entryPoint;
             // TODO: methodInvokeMetadata.DictionaryComponent
@@ -1725,10 +1747,16 @@ namespace Internal.Runtime.TypeLoader
                 if (nativeType != null)
                 {
                     MetadataReader metadataReader = nativeType.MetadataReader;
-                    IntPtr moduleHandle = ModuleList.Instance.GetModuleForMetadataReader(metadataReader);
-                    ModuleInfo moduleInfo = ModuleList.Instance.GetModuleInfoByHandle(moduleHandle);
+                    ModuleInfo moduleInfo = ModuleList.Instance.GetModuleInfoForMetadataReader(metadataReader);
 
                     return moduleInfo;
+                }
+#endif
+#if ECMA_METADATA_SUPPORT
+                Internal.TypeSystem.Ecma.EcmaType ecmaType = type as Internal.TypeSystem.Ecma.EcmaType;
+                if (ecmaType != null)
+                {
+                    return ecmaType.EcmaModule.RuntimeModuleInfo;
                 }
 #endif
                 ArrayType arrayType = type as ArrayType;
@@ -1751,6 +1779,61 @@ namespace Internal.Runtime.TypeLoader
                 // Unable to resolve the native type
                 return ModuleList.Instance.SystemModule;
             }
+        }
+
+        public bool TryGetMetadataForTypeMethodNameAndSignature(RuntimeTypeHandle declaringTypeHandle, MethodNameAndSignature nameAndSignature, out QMethodDefinition methodHandle)
+        {
+            if (!nameAndSignature.Signature.IsNativeLayoutSignature)
+            {
+                IntPtr module = nameAndSignature.Signature.ModuleHandle;
+
+                ModuleInfo moduleInfo = nameAndSignature.Signature.GetModuleInfo();
+
+#if ECMA_METADATA_SUPPORT
+                if (moduleInfo.MetadataReader != null)
+#endif
+                {
+                    methodHandle = new QMethodDefinition(moduleInfo.MetadataReader, nameAndSignature.Signature.Token.AsHandle().ToMethodHandle(null));
+                }
+#if ECMA_METADATA_SUPPORT
+                else
+                {
+                    methodHandle = new QMethodDefinition(moduleInfo.EcmaPEInfo.Reader, (System.Reflection.Metadata.MethodDefinitionHandle)System.Reflection.Metadata.Ecma335.MetadataTokens.Handle(nameAndSignature.Signature.Token));
+                }
+#endif
+                // When working with method signature that draw directly from metadata, just return the metadata token
+                return true;
+            }
+
+            QTypeDefinition qTypeDefinition;
+            RuntimeTypeHandle metadataLookupTypeHandle = GetTypeDefinition(declaringTypeHandle);
+            methodHandle = default(QMethodDefinition);
+
+            if (!TryGetMetadataForNamedType(metadataLookupTypeHandle, out qTypeDefinition))
+                return false;
+
+            MetadataReader reader = qTypeDefinition.NativeFormatReader;
+            TypeDefinitionHandle typeDefinitionHandle = qTypeDefinition.NativeFormatHandle;
+
+            TypeDefinition typeDefinition = typeDefinitionHandle.GetTypeDefinition(reader);
+
+            Debug.Assert(nameAndSignature.Signature.IsNativeLayoutSignature);
+
+            foreach (MethodHandle mh in typeDefinition.Methods)
+            {
+                Method method = mh.GetMethod(reader);
+                if (method.Name.StringEquals(nameAndSignature.Name, reader))
+                {
+                    MethodSignatureComparer methodSignatureComparer = new MethodSignatureComparer(reader, mh);
+                    if (methodSignatureComparer.IsMatchingNativeLayoutMethodSignature(nameAndSignature.Signature))
+                    {
+                        methodHandle = new QMethodDefinition(reader, mh);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
@@ -1798,7 +1798,7 @@ namespace Internal.Runtime.TypeLoader
 #if ECMA_METADATA_SUPPORT
                 else
                 {
-                    methodHandle = new QMethodDefinition(moduleInfo.EcmaPEInfo.Reader, (System.Reflection.Metadata.MethodDefinitionHandle)System.Reflection.Metadata.Ecma335.MetadataTokens.Handle(nameAndSignature.Signature.Token));
+                    methodHandle = new QMethodDefinition(((EcmaModuleInfo)moduleInfo).EcmaPEInfo.Reader, (System.Reflection.Metadata.MethodDefinitionHandle)System.Reflection.Metadata.Ecma335.MetadataTokens.Handle(nameAndSignature.Signature.Token));
                 }
 #endif
                 // When working with method signature that draw directly from metadata, just return the metadata token

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.MethodAddress.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.MethodAddress.cs
@@ -44,17 +44,19 @@ namespace Internal.Runtime.TypeLoader
             out IntPtr unboxingStubAddress,
             out MethodAddressType foundAddressType)
         {
+            methodAddress = IntPtr.Zero;
+            unboxingStubAddress = IntPtr.Zero;
+            foundAddressType = MethodAddressType.None;
+
 #if SUPPORTS_R2R_LOADING
-            // Try to find the method via a code table
-            if (TryGetCodeTableEntry(
-                method,
-                out methodAddress,
-                out unboxingStubAddress, 
-                out foundAddressType))
-            {
-                return true;
-            }
+            TryGetCodeTableEntry(method, out methodAddress, out unboxingStubAddress, out foundAddressType);
 #endif
+#if SUPPORT_JIT
+            if (foundAddressType == MethodAddressType.None)
+                MethodEntrypointStubs.TryGetMethodEntrypoint(method, out methodAddress, out unboxingStubAddress, out foundAddressType);
+#endif
+            if (foundAddressType != MethodAddressType.None)
+                return true;
 
             // Otherwise try to find it via an invoke map
             return TryGetMethodAddressFromTypeSystemMethodViaInvokeMap(method, out methodAddress, out unboxingStubAddress, out foundAddressType);
@@ -130,12 +132,12 @@ namespace Internal.Runtime.TypeLoader
         /// <summary>
         /// Attempt a virtual dispatch on a given instanceType based on the method found via a metadata token
         /// </summary>
-        private static bool TryDispatchMethodOnTarget_Inner(IntPtr moduleHandle, int metadataToken, RuntimeTypeHandle targetInstanceType, out IntPtr methodAddress)
+        private static bool TryDispatchMethodOnTarget_Inner(ModuleInfo module, int metadataToken, RuntimeTypeHandle targetInstanceType, out IntPtr methodAddress)
         {
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
             TypeSystemContext context = TypeSystemContextFactory.Create();
 
-            NativeFormatMetadataUnit metadataUnit = context.ResolveMetadataUnit(moduleHandle);
+            NativeFormatMetadataUnit metadataUnit = context.ResolveMetadataUnit(module);
             MethodDesc targetMethod = metadataUnit.GetMethod(metadataToken.AsHandle(), null);
             TypeDesc instanceType = context.ResolveRuntimeTypeHandle(targetInstanceType);
 
@@ -165,7 +167,7 @@ namespace Internal.Runtime.TypeLoader
         /// Attempt to convert the dispatch cell to a metadata token to a more efficient vtable dispatch or interface/slot dispatch.
         /// Failure to convert is not a correctness issue. We also support performing a dispatch based on metadata token alone.
         /// </summary>
-        private static DispatchCellInfo ConvertDispatchCellInfo_Inner(IntPtr module, DispatchCellInfo cellInfo)
+        private static DispatchCellInfo ConvertDispatchCellInfo_Inner(ModuleInfo module, DispatchCellInfo cellInfo)
         {
             Debug.Assert(cellInfo.CellType == DispatchCellType.MetadataToken);
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.NamedTypeLookup.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.NamedTypeLookup.cs
@@ -11,6 +11,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
+using System.Reflection.Runtime.General;
+
 using Internal.Runtime;
 using Internal.Runtime.Augments;
 
@@ -26,8 +28,7 @@ namespace Internal.Runtime.TypeLoader
         {
             public int RuntimeTypeHandleHashcode;
             public RuntimeTypeHandle RuntimeTypeHandle;
-            public MetadataReader MetadataReader;
-            public TypeDefinitionHandle TypeDefinition;
+            public QTypeDefinition QualifiedTypeDefinition;
             public IntPtr GcStaticFields;
             public IntPtr NonGcStaticFields;
             public volatile int VersionNumber;
@@ -59,8 +60,8 @@ namespace Internal.Runtime.TypeLoader
             {
                 if (value1.RuntimeTypeHandle.IsNull() || value2.RuntimeTypeHandle.IsNull())
                 {
-                    return value1.TypeDefinition.Equals(value2.TypeDefinition) &&
-                           value1.MetadataReader.Equals(value2.MetadataReader);
+                    return value1.QualifiedTypeDefinition.Token.Equals(value2.QualifiedTypeDefinition.Token) &&
+                           value1.QualifiedTypeDefinition.Reader.Equals(value2.QualifiedTypeDefinition.Reader);
                 }
                 return value1.RuntimeTypeHandle.Equals(value2.RuntimeTypeHandle);
             }
@@ -94,8 +95,7 @@ namespace Internal.Runtime.TypeLoader
                                     MetadataReader metadataReader = ModuleList.Instance.GetMetadataReaderForModule(moduleHandle);
                                     return new NamedTypeLookupResult()
                                     {
-                                        MetadataReader = metadataReader,
-                                        TypeDefinition = entryMetadataHandle.ToTypeDefinitionHandle(metadataReader),
+                                        QualifiedTypeDefinition = new QTypeDefinition(metadataReader, entryMetadataHandle.ToTypeDefinitionHandle(metadataReader)),
                                         RuntimeTypeHandle = key,
                                         RuntimeTypeHandleHashcode = hashCode
                                     };
@@ -113,15 +113,9 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private struct NamedTypeMetadataDescription
-        {
-            public MetadataReader MetadataReader;
-            public TypeDefinitionHandle TypeDefinition;
-        }
+        private QTypeDefinitionToRuntimeTypeHandleHashtable _metadataToRuntimeTypeHandleHashtable = new QTypeDefinitionToRuntimeTypeHandleHashtable();
 
-        private NamedTypeMetadataToRuntimeTypeHandleHashtable _metadataToRuntimeTypeHandleHashtable = new NamedTypeMetadataToRuntimeTypeHandleHashtable();
-
-        private class NamedTypeMetadataToRuntimeTypeHandleHashtable : LockFreeReaderHashtable<NamedTypeMetadataDescription, NamedTypeLookupResult>
+        private class QTypeDefinitionToRuntimeTypeHandleHashtable : LockFreeReaderHashtable<QTypeDefinition, NamedTypeLookupResult>
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static int _rotl(int value, int shift)
@@ -129,60 +123,65 @@ namespace Internal.Runtime.TypeLoader
                 return (int)(((uint)value << shift) | ((uint)value >> (32 - shift)));
             }
 
-            protected unsafe override int GetKeyHashCode(NamedTypeMetadataDescription key)
+            protected unsafe override int GetKeyHashCode(QTypeDefinition key)
             {
-                return key.TypeDefinition.GetHashCode() ^ _rotl(key.MetadataReader.GetHashCode(), 8);
+                return key.Token.GetHashCode() ^ _rotl(key.Reader.GetHashCode(), 8);
             }
-            protected override bool CompareKeyToValue(NamedTypeMetadataDescription key, NamedTypeLookupResult value)
+            protected override bool CompareKeyToValue(QTypeDefinition key, NamedTypeLookupResult value)
             {
-                return key.TypeDefinition.Equals(value.TypeDefinition) &&
-                       key.MetadataReader.Equals(value.MetadataReader);
+                return key.Token.Equals(value.QualifiedTypeDefinition.Token) &&
+                       key.Reader.Equals(value.QualifiedTypeDefinition.Reader);
             }
 
             protected unsafe override int GetValueHashCode(NamedTypeLookupResult value)
             {
-                return value.TypeDefinition.GetHashCode() ^ _rotl(value.MetadataReader.GetHashCode(), 8);
+                return value.QualifiedTypeDefinition.Token.GetHashCode() ^ _rotl(value.QualifiedTypeDefinition.Reader.GetHashCode(), 8);
             }
 
             protected override bool CompareValueToValue(NamedTypeLookupResult value1, NamedTypeLookupResult value2)
             {
-                return value1.TypeDefinition.Equals(value2.TypeDefinition) &&
-                       value1.MetadataReader.Equals(value2.MetadataReader);
+                return value1.QualifiedTypeDefinition.Token.Equals(value2.QualifiedTypeDefinition.Token) &&
+                        value1.QualifiedTypeDefinition.Reader.Equals(value2.QualifiedTypeDefinition.Reader);
             }
 
-            protected override NamedTypeLookupResult CreateValueFromKey(NamedTypeMetadataDescription key)
+            protected override NamedTypeLookupResult CreateValueFromKey(QTypeDefinition key)
             {
-                int hashCode = key.TypeDefinition.ComputeHashCode(key.MetadataReader);
-
-                IntPtr moduleHandle = ModuleList.Instance.GetModuleForMetadataReader(key.MetadataReader);
                 RuntimeTypeHandle foundRuntimeTypeHandle = default(RuntimeTypeHandle);
 
-                NativeReader typeMapReader;
-                if (TryGetNativeReaderForBlob(moduleHandle, ReflectionMapBlob.TypeMap, out typeMapReader))
+                if (key.IsNativeFormatMetadataBased)
                 {
-                    NativeParser typeMapParser = new NativeParser(typeMapReader, 0);
-                    NativeHashtable typeHashtable = new NativeHashtable(typeMapParser);
+                    MetadataReader metadataReader = key.NativeFormatReader;
+                    TypeDefinitionHandle typeDefHandle = key.NativeFormatHandle;
+                    int hashCode = typeDefHandle.ComputeHashCode(metadataReader);
 
-                    ExternalReferencesTable externalReferences = default(ExternalReferencesTable);
-                    externalReferences.InitializeCommonFixupsTable(moduleHandle);
+                    IntPtr moduleHandle = ModuleList.Instance.GetModuleForMetadataReader(metadataReader);
 
-                    var lookup = typeHashtable.Lookup(hashCode);
-                    NativeParser entryParser;
-                    while (!(entryParser = lookup.GetNext()).IsNull)
+                    NativeReader typeMapReader;
+                    if (TryGetNativeReaderForBlob(moduleHandle, ReflectionMapBlob.TypeMap, out typeMapReader))
                     {
-                        var foundTypeIndex = entryParser.GetUnsigned();
-                        if (entryParser.GetUnsigned().AsHandle().Equals(key.TypeDefinition))
+                        NativeParser typeMapParser = new NativeParser(typeMapReader, 0);
+                        NativeHashtable typeHashtable = new NativeHashtable(typeMapParser);
+
+                        ExternalReferencesTable externalReferences = default(ExternalReferencesTable);
+                        externalReferences.InitializeCommonFixupsTable(moduleHandle);
+
+                        var lookup = typeHashtable.Lookup(hashCode);
+                        NativeParser entryParser;
+                        while (!(entryParser = lookup.GetNext()).IsNull)
                         {
-                            foundRuntimeTypeHandle = externalReferences.GetRuntimeTypeHandleFromIndex(foundTypeIndex);
-                            break;
+                            var foundTypeIndex = entryParser.GetUnsigned();
+                            if (entryParser.GetUnsigned().AsHandle().Equals(typeDefHandle))
+                            {
+                                foundRuntimeTypeHandle = externalReferences.GetRuntimeTypeHandleFromIndex(foundTypeIndex);
+                                break;
+                            }
                         }
                     }
                 }
 
                 return new NamedTypeLookupResult()
                 {
-                    TypeDefinition = key.TypeDefinition,
-                    MetadataReader = key.MetadataReader,
+                    QualifiedTypeDefinition = key,
                     RuntimeTypeHandle = foundRuntimeTypeHandle,
                     VersionNumber = TypeLoaderEnvironment.Instance._namedTypeLookupLiveVersion
                 };
@@ -199,12 +198,11 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="runtimeTypeHandle">Runtime handle of the type in question</param>
         /// <param name="metadataReader">Metadata reader located for the type</param>
         /// <param name="typeDefHandle">TypeDef handle for the type</param>
-        public unsafe bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out MetadataReader metadataReader, out TypeDefinitionHandle typeDefHandle)
+        public unsafe bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out QTypeDefinition qTypeDefinition)
         {
             NamedTypeLookupResult result = _runtimeTypeHandleToMetadataHashtable.GetOrCreateValue(runtimeTypeHandle);
-            metadataReader = result.MetadataReader;
-            typeDefHandle = result.TypeDefinition;
-            return metadataReader != null;
+            qTypeDefinition = result.QualifiedTypeDefinition;
+            return qTypeDefinition.Reader != null;
         }
 
         /// <summary>
@@ -236,7 +234,7 @@ namespace Internal.Runtime.TypeLoader
             if (nonGcStaticsData == (IntPtr)1)
                 nonGcStaticsData = IntPtr.Zero;
 
-            return result.MetadataReader != null && !noResults;
+            return result.QualifiedTypeDefinition.Reader != null && !noResults;
         }
 
         /// <summary>
@@ -253,16 +251,10 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="metadataReader">Metadata reader for module containing the type</param>
         /// <param name="typeDefHandle">TypeDef handle for the type to look up</param>
         /// <param name="runtimeTypeHandle">Runtime type handle (EEType) for the given type</param>
-        public unsafe bool TryGetNamedTypeForMetadata(MetadataReader metadataReader, TypeDefinitionHandle typeDefHandle, out RuntimeTypeHandle runtimeTypeHandle)
+        public unsafe bool TryGetNamedTypeForMetadata(QTypeDefinition qTypeDefinition, out RuntimeTypeHandle runtimeTypeHandle)
         {
-            NamedTypeMetadataDescription description = new NamedTypeMetadataDescription()
-            {
-                MetadataReader = metadataReader,
-                TypeDefinition = typeDefHandle
-            };
-
             runtimeTypeHandle = default(RuntimeTypeHandle);
-            NamedTypeLookupResult result = _metadataToRuntimeTypeHandleHashtable.GetOrCreateValue(description);
+            NamedTypeLookupResult result = _metadataToRuntimeTypeHandleHashtable.GetOrCreateValue(qTypeDefinition);
 
             if (result.VersionNumber <= _namedTypeLookupLiveVersion)
                 runtimeTypeHandle = result.RuntimeTypeHandle;
@@ -270,16 +262,10 @@ namespace Internal.Runtime.TypeLoader
             return !runtimeTypeHandle.IsNull();
         }
 
-        public void RegisterNewNamedTypeRuntimeTypeHandle(MetadataReader metadataReader, TypeDefinitionHandle typeDefHandle, RuntimeTypeHandle runtimeTypeHandle, IntPtr nonGcStaticFields, IntPtr gcStaticFields)
+        public void RegisterNewNamedTypeRuntimeTypeHandle(QTypeDefinition qTypeDefinition, RuntimeTypeHandle runtimeTypeHandle, IntPtr nonGcStaticFields, IntPtr gcStaticFields)
         {
-            NamedTypeMetadataDescription description = new NamedTypeMetadataDescription()
-            {
-                MetadataReader = metadataReader,
-                TypeDefinition = typeDefHandle
-            };
-
             TypeLoaderLogger.WriteLine("Register new type with eetype = " + runtimeTypeHandle.ToIntPtr().LowLevelToString() + " nonGcStaticFields " + nonGcStaticFields.LowLevelToString() + " gcStaticFields " + gcStaticFields.LowLevelToString());
-            NamedTypeLookupResult result = _metadataToRuntimeTypeHandleHashtable.GetOrCreateValue(description);
+            NamedTypeLookupResult result = _metadataToRuntimeTypeHandleHashtable.GetOrCreateValue(qTypeDefinition);
 
             result.VersionNumber = _namedTypeLookupLiveVersion + 1;
             result.RuntimeTypeHandle = runtimeTypeHandle;
@@ -294,23 +280,16 @@ namespace Internal.Runtime.TypeLoader
 
             if (!Object.ReferenceEquals(rthToMetadataResult, result))
             {
-                rthToMetadataResult.TypeDefinition = typeDefHandle;
-                rthToMetadataResult.MetadataReader = metadataReader;
+                rthToMetadataResult.QualifiedTypeDefinition = qTypeDefinition;
                 rthToMetadataResult.GcStaticFields = gcStaticFields;
                 rthToMetadataResult.NonGcStaticFields = nonGcStaticFields;
             }
         }
 
-        public void UnregisterNewNamedTypeRuntimeTypeHandle(MetadataReader metadataReader, TypeDefinitionHandle typeDefHandle, RuntimeTypeHandle runtimeTypeHandle)
+        public void UnregisterNewNamedTypeRuntimeTypeHandle(QTypeDefinition qTypeDefinition, RuntimeTypeHandle runtimeTypeHandle)
         {
-            NamedTypeMetadataDescription description = new NamedTypeMetadataDescription()
-            {
-                MetadataReader = metadataReader,
-                TypeDefinition = typeDefHandle
-            };
-
             NamedTypeLookupResult metadataLookupResult;
-            if (_metadataToRuntimeTypeHandleHashtable.TryGetValue(description, out metadataLookupResult))
+            if (_metadataToRuntimeTypeHandleHashtable.TryGetValue(qTypeDefinition, out metadataLookupResult))
             {
                 metadataLookupResult.RuntimeTypeHandle = default(RuntimeTypeHandle);
                 metadataLookupResult.VersionNumber = -1;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
@@ -180,10 +180,10 @@ namespace Internal.Runtime.TypeLoader
             else
             {
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
-                MetadataReader metadataReader = ModuleList.Instance.GetMetadataReaderForModule(methodSig.ModuleHandle);
-                var methodHandle = methodSig.Token.AsHandle().ToMethodHandle(metadataReader);
-                var metadataUnit = ((TypeLoaderTypeSystemContext)context).ResolveMetadataUnit(methodSig.ModuleHandle);
-                var parser = new Internal.TypeSystem.NativeFormat.NativeFormatSignatureParser(metadataUnit, metadataReader.GetMethod(methodHandle).Signature, metadataReader);
+                ModuleInfo module = methodSig.GetModuleInfo();
+                var methodHandle = methodSig.Token.AsHandle().ToMethodHandle(module.MetadataReader);
+                var metadataUnit = ((TypeLoaderTypeSystemContext)context).ResolveMetadataUnit(module);
+                var parser = new Internal.TypeSystem.NativeFormat.NativeFormatSignatureParser(metadataUnit, module.MetadataReader.GetMethod(methodHandle).Signature, module.MetadataReader);
                 var signature = parser.ParseMethodSignature();
 
                 return GetCallingConverterDataFromMethodSignature_MethodSignature(signature, nativeLayoutContext, out hasThis, out parameters, out parametersWithGenericDependentLayout);
@@ -331,9 +331,10 @@ namespace Internal.Runtime.TypeLoader
             else
             {
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
-                MetadataReader metadataReader = ModuleList.Instance.GetMetadataReaderForModule(methodSig.ModuleHandle);
+                ModuleInfo module = methodSig.GetModuleInfo();
+                MetadataReader metadataReader = module.MetadataReader;
                 var methodHandle = methodSig.Token.AsHandle().ToMethodHandle(metadataReader);
-                var metadataUnit = ((TypeLoaderTypeSystemContext)context).ResolveMetadataUnit(methodSig.ModuleHandle);
+                var metadataUnit = ((TypeLoaderTypeSystemContext)context).ResolveMetadataUnit(module);
                 var parser = new Internal.TypeSystem.NativeFormat.NativeFormatSignatureParser(metadataUnit, metadataReader.GetMethod(methodHandle).Signature, metadataReader);
                 var signature = parser.ParseMethodSignature();
 
@@ -540,7 +541,7 @@ namespace Internal.Runtime.TypeLoader
             TypeSystemContext context = TypeSystemContextFactory.Create();
             {
                 NativeLayoutInfoLoadContext nativeLayoutContext = new NativeLayoutInfoLoadContext();
-                nativeLayoutContext._moduleHandle = moduleHandle;
+                nativeLayoutContext._module = ModuleList.GetModuleInfoByHandle(moduleHandle);
                 nativeLayoutContext._typeSystemContext = context;
 
                 TypeDesc type = nativeLayoutContext.GetExternalType(typeIndex);

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
@@ -13,7 +13,7 @@ using Internal.TypeSystem;
 
 namespace Internal.Runtime.TypeLoader
 {
-    internal static class TypeSystemContextFactory
+    public static class TypeSystemContextFactory
     {
         // Cache the most recent instance of TypeSystemContext in a weak handle, and reuse it if possible
         // This allows us to avoid recreating the type resolution context again and again, but still allows it to go away once the types are no longer being built

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemExtensions.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemExtensions.cs
@@ -9,9 +9,15 @@ using System.Collections.Generic;
 using System.Diagnostics;
 
 using Internal.NativeFormat;
+using Internal.TypeSystem.NativeFormat;
+#if ECMA_METADATA_SUPPORT
+using Internal.TypeSystem.Ecma;
+#endif
 using Internal.Runtime.Augments;
+using Internal.Runtime.CompilerServices;
 using Internal.TypeSystem;
 using Internal.TypeSystem.NoMetadata;
+using System.Reflection.Runtime.General;
 
 namespace Internal.TypeSystem.NativeFormat
 {
@@ -69,5 +75,84 @@ namespace Internal.Runtime.TypeLoader
             IntPtr rtfhValue = *(IntPtr*)&rtfh;
             return (rtfhValue.ToInt64() & 0x1) == 0x1;
         }
+    }
+
+    public static partial class RuntimeSignatureHelper
+    {
+        public static bool TryCreate(MethodDesc method, out RuntimeSignature methodSignature)
+        {
+#if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
+            MethodDesc typicalMethod = method.GetTypicalMethodDefinition();
+
+            if (typicalMethod is TypeSystem.NativeFormat.NativeFormatMethod)
+            {
+                TypeSystem.NativeFormat.NativeFormatMethod nativeFormatMethod = (TypeSystem.NativeFormat.NativeFormatMethod)typicalMethod;
+                methodSignature = RuntimeSignature.CreateFromMethodHandle(nativeFormatMethod.MetadataUnit.RuntimeModule, nativeFormatMethod.Handle.ToInt());
+                return true;
+            }
+#if ECMA_METADATA_SUPPORT
+            if (typicalMethod is TypeSystem.Ecma.EcmaMethod)
+            {
+                unsafe
+                {
+                    TypeSystem.Ecma.EcmaMethod ecmaMethod = (TypeSystem.Ecma.EcmaMethod)typicalMethod;
+                    methodSignature = RuntimeSignature.CreateFromMethodHandle(new IntPtr(ecmaMethod.Module.RuntimeModuleInfo.DynamicModulePtr), System.Reflection.Metadata.Ecma335.MetadataTokens.GetToken(ecmaMethod.Handle));
+                }
+                return true;
+            }
+#endif
+#endif 
+            methodSignature = default(RuntimeSignature);
+            return false;
+        }
+
+#if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
+        public static MethodDesc ToMethodDesc(this RuntimeMethodHandle rmh, TypeSystemContext typeSystemContext)
+        {
+            RuntimeTypeHandle declaringTypeHandle;
+            MethodNameAndSignature nameAndSignature;
+            RuntimeTypeHandle[] genericMethodArgs;
+
+            if (!TypeLoaderEnvironment.Instance.TryGetRuntimeMethodHandleComponents(rmh, out declaringTypeHandle, out nameAndSignature, out genericMethodArgs))
+            {
+                return null;
+            }
+
+            QMethodDefinition methodHandle;
+            if (!TypeLoaderEnvironment.Instance.TryGetMetadataForTypeMethodNameAndSignature(declaringTypeHandle, nameAndSignature, out methodHandle))
+            {
+                return null;
+            }
+
+            TypeDesc declaringType = typeSystemContext.ResolveRuntimeTypeHandle(declaringTypeHandle);
+
+            TypeDesc declaringTypeDefinition = declaringType.GetTypeDefinition();
+            MethodDesc typicalMethod = null;
+            if (methodHandle.IsNativeFormatMetadataBased)
+            {
+                var nativeFormatType = (NativeFormatType)declaringTypeDefinition;
+                typicalMethod = nativeFormatType.MetadataUnit.GetMethod(methodHandle.NativeFormatHandle, nativeFormatType);
+            }
+            else if (methodHandle.IsEcmaFormatMetadataBased)
+            {
+                var ecmaFormatType = (EcmaType)declaringTypeDefinition;
+                typicalMethod = ecmaFormatType.EcmaModule.GetMethod(methodHandle.EcmaFormatHandle);
+            }
+            Debug.Assert(typicalMethod != null);
+
+            MethodDesc methodOnInstantiatedType = typicalMethod;
+            if (declaringType != declaringTypeDefinition)
+                methodOnInstantiatedType = typeSystemContext.GetMethodForInstantiatedType(typicalMethod, (InstantiatedType)declaringType);
+            
+            MethodDesc instantiatedMethod = methodOnInstantiatedType;
+            if (genericMethodArgs.Length != 0)
+            {
+                Instantiation genericMethodInstantiation = typeSystemContext.ResolveRuntimeTypeHandles(genericMethodArgs);
+                typeSystemContext.GetInstantiatedMethod(methodOnInstantiatedType, genericMethodInstantiation);
+            }
+
+            return instantiatedMethod;
+        }
+#endif 
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/genericdictionarycell.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/genericdictionarycell.cs
@@ -1703,7 +1703,7 @@ namespace Internal.Runtime.TypeLoader
                     {
                         CallingConventionConverterKind flags = (CallingConventionConverterKind)parser.GetUnsigned();
                         NativeParser sigParser = parser.GetParserFromRelativeOffset();
-                        RuntimeSignature signature = RuntimeSignature.CreateFromNativeLayoutSignature(nativeLayoutInfoLoadContext._moduleHandle, sigParser.Offset);
+                        RuntimeSignature signature = RuntimeSignature.CreateFromNativeLayoutSignature(nativeLayoutInfoLoadContext._module.Handle, sigParser.Offset);
 
 #if TYPE_LOADER_TRACE
                         TypeLoaderLogger.WriteLine("CallingConventionConverter on: ");

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeDesc.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeDesc.Runtime.cs
@@ -11,6 +11,7 @@ using Debug = System.Diagnostics.Debug;
 using Internal.NativeFormat;
 using System.Collections.Generic;
 using Internal.TypeSystem.NoMetadata;
+using System.Reflection.Runtime.General;
 
 namespace Internal.TypeSystem
 {
@@ -97,7 +98,18 @@ namespace Internal.TypeSystem
                     if (mdType != null)
                     {
                         // Look up the runtime type handle in the module metadata
-                        if (TypeLoaderEnvironment.Instance.TryGetNamedTypeForMetadata(mdType.MetadataReader, mdType.Handle, out typeDefHandle))
+                        if (TypeLoaderEnvironment.Instance.TryGetNamedTypeForMetadata(new QTypeDefinition(mdType.MetadataReader, mdType.Handle), out typeDefHandle))
+                        {
+                            typeDefinition.SetRuntimeTypeHandleUnsafe(typeDefHandle);
+                        }
+                    }
+#endif
+#if ECMA_METADATA_SUPPORT
+                    Ecma.EcmaType ecmaType = typeDefinition as Ecma.EcmaType;
+                    if (ecmaType != null)
+                    {
+                        // Look up the runtime type handle in the module metadata
+                        if (TypeLoaderEnvironment.Instance.TryGetNamedTypeForMetadata(new QTypeDefinition(ecmaType.MetadataReader, ecmaType.Handle), out typeDefHandle))
                         {
                             typeDefinition.SetRuntimeTypeHandleUnsafe(typeDefHandle);
                         }

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -285,6 +285,7 @@
     <Compile Include="Internal\Runtime\TypeLoader\GenericDictionary.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\genericdictionarycell.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\LazyVtableResolverThunk.cs" />
+    <Compile Include="Internal\Runtime\TypeLoader\LockFreeObjectInterner.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\LowLevelStringConverter.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\McgIntrinsics.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\MetadataFixupKind.cs" />
@@ -334,6 +335,7 @@
     <Compile Include="Internal\TypeSystem\TypeDesc.Runtime.cs" />
     <Compile Include="Internal\TypeSystem\TypeSystemContext.Runtime.cs" />
     <Compile Include="System\Reflection\Runtime\General\QHandles.cs" />
+    <Compile Include="System\Reflection\Runtime\General\QHandles.NativeFormat.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\NativeFormat\MetadataExtensions.cs">
       <Link>NativeFormat\MetadataExtensions.cs</Link>
     </Compile>

--- a/src/System.Private.TypeLoader/src/System/Reflection/Runtime/General/QHandles.NativeFormat.cs
+++ b/src/System.Private.TypeLoader/src/System/Reflection/Runtime/General/QHandles.NativeFormat.cs
@@ -23,8 +23,8 @@ namespace System.Reflection.Runtime.General
             _handle = ((Handle)handle).AsInt();
         }
 
-        public MetadataReader NativeFormatReader { get { return _reader as MetadataReader; } }
-        public MethodHandle NativeFormatHandle { get { return _handle.AsHandle().ToMethodHandle(NativeFormatReader); } }
+        public MetadataReader NativeFormatReader { get { Debug.Assert(IsNativeFormatMetadataBased); return _reader as MetadataReader; } }
+        public MethodHandle NativeFormatHandle { get { Debug.Assert(IsNativeFormatMetadataBased); return _handle.AsHandle().ToMethodHandle(NativeFormatReader); } }
 
         public bool IsNativeFormatMetadataBased
         {
@@ -43,8 +43,8 @@ namespace System.Reflection.Runtime.General
             _handle = ((Handle)handle).AsInt();
         }
 
-        public MetadataReader NativeFormatReader { get { return _reader as MetadataReader; } }
-        public TypeDefinitionHandle NativeFormatHandle { get { return _handle.AsHandle().ToTypeDefinitionHandle(NativeFormatReader); } }
+        public MetadataReader NativeFormatReader { get { Debug.Assert(IsNativeFormatMetadataBased); return _reader as MetadataReader; } }
+        public TypeDefinitionHandle NativeFormatHandle { get { Debug.Assert(IsNativeFormatMetadataBased); return _handle.AsHandle().ToTypeDefinitionHandle(NativeFormatReader); } }
 
         public bool IsNativeFormatMetadataBased
         {

--- a/src/System.Private.TypeLoader/src/System/Reflection/Runtime/General/QHandles.NativeFormat.cs
+++ b/src/System.Private.TypeLoader/src/System/Reflection/Runtime/General/QHandles.NativeFormat.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// Collection of "qualified handle" tuples.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.Metadata.NativeFormat;
+using Internal.Runtime.TypeLoader;
+
+namespace System.Reflection.Runtime.General
+{
+
+    public partial struct QMethodDefinition
+    {
+        public QMethodDefinition(MetadataReader reader, MethodHandle handle)
+        {
+            _reader = reader;
+            _handle = ((Handle)handle).AsInt();
+        }
+
+        public MetadataReader NativeFormatReader { get { return _reader as MetadataReader; } }
+        public MethodHandle NativeFormatHandle { get { return _handle.AsHandle().ToMethodHandle(NativeFormatReader); } }
+
+        public bool IsNativeFormatMetadataBased
+        {
+            get
+            {
+                return (_reader != null) && _reader is global::Internal.Metadata.NativeFormat.MetadataReader;
+            }
+        }
+    }
+
+    public partial struct QTypeDefinition
+    {
+        public QTypeDefinition(MetadataReader reader, TypeDefinitionHandle handle)
+        {
+            _reader = reader;
+            _handle = ((Handle)handle).AsInt();
+        }
+
+        public MetadataReader NativeFormatReader { get { return _reader as MetadataReader; } }
+        public TypeDefinitionHandle NativeFormatHandle { get { return _handle.AsHandle().ToTypeDefinitionHandle(NativeFormatReader); } }
+
+        public bool IsNativeFormatMetadataBased
+        {
+            get
+            {
+                return (_reader != null) && _reader is global::Internal.Metadata.NativeFormat.MetadataReader;
+            }
+        }
+    }
+
+    public partial struct QTypeDefRefOrSpec
+    {
+        public QTypeDefRefOrSpec(MetadataReader reader, Handle handle, bool skipCheck = false)
+        {
+            if (!skipCheck)
+            {
+                if (!handle.IsTypeDefRefOrSpecHandle(reader))
+                    throw new BadImageFormatException();
+            }
+            Debug.Assert(handle.IsTypeDefRefOrSpecHandle(reader));
+            _reader = reader;
+            _handle = handle.ToIntToken();
+        }
+    
+        public bool IsNativeFormatMetadataBased
+        {
+            get
+            {
+                return (_reader != null) && Reader is global::Internal.Metadata.NativeFormat.MetadataReader;
+            }
+        }
+    }
+}

--- a/src/System.Private.TypeLoader/src/System/Reflection/Runtime/General/QHandles.cs
+++ b/src/System.Private.TypeLoader/src/System/Reflection/Runtime/General/QHandles.cs
@@ -112,7 +112,7 @@ namespace System.Reflection.Runtime.General
         public object Reader { get { return _reader; } }
         public int Token { get { return _handle; } }
 
-        public bool IsNull { get { return _reader == null; } }
+        public bool IsValid { get { return _reader == null; } }
 
         public static readonly QMethodDefinition Null = default(QMethodDefinition);
 
@@ -125,7 +125,7 @@ namespace System.Reflection.Runtime.General
         public object Reader { get { return _reader; } }
         public int Token { get { return _handle; } }
 
-        public bool IsNull { get { return _reader == null; } }
+        public bool IsValid { get { return _reader == null; } }
 
         public static readonly QTypeDefinition Null = default(QTypeDefinition);
 
@@ -139,7 +139,7 @@ namespace System.Reflection.Runtime.General
         public object Reader { get { return _reader; } }
         public int Handle { get { return _handle; } }
 
-        public bool IsNull { get { return _reader == null; } }
+        public bool IsValid { get { return _reader == null; } }
 
         public static readonly QTypeDefRefOrSpec Null = default(QTypeDefRefOrSpec);
 

--- a/src/System.Private.TypeLoader/src/System/Reflection/Runtime/General/QHandles.cs
+++ b/src/System.Private.TypeLoader/src/System/Reflection/Runtime/General/QHandles.cs
@@ -96,70 +96,50 @@ namespace System.Reflection.Runtime.General
         private readonly Handle _handle;
     }
 
-
-    public struct QTypeDefinition : IEquatable<QTypeDefinition>
+    public partial struct QMethodDefinition
     {
-        public QTypeDefinition(MetadataReader reader, TypeDefinitionHandle handle)
+        private QMethodDefinition(object reader, int token)
         {
             _reader = reader;
-            _handle = handle;
+            _handle = token;
         }
 
-        public MetadataReader Reader { get { return _reader; } }
-        public TypeDefinitionHandle Handle { get { return _handle; } }
-
-        public override bool Equals(Object obj)
+        public static QMethodDefinition FromObjectAndInt(object reader, int token)
         {
-            if (!(obj is QTypeDefinition))
-                return false;
-            return Equals((QTypeDefinition)obj);
+            return new QMethodDefinition(reader, token);
         }
 
-        public bool Equals(QTypeDefinition other)
-        {
-            if (!(_reader == other._reader))
-                return false;
-            if (!(_handle.Equals(other._handle)))
-                return false;
-            return true;
-        }
+        public object Reader { get { return _reader; } }
+        public int Token { get { return _handle; } }
 
-        public override int GetHashCode()
-        {
-            return _handle.GetHashCode();
-        }
+        public bool IsNull { get { return _reader == null; } }
 
-        private readonly MetadataReader _reader;
-        private readonly TypeDefinitionHandle _handle;
+        public static readonly QMethodDefinition Null = default(QMethodDefinition);
+
+        private readonly object _reader;
+        private readonly int _handle;
+    }
+
+    public partial struct QTypeDefinition
+    {   
+        public object Reader { get { return _reader; } }
+        public int Token { get { return _handle; } }
+
+        public bool IsNull { get { return _reader == null; } }
+
+        public static readonly QTypeDefinition Null = default(QTypeDefinition);
+
+        private readonly object _reader;
+        private readonly int _handle;
     }
 
 
-    public struct QTypeDefRefOrSpec
+    public partial struct QTypeDefRefOrSpec
     {
-        public QTypeDefRefOrSpec(MetadataReader reader, Handle handle, bool skipCheck = false)
-        {
-            if (!skipCheck)
-            {
-                if (!handle.IsTypeDefRefOrSpecHandle(reader))
-                    throw new BadImageFormatException();
-            }
-            Debug.Assert(handle.IsTypeDefRefOrSpecHandle(reader));
-            _reader = reader;
-            _handle = handle.ToIntToken();
-        }
-
         public object Reader { get { return _reader; } }
         public int Handle { get { return _handle; } }
 
         public bool IsNull { get { return _reader == null; } }
-
-        public bool IsNativeFormatMetadataBased
-        {
-            get
-            {
-                return Reader is global::Internal.Metadata.NativeFormat.MetadataReader;
-            }
-        }
 
         public static readonly QTypeDefRefOrSpec Null = default(QTypeDefRefOrSpec);
 


### PR DESCRIPTION
Reflection Core was mostly handled with a previous checkin, this change mostly affects TypeLoader and ReflectionExecution
- Move most handling of module pointers in type loader to use ModuleInfo class instead
- Add QTypeDefinition and QMethodDefinition to allow passing around the tuple of a metadata reader (of indeterminate format) and the associated token
- Add passthrough to an ECMA 335 based assembly binder for Load(byte[]) calls, and assembly name based loads. ECMA 335 based loader to be added in a separate change
- Remove gratuitous use of native format specific code, in favor of passing around indeterminate structures
- Where we need to go from indeterminate to exact, #ifs are generally used (There are some #ifs for Ecma format handling, but no correct implementations for those cases are in this change. They will follow in a separate, change)
- Move TryGetMetadataForTypeMethodNameAndSignature from ExecutionEnvironmentImplementation.MappingTables.cs to TypeLoader, as it will be necessary to correctly implement RuntimeMethodHandle parsing
- Refactor EnumInfoImplementation into an abstract base class and derived metadata specific classes
- OpenMethodResolver now needs to support holding onto a metadata reader instead of a module handle. To support this we now have an ability to have an intern table that generates GCHandles (OpenMethodResolver is stored in unmanaged memory, and so cannot hold a normal GC reference)