### PR TITLE
Reverse PInvoke delegate thunks

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.Globalization.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Globalization.cs
@@ -69,6 +69,8 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-localization-l1-2-1.dll")]
         internal extern static bool EnumSystemLocalesEx(IntPtr lpLocaleEnumProcEx, uint dwFlags, IntPtr lParam, IntPtr lpReserved);
 
+        internal delegate BOOL EnumLocalesProcEx(IntPtr lpLocaleString, uint dwFlags, IntPtr lParam);
+
         [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode)]
         internal extern static int ResolveLocaleName(string lpNameToResolve, char* lpLocaleName, int cchLocaleName);
 
@@ -110,6 +112,8 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-localization-l2-1-0.dll", CharSet = CharSet.Unicode)]
         internal extern static int EnumTimeFormatsEx(IntPtr lpTimeFmtEnumProcEx, string lpLocaleName, uint dwFlags, IntPtr lParam);
 
+        internal delegate BOOL EnumTimeFormatsProcEx(IntPtr lpTimeFormatString, IntPtr lParam);
+
         [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode)]
         internal extern static int GetCalendarInfoEx(string lpLocaleName, uint Calendar, IntPtr lpReserved, uint CalType, IntPtr lpCalData, int cchData, out int lpValue);
 
@@ -118,5 +122,7 @@ internal static partial class Interop
 
         [DllImport("api-ms-win-core-localization-l2-1-0.dll", CharSet = CharSet.Unicode)]
         internal extern static int EnumCalendarInfoExEx(IntPtr pCalInfoEnumProcExEx, string lpLocaleName, uint Calendar, string lpReserved, uint CalType, IntPtr lParam);
+
+        internal delegate BOOL EnumCalendarInfoProcExEx(IntPtr lpCalendarInfoString, uint Calendar, IntPtr lpReserved, IntPtr lParam);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.ThreadPool.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.ThreadPool.cs
@@ -34,6 +34,8 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-threadpool-l1-2-0.dll")]
         internal extern static IntPtr CreateThreadpoolWork(IntPtr pfnwk, IntPtr pv, IntPtr pcbe);
 
+        internal delegate void WorkCallback(IntPtr Instance, IntPtr Context, IntPtr Work);
+
         [DllImport("api-ms-win-core-threadpool-l1-2-0.dll")]
         internal extern static IntPtr CloseThreadpoolWork(IntPtr pfnwk);
 
@@ -42,5 +44,7 @@ internal static partial class Interop
 
         [DllImport("api-ms-win-core-threadpool-l1-2-0.dll")]
         internal extern static unsafe bool TrySubmitThreadpoolCallback(IntPtr pns, IntPtr pv, TP_CALLBACK_ENVIRON* pcbe);
+
+        internal delegate void SimpleCallback(IntPtr Instance, IntPtr Context);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.Timer.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Timer.cs
@@ -14,5 +14,7 @@ internal static partial class Interop
 
         [DllImport("api-ms-win-core-threadpool-l1-2-0.dll")]
         internal extern static unsafe IntPtr SetThreadpoolTimer(IntPtr pti, long* pftDueTime, uint msPeriod, uint msWindowLength);
+
+        internal delegate void TimerCallback(IntPtr Instance, IntPtr Context, IntPtr Timer);
     }
 }

--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -396,6 +396,35 @@ namespace Internal.IL.Stubs
         }
     }
 
+    public sealed class DelegateReversePInvokeThunk : DelegateThunk
+    {
+        internal DelegateReversePInvokeThunk(DelegateInfo delegateInfo)
+            : base(delegateInfo)
+        {
+        }
+
+        public override MethodIL EmitIL()
+        {
+            var emitter = new ILEmitter();
+            ILCodeStream codeStream = emitter.NewCodeStream();
+
+            MetadataType throwHelpersType = Context.SystemModule.GetKnownType("Internal.Runtime.CompilerHelpers", "ThrowHelpers");
+            MethodDesc throwHelper = throwHelpersType.GetKnownMethod("ThrowNotSupportedException", null);
+
+            codeStream.EmitCallThrowHelper(emitter, throwHelper);
+
+            return emitter.Link(this);
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return "InvokeReversePInvokeThunk";
+            }
+        }
+    }
+
     /// <summary>
     /// Delegate thunk that supports Delegate.DynamicInvoke. This thunk has heavy dependencies on the
     /// general dynamic invocation infrastructure in System.InvokeUtils and gets called from there

