### PR TITLE
Enable serialization for miscellaneous Reflection types

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2173,4 +2173,10 @@
   <data name="Serialization_MemberTypeNotRecognized" xml:space="preserve">
     <value>Unknown member type.</value>
   </data>
+  <data name="Serialization_BadParameterInfo" xml:space="preserve">
+    <value>Non existent ParameterInfo. Position bigger than member's parameters length.</value>
+  </data>
+  <data name="Serialization_NoParameterInfo" xml:space="preserve">
+    <value>Serialized member does not have a ParameterInfo.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System/Reflection/Missing.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Missing.cs
@@ -6,11 +6,18 @@ using System.Runtime.Serialization;
 
 namespace System.Reflection
 {
+    [Serializable]
     public sealed class Missing : ISerializable
     {
         private Missing() { }
         public static readonly Missing Value = new Missing();
 
-        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { throw new NotImplementedException(); }
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+    
+            UnitySerializationHolder.GetUnitySerializationInfo(info, this);
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
@@ -52,7 +52,49 @@ namespace System.Reflection
 
         public virtual int MetadataToken => MetadataToken_ParamDef;
 
-        public object GetRealObject(StreamingContext context) { throw new NotImplementedException(); }
+        public object GetRealObject(StreamingContext context)
+        {
+            // Once all the serializable fields have come in we can set up the real
+            // instance based on just two of them (MemberImpl and PositionImpl).
+
+            if (MemberImpl == null)
+                throw new SerializationException(SR.Serialization_InsufficientState);
+
+            ParameterInfo[] args = null;
+
+            switch (MemberImpl.MemberType)
+            {
+                case MemberTypes.Constructor:
+                case MemberTypes.Method:
+                    if (PositionImpl == -1)
+                    {
+                        if (MemberImpl.MemberType == MemberTypes.Method)
+                            return ((MethodInfo)MemberImpl).ReturnParameter;
+                        else
+                            throw new SerializationException(SR.Serialization_BadParameterInfo);
+                    }
+                    else
+                    {
+                        args = ((MethodBase)MemberImpl).GetParametersNoCopy();
+
+                        if (args != null && PositionImpl < args.Length)
+                            return args[PositionImpl];
+                        else
+                            throw new SerializationException(SR.Serialization_BadParameterInfo);
+                    }
+
+                case MemberTypes.Property:
+                    args = ((PropertyInfo)MemberImpl).GetIndexParameters();
+
+                    if (args != null && PositionImpl > -1 && PositionImpl < args.Length)
+                        return args[PositionImpl];
+                    else
+                        throw new SerializationException(SR.Serialization_BadParameterInfo);
+
+                default:
+                    throw new SerializationException(SR.Serialization_NoParameterInfo);
+            }
+        }
 
         public override string ToString() => ParameterType.FormatTypeName() + " " + Name;
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Pointer.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Pointer.cs
@@ -20,6 +20,12 @@ namespace System.Reflection
             _ptrType = ptrType;
         }
 
+        private unsafe Pointer(SerializationInfo info, StreamingContext context)
+        {
+            _ptr = ((IntPtr)(info.GetValue("_ptr", typeof(IntPtr)))).ToPointer();
+            _ptrType = (Type)info.GetValue("_ptrType", typeof(Type));
+        }
+
         [CLSCompliant(false)]
         public static object Box(void* ptr, Type type)
         {
@@ -41,7 +47,11 @@ namespace System.Reflection
             return ((Pointer)ptr)._ptr;
         }
 
-        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) { throw new NotImplementedException(); }
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("_ptr", new IntPtr(_ptr));
+            info.AddValue("_ptrType", _ptrType);
+        }
 
         private readonly void* _ptr;
         private readonly Type _ptrType;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
@@ -6,13 +6,15 @@ using System;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {
     //
     // Abstract base for all ParameterInfo objects created by the Runtime.
     //
-    internal abstract partial class RuntimeParameterInfo : ParameterInfo
+    [Serializable]
+    internal abstract partial class RuntimeParameterInfo : ParameterInfo, ISerializable
     {
         protected RuntimeParameterInfo(MemberInfo member, int position)
         {
@@ -39,6 +41,20 @@ namespace System.Reflection.Runtime.ParameterInfos
         public sealed override int GetHashCode()
         {
             return _member.GetHashCode();
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+
+            // Setting the ObjectType to ParameterInfo is partly tradition (CLR has always done this) and mostly because RuntimeParameterInfo
+            // is not discoverable via Reflection.
+            info.SetType(typeof(ParameterInfo));
+
+            // Compat note: Choosing not to serialize legacy fields such as "AttrsImpl" and "NameImpl" as they've been ignored by deserialization since CLR 4.0.
+            info.AddValue("MemberImpl", Member);
+            info.AddValue("PositionImpl", Position);
         }
 
         public abstract override bool HasDefaultValue { get; }


### PR DESCRIPTION
- Missing

  Straight port.

- Pointer

  Straight port (including the lack of parameter validation
  on "info")

  (Serializing pointers? Really?)

- ParameterInfo:

  Compat note: On the full framework, ParameterInfo
  serialization dumps a bunch of extra stuff like names,
  and default values, but deserialization ignores
  everything but "MemberImpl" and "PositionImpl" since
  ... probably CLR2.0. 

  We could dump those extra fields here but it does not
  seem worth the bloat.

- AssemblyName:

  Deserialization is not testable yet because
  CultureInfo..ctor(int LCID) is still in a NotImplemented
  state.