### PR TITLE
Linux support for multi-module

### DIFF
--- a/buildscripts/build-tests.sh
+++ b/buildscripts/build-tests.sh
@@ -2,6 +2,10 @@
 
 scriptRoot="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+if [ "$__SkipTests" == "true" ]; then
+    exit 0
+fi
+
 if [ "$BUILDVARS_DONE" != 1 ]; then
     . $scriptRoot/buildvars-setup.sh $*
 fi

--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -13,7 +13,7 @@ usage()
     echo "clangx.y - optional argument to build using clang version x.y."
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
-
+    echo "skiptests - optional argument to skip running tests after building."
     exit 1
 }
 
@@ -221,6 +221,9 @@ while [ "$1" != "" ]; do
         -officialbuildid)
             shift
             export __ExtraMsBuildArgs="$__ExtraMsBuildArgs /p:OfficialBuildId=$1"
+            ;;
+        skiptests)
+            export __SkipTests=true
             ;;
         *)
           export __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"

--- a/src/BuildIntegration/BuildFrameworkNativeObjects.proj
+++ b/src/BuildIntegration/BuildFrameworkNativeObjects.proj
@@ -29,12 +29,6 @@
     <ItemGroup>
       <LibInputs Include="$(NativeIntermediateOutputPath)\*$(NativeObjectExt)" />
     </ItemGroup>
-
-    <PropertyGroup>
-      <SharedLibrary Condition="'$(OS)' == 'Windows_NT'">$(FrameworkLibPath)\Framework$(LibFileExt)</SharedLibrary>
-      <SharedLibrary Condition="'$(OS)' != 'Windows_NT'">$(FrameworkLibPath)\libframework$(LibFileExt)</SharedLibrary>
-    </PropertyGroup>
-
   </Target>
 
   <Target Name="BuildOneFrameworkLibrary">

--- a/src/BuildIntegration/BuildFrameworkNativeObjects.proj
+++ b/src/BuildIntegration/BuildFrameworkNativeObjects.proj
@@ -31,7 +31,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <SharedLibrary>$(FrameworkLibPath)\Framework.lib</SharedLibrary>
+      <SharedLibrary Condition="'$(OS)' == 'Windows_NT'">$(FrameworkLibPath)\Framework$(LibFileExt)</SharedLibrary>
+      <SharedLibrary Condition="'$(OS)' != 'Windows_NT'">$(FrameworkLibPath)\libframework$(LibFileExt)</SharedLibrary>
     </PropertyGroup>
 
   </Target>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -20,6 +20,7 @@ See the LICENSE file in the project root for more information.
     <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang-3.9</CppCompilerAndLinker>
     <CppCompiler>$(CppCompilerAndLinker)</CppCompiler>
     <CppLinker>$(CppCompilerAndLinker)</CppLinker>
+    <CppLibCreator>ar</CppLibCreator>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,6 +32,7 @@ See the LICENSE file in the project root for more information.
   </ItemGroup>
 
   <ItemGroup>
+    <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(FrameworkLibPath)\libframework.a" />
     <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libbootstrapper.a" />
     <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libRuntime.a" />
     <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libbootstrappercpp.a" />

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -32,7 +32,7 @@ See the LICENSE file in the project root for more information.
   </ItemGroup>
 
   <ItemGroup>
-    <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(FrameworkLibPath)\libframework.a" />
+    <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(SharedLibrary)" />
     <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libbootstrapper.a" />
     <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libRuntime.a" />
     <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libbootstrappercpp.a" />

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -37,7 +37,7 @@ See the LICENSE file in the project root for more information.
     <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)\sdk\Runtime.lib" />
     <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\bootstrappercpp.lib" />
     <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\PortableRuntime.lib" />
-    <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(FrameworkLibPath)\Framework.lib" />
+    <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(SharedLibrary)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -28,6 +28,8 @@ See the LICENSE file in the project root for more information.
   <PropertyGroup>
     <NativeObjectExt Condition="'$(TargetOS)' == 'Windows_NT'">.obj</NativeObjectExt>
     <NativeObjectExt Condition="'$(TargetOS)' != 'Windows_NT'">.o</NativeObjectExt>
+    <LibFileExt Condition="'$(TargetOS)' == 'Windows_NT'">.lib</LibFileExt>
+    <LibFileExt Condition="'$(TargetOS)' != 'Windows_NT'">.a</LibFileExt>
 
     <IlcOutputFileExt>$(NativeObjectExt)</IlcOutputFileExt>
     <IlcOutputFileExt Condition="$(NativeCodeGen) == 'cpp'">.cpp</IlcOutputFileExt>
