### PR TITLE
Make Win32 build respect EnableDummyGlobalizationImplementation

### DIFF
--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -774,17 +774,6 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafeThreadPoolIOHandle.cs" />
     <Compile Condition="'$(EnableWinRT)' == 'true'" Include="System\TimeZoneInfo.WinRT.cs" />
     <Compile Condition="'$(EnableWinRT)' != 'true'" Include="System\TimeZoneInfo.Win32.cs" />
-    <Compile Condition="'$(EnableWinRT)' != 'true'" Include="System\Globalization\HijriCalendar.Win32.cs" />
-    <Compile Condition="'$(EnableWinRT)' == 'true'" Include="System\Globalization\HijriCalendar.WinRT.cs" />
-    <Compile Condition="'$(EnableWinRT)' != 'true'" Include="System\Globalization\JapaneseCalendar.Win32.cs" />
-    <Compile Condition="'$(EnableWinRT)' == 'true'" Include="System\Globalization\JapaneseCalendar.WinRT.cs" />
-    <Compile Include="System\Globalization\CultureInfo.Windows.cs" />
-    <Compile Include="System\Globalization\CompareInfo.Windows.cs" />
-    <Compile Include="System\Globalization\CultureData.Windows.cs" />
-    <Compile Include="System\Globalization\TextInfo.Windows.cs" />
-    <Compile Include="System\Globalization\CalendarData.Windows.cs" />
-    <Compile Include="System\Globalization\IdnMapping.Windows.cs" />
-    <Compile Include="System\Text\Normalization.Windows.cs" />
     <Compile Include="System\DateTime.Windows.cs" />
     <Compile Include="System\Globalization\FormatProvider.FormatAndParse.Windows.cs" />
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Windows.cs" />
@@ -796,15 +785,6 @@
     </Compile>
     <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.SetLastError.cs">
       <Link>Interop\Windows\mincore\Interop.SetLastError.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Globalization.cs">
-      <Link>Interop\Windows\mincore\Interop.Globalization.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Idna.cs">
-      <Link>Interop\Windows\mincore\Interop.Idna.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Normalization.cs">
-      <Link>Interop\Windows\mincore\Interop.Normalization.cs</Link>
     </Compile>
     <Compile Condition="'$(EnableWinRT)' != 'true'" Include="..\..\Common\src\Interop\Windows\mincore\Interop.MUI.cs">
       <Link>Interop\Windows\mincore\Interop.MUI.cs</Link>
@@ -941,6 +921,28 @@
       <Link>Interop\Windows\BCrypt\Interop.BCryptGenRandom.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)'=='true' And '$(EnableDummyGlobalizationImplementation)' != 'true'">
+    <Compile Condition="'$(EnableWinRT)' != 'true'" Include="System\Globalization\HijriCalendar.Win32.cs" />
+    <Compile Condition="'$(EnableWinRT)' == 'true'" Include="System\Globalization\HijriCalendar.WinRT.cs" />
+    <Compile Condition="'$(EnableWinRT)' != 'true'" Include="System\Globalization\JapaneseCalendar.Win32.cs" />
+    <Compile Condition="'$(EnableWinRT)' == 'true'" Include="System\Globalization\JapaneseCalendar.WinRT.cs" />
+    <Compile Include="System\Globalization\CultureInfo.Windows.cs" />
+    <Compile Include="System\Globalization\CompareInfo.Windows.cs" />
+    <Compile Include="System\Globalization\CultureData.Windows.cs" />
+    <Compile Include="System\Globalization\TextInfo.Windows.cs" />
+    <Compile Include="System\Globalization\CalendarData.Windows.cs" />
+    <Compile Include="System\Globalization\IdnMapping.Windows.cs" />
+    <Compile Include="System\Text\Normalization.Windows.cs" />
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Globalization.cs">
+      <Link>Interop\Windows\mincore\Interop.Globalization.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Idna.cs">
+      <Link>Interop\Windows\mincore\Interop.Idna.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.Normalization.cs">
+      <Link>Interop\Windows\mincore\Interop.Normalization.cs</Link>
+    </Compile>
+  </ItemGroup>
   <ItemGroup>
     <!-- CORERT-TODO: Port to Unix -->
     <Compile Include="..\..\Common\src\Interop\Windows\Interop.Libraries.cs">
@@ -978,7 +980,7 @@
     </Compile>
   </ItemGroup>
   <!-- Dummy globalization implementation -->
-  <ItemGroup Condition="'$(TargetsUnix)' == 'true' And '$(EnableDummyGlobalizationImplementation)' == 'true'">
+  <ItemGroup Condition="'$(EnableDummyGlobalizationImplementation)' == 'true'">
     <Compile Include="System\Globalization\HijriCalendar.Dummy.cs" />
     <Compile Include="System\Globalization\JapaneseCalendar.Dummy.cs" />
     <Compile Include="System\Globalization\CultureInfo.Dummy.cs" />

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -1002,6 +1002,33 @@
     <Compile Include="System\Globalization\CalendarData.Unix.cs" />
     <Compile Include="System\Globalization\IdnMapping.Unix.cs" />
     <Compile Include="System\Text\Normalization.Unix.cs" />
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Calendar.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.Calendar.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Casing.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.Casing.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Collation.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.Collation.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Idna.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.Idna.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Locale.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.Locale.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Normalization.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.Normalization.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.ResultCode.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.ResultCode.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.TimeZoneInfo.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.TimeZoneInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Utils.cs">
+      <Link>Interop\Unix\System.Globalization.Native\Interop.Utils.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
     <Compile Include="Internal\Runtime\Augments\RuntimeThread.Unix.cs" />
@@ -1121,33 +1148,6 @@
     </Compile>
     <Compile Include="..\..\Common\src\Interop\Unix\System.Native\Interop.Write.cs">
       <Link>Interop\Unix\System.Native\Interop.Write.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Calendar.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.Calendar.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Casing.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.Casing.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Collation.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.Collation.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Idna.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.Idna.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Locale.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.Locale.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Normalization.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.Normalization.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.ResultCode.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.ResultCode.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.TimeZoneInfo.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.TimeZoneInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Globalization.Native\Interop.Utils.cs">
-      <Link>Interop\Unix\System.Globalization.Native\Interop.Utils.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The msbuild/environment variable EnableDummyGlobalizationImplementation replaces a bunch of Linux globalization classes with dummy implementations. This allows the same facility on Win32 builds.