### PR TITLE
Enable multi-module on Windows

### DIFF
--- a/src/BuildIntegration/BuildFrameworkNativeObjects.proj
+++ b/src/BuildIntegration/BuildFrameworkNativeObjects.proj
@@ -1,8 +1,11 @@
-<Project ToolsVersion="14.0" DefaultTargets="BuildAllFrameworkLibraries" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="CreateLib" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <IlcCompileDependsOn>BuildOneFrameworkLibrary</IlcCompileDependsOn>
+    <CreateLibDependsOn>BuildAllFrameworkLibrariesAsSingleLib</CreateLibDependsOn>
     <IlcMultiModule>true</IlcMultiModule>
+    <NativeIntermediateOutputPath Condition="'$(FrameworkObjPath)' != ''">$(FrameworkObjPath)\</NativeIntermediateOutputPath>
+    <BuildingFrameworkLibrary>true</BuildingFrameworkLibrary>
   </PropertyGroup>
   
   <Import Project="Microsoft.NETCore.Native.targets" />
@@ -16,6 +19,19 @@
       </ProjectToBuild>
     </ItemGroup>
     <MSBuild Projects="@(ProjectToBuild)" Targets="IlcCompile" BuildInParallel="true" />
+  </Target>
+
+  <Target Name="BuildAllFrameworkLibrariesAsSingleLib"
+    DependsOnTargets="BuildAllFrameworkLibraries">
+
+    <ItemGroup>
+      <LibInputs Include="$(NativeIntermediateOutputPath)\*.obj" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <SharedLibrary>$(FrameworkLibPath)\Framework.lib</SharedLibrary>
+    </PropertyGroup>
+
   </Target>
 
   <Target Name="BuildOneFrameworkLibrary">

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -19,6 +19,7 @@ See the LICENSE file in the project root for more information.
   <PropertyGroup>
     <CppCompiler>cl</CppCompiler>
     <CppLinker>link</CppLinker>
+    <CppLibCreator>lib</CppLibCreator>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,6 +37,7 @@ See the LICENSE file in the project root for more information.
     <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)\sdk\Runtime.lib" />
     <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\bootstrappercpp.lib" />
     <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\PortableRuntime.lib" />
+    <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(FrameworkLibPath)\Framework.lib" />
   </ItemGroup>
 
   <ItemGroup>
@@ -50,6 +52,7 @@ See the LICENSE file in the project root for more information.
     <AdditionalNativeLibrary Include="oleaut32.lib" />
     <AdditionalNativeLibrary Include="uuid.lib" />
     <AdditionalNativeLibrary Include="bcrypt.lib" />
+    <AdditionalNativeLibrary Include="normaliz.lib" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -46,9 +46,12 @@ See the LICENSE file in the project root for more information.
     <IlcCompileOutput Condition="$(NativeCodeGen) == 'cpp'">$(NativeIntermediateOutputPath)$(TargetName).cpp</IlcCompileOutput>
     <LinkNativeDependsOn Condition="$(NativeCodeGen) == ''">IlcCompile</LinkNativeDependsOn>
     <LinkNativeDependsOn Condition="$(NativeCodeGen) == 'cpp'">CppCompile</LinkNativeDependsOn>
+
+    <FrameworkLibPath Condition="'$(FrameworkLibPath)' == ''">$(NativeOutputPath)</FrameworkLibPath>
+    <FrameworkObjPath Condition="'$(FrameworkObjPath)' == ''">$(NativeIntermediateOutputPath)</FrameworkObjPath>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(BuildingFrameworkLibrary) != 'true'">
     <ManagedBinary Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
   </ItemGroup>
 
@@ -57,25 +60,36 @@ See the LICENSE file in the project root for more information.
     <IlcReference Include="$(IlcPath)\framework\*.dll" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <IlcCompileDependsOn Condition="'$(IlcCompileDependsOn)'==''">Compile</IlcCompileDependsOn>
+  <PropertyGroup Condition="'$(IlcCompileDependsOn)'==''">
+    <IlcCompileDependsOn Condition="'$(BuildingFrameworkLibrary)' != 'true'">Compile</IlcCompileDependsOn>
+    <IlcCompileDependsOn Condition="'$(IlcMultiModule)' == 'true' and '$(BuildingFrameworkLibrary)' != 'true'">$(IlcCompileDependsOn);BuildFrameworkLib</IlcCompileDependsOn>
   </PropertyGroup>
 
