### PR TITLE
Step 1 for supporting custom binders on Invoke()

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Runtime;
+using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -307,6 +308,7 @@ namespace Internal.Runtime.Augments
             IntPtr dynamicInvokeHelperGenericDictionary,
             object defaultParametersContext,
             object[] parameters,
+            BinderBundle binderBundle,
             bool invokeMethodHelperIsThisCall,
             bool methodToCallIsThisCall)
         {
@@ -318,6 +320,7 @@ namespace Internal.Runtime.Augments
                 dynamicInvokeHelperGenericDictionary,
                 defaultParametersContext,
                 parameters,
+                binderBundle,
                 invokeMethodHelperIsThisCall,
                 methodToCallIsThisCall);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
@@ -628,9 +631,9 @@ namespace Internal.Runtime.Augments
             return true;
         }
 
-        public static Object CheckArgument(Object srcObject, RuntimeTypeHandle dstType)
+        public static Object CheckArgument(Object srcObject, RuntimeTypeHandle dstType, BinderBundle binderBundle)
         {
-            return InvokeUtils.CheckArgument(srcObject, dstType);
+            return InvokeUtils.CheckArgument(srcObject, dstType, binderBundle);
         }
 
         public static bool IsAssignable(Object srcObject, RuntimeTypeHandle dstType)

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -151,6 +151,7 @@
     <Compile Include="System\Reflection\AssemblyContentType.cs" />
     <Compile Include="System\Reflection\AssemblyName.cs" />
     <Compile Include="System\Reflection\Binder.cs" />
+    <Compile Include="System\Reflection\BinderBundle.cs" />
     <Compile Include="System\Reflection\BindingFlags.cs" />
     <Compile Include="System\Reflection\CallingConventions.cs" />
     <Compile Include="System\Reflection\ConstructorInfo.cs" />

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -2612,7 +2612,7 @@ namespace System
                 if (value != null && !(value.EETypePtr == pElementEEType) && pElementEEType.IsEnum)
                     throw new InvalidCastException(SR.Format(SR.Arg_ObjObjEx, value.GetType(), Type.GetTypeFromHandle(new RuntimeTypeHandle(pElementEEType))));
 
-                value = InvokeUtils.CheckArgument(value, pElementEEType, InvokeUtils.CheckArgumentSemantics.ArraySet);
+                value = InvokeUtils.CheckArgument(value, pElementEEType, InvokeUtils.CheckArgumentSemantics.ArraySet, binderBundle: null);
                 Debug.Assert(value == null || RuntimeImports.AreTypesAssignable(value.EETypePtr, pElementEEType));
 
                 nuint elementSize = ElementSize;
@@ -2718,7 +2718,7 @@ namespace System
                     if (value != null && !(value.EETypePtr == pElementEEType) && pElementEEType.IsEnum)
                         throw new InvalidCastException(SR.Format(SR.Arg_ObjObjEx, value.GetType(), Type.GetTypeFromHandle(new RuntimeTypeHandle(pElementEEType))));
 
-                    value = InvokeUtils.CheckArgument(value, pElementEEType, InvokeUtils.CheckArgumentSemantics.ArraySet);
+                    value = InvokeUtils.CheckArgument(value, pElementEEType, InvokeUtils.CheckArgumentSemantics.ArraySet, binderBundle: null);
                     Debug.Assert(value == null || RuntimeImports.AreTypesAssignable(value.EETypePtr, pElementEEType));
 
                     RuntimeImports.RhUnbox(value, pElement, pElementEEType);

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -305,7 +305,7 @@ namespace System
             else
             {
                 IntPtr invokeThunk = this.GetThunk(DelegateInvokeThunk);
-                object result = System.InvokeUtils.CallDynamicInvokeMethod(this.m_firstParameter, this.m_functionPointer, this, invokeThunk, IntPtr.Zero, this, args);
+                object result = System.InvokeUtils.CallDynamicInvokeMethod(this.m_firstParameter, this.m_functionPointer, this, invokeThunk, IntPtr.Zero, this, args, binderBundle: null);
                 DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
                 return result;
             }

