### PR TITLE
Add test coverage for shared generics in the multimodule test

### DIFF
--- a/tests/src/Simple/MultiModule/Library.cs
+++ b/tests/src/Simple/MultiModule/Library.cs
@@ -15,4 +15,36 @@ public class MultiModuleLibrary
     public static string StaticString;
     [ThreadStatic]
     public static int ThreadStaticInt;
+
+    public static bool MethodThatUsesGenerics()
+    {
+        // Force the existence of a generic dictionary for GenericClass<string>
+        // It's important we only use one canonical method and that method is not used from the consumption EXE.
+        if (GenericClass<string>.IsArrayOfT(null))
+            return false;
+        if (!GenericClass<string>.IsArrayOfT(new string[0]))
+            return false;
+
+        // Force the existence of a generic dictionary for GenericClass<GenericStruct<string>>
+        // Here we test a canonical method that will be used from the consumption EXE too.
+        if (!GenericClass<GenericStruct<string>>.IsT(new GenericStruct<string>()))
+            return false;
+
+        return true;
+    }
+
+    public class GenericClass<T>
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static bool IsT(object o) => o is T;
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static bool IsArrayOfT(object o) => o is T[];
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static bool IsMdArrayOfT(object o) => o is T[,];
+    }
+
+    public struct GenericStruct<T>
+    {
+        public T Value;
+    }
 }

--- a/tests/src/Simple/MultiModule/MultiModule.cs
+++ b/tests/src/Simple/MultiModule/MultiModule.cs
@@ -16,7 +16,10 @@ public class ReflectionTest
     {
         if (TestStaticBases() == Fail)
             return Fail;
-        
+
+        if (TestSharedGenerics() == Fail)
+            return Fail;
+
         return Pass;
     }
     
@@ -33,6 +36,25 @@ public class ReflectionTest
         if (MultiModuleLibrary.ReturnValue + MultiModuleLibrary.ThreadStaticInt != 100)
             return Fail;
         
+        return Pass;
+    }
+
+    public static int TestSharedGenerics()
+    {
+        // Use a generic dictionary that also exists in the library
+        if (!MultiModuleLibrary.GenericClass<string>.IsT("Hello"))
+            return Fail;
+        if (!MultiModuleLibrary.GenericClass<string>.IsMdArrayOfT(new string[0, 0]))
+            return Fail;
+
+        if (!MultiModuleLibrary.GenericClass<MultiModuleLibrary.GenericStruct<string>>.IsArrayOfT(new MultiModuleLibrary.GenericStruct<string>[0]))
+            return Fail;
+        if (!MultiModuleLibrary.GenericClass<MultiModuleLibrary.GenericStruct<string>>.IsT(new MultiModuleLibrary.GenericStruct<string>()))
+            return Fail;
+
+        if (!MultiModuleLibrary.MethodThatUsesGenerics())
+            return Fail;
+
         return Pass;
     }
 }

--- a/tests/src/Simple/MultiModule/MultiModule.cs
+++ b/tests/src/Simple/MultiModule/MultiModule.cs
@@ -41,6 +41,8 @@ public class ReflectionTest
 
     public static int TestSharedGenerics()
     {
+        Console.WriteLine("Testing generic dictionaries can be folded properly..");
+
         // Use a generic dictionary that also exists in the library
         if (!MultiModuleLibrary.GenericClass<string>.IsT("Hello"))
             return Fail;


### PR DESCRIPTION
This tests that we generate the same dictionaries in multimodule
scenarios. We currently don't.

This is just so that we don't have a clean precheckin run with shared
generics enabled (because without this change, we do).