### PR TITLE
Avoid unnecessary branches when fixing non-null/empty arrays

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetCwd.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetCwd.cs
@@ -34,7 +34,7 @@ internal static partial class Interop
                 {
                     checked { bufferSize *= 2; }
                     var buf = new byte[Math.Min(bufferSize, maxPath)];
-                    fixed (byte* ptr = buf)
+                    fixed (byte* ptr = &buf[0])
                     {
                         result = GetCwdHelper(ptr, buf.Length);
                         if (result != null)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -28,7 +28,7 @@ namespace Internal.Runtime.CompilerHelpers
                 int stringLength = str.Length;
                 int bufferLength = encoding.GetByteCount(pStr, stringLength);
                 var buffer = new byte[bufferLength + 1];
-                fixed (byte* pBuffer = buffer)
+                fixed (byte* pBuffer = &buffer[0])
                 {
                     encoding.GetBytes(pStr, stringLength, pBuffer, bufferLength);
                     return buffer;

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -2532,18 +2532,22 @@ namespace System
             if (indices == null)
                 throw new ArgumentNullException(nameof(indices));
 
-            if (IsSzArray && indices.Length == 1)
+            int length = indices.Length;
+
+            if (IsSzArray && length == 1)
                 return GetValue(indices[0]);
 
-            fixed (int* pIndices = indices)
-                return GetValue(pIndices, indices.Length);
+            if (Rank != length)
+                throw new ArgumentException(SR.Arg_RankIndices);
+
+            Debug.Assert(length > 0);
+            fixed (int* pIndices = &indices[0])
+                return GetValue(pIndices, length);
         }
 
         private unsafe Object GetValue(int* pIndices, int rank)
         {
-            if (this.Rank != rank)
-                throw new ArgumentException(SR.Arg_RankIndices);
-
+            Debug.Assert(Rank == rank);
             Debug.Assert(!IsSzArray);
 
             fixed (IntPtr* pThisArray = &m_pEEType)
@@ -2662,24 +2666,28 @@ namespace System
             if (indices == null)
                 throw new ArgumentNullException(nameof(indices));
 
-            if (IsSzArray && indices.Length == 1)
+            int length = indices.Length;
+
+            if (IsSzArray && length == 1)
             {
                 SetValue(value, indices[0]);
                 return;
             }
 
-            fixed (int* pIndices = indices)
+            if (Rank != length)
+                throw new ArgumentException(SR.Arg_RankIndices);
+
+            Debug.Assert(length > 0);
+            fixed (int* pIndices = &indices[0])
             {
-                SetValue(value, pIndices, indices.Length);
+                SetValue(value, pIndices, length);
                 return;
             }
         }
 
         private unsafe void SetValue(Object value, int* pIndices, int rank)
         {
-            if (this.Rank != rank)
-                throw new ArgumentException(SR.Arg_RankIndices);
-
+            Debug.Assert(Rank == rank);
             Debug.Assert(!IsSzArray);
 
             fixed (IntPtr* pThisArray = &m_pEEType)

--- a/src/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/System.Private.CoreLib/src/System/Convert.cs
@@ -2392,7 +2392,7 @@ namespace System
             string returnString = new string('\0', stringLength);
             fixed (char* outChars = returnString)
             {
-                fixed (byte* inData = inArray)
+                fixed (byte* inData = &inArray[0])
                 {
                     int j = ConvertToBase64Array(outChars, inData, offset, length, insertLineBreaks);
                     System.Diagnostics.Debug.Assert(returnString.Length == j, "returnString.Length == j");
@@ -2459,7 +2459,7 @@ namespace System
 
             fixed (char* outChars = &outArray[offsetOut])
             {
-                fixed (byte* inData = inArray)
+                fixed (byte* inData = &inArray[0])
                 {
                     retVal = ConvertToBase64Array(outChars, inData, offsetIn, length, insertLineBreaks);
                 }
@@ -2478,7 +2478,7 @@ namespace System
             int i;
 
             // get a pointer to the base64Table to avoid unnecessary range checking
-            fixed (char* base64 = base64Table)
+            fixed (char* base64 = &base64Table[0])
             {
                 for (i = offset; i < calcLength; i += 3)
                 {

--- a/src/System.Private.CoreLib/src/System/Environment.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.Win32.cs
@@ -43,7 +43,7 @@ namespace System
                 currentSize = requiredSize;
                 // need to retry since the environment variable might be changed 
                 newblob = new char[currentSize];
-                fixed (char* pText = variable, pBlob = newblob)
+                fixed (char* pText = variable, pBlob = &newblob[0])
                 {
                     requiredSize = Interop.mincore.GetEnvironmentVariable(pText, pBlob, currentSize);
                 }

--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -500,7 +500,7 @@ namespace System
                 int cbBuffer = sizeof(SERIALIZED_EXCEPTION_HEADER) + (nStackTraceElements * IntPtr.Size);
 
                 byte[] buffer = new byte[cbBuffer];
-                fixed (byte* pBuffer = buffer)
+                fixed (byte* pBuffer = &buffer[0])
                 {
                     SERIALIZED_EXCEPTION_HEADER* pHeader = (SERIALIZED_EXCEPTION_HEADER*)pBuffer;
                     pHeader->HResult = _HResult;

--- a/src/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
@@ -178,7 +178,7 @@ namespace System.Globalization
             fixed (ushort* pUshortPtr = &(s_pNumericLevel1Index[index]))
             {
                 byte* pBytePtr = (byte*)pUshortPtr;
-                fixed (byte* pByteNum = s_pNumericValues)
+                fixed (byte* pByteNum = &s_pNumericValues[0])
                 {
                     double* pDouble = (double*)pByteNum;
                     return pDouble[pBytePtr[(ch & 0x000f)]];

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
@@ -347,7 +347,7 @@ namespace System.Globalization
 
             byte[] sortKey = new byte[sortKeyLength];
 
-            fixed(byte* pSortKey = sortKey)
+            fixed (byte* pSortKey = &sortKey[0])
             {
                 Interop.GlobalizationInterop.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options);
                 return InternalHashSortKey(pSortKey, sortKeyLength, false, additionalEntropy);

--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.DateTimeFormat.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.DateTimeFormat.cs
@@ -188,7 +188,7 @@ namespace System.Globalization
                 int digits;
 
                 char[] charBuff = new char[16];
-                fixed (char* buffer = charBuff)
+                fixed (char* buffer = &charBuff[0])
                 {
                     char* p = buffer + 16;
                     int n = value;

--- a/src/System.Private.CoreLib/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/IdnMapping.Unix.cs
@@ -35,7 +35,7 @@ namespace System.Globalization
             }
 
             char[] outputHeap = new char[actualLength];
-            fixed (char* pOutputHeap = outputHeap)
+            fixed (char* pOutputHeap = &outputHeap[0])
             {
                 actualLength = Interop.GlobalizationInterop.ToAscii(flags, unicode, count, pOutputHeap, actualLength);
                 if (actualLength == 0 || actualLength > outputHeap.Length)
@@ -60,7 +60,7 @@ namespace System.Globalization
             else
             {
                 char[] output = new char[count];
-                fixed (char* pOutput = output)
+                fixed (char* pOutput = &output[0])
                 {
                     return GetUnicodeCore(ascii, count, flags, pOutput, count, reattempt: true);
                 }

--- a/src/System.Private.CoreLib/src/System/Globalization/IdnMapping.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/IdnMapping.Windows.cs
@@ -30,7 +30,7 @@ namespace System.Globalization
             else
             {
                 char[] output = new char[length];
-                fixed (char* pOutput = output)
+                fixed (char* pOutput = &output[0])
                 {
                     return GetAsciiCore(unicode, count, flags, pOutput, length);
                 }
@@ -69,7 +69,7 @@ namespace System.Globalization
             else
             {
                 char[] output = new char[length];
-                fixed (char* pOutput = output)
+                fixed (char* pOutput = &output[0])
                 {
                     return GetUnicodeCore(ascii, count, flags, pOutput, length);
                 }

--- a/src/System.Private.CoreLib/src/System/IO/FileStream.Win32.cs
+++ b/src/System.Private.CoreLib/src/System/IO/FileStream.Win32.cs
@@ -1284,7 +1284,7 @@ namespace System.IO
             int r = 0;
             int numBytesRead = 0;
 
-            fixed (byte* p = bytes)
+            fixed (byte* p = &bytes[0])
             {
                 if (_useAsyncIO)
                     r = Interop.mincore.ReadFile(handle, p + offset, count, IntPtr.Zero, overlapped);
@@ -1329,7 +1329,7 @@ namespace System.IO
             int numBytesWritten = 0;
             int r = 0;
 
-            fixed (byte* p = bytes)
+            fixed (byte* p = &bytes[0])
             {
                 if (_useAsyncIO)
                     r = Interop.mincore.WriteFile(handle, p + offset, count, IntPtr.Zero, overlapped);

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -569,7 +569,7 @@ namespace System.Runtime
             {
                 fixed (byte* pPublicKey = publicKey)
                 {
-                    fixed (byte* pPublicKeyToken = publicKeyToken)
+                    fixed (byte* pPublicKeyToken = &publicKeyToken[0])
                     {
                         RhConvertPublicKeyToPublicKeyToken(pPublicKey, publicKey.Length, pPublicKeyToken, publicKeyToken.Length);
                     }

--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -350,7 +350,7 @@ namespace System
             {
                 char[] chars = new char[length];
                 fixed (char* src = &_firstChar)
-                    fixed (char* dest = chars)
+                    fixed (char* dest = &chars[0])
                 {
                     wstrcpy(dest, src, length);
                 }
@@ -373,7 +373,7 @@ namespace System
             {
                 char[] chars = new char[length];
                 fixed (char* src = &_firstChar)
-                    fixed (char* dest = chars)
+                    fixed (char* dest = &chars[0])
                 {
                     wstrcpy(dest, src + startIndex, length);
                 }

--- a/src/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
+++ b/src/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
@@ -75,7 +75,7 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call pointer version
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
                 return GetCharCount(pBytes + index, count, flush);
         }
 
@@ -136,8 +136,8 @@ namespace System.Text
                 chars = new char[1];
 
             // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
+            fixed (byte* pBytes = &bytes[0])
+                fixed (char* pChars = &chars[0])
                     // Remember that charCount is # to decode, not size of array
                     return GetChars(pBytes + byteIndex, byteCount,
                                     pChars + charIndex, charCount, flush);
@@ -200,9 +200,9 @@ namespace System.Text
                 chars = new char[1];
 
             // Just call the pointer version (public overrides can't do this)
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
             {
-                fixed (char* pChars = chars)
+                fixed (char* pChars = &chars[0])
                 {
                     Convert(pBytes + byteIndex, byteCount, pChars + charIndex, charCount, flush,
                         out bytesUsed, out charsUsed, out completed);

--- a/src/System.Private.CoreLib/src/System/Text/EncoderNLS.cs
+++ b/src/System.Private.CoreLib/src/System/Text/EncoderNLS.cs
@@ -74,7 +74,7 @@ namespace System.Text
 
             // Just call the pointer version
             int result = -1;
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             {
                 result = GetByteCount(pChars + index, count, flush);
             }
@@ -127,8 +127,8 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call pointer version
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
+            fixed (char* pChars = &chars[0])
+                fixed (byte* pBytes = &bytes[0])
 
                     // Remember that charCount is # to decode, not size of array.
                     return GetBytes(pChars + charIndex, charCount,
@@ -188,9 +188,9 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call the pointer version (can't do this for non-msft encoders)
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             {
-                fixed (byte* pBytes = bytes)
+                fixed (byte* pBytes = &bytes[0])
                 {
                     Convert(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, flush,
                         out charsUsed, out bytesUsed, out completed);

--- a/src/System.Private.CoreLib/src/System/Text/EncodingForwarder.cs
+++ b/src/System.Private.CoreLib/src/System/Text/EncodingForwarder.cs
@@ -129,7 +129,7 @@ namespace System.Text
             if (bytes.Length == 0)
                 bytes = new byte[1];
 
-            fixed (char* pChars = s) fixed (byte* pBytes = bytes)
+            fixed (char* pChars = s) fixed (byte* pBytes = &bytes[0])
             {
                 return encoding.GetBytes(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, encoder: null);
             }
@@ -169,7 +169,7 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call the (internal) pointer version
-            fixed (char* pChars = chars) fixed (byte* pBytes = bytes)
+            fixed (char* pChars = chars) fixed (byte* pBytes = &bytes[0])
             {
                 return encoding.GetBytes(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, encoder: null);
             }
@@ -265,7 +265,7 @@ namespace System.Text
             if (chars.Length == 0)
                 chars = new char[1];
 
-            fixed (byte* pBytes = bytes) fixed (char* pChars = chars)
+            fixed (byte* pBytes = bytes) fixed (char* pChars = &chars[0])
             {
                 return encoding.GetChars(pBytes + byteIndex, byteCount, pChars + charIndex, charCount, decoder: null);
             }

--- a/src/System.Private.Interop/src/Interop/Interop.Localization.Windows.cs
+++ b/src/System.Private.Interop/src/Interop/Interop.Localization.Windows.cs
@@ -14,6 +14,7 @@
 // always manually marshal the arguments
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -90,10 +91,11 @@ namespace System.Runtime.InteropServices
         /// <returns>Return false IFF when buffer space isnt enough</returns>
         private static unsafe bool TryGetMessage(int errorCode, int bufferSize, out string errorMsg)
         {
+            Debug.Assert(bufferSize > 0);
             errorMsg = null;
             char[] buffer = new char[bufferSize];
             int result;
-            fixed (char* pinned_lpBuffer = buffer)
+            fixed (char* pinned_lpBuffer = &buffer[0])
             {
                 result = ExternalInterop.FormatMessage(
                     FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM |

--- a/src/System.Private.Interop/src/Shared/McgMarshal.cs
+++ b/src/System.Private.Interop/src/Shared/McgMarshal.cs
@@ -249,7 +249,7 @@ namespace System.Runtime.InteropServices
             if (lenUnicode > 0)
             {
                 char[] buffer = new char[lenUnicode];
-                fixed (char* pTemp = buffer)
+                fixed (char* pTemp = &buffer[0])
                 {
                     ExternalInterop.ConvertMultiByteToWideChar(new System.IntPtr(newBuffer),
                                                                lenAnsi,
@@ -446,12 +446,9 @@ namespace System.Runtime.InteropServices
         /// <param name="nativeValue">Single ANSI byte value.</param>
         public static unsafe char AnsiCharToWideChar(byte nativeValue)
         {
-            char[] buffer = new char[1];
-            fixed (char* pTemp = buffer)
-            {
-                ExternalInterop.ConvertMultiByteToWideChar(new System.IntPtr(&nativeValue), 1, new System.IntPtr(pTemp), 1);
-                return buffer[0];
-            }
+            char ch;
+            ExternalInterop.ConvertMultiByteToWideChar(new System.IntPtr(&nativeValue), 1, new System.IntPtr(&ch), 1);
+            return ch;
         }
 
         /// <summary>

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
@@ -705,7 +705,7 @@ namespace System.Runtime.InteropServices
             }
 
             char[] wideChars = new char[charsRequired + 1];
-            fixed (char* pWideChars = wideChars)
+            fixed (char* pWideChars = &wideChars[0])
             {
                 int converted = ExternalInterop.ConvertMultiByteToWideChar(sourceBuffer,
                                                                     cbSourceBuffer,

--- a/src/System.Private.StackTraceGenerator/src/Internal/StackTraceGenerator/StackTraceGenerator.Windows.cs
+++ b/src/System.Private.StackTraceGenerator/src/Internal/StackTraceGenerator/StackTraceGenerator.Windows.cs
@@ -82,9 +82,9 @@ namespace Internal.StackTraceGenerator
                 {
                     byte[] _clsid = clsId.ToByteArray();
                     byte[] _iid = iid.ToByteArray();
-                    fixed (byte* pclsid = _clsid)
+                    fixed (byte* pclsid = &_clsid[0])
                     {
-                        fixed (byte* piid = _iid)
+                        fixed (byte* piid = &_iid[0])
                         {
                             IntPtr _dataSource;
                             hr = CoCreateInstance(pclsid, (IntPtr)0, CLSCTX_INPROC, piid, out _dataSource);


### PR DESCRIPTION
When we know an array is not null or empty at the point where `fixed` is used, we can reduce the number of branches (and IL size of the method body) by using the address of the first element.

Based on the discussion here: https://github.com/dotnet/corefx/pull/15432#discussion_r97684916

Related:

 - https://github.com/dotnet/coreclr/pull/9115
 - https://github.com/dotnet/coreclr/pull/9188
 - https://github.com/dotnet/corefx/pull/15597