### PR TITLE
Remove leftover RuntimeFieldHandle bucketing code

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -3186,12 +3186,6 @@ namespace Internal.JitInterface
                     // Reloc points to something outside of the generated blocks
                     var targetObject = HandleToObject((IntPtr)target);
 
-                    if (targetObject is FieldDesc)
-                    {
-                        // We only support FieldDesc for InitializeArray intrinsic right now.
-                        throw new NotImplementedException("RuntimeFieldHandle is not implemented");
-                    }
-
                     relocTarget = (ISymbolNode)targetObject;
 
                     if (relocTarget is FatFunctionPointerNode)


### PR DESCRIPTION
This is a leftover from when we only supported `ldtoken field` in the
context of RuntimeHelpers.InitializeArray. We should not see
`targetObject` being a non-ISymbolNode anymore.