-  <Target Name="IlcFramework">
+  <!--
+    BuildFrameworkLib is invoked before IlcCompile in multi-module builds to 
+    produce the shared framework library on demand
+  -->
+  <Target Name="BuildFrameworkLib">
     <ItemGroup>
-      <ManagedBinary Include="@(IlcReference)" />
+      <ProjectToBuild Include="$(MSBuildThisFileDirectory)\BuildFrameworkNativeObjects.proj">
+        <AdditionalProperties>
+          IntermediateOutputPath=$(IntermediateOutputPath);
+          FrameworkLibPath=$(FrameworkLibPath);
+          FrameworkObjPath=$(FrameworkObjPath)
+        </AdditionalProperties>
+      </ProjectToBuild>
     </ItemGroup>
-
+    <MSBuild Projects="@(ProjectToBuild)" BuildInParallel="true" />
   </Target>
 
   <Target Name="IlcCompile" 
       Inputs="@(ManagedBinary)"
-      Outputs="$(NativeIntermediateOutputPath)%(Filename)$(IlcOutputFileExt)"
+      Outputs="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
     <ItemGroup>
       <IlcArg Include="@(ManagedBinary)" />
-      <IlcArg Include="-o:$(NativeIntermediateOutputPath)%(Filename)$(IlcOutputFileExt)" />
+      <IlcArg Include="-o:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)" />
       <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
       <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
@@ -120,7 +134,7 @@ See the LICENSE file in the project root for more information.
   </Target>
 
   <Target Name="LinkNative"
-      Inputs="$(NativeObject)"
+      Inputs="$(NativeObject);@(NativeLibrary)"
       Outputs="$(NativeBinary)"
       DependsOnTargets="$(LinkNativeDependsOn)">
 
@@ -135,5 +149,19 @@ See the LICENSE file in the project root for more information.
     <Exec Command="$(CppLinker) @(CustomLinkerArg, ' ')" Condition="'$(OS)' != 'Windows_NT'" />
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)link.rsp" Lines="@(CustomLinkerArg)" Overwrite="true" Condition="'$(OS)' == 'Windows_NT'" />
     <Exec Command="$(CppLinker)  @&quot;$(NativeIntermediateOutputPath)link.rsp&quot;" Condition="'$(OS)' == 'Windows_NT'" />
+  </Target>
+
+  <Target Name="CreateLib"
+    Inputs="@(LibInputs)"
+    Outputs="$(SharedLibrary)"
+    DependsOnTargets="$(CreateLibDependsOn)">
+
+    <ItemGroup>
+      <CustomLibArg Include="@(LibInputs->'%(Identity)')" />
+      <CustomLibArg Include="/out:$(SharedLibrary)" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)lib.rsp" Lines="@(CustomLibArg)" Overwrite="true" Condition="'$(OS)' == 'Windows_NT'" />
+    <Exec Command="$(CppLibCreator) @&quot;$(NativeIntermediateOutputPath)lib.rsp&quot;" Condition="'$(OS)' == 'Windows_NT'" />
   </Target>
 </Project>

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Internal.TypeSystem;
-using Internal.TypeSystem.Ecma;
 using Internal.IL;
 using Debug = System.Diagnostics.Debug;
 
@@ -70,7 +69,7 @@ namespace Internal.TypeSystem.Interop
             if (forceLazyResolution.HasValue)
                 return forceLazyResolution.Value;
 
-            string assemblySimpleName = ((EcmaAssembly)((MetadataType)method.OwningType).Module).GetName().Name;
+            string assemblySimpleName = ((IAssemblyDesc)((MetadataType)method.OwningType).Module).GetName().Name;
             if (assemblySimpleName == "System.Private.Interop")
             {
                 return true;

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -69,6 +69,9 @@ namespace Internal.TypeSystem.Interop
             if (forceLazyResolution.HasValue)
                 return forceLazyResolution.Value;
 
+            // In multi-module library mode, the WinRT p/invokes in System.Private.Interop cause linker failures
+            // since we don't link against the OS libraries containing those APIs. Force them to be lazy.
+            // See https://github.com/dotnet/corert/issues/2601
             string assemblySimpleName = ((IAssemblyDesc)((MetadataType)method.OwningType).Module).GetName().Name;
             if (assemblySimpleName == "System.Private.Interop")
             {

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 using Internal.IL;
 using Debug = System.Diagnostics.Debug;
 
@@ -68,6 +69,12 @@ namespace Internal.TypeSystem.Interop
             bool? forceLazyResolution = configuration.ForceLazyResolution;
             if (forceLazyResolution.HasValue)
                 return forceLazyResolution.Value;
+
+            string assemblySimpleName = ((EcmaAssembly)((MetadataType)method.OwningType).Module).GetName().Name;
+            if (assemblySimpleName == "System.Private.Interop")
+            {
+                return true;
+            }
 
             // Determine whether this call should be made through a lazy resolution or a static reference
             // Eventually, this should be controlled by a custom attribute (or an extension to the metadata format).

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -207,6 +207,32 @@ namespace ILCompiler
                     _graph.AddRoot(_factory.ConstructedTypeSymbol(type), reason);
                 }
             }
