### PR TITLE
Move away from a static NameMangler

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilation.cs
@@ -24,7 +24,7 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             Logger logger,
             CppCodegenConfigProvider options)
-            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), new CoreRTNameMangler(true), logger)
+            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), logger)
         {
             Options = options;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -11,7 +11,7 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class CppCodegenNodeFactory : NodeFactory
     {
         public CppCodegenNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup)
-            : base(context, compilationModuleGroup, new CompilerGeneratedMetadataManager(compilationModuleGroup, context))
+            : base(context, compilationModuleGroup, new CompilerGeneratedMetadataManager(compilationModuleGroup, context), new CoreRTNameMangler(true))
         {
         }
 
@@ -23,7 +23,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                return new ExternMethodSymbolNode(method);
+                return new ExternMethodSymbolNode(this, method);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
@@ -54,7 +54,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(NodeFactory.NameMangler.GetMangledMethodName(_method));
+            sb.Append(nameMangler.GetMangledMethodName(_method));
         }
         public int Offset => 0;
         public bool RepresentsIndirectionCell => false;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.DependencyAnalysis
         private TypeDesc _type;
 
         public ExternEETypeSymbolNode(NodeFactory factory, TypeDesc type)
-            : base("__EEType_" + NodeFactory.NameMangler.GetMangledTypeName(type))
+            : base("__EEType_" + factory.NameMangler.GetMangledTypeName(type))
         {
             _type = type;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternMethodSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternMethodSymbolNode.cs
@@ -14,7 +14,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private MethodDesc _method;
 
-        public ExternMethodSymbolNode(MethodDesc method) : base(NodeFactory.NameMangler.GetMangledMethodName(method))
+        public ExternMethodSymbolNode(NodeFactory factory, MethodDesc method)
+            : base(factory.NameMangler.GetMangledMethodName(method))
         {
             _method = method;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
@@ -26,7 +26,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append("__fatpointer_").Append(NodeFactory.NameMangler.GetMangledMethodName(Method));
+            sb.Append("__fatpointer_").Append(nameMangler.GetMangledMethodName(Method));
         }
         public int Offset => 0;
         public override bool IsShareable => true;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(nameMangler.CompilationUnitPrefix).Append("__Str_").Append(NodeFactory.NameMangler.GetMangledStringName(_data));
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__Str_").Append(nameMangler.GetMangledStringName(_data));
         }
 
         public override bool StaticDependenciesAreComputed => true;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticDescNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticDescNode.cs
@@ -30,13 +30,13 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(GetMangledName(_type, _isThreadStatic));
+            sb.Append(GetMangledName(nameMangler, _type, _isThreadStatic));
         }
 
-        public static string GetMangledName(MetadataType type, bool isThreadStatic)
+        public static string GetMangledName(NameMangler nameMangler, MetadataType type, bool isThreadStatic)
         {
             string prefix = isThreadStatic ? "__ThreadStaticGCDesc_" : "__GCStaticDesc_";
-            return prefix + NodeFactory.NameMangler.GetMangledTypeName(type);
+            return prefix + nameMangler.GetMangledTypeName(type);
         }
 
         public int NumSeries

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append("__GCStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName(_type));
+            sb.Append("__GCStaticBase_").Append(nameMangler.GetMangledTypeName(_type));
         }
 
         public int Offset => 0;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool HasConditionalStaticDependencies => false;
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => "__GVMDependenciesNode_" + NodeFactory.NameMangler.GetMangledMethodName(_method);
+        protected override string GetName() => "__GVMDependenciesNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
@@ -35,7 +35,7 @@ namespace ILCompiler.DependencyAnalysis
             for (int i = 0; i < _details.Instantiation.Length; i++)
             {
                 sb.Append('_');
-                sb.Append(NodeFactory.NameMangler.GetMangledTypeName(_details.Instantiation[i]));
+                sb.Append(nameMangler.GetMangledTypeName(_details.Instantiation[i]));
 
                 hasVariance |= _details.Variance[i] != 0;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -162,9 +162,9 @@ namespace ILCompiler.DependencyAnalysis
 				
 		public MethodDesc OwningMethod => _owningMethod;
 
-		public static string GetMangledName(MethodDesc owningMethod)
+		public static string GetMangledName(NameMangler nameMangler, MethodDesc owningMethod)
         {
-            return MangledNamePrefix + NodeFactory.NameMangler.GetMangledMethodName(owningMethod);
+            return MangledNamePrefix + nameMangler.GetMangledMethodName(owningMethod);
         }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -97,7 +97,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(MangledNamePrefix).Append(NodeFactory.NameMangler.GetMangledTypeName(_owningType));
+            sb.Append(MangledNamePrefix).Append(nameMangler.GetMangledTypeName(_owningType));
         }
         public override int Offset => 0;
         public override Instantiation TypeInstantiation => _owningType.Instantiation;
