### PR TITLE
Make reflection invoke work for valuetype instance methods

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
@@ -243,10 +243,12 @@ namespace Internal.IL.Stubs
                 Context.GetWellKnownType(WellKnownType.Void);
 
             MethodSignature thisCallMethodSig = new MethodSignature(0, 0, returnType, targetMethodSignature);
-            thisCallSiteSetupStream.Emit(ILOpcode.calli, emitter.NewToken(thisCallMethodSig));
+            CalliIntrinsic.EmitTransformedCalli(emitter, thisCallSiteSetupStream, thisCallMethodSig);
+            //thisCallSiteSetupStream.Emit(ILOpcode.calli, emitter.NewToken(thisCallMethodSig));
 
             MethodSignature staticCallMethodSig = new MethodSignature(MethodSignatureFlags.Static, 0, returnType, targetMethodSignature);
-            staticCallSiteSetupStream.Emit(ILOpcode.calli, emitter.NewToken(staticCallMethodSig));
+            CalliIntrinsic.EmitTransformedCalli(emitter, staticCallSiteSetupStream, staticCallMethodSig);
+            //staticCallSiteSetupStream.Emit(ILOpcode.calli, emitter.NewToken(staticCallMethodSig));
 
             if (_targetSignature.HasReturnValue)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -177,9 +177,9 @@ namespace ILCompiler.DependencyAnalysis
             // Method generic dictionaries get prefixed by the hash code of the owning method
             // to allow quick lookups of additional details by the type loader.
 
+            builder.EmitInt(_owningMethod.GetHashCode());
             if (builder.TargetPointerSize == 8)
                 builder.EmitInt(0);
-            builder.EmitInt(_owningMethod.GetHashCode());
 
             Debug.Assert(builder.CountBytes == Offset);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -85,18 +85,23 @@ namespace ILCompiler.DependencyAnalysis
             // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
             // we even start the compilation process (with the invocation stubs being compilation roots like any other).
             // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
-            if (factory.MetadataManager.HasReflectionInvokeStub(_method)
-                && !_method.IsCanonicalMethod(CanonicalFormKind.Any) /* Shared generics handled in the shadow concrete method node */)
+            if (factory.MetadataManager.HasReflectionInvokeStub(_method))
             {
                 if (dependencies == null)
                     dependencies = new DependencyList();
 
-                MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(Method);
-                MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                if (invokeStub != canonInvokeStub)
-                    dependencies.Add(new DependencyListEntry(factory.FatFunctionPointer(invokeStub), "Reflection invoke"));
-                else
-                    dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke"));
+                if (!_method.IsCanonicalMethod(CanonicalFormKind.Any) /* Shared generics handled in the shadow concrete method node */)
+                {
+                    MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(Method);
+                    MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                    if (invokeStub != canonInvokeStub)
+                        dependencies.Add(new DependencyListEntry(factory.FatFunctionPointer(invokeStub), "Reflection invoke"));
+                    else
+                        dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke"));
+                }
+
+                if (_method.OwningType.IsValueType && !_method.Signature.IsStatic)
+                    dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(_method, true), "Reflection unboxing stub"));
             }
 
             if (_method.HasInstantiation)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -101,7 +101,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
 
                 if (_method.OwningType.IsValueType && !_method.Signature.IsStatic)
-                    dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(_method, true), "Reflection unboxing stub"));
+                    dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(_method, unboxingStub: true), "Reflection unboxing stub"));
             }
 
             if (_method.HasInstantiation)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -121,9 +121,10 @@ namespace ILCompiler.DependencyAnalysis
 
                 if ((flags & InvokeTableFlags.HasEntrypoint) != 0)
                 {
+                    bool useUnboxingStub = method.OwningType.IsValueType && !method.Signature.IsStatic;
                     vertex = writer.GetTuple(vertex,
                         writer.GetUnsignedConstant(_externalReferences.GetIndex(
-                            factory.MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific)))));
+                            factory.MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific), useUnboxingStub))));
                 }
 
                 // TODO: data to generate the generic dictionary with the type loader

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
@@ -137,6 +137,11 @@ namespace Internal.Runtime.TypeLoader
         {
             return RuntimeAugments.CreateRuntimeTypeHandle(GetIntPtrFromIndex(index));
         }
+
+        public IntPtr GetGenericDictionaryFromIndex(uint index)
+        {
+            return GetIntPtrFromIndex(index);
+        }
     }
 
     public static class ExternalReferencesTableExtentions

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
@@ -103,23 +103,6 @@ namespace Internal.Runtime.TypeLoader
         }
 
         /// <summary>
