### PR TITLE
Allow invalid binaries as input files to ILC

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -193,7 +193,7 @@ namespace ILCompiler
                     var module = typeSystemContext.GetModuleFromPath(inputFile.Value);
                     inputFilePaths.Add(inputFile.Key, inputFile.Value);
                 }
-                catch (Exception)
+                catch (InvalidOperationException)
                 {
                     // Keep calm and carry on.
                 }

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -163,10 +163,7 @@ namespace ILCompiler
                 Help(syntax.GetHelpText());
                 return 1;
             }
-
-            if (_inputFilePaths.Count == 0)
-                throw new CommandLineException("No input files specified");
-
+            
             if (_outputFilePath == null)
                 throw new CommandLineException("Output filename must be specified (/out <file>)");
 
@@ -178,10 +175,37 @@ namespace ILCompiler
                 SharedGenericsMode.CanonicalReferenceTypes : SharedGenericsMode.Disabled;
 
             var typeSystemContext = new CompilerTypeSystemContext(new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT), genericsMode);
-            typeSystemContext.InputFilePaths = _inputFilePaths;
+
+            //
+            // TODO: To support our pre-compiled test tree, allow input files that aren't managed assemblies since
+            // some tests contain a mixture of both managed and native binaries.
+            //
+            // See: https://github.com/dotnet/corert/issues/2785
+            //
+            // When we undo this this hack, replace this foreach with
+            //  typeSystemContext.InputFilePaths = _inputFilePaths;
+            //
+            Dictionary<string, string> inputFilePaths = new Dictionary<string, string>();
+            foreach (var inputFile in _inputFilePaths)
+            {
+                try
+                {
+                    var module = typeSystemContext.GetModuleFromPath(inputFile.Value);
+                    inputFilePaths.Add(inputFile.Key, inputFile.Value);
+                }
+                catch (Exception)
+                {
+                    // Keep calm and carry on.
+                }
+            }
+
+            typeSystemContext.InputFilePaths = inputFilePaths;
             typeSystemContext.ReferenceFilePaths = _referenceFilePaths;
 
-            typeSystemContext.SetSystemModule(typeSystemContext.GetModuleForSimpleName(_systemModuleName));           
+            typeSystemContext.SetSystemModule(typeSystemContext.GetModuleForSimpleName(_systemModuleName));
+
+            if (typeSystemContext.InputFilePaths.Count == 0)
+                throw new CommandLineException("No input files specified");
 
             //
             // Initialize compilation group and compilation roots

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -45,6 +45,7 @@ if /i "%1" == "/coreclr"  (
 :ExtRepoTestsOk
     goto ArgLoop
 )
+if /i "%1" == "/coreclrsingletest" (set CoreRT_RunCoreCLRTests=true&set CoreRT_CoreCLRTest=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/mode" (set CoreRT_TestCompileMode=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/runtest" (set CoreRT_TestRun=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/dotnetclipath" (set CoreRT_CliDir=%2&shift&shift&goto ArgLoop)
@@ -60,6 +61,8 @@ echo     flavor        : debug / release
 echo     /mode         : Optionally restrict to a single code generator. Specify cpp/ryujit. Default: both
 echo     /runtest      : Should just compile or run compiled binary? Specify: true/false. Default: true.
 echo     /coreclr      : Download and run the CoreCLR repo tests
+echo     /coreclrsingletest ^<absolute\path\to\test.exe^>
+echo                   : Run a single CoreCLR repo test
 echo     /multimodule  : Compile the framework as a .lib and link tests against it (only supports ryujit)
 echo.
 echo     --- CoreCLR Subset ---
@@ -304,8 +307,24 @@ goto :eof
     if errorlevel 1 (
         exit /b 1
     )
-    echo runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
-    call runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
+
+    if not "%CoreRT_CoreCLRTest%" == "" (
+        if not exist %CoreRT_CoreCLRTest% (
+            echo Target test file not found: %CoreRT_CoreCLRTest%
+            exit /b 1
+        )
+
+        for %%i in (%CoreRT_CoreCLRTest%) do (
+            set TestFolderName=%%~dpi
+            set TestFileName=%%~nxi
+        )
+        %CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd !TestFolderName! !TestFileName!
+    )
+    else (
+        echo runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
+        call runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
+    )
+    
     set __SavedErrorLevel=%ErrorLevel%
     popd
     exit /b %__SavedErrorLevel%

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -309,7 +309,7 @@ goto :eof
     )
 
     if not "%CoreRT_CoreCLRTest%" == "" (
-        if not exist %CoreRT_CoreCLRTest% (
+        if not exist "%CoreRT_CoreCLRTest%" (
             echo Target test file not found: %CoreRT_CoreCLRTest%
             exit /b 1
         )
@@ -318,9 +318,8 @@ goto :eof
             set TestFolderName=%%~dpi
             set TestFileName=%%~nxi
         )
-        %CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd !TestFolderName! !TestFileName!
-    )
-    else (
+        call %CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd !TestFolderName! !TestFileName!
+    ) else (
         echo runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
         call runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
     )


### PR DESCRIPTION
This is a hopefully short-term hack which allows files specified as
inputs to ILC to be actually native binaries that we ignore and proceed
with compilation.  The CoreCLR drops we test against contain a mixture
of managed and native binaries in test folders in some cases.

Also, add a quality of life switch to runtest.cmd (/CoreCLRSingleTest)
that allows specifying a single CoreCLR test to run by executable path.
This downloads the test blob and sets the correct environment variables
first.