### PR TITLE
Add back V1/V2 Delegate.CreateDelegate() apis

### DIFF
--- a/src/Common/src/System/CommonRuntimeTypes.cs
+++ b/src/Common/src/System/CommonRuntimeTypes.cs
@@ -35,6 +35,7 @@ namespace System
         internal static Type DateTime { get { return s_datetime; } }
         internal static Type Nullable { get { return s_nullable; } }
         internal static Type Void { get { return s_void; } }
+        internal static Type MulticastDelegate { get { return s_multicastDelegate; } }
 
         private static Type s_object = typeof(Object);
         private static Type s_valuetype = typeof(ValueType);
@@ -61,5 +62,6 @@ namespace System
         private static Type s_datetime = typeof(DateTime);
         private static Type s_nullable = typeof(Nullable<>);
         private static Type s_void = typeof(void);
+        private static Type s_multicastDelegate = typeof(MulticastDelegate);
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -129,5 +129,17 @@ namespace Internal.Reflection.Augments
 
         public abstract object ActivatorCreateInstance(Type type, bool nonPublic);
         public abstract object ActivatorCreateInstance(Type type, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes);
+
+        // V2 api: Creates open or closed delegates to static or instance methods - relaxed signature checking allowed. 
+        public abstract Delegate CreateDelegate(Type type, object firstArgument, MethodInfo method, bool throwOnBindFailure);
+
+        // V1 api: Creates open delegates to static or instance methods - relaxed signature checking allowed.
+        public abstract Delegate CreateDelegate(Type type, MethodInfo method, bool throwOnBindFailure);
+
+        // V1 api: Creates closed delegates to instance methods only, relaxed signature checking disallowed.
+        public abstract Delegate CreateDelegate(Type type, object target, string method, bool ignoreCase, bool throwOnBindFailure);
+
+        // V1 api: Creates open delegates to static methods only, relaxed signature checking disallowed.
+        public abstract Delegate CreateDelegate(Type type, Type target, string method, bool ignoreCase, bool throwOnBindFailure);
     }
 }

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -9,6 +9,7 @@ using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using Internal.Reflection.Augments;
 using Internal.Runtime.Augments;
 using Internal.Runtime.CompilerServices;
 
@@ -702,6 +703,24 @@ namespace System
                 return m_firstParameter;
             }
         }
