### PR TITLE
Make DgmlWriter call GetName instead of ToString

### DIFF
--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNode.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNode.cs
@@ -40,7 +40,7 @@ namespace ILCompiler.DependencyAnalysisFramework
         }
 
         // Force all non-abstract nodes to provide a name
-        protected abstract string GetName();
+        protected internal abstract string GetName();
 
         public override string ToString()
         {


### PR DESCRIPTION
We agreed in the past that `ToString` is allowed to return
debugger-friendly strings and doesn't need to be the symbolic name.
Disentangle pieces of `DgmlWriter` so that it can call the right method
instead of `ToString`.

This is a step towards getting rid of the static name mangler. In the
next step, `GetName` will be updated to accept a `DependencyContextType`
parameter (`NodeFactory` in the `ILCompiler` world) so that it can get
to the `NameMangler` associated with the factory and we can get rid of
the static that makes everything non-unit testable (two different name
manglers can't coexist in a single process right now), limiting what we
can test in xunit.