### PR TITLE
Add case-insensitive String.Replace overloads

### DIFF
--- a/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -25,7 +25,7 @@ internal static partial class Interop
 
         [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOf")]
-        internal unsafe static extern int IndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options);
+        internal unsafe static extern int IndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options, int* matchLengthPtr);
 
         [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_LastIndexOf")]

--- a/src/Common/src/Interop/Windows/mincore/Interop.Globalization.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Globalization.cs
@@ -32,7 +32,8 @@ internal static partial class Interop
                     int* pcchFound,
                     void* lpVersionInformation,
                     void* lpReserved,
-                    IntPtr sortHandle);
+                    IntPtr sortHandle,
+                    int* matchLengthPtr);
 
         [DllImport("api-ms-win-core-string-l1-1-0.dll", EntryPoint = "CompareStringEx")]
         internal extern static unsafe int CompareStringEx(

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
@@ -159,30 +159,46 @@ namespace System.Globalization
             }
         }
 
-        private unsafe int IndexOfCore(string source, string target, int startIndex, int count, CompareOptions options)
+        internal unsafe int IndexOfCore(string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!string.IsNullOrEmpty(source));
             Debug.Assert(target != null);
             Debug.Assert((options & CompareOptions.OrdinalIgnoreCase) == 0);
 
+            int index;
+
             if (target.Length == 0)
             {
+                if(matchLengthPtr != null)
+                    *matchLengthPtr = 0;
                 return startIndex;
             }
 
             if (options == CompareOptions.Ordinal)
             {
-                return IndexOfOrdinal(source, target, startIndex, count, ignoreCase: false);
+                index = IndexOfOrdinal(source, target, startIndex, count, ignoreCase: false);
+                if(index != -1)
+                {
+                    if(matchLengthPtr != null)
+                        *matchLengthPtr = target.Length;
+                }
+                return index;
             }
 #if CORECLR
             if (_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsFastSort() && target.IsFastSort())
             {
-                return IndexOf(source, target, startIndex, count, GetOrdinalCompareOptions(options));
+                index = IndexOf(source, target, startIndex, count, GetOrdinalCompareOptions(options));
+                if(index != -1)
+                {
+                    if(matchLengthPtr != null)
+                        *matchLengthPtr = target.Length;
+                }
+                return index;
             }
 #endif
             fixed (char* pSource = source)
             {
-                int index = Interop.GlobalizationInterop.IndexOf(_sortHandle, target, target.Length, pSource + startIndex, count, options);
+                index = Interop.GlobalizationInterop.IndexOf(_sortHandle, target, target.Length, pSource + startIndex, count, options, matchLengthPtr);
 
                 return index != -1 ? index + startIndex : -1;
             }

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -659,7 +659,7 @@ namespace System.Globalization
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
 
-            return IndexOfCore(source, new string(value, 1), startIndex, count, options);
+            return IndexOfCore(source, new string(value, 1), startIndex, count, options, null);
         }
 
 
@@ -706,7 +706,7 @@ namespace System.Globalization
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
 
-            return IndexOfCore(source, value, startIndex, count, options);
+            return IndexOfCore(source, value, startIndex, count, options, null);
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/packaging/netcoreapp/project.json
+++ b/src/packaging/netcoreapp/project.json
@@ -9,7 +9,7 @@
         "System.Runtime.CompilerServices.Unsafe": "4.4.0-beta-24913-02",
 
         "runtime.native.System": "4.4.0-beta-24913-02",
-        "Microsoft.NETCore.Native": "1.2.0-beta-24911-02"
+        "Microsoft.NETCore.Native": "2.0.0-beta-25021-03"
       }
     }
   },

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -27,7 +27,7 @@
 
             <JitPackageVersion>2.0.0-beta-25015-04</JitPackageVersion>
 
-            <MicrosoftNetCoreNativePackageVersion>1.2.0-beta-24911-02</MicrosoftNetCoreNativePackageVersion>
+            <MicrosoftNetCoreNativePackageVersion>2.0.0-beta-25021-03</MicrosoftNetCoreNativePackageVersion>
 
             <ObjectWriterPackageVersion>1.0.14-prerelease-00001</ObjectWriterPackageVersion>
             <ObjectWriterNuPkgRid Condition="'$(OSGroup)'=='Linux'">ubuntu.14.04-x64</ObjectWriterNuPkgRid>


### PR DESCRIPTION
Added overloads for String.Replace so that they now accept
StringComparison and CultureInfo as input parameters.