### PR TITLE
[Arm Unix build] Fixes for cross building corert tests for arm architectures on Linux

### DIFF
--- a/buildscripts/build-managed.sh
+++ b/buildscripts/build-managed.sh
@@ -31,7 +31,13 @@ build_managed_corert()
         ToolchainMilestone=testing
     fi
 
-    $__ProjectRoot/Tools/msbuild.sh "$__buildproj" /m /nologo /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__buildlog" /t:Build /p:RepoPath=$__ProjectRoot /p:RepoLocalBuild="true" /p:RelativeProductBinDir=$__RelativeProductBinDir /p:CleanedTheBuild=$__CleanBuild /p:NuPkgRid=$__NugetRuntimeId /p:TestNugetRuntimeId=$__NugetRuntimeId /p:OSGroup=$__BuildOS /p:Configuration=$__BuildType /p:Platform=$__BuildArch /p:COMPUTERNAME=$(hostname) /p:USERNAME=$(id -un) /p:ToolchainMilestone=${ToolchainMilestone} $__UnprocessedBuildArgs $__ExtraMsBuildArgs
+    __buildarch="$__BuildArch"
+    if [ "$__buildarch" = "armel" ]; then
+        __buildarch=arm
+        __ExtraMsBuildArgs="$__ExtraMsBuildArgs /p:BinDirPlatform=armel"
+    fi
+
+    $__ProjectRoot/Tools/msbuild.sh "$__buildproj" /m /nologo /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__buildlog" /t:Build /p:RepoPath=$__ProjectRoot /p:RepoLocalBuild="true" /p:RelativeProductBinDir=$__RelativeProductBinDir /p:CleanedTheBuild=$__CleanBuild /p:NuPkgRid=$__NugetRuntimeId /p:TestNugetRuntimeId=$__NugetRuntimeId /p:OSGroup=$__BuildOS /p:Configuration=$__BuildType /p:Platform=$__buildarch /p:COMPUTERNAME=$(hostname) /p:USERNAME=$(id -un) /p:ToolchainMilestone=${ToolchainMilestone} $__UnprocessedBuildArgs $__ExtraMsBuildArgs
     export BUILDERRORLEVEL=$?
 
     echo

--- a/buildscripts/build-tests.sh
+++ b/buildscripts/build-tests.sh
@@ -7,7 +7,7 @@ if [ "$BUILDVARS_DONE" != 1 ]; then
 fi
 
 pushd ${__ProjectRoot}/tests
-source ${__ProjectRoot}/tests/runtest.sh $__BuildOS $__BuildArch $__BuildType -dotnetclipath $__dotnetclipath
+source ${__ProjectRoot}/tests/runtest.sh $__BuildOS $__BuildArch $__BuildType -cross $__CrossBuild -dotnetclipath $__dotnetclipath
 TESTERRORLEVEL=$?
 popd
 if [ $TESTERRORLEVEL != 0 ]; then

--- a/src/Native/Runtime/arm/AllocFast.S
+++ b/src/Native/Runtime/arm/AllocFast.S
@@ -4,4 +4,87 @@
 
 #include <unixasmmacros.inc>
 
+.syntax unified
+.thumb
+
 // TODO: Implement Arm support