--- a/src/System.Private.CoreLib/src/System/Reflection/BinderBundle.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/BinderBundle.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Globalization;
+
+namespace System.Reflection
+{
+    // If allocated, indicates the non-default Binder and culture to use for coercing parameters to a dynamic Invoke. Combining
+    // these two items in a class makes custom binders more pay-for-play (one less parameter and TLS local for the non-binder case
+    // to manage.)
+    //
+    // This is not an api type but needs to be public as both Reflection.Core and System.Private.Corelib accesses it.
+    public sealed class BinderBundle
+    {
+        public BinderBundle(Binder binder, CultureInfo culture)
+        {
+            // This is not just performance, it is correctness too. The default binder's ChangeType() method throws a NotSupportedException so you really can't treat it
+            // as "just another binder."
+            Debug.Assert(binder != null && binder != Type.DefaultBinder, "Not permitted to allocate a BinderBundle for the default Binder. Must pass a null BinderBundle instread.");
+            _binder = binder;
+            _culture = culture;
+        }
+
+        public object ChangeType(object value, Type type)
+        {
+            return _binder.ChangeType(value, type, _culture);
+        }
+
+        private readonly Binder _binder;
+        private readonly CultureInfo _culture;
+    }
+}

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/FieldAccessor.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/FieldAccessor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Reflection;
 using System.Collections.Generic;
 
 namespace Internal.Reflection.Core.Execution
@@ -14,6 +15,6 @@ namespace Internal.Reflection.Core.Execution
     {
         protected FieldAccessor() { }
         public abstract Object GetField(Object obj);
-        public abstract void SetField(Object obj, Object value);
+        public abstract void SetField(Object obj, Object value, BinderBundle binderBundle);
     }
 }

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/MethodInvoker.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/MethodInvoker.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Reflection;
 using System.Diagnostics;
+using System.Globalization;
+using System.Reflection.Runtime.General;
 
 namespace Internal.Reflection.Core.Execution
 {
@@ -16,7 +18,12 @@ namespace Internal.Reflection.Core.Execution
     {
         protected MethodInvoker() { }
 
-        public abstract Object Invoke(Object thisObject, Object[] arguments);
+        public Object Invoke(Object thisObject, Object[] arguments, Binder binder, BindingFlags invokeAttr, CultureInfo cultureInfo)
+        {
+            BinderBundle binderBundle = binder.ToBinderBundle(invokeAttr, cultureInfo);
+            return Invoke(thisObject, arguments, binderBundle);
+        }
+        public abstract Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle);
         public abstract Delegate CreateDelegate(RuntimeTypeHandle delegateType, Object target, bool isStatic, bool isVirtual, bool isOpen);
     }
 }

--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -264,9 +264,6 @@
   <data name="NotSupported_ChangeType" xml:space="preserve">
     <value>ChangeType operation is not supported.</value>
   </data>
-  <data name="PlatformNotSupported_CustomBinder" xml:space="preserve">
-    <value>Passing a binder object other than Type.DefaultBinder is not supported on this platform.</value>
-  </data>
   <data name="Arg_NoDefCTor" xml:space="preserve">
     <value>No parameterless constructor defined for this object.</value>
   </data>

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/LiteralFieldAccessor.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/LiteralFieldAccessor.cs
@@ -30,7 +30,7 @@ namespace System.Reflection.Runtime.FieldInfos
             return _value;
         }
 
-        public sealed override void SetField(Object obj, Object value)
+        public sealed override void SetField(Object obj, Object value, BinderBundle binderBundle)
         {
             throw new FieldAccessException(SR.Acc_ReadOnly);
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -118,10 +118,9 @@ namespace System.Reflection.Runtime.FieldInfos
                 ReflectionTrace.FieldInfo_SetValue(this, obj, value);
 #endif
 
-            binder.EnsureNotCustomBinder();
-
             FieldAccessor fieldAccessor = this.FieldAccessor;
-            fieldAccessor.SetField(obj, value);
+            BinderBundle binderBundle = binder.ToBinderBundle(invokeAttr, culture);
+            fieldAccessor.SetField(obj, value, binderBundle);
         }
 
         Type ITraceableTypeMember.ContainingType

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -6,6 +6,7 @@ using System;
 using System.Text;
 using System.Reflection;
 using System.Diagnostics;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