--- a/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
@@ -85,8 +85,25 @@ namespace ILCompiler
                 if (!closed)
                 {
                     // Open delegate to a static method
-                    invokeThunk = delegateInfo.Thunks[DelegateThunkKind.OpenStaticThunk];
-                    initMethod = systemDelegate.GetKnownMethod("InitializeOpenStaticThunk", null);
+                    if (targetMethod.IsNativeCallable)
+                    {
+                        // If target method is native callable, create a reverse PInvoke delegate
+                        initMethod = systemDelegate.GetKnownMethod("InitializeReversePInvokeThunk", null);
+                        invokeThunk = delegateInfo.Thunks[DelegateThunkKind.ReversePinvokeThunk];
+
+                        // You might hit this when the delegate is generic: you need to make the delegate non-generic.
+                        // If the code works on Project N, it's because the delegate is used in connection with
+                        // AddrOf intrinsic (please validate that). We don't have the necessary AddrOf expansion in
+                        // the codegen to make this work without actually constructing the delegate. You can't construct
+                        // the delegate if it's generic, even on Project N.
+                        // TODO: Make this throw something like "TypeSystemException.InvalidProgramException"?
+                        Debug.Assert(invokeThunk != null, "Delegate with a non-native signature for a NativeCallable method");
+                    }
+                    else
+                    {
+                        initMethod = systemDelegate.GetKnownMethod("InitializeOpenStaticThunk", null);
+                        invokeThunk = delegateInfo.Thunks[DelegateThunkKind.OpenStaticThunk];
+                    }
                 }
                 else
                 {

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -45,6 +45,11 @@ namespace Internal.Runtime.CompilerHelpers
             throw new PlatformNotSupportedException();
         }
 
