### PR TITLE
Removed Sdk.props and Sdk.targets imports

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -27,11 +27,10 @@ You should now be able to use the `dotnet` commands of the CLI tools.
 * Ensure that you have done a repo build per the instructions above.
 * Create a new folder and switch into it. 
 * Run `dotnet new` on the command/shell prompt. This will add a project template. If you get an error, please ensure the [pre-requisites](prerequisites-for-building.md) are installed. 
-* Modify `.csproj` file that is part of your project. A few lines at the top and at the bottom are different from the default template.
+* Modify `.csproj` file that is part of your project. A line at the bottom are different from the default template.
 
 ```
 <Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\Sdk.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -47,7 +46,6 @@ You should now be able to use the `dotnet` commands of the CLI tools.
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\Sdk.targets" />
   <Import Project="$(IlcPath)\Microsoft.NETCore.Native.targets" />
 </Project>
 

--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -27,7 +27,7 @@ You should now be able to use the `dotnet` commands of the CLI tools.
 * Ensure that you have done a repo build per the instructions above.
 * Create a new folder and switch into it. 
 * Run `dotnet new` on the command/shell prompt. This will add a project template. If you get an error, please ensure the [pre-requisites](prerequisites-for-building.md) are installed. 
-* Modify `.csproj` file that is part of your project. A line at the bottom are different from the default template.
+* Modify `.csproj` file that is part of your project. A line at the bottom is different from the default template.
 
 ```
 <Project ToolsVersion="15.0">
@@ -46,6 +46,7 @@ You should now be able to use the `dotnet` commands of the CLI tools.
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
   </ItemGroup>
 
+  <!-- This is the line that needs to be added -->
   <Import Project="$(IlcPath)\Microsoft.NETCore.Native.targets" />
 </Project>
 


### PR DESCRIPTION
These seem not to be needed any more; they cause a warning to be printed out on build:

```
/Volumes/extra/git/perlun/zup/zup.csproj(2,3): warning MSB4011: "/usr/local/share/dotnet/sdk/1.0.0-preview4-004233/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.props" cannot be imported again. It was already imported at "/Volumes/extra/git/perlun/zup/zup.csproj". This is most likely a build authoring error. This subsequent import will be ignored.
/Volumes/extra/git/perlun/zup/zup.csproj : warning MSB4011: "/usr/local/share/dotnet/sdk/1.0.0-preview4-004233/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.targets" cannot be imported again. It was already imported at "/Volumes/extra/git/perlun/zup/zup.csproj (34,3)". This is most likely a build authoring error. This subsequent import will be ignored.
```