### PR TITLE
Fix stack overflow in execution of class constructors

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Runtime;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -18,6 +19,7 @@ namespace Internal.Runtime.CompilerHelpers
     {
         public static void InitializeLibrary()
         {
+            Lock.Initialize();
             PreallocatedOutOfMemoryException.Initialize();
             ClassConstructorRunner.Initialize();
             TypeLoaderExports.Initialize();

--- a/src/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -14,8 +14,13 @@ namespace System.Threading
         // class construction.  If Lock has its own class constructor, this can lead to infinite recursion.
         // All static data in Lock must be pre-initialized.
         //
-        [PreInitialized]
-        private static int s_maxSpinCount = -1; // -1 means the spin count has not yet beeen determined.
+        private static int s_maxSpinCount;
+
+        // Eager construction called from LibraryInitialize
+        internal static void Initialize()
+        {
+            s_maxSpinCount = -1; // -1 means the spin count has not yet beeen determined.
+        }
 
         //
         // m_state layout:


### PR DESCRIPTION
The System.Threading.Lock class has a static field marked with the PreInitialized attribute. The CoreRT compiler does not support this attribute yet. This static field is accessed in the Lock.TryAcquireContended method.

The ClassConstructorRunner class used the Lock type for internal synchronization. As a result, we can get into an infinite recursion if there is contention the ClassConstructorRunners lock before the cctor of
the Lock type had a change to execute.

This change fixes the issue by changing the Lock class to use Library Initializers.

Note: this is issue was the root cause of the failures in the BasicThreading test that we observed a couple times in the CI.
