### PR TITLE
NS2.0: ToString() methods

### DIFF
--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -674,6 +674,7 @@
     <Compile Include="System\TupleExtensions.cs" />
     <Compile Include="System\Type.cs" />
     <Compile Include="System\Type.Helpers.cs" />
+    <Compile Include="System\Type.Internal.cs" />
     <Compile Include="System\TypeUnificationKey.cs" />
     <Compile Include="System\TypeAccessException.cs" />
     <Compile Include="System\TypeCode.cs" />

--- a/src/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
@@ -54,7 +54,7 @@ namespace System.Reflection
 
         public object GetRealObject(StreamingContext context) { throw new NotImplementedException(); }
 
-        public override string ToString() { throw new NotImplementedException(); }
+        public override string ToString() => ParameterType.FormatTypeName() + " " + Name;
 
         protected ParameterAttributes AttrsImpl;
         protected Type ClassImpl;

--- a/src/System.Private.CoreLib/src/System/Type.Internal.cs
+++ b/src/System.Private.CoreLib/src/System/Type.Internal.cs
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace System
+{
+    //
+    // This file contains methods on Type that are internal to the framework.
+    //
+    // Before adding new entries to this, ask yourself: is it ever referenced by System.Private.CoreLib? 
+    // If not, don't put it here. Put it on RuntimeTypeInfo instead.
+    //
+    // Some of these "internal" methods are declared "public" because both Reflection.Core and System.Private.CoreLib need to reference them.
+    //
+    public abstract partial class Type
+    {
+        /// <summary>
+        /// Return Type.Name if sufficient metadata is available to do so - otherwise return null.
+        /// </summary>
+        public string InternalNameIfAvailable
+        {
+            get
+            {
+                Type ignore = null;
+                return InternalGetNameIfAvailable(ref ignore);
+            }
+        }
+
+        /// <summary>
+        /// Return Type.Name if sufficient metadata is available to do so - otherwise return null and set "rootCauseForFailure" to an object to pass to MissingMetadataException.
+        /// </summary>
+        public virtual string InternalGetNameIfAvailable(ref Type rootCauseForFailure) => Name;
+
+        /// <summary>
+        /// Return Type.Name if sufficient metadata is available to do so - otherwise return a default (non-null) string.
+        /// </summary>
+        internal string NameOrDefault
+        {
+            get
+            {
+                string name = InternalNameIfAvailable;
+                return name != null ? name : DefaultTypeNameWhenMissingMetadata;
+            }
+        }
+
+        /// <summary>
+        /// Return Type.FullName if sufficient metadata is available to do so - otherwise return a default (non-null) string.
+        /// </summary>
+        internal string FullNameOrDefault
+        {
+            get
+            {
+                // First, see if Type.Name is available. If Type.Name is available, then we can be reasonably confident that it is safe to call Type.FullName.
+                // We'll still wrap the call in a try-catch as a failsafe.
+                if (InternalNameIfAvailable == null)
+                    return DefaultTypeNameWhenMissingMetadata;
+
+                try
+                {
+                    return FullName;
+                }
+                catch (MissingMetadataException)
+                {
+                    return DefaultTypeNameWhenMissingMetadata;
+                }
+            }
+        }
+
+        // 
+        // This is a port of the desktop CLR's RuntimeType.FormatTypeName() routine. This routine is used by various Reflection ToString() methods
+        // to display the name of a type. Do not use for any other purpose as it inherits some pretty quirky desktop behavior.
+        //
+        // The Project N version takes a raw metadata handle rather than a completed type so that it remains robust in the face of missing metadata.
+        //
+        public string FormatTypeName()
+        {
+            try
+            {
+                // Though we wrap this in a try-catch as a failsafe, this code must still strive to avoid triggering MissingMetadata exceptions
+                // (non-error exceptions are very annoying when debugging.)
+
+                // Legacy: this doesn't make sense, why use only Name for nested types but otherwise
+                // ToString() which contains namespace.
+                Type rootElementType = this;
+                while (rootElementType.HasElementType)
+                    rootElementType = rootElementType.GetElementType();
+                if (rootElementType.IsNested)
+                {
+                    string name = InternalNameIfAvailable;
+                    return name == null ? DefaultTypeNameWhenMissingMetadata : name;
+                }
+
+                // Legacy: why removing "System"? Is it just because C# has keywords for these types?
+                // If so why don't we change it to lower case to match the C# keyword casing?
+                string typeName = ToString();
+                if (typeName.StartsWith("System."))
+                {
+                    if (rootElementType.IsPrimitive || rootElementType.Equals(CommonRuntimeTypes.Void))
+                    {
+                        typeName = typeName.Substring("System.".Length);
+                    }
+                }
+                return typeName;
+            }
+            catch (Exception)
+            {
+                return DefaultTypeNameWhenMissingMetadata;
+            }
+        }
+
+        public const string DefaultTypeNameWhenMissingMetadata = "UnknownType";
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
@@ -62,7 +62,7 @@ namespace System.Reflection.Runtime.General
                 Exception exception = null;
                 RuntimeTypeInfo runtimeType = TryResolve(typeContext, ref exception);
                 if (runtimeType == null)
-                    return ToStringUtils.UnavailableType;
+                    return Type.DefaultTypeNameWhenMissingMetadata;
 
                 // Because this runtimeType came from a successful TryResolve() call, it is safe to querying the TypeInfo's of the type and its component parts.
                 // If we're wrong, we do have the safety net of a try-catch.
@@ -70,7 +70,7 @@ namespace System.Reflection.Runtime.General
             }
             catch (Exception)
             {
-                return ToStringUtils.UnavailableType;
+                return Type.DefaultTypeNameWhenMissingMetadata;
             }
         }        
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ToStringUtils.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ToStringUtils.cs
@@ -25,7 +25,7 @@ namespace System.Reflection.Runtime.General
                 Exception exception = null;
                 RuntimeTypeInfo runtimeType = qualifiedTypeHandle.TryResolve(typeContext, ref exception);
                 if (runtimeType == null)
