### PR TITLE
Enable serialization for MemberInfo objects.

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2152,4 +2152,16 @@
   <data name="Argument_InvalidUnity" xml:space="preserve">
     <value>Invalid Unity type.</value>
   </data>
+  <data name="Serialization_InsufficientState" xml:space="preserve">
+    <value>Insufficient state to return the real object.</value>
+  </data>
+  <data name="Serialization_UnknownMember" xml:space="preserve">
+    <value>Cannot get the member '{0}'.</value>
+  </data>
+  <data name="Serialization_NullSignature" xml:space="preserve">
+    <value>The method signature cannot be null.</value>
+  </data>
+  <data name="Serialization_MemberTypeNotRecognized" xml:space="preserve">
+    <value>Unknown member type.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -176,6 +176,8 @@
     <Compile Include="System\Reflection\ManifestResourceInfo.cs" />
     <Compile Include="System\Reflection\MemberFilter.cs" />
     <Compile Include="System\Reflection\MemberInfo.cs" />
+    <Compile Include="System\Reflection\MemberInfoSerializationHolder.cs" />
+    <Compile Include="System\Reflection\MemberSerializationStringGenerator.cs" />
     <Compile Include="System\Reflection\MemberTypes.cs" />
     <Compile Include="System\Reflection\MethodAttributes.cs" />
     <Compile Include="System\Reflection\MethodBase.cs" />

