### PR TITLE
Fix a couple places around shared generics with multifile

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalDefinitionEETypeNode.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory) => false;
         public override bool StaticDependenciesAreComputed => true;
-        public override bool IsShareable => IsTypeNodeShareable(_type);
+        public override bool IsShareable => true;
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory) => null;
         protected override int GCDescSize => 0;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -33,6 +33,8 @@ namespace ILCompiler.DependencyAnalysis
         
         public sealed override bool StaticDependenciesAreComputed => true;
 
+        public sealed override bool IsShareable => true;
+
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             return new DependencyList
@@ -98,7 +100,6 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append(MangledNamePrefix).Append(NodeFactory.NameMangler.GetMangledTypeName(_owningType));
         }
         public override int Offset => 0;
-        public override bool IsShareable => false;
         public override Instantiation TypeInstantiation => _owningType.Instantiation;
         public override Instantiation MethodInstantiation => new Instantiation();
         protected override TypeSystemContext Context => _owningType.Context;
@@ -155,7 +156,6 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append(MangledNamePrefix).Append(NodeFactory.NameMangler.GetMangledMethodName(_owningMethod));
         }
         public override int Offset => _owningMethod.Context.Target.PointerSize;
-        public override bool IsShareable => false;
         public override Instantiation TypeInstantiation => _owningMethod.OwningType.Instantiation;
         public override Instantiation MethodInstantiation => _owningMethod.Instantiation;
         protected override TypeSystemContext Context => _owningMethod.Context;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
@@ -26,7 +26,7 @@ namespace ILCompiler.DependencyAnalysis
         public int Offset => 0;
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
-        public override bool IsShareable => false;
+        public override bool IsShareable => true;
 
         public override bool StaticDependenciesAreComputed => true;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -12,10 +13,12 @@ namespace ILCompiler.DependencyAnalysis
     public class IndirectionNode : ObjectNode, ISymbolNode
     {
         private ISymbolNode _indirectedNode;
+        private TargetDetails _target;
 
-        public IndirectionNode(ISymbolNode indirectedNode)
+        public IndirectionNode(TargetDetails target, ISymbolNode indirectedNode)
         {
             _indirectedNode = indirectedNode;
+            _target = target;
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -25,7 +28,17 @@ namespace ILCompiler.DependencyAnalysis
         }
         public int Offset => 0;
 
-        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override ObjectNodeSection Section
+        {
+            get
+            {
+                if (_target.IsWindows)
+                    return ObjectNodeSection.ReadOnlyDataSection;
+                else
+                    return ObjectNodeSection.DataSection;
+            }
+        }
+
         public override bool IsShareable => true;
 
         public override bool StaticDependenciesAreComputed => true;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -249,7 +249,7 @@ namespace ILCompiler.DependencyAnalysis
 
             _indirectionNodes = new NodeCache<ISymbolNode, IndirectionNode>(symbol =>
             {
-                return new IndirectionNode(symbol);
+                return new IndirectionNode(Target, symbol);
             });
 
             _frozenStringNodes = new NodeCache<string, FrozenStringNode>((string data) =>


### PR DESCRIPTION
* Canonical definition EETypes (`__Canon` and `__UniversalCanon`) should
be generated into each module that needs it and then folded at runtime
* Generic dictionaries should be folded at runtime too (though we might
need extra work later to make them look the same too)
* Indirection node can be folded