@@ -158,11 +160,13 @@ See the LICENSE file in the project root for more information.
     DependsOnTargets="$(CreateLibDependsOn)">
 
     <ItemGroup>
+      <CustomLibArg Include="/out:$(SharedLibrary)" Condition="'$(OS)' == 'Windows_NT'" />
+      <CustomLibArg Include="-crs $(SharedLibrary)" Condition="'$(OS)' != 'Windows_NT'" />
       <CustomLibArg Include="@(LibInputs->'%(Identity)')" />
-      <CustomLibArg Include="/out:$(SharedLibrary)" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)lib.rsp" Lines="@(CustomLibArg)" Overwrite="true" Condition="'$(OS)' == 'Windows_NT'" />
     <Exec Command="$(CppLibCreator) @&quot;$(NativeIntermediateOutputPath)lib.rsp&quot;" Condition="'$(OS)' == 'Windows_NT'" />
+    <Exec Command="$(CppLibCreator) @(CustomLibArg, ' ')" Condition="'$(OS)' != 'Windows_NT'" />
   </Target>
 </Project>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -51,6 +51,9 @@ See the LICENSE file in the project root for more information.
 
     <FrameworkLibPath Condition="'$(FrameworkLibPath)' == ''">$(NativeOutputPath)</FrameworkLibPath>
     <FrameworkObjPath Condition="'$(FrameworkObjPath)' == ''">$(NativeIntermediateOutputPath)</FrameworkObjPath>
+
+    <SharedLibrary Condition="'$(OS)' == 'Windows_NT'">$(FrameworkLibPath)\Framework$(LibFileExt)</SharedLibrary>
+    <SharedLibrary Condition="'$(OS)' != 'Windows_NT'">$(FrameworkLibPath)\libframework$(LibFileExt)</SharedLibrary>
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildingFrameworkLibrary) != 'true'">

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -441,7 +441,12 @@ namespace ILCompiler.DependencyAnalysis
                 int len = frameInfo.BlobData.Length;
                 byte[] blob = frameInfo.BlobData;
 
-                SwitchSection(_nativeObjectWriter, LsdaSection.Name);
+                ObjectNodeSection lsdaSection = LsdaSection;
+                if (ShouldShareSymbol(node))
+                {
+                    lsdaSection = lsdaSection.GetSharedSection(((ISymbolNode)node).GetMangledName());
+                }
+                SwitchSection(_nativeObjectWriter, lsdaSection.Name, GetCustomSectionAttributes(lsdaSection), lsdaSection.ComdatName);
 
                 _sb.Clear().Append("_lsda").Append(i.ToStringInvariant()).Append(_currentNodeZeroTerminatedName);
                 byte[] blobSymbolName = _sb.ToUtf8String().UnderlyingArray;
@@ -719,7 +724,7 @@ namespace ILCompiler.DependencyAnalysis
             if (_nodeFactory.CompilationModuleGroup.IsSingleFileCompilation)
                 return false;
 
-            if (!_targetPlatform.IsWindows)
+            if (_targetPlatform.OperatingSystem == TargetOS.OSX)
                 return false;
 
             // Types and methods from the compiler generated assembly are always shareable

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -29,7 +29,7 @@
 
             <MicrosoftNetCoreNativePackageVersion>2.0.0-beta-25021-03</MicrosoftNetCoreNativePackageVersion>
 
-            <ObjectWriterPackageVersion>1.0.14-prerelease-00001</ObjectWriterPackageVersion>
+            <ObjectWriterPackageVersion>1.0.15-prerelease-00001</ObjectWriterPackageVersion>
             <ObjectWriterNuPkgRid Condition="'$(OSGroup)'=='Linux'">ubuntu.14.04-x64</ObjectWriterNuPkgRid>
             <ObjectWriterNuPkgRid Condition="'$(ObjectWriterNuPkgRid)'==''">$(NuPkgRid)</ObjectWriterNuPkgRid>
         </PropertyGroup>

