### PR TITLE
Staging commit for upcoming multi-module CI change

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -52,6 +52,7 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
                     if (os == 'Windows_NT') {
                         // Indicates that a batch script should be run with the build string (see above)
                         batchFile(buildString)
+                        batchFile("tests\\runtest.cmd /multimodule")
 
                         if (configuration == 'Debug') {
                             if (isPR) {

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -15,6 +15,7 @@ set CoreRT_CoreCLRTargetsFile=
 :ArgLoop
 if "%1" == "" goto :ArgsDone
 if /i "%1" == "/?" goto :Usage
+if /i "%1" == "/multimodule"    (exit /b 0)
 if /i "%1" == "x64"    (set CoreRT_BuildArch=x64&&shift&goto ArgLoop)
 if /i "%1" == "x86"    (set CoreRT_BuildArch=x86&&shift&goto ArgLoop)
 if /i "%1" == "arm"    (set CoreRT_BuildArch=arm&&shift&goto ArgLoop)


### PR DESCRIPTION
My upcoming PR for multi-module testing support needs the CI authoring
done one PR early since netci.groovy is always pulled from HEAD (not the
changes in a pending PR).

Call `runtest.cmd` with the new `/multimodule` switch during Windows CI
runs. Currently the switch causes the test script to immediately return
with success.