### PR TITLE
Clean up ObjectDataBuilder API

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
@@ -67,7 +67,7 @@ namespace ILCompiler.DependencyAnalysis
                 node.EncodeData(ref builder, factory, relocsOnly);
                 if (node is ISymbolNode)
                 {
-                    builder.DefinedSymbols.Add((ISymbolNode)node);
+                    builder.AddSymbol((ISymbolNode)node);
                 }
             }
         }
@@ -75,17 +75,17 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory);
-            builder.Alignment = factory.Target.PointerSize;
+            builder.RequireInitialPointerAlignment();
 
             if (_sorter != null)
                 _nestedNodesList.Sort(_sorter);
 
-            builder.DefinedSymbols.Add(_startSymbol);
+            builder.AddSymbol(_startSymbol);
 
             GetElementDataForNodes(ref builder, factory, relocsOnly);
 
             _endSymbol.SetSymbolOffset(builder.CountBytes);
-            builder.DefinedSymbols.Add(_endSymbol);
+            builder.AddSymbol(_endSymbol);
 
             ObjectData objData = builder.ToObjectData();
             return objData;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
@@ -33,7 +33,7 @@ namespace ILCompiler.DependencyAnalysis
                 node.EncodeData(ref builder, factory, relocsOnly);
                 if (node is ISymbolNode)
                 {
-                    builder.DefinedSymbols.Add((ISymbolNode)node);
+                    builder.AddSymbol((ISymbolNode)node);
                 }
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
@@ -31,22 +31,22 @@ namespace ILCompiler.DependencyAnalysis
                 case TargetArchitecture.X64:
                     X64.X64Emitter x64Emitter = new X64.X64Emitter(factory);
                     EmitCode(factory, ref x64Emitter, relocsOnly);
-                    x64Emitter.Builder.Alignment = factory.Target.MinimumFunctionAlignment;
-                    x64Emitter.Builder.DefinedSymbols.Add(this);
+                    x64Emitter.Builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);
+                    x64Emitter.Builder.AddSymbol(this);
                     return x64Emitter.Builder.ToObjectData();
 
                 case TargetArchitecture.X86:
                     X86.X86Emitter x86Emitter = new X86.X86Emitter(factory);
                     EmitCode(factory, ref x86Emitter, relocsOnly);
-                    x86Emitter.Builder.Alignment = factory.Target.MinimumFunctionAlignment;
-                    x86Emitter.Builder.DefinedSymbols.Add(this);
+                    x86Emitter.Builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);
+                    x86Emitter.Builder.AddSymbol(this);
                     return x86Emitter.Builder.ToObjectData();
 
                 case TargetArchitecture.ARM:
                     ARM.ARMEmitter armEmitter = new ARM.ARMEmitter(factory);
                     EmitCode(factory, ref armEmitter, relocsOnly);
-                    armEmitter.Builder.Alignment = factory.Target.MinimumFunctionAlignment;
-                    armEmitter.Builder.DefinedSymbols.Add(this);
+                    armEmitter.Builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);
+                    armEmitter.Builder.AddSymbol(this);
                     return armEmitter.Builder.ToObjectData();
 
                 default:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -156,8 +156,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
-            objData.Alignment = objData.TargetPointerSize;
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialPointerAlignment();
+            objData.AddSymbol(this);
 
             ComputeOptionalEETypeFields(factory, relocsOnly);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -47,8 +47,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
-            objData.RequirePointerAlignment();
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialPointerAlignment();
+            objData.AddSymbol(this);
 
             if (!relocsOnly)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
@@ -30,7 +30,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
-            dataBuilder.RequirePointerAlignment();
+            dataBuilder.RequireInitialPointerAlignment();
             dataBuilder.EmitPointerReloc(Target);
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
@@ -79,8 +79,8 @@ namespace ILCompiler.DependencyAnalysis
 
             _endSymbol.SetSymbolOffset(builder.CountBytes);
             
-            builder.DefinedSymbols.Add(this);
-            builder.DefinedSymbols.Add(_endSymbol);
+            builder.AddSymbol(this);
+            builder.AddSymbol(_endSymbol);
 
             return builder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