+
+        // V2 api: Creates open or closed delegates to static or instance methods - relaxed signature checking allowed. 
+        public static Delegate CreateDelegate(Type type, object firstArgument, MethodInfo method) => CreateDelegate(type, firstArgument, method, throwOnBindFailure: true);
+        public static Delegate CreateDelegate(Type type, object firstArgument, MethodInfo method, bool throwOnBindFailure) => ReflectionAugments.ReflectionCoreCallbacks.CreateDelegate(type, firstArgument, method, throwOnBindFailure);
+
+        // V1 api: Creates open delegates to static or instance methods - relaxed signature checking allowed.
+        public static Delegate CreateDelegate(Type type, MethodInfo method) => CreateDelegate(type, method, throwOnBindFailure: true);
+        public static Delegate CreateDelegate(Type type, MethodInfo method, bool throwOnBindFailure) => ReflectionAugments.ReflectionCoreCallbacks.CreateDelegate(type, method, throwOnBindFailure);
+
+        // V1 api: Creates closed delegates to instance methods only, relaxed signature checking disallowed.
+        public static Delegate CreateDelegate(Type type, object target, string method) => CreateDelegate(type, target, method, ignoreCase: false, throwOnBindFailure: true);
+        public static Delegate CreateDelegate(Type type, object target, string method, bool ignoreCase) => CreateDelegate(type, target, method, ignoreCase, throwOnBindFailure: true);
+        public static Delegate CreateDelegate(Type type, object target, string method, bool ignoreCase, bool throwOnBindFailure) => ReflectionAugments.ReflectionCoreCallbacks.CreateDelegate(type, target, method, ignoreCase, throwOnBindFailure);
+
+        // V1 api: Creates open delegates to static methods only, relaxed signature checking disallowed.
+        public static Delegate CreateDelegate(Type type, Type target, string method) => CreateDelegate(type, target, method, ignoreCase: false, throwOnBindFailure: true);
+        public static Delegate CreateDelegate(Type type, Type target, string method, bool ignoreCase) => CreateDelegate(type, target, method, ignoreCase, throwOnBindFailure: true);
+        public static Delegate CreateDelegate(Type type, Type target, string method, bool ignoreCase, bool throwOnBindFailure) => ReflectionAugments.ReflectionCoreCallbacks.CreateDelegate(type, target, method, ignoreCase, throwOnBindFailure);
 
         public virtual object Clone()
         {

--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -334,4 +334,10 @@
   <data name="Arg_PlatformNotSupportedInvokeMemberCom" xml:space="preserve">
     <value>InvokeMember on a COM object is not supported on this platform.</value>
   </data>
+  <data name="Argument_MustBeRuntimeType" xml:space="preserve">
+    <value>Type must be a runtime Type object.</value>
+  </data>
+  <data name="Argument_MustBeRuntimeMethodInfo" xml:space="preserve">
+    <value>MethodInfo must be a runtime MethodInfo object.</value>
+  </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -59,6 +59,7 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
+        // V4.5 api - Creates open delegates over static or instance methods.
         public sealed override Delegate CreateDelegate(Type delegateType)
         {
 #if ENABLE_REFLECTION_TRACE
@@ -66,11 +67,10 @@ namespace System.Reflection.Runtime.MethodInfos
                 ReflectionTrace.MethodInfo_CreateDelegate(this, delegateType);
 #endif
 
-            // Legacy: The only difference between calling CreateDelegate(type) and CreateDelegate(type, null) is that the former
-            // disallows closed instance delegates for V1.1 backward compatibility.
-            return CreateDelegate(delegateType, null, allowClosedInstanceDelegates: false);
+            return CreateDelegateWorker(delegateType, null, allowClosed: false);
         }
 
+        // V4.5 api - Creates open or closed delegates over static or instance methods.
         public sealed override Delegate CreateDelegate(Type delegateType, Object target)
         {
 #if ENABLE_REFLECTION_TRACE
@@ -78,7 +78,25 @@ namespace System.Reflection.Runtime.MethodInfos
                 ReflectionTrace.MethodInfo_CreateDelegate(this, delegateType, target);
 #endif
 
-            return CreateDelegate(delegateType, target, allowClosedInstanceDelegates: true);
+            return CreateDelegateWorker(delegateType, target, allowClosed: true);
+        }
+
+        private Delegate CreateDelegateWorker(Type delegateType, object target, bool allowClosed)
+        {
+            if (delegateType == null)
+                throw new ArgumentNullException(nameof(delegateType));
+
+            RuntimeTypeInfo runtimeDelegateType = delegateType as RuntimeTypeInfo;
+            if (runtimeDelegateType == null)
+                throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(delegateType));
+
+            if (!runtimeDelegateType.IsDelegate)
+                throw new ArgumentException(SR.Arg_MustBeDelegate);
+
+            Delegate result = CreateDelegateNoThrowOnBindFailure(runtimeDelegateType, target, allowClosed);
+            if (result == null)
+                throw new ArgumentException(SR.Arg_DlgtTargMeth);
+            return result;
         }
 
         public abstract override IEnumerable<CustomAttributeData> CustomAttributes
@@ -321,36 +339,20 @@ namespace System.Reflection.Runtime.MethodInfos
 
         private volatile MethodInvoker _lazyMethodInvoker = null;
 