+
+// Allocate non-array, non-finalizable object. If the allocation doesn't fit into the current thread's
+// allocation context then automatically fallback to the slow allocation path.
+//  r0 == EEType
+    LEAF_ENTRY RhpNewFast, _TEXT
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    LEAF_END RhpNewFast, _TEXT
+
+// Allocate non-array object with finalizer.
+//  r0 == EEType
+    LEAF_ENTRY RhpNewFinalizable, _TEXT
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    LEAF_END RhpNewFinalizable, _TEXT
+
+// Allocate non-array object.
+//  r0 == EEType
+//  r1 == alloc flags
+    NESTED_ENTRY RhpNewObject, _TEXT, NoHandler
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    NESTED_END RhpNewObject, _TEXT
+
+// Allocate one dimensional, zero based array (SZARRAY).
+//  r0 == EEType
+//  r1 == element count
+    LEAF_ENTRY RhpNewArray, _TEXT
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    LEAF_END RhpNewArray, _TEXT
+
+// Allocate one dimensional, zero based array (SZARRAY) using the slow path that calls a runtime helper.
+//  r0 == EEType
+//  r1 == element count
+//  r2 == array size + Thread::m_alloc_context::alloc_ptr
+//  r3 == Thread
+    NESTED_ENTRY RhpNewArrayRare, _TEXT, NoHandler
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    NESTED_END RhpNewArrayRare, _TEXT
+
+// Allocate simple object (not finalizable, array or value type) on an 8 byte boundary.
+//  r0 == EEType
+    LEAF_ENTRY RhpNewFastAlign8, _TEXT
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    LEAF_END RhpNewFastAlign8, _TEXT
+
+// Allocate a finalizable object (by definition not an array or value type) on an 8 byte boundary.
+//  r0 == EEType
+    LEAF_ENTRY RhpNewFinalizableAlign8, _TEXT
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    LEAF_END RhpNewFinalizableAlign8, _TEXT
+
+// Allocate a value type object (i.e. box it) on an 8 byte boundary + 4 (so that the value type payload
+// itself is 8 byte aligned).
+//  r0 == EEType
+    LEAF_ENTRY RhpNewFastMisalign, _TEXT
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    LEAF_END RhpNewFastMisalign, _TEXT
+
+// Allocate an array on an 8 byte boundary.
+//  r0 == EEType
+//  r1 == element count
+    NESTED_ENTRY RhpNewArrayAlign8, _TEXT, NoHandler
+#ifdef _DEBUG
+        bl C_FUNC(NYI_Assert)
+#endif
+    NESTED_END RhpNewArrayAlign8, _TEXT

--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -171,6 +171,36 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArray, (EEType * pArrayEEType, int numElement
     return pObject;
 }
 
+#ifdef _ARM_
+COOP_PINVOKE_HELPER(Object *, RhpNewFinalizableAlign8, (EEType* pEEType))
+{
+    Object * pObject = nullptr;
+    /* TODO */ ASSERT_UNCONDITIONALLY("NYI");
+    return pObject;
+}
+
+COOP_PINVOKE_HELPER(Object *, RhpNewFastMisalign, (EEType* pEEType))
+{
+    Object * pObject = nullptr;
+    /* TODO */ ASSERT_UNCONDITIONALLY("NYI");
+    return pObject;
+}
+
+COOP_PINVOKE_HELPER(Object *, RhpNewFastAlign8, (EEType* pEEType))
+{
+    Object * pObject = nullptr;
+    /* TODO */ ASSERT_UNCONDITIONALLY("NYI");
+    return pObject;
+}
+
+COOP_PINVOKE_HELPER(Array *, RhpNewArrayAlign8, (EEType * pArrayEEType, int numElements))
+{
+    Array * pObject = nullptr;
+    /* TODO */ ASSERT_UNCONDITIONALLY("NYI");
+    return pObject;
+}
+#endif
+
 //
 // PInvoke
 //

--- a/src/Native/Runtime/rhassert.cpp
+++ b/src/Native/Runtime/rhassert.cpp
@@ -95,4 +95,8 @@ void Assert(const char * expr, const char * file, UInt32 line_num, const char * 
 #endif //!DACCESS_COMPILE
 }
 
+void NYI_Assert()
+{
+    ASSERT_UNCONDITIONALLY("NYI");
+}
 #endif // _DEBUG

--- a/src/Native/Runtime/rhassert.h
+++ b/src/Native/Runtime/rhassert.h
@@ -26,6 +26,8 @@
 
 void Assert(const char * expr, const char * file, unsigned int line_num, const char * message);
 
+void NYI_Assert();
+
 #else
 
 #define ASSERT(expr)

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -207,9 +207,9 @@ goto :eof
         )
     )
 