@@ -51,9 +51,9 @@ namespace ILCompiler.DependencyAnalysis
             var builder = new ObjectDataBuilder(factory);
 
             // These need to be aligned the same as methods because they show up in same contexts
-            builder.RequireAlignment(factory.Target.MinimumFunctionAlignment);
+            builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);
 
-            builder.DefinedSymbols.Add(this);
+            builder.AddSymbol(this);
 
             MethodDesc canonMethod = Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -62,8 +62,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             ObjectDataBuilder dataBuilder = new ObjectDataBuilder(factory);
-            dataBuilder.Alignment = 16;
-            dataBuilder.DefinedSymbols.Add(this);
+            dataBuilder.RequireInitialAlignment(16);
+            dataBuilder.AddSymbol(this);
 
             // +2 for SyncBlock and EETypePtr field
             int totalSize = (_gcMap.Size + 2) * _target.PointerSize;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -57,9 +57,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory);
 
-            builder.RequirePointerAlignment();
+            builder.RequireInitialPointerAlignment();
             builder.EmitPointerReloc(GetGCStaticEETypeNode(factory), 1);
-            builder.DefinedSymbols.Add(this);
+            builder.AddSymbol(this);
 
             return builder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
@@ -86,9 +86,9 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             var builder = new ObjectDataBuilder(factory);
-            builder.DefinedSymbols.Add(this);
+            builder.AddSymbol(this);
 
-            builder.RequirePointerAlignment();
+            builder.RequireInitialPointerAlignment();
 
             builder.EmitShort((short)checked((UInt16)_details.Instantiation.Length));
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -35,8 +35,8 @@ namespace ILCompiler.DependencyAnalysis
         {
             ObjectDataBuilder dataBuilder = new ObjectDataBuilder(factory);
 
-            dataBuilder.Alignment = dataBuilder.TargetPointerSize;
-            dataBuilder.DefinedSymbols.Add(this);
+            dataBuilder.RequireInitialPointerAlignment();
+            dataBuilder.AddSymbol(this);
             EETypeRareFlags rareFlags = 0;
 
             short flags = (short)EETypeKind.GenericTypeDefEEType;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -47,8 +47,8 @@ namespace ILCompiler.DependencyAnalysis
         public sealed override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory);
-            builder.DefinedSymbols.Add(this);
-            builder.RequirePointerAlignment();
+            builder.AddSymbol(this);
+            builder.RequireInitialPointerAlignment();
 
             // Node representing the generic dictionary doesn't have any dependencies for
             // dependency analysis purposes. The dependencies are tracked as dependencies of the

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
@@ -35,8 +35,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             var builder = new ObjectDataBuilder(factory);
-            builder.RequirePointerAlignment();
-            builder.DefinedSymbols.Add(this);
+            builder.RequireInitialPointerAlignment();
+            builder.AddSymbol(this);
 
             builder.EmitPointerReloc(_indirectedNode);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -55,8 +55,8 @@ namespace ILCompiler.DependencyAnalysis
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
             // The interface dispatch cell has an alignment requirement of 2 * [Pointer size] as part of the 
             // synchronization mechanism of the two values in the runtime.
-            objData.Alignment = _targetMethod.Context.Target.PointerSize * 2;
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialAlignment(_targetMethod.Context.Target.PointerSize * 2);
+            objData.AddSymbol(this);
 
             if (factory.Target.Architecture == TargetArchitecture.ARM)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -100,8 +100,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
-            objData.Alignment = 16;
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialAlignment(16);
+            objData.AddSymbol(this);
 
             if (!relocsOnly)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
@@ -46,8 +46,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
-            objData.RequirePointerAlignment();
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialPointerAlignment();
+            objData.AddSymbol(this);
             objData.EmitPointerReloc(factory.ReadyToRunHeader);
 
             return objData.ToObjectData();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutSignatureNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutSignatureNode.cs
@@ -54,8 +54,8 @@ namespace ILCompiler.DependencyAnalysis
 
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
 