@@ -168,13 +169,6 @@ namespace System.Reflection.Runtime.General
 
         private static readonly char[] s_charsToEscape = new char[] { '\\', '[', ']', '+', '*', '&', ',' };
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void EnsureNotCustomBinder(this Binder binder)
-        {
-            if (!(binder == null || binder is DefaultBinder))
-                throw new PlatformNotSupportedException(SR.PlatformNotSupported_CustomBinder);
-        }
-
         public static RuntimeMethodInfo GetInvokeMethod(this RuntimeTypeInfo delegateType)
         {
             Debug.Assert(delegateType.IsDelegate);
@@ -191,6 +185,13 @@ namespace System.Reflection.Runtime.General
                 throw new MissingMetadataException(SR.Format(SR.Arg_InvokeMethodMissingMetadata, fullName)); // No invoke method found.
             }
             return (RuntimeMethodInfo)invokeMethod;
+        }
+
+        public static BinderBundle ToBinderBundle(this Binder binder, BindingFlags invokeAttr, CultureInfo cultureInfo)
+        {
+            if (binder == null || binder is DefaultBinder || ((invokeAttr & BindingFlags.ExactBinding) != 0))
+                return null;
+            return new BinderBundle(binder, cultureInfo);
         }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/OpenMethodInvoker.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/OpenMethodInvoker.cs
@@ -15,7 +15,7 @@ namespace System.Reflection.Runtime.MethodInfos
 {
     internal sealed class OpenMethodInvoker : MethodInvoker
     {
-        public sealed override Object Invoke(Object thisObject, Object[] arguments)
+        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
         {
             throw new InvalidOperationException(SR.Arg_UnboundGenParam);
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -87,8 +87,6 @@ namespace System.Reflection.Runtime.MethodInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodBase_Invoke(this, obj, parameters);
 #endif
-            binder.EnsureNotCustomBinder();
-
             if (parameters == null)
                 parameters = Array.Empty<Object>();
             MethodInvoker methodInvoker;
@@ -116,7 +114,7 @@ namespace System.Reflection.Runtime.MethodInfos
                 throw;
             }
 
-            return methodInvoker.Invoke(obj, parameters);
+            return methodInvoker.Invoke(obj, parameters, binder, invokeAttr, culture);
         }
 
         public abstract override int MetadataToken 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -182,12 +182,10 @@ namespace System.Reflection.Runtime.MethodInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.MethodBase_Invoke(this, obj, parameters);
 #endif
-            binder.EnsureNotCustomBinder();
-
             if (parameters == null)
                 parameters = Array.Empty<Object>();
             MethodInvoker methodInvoker = this.MethodInvoker;
-            object result = methodInvoker.Invoke(obj, parameters);
+            object result = methodInvoker.Invoke(obj, parameters, binder, invokeAttr, culture);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
             return result;
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -94,8 +94,6 @@ namespace System.Reflection.Runtime.MethodInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.ConstructorInfo_Invoke(this, parameters);
 #endif
-            binder.EnsureNotCustomBinder();
-
             if (parameters == null)
                 parameters = Array.Empty<Object>();
 
@@ -104,7 +102,7 @@ namespace System.Reflection.Runtime.MethodInfos
             // Reflection.Core does not hardcode these special cases. It's up to the ExecutionEnvironment to steer 
             // us the right way by coordinating the implementation of NewObject and MethodInvoker.
             Object newObject = ReflectionCoreExecution.ExecutionEnvironment.NewObject(this.DeclaringType.TypeHandle);
-            Object ctorAllocatedObject = this.MethodInvoker.Invoke(newObject, parameters);
+            Object ctorAllocatedObject = this.MethodInvoker.Invoke(newObject, parameters, binder, invokeAttr, culture);
             return newObject != null ? newObject : ctorAllocatedObject;
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
@@ -71,12 +71,10 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
         {
-            binder.EnsureNotCustomBinder();
-
             if (parameters == null)
                 parameters = Array.Empty<Object>();
 
-            Object ctorAllocatedObject = this.MethodInvoker.Invoke(null, parameters);
+            Object ctorAllocatedObject = this.MethodInvoker.Invoke(null, parameters, binder, invokeAttr, culture);
             return ctorAllocatedObject;
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -151,8 +151,6 @@ namespace System.Reflection.Runtime.PropertyInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.PropertyInfo_GetValue(this, obj, index);
 #endif
-            binder.EnsureNotCustomBinder();
-
             if (_lazyGetterInvoker == null)
             {
                 if (!CanRead)
@@ -162,7 +160,7 @@ namespace System.Reflection.Runtime.PropertyInfos
             }
             if (index == null)
                 index = Array.Empty<Object>();
-            return _lazyGetterInvoker.Invoke(obj, index);
+            return _lazyGetterInvoker.Invoke(obj, index, binder, invokeAttr, culture);
         }
 
         public sealed override Module Module
@@ -227,8 +225,6 @@ namespace System.Reflection.Runtime.PropertyInfos
             if (ReflectionTrace.Enabled)
                 ReflectionTrace.PropertyInfo_SetValue(this, obj, value, index);
 #endif
-            binder.EnsureNotCustomBinder();
-
             if (_lazySetterInvoker == null)
             {
                 if (!CanWrite)
@@ -250,7 +246,7 @@ namespace System.Reflection.Runtime.PropertyInfos
                 }
                 arguments[index.Length] = value;
             }