@@ -153,7 +153,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(MangledNamePrefix).Append(NodeFactory.NameMangler.GetMangledMethodName(_owningMethod));
+            sb.Append(MangledNamePrefix).Append(nameMangler.GetMangledMethodName(_owningMethod));
         }
         public override int Offset => _owningMethod.Context.Target.PointerSize;
         public override Instantiation TypeInstantiation => _owningMethod.OwningType.Instantiation;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.DependencyAnalysis
             if (sb == null)
                 sb = new Utf8StringBuilder();
 
-            symbolNode.AppendMangledName(NodeFactory.NameMangler, sb);
+            symbolNode.AppendMangledName(NodeFactory.NameManglerDoNotUse, sb);
             string ret = sb.ToString();
 
             sb.Clear();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ImportedEETypeSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ImportedEETypeSymbolNode.cs
@@ -16,8 +16,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private TypeDesc _type;
 
-        public ImportedEETypeSymbolNode(TypeDesc type)
-            : base("__imp___EEType_" + NodeFactory.NameMangler.GetMangledTypeName(type))
+        public ImportedEETypeSymbolNode(NodeFactory factory, TypeDesc type)
+            : base("__imp___EEType_" + factory.NameMangler.GetMangledTypeName(type))
         {
             _type = type;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -26,15 +26,15 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(GetMangledName(_targetMethod, _callSiteIdentifier));
+            sb.Append(GetMangledName(nameMangler, _targetMethod, _callSiteIdentifier));
         }
         public int Offset => 0;
 
         public override bool IsShareable => false;
 