-            objData.Alignment = objData.TargetPointerSize;
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialPointerAlignment();
+            objData.AddSymbol(this);
 
             objData.EmitPointerReloc(factory.TypeManagerIndirection);
             objData.EmitNaturalInt(_nativeSignature.SavedVertex.VertexOffset);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -85,7 +85,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 int alignmentRequired = Math.Max(_type.NonGCStaticFieldAlignment, GetClassConstructorContextAlignment(_type.Context.Target));
                 int classConstructorContextStorageSize = GetClassConstructorContextStorageSize(factory.Target, _type);
-                builder.RequireAlignment(alignmentRequired);
+                builder.RequireInitialAlignment(alignmentRequired);
                 
                 Debug.Assert(classConstructorContextStorageSize >= GetClassConstructorContextSize(_type.Context.Target));
 
@@ -103,11 +103,11 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                builder.RequireAlignment(_type.NonGCStaticFieldAlignment);
+                builder.RequireInitialAlignment(_type.NonGCStaticFieldAlignment);
             }
 
             builder.EmitZeros(_type.NonGCStaticFieldSize);
-            builder.DefinedSymbols.Add(this);
+            builder.AddSymbol(this);
 
             return builder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.DependencyAnalysis
             _data = new ArrayBuilder<byte>();
             _relocs = new ArrayBuilder<Relocation>();
             Alignment = 1;
-            DefinedSymbols = new ArrayBuilder<ISymbolNode>();
+            _definedSymbols = new ArrayBuilder<ISymbolNode>();
 #if DEBUG
             _numReservations = 0;
 #endif
@@ -27,8 +27,8 @@ namespace ILCompiler.DependencyAnalysis
         private TargetDetails _target;
         private ArrayBuilder<Relocation> _relocs;
         private ArrayBuilder<byte> _data;
-        public int Alignment;
-        internal ArrayBuilder<ISymbolNode> DefinedSymbols;
+        public int Alignment { get; private set; }
+        private ArrayBuilder<ISymbolNode> _definedSymbols;
 
 #if DEBUG
         private int _numReservations;
@@ -50,14 +50,22 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public void RequireAlignment(int align)
+        /// <summary>
+        /// Raise the alignment requirement of this object to <paramref name="align"/>. This has no effect
+        /// if the alignment requirement is already larger than <paramref name="align"/>.
+        /// </summary>
+        public void RequireInitialAlignment(int align)
         {
             Alignment = Math.Max(align, Alignment);
         }
 
-        public void RequirePointerAlignment()
+        /// <summary>
+        /// Raise the alignment requirement of this object to the target pointer size. This has no effect
+        /// if the alignment requirement is already larger than a pointer size.
+        /// </summary>
+        public void RequireInitialPointerAlignment()
         {
-            RequireAlignment(_target.PointerSize);
+            RequireInitialAlignment(_target.PointerSize);
         }
 
         public void EmitByte(byte emit)
@@ -260,7 +268,7 @@ namespace ILCompiler.DependencyAnalysis
             ObjectNode.ObjectData returnData = new ObjectNode.ObjectData(_data.ToArray(),
                                                                          _relocs.ToArray(),
                                                                          Alignment,
-                                                                         DefinedSymbols.ToArray());
+                                                                         _definedSymbols.ToArray());
 
             return returnData;
         }
@@ -269,7 +277,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AddSymbol(ISymbolNode node)
         {
-            DefinedSymbols.Add(node);
+            _definedSymbols.Add(node);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -41,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory);
-            builder.DefinedSymbols.Add(this);
+            builder.AddSymbol(this);
 
             //
             // Emit a MethodFixupCell struct

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
@@ -35,7 +35,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory);
-            builder.DefinedSymbols.Add(this);
+            builder.AddSymbol(this);
 
             ISymbolNode nameSymbol = factory.ConstantUtf8String(_moduleName);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
