### PR TITLE
Enable multi-module for CoreCLR tests

### DIFF
--- a/src/BuildIntegration/BuildFrameworkNativeObjects.proj
+++ b/src/BuildIntegration/BuildFrameworkNativeObjects.proj
@@ -10,7 +10,9 @@
   
   <Import Project="Microsoft.NETCore.Native.targets" />
 
-  <Target Name="BuildAllFrameworkLibraries">
+  <Target Name="BuildAllFrameworkLibraries"
+    Inputs="@(IlcReference)"
+    Outputs="@(IlcReference->'$(NativeIntermediateOutputPath)\%(Filename)$(NativeObjectExt)')">
     <ItemGroup>
       <ProjectToBuild Include="$(MSBuildProjectFullPath)">
         <AdditionalProperties>
@@ -25,7 +27,7 @@
     DependsOnTargets="BuildAllFrameworkLibraries">
 
     <ItemGroup>
-      <LibInputs Include="$(NativeIntermediateOutputPath)\*.obj" />
+      <LibInputs Include="$(NativeIntermediateOutputPath)\*$(NativeObjectExt)" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -37,6 +39,7 @@
   <Target Name="BuildOneFrameworkLibrary">
     <ItemGroup>
         <ManagedBinary Include="$(LibraryToCompile)" />
+        <IlcCompileInput Include="@(ManagedBinary)" />
     </ItemGroup>
   </Target>
   

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -56,6 +56,7 @@ See the LICENSE file in the project root for more information.
   </ItemGroup>
 
   <ItemGroup>
+    <IlcCompileInput Include="@(ManagedBinary)" />
     <IlcReference Include="$(IlcPath)\sdk\*.dll" />
     <IlcReference Include="$(IlcPath)\framework\*.dll" />
   </ItemGroup>
@@ -83,12 +84,12 @@ See the LICENSE file in the project root for more information.
   </Target>
 
   <Target Name="IlcCompile" 
-      Inputs="@(ManagedBinary)"
+      Inputs="@(IlcCompileInput)"
       Outputs="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
     <ItemGroup>
-      <IlcArg Include="@(ManagedBinary)" />
+      <IlcArg Include="@(IlcCompileInput)" />
       <IlcArg Include="-o:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)" />
       <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
       <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />

--- a/tests/CoreCLR/Test.csproj
+++ b/tests/CoreCLR/Test.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!-- Some tests consist of multiple assemblies - make sure ILC sees them -->
-    <IlcReference Include="$(MSBuildProjectDirectory)\*.dll" />
+    <IlcCompileInput Include="$(MSBuildProjectDirectory)\*.dll" />
   </ItemGroup>
   
   <Import Project="$(CoreRT_TestRoot)\Test.Common.targets" />

--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -10,8 +10,6 @@
 @echo OFF
 setlocal ENABLEDELAYEDEXPANSION
 
-echo CoreRT_ToolchainDir %CoreRT_ToolchainDir%
-
 set TestFolder=%1
 
 ::
@@ -37,8 +35,8 @@ if "%CoreRT_BuildArch%" == "x64" (
     call "%VS140COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat"
 )
 
-echo msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" %TestFolder%\Test.csproj
-msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" %TestFolder%\Test.csproj
+echo msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" %TestFolder%\Test.csproj
+msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" %TestFolder%\Test.csproj
 if errorlevel 1 (
     set TestExitCode=!ERRORLEVEL!
     goto :Cleanup

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -86,7 +86,7 @@ set __CoreRTTestBinDir=%CoreRT_TestRoot%..\bin\tests
 :: multi-module test results are visible to the CI tooling
 if NOT "%CoreRT_MultiFileConfiguration%" == "" (
     set CoreRT_TestLogFileName=%CoreRT_MultiFileConfiguration%\%CoreRT_TestLogFileName%
-    mkdir %__CoreRTTestBinDir%\%CoreRT_MultiFileConfiguration%
+    if not exist %__CoreRTTestBinDir%\%CoreRT_MultiFileConfiguration%\ mkdir %__CoreRTTestBinDir%\%CoreRT_MultiFileConfiguration%
 )
 
 set __LogDir=%CoreRT_TestRoot%\..\bin\Logs\%__BuildStr%\tests
@@ -207,9 +207,9 @@ goto :eof
         )
     )
 
-    echo msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:Platform=%CoreRT_BuildArch%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
+    echo msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:Platform=%CoreRT_BuildArch%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
     echo.
-    msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:Platform=%CoreRT_BuildArch%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0\..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0\..\bin\obj\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
+    msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:Platform=%CoreRT_BuildArch%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\bin\Product\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" !extraArgs! !__SourceFile!.csproj
     endlocal
 
     set __SavedErrorLevel=%ErrorLevel%
@@ -296,7 +296,10 @@ goto :eof
     set CORE_ROOT=%CoreRT_TestRoot%\..\Tools\dotnetcli\shared\Microsoft.NETCore.App\1.0.0
     echo CORE_ROOT IS NOW %CORE_ROOT%
     pushd %CoreRT_TestRoot%\CoreCLR\runtest
- 
+    if "%CoreRT_MultiFileConfiguration%" == "MultiModule" (
+        set IlcMultiModule=true
+    )
+
     msbuild "/p:RepoLocalBuild=true" src\TestWrappersConfig\XUnitTooling.depproj
     if errorlevel 1 (
         exit /b 1


### PR DESCRIPTION
* Allows runtest.cmd /multimodule /coreclr
* Modify build integration targets to allow for tests with multiple
assemblies. We have two set of assembly inputs to ILC: @(ManagedLibrary)
which despite being an Item contains the main managed assembly to use as
the template name for the response file and output object file base
name. @(IlcCompileInput) is the list of assemblies that are inputs to
Ilc. This change allows us to compile all the app assemblies into a
single object file.
* Specify the inputs / outputs to the MSBuild task that builds the
framework assembly obj files. This removes a page of spam per test when
MSBuild skips over the already-built obj files.
* Currently 12 tests fail due to some EH issue that needs investigating.