### PR TITLE
Fix MDArray Address method for shared generics

### DIFF
--- a/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
+++ b/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
@@ -239,5 +239,15 @@ namespace Internal.TypeSystem
                 return true;
             }
         }
+
+        public override bool IsNoInlining
+        {
+            get
+            {
+                // Do not allow inlining the Address method. The method that actually gets called is
+                // the one that has a hidden argument with the expected array type.
+                return Kind == ArrayMethodKind.Address;
+            }
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -173,7 +173,18 @@ namespace Internal.TypeSystem
     /// classes backed by metadata, they do have methods that can be referenced from the IL
     /// and the type system needs to provide a way to represent them.
     /// </summary>
-    public partial class ArrayMethod : MethodDesc
+    /// <remarks>
+    /// There are two array Address methods (<see cref="ArrayMethodKind.Address"/> and 
+    /// <see cref="ArrayMethodKind.AddressWithHiddenArg"/>). One is used when referencing Address
+    /// method from IL, the other is used when *compiling* the method body.
+    /// The reason we need to do this is that the Address method is required to do a type check using a type
+    /// that is only known at the callsite. The trick we use is that we tell codegen that the
+    /// <see cref="ArrayMethodKind.Address"/> method requires a hidden instantiation parameter (even though it doesn't).
+    /// The instantiation parameter is where we capture the type at the callsite.
+    /// When we compile the method body, we compile it as <see cref="ArrayMethodKind.AddressWithHiddenArg"/> that
+    /// has the hidden argument explicitly listed in it's signature and is available as a regular parameter.
+    /// </remarks>
+    public sealed partial class ArrayMethod : MethodDesc
     {
         private ArrayType _owningType;
         private ArrayMethodKind _kind;

--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -164,6 +164,7 @@ namespace Internal.TypeSystem
         Get,
         Set,
         Address,
+        AddressWithHiddenArg,
         Ctor
     }
 
@@ -192,6 +193,14 @@ namespace Internal.TypeSystem
         }
 
         public override TypeDesc OwningType