-        public static string GetMangledName(MethodDesc method, string callSiteIdentifier)
+        public static string GetMangledName(NameMangler nameMangler, MethodDesc method, string callSiteIdentifier)
         {
-            string name = NodeFactory.NameMangler.CompilationUnitPrefix + "__InterfaceDispatchCell_" + NodeFactory.NameMangler.GetMangledMethodName(method);
+            string name = nameMangler.CompilationUnitPrefix + "__InterfaceDispatchCell_" + nameMangler.GetMangledMethodName(method);
 
             if (!string.IsNullOrEmpty(callSiteIdentifier))
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -212,7 +212,7 @@ namespace ILCompiler.DependencyAnalysis
 
     internal sealed class NativeLayoutMethodLdTokenVertexNode : NativeLayoutMethodEntryVertexNode
     {
-        protected override string GetName() => "NativeLayoutMethodLdTokenVertexNode_" + NodeFactory.NameMangler.GetMangledMethodName(_method);
+        protected override string GetName() => "NativeLayoutMethodLdTokenVertexNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
 
         public NativeLayoutMethodLdTokenVertexNode(NodeFactory factory, MethodDesc method) 
             : base(factory, method, 0)
@@ -237,7 +237,7 @@ namespace ILCompiler.DependencyAnalysis
             _containingTypeSig = factory.NativeLayout.TypeSignatureVertex(field.OwningType);
         }
 
-        protected override string GetName() => "NativeLayoutFieldLdTokenVertexNode_" + NodeFactory.NameMangler.GetMangledFieldName(_field);
+        protected override string GetName() => "NativeLayoutFieldLdTokenVertexNode_" + NodeFactory.NameManglerDoNotUse.GetMangledFieldName(_field);
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
@@ -263,7 +263,7 @@ namespace ILCompiler.DependencyAnalysis
         private NativeLayoutTypeSignatureVertexNode _returnTypeSig;
         private NativeLayoutTypeSignatureVertexNode[] _parametersSig;
 
-        protected override string GetName() => "NativeLayoutMethodSignatureVertexNode" + NodeFactory.NameMangler.GetMangledMethodName(_method);
+        protected override string GetName() => "NativeLayoutMethodSignatureVertexNode" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
 
         public NativeLayoutMethodSignatureVertexNode(NodeFactory factory, MethodDesc method)
         {
@@ -311,7 +311,7 @@ namespace ILCompiler.DependencyAnalysis
         private MethodDesc _method;
         private NativeLayoutMethodSignatureVertexNode _methodSig;
 
-        protected override string GetName() => "NativeLayoutMethodNameAndSignatureVertexNode" + NodeFactory.NameMangler.GetMangledMethodName(_method);
+        protected override string GetName() => "NativeLayoutMethodNameAndSignatureVertexNode" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
 
         public NativeLayoutMethodNameAndSignatureVertexNode(NodeFactory factory, MethodDesc method)
         {
@@ -524,7 +524,7 @@ namespace ILCompiler.DependencyAnalysis
 
     internal sealed class NativeLayoutTemplateMethodSignatureVertexNode : NativeLayoutMethodEntryVertexNode
     {
-        protected override string GetName() => "NativeLayoutTemplateMethodSignatureVertexNode_" + NodeFactory.NameMangler.GetMangledMethodName(_method);
+        protected override string GetName() => "NativeLayoutTemplateMethodSignatureVertexNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
 
         public NativeLayoutTemplateMethodSignatureVertexNode(NodeFactory factory, MethodDesc method)
             : base(factory, method, MethodEntryFlags.CreateInstantiatedSignature | MethodEntryFlags.SaveEntryPoint)
@@ -542,7 +542,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         private MethodDesc _method;
 
-        protected override string GetName() => "NativeLayoutTemplateMethodLayoutVertexNode" + NodeFactory.NameMangler.GetMangledMethodName(_method);
+        protected override string GetName() => "NativeLayoutTemplateMethodLayoutVertexNode" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
 
         public NativeLayoutTemplateMethodLayoutVertexNode(NodeFactory factory, MethodDesc method)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -24,11 +24,13 @@ namespace ILCompiler.DependencyAnalysis
         private CompilerTypeSystemContext _context;
         private CompilationModuleGroup _compilationModuleGroup;
 
-        public NodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager)
+        public NodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup,
+            MetadataManager metadataManager, NameMangler nameMangler)
         {
             _target = context.Target;
             _context = context;
             _compilationModuleGroup = compilationModuleGroup;
+            NameMangler = nameMangler;
             CreateNodeCaches();
 
             MetadataManager = metadataManager;
@@ -61,6 +63,11 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         public MetadataManager MetadataManager
+        {
+            get;
+        }
+
+        public NameMangler NameMangler
         {
             get;
         }
@@ -113,7 +120,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
                 else if (_compilationModuleGroup.ShouldReferenceThroughImportTable(type))
                 {
-                    return new ImportedEETypeSymbolNode(type);
+                    return new ImportedEETypeSymbolNode(this, type);
                 }
                 else
                 {
@@ -136,7 +143,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
                 else if (_compilationModuleGroup.ShouldReferenceThroughImportTable(type))
                 {
-                    return new ImportedEETypeSymbolNode(type);
+                    return new ImportedEETypeSymbolNode(this, type);
                 }
                 else
                 {
@@ -373,7 +380,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                return ExternSymbol(NonGCStaticsNode.GetMangledName(type, NodeFactory.NameMangler));
+                return ExternSymbol(NonGCStaticsNode.GetMangledName(type, NameMangler));
             }
         }
         
@@ -387,7 +394,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                return ExternSymbol(GCStaticsNode.GetMangledName(type, NodeFactory.NameMangler));
+                return ExternSymbol(GCStaticsNode.GetMangledName(type, NameMangler));
             }
         }
 
@@ -762,7 +769,12 @@ namespace ILCompiler.DependencyAnalysis
 
         protected internal TypeManagerIndirectionNode TypeManagerIndirection = new TypeManagerIndirectionNode();
 
-        public static NameMangler NameMangler;
+        /// <summary>
+        /// New code should use <see cref="NameMangler"/> instance property.
+        /// This global variable is only to support existing code and will be going away.
+        /// Do not add new references to it, unless it's from a GetName override.
+        /// </summary>
+        public static NameMangler NameManglerDoNotUse;
 
         public virtual void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonExternMethodSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonExternMethodSymbolNode.cs
@@ -17,7 +17,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private MethodDesc _method;
 
-        public NonExternMethodSymbolNode(MethodDesc method) : base(NodeFactory.NameMangler.GetMangledMethodName(method))
+        public NonExternMethodSymbolNode(NodeFactory factory, MethodDesc method)
+            : base(factory.NameMangler.GetMangledMethodName(method))
         {
             _method = method;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis
  
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append("__NonGCStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName(_type)); 
+            sb.Append("__NonGCStaticBase_").Append(nameMangler.GetMangledTypeName(_type)); 
         }
 
         public int Offset => 0;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -335,7 +335,7 @@ namespace ILCompiler.DependencyAnalysis
         }
 
 
-        public void PublishUnwindInfo(NodeFactory factory, ObjectNode node)
+        public void PublishUnwindInfo(ObjectNode node)
         {
             INodeWithCodeInfo nodeWithCodeInfo = node as INodeWithCodeInfo;
             if (nodeWithCodeInfo == null)
@@ -361,7 +361,7 @@ namespace ILCompiler.DependencyAnalysis
                 int len = frameInfo.BlobData.Length;
                 byte[] blob = frameInfo.BlobData;
                 
-                _sb.Clear().Append(NodeFactory.NameMangler.CompilationUnitPrefix).Append("_unwind").Append(i.ToStringInvariant());
+                _sb.Clear().Append(_nodeFactory.NameMangler.CompilationUnitPrefix).Append("_unwind").Append(i.ToStringInvariant());
 
                 ObjectNodeSection section = ObjectNodeSection.XDataSection;
                 SwitchSection(_nativeObjectWriter, section.Name);
@@ -383,7 +383,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (ehInfo != null)
                 {
-                    EmitSymbolRef(_sb.Clear().Append(NodeFactory.NameMangler.CompilationUnitPrefix).Append("_ehInfo").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_ABSOLUTE);
+                    EmitSymbolRef(_sb.Clear().Append(_nodeFactory.NameMangler.CompilationUnitPrefix).Append("_ehInfo").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_ABSOLUTE);
                 }
 
                 if (gcInfo != null)
@@ -581,7 +581,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 _sb.Clear();
                 AppendExternCPrefix(_sb);
-                symbolNode.AppendMangledName(NodeFactory.NameMangler, _sb);
+                symbolNode.AppendMangledName(_nodeFactory.NameMangler, _sb);
                 _currentNodeZeroTerminatedName = _sb.Append('\0').ToUtf8String();
             }
             else
@@ -605,7 +605,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             _sb.Clear();
             AppendExternCPrefix(_sb);
-            target.AppendMangledName(NodeFactory.NameMangler, _sb);
+            target.AppendMangledName(_nodeFactory.NameMangler, _sb);
 
             return EmitSymbolRef(_sb, relocType, delta);
         }
