### PR TITLE
Throw BadImageFormatException for modules with no metadata

### DIFF
--- a/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
+++ b/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
@@ -30,5 +30,8 @@ namespace Internal.TypeSystem
         InvalidProgramSpecific,
         InvalidProgramVararg,
         InvalidProgramCallVirtFinalize,
+
+        // BadImageFormatException
+        BadImageFormatGeneric,
     }
 }

--- a/src/Common/src/TypeSystem/Common/TypeSystemException.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemException.cs
@@ -169,6 +169,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public class BadImageFormatException : TypeSystemException
+        {
+            public BadImageFormatException()
+                : base(ExceptionStringID.BadImageFormatGeneric)
+            {
+            }
+        }
+
         #region Formatting helpers
 
         private static class Format

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -187,6 +187,11 @@ namespace Internal.TypeSystem.Ecma
 
         private static MetadataReader CreateMetadataReader(TypeSystemContext context, PEReader peReader)
         {
+            if (!peReader.HasMetadata)
+            {
+                throw new TypeSystemException.BadImageFormatException();
+            }
+
             var stringDecoderProvider = context as IMetadataStringDecoderProvider;
 
             MetadataReader metadataReader = peReader.GetMetadataReader(MetadataReaderOptions.None /* MetadataReaderOptions.ApplyWindowsRuntimeProjections */,

--- a/src/Common/src/TypeSystem/IL/Stubs/TypeSystemThrowingILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/TypeSystemThrowingILEmitter.cs
@@ -53,6 +53,10 @@ namespace Internal.IL.Stubs
             {
                 helper = context.GetHelperEntryPoint("ThrowHelpers", "ThrowInvalidProgramException");
             }
+            else if (exceptionType == typeof(TypeSystemException.BadImageFormatException))
+            {
+                helper = context.GetHelperEntryPoint("ThrowHelpers", "ThrowBadImageFormatException");
+            }
             else
             {
                 throw new NotImplementedException();

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -144,6 +144,8 @@ namespace ILCompiler
 
         public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name, bool throwIfNotFound)
         {
+            // TODO: catch typesystem BadImageFormatException and throw a new one that also captures the
+            // assembly name that caused the failure. (Along with the reason, which makes this rather annoying).
             return GetModuleForSimpleName(name.Name, throwIfNotFound);
         }
 

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -193,7 +193,7 @@ namespace ILCompiler
                     var module = typeSystemContext.GetModuleFromPath(inputFile.Value);
                     inputFilePaths.Add(inputFile.Key, inputFile.Value);
                 }
-                catch (InvalidOperationException)
+                catch (TypeSystemException.BadImageFormatException)
                 {
                     // Keep calm and carry on.
                 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -50,6 +50,11 @@ namespace Internal.Runtime.CompilerHelpers
             throw new NotSupportedException();
         }
 
+        public static void ThrowBadImageFormatException(ExceptionStringID id)
+        {
+            throw TypeLoaderExceptionHelper.CreateBadImageFormatException(id);
+        }
+
         public static void ThrowTypeLoadException(ExceptionStringID id, string className, string typeName)
         {
             throw TypeLoaderExceptionHelper.CreateTypeLoadException(id, className, typeName);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
@@ -18,6 +18,11 @@ namespace Internal.Runtime
     /// </summary>
     internal static class TypeLoaderExceptionHelper
     {
+        public static Exception CreateBadImageFormatException(ExceptionStringID id)
+        {
+            return new BadImageFormatException(GetFormatString(id));
+        }
+
         public static Exception CreateTypeLoadException(ExceptionStringID id, string typeName, string moduleName)
         {
             return new TypeLoadException(SR.Format(GetFormatString(id), typeName, moduleName), typeName);
@@ -77,6 +82,8 @@ namespace Internal.Runtime
                     return SR.EE_MissingMethod;
                 case ExceptionStringID.FileLoadErrorGeneric:
                     return SR.IO_FileNotFound_FileName;
+                case ExceptionStringID.BadImageFormatGeneric:
+                    return SR.Arg_BadImageFormatException;
                 default:
                     Debug.Assert(false);
                     throw new NotImplementedException();


### PR DESCRIPTION
This converts a compile time failure when one of the references was a
bad image to a runtime failure.