-
-        //
-        // Common CreateDelegate worker.
-        //
-        private Delegate CreateDelegate(Type delegateType, Object target, bool allowClosedInstanceDelegates)
+        /// <summary>
+        /// Common CreateDelegate worker. NOTE: If the method signature is not compatible, this method returns null rather than throwing an ArgumentException.
+        /// This is needed to support the api overloads that have a "throwOnBindFailure" parameter.
+        /// </summary>
+        internal Delegate CreateDelegateNoThrowOnBindFailure(RuntimeTypeInfo runtimeDelegateType, Object target, bool allowClosed)
         {
-            if (delegateType == null)
-                throw new ArgumentNullException(nameof(delegateType));
+            Debug.Assert(runtimeDelegateType.IsDelegate);
 
             ExecutionEnvironment executionEnvironment = ReflectionCoreExecution.ExecutionEnvironment;
-            RuntimeTypeHandle delegateTypeHandle = delegateType.TypeHandle;
-            if (!executionEnvironment.IsAssignableFrom(typeof(Delegate).TypeHandle, delegateTypeHandle))
-                throw new ArgumentException(SR.Arg_MustBeDelegate);
-            IEnumerator<MethodInfo> invokeMethodEnumerator = delegateType.GetTypeInfo().GetDeclaredMethods("Invoke").GetEnumerator();
-            if (!invokeMethodEnumerator.MoveNext())
-            {
-                // No Invoke method found. Since delegate types are compiler constructed, the most likely cause is missing metadata rather than
-                // a missing Invoke method. 
-
-                // We're deliberating calling FullName rather than ToString() because if it's the type that's missing metadata, 
-                // the FullName property constructs a more informative MissingMetadataException than we can. 
-                String fullName = delegateType.FullName;
-                throw new MissingMetadataException(SR.Format(SR.Arg_InvokeMethodMissingMetadata, fullName)); // No invoke method found.
-            }
-            MethodInfo invokeMethod = invokeMethodEnumerator.Current;
-            if (invokeMethodEnumerator.MoveNext())
-                throw new ArgumentException(SR.Arg_MustBeDelegate); // Multiple invoke methods found.
+            MethodInfo invokeMethod = runtimeDelegateType.GetInvokeMethod();
 
             // Make sure the return type is assignment-compatible.
-            CheckIsAssignableFrom(executionEnvironment, invokeMethod.ReturnParameter.ParameterType, this.ReturnParameter.ParameterType);
+            if (!IsAssignableFrom(executionEnvironment, invokeMethod.ReturnParameter.ParameterType, this.ReturnParameter.ParameterType))
+                return null;
 
             IList<ParameterInfo> delegateParameters = invokeMethod.GetParametersNoCopy();
             IList<ParameterInfo> targetParameters = this.GetParametersNoCopy();
@@ -366,17 +368,19 @@ namespace System.Reflection.Runtime.MethodInfos
                     // Open static: This is the "typical" case of calling a static method.
                     isOpen = true;
                     if (target != null)
-                        throw new ArgumentException(SR.Arg_DlgtTargMeth);
+                        return null;
                 }
                 else
                 {
                     // Closed static: This is the "weird" v2.0 case where the delegate is closed over the target method's first parameter.
                     //   (it make some kinda sense if you think of extension methods.)
+                    if (!allowClosed)
+                        return null;
                     isOpen = false;
                     if (!targetParameterEnumerator.MoveNext())
-                        throw new ArgumentException(SR.Arg_DlgtTargMeth);
-                    if (target != null)
-                        CheckIsAssignableFrom(executionEnvironment, targetParameterEnumerator.Current.ParameterType, target.GetType());
+                        return null;
+                    if (target != null && !IsAssignableFrom(executionEnvironment, targetParameterEnumerator.Current.ParameterType, target.GetType()))
+                        return null;
                 }
             }
             else
@@ -385,21 +389,22 @@ namespace System.Reflection.Runtime.MethodInfos
                 {
                     // Closed instance: This is the "typical" case of invoking an instance method.
                     isOpen = false;
-                    if (!allowClosedInstanceDelegates)
-                        throw new ArgumentException(SR.Arg_DlgtTargMeth);
-                    if (target != null)
-                        CheckIsAssignableFrom(executionEnvironment, this.DeclaringType, target.GetType());
+                    if (!allowClosed)
+                        return null;
+                    if (target != null && !IsAssignableFrom(executionEnvironment, this.DeclaringType, target.GetType()))
+                        return null;
                 }
                 else
                 {
                     // Open instance: This is the "weird" v2.0 case where the delegate has a leading extra parameter that's assignable to the target method's
                     // declaring type.
                     if (!delegateParameterEnumerator.MoveNext())
-                        throw new ArgumentException(SR.Arg_DlgtTargMeth);
+                        return null;
                     isOpen = true;
-                    CheckIsAssignableFrom(executionEnvironment, this.DeclaringType, delegateParameterEnumerator.Current.ParameterType);
+                    if (!IsAssignableFrom(executionEnvironment, this.DeclaringType, delegateParameterEnumerator.Current.ParameterType))
+                        return null;
                     if (target != null)
-                        throw new ArgumentException(SR.Arg_DlgtTargMeth);
+                        return null;
                 }
             }
 
@@ -407,36 +412,41 @@ namespace System.Reflection.Runtime.MethodInfos
             while (delegateParameterEnumerator.MoveNext())
             {
                 if (!targetParameterEnumerator.MoveNext())
-                    throw new ArgumentException(SR.Arg_DlgtTargMeth);
-                CheckIsAssignableFrom(executionEnvironment, targetParameterEnumerator.Current.ParameterType, delegateParameterEnumerator.Current.ParameterType);
+                    return null;
+                if (!IsAssignableFrom(executionEnvironment, targetParameterEnumerator.Current.ParameterType, delegateParameterEnumerator.Current.ParameterType))
+                    return null;
             }
             if (targetParameterEnumerator.MoveNext())
-                throw new ArgumentException(SR.Arg_DlgtTargMeth);
+                return null;
 