@@ -661,7 +661,7 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     _sb.Clear();
                     AppendExternCPrefix(_sb);
-                    name.AppendMangledName(NodeFactory.NameMangler, _sb);
+                    name.AppendMangledName(_nodeFactory.NameMangler, _sb);
 
                     EmitSymbolDef(_sb);
 
@@ -871,7 +871,7 @@ namespace ILCompiler.DependencyAnalysis
 
                     // Publish Windows unwind info.
                     if (factory.Target.IsWindows)
-                        objectWriter.PublishUnwindInfo(factory, node);
+                        objectWriter.PublishUnwindInfo(node);
 
                     // Emit the last CFI to close the frame.
                     objectWriter.EmitCFICodes(nodeContents.Data.Length);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -120,9 +120,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             Utf8String mangledContextName;
             if (_dictionaryOwner is MethodDesc)
-                mangledContextName = NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_dictionaryOwner);
+                mangledContextName = nameMangler.GetMangledMethodName((MethodDesc)_dictionaryOwner);
             else
-                mangledContextName = NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
+                mangledContextName = nameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
 
             sb.Append("__GenericLookupFromDict_").Append(mangledContextName).Append("_");
             _lookupSignature.AppendMangledName(nameMangler, sb);
@@ -140,9 +140,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             Utf8String mangledContextName;
             if (_dictionaryOwner is MethodDesc)
-                mangledContextName = NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_dictionaryOwner);
+                mangledContextName = nameMangler.GetMangledMethodName((MethodDesc)_dictionaryOwner);
             else
