### PR TITLE
Fix ICastable implementation

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalDefinitionEETypeNode.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory) => null;
         protected override int GCDescSize => 0;
 
-        protected override void ComputeOptionalEETypeFields(NodeFactory factory)
+        protected internal override void ComputeOptionalEETypeFields(NodeFactory factory, bool relocsOnly)
         {
             // TODO: handle the __UniversalCanon case (valuetype padding optional field...)
             Debug.Assert(_type.IsCanonicalDefinitionType(CanonicalFormKind.Specific));

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -40,6 +40,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {
+            _owner.ComputeOptionalEETypeFields(factory, relocsOnly: false);
             return _owner.ShouldSkipEmittingObjectNode(factory) || !_owner.HasOptionalFields;
         }
 
@@ -51,7 +52,8 @@ namespace ILCompiler.DependencyAnalysis
 
             if (!relocsOnly)
             {
-                objData.EmitBytes(_owner.GetOptionalFieldsData());
+                _owner.ComputeOptionalEETypeFields(factory, relocsOnly: false);
+                objData.EmitBytes(_owner.GetOptionalFieldsData(factory));
             }
             
             return objData.ToObjectData();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -27,6 +27,10 @@ namespace ILCompiler.DependencyAnalysis
             return null;
         }
 
+        protected internal override void ComputeOptionalEETypeFields(NodeFactory factory, bool relocsOnly)
+        {
+        }
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder dataBuilder = new ObjectDataBuilder(factory);


### PR DESCRIPTION
Required a few fixes:

* Make sure ICastable slot computation only happens during object
emission phase when the slot numbers have been stabilized
* Declare ICastable implementation methods as non-reloc dependencies to
get them generated
* Interface types that declare ICastable in their interface list need to
have the flag set
* ICastable slots are implementation slots on the type, not slots on the
interface