--- a/src/System.Private.CoreLib/src/System/Reflection/MemberSerializationStringGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MemberSerializationStringGenerator.cs
@@ -1,0 +1,250 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+namespace System
+{
+    internal static class MemberSerializationStringGenerator
+    {
+        //
+        // Generate the "Signature2" binary serialization string for PropertyInfos
+        //
+        // Because the string is effectively a file format for serialized Reflection objects, it must be exactly correct. If missing
+        // metadata prevents generating the string, this method throws a MissingMetadata exception.
+        // 
+        public static string SerializationToString(this PropertyInfo property)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendSerializationString(property.PropertyType);
+            sb.Append(' ');
+            sb.Append(property.Name);
+            ParameterInfo[] parameters = property.GetIndexParameters();
+            if (parameters.Length != 0)
+            {
+                sb.Append(" [");
+                sb.AppendParameters(parameters, isVarArg: false);
+                sb.Append(']');
+            }
+            return sb.ToString();
+        }
+
+        //
+        // Generate the "Signature2" binary serialization string for ConstructorInfos
+        //
+        // Because the string is effectively a file format for serialized Reflection objects, it must be exactly correct. If missing
+        // metadata prevents generating the string, this method throws a MissingMetadata exception.
+        // 
+        public static string SerializationToString(this ConstructorInfo constructor)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(constructor.Name);
+            sb.Append('(');
+            sb.AppendParameters(constructor.GetParametersNoCopy(), constructor.CallingConvention == CallingConventions.VarArgs);
+            sb.Append(')');
+            return sb.ToString();
+        }
+
+        //
+        // Generate the "Signature2" binary serialization string for MethodInfos
+        //
+        // Because the string is effectively a file format for serialized Reflection objects, it must be exactly correct. If missing
+        // metadata prevents generating the string, this method throws a MissingMetadata exception.
+        // 
+        public static string SerializationToString(this MethodInfo method)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendSerializationString(method.ReturnType);
+            sb.Append(' ');
+            sb.Append(method.Name);
+            if (method.IsGenericMethod)
+            {
+                // Method is a generic method definition or a constructed generic method. Either way, the emit the generic parameters or arguments in brackets.
+                sb.AppendGenericTypeArguments(method.GetGenericArguments());
+            }
+            sb.Append('(');
+            sb.AppendParameters(method.GetParametersNoCopy(), method.CallingConvention == CallingConventions.VarArgs);
+            sb.Append(')');
+            return sb.ToString();
+        }
+
+        //
+        // Generated the Signature2 substring for the parameters of a method, constructor or property.
+        //
+        private static void AppendParameters(this StringBuilder sb, ParameterInfo[] parameters, bool isVarArg)
+        {
+            string comma = string.Empty;
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                sb.Append(comma);
+                sb.AppendSerializationString(parameters[i].ParameterType, withinGenericTypeArgument: false);
+                comma = ", ";
+            }
+
+            if (isVarArg)
+            {
+                sb.Append(comma);
+                sb.Append("...");
+            }
+        }
+
+        //
+        // Generate the "Signature2" binary serialization string for Type objects appearing inside serialized MethodBase and PropertyInfo signatures.
+        //
+        // Because the string is effectively a file format for serialized Reflection objects, it must be exactly correct. If missing
+        // metadata prevents generating the string, this method throws a MissingMetadata exception.
+        //
+        // "withinGenericArgument" is used to track whether we're in the middle of serializing a generic type argument.
+        // Some of the string-generation rules change when in that state:
+        //
+        //    - Generic type parameters no longer get prepended with "!" or "!!".
+        //    - Plain old types are serialized as assembly-qualified names enclosed in square brackets.
+        //
+        private static void AppendSerializationString(this StringBuilder sb, Type type, bool withinGenericTypeArgument = false)
+        {
+            if (type.HasElementType)
+            {
+                sb.AppendSerializationString(type.GetElementType(), withinGenericTypeArgument);
+                if (type.IsSzArray)
+                {
+                    sb.Append("[]");
+                }
+                else if (type.IsArray)
+                {
+                    int rank = type.GetArrayRank();
+                    if (rank == 1)
+                    {
+                        sb.Append('*');
+                    }
+                    else
+                    {
+                        sb.Append('[');
+                        sb.Append(',', rank - 1);
+                        sb.Append(']');
+                    }
+                }
+                else if (type.IsByRef)
+                {
+                    sb.Append('&');
+                }
+                else if (type.IsPointer)
+                {
+                    sb.Append('*');
+                }
+                else
+                {
+                    Debug.Fail("Should not get here.");
+                    throw new InvalidOperationException(); //Unexpected error: Runtime Reflection is a trusted source so we should not have gotten here.
+                }
+            }
+            else if (type.IsGenericParameter)
+            {
+                if (!withinGenericTypeArgument)
+                {
+                    // This special rule causes generic type variables ("T") to serialize as "!T" (variable on type) or "!!T" (variable on method)
+                    // to distinguish them from a plain old type named "T".
+                    //
+                    // This rule does not kick in if we're serializing a type variable embedded inside a generic type argument list. (Fortunately, there 
+                    // is no risk of ambiguity in that case because generic type argument lists always serialize plain old types as "[<assembly-qualified-name>]".) 
+                    sb.Append('!');
+                    if (type.DeclaringMethod != null)
+                    {
+                        sb.Append('!');
+                    }
+                }
+                sb.Append(type.Name);
+            }
+            else
+            {
+                // If we got here, "type" is either a plain old type or a constructed generic type.
+
+                if (withinGenericTypeArgument)
+                {
+                    sb.Append('[');
+                }
+
+                Type plainOldType;
+                Type[] instantiation;
+                SplitIntoPlainOldTypeAndInstantiation(type, out plainOldType, out instantiation);
+                sb.Append(plainOldType.FullName);
+                if (instantiation != null)
+                {
+                    sb.AppendGenericTypeArguments(instantiation);
+                }
+                if (withinGenericTypeArgument)
+                {
+                    sb.Append(", ");
+                    sb.Append(plainOldType.Assembly.FullName);
+                    sb.Append(']');
+                }
+            }
+        }
+
+        private static void AppendGenericTypeArguments(this StringBuilder sb, Type[] genericTypeArguments)
+        {
+            sb.Append('[');
+            for (int i = 0; i < genericTypeArguments.Length; i++)
+            {
+                if (i != 0)
+                {
+                    sb.Append(',');
+                }
+                sb.AppendSerializationString(genericTypeArguments[i], withinGenericTypeArgument: true);
+            }
+            sb.Append(']');
+        }
+
+        /// <summary>
+        /// Sets "instatiation" to null if there are no generic type arguments to serialize. Do a full framework quirk, this is not equivalent
+        /// to testing Type.IsConstructedGenericType.
+        /// </summary>
+        private static void SplitIntoPlainOldTypeAndInstantiation(Type type, out Type plainOldType, out Type[] instantiation)
+        {
+            if (!type.IsConstructedGenericType)
+            {
+                plainOldType = type;
+                instantiation = null;
+                return;
+            }
+
+            plainOldType = type.GetGenericTypeDefinition();
+            instantiation = type.GenericTypeArguments;
+
+            // Check for a special case for compatibility: if the generic type arguments are exactly the generic type parameters, serialize it
+            // as if the type was simply the generic type definition itself.
+
+            // First, a quick pass to eliminate the common case before we incur an allocation (via GenericTypeParameters.)
+            foreach (Type genericTypeArgument in instantiation)
+            {
+                if (!genericTypeArgument.IsGenericParameter)
+                    return;
+            }
+
+            Type[] genericTypeParameters = plainOldType.GetTypeInfo().GenericTypeParameters;
+            Debug.Assert(genericTypeParameters.Length == instantiation.Length); // This invariant is guaranteed by Reflection.
+
+            for (int i = 0; i < instantiation.Length; i++)
+            {
+                if (!(instantiation[i].Equals(genericTypeParameters[i])))
+                    return;
+            }
+
+            // If we got here, we hit the special case. Just serialize it as a plain old (generic) type. Never mind that such a thing cannot legally appear
+            // in a method signature - this is an artifact of how the desktop represents these things.
+            instantiation = null;
+        }
+
+        // @todo: https://github.com/dotnet/corert/issues/2674
+        // For some reason, ILC fails in building the shared library if MemberInfoSerializationHolder calls MakeGenericMethod() directory.
+        // This is our workaround.
+        public static MethodInfo MakeGenericMethodInternal(this MethodInfo method, Type[] genericTypeArguments)
+        {
+            return method.MakeGenericMethod(genericTypeArguments);
+        }
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -6,6 +6,7 @@ using System;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
@@ -20,8 +21,9 @@ namespace System.Reflection.Runtime.EventInfos
     //
     // The runtime's implementation of EventInfo's
     //