-            _lazySetterInvoker.Invoke(obj, arguments);
+            _lazySetterInvoker.Invoke(obj, arguments, binder, invokeAttr, culture);
         }
 
         public sealed override String ToString()

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/InstanceFieldAccessor.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/InstanceFieldAccessor.cs
@@ -33,13 +33,13 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return UncheckedGetField(obj);
         }
 
-        public sealed override void SetField(Object obj, Object value)
+        public sealed override void SetField(Object obj, Object value, BinderBundle binderBundle)
         {
             if (obj == null)
                 throw new TargetException(SR.RFLCT_Targ_StatFldReqTarg);
             if (!RuntimeAugments.IsAssignable(obj, this.DeclaringTypeHandle))
                 throw new ArgumentException();
-            value = RuntimeAugments.CheckArgument(value, this.FieldTypeHandle);
+            value = RuntimeAugments.CheckArgument(value, this.FieldTypeHandle, binderBundle);
             UncheckedSetField(obj, value);
         }
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForStaticFields.cs
@@ -31,9 +31,9 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadReferenceTypeField(_fieldAddress);
         }
 
-        protected sealed override void SetFieldBypassCctor(Object obj, Object value)
+        protected sealed override void SetFieldBypassCctor(Object obj, Object value, BinderBundle binderBundle)
         {
-            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle);
+            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle, binderBundle);
             RuntimeAugments.StoreReferenceTypeField(_fieldAddress, value);
         }
     }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForThreadStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForThreadStaticFields.cs
@@ -34,9 +34,9 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadReferenceTypeField(fieldAddress);
         }
 
-        protected sealed override void SetFieldBypassCctor(Object obj, Object value)
+        protected sealed override void SetFieldBypassCctor(Object obj, Object value, BinderBundle binderBundle)
         {
-            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle);
+            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle, binderBundle);
             IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(_declaringTypeHandle, _cookie);
             RuntimeAugments.StoreReferenceTypeField(fieldAddress, value);
         }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForUniversalThreadStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForUniversalThreadStaticFields.cs
@@ -35,9 +35,9 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadReferenceTypeField(fieldAddress);
         }
 
