### PR TITLE
Fix DGML log emission

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -307,7 +307,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName() => "NativeLayoutTypeSignatureVertexNode" + NodeFactory.NameMangler.GetMangledTypeName(_type);
+        protected override string GetName() => "NativeLayoutTypeSignatureVertexNode: " + _type.ToString();
 
         public static NativeLayoutTypeSignatureVertexNode NewTypeSignatureVertexNode(NodeFactory factory, TypeDesc type)
         {


### PR DESCRIPTION
This was broken because `NativeLayoutVertexNode` was asking for mangled
names of signature variables. They don't have mangled names because they
never get emitted into the object file. Neither does
`NativeLayoutVertexNode`.