### PR TITLE
Fix an assertion in the BitEnumerator class

### DIFF
--- a/src/Common/src/TypeSystem/Common/Utilities/GCPointerMap.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/GCPointerMap.cs
@@ -232,7 +232,7 @@ namespace Internal.TypeSystem
         public BitEnumerator(int[] buffer, int startBit, int numBits)
         {
             Debug.Assert(startBit >= 0 && numBits >= 0);
-            Debug.Assert(startBit + numBits < buffer.Length << 5);
+            Debug.Assert(startBit + numBits <= buffer.Length << 5);
 
             _buffer = buffer;
             _currentBit = startBit - 1;

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/GCPointerMap.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/GCPointerMap.cs
@@ -36,6 +36,28 @@ namespace GCPointerMap
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    struct Struct4GcPointers
+    {
+        public object o1;
+        public object o2;
+        public object o3;
+        public object o4;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct Struct32GcPointers
+    {
+        public Struct4GcPointers x1;
+        public Struct4GcPointers x2;
+        public Struct4GcPointers x3;
+        public Struct4GcPointers x4;
+        public Struct4GcPointers x5;
+        public Struct4GcPointers x6;
+        public Struct4GcPointers x7;
+        public Struct4GcPointers x8;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     struct StructWithSameGCLayoutAsMixedStruct
     {
         MixedStruct s;

--- a/src/ILCompiler.TypeSystem/tests/GCPointerMapTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/GCPointerMapTests.cs
@@ -31,6 +31,7 @@ namespace TypeSystemTests
             MetadataType structWithSameGCLayoutAsMixedStruct = _testModule.GetType("GCPointerMap", "StructWithSameGCLayoutAsMixedStruct");
             MetadataType doubleMixedStructLayout = _testModule.GetType("GCPointerMap", "DoubleMixedStructLayout");
             MetadataType explicitlyFarPointer = _testModule.GetType("GCPointerMap", "ExplicitlyFarPointer");
+            MetadataType struct32GcPointers = _testModule.GetType("GCPointerMap", "Struct32GcPointers");
 
             {
                 var map = GCPointerMap.FromInstanceLayout(classWithArrayFields);
@@ -67,6 +68,12 @@ namespace TypeSystemTests
                 var map = GCPointerMap.FromInstanceLayout(explicitlyFarPointer);
                 Assert.Equal(map.Size, 117);
                 Assert.Equal("100000000000000000000000000000000000000000000000000000000000000010000000000000001000000000000000000000000000000001001", map.ToString());
+            }
+
+            {
+                var map = GCPointerMap.FromInstanceLayout(struct32GcPointers);
+                Assert.Equal(map.Size, 32);
+                Assert.Equal("11111111111111111111111111111111", map.ToString());
             }
         }
 


### PR DESCRIPTION
This change fixes an assertion in the BitEnumerator class that had incorrect check for a boundary condition.
A regression test added as well.