-        protected sealed override void SetFieldBypassCctor(Object obj, Object value)
+        protected sealed override void SetFieldBypassCctor(Object obj, Object value, BinderBundle binderBundle)
         {
-            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle);
+            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle, binderBundle);
             IntPtr tlsFieldsStartAddress = RuntimeAugments.GetThreadStaticFieldAddress(_declaringTypeHandle, IntPtr.Zero);
             IntPtr fieldAddress = tlsFieldsStartAddress + _fieldOffset;
             RuntimeAugments.StoreReferenceTypeField(fieldAddress, value);

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/StaticFieldAccessor.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/StaticFieldAccessor.cs
@@ -37,16 +37,16 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return GetFieldBypassCctor(obj);
         }
 
-        public sealed override void SetField(Object obj, Object value)
+        public sealed override void SetField(Object obj, Object value, BinderBundle binderBundle)
         {
             if (_cctorContext != IntPtr.Zero)
             {
                 RuntimeAugments.EnsureClassConstructorRun(_cctorContext);
             }
-            SetFieldBypassCctor(obj, value);
+            SetFieldBypassCctor(obj, value, binderBundle);
         }
 
         protected abstract Object GetFieldBypassCctor(Object obj);
-        protected abstract void SetFieldBypassCctor(Object obj, Object value);
+        protected abstract void SetFieldBypassCctor(Object obj, Object value, BinderBundle binderBundle);
     }
 }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForStaticFields.cs
@@ -33,9 +33,9 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadValueTypeField(_fieldAddress, FieldTypeHandle);
         }
 
-        protected sealed override void SetFieldBypassCctor(Object obj, Object value)
+        protected sealed override void SetFieldBypassCctor(Object obj, Object value, BinderBundle binderBundle)
         {
-            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle);
+            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle, binderBundle);
             RuntimeAugments.StoreValueTypeField(_fieldAddress, value, FieldTypeHandle);
         }
     }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForThreadStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForThreadStaticFields.cs
@@ -36,9 +36,9 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadValueTypeField(fieldAddress, FieldTypeHandle);
         }
 
-        protected sealed override void SetFieldBypassCctor(Object obj, Object value)
+        protected sealed override void SetFieldBypassCctor(Object obj, Object value, BinderBundle binderBundle)
         {
-            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle);
+            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle, binderBundle);
             IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(_declaringTypeHandle, _cookie);
             RuntimeAugments.StoreValueTypeField(fieldAddress, value, FieldTypeHandle);
         }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForUniversalThreadStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForUniversalThreadStaticFields.cs
@@ -37,9 +37,9 @@ namespace Internal.Reflection.Execution.FieldAccessors
             return RuntimeAugments.LoadValueTypeField(fieldAddress, FieldTypeHandle);
         }
 
-        protected sealed override void SetFieldBypassCctor(Object obj, Object value)
+        protected sealed override void SetFieldBypassCctor(Object obj, Object value, BinderBundle binderBundle)
         {
-            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle);
+            value = RuntimeAugments.CheckArgument(value, FieldTypeHandle, binderBundle);
             IntPtr tlsFieldsStartAddress = RuntimeAugments.GetThreadStaticFieldAddress(_declaringTypeHandle, IntPtr.Zero);
             IntPtr fieldAddress = tlsFieldsStartAddress + _fieldOffset;
             RuntimeAugments.StoreValueTypeField(fieldAddress, value, FieldTypeHandle);

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/InstanceMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/InstanceMethodInvoker.cs
@@ -30,7 +30,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
         }
 
         [DebuggerGuidedStepThroughAttribute]
-        public sealed override Object Invoke(Object thisObject, Object[] arguments)
+        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
         {
             MethodInvokerUtils.ValidateThis(thisObject, _declaringTypeHandle);
             object result = RuntimeAugments.CallDynamicInvokeMethod(
@@ -41,6 +41,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 MethodInvokeInfo.DynamicInvokeGenericDictionary,
                 MethodInvokeInfo.MethodInfo,
                 arguments,
+                binderBundle,
                 invokeMethodHelperIsThisCall: false, 
                 methodToCallIsThisCall: true);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/IntPtrConstructorMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/IntPtrConstructorMethodInvoker.cs
@@ -62,14 +62,14 @@ namespace Internal.Reflection.Execution.MethodInvokers
             }
         }
 
