### PR TITLE
NS2.0 PNSE a bunch of apis.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -73,6 +73,11 @@ namespace System.Reflection.Runtime.EventInfos
             MemberInfoSerializationHolder.GetSerializationInfo(info, this);
         }
 
+        public sealed override MethodInfo[] GetOtherMethods(bool nonPublic)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public sealed override Module Module
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ApiToDoList.cs
@@ -16,35 +16,11 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
 
-namespace System.Reflection.Runtime.Assemblies
-{
-    internal partial class RuntimeAssembly
-    {
-        public sealed override object CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes) { throw new NotImplementedException(); }
-    }
-}
-
 namespace System.Reflection.Runtime.MethodInfos
 {
     internal abstract partial class RuntimeConstructorInfo
     {
-        public sealed override MethodBody GetMethodBody() { throw new NotImplementedException(); }
         public sealed override RuntimeMethodHandle MethodHandle { get { throw new NotImplementedException(); } }
-    }
-}
-
-namespace System.Reflection.Runtime.CustomAttributes
-{
-    internal abstract partial class RuntimeCustomAttributeData
-    {
-    }
-}
-
-namespace System.Reflection.Runtime.EventInfos
-{
-    internal abstract partial class RuntimeEventInfo
-    {
-        public sealed override MethodInfo[] GetOtherMethods(bool nonPublic) { throw new NotImplementedException(); }
     }
 }
 
@@ -60,45 +36,6 @@ namespace System.Reflection.Runtime.MethodInfos
 {
     internal abstract partial class RuntimeMethodInfo
     {
-        public sealed override MethodBody GetMethodBody() { throw new NotImplementedException(); }
         public sealed override RuntimeMethodHandle MethodHandle { get { throw new NotImplementedException(); } }
-    }
-}
-
-namespace System.Reflection.Runtime.Modules
-{
-    internal sealed partial class RuntimeModule
-    {
-        public sealed override FieldInfo GetField(string name, BindingFlags bindingAttr) { throw new NotImplementedException(); }
-        public sealed override FieldInfo[] GetFields(BindingFlags bindingFlags) { throw new NotImplementedException(); }
-        protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new NotImplementedException(); }
-        public sealed override MethodInfo[] GetMethods(BindingFlags bindingFlags) { throw new NotImplementedException(); }
-        public sealed override FieldInfo ResolveField(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new NotImplementedException(); }
-        public sealed override MemberInfo ResolveMember(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new NotImplementedException(); }
-        public sealed override MethodBase ResolveMethod(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new NotImplementedException(); }
-        public sealed override byte[] ResolveSignature(int metadataToken) { throw new NotImplementedException(); }
-        public sealed override string ResolveString(int metadataToken) { throw new NotImplementedException(); }
-        public sealed override Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new NotImplementedException(); }
-    }
-}
-
-namespace System.Reflection.Runtime.ParameterInfos
-{
-    internal abstract partial class RuntimeParameterInfo
-    {
-    }
-}
-
-namespace System.Reflection.Runtime.PropertyInfos
-{
-    internal abstract partial class RuntimePropertyInfo
-    {
-    }
-}
-
-namespace System.Reflection.Runtime.TypeInfos
-{
-    internal abstract partial class RuntimeTypeInfo
-    {
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -32,6 +32,7 @@ namespace System.Reflection.Runtime.Assemblies
     internal partial class RuntimeAssembly
     {
 #if DEBUG
+        public sealed override object CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes) => base.CreateInstance(typeName, ignoreCase, bindingAttr, binder, args, culture, activationAttributes);
         public sealed override Type GetType(string name) => base.GetType(name);
         public sealed override Type GetType(string name, bool throwOnError) => base.GetType(name, throwOnError);
         public sealed override bool IsDynamic => base.IsDynamic;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -46,6 +46,11 @@ namespace System.Reflection.Runtime.MethodInfos
             throw new NotSupportedException();
         }
 
+        public sealed override MethodBody GetMethodBody()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -149,6 +149,11 @@ namespace System.Reflection.Runtime.MethodInfos
             MemberInfoSerializationHolder.GetSerializationInfo(info, this);
         }
 
+        public sealed override MethodBody GetMethodBody()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public sealed override ParameterInfo[] GetParameters()
         {
 #if ENABLE_REFLECTION_TRACE

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -115,6 +115,17 @@ namespace System.Reflection.Runtime.Modules
         public sealed override int MDStreamVersion { get { throw new PlatformNotSupportedException(); } }
         public sealed override string ScopeName { get { throw new PlatformNotSupportedException(); } }
 
+        public sealed override FieldInfo GetField(string name, BindingFlags bindingAttr) { throw new PlatformNotSupportedException(); }
+        public sealed override FieldInfo[] GetFields(BindingFlags bindingFlags) { throw new PlatformNotSupportedException(); }
+        protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) { throw new PlatformNotSupportedException(); }
+        public sealed override MethodInfo[] GetMethods(BindingFlags bindingFlags) { throw new PlatformNotSupportedException(); }
+        public sealed override FieldInfo ResolveField(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public sealed override MemberInfo ResolveMember(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public sealed override MethodBase ResolveMethod(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public sealed override byte[] ResolveSignature(int metadataToken) { throw new PlatformNotSupportedException(); }
+        public sealed override string ResolveString(int metadataToken) { throw new PlatformNotSupportedException(); }
+        public sealed override Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+
         private readonly Assembly _assembly;
     }
 }


### PR DESCRIPTION
Members on <Module> type.

  Lots of discussion back and forth: low usage,
  high implementation cost.

Non-add/remove/fire methods on events.

  Lots of discussion back and forth: zero usage,
  high implementation cost.

Method bodies and IL inspection.

Also took Assembly.CreateInstance() off the NYI list.
It's been implemented in the base class for some time -
we just needed to stop blocking access to it
in RuntimeAssembly.

ApiToList.cs now reduced to FieldHandle and MethodHandle
work. Last one out - please turn out the lights on
this file...