-                mangledContextName = NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
+                mangledContextName = nameMangler.GetMangledTypeName((TypeDesc)_dictionaryOwner);
 
             sb.Append("__GenericLookupFromType_").Append(mangledContextName).Append("_");
             _lookupSignature.AppendMangledName(nameMangler, sb);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -97,28 +97,28 @@ namespace ILCompiler.DependencyAnalysis
             switch (_id)
             {
                 case ReadyToRunHelperId.NewHelper:
-                    sb.Append("__NewHelper_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    sb.Append("__NewHelper_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
                     break;
                 case ReadyToRunHelperId.NewArr1:
-                    sb.Append("__NewArr1_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    sb.Append("__NewArr1_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
                     break;
                 case ReadyToRunHelperId.VirtualCall:
-                    sb.Append("__VirtualCall_").Append(NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target));
+                    sb.Append("__VirtualCall_").Append(nameMangler.GetMangledMethodName((MethodDesc)_target));
                     break;
                 case ReadyToRunHelperId.IsInstanceOf:
-                    sb.Append("__IsInstanceOf_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    sb.Append("__IsInstanceOf_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
                     break;
                 case ReadyToRunHelperId.CastClass:
-                    sb.Append("__CastClass_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    sb.Append("__CastClass_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
                     break;
                 case ReadyToRunHelperId.GetNonGCStaticBase:
-                    sb.Append("__GetNonGCStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    sb.Append("__GetNonGCStaticBase_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
                     break;
                 case ReadyToRunHelperId.GetGCStaticBase:
-                    sb.Append("__GetGCStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    sb.Append("__GetGCStaticBase_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
                     break;
                 case ReadyToRunHelperId.GetThreadStaticBase:
-                    sb.Append("__GetThreadStaticBase_").Append(NodeFactory.NameMangler.GetMangledTypeName((TypeDesc)_target));
+                    sb.Append("__GetThreadStaticBase_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
                     break;
                 case ReadyToRunHelperId.DelegateCtor:
                     {
@@ -136,7 +136,7 @@ namespace ILCompiler.DependencyAnalysis
                     break;
                 case ReadyToRunHelperId.ResolveVirtualFunction:
                     sb.Append("__ResolveVirtualFunction_");
-                    sb.Append(NodeFactory.NameMangler.GetMangledMethodName((MethodDesc)_target));
+                    sb.Append(nameMangler.GetMangledMethodName((MethodDesc)_target));
                     break;
                 default:
                     throw new NotImplementedException();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             sb.Append(nameMangler.CompilationUnitPrefix)
               .Append("__RuntimeFieldHandle_")
-              .Append(NodeFactory.NameMangler.GetMangledFieldName(_targetField));
+              .Append(nameMangler.GetMangledFieldName(_targetField));
         }
         public int Offset => 0;
         protected override string GetName() => this.GetMangledName();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             sb.Append(nameMangler.CompilationUnitPrefix)
               .Append("__RuntimeMethodHandle_")
-              .Append(NodeFactory.NameMangler.GetMangledMethodName(_targetMethod));
+              .Append(nameMangler.GetMangledMethodName(_targetMethod));
         }
         public int Offset => 0;
         protected override string GetName() => this.GetMangledName();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class RyuJitNodeFactory : NodeFactory
     {
         public RyuJitNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup)
-            : base(context, compilationModuleGroup, new CompilerGeneratedMetadataManager(compilationModuleGroup, context))
+            : base(context, compilationModuleGroup, new CompilerGeneratedMetadataManager(compilationModuleGroup, context), new CoreRTNameMangler(false))
         {
         }
 
@@ -45,7 +45,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                return new ExternMethodSymbolNode(method);
+                return new ExternMethodSymbolNode(this, method);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringAllocatorMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringAllocatorMethodNode.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(NodeFactory.NameMangler.GetMangledMethodName(_allocationMethod));
+            sb.Append(nameMangler.GetMangledMethodName(_allocationMethod));
         }
         public int Offset => 0;
         public bool RepresentsIndirectionCell => false;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsOffsetNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsOffsetNode.cs
@@ -27,12 +27,12 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(GetMangledName(_type));
+            sb.Append(GetMangledName(nameMangler, _type));
         }
 
-        public static string GetMangledName(TypeDesc type)
+        public static string GetMangledName(NameMangler nameMangler, TypeDesc type)
         {
-           return "__ThreadStaticBaseOffset_" + NodeFactory.NameMangler.GetMangledTypeName(type);
+           return "__ThreadStaticBaseOffset_" + nameMangler.GetMangledTypeName(type);
         }            
 
         protected override void OnMarked(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
@@ -44,7 +44,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool HasDynamicDependencies => false;
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => "__TypeGVMEntriesNode_" + NodeFactory.NameMangler.GetMangledTypeName(_associatedType);
+        protected override string GetName() => "__TypeGVMEntriesNode_" + NodeFactory.NameManglerDoNotUse.GetMangledTypeName(_associatedType);
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
         {
             return Array.Empty<CombinedDependencyListEntry>();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
             sb.Append("__TypeThreadStaticIndex_")
-              .Append(NodeFactory.NameMangler.GetMangledTypeName(_type));
+              .Append(nameMangler.GetMangledTypeName(_type));
         }
         public int Offset => 0;
         protected override string GetName() => this.GetMangledName();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append("unbox_").Append(NodeFactory.NameMangler.GetMangledMethodName(_target));
+            sb.Append("unbox_").Append(nameMangler.GetMangledMethodName(_target));
         }
 
         public override bool IsShareable => true;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
@@ -72,7 +72,7 @@ namespace ILCompiler
         }
 
         public UtcNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, IEnumerable<ModuleDesc> inputModules, string metadataFile, string outputFile) 
-            : base(context, compilationModuleGroup, PickMetadataManager(context, compilationModuleGroup, inputModules, metadataFile))
+            : base(context, compilationModuleGroup, PickMetadataManager(context, compilationModuleGroup, inputModules, metadataFile), null /* pick name mangler */)
         {
             CreateHostedNodeCaches();
             CompilationUnitPrefix = Path.GetFileNameWithoutExtension(outputFile);
@@ -108,7 +108,7 @@ namespace ILCompiler
 
             _nonExternMethodSymbols = new NodeCache<MethodDesc, NonExternMethodSymbolNode>((MethodDesc method) =>
             {
-                return new NonExternMethodSymbolNode(method);
+                return new NonExternMethodSymbolNode(this, method);
             });
         }
 
@@ -155,7 +155,7 @@ namespace ILCompiler
                 return new RuntimeImportMethodNode(method);
             }
 
-            return new ExternMethodSymbolNode(method);
+            return new ExternMethodSymbolNode(this, method);
         }
 
         protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
