### PR TITLE
Improved link speed with multi module

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
@@ -49,7 +49,7 @@ namespace ILCompiler.DependencyAnalysis
             if (IsStandardSection)
                 standardSectionPrefix = ".";
 
-            return new ObjectNodeSection(standardSectionPrefix + Name + "$" + key, Type, key);
+            return new ObjectNodeSection(standardSectionPrefix + Name, Type, key);
         }
 
         public static readonly ObjectNodeSection XDataSection = new ObjectNodeSection("xdata", SectionType.ReadOnly);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -341,6 +341,81 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+
+        public void PublishUnwindInfo(NodeFactory factory, ObjectNode node)
+        {
+            INodeWithCodeInfo nodeWithCodeInfo = node as INodeWithCodeInfo;
+            if (nodeWithCodeInfo == null)
+            {
+                return;
+            }
+
+            FrameInfo[] frameInfos = nodeWithCodeInfo.FrameInfos;
+            if (frameInfos == null)
+            {
+                return;
+            }
+
+            byte[] gcInfo = nodeWithCodeInfo.GCInfo;
+            ObjectNode.ObjectData ehInfo = nodeWithCodeInfo.EHInfo;
+
+            for (int i = 0; i < frameInfos.Length; i++)
+            {
+                FrameInfo frameInfo = frameInfos[i];
+
+                int start = frameInfo.StartOffset;
+                int end = frameInfo.EndOffset;
+                int len = frameInfo.BlobData.Length;
+                byte[] blob = frameInfo.BlobData;
+                
+                _sb.Clear().Append(NodeFactory.NameMangler.CompilationUnitPrefix).Append("_unwind").Append(i.ToStringInvariant());
+
+                ObjectNodeSection section = ObjectNodeSection.XDataSection;
+                SwitchSection(_nativeObjectWriter, section.Name);
+
+                byte[] blobSymbolName = _sb.Append(_currentNodeZeroTerminatedName).ToUtf8String().UnderlyingArray;
+
+                EmitAlignment(4);
+                EmitSymbolDef(blobSymbolName);
+
+                FrameInfoFlags flags = frameInfo.Flags;
+                if (ehInfo != null)
+                {
+                    flags |= FrameInfoFlags.HasEHInfo;
+                }
+
+                EmitBlob(blob);
+
+                EmitIntValue((byte)flags, 1);
+
+                if (ehInfo != null)
+                {
+                    EmitSymbolRef(_sb.Clear().Append(NodeFactory.NameMangler.CompilationUnitPrefix).Append("_ehInfo").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_ABSOLUTE);
+                }
+
+                if (gcInfo != null)
+                {
+                    EmitBlob(gcInfo);
+                    gcInfo = null;
+                }
+
+                if (ehInfo != null)
+                {
+                    // TODO: Place EHInfo into different section for better locality
+                    Debug.Assert(ehInfo.Alignment == 1);
+                    Debug.Assert(ehInfo.DefinedSymbols.Length == 0);
+                    EmitSymbolDef(_sb /* ehInfo */);
+                    EmitBlobWithRelocs(ehInfo.Data, ehInfo.Relocs);
+                    ehInfo = null;
+                }
+
+                // For window, just emit the frame blob (UNWIND_INFO) as a whole.
+                EmitWinFrameInfo(start, end, len, blobSymbolName);
+                
+                EnsureCurrentSection();
+            }
+        }
+
         public void BuildCFIMap(NodeFactory factory, ObjectNode node)
         {
             _offsetToCfis.Clear();
@@ -373,122 +448,73 @@ namespace ILCompiler.DependencyAnalysis
                 int len = frameInfo.BlobData.Length;
                 byte[] blob = frameInfo.BlobData;
 
-                if (_targetPlatform.OperatingSystem == TargetOS.Windows)
+                SwitchSection(_nativeObjectWriter, LsdaSection.Name);
+
+                _sb.Clear().Append("_lsda").Append(i.ToStringInvariant()).Append(_currentNodeZeroTerminatedName);
+                byte[] blobSymbolName = _sb.ToUtf8String().UnderlyingArray;
+                EmitSymbolDef(blobSymbolName);
+
+                FrameInfoFlags flags = frameInfo.Flags;
+                if (ehInfo != null)
                 {
-                    _sb.Clear().Append(NodeFactory.NameMangler.CompilationUnitPrefix).Append("_unwind").Append(i.ToStringInvariant());
-
-                    ObjectNodeSection section = ObjectNodeSection.XDataSection;
-                    SwitchSection(_nativeObjectWriter, section.Name);
-
-                    byte[] blobSymbolName = _sb.Append(_currentNodeZeroTerminatedName).ToUtf8String().UnderlyingArray;
-
-                    EmitAlignment(4);
-                    EmitSymbolDef(blobSymbolName);
-
-                    FrameInfoFlags flags = frameInfo.Flags;
-                    if (ehInfo != null)
-                    {
-                        flags |= FrameInfoFlags.HasEHInfo;
-                    }
-
-                    EmitBlob(blob);
-
-                    EmitIntValue((byte)flags, 1);
-
-                    if (ehInfo != null)
-                    {
-                        EmitSymbolRef(_sb.Clear().Append(NodeFactory.NameMangler.CompilationUnitPrefix).Append("_ehInfo").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_ABSOLUTE);
-                    }
-
-                    if (gcInfo != null)
-                    {
-                        EmitBlob(gcInfo);
-                        gcInfo = null;
-                    }
-
-                    if (ehInfo != null)
-                    {
-                        // TODO: Place EHInfo into different section for better locality
-                        Debug.Assert(ehInfo.Alignment == 1);
-                        Debug.Assert(ehInfo.DefinedSymbols.Length == 0);
-                        EmitSymbolDef(_sb /* ehInfo */);
-                        EmitBlobWithRelocs(ehInfo.Data, ehInfo.Relocs);
-                        ehInfo = null;
-                    }
-                    
-                    // For window, just emit the frame blob (UNWIND_INFO) as a whole.
-                    EmitWinFrameInfo(start, end, len, blobSymbolName);
+                    flags |= FrameInfoFlags.HasEHInfo;
                 }
-                else
+                EmitIntValue((byte)flags, 1);
+
+                if (i != 0)
                 {
-                    SwitchSection(_nativeObjectWriter, LsdaSection.Name);
+                    EmitSymbolRef(_sb.Clear().Append("_lsda0").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_REL32, 4);
 
-                    _sb.Clear().Append("_lsda").Append(i.ToStringInvariant()).Append(_currentNodeZeroTerminatedName);
-                    byte[] blobSymbolName = _sb.ToUtf8String().UnderlyingArray;
-                    EmitSymbolDef(blobSymbolName);
-
-                    FrameInfoFlags flags = frameInfo.Flags;
-                    if (ehInfo != null)
-                    {
-                        flags |= FrameInfoFlags.HasEHInfo;
-                    }
-                    EmitIntValue((byte)flags, 1);
-
-                    if (i != 0)
-                    {
-                        EmitSymbolRef(_sb.Clear().Append("_lsda0").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_REL32, 4);
-
-                        // emit relative offset from the main function
-                        EmitIntValue((ulong)(start - frameInfos[0].StartOffset), 4);
-                    }
-
-                    if (ehInfo != null)
-                    {
-                        EmitSymbolRef(_sb.Clear().Append("_ehInfo").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_REL32, 4);
-                    }
-
-                    if (gcInfo != null)
-                    {
-                        EmitBlob(gcInfo);
-                        gcInfo = null;
-                    }
-
-                    if (ehInfo != null)
-                    {
-                        // TODO: Place EHInfo into different section for better locality
-                        Debug.Assert(ehInfo.Alignment == 1);
-                        Debug.Assert(ehInfo.DefinedSymbols.Length == 0);
-                        EmitSymbolDef(_sb /* ehInfo */);
-                        EmitBlobWithRelocs(ehInfo.Data, ehInfo.Relocs);
-                        ehInfo = null;
-                    }
-
-                    // For Unix, we build CFI blob map for each offset.
-                    Debug.Assert(len % CfiCodeSize == 0);
-
-                    // Record start/end of frames which shouldn't be overlapped.
-                    _offsetToCfiStart.Add(start);
-                    _offsetToCfiEnd.Add(end);
-                    _offsetToCfiLsdaBlobName.Add(start, blobSymbolName);
-                    for (int j = 0; j < len; j += CfiCodeSize)
-                    {
-                        // The first byte of CFI_CODE is offset from the range the frame covers.
-                        // Compute code offset from the root method.
-                        int codeOffset = blob[j] + start;
-                        List<byte[]> cfis;
-                        if (!_offsetToCfis.TryGetValue(codeOffset, out cfis))
-                        {
-                            cfis = new List<byte[]>();
-                            _offsetToCfis.Add(codeOffset, cfis);
-                        }
-                        byte[] cfi = new byte[CfiCodeSize];
-                        Array.Copy(blob, j, cfi, 0, CfiCodeSize);
-                        cfis.Add(cfi);
-                    }
+                    // emit relative offset from the main function
+                    EmitIntValue((ulong)(start - frameInfos[0].StartOffset), 4);
                 }
 
-                EnsureCurrentSection();
+                if (ehInfo != null)
+                {
+                    EmitSymbolRef(_sb.Clear().Append("_ehInfo").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_REL32, 4);
+                }
+
+                if (gcInfo != null)
+                {
+                    EmitBlob(gcInfo);
+                    gcInfo = null;
+                }
+
+                if (ehInfo != null)
+                {
+                    // TODO: Place EHInfo into different section for better locality
+                    Debug.Assert(ehInfo.Alignment == 1);
+                    Debug.Assert(ehInfo.DefinedSymbols.Length == 0);
+                    EmitSymbolDef(_sb /* ehInfo */);
+                    EmitBlobWithRelocs(ehInfo.Data, ehInfo.Relocs);
+                    ehInfo = null;
+                }
+
+                // For Unix, we build CFI blob map for each offset.
+                Debug.Assert(len % CfiCodeSize == 0);
+
+                // Record start/end of frames which shouldn't be overlapped.
+                _offsetToCfiStart.Add(start);
+                _offsetToCfiEnd.Add(end);
+                _offsetToCfiLsdaBlobName.Add(start, blobSymbolName);
+                for (int j = 0; j < len; j += CfiCodeSize)
+                {
+                    // The first byte of CFI_CODE is offset from the range the frame covers.
+                    // Compute code offset from the root method.
+                    int codeOffset = blob[j] + start;
+                    List<byte[]> cfis;
+                    if (!_offsetToCfis.TryGetValue(codeOffset, out cfis))
+                    {
+                        cfis = new List<byte[]>();
+                        _offsetToCfis.Add(codeOffset, cfis);
+                    }
+                    byte[] cfi = new byte[CfiCodeSize];
+                    Array.Copy(blob, j, cfi, 0, CfiCodeSize);
+                    cfis.Add(cfi);
+                }
             }
