### PR TITLE
Fix ProjectN build break

### DIFF
--- a/src/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -387,14 +387,6 @@ namespace System.Runtime
         [ManuallyManaged(GcPollPolicy.Never)]
         internal extern static IntPtr RhpGetNextThunkStubsBlockAddress(IntPtr currentThunkStubsBlockAddress);
 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        [RuntimeImport(Redhawk.BaseName, "RhpGetCurrentThunkContext")]
-        public static extern IntPtr GetCurrentInteropThunkContext();
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        [RuntimeImport(Redhawk.BaseName, "RhpGetCommonStubAddress")]
-        public static extern IntPtr GetInteropCommonStubAddress();
-
         //------------------------------------------------------------------------------------------------------------
         // PInvoke-based internal calls
         //

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -213,7 +213,7 @@ namespace Internal.Runtime.CompilerHelpers
 
         internal static IntPtr GetDelegateFunctionPointer()
         {
-            IntPtr pContext = InternalCalls.GetCurrentInteropThunkContext();
+            IntPtr pContext = RuntimeImports.GetCurrentInteropThunkContext();
             Debug.Assert(pContext != null);
 
             IntPtr fnPtr;
@@ -247,7 +247,7 @@ namespace Internal.Runtime.CompilerHelpers
 
             if (s_thunkPoolHeap == null)
             {
-                s_thunkPoolHeap = RuntimeAugments.CreateThunksHeap(InternalCalls.GetInteropCommonStubAddress());
+                s_thunkPoolHeap = RuntimeAugments.CreateThunksHeap(RuntimeImports.GetInteropCommonStubAddress());
                 Debug.Assert(s_thunkPoolHeap != null);
             }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -512,6 +512,14 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhSetThreadStaticStorageForModule")]
         internal static unsafe extern bool RhSetThreadStaticStorageForModule(Array storage, Int32 moduleIndex);
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhpGetCurrentThunkContext")]
+        internal static extern IntPtr GetCurrentInteropThunkContext();
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhpGetCommonStubAddress")]
+        internal static extern IntPtr GetInteropCommonStubAddress();
 #endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
Remove direct reference between S.P.CoreLib and Runtime.Base. Use RuntimeImports instead.