### PR TITLE
Fix SafeHandle out marshalling

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -1049,7 +1049,7 @@ namespace Internal.TypeSystem.Interop
 
                 unmarshallingCodeStream.EmitLdLoc(vOutArg);
                 unmarshallingCodeStream.EmitLdLoc(vSafeHandle);
-                unmarshallingCodeStream.Emit(ILOpcode.stind_i);
+                unmarshallingCodeStream.Emit(ILOpcode.stind_ref);
 
                 NativeParameterType = nativeType;
             }


### PR DESCRIPTION
Using `stind.i` to store a `SafeHandle` doesn't meet IL correctness
requirements because `SafeHandle` is not *verifier-assignable-to* IntPtr
(even though they're the same size so it kind of worked - but maybe had
a GC hole, who knows).

This was asserting RyuJIT.