+    [Serializable]
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimeEventInfo : EventInfo, ITraceableTypeMember
+    internal abstract partial class RuntimeEventInfo : EventInfo, ISerializable, ITraceableTypeMember
     {
         protected RuntimeEventInfo(RuntimeTypeInfo contextTypeInfo, RuntimeTypeInfo reflectedType)
         {
@@ -62,6 +64,13 @@ namespace System.Reflection.Runtime.EventInfos
 
                 return ContextTypeInfo;
             }
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+            MemberInfoSerializationHolder.GetSerializationInfo(info, this);
         }
 
         public sealed override Module Module

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 
 using System.Reflection.Runtime.General;
@@ -24,8 +25,9 @@ namespace System.Reflection.Runtime.FieldInfos
     //
     // The Runtime's implementation of fields.
     //
+    [Serializable]
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimeFieldInfo : FieldInfo, ITraceableTypeMember
+    internal abstract partial class RuntimeFieldInfo : FieldInfo, ISerializable, ITraceableTypeMember
     {
         //
         // contextType    - the type that supplies the type context (i.e. substitutions for generic parameters.) Though you
@@ -69,6 +71,13 @@ namespace System.Reflection.Runtime.FieldInfos
             {
                 return this.FieldRuntimeType;
             }
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+            MemberInfoSerializationHolder.GetSerializationInfo(info, this);
         }
 
         public sealed override Object GetValue(Object obj)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
 using System.Reflection.Runtime.ParameterInfos;
@@ -20,7 +21,8 @@ namespace System.Reflection.Runtime.MethodInfos
     //
     // The runtime's implementation of ConstructorInfo.
     //
-    internal abstract partial class RuntimeConstructorInfo : ConstructorInfo
+    [Serializable]
+    internal abstract partial class RuntimeConstructorInfo : ConstructorInfo, ISerializable
     {
         public abstract override MethodAttributes Attributes { get; }
 
@@ -42,6 +44,13 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             // Constructors cannot be generic. Desktop compat dictates that We throw NotSupported rather than returning a 0-length array.
             throw new NotSupportedException();
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+            MemberInfoSerializationHolder.GetSerializationInfo(info, this);
         }
 
         public sealed override ParameterInfo[] GetParameters()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
@@ -22,7 +23,7 @@ namespace System.Reflection.Runtime.MethodInfos
     // Abstract base class for RuntimeNamedMethodInfo, RuntimeConstructedGenericMethodInfo.
     //
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimeMethodInfo : MethodInfo, ITraceableTypeMember
+    internal abstract partial class RuntimeMethodInfo : MethodInfo, ISerializable, ITraceableTypeMember
     {
         protected RuntimeMethodInfo()
         {
@@ -140,6 +141,13 @@ namespace System.Reflection.Runtime.MethodInfos
         }
 
         public abstract override MethodInfo GetGenericMethodDefinition();
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+            MemberInfoSerializationHolder.GetSerializationInfo(info, this);
+        }
 
         public sealed override ParameterInfo[] GetParameters()
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
@@ -27,7 +28,7 @@ namespace System.Reflection.Runtime.PropertyInfos
     // The runtime's implementation of PropertyInfo's
     //
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimePropertyInfo : PropertyInfo, ITraceableTypeMember
+    internal abstract partial class RuntimePropertyInfo : PropertyInfo, ISerializable, ITraceableTypeMember
     {
         //
         // propertyHandle - the "tkPropertyDef" that identifies the property.
@@ -118,6 +119,13 @@ namespace System.Reflection.Runtime.PropertyInfos
                 result[i] = indexParameters[i];
             }
             return result;
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+            MemberInfoSerializationHolder.GetSerializationInfo(info, this);
         }
 
         public sealed override MethodInfo GetMethod


### PR DESCRIPTION
* MemberInfoSerializationHolder.cs is the CoreClr code
  with the minimal number of tweaks needed to make it
  work in N:

  - Some members made public so they can be whitelisted
    and/or accessed from Reflection.Core.

  - Gratuitous references to CoreClr-specific
    RuntimeType/RuntimeAssembly classes replaced by public api
    calls.

  - Remove Environment.GetResourceString() as usual.

  - Replace FormatterServices.LoadAssemblyFromString()
    with Assembly.Load() (which is all that the aforementioned
    routine was doing anyway.)

  - and one discretionary change: Move the GetObjectData()
    bodies into this file so that knowledge about
    the serialization format is self-contained in this
    one file and not spread around the Reflection codebase.

  (other possible changes like de-Hungarianizing the field
  names and getting rid of the annoying #region directives,
  I'll leave to whoever's reconciling corelib/corert.)

* MemberSerializatinoStringGenerator.cs implements the
  SerializationToString() extension methods that
  generate the Signature2 string (In CoreClr, these
  are private instance methods on the Runtime*Info
  classes themselves, but these cannot be directly
  reused as they wind in and out of FCalls as well
  as the ToString() implementation in a way that would
  be very unnatural for CoreRt.)

  This refactoring keeps Serialization decoupled from
  Reflection.