### PR TITLE
Fix stack overflow in execution of class constructors

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -9,13 +9,17 @@ namespace System.Threading
 {
     public sealed class Lock
     {
+        // The following constants define characteristics of spinning logic in the Lock class
+        private const int SpinningNotInitialized = 0;
+        private const int SpinningDisabled = -1;
+        private const int MaxSpinningValue = 10000;
+
         //
         // NOTE: Lock must not have a static (class) constructor, as Lock itself is used to synchronize
         // class construction.  If Lock has its own class constructor, this can lead to infinite recursion.
         // All static data in Lock must be pre-initialized.
         //
-        [PreInitialized]
-        private static int s_maxSpinCount = -1; // -1 means the spin count has not yet beeen determined.
+        private static int s_maxSpinCount;
 
         //
         // m_state layout:
@@ -132,9 +136,9 @@ namespace System.Threading
 
             int spins = 1;
 
-            if (s_maxSpinCount < 0)
+            if (s_maxSpinCount == SpinningNotInitialized)
             {
-                s_maxSpinCount = (Environment.ProcessorCount > 1) ? 10000 : 0;
+                s_maxSpinCount = (Environment.ProcessorCount > 1) ? MaxSpinningValue : SpinningDisabled;
             }
 
             while (true)


### PR DESCRIPTION
The System.Threading.Lock class has a static field marked with the PreInitialized attribute. The CoreRT compiler does not support this attribute yet. This static field is accessed in the Lock.TryAcquireContended method.

The ClassConstructorRunner class used the Lock type for internal synchronization. As a result, we can get into an infinite recursion if there is contention the ClassConstructorRunners lock before the cctor of the Lock type had a change to execute.

This change fixes the issue by getting rid of eager initialization in the Lock class.

Note: this is issue was the root cause of the failures in the BasicThreading test that we observed a few times in the CI.