+
+            public void RootStaticBasesForType(TypeDesc type, string reason)
+            {
+                if (type.IsGenericDefinition)
+                    return;
+
+                MetadataType metadataType = type as MetadataType;
+                if (metadataType != null)
+                {
+                    if (metadataType.ThreadStaticFieldSize > 0)
+                    {
+                        _graph.AddRoot(_factory.TypeThreadStaticsSymbol(metadataType), reason);
+                        _graph.AddRoot(_factory.TypeThreadStaticIndex(metadataType), reason);
+                    }
+
+                    if (metadataType.GCStaticFieldSize > 0)
+                    {
+                        _graph.AddRoot(_factory.TypeGCStaticsSymbol(metadataType), reason);
+                    }
+
+                    if (metadataType.NonGCStaticFieldSize > 0)
+                    {
+                        _graph.AddRoot(_factory.TypeNonGCStaticsSymbol(metadataType), reason);
+                    }
+                }
+            }
         }
     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -65,9 +65,6 @@ namespace ILCompiler
             // https://github.com/dotnet/corert/issues/2454
             // https://github.com/dotnet/corert/issues/2149
             if (this is CppCodegenCompilation) forceLazyPInvokeResolution = false;
-            // TODO: Workaround missing PInvokes with multifile compilation
-            // https://github.com/dotnet/corert/issues/2454
-            if (!nodeFactory.CompilationModuleGroup.IsSingleFileCompilation) forceLazyPInvokeResolution = true;
             PInvokeILProvider = new PInvokeILProvider(new PInvokeILEmitterConfiguration(forceLazyPInvokeResolution));
 
             _methodILCache = new ILProvider(PInvokeILProvider);

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -210,15 +210,13 @@ namespace ILCompiler
 
             public void RootStaticBasesForType(TypeDesc type, string reason)
             {
-                if (type.IsGenericDefinition)
-                    return;
+                Debug.Assert(!type.IsGenericDefinition);
 
                 MetadataType metadataType = type as MetadataType;
                 if (metadataType != null)
                 {
                     if (metadataType.ThreadStaticFieldSize > 0)
                     {
-                        _graph.AddRoot(_factory.TypeThreadStaticsSymbol(metadataType), reason);
                         _graph.AddRoot(_factory.TypeThreadStaticIndex(metadataType), reason);
                     }
 
@@ -232,6 +230,7 @@ namespace ILCompiler
                         _graph.AddRoot(_factory.TypeNonGCStaticsSymbol(metadataType), reason);
                     }
                 }
+
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
@@ -110,7 +110,7 @@ namespace ILCompiler.DependencyAnalysis
 
             public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
             {
-                sb.Append(_parentNode._startSymbolMangledName).Append("_").Append(_id.ToStringInvariant());
+                sb.Append(nameMangler.CompilationUnitPrefix).Append(_parentNode._startSymbolMangledName).Append("_").Append(_id.ToStringInvariant());
             }
         }
         

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append(_name);
         }
         public int Offset => 0;
-        public override bool IsShareable => false;
+        public override bool IsShareable => true;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -126,7 +126,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public static bool IsTypeNodeShareable(TypeDesc type)
         {
-            return type.IsParameterizedType || type.IsFunctionPointer || type is InstantiatedType;
+            return type.IsParameterizedType || type.IsFunctionPointer || type is InstantiatedType || type is CompilerGeneratedType;
         }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -126,7 +126,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public static bool IsTypeNodeShareable(TypeDesc type)
         {
-            return type.IsParameterizedType || type.IsFunctionPointer || type is InstantiatedType || type is CompilerGeneratedType;
+            return type.IsParameterizedType || type.IsFunctionPointer || type is InstantiatedType;
         }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -772,7 +772,8 @@ namespace ILCompiler.DependencyAnalysis
                     objectWriter.BuildSymbolDefinitionMap(node, nodeContents.DefinedSymbols);
 
                     // Build CFI map (Unix) or publish unwind blob (Windows).