+        {
+            get
+            {
+                return _owningType;
+            }
+        }
+
+        public ArrayType OwningArray
         {
             get
             {
@@ -242,6 +251,15 @@ namespace Internal.TypeSystem
                                 _signature = new MethodSignature(0, 0, _owningType.ElementType.MakeByRefType(), parameters);
                             }
                             break;
+                        case ArrayMethodKind.AddressWithHiddenArg:
+                            {
+                                var parameters = new TypeDesc[_owningType.Rank + 1];
+                                parameters[0] = Context.SystemModule.GetType("System", "EETypePtr");
+                                for (int i = 0; i < _owningType.Rank; i++)
+                                    parameters[i + 1] = _owningType.Context.GetWellKnownType(WellKnownType.Int32);
+                                _signature = new MethodSignature(0, 0, _owningType.ElementType.MakeByRefType(), parameters);
+                            }
+                            break;
                         default:
                             {
                                 int numArgs;
@@ -277,6 +295,7 @@ namespace Internal.TypeSystem
                     case ArrayMethodKind.Set:
                         return "Set";
                     case ArrayMethodKind.Address:
+                    case ArrayMethodKind.AddressWithHiddenArg:
                         return "Address";
                     default:
                         return ".ctor";

--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -21,6 +21,8 @@ namespace Internal.IL.Stubs
 
         private ArrayMethodILEmitter(ArrayMethod method)
         {
+            Debug.Assert(method.Kind != ArrayMethodKind.Address, "Should be " + nameof(ArrayMethodKind.AddressWithHiddenArg));
+
             _method = method;
 
             ArrayType arrayType = (ArrayType)method.OwningType;
@@ -47,7 +49,7 @@ namespace Internal.IL.Stubs
             {
                 case ArrayMethodKind.Get:
                 case ArrayMethodKind.Set:
-                case ArrayMethodKind.Address:
+                case ArrayMethodKind.AddressWithHiddenArg:
                     EmitILForAccessor();
                     break;
 
@@ -80,6 +82,8 @@ namespace Internal.IL.Stubs
 
             int pointerSize = context.Target.PointerSize;
 
+            int argStartOffset = _method.Kind == ArrayMethodKind.AddressWithHiddenArg ? 2 : 1;
+
             var rangeExceptionLabel = _emitter.NewCodeLabel();
             ILCodeLabel typeMismatchExceptionLabel = null;
 
@@ -92,17 +96,14 @@ namespace Internal.IL.Stubs
                         context.SystemModule.GetKnownType("System.Runtime", "RuntimeImports").GetKnownMethod("RhCheckArrayStore", null);
 
                     codeStream.EmitLdArg(0);
-                    codeStream.EmitLdArg(_rank + 1);
+                    codeStream.EmitLdArg(_rank + argStartOffset);
 
                     codeStream.Emit(ILOpcode.call, _emitter.NewToken(checkArrayStore));
                 }
-                else if (_method.Kind == ArrayMethodKind.Address)
+                else if (_method.Kind == ArrayMethodKind.AddressWithHiddenArg)
                 {
                     TypeDesc objectType = context.GetWellKnownType(WellKnownType.Object);
                     TypeDesc eetypePtrType = context.SystemModule.GetKnownType("System", "EETypePtr");
-
-                    MethodDesc eetypePtrOfMethod = eetypePtrType.GetKnownMethod("EETypePtrOf", null)
-                        .MakeInstantiatedMethod(_elementType);
 
                     typeMismatchExceptionLabel = _emitter.NewCodeLabel();
 
@@ -116,8 +117,10 @@ namespace Internal.IL.Stubs
                     codeStream.Emit(ILOpcode.call,
                         _emitter.NewToken(eetypePtrType.GetKnownMethod("get_ArrayElementType", null)));
 
-                    // EETypePtr expectedElementType = EETypePtr.EETypePtrOf<_elementType>();
-                    codeStream.Emit(ILOpcode.call, _emitter.NewToken(eetypePtrOfMethod));
+                    // EETypePtr expectedElementType = hiddenArg.ArrayElementType;
+                    codeStream.EmitLdArga(1);
+                    codeStream.Emit(ILOpcode.call,
+                        _emitter.NewToken(eetypePtrType.GetKnownMethod("get_ArrayElementType", null)));
 
                     // if (expectedElementType != actualElementType)
                     //     ThrowHelpers.ThrowArrayTypeMismatchException();
@@ -135,7 +138,7 @@ namespace Internal.IL.Stubs
                 codeStream.Emit(ILOpcode.ldind_i4);
                 codeStream.EmitStLoc(lengthLocalNum);
 
-                codeStream.EmitLdArg(i + 1);
+                codeStream.EmitLdArg(i + argStartOffset);
 
                 // Compare with length
                 codeStream.Emit(ILOpcode.dup);
@@ -175,11 +178,11 @@ namespace Internal.IL.Stubs
                     break;
 
                 case ArrayMethodKind.Set:
-                    codeStream.EmitLdArg(_rank + 1);
+                    codeStream.EmitLdArg(_rank + argStartOffset);
                     codeStream.Emit(ILOpcode.stobj, _emitter.NewToken(_elementType));
                     break;
 
-                case ArrayMethodKind.Address:
+                case ArrayMethodKind.AddressWithHiddenArg:
                     break;
             }
 

--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -102,6 +102,20 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public void EmitLdArga(int index)
+        {
+            if (index < 0x100)
+            {
+                Emit(ILOpcode.ldarga_s);
+                EmitByte((byte)index);
+            }
+            else
+            {
+                Emit(ILOpcode.ldarga);
+                EmitUInt16((ushort)index);
+            }
+        }
+
         public void EmitLdLoc(ILLocalVariable variable)
         {
             int index = (int)variable;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -34,15 +34,13 @@ namespace ILCompiler.DependencyAnalysis
 
             if (CompilationModuleGroup.ContainsMethod(method))
             {
-                ArrayMethod arrayMethod = method as ArrayMethod;
-
                 if (TypeSystemContext.IsSpecialUnboxingThunkTargetMethod(method))
                 {
                     return MethodEntrypoint(TypeSystemContext.GetRealSpecialUnboxingThunkTargetMethod(method));
                 }
-                else if (arrayMethod != null && arrayMethod.Kind == ArrayMethodKind.Address)
+                else if (method.IsArrayAddressMethod())
                 {
-                    return MethodEntrypoint(arrayMethod.OwningArray.GetArrayMethod(ArrayMethodKind.AddressWithHiddenArg));
+                    return MethodEntrypoint(((ArrayType)method.OwningType).GetArrayMethod(ArrayMethodKind.AddressWithHiddenArg));
                 }
                 else
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -34,9 +34,15 @@ namespace ILCompiler.DependencyAnalysis
 
             if (CompilationModuleGroup.ContainsMethod(method))
             {
+                ArrayMethod arrayMethod = method as ArrayMethod;
+
                 if (TypeSystemContext.IsSpecialUnboxingThunkTargetMethod(method))
                 {
                     return MethodEntrypoint(TypeSystemContext.GetRealSpecialUnboxingThunkTargetMethod(method));
+                }
+                else if (arrayMethod != null && arrayMethod.Kind == ArrayMethodKind.Address)
+                {
+                    return MethodEntrypoint(arrayMethod.OwningArray.GetArrayMethod(ArrayMethodKind.AddressWithHiddenArg));
                 }
                 else
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -85,6 +85,14 @@ namespace ILCompiler
                 !method.ImplementationType.IsValueType;
         }
 
+        /// <summary>
+        /// Returns true if '<paramref name="method"/>' is the "Address" method on multidimensional array types.
+        /// </summary>
+        public static bool IsArrayAddressMethod(this MethodDesc method)
+        {
+            var arrayMethod = method as ArrayMethod;
+            return arrayMethod != null && arrayMethod.Kind == ArrayMethodKind.Address;
+        }
 
         /// <summary>
         /// Gets a value indicating whether this type has any generic virtual methods.


### PR DESCRIPTION
I admit this required special casing in places I don't like, but the
`Address` methods on multidimensional arrays are... well, special.

The problem with the `Address` method is that it needs to do an exact
type check in it's body - the array element type that is expected at the
callsite needs to match the runtime type of the array passed in. We need
this because of array covariance (`string[,]` is allowed to be cast to
`object[,]` and we need to disallow making a `ref object` to an array
element if the runtime type of the array is not exactly `object[,]`).

This changes mirrors how Address methods get compiled on CoreCLR. The
story begins at the callsite:

1. We tell the codegen in `getCallInfo` that `Address` is a method that
requires an instantiation argument (just like e.g. static methods on
shared generic types), but disallow inlining it so that we are forced to
generate a standalone body. Method's owning type becomes the
instantiation argument.
2. We make sure the dependency tracking doesn't track the `Address`
method as a runtime determined method. It's difficult to represent it in
the RuntimeDetermined infrastructure (for the simple reason that
RuntimeDetermined types need to be DefTypes). We can get away with it
because the `Address` method doesn't actually do generic lookups anyway.
3. When we get to compile the method body, we pull the old switcheroo
and replace the method with one that has the instantiation argument in
the signature (so that we can refer to the argument from IL). We then
use the hidden argument to do the type check within the method body.

Fixes #2104.