### PR TITLE
Add type system support for default ctors

### DIFF
--- a/src/Common/src/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedMethod.cs
@@ -125,6 +125,14 @@ namespace Internal.TypeSystem
             return _methodDef.HasCustomAttribute(attributeNamespace, attributeName);
         }
 
+        public override bool IsDefaultConstructor
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public override MethodDesc GetMethodDefinition()
         {
             return _methodDef;

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -154,6 +154,14 @@ namespace Internal.TypeSystem
             return _typeDef.Context.GetMethodForInstantiatedType(typicalCctor, this);
         }
 
+        public override MethodDesc GetDefaultConstructor()
+        {
+            MethodDesc typicalCtor = _typeDef.GetDefaultConstructor();
+            if (typicalCtor == null)
+                return null;
+            return _typeDef.Context.GetMethodForInstantiatedType(typicalCtor, this);
+        }
+
         public override MethodDesc GetFinalizer()
         {
             MethodDesc typicalFinalizer = _typeDef.GetFinalizer();
@@ -303,6 +311,14 @@ namespace Internal.TypeSystem
             get
             {
                 return _typeDef.IsSealed;
+            }
+        }
+
+        public override bool IsAbstract
+        {
+            get
+            {
+                return _typeDef.IsAbstract;
             }
         }
 

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -191,6 +191,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool HasFinalizer
+        {
+            get
+            {
+                return _typeDef.HasFinalizer;
+            }
+        }
+
         public override IEnumerable<FieldDesc> GetFields()
         {
             foreach (var fieldDef in _typeDef.GetFields())

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -75,6 +75,11 @@ namespace Internal.TypeSystem
         public abstract bool IsSealed { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the type is abstract and cannot be allocated.
+        /// </summary>
+        public abstract bool IsAbstract { get; }
+
+        /// <summary>
         /// Returns true if the type has given custom attribute.
         /// </summary>
         public abstract bool HasCustomAttribute(string attributeNamespace, string attributeName);

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -346,6 +346,18 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
+        /// Gets a value indicating whether this is a public parameterless instance constructor
+        /// on a non-abstract type.
+        /// </summary>
+        public virtual bool IsDefaultConstructor
+        {
+            get
+            {
+                return OwningType.GetDefaultConstructor() == this;
+            }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether this method is a static constructor.
         /// </summary>
         public bool IsStaticConstructor

--- a/src/Common/src/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -119,6 +119,14 @@ namespace Internal.TypeSystem
             return _typicalMethodDef;
         }
 
+        public override bool IsDefaultConstructor
+        {
+            get
+            {
+                return _typicalMethodDef.IsDefaultConstructor;
+            }
+        }
+
         public override string Name
         {
             get

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -502,6 +502,15 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
+        /// Retrieves the public parameterless constructor method of the type, or null if there isn't one
+        /// or the type is abstract.
+        /// </summary>
+        public virtual MethodDesc GetDefaultConstructor()
+        {
+            return null;
+        }
+
+        /// <summary>
         /// Gets all fields on the type as defined in the metadata.
         /// </summary>
         public virtual IEnumerable<FieldDesc> GetFields()

--- a/src/Common/src/TypeSystem/Common/TypeSystemConstaintsHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemConstaintsHelpers.cs
@@ -12,8 +12,11 @@ namespace Internal.TypeSystem
         private static bool VerifyGenericParamConstraint(Instantiation typeInstantiation, Instantiation methodInstantiation, GenericParameterDesc genericParam, TypeDesc instantiationParam)
         {
             // Check class constraint
-            if (genericParam.HasReferenceTypeConstraint && !instantiationParam.IsGCPointer)
-                return false;
+            if (genericParam.HasReferenceTypeConstraint)
+            {
+                if (!instantiationParam.IsGCPointer)
+                    return false;
+            }
 
             // Check default constructor constraint
             if (genericParam.HasDefaultConstructorConstraint)
@@ -44,11 +47,12 @@ namespace Internal.TypeSystem
 
         public static bool CheckConstraints(this TypeDesc type)
         {
+            TypeDesc uninstantiatedType = type.GetTypeDefinition();
+
             // Non-generic types always pass constraints check
-            if (!type.HasInstantiation)
+            if (uninstantiatedType == type)
                 return true;
 
-            TypeDesc uninstantiatedType = type.GetTypeDefinition();
             for (int i = 0; i < uninstantiatedType.Instantiation.Length; i++)
             {
                 if (!VerifyGenericParamConstraint(type.Instantiation, default(Instantiation), (GenericParameterDesc)uninstantiatedType.Instantiation[i], type.Instantiation[i]))

--- a/src/Common/src/TypeSystem/Common/TypeSystemConstaintsHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemConstaintsHelpers.cs
@@ -18,10 +18,7 @@ namespace Internal.TypeSystem
             // Check default constructor constraint
             if (genericParam.HasDefaultConstructorConstraint)
             {
-                if (!instantiationParam.IsDefType)
-                    return false;
-
-                if (!instantiationParam.IsValueType && instantiationParam.GetDefaultConstructor() == null)
+                if (!instantiationParam.HasExplicitOrImplicitDefaultConstructor())
                     return false;
             }
 

--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -72,11 +72,19 @@ namespace Internal.TypeSystem
             }
         }
 
-        public static MethodDesc GetDefaultConstructor(this TypeDesc type)
+        /// <summary>
+        /// Gets the parameterless instance constructor on the specified type. To get the default constructor, use <see cref="TypeDesc.GetDefaultConstructor"/>.
+        /// </summary>
+        public static MethodDesc GetParameterlessConstructor(this TypeDesc type)
         {
             // TODO: Do we want check for specialname/rtspecialname? Maybe add another overload on GetMethod?
             var sig = new MethodSignature(0, 0, type.Context.GetWellKnownType(WellKnownType.Void), TypeDesc.EmptyTypes);
             return type.GetMethod(".ctor", sig);
+        }
+
+        public static bool HasExplicitOrImplicitDefaultConstructor(this TypeDesc type)
+        {
+            return type.IsValueType || type.GetDefaultConstructor() != null;
         }
 
         internal static MethodDesc FindMethodOnExactTypeWithMatchingTypicalMethod(this TypeDesc type, MethodDesc method)

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -315,6 +315,19 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
+        public override bool IsDefaultConstructor
+        {
+            get
+            {
+                MethodAttributes attributes = Attributes;
+                return attributes.IsRuntimeSpecialName() 
+                    && attributes.IsPublic()
+                    && Signature.Length == 0
+                    && Name == ".ctor"
+                    && !_type.IsAbstract;
+            }
+        }
+
         public MethodAttributes Attributes
         {
             get

--- a/src/Common/src/TypeSystem/Ecma/MetadataExtensions.cs
+++ b/src/Common/src/TypeSystem/Ecma/MetadataExtensions.cs
@@ -157,5 +157,16 @@ namespace Internal.TypeSystem.Ecma
         {
             return (flags & NestedMask) != 0;
         }
+
+        public static bool IsRuntimeSpecialName(this MethodAttributes flags)
+        {
+            return (flags & (MethodAttributes.SpecialName | MethodAttributes.RTSpecialName))
+                == (MethodAttributes.SpecialName | MethodAttributes.RTSpecialName);
+        }
+
+        public static bool IsPublic(this MethodAttributes flags)
+        {
+            return (flags & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
+        }
     }
 }

--- a/src/Common/src/TypeSystem/IL/Stubs/CreateInstanceIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/CreateInstanceIntrinsic.cs
@@ -40,7 +40,7 @@ namespace Internal.IL.Stubs
                 else
                 {
                     var missingCtor = type.Context.SystemModule.GetKnownType("System", "Activator").
-                        GetNestedType("ClassWithMissingConstructor").GetDefaultConstructor();
+                        GetNestedType("ClassWithMissingConstructor").GetParameterlessConstructor();
 
                     codeStream.Emit(ILOpcode.newobj, emitter.NewToken(missingCtor));
                 }

--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -1038,7 +1038,7 @@ namespace Internal.TypeSystem.Interop
                 var nativeType = PInvokeMethodData.Context.GetWellKnownType(WellKnownType.IntPtr).MakeByRefType();
                 var vOutValue = emitter.NewLocal(PInvokeMethodData.Context.GetWellKnownType(WellKnownType.IntPtr));
                 var vSafeHandle = emitter.NewLocal(resolvedType);
-                marshallingCodeStream.Emit(ILOpcode.newobj, emitter.NewToken(resolvedType.GetDefaultConstructor()));
+                marshallingCodeStream.Emit(ILOpcode.newobj, emitter.NewToken(resolvedType.GetParameterlessConstructor()));
                 marshallingCodeStream.EmitStLoc(vSafeHandle);
                 marshallingCodeStream.EmitLdLoca(vOutValue);
 
@@ -1087,7 +1087,7 @@ namespace Internal.TypeSystem.Interop
             var vSafeHandle = emitter.NewLocal(ManagedParameterType);
             var vReturnValue = emitter.NewLocal(NativeParameterType);
 
-            marshallingCodeStream.Emit(ILOpcode.newobj, emitter.NewToken(ManagedParameterType.GetDefaultConstructor()));
+            marshallingCodeStream.Emit(ILOpcode.newobj, emitter.NewToken(ManagedParameterType.GetParameterlessConstructor()));
             marshallingCodeStream.EmitStLoc(vSafeHandle);
 
             returnValueMarshallingCodeStream.EmitStLoc(vReturnValue);

--- a/src/Common/src/TypeSystem/NativeFormat/MetadataExtensions.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/MetadataExtensions.cs
@@ -164,6 +164,18 @@ namespace Internal.TypeSystem.NativeFormat
             return (flags & NestedMask) != 0;
         }
 
+
+        public static bool IsRuntimeSpecialName(this MethodAttributes flags)
+        {
+            return (flags & (MethodAttributes.SpecialName | MethodAttributes.RTSpecialName))
+                == (MethodAttributes.SpecialName | MethodAttributes.RTSpecialName);
+        }
+
+        public static bool IsPublic(this MethodAttributes flags)
+        {
+            return (flags & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
+        }
+
         /// <summary>
         /// Convert a metadata Handle to a integer (that can be round-tripped back into a handle)
         /// </summary>

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatMethod.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatMethod.cs
@@ -333,6 +333,19 @@ namespace Internal.TypeSystem.NativeFormat
             }
         }
 
+        public override bool IsDefaultConstructor
+        {
+            get
+            {
+                MethodAttributes attributes = Attributes;
+                return attributes.IsRuntimeSpecialName() 
+                    && attributes.IsPublic()
+                    && Signature.Length == 0
+                    && Name == ".ctor"
+                    && !_type.IsAbstract;
+            }
+        }
+
         public MethodAttributes Attributes
         {
             get

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedType.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedType.cs
@@ -170,6 +170,14 @@ namespace ILCompiler
             }
         }
 
+        public override bool IsAbstract
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public override DefType ContainingType
         {
             get

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -247,6 +247,7 @@ namespace ILCompiler
             public override bool IsBeforeFieldInit => false;
             public override MetadataType MetadataBaseType => (MetadataType)Context.GetWellKnownType(WellKnownType.Object);
             public override bool IsSealed => true;
+            public override bool IsAbstract => false;
             public override DefType ContainingType => null;
             public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
             public override TypeSystemContext Context => ValueTypeRepresented.Context;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -82,8 +82,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (method.GetCanonMethodTarget(CanonicalFormKind.Specific).RequiresInstArg())
                     flags |= InvokeTableFlags.RequiresInstArg;
 
-                // TODO: better check for default public(!) constructor
-                if (method.IsConstructor && method.Signature.Length == 0)
+                if (method.IsDefaultConstructor)
                     flags |= InvokeTableFlags.IsDefaultConstructor;
 
                 // TODO: HasVirtualInvoke

--- a/src/ILCompiler.TypeSystem/tests/ConstraintsValidationTest.cs
+++ b/src/ILCompiler.TypeSystem/tests/ConstraintsValidationTest.cs
@@ -21,6 +21,8 @@ namespace TypeSystemTests
         private MetadataType _structArgWithDefaultCtorType;
         private MetadataType _structArgWithoutDefaultCtorType;
         private MetadataType _classArgWithDefaultCtorType;
+        private MetadataType _classArgWithPrivateDefaultCtorType;
+        private MetadataType _abstractClassArgWithDefaultCtorType;
         private MetadataType _classArgWithoutDefaultCtorType;
         private MetadataType _referenceTypeConstraintType;
         private MetadataType _defaultConstructorConstraintType;
@@ -49,6 +51,8 @@ namespace TypeSystemTests
             _structArgWithDefaultCtorType = _testModule.GetType("GenericConstraints", "StructArgWithDefaultCtor");
             _structArgWithoutDefaultCtorType = _testModule.GetType("GenericConstraints", "StructArgWithoutDefaultCtor");
             _classArgWithDefaultCtorType = _testModule.GetType("GenericConstraints", "ClassArgWithDefaultCtor");
+            _classArgWithPrivateDefaultCtorType = _testModule.GetType("GenericConstraints", "ClassArgWithPrivateDefaultCtor");
+            _abstractClassArgWithDefaultCtorType = _testModule.GetType("GenericConstraints", "AbstractClassArgWithDefaultCtor");
             _classArgWithoutDefaultCtorType = _testModule.GetType("GenericConstraints", "ClassArgWithoutDefaultCtor");
 
             _referenceTypeConstraintType = _testModule.GetType("GenericConstraints", "ReferenceTypeConstraint`1");
@@ -94,6 +98,12 @@ namespace TypeSystemTests
 
                 instantiatedType = _defaultConstructorConstraintType.MakeInstantiatedType(_classArgWithDefaultCtorType);
                 Assert.True(instantiatedType.CheckConstraints());
+
+                instantiatedType = _defaultConstructorConstraintType.MakeInstantiatedType(_classArgWithPrivateDefaultCtorType);
+                Assert.False(instantiatedType.CheckConstraints());
+
+                instantiatedType = _defaultConstructorConstraintType.MakeInstantiatedType(_abstractClassArgWithDefaultCtorType);
+                Assert.False(instantiatedType.CheckConstraints());
 
                 instantiatedType = _defaultConstructorConstraintType.MakeInstantiatedType(_classArgWithoutDefaultCtorType);
                 Assert.False(instantiatedType.CheckConstraints());

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/GenericConstraints.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/GenericConstraints.cs
@@ -26,6 +26,16 @@ namespace GenericConstraints
         public ClassArgWithDefaultCtor() { }
     }
 
+    public abstract class AbstractClassArgWithDefaultCtor : IGen<object>
+    {
+        public AbstractClassArgWithDefaultCtor() { }
+    }
+
+    public class ClassArgWithPrivateDefaultCtor : IGen<object>
+    {
+        private ClassArgWithPrivateDefaultCtor() { }
+    }
+
     public class ClassArgWithoutDefaultCtor : IGen<object>
     {
         public ClassArgWithoutDefaultCtor(int argument) { }


### PR DESCRIPTION
This adds two things:

* `TypeDesc::GetDefaultConstructor`. We can support this API both at compile time and at runtime, so it can go to the most common type system files.
* `MethodDesc::IsDefaultConstructor`. This provides an inefficient implementation in the base that can be overriden by more efficient ones in derived classes.

There is a separate commit with two unrelated type system improvements for things I noticed.