### PR TITLE
NS2.0: Bring up GetCustomModifiers() api.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/NativeFormat/NativeFormatCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/NativeFormat/NativeFormatCustomAttributeData.cs
@@ -79,7 +79,7 @@ namespace System.Reflection.Runtime.CustomAttributes.NativeFormat
                     foreach (Handle _parameterHandle in parameters)
                     {
                         Handle parameterHandle = _parameterHandle;
-                        expectedParameterTypes[index++] = parameterHandle.WithoutCustomModifiers(reader).Resolve(reader, attributeType.TypeContext);
+                        expectedParameterTypes[index++] = parameterHandle.Resolve(reader, attributeType.TypeContext);
                     }
                     return ResolveAttributeConstructor(attributeType, expectedParameterTypes);
                 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/EcmaFormat/EcmaFormatRuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/EcmaFormat/EcmaFormatRuntimeFieldInfo.cs
@@ -150,6 +150,10 @@ namespace System.Reflection.Runtime.FieldInfos.EcmaFormat
             return _fieldHandle.GetHashCode();
         }
 
+        public sealed override Type[] GetOptionalCustomModifiers() { throw new NotImplementedException(); }
+
+        public sealed override Type[] GetRequiredCustomModifiers() { throw new NotImplementedException(); }
+
         protected sealed override bool TryGetDefaultValue(out object defaultValue)
         {
             return DefaultValueProcessing.GetDefaultValueIfAny(_reader, ref _field, this, out defaultValue);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
@@ -84,6 +84,10 @@ namespace System.Reflection.Runtime.FieldInfos.NativeFormat
             }
         }
 
+        public sealed override Type[] GetOptionalCustomModifiers() => FieldTypeHandle.GetCustomModifiers(_reader, optional: true);
+
+        public sealed override Type[] GetRequiredCustomModifiers() => FieldTypeHandle.GetCustomModifiers(_reader, optional: false);
+
         public sealed override int MetadataToken
         {
             get
@@ -148,12 +152,13 @@ namespace System.Reflection.Runtime.FieldInfos.NativeFormat
             get
             {
                 TypeContext typeContext = _contextTypeInfo.TypeContext;
-                Handle typeHandle = _field.Signature.GetFieldSignature(_reader).Type;
-                return typeHandle.Resolve(_reader, typeContext);
+                return FieldTypeHandle.Resolve(_reader, typeContext);
             }
         }
 
         protected sealed override RuntimeTypeInfo DefiningType { get { return _definingTypeInfo; } }
+
+        private Handle FieldTypeHandle => _field.Signature.GetFieldSignature(_reader).Type;
 
         private readonly NativeFormatRuntimeNamedTypeInfo _definingTypeInfo;
         private readonly FieldHandle _fieldHandle;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -80,6 +80,10 @@ namespace System.Reflection.Runtime.FieldInfos
             MemberInfoSerializationHolder.GetSerializationInfo(info, this);
         }
 
+        public abstract override Type[] GetOptionalCustomModifiers();
+
+        public abstract override Type[] GetRequiredCustomModifiers();
+
         public sealed override Object GetValue(Object obj)
         {
 #if ENABLE_REFLECTION_TRACE

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -54,8 +54,6 @@ namespace System.Reflection.Runtime.FieldInfos
     internal abstract partial class RuntimeFieldInfo
     {
         public sealed override RuntimeFieldHandle FieldHandle { get { throw new NotImplementedException(); } }
-        public sealed override Type[] GetOptionalCustomModifiers() { throw new NotImplementedException(); }
-        public sealed override Type[] GetRequiredCustomModifiers() { throw new NotImplementedException(); }
     }
 }
 
@@ -89,8 +87,6 @@ namespace System.Reflection.Runtime.ParameterInfos
 {
     internal abstract partial class RuntimeParameterInfo
     {
-        public sealed override Type[] GetOptionalCustomModifiers() { throw new NotImplementedException(); }
-        public sealed override Type[] GetRequiredCustomModifiers() { throw new NotImplementedException(); }
     }
 }
 
