### PR TITLE
Fix alignment of GCStaticEETypeNode

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -62,7 +62,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             ObjectDataBuilder dataBuilder = new ObjectDataBuilder(factory);
-            dataBuilder.RequireInitialAlignment(16);
+            objData.RequireInitialPointerAlignment();
             dataBuilder.AddSymbol(this);
 
             // +2 for SyncBlock and EETypePtr field

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -62,7 +62,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             ObjectDataBuilder dataBuilder = new ObjectDataBuilder(factory);
-            objData.RequireInitialPointerAlignment();
+            dataBuilder.RequireInitialPointerAlignment();
             dataBuilder.AddSymbol(this);
 
             // +2 for SyncBlock and EETypePtr field


### PR DESCRIPTION
This is an EETypeNode like any other. I missed this in #1916 but noticed
it when I was reviewing #2652 that touched the line. We really should
find a way to have a common base class for these to prevent bugs like
this.