@@ -67,8 +67,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory);
-            builder.Alignment = factory.Target.PointerSize;
-            builder.DefinedSymbols.Add(this);
+            builder.RequireInitialPointerAlignment();
+            builder.AddSymbol(this);
 
             // Don't bother sorting if we're not emitting the contents
             if (!relocsOnly)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -36,8 +36,8 @@ namespace ILCompiler.DependencyAnalysis
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
 
-            objData.Alignment = objData.TargetPointerSize;
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialPointerAlignment();
+            objData.AddSymbol(this);
 
             NativeLayoutMethodLdTokenVertexNode ldtokenSigNode = factory.NativeLayout.MethodLdTokenVertex(_targetMethod);
             objData.EmitPointerReloc(factory.NativeLayout.NativeLayoutSignature(ldtokenSigNode));

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsIndexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsIndexNode.cs
@@ -61,13 +61,13 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
-            objData.Alignment = factory.Target.PointerSize;
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialPointerAlignment();
+            objData.AddSymbol(this);
 
             // Emit an aliased symbol named _tls_index for native P/Invoke code that uses TLS. This is required
             // because we do not link against libcmt.lib.
             ObjectAndOffsetSymbolNode aliasedSymbol = new ObjectAndOffsetSymbolNode(this, objData.CountBytes, "_tls_index", false);
-            objData.DefinedSymbols.Add(aliasedSymbol);
+            objData.AddSymbol(aliasedSymbol);
 
             // This is the TLS index field which is a 4-byte integer. Emit an 8-byte interger which includes a
             // 4-byte padding to make an pointer-sized alignment for the subsequent fields for all targets.
@@ -98,7 +98,7 @@ namespace ILCompiler.DependencyAnalysis
             */
             // In order to utilize linker support, the struct variable needs to be named _tls_used
             ObjectAndOffsetSymbolNode structSymbol = new ObjectAndOffsetSymbolNode(this, objData.CountBytes, "_tls_used", false);
-            objData.DefinedSymbols.Add(structSymbol);
+            objData.AddSymbol(structSymbol);
             objData.EmitPointerReloc(factory.ThreadStaticsRegion.StartSymbol);     // start of tls data
             objData.EmitPointerReloc(factory.ThreadStaticsRegion.EndSymbol);     // end of tls data
             objData.EmitPointerReloc(this);     // address of tls_index

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -60,7 +60,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void EncodeData(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
         {
-            builder.RequirePointerAlignment();
+            builder.RequireInitialPointerAlignment();
 
             // At runtime, an instance of the GCStaticEEType will be created and a GCHandle to it
             // will be written in this location.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeManagerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeManagerIndirectionNode.cs
@@ -24,8 +24,8 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
-            objData.DefinedSymbols.Add(this);
-            objData.RequirePointerAlignment();
+            objData.AddSymbol(this);
+            objData.RequireInitialPointerAlignment();
             objData.EmitZeroPointer();
             objData.EmitZeroPointer();
             return objData.ToObjectData();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
@@ -42,8 +42,8 @@ namespace ILCompiler.DependencyAnalysis
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory);
 
-            objData.Alignment = objData.TargetPointerSize;
-            objData.DefinedSymbols.Add(this);
+            objData.RequireInitialPointerAlignment();
+            objData.AddSymbol(this);
 
             int typeTlsIndex = 0;
             if (!relocsOnly)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -248,7 +248,7 @@ namespace Internal.JitInterface
         private ObjectNode.ObjectData EncodeEHInfo()
         {
             var builder = new ObjectDataBuilder();
-            builder.Alignment = 1;
+            builder.RequireInitialAlignment(1);
 
             int totalClauses = _ehClauses.Length;
 


### PR DESCRIPTION
https://github.com/dotnet/corert/pull/2648 added
`ObjectDataBuilder.AddSymbol` to avoid exposing ArrayBuilder class.
Migrate all uses of `ObjectDataBuilder.DefinedSymbols.Add` to
`AddSymbol`.

Rename the alignment methods to be clearer that they set the overall
alignment; ie, they don't provide padding between each emission of data
within the object.

Fixes part of https://github.com/dotnet/corert/issues/2645.