@@ -98,8 +94,6 @@ namespace System.Reflection.Runtime.PropertyInfos
 {
     internal abstract partial class RuntimePropertyInfo
     {
-        public sealed override Type[] GetOptionalCustomModifiers() { throw new NotImplementedException(); }
-        public sealed override Type[] GetRequiredCustomModifiers() { throw new NotImplementedException(); }
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
@@ -47,7 +47,19 @@ namespace System.Reflection.Runtime.General
 
             throw new BadImageFormatException();  // Expected TypeRef, Def or Spec with MetadataReader
         }
-        
+
+        // Return any custom modifiers modifying the passed-in type and whose required/optional bit matches the passed in boolean.
+        // Because this is intended to service the GetCustomModifiers() apis, this helper will always return a freshly allocated array
+        // safe for returning to api callers.
+        internal Type[] GetCustomModifiers(bool optional)
+        {
+#if ECMA_METADATA_SUPPORT
+            throw new NotImplementedException();
+#else
+            return _handle.GetCustomModifiers((global::Internal.Metadata.NativeFormat.MetadataReader)Reader, optional);
+#endif
+        }
+
         // 
         // This is a port of the desktop CLR's RuntimeType.FormatTypeName() routine. This routine is used by various Reflection ToString() methods
         // to display the name of a type. Do not use for any other purpose as it inherits some pretty quirky desktop behavior.

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.NativeFormat.cs
@@ -23,7 +23,7 @@ namespace System.Reflection.Runtime.General
     internal static partial class TypeResolver
     {
         //
-        // Main routine to resolve a typeDef/Ref/Spec.
+        // Main routine to resolve a typeDef/Ref/Spec. Also accepts ModifiedTypes (will unwrap and ignore the custom modifiers.)
         //
         internal static RuntimeTypeInfo Resolve(this Handle typeDefRefOrSpec, MetadataReader reader, TypeContext typeContext)
         {
@@ -43,6 +43,11 @@ namespace System.Reflection.Runtime.General
                 return typeDefRefOrSpec.ToTypeReferenceHandle(reader).TryResolveTypeReference(reader, ref exception);
             else if (handleType == HandleType.TypeSpecification)
                 return typeDefRefOrSpec.ToTypeSpecificationHandle(reader).TryResolveTypeSignature(reader, typeContext, ref exception);
+            else if (handleType == HandleType.ModifiedType)
+            {
+                ModifiedType modifiedType = typeDefRefOrSpec.ToModifiedTypeHandle(reader).GetModifiedType(reader);
+                return modifiedType.Type.TryResolve(reader, typeContext, ref exception);
+            }
             else
                 throw new BadImageFormatException();  // Expected TypeRef, Def or Spec.
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
@@ -25,6 +25,10 @@ namespace System.Reflection.Runtime.ParameterInfos
             _typeContext = typeContext;
         }
 
+        public sealed override Type[] GetOptionalCustomModifiers() => QualifiedParameterTypeHandle.GetCustomModifiers(optional: true);
+
+        public sealed override Type[] GetRequiredCustomModifiers() => QualifiedParameterTypeHandle.GetCustomModifiers(optional: false);
+
         public sealed override Type ParameterType
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
@@ -57,6 +57,10 @@ namespace System.Reflection.Runtime.ParameterInfos
             info.AddValue("PositionImpl", Position);
         }
 
+        public abstract override Type[] GetOptionalCustomModifiers();
+
+        public abstract override Type[] GetRequiredCustomModifiers();
+
         public abstract override bool HasDefaultValue { get; }
 
         public abstract override int MetadataToken

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimePropertyIndexParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimePropertyIndexParameterInfo.cs
@@ -46,6 +46,17 @@ namespace System.Reflection.Runtime.ParameterInfos
             }
         }
 
+
+        public sealed override Type[] GetOptionalCustomModifiers()
+        {
+            return _backingParameter.GetOptionalCustomModifiers();
+        }
+
+        public sealed override Type[] GetRequiredCustomModifiers()
+        {
+            return _backingParameter.GetRequiredCustomModifiers();
+        }
+
         public sealed override bool HasDefaultValue
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeSyntheticParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeSyntheticParameterInfo.cs
@@ -57,6 +57,10 @@ namespace System.Reflection.Runtime.ParameterInfos
             }
         }
 
+        public sealed override Type[] GetOptionalCustomModifiers() => Array.Empty<Type>();
+
+        public sealed override Type[] GetRequiredCustomModifiers() => Array.Empty<Type>();
+
         public sealed override String Name
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -141,6 +141,10 @@ namespace System.Reflection.Runtime.PropertyInfos
             }
         }
 
+        public sealed override Type[] GetOptionalCustomModifiers() => PropertyTypeHandle.GetCustomModifiers(optional: true);
+
+        public sealed override Type[] GetRequiredCustomModifiers() => PropertyTypeHandle.GetCustomModifiers(optional: false);
+
         public sealed override object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
         {
 #if ENABLE_REFLECTION_TRACE


### PR DESCRIPTION
Also fixes a regression where retrieving
the field/property/parameter type throws
an exception if a custom modifier is present.