-    echo msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
+    echo msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:Platform=%CoreRT_BuildArch%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
     echo.
-    msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
+    msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:Platform=%CoreRT_BuildArch%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
     endlocal
 
     set __SavedErrorLevel=%ErrorLevel%
@@ -218,7 +218,7 @@ goto :eof
     if "%__SavedErrorLevel%"=="0" (
         echo.
         echo Running test !__SourceFileName!
-        call !__SourceFile!.cmd !__SourceFolder!\bin\%CoreRT_BuildType%\native !__SourceFileName!.exe
+        call !__SourceFile!.cmd !__SourceFolder!\bin\%CoreRT_BuildType%\%CoreRT_BuildArch%\native !__SourceFileName!.exe
         set __SavedErrorLevel=!ErrorLevel!
     )
 

--- a/tests/src/Simple/PInvoke/PInvoke.csproj
+++ b/tests/src/Simple/PInvoke/PInvoke.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\native\</IntermediateOutputPath>
+    <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(Platform)\native\</IntermediateOutputPath>
     <OutputName>PInvokeNative</OutputName>
     <NativeObjectExt Condition="'$(OS)' == 'Windows_NT'">.obj</NativeObjectExt>
     <NativeObjectExt Condition="'$(OS)' != 'Windows_NT'">.o</NativeObjectExt>

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -3,8 +3,8 @@
 
   <PropertyGroup>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
-    <OutputPath>$(MSBuildProjectDirectory)\bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\</IntermediateOutputPath>
+    <OutputPath>$(MSBuildProjectDirectory)\bin\$(Configuration)\$(Platform)\</OutputPath>
+    <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,4 +35,9 @@
 
   <!-- Use the source primary copy for development convenience -->
   <Import Project="$(MSBuildThisFileDirectory)\..\..\Test.Common.targets" />
+
+  <ItemGroup>
+    <CustomLinkerArg Include="$(AdditionalLinkerFlags)" />
+  </ItemGroup>
+
 </Project>

--- a/tests/testenv.sh
+++ b/tests/testenv.sh
@@ -23,6 +23,9 @@ for i in "$@"
 		arm)
 			CoreRT_BuildArch=arm
 			;;
+		armel)
+			CoreRT_BuildArch=armel
+			;;
 		arm64)
 			CoreRT_BuildArch=arm64
 			;;


### PR DESCRIPTION
This pull request contains fixes  for the cross building corert tests for arm architectures (arm&armel) on Ubuntu 16.04 x64.

Unfortunately, there are two problems just now:

1. The following error arises during building jit-variants of tests 
```
       IlcCompile:
         Creating directory ".../corert/tests/src/Simple/Delegates/obj/Debug/armel/native/".
         ".../corert/tests/../bin/Product/Linux.armel.Debug/packaging/publish1/corerun" ".../corert/tests/../bin/Product/Linux.armel.Debug/packaging/publish1/ilc.dll" @".../corert/tests/src/Simple/Delegates/obj/Debug/armel/native/Delegates.ilc.rsp"
         
         Unhandled Exception: System.DllNotFoundException: Unable to load DLL 'jitinterface': The specified module could not be found.
          (Exception from HRESULT: 0x8007007E)
            at Internal.JitInterface.CorInfoImpl.GetJitHost(IntPtr configProvider)
            at Internal.JitInterface.CorInfoImpl..ctor(Compilation compilation, JitConfigProvider jitConfig)
            at ILCompiler.RyuJitCompilation.CompileInternal(String outputFile)
            at ILCompiler.Compilation.ILCompiler.ICompilation.Compile(String outputFile)
            at ILCompiler.Program.Run(String[] args)
            at ILCompiler.Program.Main(String[] args)
         Aborted (core dumped)
```
x64 native variant doesn't create this fail.

2. I don't know yet how to pass archtecture-specific c++ compiler options for building cpp-variant of tests

any help will be accepted with gratitude