### PR TITLE
Use a better mangled name for unbox+instantiating thunks

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -202,43 +202,7 @@ namespace ILCompiler
 
             public override string Name => "Boxed_" + ValueTypeRepresented.Name;
 
-            public override string Namespace
-            {
-                get
-                {
-                    // Mangle the namespace in the hopes that it won't conflict with anything else.
-
-                    StringBuilder sb = new StringBuilder();
-
-                    ArrayBuilder<string> prefixes = new ArrayBuilder<string>();
-
-                    DefType currentType = ValueTypeRepresented;
-                    if (currentType.ContainingType != null)
-                    {
-                        while (currentType.ContainingType != null)
-                        {
-                            prefixes.Add(currentType.Name);
-                            currentType = currentType.ContainingType;
-                        }
-
-                        prefixes.Add(currentType.Name);
-                    }
-
-                    sb.Append(((IAssemblyDesc)((MetadataType)currentType).Module).GetName().Name);
-                    sb.Append('_');
-                    sb.Append(currentType.Namespace);
-
-                    for (int i = prefixes.Count - 1; i >= 0; i--)
-                    {
-                        sb.Append(prefixes[i]);
-
-                        if (i > 0)
-                            sb.Append('+');
-                    }
-
-                    return sb.ToString();
-                }
-            }
+            public override string Namespace => ValueTypeRepresented.Namespace;
 
             public override Instantiation Instantiation => ValueTypeRepresented.Instantiation;
             public override PInvokeStringFormat PInvokeStringFormat => PInvokeStringFormat.AutoClass;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -51,9 +51,9 @@ namespace ILCompiler.DependencyAnalysis
         
         public override bool StaticDependenciesAreComputed => _methodCode != null;
 
-        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        public virtual void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(NodeFactory.NameMangler.GetMangledMethodName(_method));
+            sb.Append(nameMangler.GetMangledMethodName(_method));
         }
         public int Offset => 0;
         public override bool IsShareable => _method is InstantiatedMethod || EETypeNode.IsTypeNodeShareable(_method.OwningType);
@@ -126,6 +126,22 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(_debugVarInfos == null);
             _debugVarInfos = debugVarInfos;
+        }
+    }
+
+    internal class UnboxingThunkMethodCodeNode : MethodCodeNode
+    {
+        private MethodDesc _targetMethod;
+
+        public UnboxingThunkMethodCodeNode(MethodDesc method, MethodDesc targetMethod)
+            : base(method)
+        {
+            _targetMethod = targetMethod;
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("__unbox_").Append(nameMangler.GetMangledMethodName(_targetMethod));
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis
                 // 'this' and also provides an instantiation argument (we do a calling convention conversion).
                 // We don't do this for generic instance methods though because they don't use the EEType
                 // for the generic context anyway.
-                return new MethodCodeNode(TypeSystemContext.GetSpecialUnboxingThunk(method, CompilationModuleGroup.GeneratedAssembly));
+                return new UnboxingThunkMethodCodeNode(TypeSystemContext.GetSpecialUnboxingThunk(method, CompilationModuleGroup.GeneratedAssembly), method);
             }
             else
             {


### PR DESCRIPTION
There was a bunch of code that I wrote to generate a name for
unbox+instantiating stubs that `// Mangle the namespace in the hopes
that it won't conflict with anything else.`

Turns out this is really hard because we need to also account for e.g.
method overloads and having to append suffixes that disambiguate between
them. There's one place in the compiler that can do this: the name
mangler.

What we really want is something like `"__unbox_" +
MangledNameOfTheInstanceMethod`.

Since the compiler type system context (which is where we make the
thunks) doesn't have a very convenient access to the name mangler (and
it would likely be a layering violation anyway), I explored two options:

* A secret interface (`IManglableMethod` that a `MethodDesc` could
implement) to provide custom mangling rules for the name mangler, or
* A new node type deriving from `MethodCodeNode` that has the name
mangling rule built in.

I chose the latter because it's simpler.