-                    objectWriter.BuildCFIMap(factory, node);
+                    if (!objectWriter.ShouldShareSymbol(node))
+                        objectWriter.BuildCFIMap(factory, node);
 
                     // Build debug location map
                     objectWriter.BuildDebugLocInfoMap(node);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -703,6 +703,14 @@ namespace ILCompiler.DependencyAnalysis
             if (!_targetPlatform.IsWindows)
                 return false;
 
+            // Types and methods from the compiler generated assembly are always shareable
+            CompilerGeneratedType type = (node is EETypeNode ? ((EETypeNode)node).Type : (node as MethodCodeNode)?.Method.OwningType) as CompilerGeneratedType;
+            if (type != null &&
+                type.Module == _nodeFactory.CompilationModuleGroup.GeneratedAssembly)
+            {
+                return true;
+            }
+            
             return node.IsShareable;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -704,7 +704,7 @@ namespace ILCompiler.DependencyAnalysis
                 return false;
 
             // Types and methods from the compiler generated assembly are always shareable
-            CompilerGeneratedType type = (node is EETypeNode ? ((EETypeNode)node).Type : (node as MethodCodeNode)?.Method.OwningType) as CompilerGeneratedType;
+            MetadataType type = (node is EETypeNode ? ((EETypeNode)node).Type : (node as MethodCodeNode)?.Method.OwningType) as MetadataType;
             if (type != null &&
                 type.Module == _nodeFactory.CompilationModuleGroup.GeneratedAssembly)
             {
@@ -737,7 +737,7 @@ namespace ILCompiler.DependencyAnalysis
                                                             MethodCodeNode.EndSection.GetSharedSection("__managedcode_z");
                     objectWriter.SetSection(codeEndSection);
                     objectWriter.EmitSymbolDef(new Utf8StringBuilder().Append("__managedcode_z"));
-                    objectWriter.EmitIntValue(0, 1);
+                    objectWriter.EmitIntValue(1, 1);
                 }
                 else
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
@@ -35,6 +35,8 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append("unbox_").Append(NodeFactory.NameMangler.GetMangledMethodName(_target));
         }
 
+        public override bool IsShareable => true;
+
         protected override string GetName() => this.GetMangledName();
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
@@ -13,5 +13,6 @@ namespace ILCompiler
     {
         void AddCompilationRoot(MethodDesc method, string reason, string exportName = null);
         void AddCompilationRoot(TypeDesc type, string reason);
+        void RootStaticBasesForType(TypeDesc type, string reason);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -45,6 +45,8 @@ namespace ILCompiler
                 // If this is not a generic definition, root all methods
                 if (!type.HasInstantiation)
                     RootMethods(type, "Library module method", rootProvider);
+
+                rootProvider.RootStaticBasesForType(type, "Library module type statics");
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -53,7 +53,7 @@ namespace ILCompiler
             foreach (MethodDesc method in type.GetMethods())
             {
                 // Skip methods with no IL and uninstantiated generic methods
-                if (method.IsIntrinsic || method.IsAbstract || method.HasInstantiation)
+                if (method.IsAbstract || method.HasInstantiation)
                     continue;
 
                 if (method.IsInternalCall)

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -44,9 +44,10 @@ namespace ILCompiler
 
                 // If this is not a generic definition, root all methods
                 if (!type.HasInstantiation)
+                {
                     RootMethods(type, "Library module method", rootProvider);
-
-                rootProvider.RootStaticBasesForType(type, "Library module type statics");
+                    rootProvider.RootStaticBasesForType(type, "Library module type statics");
+                }
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataGeneration.cs
@@ -296,12 +296,6 @@ namespace ILCompiler
                     _modulesSeen.Add(mdType.Module);
                 }
             }