-        public sealed override Object Invoke(Object thisObject, Object[] arguments)
+        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
         {
             switch (_id)
             {
                 case IntPtrConstructorId.Int32:
                     {
                         CheckArgumentCount(arguments, 1);
-                        Int32 value = (Int32)(RuntimeAugments.CheckArgument(arguments[0], typeof(Int32).TypeHandle));
+                        Int32 value = (Int32)(RuntimeAugments.CheckArgument(arguments[0], typeof(Int32).TypeHandle, binderBundle));
                         try
                         {
                             return new IntPtr(value);
@@ -83,7 +83,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 case IntPtrConstructorId.Int64:
                     {
                         CheckArgumentCount(arguments, 1);
-                        Int64 value = (Int64)(RuntimeAugments.CheckArgument(arguments[0], typeof(Int64).TypeHandle));
+                        Int64 value = (Int64)(RuntimeAugments.CheckArgument(arguments[0], typeof(Int64).TypeHandle, binderBundle));
                         try
                         {
                             return new IntPtr(value);
@@ -97,7 +97,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 case IntPtrConstructorId.UInt32:
                     {
                         CheckArgumentCount(arguments, 1);
-                        UInt32 value = (UInt32)(RuntimeAugments.CheckArgument(arguments[0], typeof(UInt32).TypeHandle));
+                        UInt32 value = (UInt32)(RuntimeAugments.CheckArgument(arguments[0], typeof(UInt32).TypeHandle, binderBundle));
                         try
                         {
                             return new UIntPtr(value);
@@ -111,7 +111,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 case IntPtrConstructorId.UInt64:
                     {
                         CheckArgumentCount(arguments, 1);
-                        UInt64 value = (UInt64)(RuntimeAugments.CheckArgument(arguments[0], typeof(UInt64).TypeHandle));
+                        UInt64 value = (UInt64)(RuntimeAugments.CheckArgument(arguments[0], typeof(UInt64).TypeHandle, binderBundle));
                         try
                         {
                             return new UIntPtr(value);

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/NullableInstanceMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/NullableInstanceMethodInvoker.cs
@@ -84,7 +84,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
             }
         }
 
-        public sealed override Object Invoke(Object thisObject, Object[] arguments)
+        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
         {
             Object value = thisObject;
             bool hasValue = (thisObject != null);
@@ -120,7 +120,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                         // version of Nullable<T> which conveniently happens to be equal to the value we were passed in.
                         CheckArgumentCount(arguments, 1);
                         RuntimeTypeHandle theT = RuntimeAugments.GetNullableType(_nullableTypeHandle);
-                        Object argument = RuntimeAugments.CheckArgument(arguments[0], theT);
+                        Object argument = RuntimeAugments.CheckArgument(arguments[0], theT, binderBundle);
                         return argument;
                     }
 
@@ -147,7 +147,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                     {
                         CheckArgumentCount(arguments, 1);
                         RuntimeTypeHandle theT = RuntimeAugments.GetNullableType(_nullableTypeHandle);
-                        Object defaultValue = RuntimeAugments.CheckArgument(arguments[0], theT);
+                        Object defaultValue = RuntimeAugments.CheckArgument(arguments[0], theT, binderBundle);
                         return hasValue ? value : defaultValue;
                     }
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StaticMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StaticMethodInvoker.cs
@@ -25,7 +25,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
         }
 
         [DebuggerGuidedStepThroughAttribute]
-        public sealed override Object Invoke(Object thisObject, Object[] arguments)
+        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
         {
             object result = RuntimeAugments.CallDynamicInvokeMethod(
                 thisObject,
@@ -35,6 +35,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 MethodInvokeInfo.DynamicInvokeGenericDictionary,
                 MethodInvokeInfo.MethodInfo,
                 arguments,
+                binderBundle,
                 invokeMethodHelperIsThisCall: false,
                 methodToCallIsThisCall: false);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StringConstructorMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StringConstructorMethodInvoker.cs
@@ -58,31 +58,31 @@ namespace Internal.Reflection.Execution.MethodInvokers
             }
         }
 
-        public sealed override Object Invoke(Object thisObject, Object[] arguments)
+        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
         {
             switch (_id)
             {
                 case StringConstructorId.CharArray:
                     {
                         CheckArgumentCount(arguments, 1);
-                        char[] value = (char[])(RuntimeAugments.CheckArgument(arguments[0], typeof(char[]).TypeHandle));
+                        char[] value = (char[])(RuntimeAugments.CheckArgument(arguments[0], typeof(char[]).TypeHandle, binderBundle));
                         return new String(value);
                     }
 
                 case StringConstructorId.Char_Int:
                     {
                         CheckArgumentCount(arguments, 2);
-                        char c = (char)(RuntimeAugments.CheckArgument(arguments[0], typeof(char).TypeHandle));
-                        int count = (int)(RuntimeAugments.CheckArgument(arguments[1], typeof(int).TypeHandle));
+                        char c = (char)(RuntimeAugments.CheckArgument(arguments[0], typeof(char).TypeHandle, binderBundle));
+                        int count = (int)(RuntimeAugments.CheckArgument(arguments[1], typeof(int).TypeHandle, binderBundle));
                         return new String(c, count);
                     }
 
                 case StringConstructorId.CharArray_Int_Int:
                     {
                         CheckArgumentCount(arguments, 3);
-                        char[] value = (char[])(RuntimeAugments.CheckArgument(arguments[0], typeof(char[]).TypeHandle));
-                        int startIndex = (int)(RuntimeAugments.CheckArgument(arguments[1], typeof(int).TypeHandle));
-                        int length = (int)(RuntimeAugments.CheckArgument(arguments[2], typeof(int).TypeHandle));
+                        char[] value = (char[])(RuntimeAugments.CheckArgument(arguments[0], typeof(char[]).TypeHandle, binderBundle));
+                        int startIndex = (int)(RuntimeAugments.CheckArgument(arguments[1], typeof(int).TypeHandle, binderBundle));
+                        int length = (int)(RuntimeAugments.CheckArgument(arguments[2], typeof(int).TypeHandle, binderBundle));
                         return new String(value, startIndex, length);
                     }
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/SyntheticMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/SyntheticMethodInvoker.cs
@@ -29,7 +29,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
             _parameterTypes = parameterTypes;
         }
 
-        public override Object Invoke(Object thisObject, Object[] arguments)
+        public override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
         {
             //@todo: This does not handle optional parameters (nor does it need to as today we're only using it for three synthetic array methods.)
             if (!(thisObject == null && 0 != (_options & InvokerOptions.AllowNullThis)))
@@ -41,7 +41,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
             Object[] convertedArguments = new Object[arguments.Length];
             for (int i = 0; i < arguments.Length; i++)
             {
-                convertedArguments[i] = RuntimeAugments.CheckArgument(arguments[i], _parameterTypes[i]);
+                convertedArguments[i] = RuntimeAugments.CheckArgument(arguments[i], _parameterTypes[i], binderBundle);
             }
             Object result;
             try

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
@@ -54,7 +54,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
         }
 
         [DebuggerGuidedStepThroughAttribute]
-        public sealed override Object Invoke(Object thisObject, Object[] arguments)
+        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
         {
             MethodInvokerUtils.ValidateThis(thisObject, _declaringTypeHandle);
 
@@ -68,6 +68,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 MethodInvokeInfo.DynamicInvokeGenericDictionary,
                 MethodInvokeInfo.MethodInfo,
                 arguments,
+                binderBundle,
                 invokeMethodHelperIsThisCall: false,
                 methodToCallIsThisCall: true);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();


### PR DESCRIPTION
Before this change, passing a custom binder to
MethodBase.Invoke() or FieldInfo.SetValue() threw
a PNSE.

After this change, it still throws a PNSE but
we've put in all the plumbing to get the binder
to the point where we'd actually act on it.

Since this touches a lot of files but is completely
mechanical, I'm doing this separately so the
actual change to integrate the binder isn't
buried in it.