--- a/src/packaging/project.json
+++ b/src/packaging/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Jit": "2.0.0-beta-25015-04",
-    "Microsoft.DotNet.ObjectWriter": "1.0.14-prerelease-00001"
+    "Microsoft.DotNet.ObjectWriter": "1.0.15-prerelease-00001"
   },
   "frameworks": {
     "dnxcore50": { }

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -139,7 +139,7 @@ CoreRT_CliBinDir=${CoreRT_TestRoot}/../Tools/dotnetcli
 CoreRT_BuildArch=x64
 CoreRT_BuildType=Debug
 CoreRT_TestRun=true
-CoreRT_TestCompileMode=ryujit
+CoreRT_TestCompileMode=
 CoreRT_CrossRootFS=
 CoreRT_CrossCXXFlags=
 CoreRT_CrossLinkerFlags=
@@ -291,7 +291,7 @@ __BuildOsLowcase=$(echo "${CoreRT_BuildOS}" | tr '[:upper:]' '[:lower:]')
 for csproj in $(find src -name "*.csproj")
 do
     if [ ! -e `dirname ${csproj}`/no_unix ]; then
-        if [ ! "${CoreRT_TestCompileMode}" == "cpp" ]; then
+        if [ "${CoreRT_TestCompileMode}" != "cpp" ]; then
             run_test_dir ${csproj} "Jit"
         fi
         if [ ! -e `dirname ${csproj}`/no_cpp ]; then

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -6,6 +6,7 @@ usage()
     echo "    -mode         : Compilation mode. Specify cpp/ryujit. Default: ryujit"
     echo "    -runtest      : Should just compile or run compiled binary? Specify: true/false. Default: true."
     echo "    -coreclr      : Download and run the CoreCLR repo tests"
+    echo "    -multimodule  : Compile the framework as a .so and link tests against it (ryujit only)"
     echo ""
     echo "    --- CoreCLR Subset ---"
     echo "       top200     : Runs broad coverage / CI validation (~200 tests)."
@@ -42,12 +43,16 @@ run_test_dir()
     if [ -n "${__extra_cxxflags}" ]; then
         __extra_linkflags="/p:AdditionalLinkerFlags=\"${__extra_linkflags}\""
     fi
+    if [ "${CoreRT_MultiFileConfiguration}" = "MultiModule" ]; then
+        __extra_args="${__extra_args} /p:IlcMultiModule=true"
+    fi
 
     rm -rf ${__dir_path}/bin ${__dir_path}/obj
 
     local __msbuild_dir=${CoreRT_TestRoot}/../Tools
-    echo ${__msbuild_dir}/dotnetcli/dotnet ${__msbuild_dir}/MSBuild.dll /ds /m /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} /p:Platform=${CoreRT_BuildArch} /p:RepoLocalBuild=true ${__extra_args} "${__extra_cxxflags}" "${__extra_linkflags}" ${__dir_path}/${__filename}.csproj
-    ${__msbuild_dir}/dotnetcli/dotnet ${__msbuild_dir}/MSBuild.dll /ds /m /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} /p:Platform=${CoreRT_BuildArch} /p:RepoLocalBuild=true ${__extra_args} "${__extra_cxxflags}" "${__extra_linkflags}" ${__dir_path}/${__filename}.csproj
+
+    echo ${__msbuild_dir}/dotnetcli/dotnet ${__msbuild_dir}/MSBuild.dll /ds /m /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} /p:Platform=${CoreRT_BuildArch} /p:RepoLocalBuild=true "/p:FrameworkLibPath=${CoreRT_TestRoot}/../bin/Product/${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}/lib" "/p:FrameworkObjPath=${CoreRT_TestRoot}/../bin/obj/${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}/Framework" ${__extra_args} "${__extra_cxxflags}" "${__extra_linkflags}" ${__dir_path}/${__filename}.csproj
+    ${__msbuild_dir}/dotnetcli/dotnet ${__msbuild_dir}/MSBuild.dll /ds /m /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} /p:Platform=${CoreRT_BuildArch} /p:RepoLocalBuild=true "/p:FrameworkLibPath=${CoreRT_TestRoot}/../bin/Product/${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}/lib" "/p:FrameworkObjPath=${CoreRT_TestRoot}/../bin/obj/${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}/Framework" ${__extra_args} "${__extra_cxxflags}" "${__extra_linkflags}" ${__dir_path}/${__filename}.csproj
 
     local __exitcode=$?
 
@@ -195,6 +200,9 @@ while [ "$1" != "" ]; do
                 exit -1
             fi
             ;;
+        -multimodule)
+            CoreRT_MultiFileConfiguration=MultiModule;
+            ;;
         *)
             ;;
     esac
@@ -252,6 +260,11 @@ __CoreRTTestBinDir=${CoreRT_TestRoot}/../bin/tests
 __LogDir=${CoreRT_TestRoot}/../bin/Logs/${__BuildStr}/tests
 __build_os_lowcase=$(echo "${CoreRT_BuildOS}" | tr '[:upper:]' '[:lower:]')
 