-            else if (type.HasInstantiation)
-            {
-                AddGeneratedType(type.GetTypeDefinition());
-                foreach (var argument in type.Instantiation)
-                    AddGeneratedType(argument);
-            }
             else if (type.IsArray)
             {
                 var arrayType = (ArrayType)type;

--- a/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
+++ b/src/System.Private.CoreLib/src/Interop/Interop.manual.cs
@@ -33,7 +33,7 @@ internal partial class Interop
     }
 
     // MCG doesn't currently support constants that are not uint.
-    internal static IntPtr InvalidHandleValue = new IntPtr(-1);
+    internal static IntPtr InvalidHandleValue => new IntPtr(-1);
 
     internal enum _APTTYPE : uint
     {

--- a/src/System.Private.Interop/src/Shared/McgIntrinsics.cs
+++ b/src/System.Private.Interop/src/Shared/McgIntrinsics.cs
@@ -370,7 +370,7 @@ namespace System.Runtime.InteropServices
         // We need to call via an imported stub to do a stdcall without triggering GC
         // We can't use managed calli because the native target address could potentially satisfy a magic
         // bit check and causing the stub to believe it is a managed method which leads to crash.
-#if !RHTESTCL && !CORECLR
+#if !RHTESTCL && !CORECLR && !CORERT
         [MethodImplAttribute(InternalCall)]
 #if X86
         [RuntimeImport("*", "@StdCallCOOP0@8")]

--- a/src/System.Private.Interop/src/Shared/McgMarshal.cs
+++ b/src/System.Private.Interop/src/Shared/McgMarshal.cs
@@ -1364,7 +1364,7 @@ namespace System.Runtime.InteropServices
         
         #region "PInvoke Delegate"
 
-#if !CORECLR
+#if !CORECLR && !CORERT
         private static class AsmCode
         {
             private const MethodImplOptions InternalCall = (MethodImplOptions)0x1000;
@@ -1692,7 +1692,7 @@ namespace System.Runtime.InteropServices
         /// </summary>
         public static IntPtr GetCurrentCalleeOpenStaticDelegateFunctionPointer()
         {
-#if RHTESTCL || CORECLR
+#if RHTESTCL || CORECLR || CORERT
             throw new NotSupportedException();
 #else
             //
@@ -1720,7 +1720,7 @@ namespace System.Runtime.InteropServices
         /// </summary>
         public static T GetCurrentCalleeDelegate<T>() where T : class // constraint can't be System.Delegate
         {
-#if RHTESTCL || CORECLR
+#if RHTESTCL || CORECLR || CORERT
             throw new NotSupportedException();
 #else
             //

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ConstrainedCallSupport.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ConstrainedCallSupport.cs
@@ -36,8 +36,10 @@ namespace Internal.Runtime.TypeLoader
 #endif
         private delegate IntPtr RuntimeCacheFuncSignatureDel(IntPtr context, IntPtr callDescIntPtr, object contextObject, out IntPtr auxResult);
 
+#if !CORERT
         [DllImport("*", ExactSpelling = true, EntryPoint = "ConstrainedCallSupport_GetStubs")]
         private extern static unsafe void ConstrainedCallSupport_GetStubs(out IntPtr constrainedCallSupport_DerefThisAndCall_CommonCallingStub, out IntPtr constrainedCallSupport_DirectConstrainedCall_CommonCallingStub);
+#endif
 
         private static IntPtr s_constrainedCallSupport_DerefThisAndCall_CommonCallingStub;
         private static IntPtr s_constrainedCallSupport_DirectConstrainedCall_CommonCallingStub;

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -197,13 +197,13 @@ goto :eof
         )
     ) else (
         if "%CoreRT_MultiFileConfiguration%" == "MultiModule" (
-            set extraArgs=!extraArgs! "/p:IlcMultiModule=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework"
+            set extraArgs=!extraArgs! "/p:IlcMultiModule=true"
         )
     )
 
-    echo msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" !extraArgs! !__SourceFile!.csproj
+    echo msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
     echo.
-    msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" !extraArgs! !__SourceFile!.csproj
+    msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
     endlocal
 
     set __SavedErrorLevel=%ErrorLevel%

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -11,11 +11,11 @@ set CoreRT_TestRun=true
 set CoreRT_TestCompileMode=
 set CoreRT_RunCoreCLRTests=
 set CoreRT_CoreCLRTargetsFile=
+set CoreRT_TestLogFileName=testresults.xml
 
 :ArgLoop
 if "%1" == "" goto :ArgsDone
 if /i "%1" == "/?" goto :Usage
-if /i "%1" == "/multimodule"    (exit /b 0)
 if /i "%1" == "x64"    (set CoreRT_BuildArch=x64&&shift&goto ArgLoop)
 if /i "%1" == "x86"    (set CoreRT_BuildArch=x86&&shift&goto ArgLoop)
 if /i "%1" == "arm"    (set CoreRT_BuildArch=arm&&shift&goto ArgLoop)
@@ -48,6 +48,7 @@ if /i "%1" == "/coreclr"  (
 if /i "%1" == "/mode" (set CoreRT_TestCompileMode=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/runtest" (set CoreRT_TestRun=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/dotnetclipath" (set CoreRT_CliDir=%2&shift&shift&goto ArgLoop)
+if /i "%1" == "/multimodule" (set CoreRT_MultiFileConfiguration=MultiModule&shift&goto ArgLoop)
 
 echo Invalid command line argument: %1
 goto :Usage
@@ -59,6 +60,7 @@ echo     flavor        : debug / release
 echo     /mode         : Optionally restrict to a single code generator. Specify cpp/ryujit. Default: both
 echo     /runtest      : Should just compile or run compiled binary? Specify: true/false. Default: true.
 echo     /coreclr      : Download and run the CoreCLR repo tests
+echo     /multimodule  : Compile the framework as a .lib and link tests against it (only supports ryujit)
 echo.
 echo     --- CoreCLR Subset ---
 echo        Top200     : Runs broad coverage / CI validation (~200 tests).
@@ -68,12 +70,25 @@ exit /b 2
 
 :ArgsDone
 
+:: Cpp Codegen does not support multi-module compilation, so force Ryujit
+if "%CoreRT_MultiFileConfiguration%"=="MultiModule" (
+    set CoreRT_TestCompileMode=ryujit
+)
+
 call %CoreRT_TestRoot%testenv.cmd
 
 set CoreRT_RspTemplateDir=%CoreRT_TestRoot%..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%
 
 set __BuildStr=%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%
 set __CoreRTTestBinDir=%CoreRT_TestRoot%..\bin\tests
+
+:: Place test logs in a subfolder in multi-module mode so both single-file and
+:: multi-module test results are visible to the CI tooling
+if NOT "%CoreRT_MultiFileConfiguration%" == "" (
+    set CoreRT_TestLogFileName=%CoreRT_MultiFileConfiguration%\%CoreRT_TestLogFileName%
+    mkdir %__CoreRTTestBinDir%\%CoreRT_MultiFileConfiguration%
+)
+
 set __LogDir=%CoreRT_TestRoot%\..\bin\Logs\%__BuildStr%\tests
 
 call "!VS140COMNTOOLS!\..\..\VC\vcvarsall.bat" %CoreRT_BuildArch%
@@ -117,14 +132,14 @@ set /a __TotalTests=%__JitTotalTests%+%__CppTotalTests%
 set /a __PassedTests=%__JitPassedTests%+%__CppPassedTests%
 set /a __FailedTests=%__JitFailedTests%+%__CppFailedTests%
 
-echo ^<?xml version="1.0" encoding="utf-8"?^> > %__CoreRTTestBinDir%\testResults.xml
-echo ^<assemblies^>  >> %__CoreRTTestBinDir%\testResults.xml
-echo ^<assembly name="ILCompiler" total="%__TotalTests%" passed="%__PassedTests%" failed="%__FailedTests%" skipped="0"^>  >> %__CoreRTTestBinDir%\testResults.xml
-echo ^<collection total="%__TotalTests%" passed="%__PassedTests%" failed="%__FailedTests%" skipped="0"^>  >> %__CoreRTTestBinDir%\testResults.xml
-type %__CoreRTTestBinDir%\testResults.tmp >> %__CoreRTTestBinDir%\testResults.xml
-echo ^</collection^>  >> %__CoreRTTestBinDir%\testResults.xml
-echo ^</assembly^>  >> %__CoreRTTestBinDir%\testResults.xml
-echo ^</assemblies^>  >> %__CoreRTTestBinDir%\testResults.xml
+echo ^<?xml version="1.0" encoding="utf-8"?^> > %__CoreRTTestBinDir%\%CoreRT_TestLogFileName%
+echo ^<assemblies^>  >> %__CoreRTTestBinDir%\%CoreRT_TestLogFileName%
+echo ^<assembly name="ILCompiler" total="%__TotalTests%" passed="%__PassedTests%" failed="%__FailedTests%" skipped="0"^>  >> %__CoreRTTestBinDir%\%CoreRT_TestLogFileName%
+echo ^<collection total="%__TotalTests%" passed="%__PassedTests%" failed="%__FailedTests%" skipped="0"^>  >> %__CoreRTTestBinDir%\%CoreRT_TestLogFileName%
+type %__CoreRTTestBinDir%\testResults.tmp >> %__CoreRTTestBinDir%\%CoreRT_TestLogFileName%
+echo ^</collection^>  >> %__CoreRTTestBinDir%\%CoreRT_TestLogFileName%
+echo ^</assembly^>  >> %__CoreRTTestBinDir%\%CoreRT_TestLogFileName%
+echo ^</assemblies^>  >> %__CoreRTTestBinDir%\%CoreRT_TestLogFileName%
 
 echo.
 set __JitStatusPassed=1
@@ -179,6 +194,10 @@ goto :eof
         set extraArgs=!extraArgs! /p:NativeCodeGen=cpp
         if /i "%CoreRT_BuildType%" == "debug" (
             set extraArgs=!extraArgs! /p:UseDebugCrt=true
+        )
+    ) else (
+        if "%CoreRT_MultiFileConfiguration%" == "MultiModule" (
+            set extraArgs=!extraArgs! "/p:IlcMultiModule=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework"
         )
     )
 

--- a/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.csproj
+++ b/tests/src/Simple/BuildMultiModuleLibraries/BuildMultiModuleLibraries.csproj
@@ -1,9 +1,5 @@
 <Project ToolsVersion="14.0" DefaultTargets="BuildAllFrameworkLibraries" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <NativeIntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\native\</NativeIntermediateOutputPath>
-  </PropertyGroup>
-
   <Import Project="..\..\..\..\src\BuildIntegration\BuildFrameworkNativeObjects.proj" />
 
 </Project>

--- a/tests/src/Simple/BuildMultiModuleLibraries/no_unix
+++ b/tests/src/Simple/BuildMultiModuleLibraries/no_unix
@@ -1,0 +1,1 @@
+Doesn't work on OSX.

--- a/tests/src/Simple/MultiModule/Library.cs
+++ b/tests/src/Simple/MultiModule/Library.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+public class MultiModuleLibrary
+{
+    public static int ReturnValue = 50;
+    public static string StaticString;
+    [ThreadStatic]
+    public static int ThreadStaticInt = 50;
+    
+}

--- a/tests/src/Simple/MultiModule/Library.cs
+++ b/tests/src/Simple/MultiModule/Library.cs
@@ -9,9 +9,10 @@ using System.Runtime.CompilerServices;
 
 public class MultiModuleLibrary
 {
-    public static int ReturnValue = 50;
+    // Do not reference these three (3) statics in this assembly.
+    // We're testing that statics in library code are rooted for use by consuming application code.
+    public static int ReturnValue;
     public static string StaticString;
     [ThreadStatic]
-    public static int ThreadStaticInt = 50;
-    
+    public static int ThreadStaticInt;
 }

--- a/tests/src/Simple/MultiModule/Library.csproj
+++ b/tests/src/Simple/MultiModule/Library.csproj
@@ -1,0 +1,10 @@
+<Project DefaultTargets="Build;IlcCompile" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <IlcMultiModule>true</IlcMultiModule>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Library.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SimpleTest.targets))\SimpleTest.targets" />
+</Project>

--- a/tests/src/Simple/MultiModule/MultiModule.cmd
+++ b/tests/src/Simple/MultiModule/MultiModule.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+"%1\%2"
+set ErrorCode=%ERRORLEVEL%
+IF "%ErrorCode%"=="100" (
+    echo %~n0: pass
+    EXIT /b 0
+) ELSE (
+    echo %~n0: fail
+    EXIT /b 1
+)
+endlocal

--- a/tests/src/Simple/MultiModule/MultiModule.cs
+++ b/tests/src/Simple/MultiModule/MultiModule.cs
@@ -23,6 +23,8 @@ public class ReflectionTest
     public static int TestStaticBases()
     {
         Console.WriteLine("Testing static bases in library code are available..");
+        MultiModuleLibrary.ReturnValue = 50;
+        MultiModuleLibrary.ThreadStaticInt = 50;
         
         MultiModuleLibrary.StaticString = MultiModuleLibrary.ReturnValue.ToString() + MultiModuleLibrary.ThreadStaticInt.ToString();
         if (MultiModuleLibrary.StaticString != "5050")

--- a/tests/src/Simple/MultiModule/MultiModule.cs
+++ b/tests/src/Simple/MultiModule/MultiModule.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+public class ReflectionTest
+{
+    const int Pass = 100;
+    const int Fail = -1;
+
+    public static int Main()
+    {
+        if (TestStaticBases() == Fail)
+            return Fail;
+        
+        return Pass;
+    }
+    
+    public static int TestStaticBases()
+    {
+        Console.WriteLine("Testing static bases in library code are available..");
+        
+        MultiModuleLibrary.StaticString = MultiModuleLibrary.ReturnValue.ToString() + MultiModuleLibrary.ThreadStaticInt.ToString();
+        if (MultiModuleLibrary.StaticString != "5050")
+            return Fail;
+        
+        if (MultiModuleLibrary.ReturnValue + MultiModuleLibrary.ThreadStaticInt != 100)
+            return Fail;
+        
+        return Pass;
+    }
+}

--- a/tests/src/Simple/MultiModule/MultiModule.csproj
+++ b/tests/src/Simple/MultiModule/MultiModule.csproj
@@ -1,0 +1,16 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <IlcMultiModule>true</IlcMultiModule>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="MultiModule.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="Library.csproj" />
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SimpleTest.targets))\SimpleTest.targets" />
+</Project>

