### PR TITLE
Fix uninitialized CoreRT_CrossBuild variable

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -138,6 +138,7 @@ CoreRT_TestCompileMode=ryujit
 CoreRT_CrossRootFS=
 CoreRT_CrossCXXFlags=
 CoreRT_CrossLinkerFlags=
+CoreRT_CrossBuild=0
 
 while [ "$1" != "" ]; do
         lowerI="$(echo $1 | awk '{print tolower($0)}')"


### PR DESCRIPTION
`CoreRT_CrossBuild` wasn't being initialized, but the test for it does the following: 

```sh
if [ ${CoreRT_CrossBuild} != 0 ]; then
 ...
```

Because single brackets are used, the uninitialized variable disappears and we end up with broken syntax and an error saying `[: !=: unary operator expected`. There are a few different ways to fix this, but I guess just initializing the variable to 0 keeps it closest to the originally intended behavior.