+
+            EnsureCurrentSection();
         }
 
         public void EmitCFICodes(int offset)
@@ -779,8 +805,7 @@ namespace ILCompiler.DependencyAnalysis
                     // Build symbol definition map.
                     objectWriter.BuildSymbolDefinitionMap(node, nodeContents.DefinedSymbols);
 
-                    // Build CFI map (Unix) or publish unwind blob (Windows).
-                    if (!objectWriter.ShouldShareSymbol(node))
+                    if (!factory.Target.IsWindows)
                         objectWriter.BuildCFIMap(factory, node);
 
                     // Build debug location map
@@ -845,6 +870,10 @@ namespace ILCompiler.DependencyAnalysis
 
                     // It is possible to have a symbol just after all of the data.
                     objectWriter.EmitSymbolDefinition(nodeContents.Data.Length);
+
+                    // Publish Windows unwind info.
+                    if (factory.Target.IsWindows)
+                        objectWriter.PublishUnwindInfo(factory, node);
 
                     // Emit the last CFI to close the frame.
                     objectWriter.EmitCFICodes(nodeContents.Data.Length);

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -29,7 +29,7 @@
 
             <MicrosoftNetCoreNativePackageVersion>1.2.0-beta-24911-02</MicrosoftNetCoreNativePackageVersion>
 
