### PR TITLE
[arm32 unix building] Passing target platform and os to IlcCompiler for cross compiling

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
@@ -43,6 +43,7 @@ namespace ILCompiler.DependencyAnalysis
                     return x86Emitter.Builder.ToObjectData();
 
                 case TargetArchitecture.ARM:
+                case TargetArchitecture.ARMEL:
                     ARM.ARMEmitter armEmitter = new ARM.ARMEmitter(factory);
                     EmitCode(factory, ref armEmitter, relocsOnly);
                     armEmitter.Builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
@@ -11,12 +11,91 @@ using ILCompiler.DependencyAnalysis.ARM;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    // ARM specific portions of ReadyToRunHelperNode
+    /// <summary>
+    /// ARM specific portions of ReadyToRunHelperNode
+    /// </summary>
     partial class ReadyToRunHelperNode
     {
+        private ExternSymbolNode NYI_Assert;
         protected override void EmitCode(NodeFactory factory, ref ARMEmitter encoder, bool relocsOnly)
         {
-            throw new NotImplementedException();
+            NYI_Assert = new ExternSymbolNode("NYI_Assert");
+
+            switch (Id)
+            {
+                case ReadyToRunHelperId.NewHelper:
+                    {
+                        TypeDesc target = (TypeDesc)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.VirtualCall:
+                    {
+                        MethodDesc targetMethod = (MethodDesc)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.IsInstanceOf:
+                    {
+                        TypeDesc target = (TypeDesc)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.CastClass:
+                    {
+                        TypeDesc target = (TypeDesc)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.NewArr1:
+                    {
+                        TypeDesc target = (TypeDesc)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    {
+                        MetadataType target = (MetadataType)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.DelegateCtor:
+                    {
+                        DelegateCreationInfo target = (DelegateCreationInfo)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.ResolveVirtualFunction:
+                    {
+                        MethodDesc targetMethod = (MethodDesc)Target;
+                        encoder.EmitJMP(NYI_Assert);
+                    }
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/TargetRegisterMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/TargetRegisterMap.cs
@@ -19,18 +19,9 @@ namespace ILCompiler.DependencyAnalysis.ARM
 
         public TargetRegisterMap(TargetOS os)
         {
-            switch (os)
-            {
-                case TargetOS.Windows:
-                case TargetOS.Linux:
-                    Arg0 = Register.R0;
-                    Arg1 = Register.R1;
-                    Result = Register.R0;
-                    break;
-                    
-                default:
-                    throw new NotImplementedException();
-            }
+            Arg0 = Register.R0;
+            Arg1 = Register.R1;
+            Result = Register.R0;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/TargetRegisterMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/TargetRegisterMap.cs
@@ -22,6 +22,7 @@ namespace ILCompiler.DependencyAnalysis.ARM
             switch (os)
             {
                 case TargetOS.Windows:
+                case TargetOS.Linux:
                     Arg0 = Register.R0;
                     Arg1 = Register.R1;
                     Result = Register.R0;

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -28,7 +28,9 @@ namespace ILCompiler
         private bool _generateFullDgmlLog;
 
         private TargetArchitecture _targetArchitecture;
+        private string _targetArchitectureStr;
         private TargetOS _targetOS;
+        private string _targetOSStr;
         private OptimizationMode _optimizationMode;
         private bool _enableDebugInfo;
         private string _systemModuleName = "System.Private.CoreLib";
@@ -130,6 +132,9 @@ namespace ILCompiler
                 syntax.DefineOptionList("codegenopt", ref _codegenOptions, "Define a codegen option");
                 syntax.DefineOptionList("rdxml", ref _rdXmlFilePaths, "RD.XML file(s) for compilation");
 
+                syntax.DefineOption("targetarch", ref _targetArchitectureStr, "Target architecture for cross compilation");
+                syntax.DefineOption("targetos", ref _targetOSStr, "Target OS for cross compilation");
+
                 syntax.DefineOption("singlemethodtypename", ref _singleMethodTypeName, "Single method compilation: name of the owning type");
                 syntax.DefineOption("singlemethodname", ref _singleMethodName, "Single method compilation: name of the method");
                 syntax.DefineOptionList("singlemethodgenericarg", ref _singleMethodGenericArgs, "Single method compilation: generic arguments to the method");
@@ -166,6 +171,36 @@ namespace ILCompiler
             
             if (_outputFilePath == null)
                 throw new CommandLineException("Output filename must be specified (/out <file>)");
+
+            //
+            // Set target Architecture and OS
+            //
+            if (_targetArchitectureStr != null)
+            {
+                if (_targetArchitectureStr.Equals("x86"))
+                    _targetArchitecture = TargetArchitecture.X86;
+                else if (_targetArchitectureStr.Equals("x64"))
+                    _targetArchitecture = TargetArchitecture.X64;
+                else if (_targetArchitectureStr.Equals("arm"))
+                    _targetArchitecture = TargetArchitecture.ARM;
+                else if (_targetArchitectureStr.Equals("armel"))
+                    _targetArchitecture = TargetArchitecture.ARMEL;
+                else if (_targetArchitectureStr.Equals("arm64"))
+                    _targetArchitecture = TargetArchitecture.ARM64;
+                else
+                    throw new NotImplementedException();
+            }
+            if (_targetOSStr != null)
+            {
+                if (_targetOSStr.Equals("windows"))
+                    _targetOS = TargetOS.Windows;
+                else if (_targetOSStr.Equals("linux"))
+                    _targetOS = TargetOS.Linux;
+                else if (_targetOSStr.Equals("osx"))
+                    _targetOS = TargetOS.OSX;
+                else
+                    throw new NotImplementedException();
+            }
 
             //
             // Initialize type system context

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -177,29 +177,29 @@ namespace ILCompiler
             //
             if (_targetArchitectureStr != null)
             {
-                if (_targetArchitectureStr.Equals("x86"))
+                if (_targetArchitectureStr.Equals("x86", StringComparison.OrdinalIgnoreCase))
                     _targetArchitecture = TargetArchitecture.X86;
-                else if (_targetArchitectureStr.Equals("x64"))
+                else if (_targetArchitectureStr.Equals("x64", StringComparison.OrdinalIgnoreCase))
                     _targetArchitecture = TargetArchitecture.X64;
-                else if (_targetArchitectureStr.Equals("arm"))
+                else if (_targetArchitectureStr.Equals("arm", StringComparison.OrdinalIgnoreCase))
                     _targetArchitecture = TargetArchitecture.ARM;
-                else if (_targetArchitectureStr.Equals("armel"))
+                else if (_targetArchitectureStr.Equals("armel", StringComparison.OrdinalIgnoreCase))
                     _targetArchitecture = TargetArchitecture.ARMEL;
-                else if (_targetArchitectureStr.Equals("arm64"))
+                else if (_targetArchitectureStr.Equals("arm64", StringComparison.OrdinalIgnoreCase))
                     _targetArchitecture = TargetArchitecture.ARM64;
                 else
-                    throw new NotImplementedException();
+                    throw new CommandLineException("Target architecture is not supported");
             }
             if (_targetOSStr != null)
             {
-                if (_targetOSStr.Equals("windows"))
+                if (_targetOSStr.Equals("windows", StringComparison.OrdinalIgnoreCase))
                     _targetOS = TargetOS.Windows;
-                else if (_targetOSStr.Equals("linux"))
+                else if (_targetOSStr.Equals("linux", StringComparison.OrdinalIgnoreCase))
                     _targetOS = TargetOS.Linux;
-                else if (_targetOSStr.Equals("osx"))
+                else if (_targetOSStr.Equals("osx", StringComparison.OrdinalIgnoreCase))
                     _targetOS = TargetOS.OSX;
                 else
-                    throw new NotImplementedException();
+                    throw new CommandLineException("Target OS is not supported");
             }
 
             //

--- a/src/Native/Runtime/arm/InteropThunksHelpers.S
+++ b/src/Native/Runtime/arm/InteropThunksHelpers.S
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <unixasmmacros.inc>
+
+.syntax unified
+.thumb
+
+// TODO: Implement Arm support
+
+//
+// InteropNative_CommonStub
+//
+NESTED_ENTRY InteropNative_CommonStub, _TEXT, NoHandler
+#ifdef _DEBUG
+    bl C_FUNC(NYI_Assert)
+#endif
+NESTED_END InteropNative_CommonStub, _TEXT
+
+//
+// IntPtr InteropNative_GetCommonStubAddress()
+//
+LEAF_ENTRY InteropNative_GetCommonStubAddress, _TEXT
+#ifdef _DEBUG
+    bl C_FUNC(NYI_Assert)
+#endif
+LEAF_END InteropNative_GetCommonStubAddress, _TEXT
+
+//
+// IntPtr InteropNative_GetCurrentThunkContext()
+//
+LEAF_ENTRY InteropNative_GetCurrentThunkContext, _TEXT
+#ifdef _DEBUG
+    bl C_FUNC(NYI_Assert)
+#endif
+LEAF_END 	InteropNative_GetCurrentThunkContext, _TEXT

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -732,72 +732,9 @@ bool QueryCacheSize()
     g_cbLargestOnDieCache = 0;
 
 #ifdef __linux__
+
     g_cbLargestOnDieCache = GetLogicalProcessorCacheSizeFromOS();
 
-    if (g_cbLargestOnDieCache == 0)
-    {
-        DIR* cpuDir = opendir("/sys/devices/system/cpu");
-        if (cpuDir == nullptr)
-        {
-            ASSERT_UNCONDITIONALLY("opendir on /sys/devices/system/cpu failed\n");
-            return false;
-        }
-
-        dirent* cpuEntry;
-        // Process entries starting with "cpu" (cpu0, cpu1, ...) in the directory
-        while (success && (cpuEntry = readdir(cpuDir)) != nullptr)
-        {
-            if ((strncmp(cpuEntry->d_name, "cpu", 3) == 0) && isdigit(cpuEntry->d_name[3]))
-            {
-                char cpuCachePath[64] = "/sys/devices/system/cpu/";
-                strcat(cpuCachePath, cpuEntry->d_name);
-                strcat(cpuCachePath, "/cache");
-                DIR* cacheDir = opendir(cpuCachePath);
-                if (cacheDir == nullptr)
-                {
-                    success = false;
-                    break;
-                }
-
-                strcat(cpuCachePath, "/");
-                int cpuCacheBasePathLength = strlen(cpuCachePath);
-
-                dirent* cacheEntry;
-                // For all entries in the directory
-                while ((cacheEntry = readdir(cacheDir)) != nullptr)
-                {
-                    if (strncmp(cacheEntry->d_name, "index", 5) == 0)
-                    {
-                        cpuCachePath[cpuCacheBasePathLength] = '\0';
-                        strcat(cpuCachePath, cacheEntry->d_name);
-                        strcat(cpuCachePath, "/size");
-
-                        int fd = open(cpuCachePath, O_RDONLY);
-                        if (fd < 0)
-                        {
-                            success = false;
-                            break;
-                        }
-
-                        char cacheSizeStr[16];
-                        int bytesRead = read(fd, cacheSizeStr, sizeof(cacheSizeStr) - 1);
-                        cacheSizeStr[bytesRead] = '\0';
-
-                        // Parse the cache size that is formatted as a number followed by the K letter
-                        char* lastChar;
-                        int cacheSize = strtol(cacheSizeStr, &lastChar, 10) * 1024;
-                        ASSERT(*lastChar == 'K');
-                        g_cbLargestOnDieCache = max(g_cbLargestOnDieCache, cacheSize);
-
-                        close(fd);
-                    }
-                }
-
-                closedir(cacheDir);
-            }
-        }
-        closedir(cpuDir);
-    }
 #elif HAVE_SYSCTL
 
     int64_t g_cbLargestOnDieCache;

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -734,6 +734,11 @@ bool QueryCacheSize()
 #ifdef __linux__
 
     g_cbLargestOnDieCache = GetLogicalProcessorCacheSizeFromOS();
+#ifndef _ARM_
+    // TODO Some systems on arm does not give the info about cache sizes by this method so we need to find another way
+    if (g_cbLargestOnDieCache == 0)
+        success = false;
+#endif
 
 #elif HAVE_SYSCTL
 
@@ -759,11 +764,6 @@ bool QueryCacheSize()
 
     // TODO: implement adjusted cache size
     g_cbLargestOnDieCacheAdjusted = g_cbLargestOnDieCache;
-
-#ifdef _ARM_
-    // TODO Some system on arm32 does not give the info about cache sizes by these methods so we need to find another ways
-    success = true;
-#endif
 
     return success;
 }

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -47,7 +47,7 @@ run_test_dir()
         __extra_args="${__extra_args} /p:IlcMultiModule=true"
     fi
 
-    rm -rf ${__dir_path}/bin ${__dir_path}/obj
+    rm -rf ${__dir_path}/bin/${CoreRT_BuildArch} ${__dir_path}/obj/${CoreRT_BuildArch}
 
     local __msbuild_dir=${CoreRT_TestRoot}/../Tools
 

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <IlsArg Include="--targetarch=$(Platform)" />
+    <IlcArg Include="--targetarch=$(Platform)" />
   </ItemGroup>
 
 </Project>

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -40,4 +40,8 @@
     <CustomLinkerArg Include="$(AdditionalLinkerFlags)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <IlsArg Include="--targetarch=$(Platform)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This pull request contains some fixes for test cross building on arm32 systems. 

There are several problems:
1. Some linux on arm does not give information about processor cache sizes.  There are no the directories /sys/devices/system/cpu/cpu*/cache and lscpu does not show this info also.  I've checked out for example 
Linux raspberrypi 4.1.19-v7+ #858 SMP  armv7l GNU/Linux and
Linux odroid 4.9.6 #3 SMP PREEMPT  armv7l armv7l armv7l GNU/Linux
2. There are no implementation for src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs: EmitCode. After I comment throw Exception in this method the issue https://github.com/dotnet/corert/issues/2780 disappears so it can be closed if this pull request  is accepted
3. There is another issue with the Hello test on arm32 about string processing. It is under investigation.