### PR TITLE
Enable shared generics test on Unixes

### DIFF
--- a/tests/src/Simple/Generics/no_unix
+++ b/tests/src/Simple/Generics/no_unix
@@ -1,1 +1,0 @@
-Doesn't work on OSX.


### PR DESCRIPTION
Whatever the hell #2169 was about, I can't repro it on OSX anymore.
Maybe the ObjectWriter update helped.

Closes #2169.