-            <ObjectWriterPackageVersion>1.0.13-prerelease-00001</ObjectWriterPackageVersion>
+            <ObjectWriterPackageVersion>1.0.14-prerelease-00001</ObjectWriterPackageVersion>
             <ObjectWriterNuPkgRid Condition="'$(OSGroup)'=='Linux'">ubuntu.14.04-x64</ObjectWriterNuPkgRid>
             <ObjectWriterNuPkgRid Condition="'$(ObjectWriterNuPkgRid)'==''">$(NuPkgRid)</ObjectWriterNuPkgRid>
         </PropertyGroup>

--- a/src/packaging/project.json
+++ b/src/packaging/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Jit": "2.0.0-beta-25013-02",
-    "Microsoft.DotNet.ObjectWriter": "1.0.13-prerelease-00001"
+    "Microsoft.DotNet.ObjectWriter": "1.0.14-prerelease-00001"
   },
   "frameworks": {
     "dnxcore50": { }


### PR DESCRIPTION
Speed up linking against the framework lib by not naming each Comdat
section with the full mangled name of its associated `ObjectNode`.
Instead, use the same name differentiating solely on the Comdat symbol.

Remove the custom section name hash set from `ObjectWriter`. It's
needless book-keeping; LLVM will get / create sections automatically.

On Windows, publish unwind info after the method's symbol has been emitted. This is needed because the unwind info has a Comdat symbol reference that depends on the method symbol.