-                    return UnavailableType;
+                    return Type.DefaultTypeNameWhenMissingMetadata;
 
                 // Because this runtimeType came from a successful TryResolve() call, it is safe to querying the TypeInfo's of the type and its component parts.
                 // If we're wrong, we do have the safety net of a try-catch.
@@ -33,56 +33,8 @@ namespace System.Reflection.Runtime.General
             }
             catch (Exception)
             {
-                return UnavailableType;
+                return Type.DefaultTypeNameWhenMissingMetadata;
             }
         }
-
-        // 
-        // This is a port of the desktop CLR's RuntimeType.FormatTypeName() routine. This routine is used by various Reflection ToString() methods
-        // to display the name of a type. Do not use for any other purpose as it inherits some pretty quirky desktop behavior.
-        //
-        // The Project N version takes a raw metadata handle rather than a completed type so that it remains robust in the face of missing metadata.
-        //
-        public static String FormatTypeName(this RuntimeTypeInfo runtimeType)
-        {
-            try
-            {
-                // Though we wrap this in a try-catch as a failsafe, this code must still strive to avoid triggering MissingMetadata exceptions
-                // (non-error exceptions are very annoying when debugging.)
-
-                // Legacy: this doesn't make sense, why use only Name for nested types but otherwise
-                // ToString() which contains namespace.
-                RuntimeTypeInfo rootElementType = runtimeType;
-                while (rootElementType.HasElementType)
-                    rootElementType = rootElementType.InternalRuntimeElementType;
-                if (rootElementType.IsNested)
-                {
-                    String name = runtimeType.InternalNameIfAvailable;
-                    return name == null ? UnavailableType : name;
-                }
-
-                // Legacy: why removing "System"? Is it just because C# has keywords for these types?
-                // If so why don't we change it to lower case to match the C# keyword casing?
-                String typeName = runtimeType.ToString();
-                if (typeName.StartsWith("System."))
-                {
-                    foreach (Type pt in ReflectionCoreExecution.ExecutionDomain.PrimitiveTypes)
-                    {
-                        if (pt.Equals(rootElementType) || rootElementType.Equals(CommonRuntimeTypes.Void))
-                        {
-                            typeName = typeName.Substring("System.".Length);
-                            break;
-                        }
-                    }
-                }
-                return typeName;
-            }
-            catch (Exception)
-            {
-                return UnavailableType;
-            }
-        }
-
-        public const String UnavailableType = "UnknownType";
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodHelpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodHelpers.cs
@@ -102,7 +102,7 @@ namespace System.Reflection.Runtime.MethodInfos
                     sep = ",";
                     String name = methodTypeArgument.InternalNameIfAvailable;
                     if (name == null)
-                        name = ToStringUtils.UnavailableType;
+                        name = Type.DefaultTypeNameWhenMissingMetadata;
                     sb.Append(methodTypeArgument.Name);
                 }
                 sb.Append(']');

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfo.cs
@@ -66,7 +66,7 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
 
         protected MetadataReader Reader { get; }
 
-        internal sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
+        public sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
         {
             if (_genericParameter.Name.IsNull(Reader))
                 return string.Empty;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -202,7 +202,7 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
             }
         }
 
-        internal sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
+        public sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
         {
             ConstantStringValueHandle nameHandle = _typeDefinition.Name;
             string name = nameHandle.GetString(_reader);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -182,7 +182,7 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        internal sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
+        public sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
         {
             return GeneratedName;
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -264,7 +264,7 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        internal sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
+        public sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
         {
             return GenericTypeDefinitionTypeInfo.InternalGetNameIfAvailable(ref rootCauseForFailure);
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
@@ -147,7 +147,7 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        internal sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
+        public sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
         {
             string elementTypeName = _key.ElementType.InternalGetNameIfAvailable(ref rootCauseForFailure);
             if (elementTypeName == null)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
@@ -158,7 +158,7 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        internal sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
+        public sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure)
         {
             rootCauseForFailure = this;
             return null;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -671,7 +671,7 @@ namespace System.Reflection.Runtime.TypeInfos
         //
         internal abstract string InternalFullNameOfAssembly { get; }
 
-        internal abstract string InternalGetNameIfAvailable(ref Type rootCauseForFailure);
+        public abstract override string InternalGetNameIfAvailable(ref Type rootCauseForFailure);
 
         // Left unsealed so that multidim arrays can override.
         internal virtual bool InternalIsMultiDimArray
@@ -679,15 +679,6 @@ namespace System.Reflection.Runtime.TypeInfos
             get
             {
                 return false;
-            }
-        }
-
-        internal string InternalNameIfAvailable
-        {
-            get
-            {
-                Type ignore = null;
-                return InternalGetNameIfAvailable(ref ignore);
             }
         }
 


### PR DESCRIPTION
For ParameterInfo, CustomAttributeTypedArgument,
CustomAttributeNamedArgument.

These mimic CoreClr's algorithms with the twist
of being aware that asking for someone's name
can throw a MissingMetadataException.