-        /// Locate generic dictionary based on given module handle and RVA. If bit #31 is set
-        /// in the RVA, the RVA is indirect i.e. an indirection is performed through the indirection cell
-        /// specified by the RVA.
-        /// </summary>
-        /// <param name="moduleHandle">Handle (address) of module containing the RVA</param>
-        /// <param name="rva">Relative virtual address of generic dictionary or indirection cell (when bit 31 is set)</param>
-        /// <returns>Final address of generic dictionary</return>
-        private static unsafe IntPtr RvaToGenericDictionary(IntPtr moduleHandle, uint rva)
-        {
-            // Generic dictionaries may be imported as well. As with types, this is indicated by the high bit set
-            if ((rva & 0x80000000) != 0)
-                return *((IntPtr*)((byte*)moduleHandle + (rva & ~0x80000000)));
-            else
-                return (IntPtr)((byte*)moduleHandle + rva);
-        }
-
-        /// <summary>
         /// Compare two arrays sequentially.
         /// </summary>
         /// <param name="seq1">First array to compare</param>
@@ -1616,7 +1599,7 @@ namespace Internal.Runtime.TypeLoader
                     }
                 }
                 else if (((_flags & InvokeTableFlags.RequiresInstArg) != 0) && _hasEntryPoint)
-                    _entryDictionary = RvaToGenericDictionary(_moduleHandle, extRefTable.GetRvaFromIndex(entryParser.GetUnsigned()));
+                    _entryDictionary = extRefTable.GetGenericDictionaryFromIndex(entryParser.GetUnsigned());
                 else
                     _methodInstantiation = GetTypeSequence(ref extRefTable, ref entryParser);
             }

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 class Program
@@ -15,6 +16,7 @@ class Program
         TestDelegateFatFunctionPointers.Run();
         TestVirtualMethodUseTracking.Run();
         TestSlotsInHierarchy.Run();
+        TestReflectionInvoke.Run();
         TestDelegateVirtualMethod.Run();
         TestDelegateInterfaceMethod.Run();
         TestThreadStaticFieldAccess.Run();
@@ -323,6 +325,52 @@ class Program
 
             if (derived.Cast("Hello") != "Hello")
                 throw new Exception();
+        }
+    }
+
+    class TestReflectionInvoke
+    {
+        struct Foo<T>
+        {
+            public int Value;
+
+            public bool SetAndCheck<U>(int value, U check)
+            {
+                Value = value;
+                return check != null && typeof(T) == typeof(U);
+            }
+        }
+
+        public static void Run()
+        {
+            if (String.Empty.Length > 0)
+            {
+                // Make sure we compile this method body.
+                var tmp = new Foo<string>();
+                tmp.SetAndCheck<string>(0, null);
+                tmp.SetAndCheck<object>(0, null);
+            }
+
+            object o = new Foo<string>();
+
+            {
+                MethodInfo mi = typeof(Foo<string>).GetTypeInfo().GetDeclaredMethod("SetAndCheck").MakeGenericMethod(typeof(string));
+                if (!(bool)mi.Invoke(o, new object[] { 123, "hello" }))
+                    throw new Exception();
+
+                var foo = (Foo<string>)o;
+                if (foo.Value != 123)
+                    throw new Exception();
+
+                if ((bool)mi.Invoke(o, new object[] { 123, null }))
+                    throw new Exception();
+            }
+
+            {
+                MethodInfo mi = typeof(Foo<string>).GetTypeInfo().GetDeclaredMethod("SetAndCheck").MakeGenericMethod(typeof(object));
+                if ((bool)mi.Invoke(o, new object[] { 123, new object() }))
+                    throw new Exception();
+            }
         }
     }
 

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -334,6 +334,7 @@ class Program
         {
             public int Value;
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public bool SetAndCheck<U>(int value, U check)
             {
                 Value = value;


### PR DESCRIPTION
This is a bunch of things:

* Make the reflection dynamic invoke thunk use the transformed calli
intrinsic to do the call (to handle fat function pointers)
* Generic dictionary nodes are prefixed with the hash code, but I put
the padding in the wrong location. That's what I get for writing code
off memory without crosschecking with Project N binder...
* Make MethodCodeNode depend on it's unboxig stub. This is in the hacky
section with a big comment explaining why we need it for now. (Method
being compiled determines it's reflectability.)
* Emit a pointer to the unboxing stub in the reflection mapping table if
needed.
* Remove a another usage of GetRvaFromIndex from the type loader
* Add a test