### PR TITLE
Don't add VTable for Finalize method in multi-module

### DIFF
--- a/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
+++ b/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
@@ -29,5 +29,6 @@ namespace Internal.TypeSystem
         // InvalidProgramException
         InvalidProgramSpecific,
         InvalidProgramVararg,
+        InvalidProgramCallVirtFinalize,
     }
 }

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -458,6 +458,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public bool IsFinalizer
+        {
+            get
+            {
+                return OwningType.GetFinalizer() == this || OwningType.IsObject && Name == "Finalize";
+            }
+        }
+
         public virtual MethodDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
             Instantiation instantiation = Instantiation;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -77,6 +77,14 @@ namespace ILCompiler.DependencyAnalysis
                         defType.ComputeStaticFieldLayout(StaticLayoutKind.StaticRegionSizesAndFields);
                     }
                     break;
+                case ReadyToRunHelperId.VirtualCall:
+                    {
+                        // Make sure we aren't trying to callvirt Object.Finalize
+                        MethodDesc method = (MethodDesc)target;
+                        if (method.IsFinalizer)
+                            throw new TypeSystemException.InvalidProgramException(ExceptionStringID.InvalidProgramCallVirtFinalize, method);
+                    }
+                    break;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -54,6 +54,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             var slots = new ArrayBuilder<MethodDesc>();
 
+            MethodDesc finalizerMethod = type.GetFinalizer();
             DefType defType = _type.GetClosestDefType();
             foreach (var method in defType.GetAllMethods())
             {
@@ -62,6 +63,10 @@ namespace ILCompiler.DependencyAnalysis
 
                 // GVMs are not emitted in the type's vtable.
                 if (method.HasInstantiation)
+                    continue;
+
+                // Finalizers are called via a field on the EEType, not through the VTable
+                if (finalizerMethod == method || (type.IsObject && method.Name == "Finalize"))
                     continue;
 
                 slots.Add(method);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
@@ -69,6 +69,8 @@ namespace Internal.Runtime
                     return SR.InvalidProgram_Specific;
                 case ExceptionStringID.InvalidProgramVararg:
                     return SR.InvalidProgram_Vararg;
+                case ExceptionStringID.InvalidProgramCallVirtFinalize:
+                    return SR.InvalidProgram_CallVirtFinalize;
                 case ExceptionStringID.MissingField:
                     return SR.EE_MissingField;
                 case ExceptionStringID.MissingMethod:

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1137,6 +1137,9 @@
   <data name="InvalidProgram_Vararg" xml:space="preserve">
     <value>Method '{0}' has a variable argument list. Variable argument lists are not supported in .NET Core.</value>
   </data>
+  <data name="InvalidProgram_CallVirtFinalize" xml:space="preserve">
+    <value>Object.Finalize() can not be called directly. It is only callable by the runtime.</value>
+  </data>
   <data name="InvalidTimeZone_InvalidRegistryData" xml:space="preserve">
     <value>The time zone ID '{0}' was found on the local computer, but the registry information was corrupt.</value>
   </data>

--- a/tests/src/Simple/BasicThreading/BasicThreading.cs
+++ b/tests/src/Simple/BasicThreading/BasicThreading.cs
@@ -24,16 +24,6 @@ class Program
 
 class FinalizeTest
 {
-    struct FillStack
-    {
-        public long a;
-        public long b;
-        public long c;
-        public long d;
-        public long e;
-        public long f;
-    }
-
     public static bool visited = false;
     public class Dummy
     {
@@ -44,49 +34,14 @@ class FinalizeTest
         }
     }
 
-    public class CreateObj
-    {
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public void CreateDummy()
-        {
-            Dummy dummy = new Dummy();
-            dummy = null;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public void SanitizeStack()
-        {
-            FillStack f;
-            f.a = 1L;
-            f.b = 2L;
-            f.c = 3L;
-            f.d = 4L;
-            f.e = 5L;
-            f.f = 6L;
-        }
-
-
-        public void RunTest()
-        {
-            CreateDummy();
-
-            //
-            // Currently CoreRT uses conservative GC which treats any object pointer in the
-            // stack as a possible GC ref, even if it's no longer live. Work around this 
-            // by immediately torching the stack with a large value type.
-            //
-            SanitizeStack();
-
-            GC.Collect();
-            GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
-        }
-    }
-
     public static int Run()
     {
-        CreateObj temp = new CreateObj();
-        temp.RunTest();
-
+        int iterationCount = 0;
+        while (!visited && iterationCount++ < 1000000)
+        {
+           GC.KeepAlive(new Dummy());
+           GC.Collect();
+        }
 
         if (visited)
         {


### PR DESCRIPTION
Finalize is not added to the VTable with the CoreRT runtime; instead it
is added after the VTable in conjunction with an EEType flag to save
VTable space. In multi-module library mode with eagerly built VTables,
skip the Finalize method (since it appears in the type system as a
virtual on `System.Object`).

Add a test to validate finalizers are run.