### PR TITLE
 Port Interface Dispatch Cell for Virtual Dispatch Lookup

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis
     /// are runtime-determined - the concrete dependency depends on the generic context the canonical
     /// entity is instantiated with.
     /// </remarks>
-    class DictionaryLayoutNode : DependencyNodeCore<NodeFactory>
+    public class DictionaryLayoutNode : DependencyNodeCore<NodeFactory>
     {
         class EntryHashTable : LockFreeReaderHashtable<GenericLookupResult, GenericLookupResult>
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -16,17 +16,17 @@ namespace ILCompiler.DependencyAnalysis
     /// at runtime to look up runtime artifacts that depend on the concrete
     /// context the generic type or method was instantiated with.
     /// </summary>
-    internal abstract class GenericDictionaryNode : ObjectNode, ISymbolNode
+    public abstract class GenericDictionaryNode : ObjectNode, ISymbolNode
     {
         protected const string MangledNamePrefix = "__GenericDict_";
 
         protected abstract TypeSystemContext Context { get; }
 
-        protected abstract Instantiation TypeInstantiation { get; }
+        public abstract Instantiation TypeInstantiation { get; }
 
-        protected abstract Instantiation MethodInstantiation { get; }
+        public abstract Instantiation MethodInstantiation { get; }
 
-        protected abstract DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory);
+        public abstract DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory);
 
         public sealed override ObjectNodeSection Section =>
             Context.Target.IsWindows ? ObjectNodeSection.ReadOnlyDataSection : ObjectNodeSection.DataSection;
@@ -75,7 +75,7 @@ namespace ILCompiler.DependencyAnalysis
                 int offsetBefore = builder.CountBytes;
 #endif
 
-                lookupResult.EmitDictionaryEntry(ref builder, factory, typeInst, methodInst);
+                lookupResult.EmitDictionaryEntry(ref builder, factory, typeInst, methodInst, this);
 
 #if DEBUG
                 Debug.Assert(builder.CountBytes - offsetBefore == factory.Target.PointerSize);
@@ -99,13 +99,13 @@ namespace ILCompiler.DependencyAnalysis
         }
         public override int Offset => 0;
         public override bool IsShareable => false;
-        protected override Instantiation TypeInstantiation => _owningType.Instantiation;
-        protected override Instantiation MethodInstantiation => new Instantiation();
+        public override Instantiation TypeInstantiation => _owningType.Instantiation;
+        public override Instantiation MethodInstantiation => new Instantiation();
         protected override TypeSystemContext Context => _owningType.Context;
 
         public TypeDesc OwningType => _owningType;
 
-        protected override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)
+        public override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)
         {
             return factory.GenericDictionaryLayout(_owningType.ConvertToCanonForm(CanonicalFormKind.Specific));
         }
@@ -156,8 +156,8 @@ namespace ILCompiler.DependencyAnalysis
         }
         public override int Offset => _owningMethod.Context.Target.PointerSize;
         public override bool IsShareable => false;
-        protected override Instantiation TypeInstantiation => _owningMethod.OwningType.Instantiation;
-        protected override Instantiation MethodInstantiation => _owningMethod.Instantiation;
+        public override Instantiation TypeInstantiation => _owningMethod.OwningType.Instantiation;
+        public override Instantiation MethodInstantiation => _owningMethod.Instantiation;
         protected override TypeSystemContext Context => _owningMethod.Context;
 
         public MethodDesc OwningMethod => _owningMethod;
@@ -167,7 +167,7 @@ namespace ILCompiler.DependencyAnalysis
             return GenericMethodsHashtableNode.GetGenericMethodsHashtableDependenciesForMethod(factory, _owningMethod);
         }
 
-        protected override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)
+        public override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)
         {
             return factory.GenericDictionaryLayout(_owningMethod.GetCanonMethodTarget(CanonicalFormKind.Specific));
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -84,12 +84,16 @@ namespace ILCompiler.DependencyAnalysis
 
                         if (factory.TypeSystemContext.HasLazyStaticConstructor(type))
                         {
+                            // TODO: Make _dictionaryOwner a RuntimeDetermined type/method and make a substitution with 
+                            // typeInstantiation/methodInstantiation to get a concrete type. Then pass the generic dictionary
+                            // node of the concrete type to the GetTarget call. Also change the signature of GetTarget to 
+                            // take only the factory and dictionary as input.
                             return new[] {
                                 new DependencyListEntry(
-                                    factory.GenericLookup.TypeNonGCStaticBase(type).GetTarget(factory, typeInstantiation, methodInstantiation),
+                                    factory.GenericLookup.TypeNonGCStaticBase(type).GetTarget(factory, typeInstantiation, methodInstantiation, null),
                                     "Dictionary dependency"),
                                 new DependencyListEntry(
-                                    _lookupSignature.GetTarget(factory, typeInstantiation, methodInstantiation),
+                                    _lookupSignature.GetTarget(factory, typeInstantiation, methodInstantiation, null),
                                     "Dictionary dependency") };
                         }
                     }
@@ -98,7 +102,7 @@ namespace ILCompiler.DependencyAnalysis
 
             // All other generic lookups just depend on the thing they point to
             return new[] { new DependencyListEntry(
-                        _lookupSignature.GetTarget(factory, typeInstantiation, methodInstantiation),
+                        _lookupSignature.GetTarget(factory, typeInstantiation, methodInstantiation, null),
                         "Dictionary dependency") };
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -75,18 +75,21 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
-            // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
-            // we even start the compilation process (with the invocation stubs being compilation roots like any other).
-            // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
-            if (factory.MetadataManager.HasReflectionInvokeStub(Method))
+            if (factory.Target.Abi == TargetAbi.CoreRT)
             {
-                MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(Method);
-                MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                if (invokeStub != canonInvokeStub)
-                    yield return new DependencyListEntry(factory.FatFunctionPointer(invokeStub), "Reflection invoke");
-                else
-                    yield return new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke");
+                // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
+                // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
+                // we even start the compilation process (with the invocation stubs being compilation roots like any other).
+                // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
+                if (factory.MetadataManager.HasReflectionInvokeStub(Method))
+                {
+                    MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(Method);
+                    MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                    if (invokeStub != canonInvokeStub)
+                        yield return new DependencyListEntry(factory.FatFunctionPointer(invokeStub), "Reflection invoke");
+                    else
+                        yield return new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke");
+                }
             }
 
             if (Method.HasInstantiation)


### PR DESCRIPTION
We put a ready-to-run helper in a generic dictionary for VirtualDispatchGenericLookupResult and VirtualResolveGenericLookupResult in CoreRT. Differently, we need an interface dispatch cell instead in ProjectN.