### PR TITLE
Fix a TODO in generating reflection invoke stubs

### DIFF
--- a/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Internal.TypeSystem
 {
-    public abstract partial class MethodDesc
+    // Additional extensions to MethodDesc related to interop
+    partial class MethodDesc
     {
         /// <summary>
         /// Gets a value indicating whether this method is a (native unmanaged) platform invoke.
@@ -34,7 +34,7 @@ namespace Internal.TypeSystem
         /// </summary>
         public virtual ParameterMetadata[] GetParameterMetadata()
         {
-            return default(ParameterMetadata[]);
+            return Array.Empty<ParameterMetadata>();
         }
     }
 
@@ -53,6 +53,11 @@ namespace Internal.TypeSystem
     {
         private  readonly ParameterMetadataAttributes _attributes;
         public readonly MarshalAsDescriptor MarshalAsDescriptor;
+
+        /// <summary>
+        /// Gets a 1-based index of the parameter within the signature the metadata refers to.
+        /// Index 0 is the return value.
+        /// </summary>
         public readonly int Index;
 
         public bool In { get { return (_attributes & ParameterMetadataAttributes.In) == ParameterMetadataAttributes.In; } }
@@ -132,6 +137,22 @@ namespace Internal.TypeSystem
                 default:
                     throw new BadImageFormatException();
             }
+        }
+    }
+
+    partial class InstantiatedMethod
+    {
+        public override ParameterMetadata[] GetParameterMetadata()
+        {
+            return _methodDef.GetParameterMetadata();
+        }
+    }
+
+    partial class MethodForInstantiatedType
+    {
+        public override ParameterMetadata[] GetParameterMetadata()
+        {
+            return _typicalMethodDef.GetParameterMetadata();
         }
     }
 }


### PR DESCRIPTION
I couldn't implement this at the point I added the TODO because we had
no way to access parameter metadata in the type system. We have it now.

I also had to make a few tweaks:
* Propagate parameter metadata to methods on instantiated types and
instantiated methods (doesn't make sense for interop's purposes, but
interop is not the only consumer)
* Empty array is a more convenient default value for the list

This has no test because this will only be testable once we start
instantiating the invoke stubs using the runtime typeloader.