+
+if [ "$CoreRT_MultiFileConfiguration" = "MultiModule" ]; then
+    CoreRT_TestCompileMode=ryujit
+fi
+
 if [ ! -d $__LogDir ]; then
     mkdir -p $__LogDir
 fi
@@ -278,9 +291,13 @@ __BuildOsLowcase=$(echo "${CoreRT_BuildOS}" | tr '[:upper:]' '[:lower:]')
 for csproj in $(find src -name "*.csproj")
 do
     if [ ! -e `dirname ${csproj}`/no_unix ]; then
-        run_test_dir ${csproj} "Jit"
+        if [ ! "${CoreRT_TestCompileMode}" == "cpp" ]; then
+            run_test_dir ${csproj} "Jit"
+        fi
         if [ ! -e `dirname ${csproj}`/no_cpp ]; then
-            run_test_dir ${csproj} "Cpp" "$CoreRT_ExtraCXXFlags" "$CoreRT_ExtraLinkFlags"
+            if [ "${CoreRT_TestCompileMode}" != "ryujit" ]; then
+                run_test_dir ${csproj} "Cpp" "$CoreRT_ExtraCXXFlags" "$CoreRT_ExtraLinkFlags"
+            fi
         fi
     fi
 done
@@ -289,14 +306,23 @@ __TotalTests=$((${__JitTotalTests} + ${__CppTotalTests}))
 __PassedTests=$((${__JitPassedTests} + ${__CppPassedTests}))
 __FailedTests=$((${__TotalTests} - ${__PassedTests}))
 
-echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>" > ${__CoreRTTestBinDir}/testResults.xml
-echo "<assemblies>"  >> ${__CoreRTTestBinDir}/testResults.xml
-echo "<assembly name=\"ILCompiler\" total=\"${__TotalTests}\" passed=\"${__PassedTests}\" failed=\"${__FailedTests}\" skipped=\"0\">"  >> ${__CoreRTTestBinDir}/testResults.xml
-echo "<collection total=\"${__TotalTests}\" passed=\"${__PassedTests}\" failed=\"${__FailedTests}\" skipped=\"0\">"  >> ${__CoreRTTestBinDir}/testResults.xml
-cat "${__CoreRTTestBinDir}/testResults.tmp" >> ${__CoreRTTestBinDir}/testResults.xml
-echo "</collection>"  >> ${__CoreRTTestBinDir}/testResults.xml
-echo "</assembly>"  >> ${__CoreRTTestBinDir}/testResults.xml
-echo "</assemblies>"  >> ${__CoreRTTestBinDir}/testResults.xml
+if [ "$CoreRT_MultiFileConfiguration" = "MultiModule" ]; then
+    __TestResultsLog=${__CoreRTTestBinDir}/${CoreRT_MultiFileConfiguration}/testResults.xml
+    if [ ! -d ${__CoreRTTestBinDir}/${CoreRT_MultiFileConfiguration} ]; then
+        mkdir -p ${__CoreRTTestBinDir}/${CoreRT_MultiFileConfiguration}
+    fi
+else
+    __TestResultsLog=${__CoreRTTestBinDir}/testResults.xml
+fi
+
+echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>" > ${__TestResultsLog}
+echo "<assemblies>"  >> ${__TestResultsLog}
+echo "<assembly name=\"ILCompiler\" total=\"${__TotalTests}\" passed=\"${__PassedTests}\" failed=\"${__FailedTests}\" skipped=\"0\">"  >> ${__TestResultsLog}
+echo "<collection total=\"${__TotalTests}\" passed=\"${__PassedTests}\" failed=\"${__FailedTests}\" skipped=\"0\">"  >> ${__TestResultsLog}
+cat "${__CoreRTTestBinDir}/testResults.tmp" >> ${__TestResultsLog}
+echo "</collection>"  >> ${__TestResultsLog}
+echo "</assembly>"  >> ${__TestResultsLog}
+echo "</assemblies>"  >> ${__TestResultsLog}
 
 
 echo "JIT - TOTAL: ${__JitTotalTests} PASSED: ${__JitPassedTests}"


### PR DESCRIPTION
* Alter build integration scripts to support different naming / tool invocations on Linux.
* Add GC / frame info for ELF to the same group as its associated method so it gets Comdat folded properly.
* Add -multimodule switch to runtest.sh to run tests against a shared pre-compiled framework library.
* Update ObjectWriter Nuget package which brings changes need to support Elf Comdat sections.