@@ -209,7 +209,7 @@ namespace ILCompiler
             }
             else
             {
-                return ExternSymbol(GCStaticDescNode.GetMangledName(type, false));
+                return ExternSymbol(GCStaticDescNode.GetMangledName(NameMangler, type, false));
             }
         }
 
@@ -223,7 +223,7 @@ namespace ILCompiler
             }
             else
             {
-                return ExternSymbol(GCStaticDescNode.GetMangledName(type, true));
+                return ExternSymbol(GCStaticDescNode.GetMangledName(NameMangler, type, true));
             }
         }
 
@@ -237,7 +237,7 @@ namespace ILCompiler
             }
             else
             {
-                return ExternSymbol(ThreadStaticsOffsetNode.GetMangledName(type));
+                return ExternSymbol(ThreadStaticsOffsetNode.GetMangledName(NameMangler, type));
             }
         }
 
@@ -249,7 +249,7 @@ namespace ILCompiler
             }
             else
             {
-                return ExternSymbol(ThreadStaticsOffsetNode.GetMangledName(type));
+                return ExternSymbol(ThreadStaticsOffsetNode.GetMangledName(NameMangler, type));
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
             get;
         }
 
-        protected override string GetName() => $"__vtable_{NodeFactory.NameMangler.GetMangledTypeName(_type).ToString()}";
+        protected override string GetName() => $"__vtable_{NodeFactory.NameManglerDoNotUse.GetMangledTypeName(_type).ToString()}";
 
         public override bool StaticDependenciesAreComputed => true;
 

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -330,7 +330,7 @@ namespace ILCompiler
             var lookupSig = new DelegateInvokeMethodSignature(delegateType);
             if (!DelegateMarshalingThunks.TryGetValue(lookupSig, out thunk))
             {
-                string stubName = "ReverseDelegateStub__" + NodeFactory.NameMangler.GetMangledTypeName(delegateType);
+                string stubName = "ReverseDelegateStub__" + NodeFactory.NameManglerDoNotUse.GetMangledTypeName(delegateType);
                 thunk = new DelegateMarshallingMethodThunk(_compilationModuleGroup.GeneratedAssembly.GetGlobalModuleType(), delegateType, stubName);
                 DelegateMarshalingThunks.Add(lookupSig, thunk);
             }

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
@@ -25,7 +25,7 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             Logger logger,
             JitConfigProvider configProvider)
-            : base(dependencyGraph, nodeFactory, roots, new CoreRTNameMangler(false), logger)
+            : base(dependencyGraph, nodeFactory, roots, logger)
         {
             _jitConfigProvider = configProvider;
         }


### PR DESCRIPTION
Having a static NameMangler makes it an easy target for misuse and layering violations. Violating layering shouldn't be as easy as writing a one-liner that is easy to miss in a code review.

Having NameMangler not be static is also a requirement for making the code that uses it unit testable.