### PR TITLE
Clean test bin/ and obj/ before running Unix tests

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -47,7 +47,7 @@ run_test_dir()
         __extra_args="${__extra_args} /p:IlcMultiModule=true"
     fi
 
-    rm -rf ${__dir_path}/bin/${CoreRT_BuildArch} ${__dir_path}/obj/${CoreRT_BuildArch}
+    rm -rf ${__dir_path}/bin/${CoreRT_BuildType} ${__dir_path}/obj/${CoreRT_BuildType}
 
     local __msbuild_dir=${CoreRT_TestRoot}/../Tools
 


### PR DESCRIPTION
Stale obj files were causing MSBuild to skip running ILC. This causes breaks when switching between single-file and multi-module compilation modes.