### PR TITLE
Print message for stack oveflow

### DIFF
--- a/src/Native/Runtime/EHHelpers.cpp
+++ b/src/Native/Runtime/EHHelpers.cpp
@@ -405,6 +405,8 @@ Int32 __stdcall RhpHardwareExceptionHandler(UIntNative faultCode, UIntNative fau
         }
         else if (faultCode == STATUS_STACK_OVERFLOW)
         {
+            // Do not use ASSERT_UNCONDITIONALLY here. It will crash because of it consumes too much stack.
+
             PalPrintFatalError("\nProcess is terminating due to StackOverflowException.\n");
             RhFailFast();
         }
@@ -447,8 +449,10 @@ Int32 __stdcall RhpVectoredExceptionHandler(PEXCEPTION_POINTERS pExPtrs)
         }
         else if (faultCode == STATUS_STACK_OVERFLOW)
         {
+            // Do not use ASSERT_UNCONDITIONALLY here. It will crash because of it consumes too much stack.
+
             PalPrintFatalError("\nProcess is terminating due to StackOverflowException.\n");
-            RhFailFast2(pExPtrs->ExceptionRecord, pExPtrs->ContextRecord);
+            PalRaiseFailFastException(pExPtrs->ExceptionRecord, pExPtrs->ContextRecord, 0);
         }
 
         pExPtrs->ContextRecord->SetIp((UIntNative)&RhpThrowHwEx);
@@ -484,7 +488,7 @@ Int32 __stdcall RhpVectoredExceptionHandler(PEXCEPTION_POINTERS pExPtrs)
             // Generally any form of hardware exception within the runtime itself is considered a fatal error.
             // Note this includes the managed code within the runtime.
             ASSERT_UNCONDITIONALLY("Hardware exception raised inside the runtime.");
-            RhFailFast2(pExPtrs->ExceptionRecord, pExPtrs->ContextRecord);
+            PalRaiseFailFastException(pExPtrs->ExceptionRecord, pExPtrs->ContextRecord, 0);
         }
     }
 

--- a/src/Native/Runtime/EHHelpers.cpp
+++ b/src/Native/Runtime/EHHelpers.cpp
@@ -405,7 +405,7 @@ Int32 __stdcall RhpHardwareExceptionHandler(UIntNative faultCode, UIntNative fau
         }
         else if (faultCode == STATUS_STACK_OVERFLOW)
         {
-            ASSERT_UNCONDITIONALLY("managed stack overflow");
+            PalPrintFatalError("\nProcess is terminating due to StackOverflowException.\n");
             RhFailFast();
         }
 
@@ -447,7 +447,7 @@ Int32 __stdcall RhpVectoredExceptionHandler(PEXCEPTION_POINTERS pExPtrs)
         }
         else if (faultCode == STATUS_STACK_OVERFLOW)
         {
-            ASSERT_UNCONDITIONALLY("managed stack overflow");
+            PalPrintFatalError("\nProcess is terminating due to StackOverflowException.\n");
             RhFailFast2(pExPtrs->ExceptionRecord, pExPtrs->ContextRecord);
         }
 

--- a/src/Native/Runtime/PalRedhawk.h
+++ b/src/Native/Runtime/PalRedhawk.h
@@ -839,6 +839,8 @@ REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalDetachThread(void* thread);
 
 REDHAWK_PALIMPORT UInt64 PalGetCurrentThreadIdForLogging();
 
+REDHAWK_PALIMPORT void PalPrintFatalError(const char* message);
+
 #ifdef PLATFORM_UNIX
 REDHAWK_PALIMPORT Int32 __cdecl _stricmp(const char *string1, const char *string2);
 #endif // PLATFORM_UNIX

--- a/src/Native/Runtime/rhassert.h
+++ b/src/Native/Runtime/rhassert.h
@@ -52,10 +52,4 @@ void Assert(const char * expr, const char * file, unsigned int line_num, const c
 
 #define FAIL_FAST_GENERATE_EXCEPTION_ADDRESS 0x1
 
-#define RhFailFast()  RhFailFast2(NULL, NULL)
-
-#define RhFailFast2(pExRec, pExCtx) \
-{ \
-    ASSERT_UNCONDITIONALLY("FailFast"); \
-    PalRaiseFailFastException((pExRec), (pExCtx), (pExRec)==NULL ? FAIL_FAST_GENERATE_EXCEPTION_ADDRESS : 0); \
-}
+#define RhFailFast() PalRaiseFailFastException(NULL, NULL, FAIL_FAST_GENERATE_EXCEPTION_ADDRESS)

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -697,6 +697,13 @@ REDHAWK_PALEXPORT HANDLE REDHAWK_PALAPI PalGetModuleHandleFromPointer(_In_ void*
     return moduleHandle;
 }
 
+REDHAWK_PALEXPORT void PalPrintFatalError(const char* message)
+{
+    // Write the message using lowest-level OS API available. This is used to print the stack overflow
+    // message, so there is not much that can be done here.
+    write(STDERR_FILENO, message, sizeof(message));
+}
+
 bool QueryCacheSize()
 {
     bool success = true;

--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -434,6 +434,14 @@ REDHAWK_PALEXPORT void* REDHAWK_PALAPI PalAddVectoredExceptionHandler(UInt32 fir
     return AddVectoredExceptionHandler(firstHandler, vectoredHandler);
 }
 
+REDHAWK_PALEXPORT void PalPrintFatalError(const char* message)
+{
+    // Write the message using lowest-level OS API available. This is used to print the stack overflow
+    // message, so there is not much that can be done here.
+    DWORD dwBytesWritten;
+    WriteFile(GetStdHandle(STD_ERROR_HANDLE), message, strlen(message), &dwBytesWritten, NULL);
+}
+
 //
 // -----------------------------------------------------------------------------------------------------------
 //


### PR DESCRIPTION
Follow up on discussion in https://github.com/dotnet/corert/pull/2710#issuecomment-279052353

This makes the error message for stackoverflow to match CoreCLR. It does work too well on Unix because of https://github.com/dotnet/coreclr/issues/1504. If it gets fixed for CoreCLR, we should look into porting the fix to CoreRT as well.

cc @janvorli @MichalStrehovsky