### PR TITLE
RuntimeMethodHandle Lookups

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -61,6 +61,34 @@ namespace ILCompiler.DependencyAnalysis
     }
 
     /// <summary>
+    /// Generic lookup result that points to a RuntimeMethodHandle.
+    /// </summary>
+    internal sealed class MethodHandleGenericLookupResult : GenericLookupResult
+    {
+        private MethodDesc _method;
+
+        public MethodHandleGenericLookupResult(MethodDesc method)
+        {
+            Debug.Assert(method.IsRuntimeDeterminedExactMethod, "Concrete method in a generic dictionary?");
+            _method = method;
+        }
+
+        public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            MethodDesc instantiatedMethod = _method.InstantiateSignature(typeInstantiation, methodInstantiation);
+            return factory.RuntimeMethodHandle(instantiatedMethod);
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("MethodHandle_");
+            sb.Append(nameMangler.GetMangledMethodName(_method));
+        }
+
+        public override string ToString() => $"MethodHandle: {_method}";
+    }
+
+    /// <summary>
     /// Generic lookup result that points to a method dictionary.
     /// </summary>
     internal sealed class MethodDictionaryGenericLookupResult : GenericLookupResult
@@ -81,11 +109,11 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append("MethodHandle_");
+            sb.Append("MethodDictionary_");
             sb.Append(nameMangler.GetMangledMethodName(_method));
         }
 
-        public override string ToString() => $"MethodHandle: {_method}";
+        public override string ToString() => $"MethodDictionary: {_method}";
     }
 
     /// <summary>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -111,8 +111,11 @@ namespace ILCompiler.DependencyAnalysis
 
             dependencies.Add(new DependencyListEntry(_containingTypeSig, "NativeLayoutLdTokenVertexNode containing type signature"));
             dependencies.Add(new DependencyListEntry(_methodSig, "NativeLayoutLdTokenVertexNode method signature"));
-            foreach (var arg in _instantiationArgsSig)
-                dependencies.Add(new DependencyListEntry(arg, "NativeLayoutLdTokenVertexNode instantiation argument signature"));
+            if (_method.HasInstantiation)
+            {
+                foreach (var arg in _instantiationArgsSig)
+                    dependencies.Add(new DependencyListEntry(arg, "NativeLayoutLdTokenVertexNode instantiation argument signature"));
+            }
 
             return dependencies;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -27,6 +27,11 @@ namespace ILCompiler.DependencyAnalysis
                     return new TypeHandleGenericLookupResult(type);
                 });
 
+                _methodHandles = new NodeCache<MethodDesc, GenericLookupResult>(method =>
+                {
+                    return new MethodHandleGenericLookupResult(method);
+                });
+
                 _methodDictionaries = new NodeCache<MethodDesc, GenericLookupResult>(method =>
                 {
                     return new MethodDictionaryGenericLookupResult(method);
@@ -68,6 +73,13 @@ namespace ILCompiler.DependencyAnalysis
             public GenericLookupResult Type(TypeDesc type)
             {
                 return _typeSymbols.GetOrAdd(type);
+            }
+
+            private NodeCache<MethodDesc, GenericLookupResult> _methodHandles;
+
+            public GenericLookupResult MethodHandle(MethodDesc method)
+            {
+                return _methodHandles.GetOrAdd(method);
             }
 
             private NodeCache<TypeDesc, GenericLookupResult> _typeThreadStaticBaseIndexSymbols;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -32,6 +32,8 @@ namespace ILCompiler.DependencyAnalysis
             {
                 case ReadyToRunHelperId.TypeHandle:
                     return factory.GenericLookup.Type((TypeDesc)target);
+                case ReadyToRunHelperId.MethodHandle:
+                    return factory.GenericLookup.MethodHandle((MethodDesc)target);
                 case ReadyToRunHelperId.GetGCStaticBase:
                     return factory.GenericLookup.TypeGCStaticBase((TypeDesc)target);
                 case ReadyToRunHelperId.GetNonGCStaticBase:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -28,6 +28,7 @@ namespace ILCompiler.DependencyAnalysis
 
         // The following helpers are used for generic lookups only
         TypeHandle,
+        MethodHandle,
         FieldHandle,
         MethodDictionary,
         MethodEntry

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -89,8 +89,14 @@ namespace ILCompiler.DependencyAnalysis
                     yield return new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke");
             }
 
-            if (Method.HasInstantiation && Method.IsVirtual)
-                yield return new DependencyListEntry(factory.GVMDependencies(Method), "GVM Dependencies Support for method dictinoary");
+            if (Method.HasInstantiation)
+            {
+                if (Method.IsVirtual)
+                    yield return new DependencyListEntry(factory.GVMDependencies(Method), "GVM Dependencies Support for method dictionary");
+
+                // Dictionary dependency
+                yield return new DependencyListEntry(factory.MethodGenericDictionary(Method), "Method dictionary");
+            }
         }
 
         protected override string GetName() => $"{Method.ToString()} backed by {CanonicalMethodNode.GetMangledName()}";

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -137,6 +137,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 // These are all simple: just get the thing from the dictionary and we're done
                 case ReadyToRunHelperId.TypeHandle:
+                case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.MethodDictionary:
                 case ReadyToRunHelperId.VirtualCall:
                 case ReadyToRunHelperId.ResolveVirtualFunction:

--- a/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
@@ -99,7 +99,9 @@ namespace ILCompiler
                 case ReadyToRunHelper.GetRuntimeTypeHandle:
                     methodDesc = context.GetHelperEntryPoint("LdTokenHelpers", "GetRuntimeTypeHandle");
                     break;
-                case ReadyToRunHelper.GetRuntimeMethodHandle: // TODO: Reflection
+                case ReadyToRunHelper.GetRuntimeMethodHandle:
+                    methodDesc = context.GetHelperEntryPoint("LdTokenHelpers", "GetRuntimeMethodHandle");
+                    break;
                 case ReadyToRunHelper.GetRuntimeFieldHandle: // TODO: Reflection
                     mangledName = "__fail_fast";
                     break;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2332,11 +2332,19 @@ namespace Internal.JitInterface
 
                 if (!runtimeLookup)
                 {
-                    throw new NotImplementedException("LDTOKEN Method");
+                    if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Ldtoken)
+                        pResult.lookup.constLookup.handle = (CORINFO_GENERIC_STRUCT_*)ObjectToHandle(_compilation.NodeFactory.RuntimeMethodHandle(md));
+                    else
+                        throw new NotImplementedException();
                 }
                 else
                 {
-                    pResult.lookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.MethodDictionary;
+                    if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Ldtoken)
+                        pResult.lookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.MethodHandle;
+                    else if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Method)
+                        pResult.lookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.MethodDictionary;
+                    else
+                        throw new NotImplementedException();
                 }
             }
             else if (!fEmbedParent && pResolvedToken.hField != null)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LdTokenHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LdTokenHelpers.cs
@@ -17,5 +17,12 @@ namespace Internal.Runtime.CompilerHelpers
         {
             return new RuntimeTypeHandle(new EETypePtr(pEEType));
         }
+
+        private static unsafe RuntimeMethodHandle GetRuntimeMethodHandle(IntPtr pHandleSignature)
+        {
+            RuntimeMethodHandle returnValue = default(RuntimeMethodHandle);
+            *(IntPtr*)&returnValue = pHandleSignature;
+            return returnValue;
+        }
     }
 }


### PR DESCRIPTION
Enabling the JIT interface to correctly lookup RuntimeMethodHandles in both shared and non-shared generics.