+        public static void ThrowNotSupportedException()
+        {
+            throw new NotSupportedException();
+        }
+
         public static void ThrowTypeLoadException(ExceptionStringID id, string className, string typeName)
         {
             throw TypeLoaderExceptionHelper.CreateTypeLoadException(id, className, typeName);

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -121,13 +121,10 @@ namespace System
         // @todo: Not an api but some NativeThreadPool code still depends on it.
         internal IntPtr GetNativeFunctionPointer()
         {
-            // CORERT-TODO: PInvoke delegate marshalling
-#if !CORERT
             if (GetThunk(ReversePinvokeThunk) != m_functionPointer)
             {
                 throw new InvalidOperationException("GetNativeFunctionPointer may only be used on a reverse pinvoke delegate");
             }
-#endif
 
             return m_extraFunctionPointerOrData;
         }

--- a/src/System.Private.CoreLib/src/System/Globalization/CalendarData.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CalendarData.Windows.cs
@@ -143,7 +143,7 @@ namespace System.Globalization
             try
             {
                 // Now call the enumeration API. Work is done by our callback function
-                IntPtr callback = AddrofIntrinsics.AddrOf<Func<IntPtr, uint, IntPtr, IntPtr, Interop.BOOL>>(EnumCalendarsCallback);
+                IntPtr callback = AddrofIntrinsics.AddrOf<Interop.mincore.EnumCalendarInfoProcExEx>(EnumCalendarsCallback);
                 Interop.mincore.EnumCalendarInfoExEx(callback, localeName, ENUM_ALL_CALENDARS, null, CAL_ICALINTVALUE, (IntPtr)contextHandle);
             }
             finally
@@ -333,7 +333,7 @@ namespace System.Globalization
             try
             {
                 // Now call the enumeration API. Work is done by our callback function
-                IntPtr callback = AddrofIntrinsics.AddrOf<Func<IntPtr, uint, IntPtr, IntPtr, Interop.BOOL>>(EnumCalendarInfoCallback);
+                IntPtr callback = AddrofIntrinsics.AddrOf<Interop.mincore.EnumCalendarInfoProcExEx>(EnumCalendarInfoCallback);
                 Interop.mincore.EnumCalendarInfoExEx(callback, localeName, (uint)calendar, null, calType, (IntPtr)contextHandle);
             }
             finally

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
@@ -250,7 +250,7 @@ namespace System.Globalization
             GCHandle contextHandle = GCHandle.Alloc(context);
             try
             {
-                IntPtr callback = AddrofIntrinsics.AddrOf<Func<IntPtr, uint, IntPtr, Interop.BOOL>>(EnumSystemLocalesProc);
+                IntPtr callback = AddrofIntrinsics.AddrOf<Interop.mincore.EnumLocalesProcEx>(EnumSystemLocalesProc);
                 Interop.mincore.EnumSystemLocalesEx(callback, LOCALE_SPECIFICDATA | LOCALE_SUPPLEMENTAL, (IntPtr)contextHandle, IntPtr.Zero);
             }
             finally
@@ -559,7 +559,7 @@ namespace System.Globalization
             try
             {
                 // Now call the enumeration API. Work is done by our callback function
-                IntPtr callback = AddrofIntrinsics.AddrOf<Func<IntPtr, IntPtr, Interop.BOOL>>(EnumTimeCallback);
+                IntPtr callback = AddrofIntrinsics.AddrOf<Interop.mincore.EnumTimeFormatsProcEx>(EnumTimeCallback);
                 Interop.mincore.EnumTimeFormatsEx(callback, localeName, (uint)dwFlags, (IntPtr)dataHandle);
             }
             finally

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Win32.cs
@@ -25,7 +25,7 @@ namespace System.Threading
         {
             if (s_work == IntPtr.Zero)
             {
-                IntPtr nativeCallback = AddrofIntrinsics.AddrOf<Action<IntPtr, IntPtr, IntPtr>>(DispatchCallback);
+                IntPtr nativeCallback = AddrofIntrinsics.AddrOf<Interop.mincore.WorkCallback>(DispatchCallback);
 
                 IntPtr work = Interop.mincore.CreateThreadpoolWork(nativeCallback, IntPtr.Zero, IntPtr.Zero);
                 if (work == IntPtr.Zero)
@@ -55,7 +55,7 @@ namespace System.Threading
             environ.Initialize();
             environ.SetLongFunction();
 
-            IntPtr nativeCallback = AddrofIntrinsics.AddrOf<Action<IntPtr, IntPtr>>(LongRunningWorkCallback);
+            IntPtr nativeCallback = AddrofIntrinsics.AddrOf<Interop.mincore.SimpleCallback>(LongRunningWorkCallback);
 
             GCHandle gcHandle = GCHandle.Alloc(callback);
             if (!Interop.mincore.TrySubmitThreadpoolCallback(nativeCallback, GCHandle.ToIntPtr(gcHandle), &environ))

--- a/src/System.Private.CoreLib/src/System/Threading/Timer.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.Win32.cs
@@ -17,7 +17,7 @@ namespace System.Threading
         {
             if (_nativeTimer == IntPtr.Zero)
             {
-                IntPtr nativeCallback = AddrofIntrinsics.AddrOf<Action<IntPtr, IntPtr, IntPtr>>(TimerCallback);
+                IntPtr nativeCallback = AddrofIntrinsics.AddrOf<Interop.mincore.TimerCallback>(TimerCallback);
 
                 _nativeTimer = Interop.mincore.CreateThreadpoolTimer(nativeCallback, IntPtr.Zero, IntPtr.Zero);
                 if (_nativeTimer == IntPtr.Zero)

--- a/src/System.Private.CoreLib/src/System/Threading/Win32ThreadPoolBoundHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Win32ThreadPoolBoundHandle.cs
@@ -38,7 +38,7 @@ namespace System.Threading
             if (handle.IsClosed || handle.IsInvalid)
                 throw new ArgumentException(SR.Argument_InvalidHandle, nameof(handle));
 
-            IntPtr callback = AddrofIntrinsics.AddrOf<Action<IntPtr, IntPtr, IntPtr, uint, UIntPtr, IntPtr>>(OnNativeIOCompleted);
+            IntPtr callback = AddrofIntrinsics.AddrOf<Interop.NativeIoCompletionCallback>(OnNativeIOCompleted);
             SafeThreadPoolIOHandle threadPoolHandle = Interop.mincore.CreateThreadpoolIo(handle, callback, IntPtr.Zero, IntPtr.Zero);
             if (threadPoolHandle.IsInvalid)
             {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallInterceptor.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallInterceptor.cs
@@ -1058,9 +1058,9 @@ namespace Internal.Runtime.CallInterceptor
         static CallInterceptor()
         {
             s_managedToManagedCommonStubData = CallConverterThunk.s_commonStubData;
-            s_managedToManagedCommonStubData.ManagedCallConverterThunk = Intrinsics.AddrOf<Func<IntPtr, IntPtr, IntPtr>>(CallInterceptorThunk);
+            s_managedToManagedCommonStubData.ManagedCallConverterThunk = Intrinsics.AddrOf<CallInterceptorThunkDelegate>(CallInterceptorThunk);
             s_nativeToManagedCommonStubData = CallConverterThunk.s_commonStubData;
-            s_nativeToManagedCommonStubData.ManagedCallConverterThunk = Intrinsics.AddrOf<Func<IntPtr, IntPtr, IntPtr>>(CallInterceptorThunkNativeCallable);
+            s_nativeToManagedCommonStubData.ManagedCallConverterThunk = Intrinsics.AddrOf<CallInterceptorThunkDelegate>(CallInterceptorThunkNativeCallable);
         }
 
         /// <summary>
@@ -1355,6 +1355,8 @@ namespace Internal.Runtime.CallInterceptor
 
             return callConversionOps.ToArray();
         }
+
+        private delegate IntPtr CallInterceptorThunkDelegate(IntPtr callerTransitionBlockParam, IntPtr thunkId);
 
         private static unsafe IntPtr CallInterceptorThunk(IntPtr callerTransitionBlockParam, IntPtr thunkId)
         {


### PR DESCRIPTION
This change has two parts:

1. Remove uses of generic delegates for `NativeCallable` methods within the class library. These are not valid delegate targets (see IsNativeCallingConventionCompatible in Project N Delegate transform) and this use only works because IL2IL on Project N optimizes them away when rewriting AddrOf intrinsic. We don't have the IL rewriting to make that happen on CoreRT.
2. Enable emission of reverse P/Invoke thunks for delegate types. The conditions for generating them should be identical to Project N, including the buggy `IsNativeCallingConventionCompatible` method.