--- a/tests/src/Simple/MultiModule/MultiModule.sh
+++ b/tests/src/Simple/MultiModule/MultiModule.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+$1/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/MultiModule/no_cpp
+++ b/tests/src/Simple/MultiModule/no_cpp
@@ -1,0 +1,1 @@
+Skip this test for cpp codegen mode

--- a/tests/src/Simple/MultiModule/no_unix
+++ b/tests/src/Simple/MultiModule/no_unix
@@ -1,0 +1,1 @@
+Doesn't work on OSX.

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
     <OutputPath>$(MSBuildProjectDirectory)\bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
@@ -16,6 +16,21 @@
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
   </PropertyGroup>
 
+  <!--
+    When building a library as a reference, the returned build outputs include both the 
+    IL assembly produced by CSC and the native obj produced by Ilc. Separate the native
+    object file here so it isn't passed to CSC, and instead redirect it to be picked up
+    by the LinkNative target.
+  -->
+  <Target Name="RemoveObjFiles" AfterTargets="ResolveProjectReferences" Condition="'$(IlcMultiModule)' == 'true'">
+    <ItemGroup>
+        <ObjFiles Include="@(_ResolvedProjectReferencePaths)" Condition="'%(Extension)' == '.obj'" />
+        <LinkerArg Include="@(_ResolvedProjectReferencePaths)" Condition="'%(Extension)' == '.obj'" />
+        <IlcReference Include="@(_ResolvedProjectReferencePaths)" Condition="'%(Extension)' == '.dll'" />
+        <_ResolvedProjectReferencePaths Remove="@(ObjFiles)" />
+    </ItemGroup>
+  </Target>
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
   <!-- Use the source primary copy for development convenience -->


### PR DESCRIPTION
Enable multi-module compilation for tests in CI through a new switch:
`runtest.cmd /multimodule`. This will compile the framework assemblies
into a single Framework.lib that tests are linked against.

* Adjust several dependency nodes in the compiler to tidy up sharing of
nodes / naming for uniqueness.
* Add handling in ObjectWriter for compiler generated types and their
methods to force sharing.
* Ifdef out runtime imports for StdCall which are implemented in
Native.Interop, a library that hasn't been ported to CoreRT yet.
* Remove metadata generation for type args to an instantiation. This was
breaking type unification because we were treating type args as type
defs, even when they are present in another module and we weren't
emitting the actual EEType, causing a null type handle at runtime.
* Alter build integration MSBuild authoring to produce the framework lib
in multi-module builds on demand. By default, the lib is emitted in the
app binary folder. For test runs there are overrides to control where
the framework objs and lib are placed so they can be shared
(`FrameworkLibPath` and `FrameworkObjPath`).
* Alter test harness to take `/multimodule` switch which links all
Ryujit applicable tests against Framework.lib.