### PR TITLE
Fix RelatedTypeViaIat computation

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -252,7 +252,7 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             TypeDesc relatedType = null;
-            if (_type.IsArray || _type.IsPointer)
+            if (_type.IsArray || _type.IsPointer || _type.IsByRef)
             {
                 relatedType = ((ParameterizedType)_type).ParameterType;
             }


### PR DESCRIPTION
This should match what we put in RelatedType: ByRefs have a related type
too. They probably didn't when this code was being added on the TFS
side.