-            return this.MethodInvoker.CreateDelegate(delegateType.TypeHandle, target, isStatic: isStatic, isVirtual: false, isOpen: isOpen);
+            return CreateDelegateWithoutSignatureValidation(runtimeDelegateType, target, isStatic: isStatic, isOpen: isOpen);
         }
 
+        internal Delegate CreateDelegateWithoutSignatureValidation(Type delegateType, object target, bool isStatic, bool isOpen)
+        {
+            return MethodInvoker.CreateDelegate(delegateType.TypeHandle, target, isStatic: isStatic, isVirtual: false, isOpen: isOpen);
+        }
 
-        private static void CheckIsAssignableFrom(ExecutionEnvironment executionEnvironment, Type dstType, Type srcType)
+        private static bool IsAssignableFrom(ExecutionEnvironment executionEnvironment, Type dstType, Type srcType)
         {
             // byref types do not have a TypeHandle so we must treat these separately.
             if (dstType.IsByRef && srcType.IsByRef)
             {
                 if (!dstType.Equals(srcType))
-                    throw new ArgumentException(SR.Arg_DlgtTargMeth);
+                    return false;
             }
 
             // Enable pointers (which don't necessarily have typehandles). todo:be able to handle intptr <-> pointer, check if we need to handle 
             // casts via pointer where the pointer types aren't identical
             if (dstType.Equals(srcType))
             {
-                return;
+                return true;
             }
 
             // If assignment compatible in the normal way, allow
             if (executionEnvironment.IsAssignableFrom(dstType.TypeHandle, srcType.TypeHandle))
             {
-                return;
+                return true;
             }
 
             // they are not compatible yet enums can go into each other if their underlying element type is the same
@@ -453,10 +463,10 @@ namespace System.Reflection.Runtime.MethodInfos
             }
             if (dstTypeUnderlying.Equals(srcTypeUnderlying))
             {
-                return;
+                return true;
             }
 
-            throw new ArgumentException(SR.Arg_DlgtTargMeth);
+            return false;
         }
 
         protected RuntimeMethodInfo WithDebugName()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -707,6 +707,14 @@ namespace System.Reflection.Runtime.TypeInfos
 
         internal abstract RuntimeTypeHandle InternalTypeHandleIfAvailable { get; }
 
+        internal bool IsDelegate
+        {
+            get
+            {
+                return 0 != (Classification & TypeClassification.IsDelegate);
+            }
+        }
+
         //
         // Returns true if it's possible to ask for a list of members and the base type without triggering a MissingMetadataException.
         //
@@ -883,6 +891,8 @@ namespace System.Reflection.Runtime.TypeInfos
 
                         if (baseType.Equals(enumType))
                             classification |= TypeClassification.IsEnum | TypeClassification.IsValueType;
+                        if (baseType.Equals(CommonRuntimeTypes.MulticastDelegate))
+                            classification |= TypeClassification.IsDelegate;
                         if (baseType.Equals(valueType) && !(this.Equals(enumType)))
                         {
                             classification |= TypeClassification.IsValueType;
@@ -909,6 +919,7 @@ namespace System.Reflection.Runtime.TypeInfos
             IsValueType = 0x00000002,
             IsEnum = 0x00000004,
             IsPrimitive = 0x00000008,
+            IsDelegate = 0x00000010,
         }
 
         object ICloneable.Clone()


### PR DESCRIPTION
Also fixes MethodInfo.CreateDelegate(Type)
overload to disallow creation of closed delegates
over statics (to match the full framework behavior.)

This work requires refactoring the existing
CreateDelegate() methods to hoist the decision
to throw an ArgumentException on a sig mismatch
up to the top level caller.

The cheat sheet:

                                                        Added SigMatch Can use to create...
                                                        ----- -------- ------------------------------------------------------

 Delegate.CreateDelegate(Type, Type, String)            1.0   Strict   OpenStatic  -             -             -
 Delegate.CreateDelegate(Type, Object, String)          1.0   Strict   -           -             -             ClosedInstance

 Delegate.CreateDelegate(Type, MethodInfo)              2.0   Relaxed  OpenStatic  OpenInstance  -             -
 Delegate.CreateDelegate(Type, Object, MethodInfo)      2.0   Relaxed  OpenStatic  OpenInstance  ClosedStatic  ClosedInstance

 MethodInfo.CreateDelegate(Type)                        4.5   Relaxed  OpenStatic  OpenInstance  -             -
 MethodInfo.CreateDelegate(Type, Object)                4.5   Relaxed  OpenStatic  OpenInstance  ClosedStatic  ClosedInstance