### PR TITLE
Add type loader support for building ByRef types

### DIFF
--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -556,7 +556,6 @@ namespace Internal.Runtime
                 _uBaseSize = value;
             }
 #endif
-
         }
 
         internal bool IsRelatedTypeViaIAT

--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -550,6 +550,13 @@ namespace Internal.Runtime
             {
                 return _uBaseSize;
             }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                _uBaseSize = value;
+            }
+#endif
+
         }
 
         internal bool IsRelatedTypeViaIAT

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -613,6 +613,11 @@ namespace Internal.Runtime.Augments
             return typeHandle.ToEETypePtr().IsPointer;
         }
 
+        public static bool IsByRefType(RuntimeTypeHandle typeHandle)
+        {
+            return typeHandle.ToEETypePtr().IsByRef;
+        }
+
         public static bool IsGenericTypeDefinition(RuntimeTypeHandle typeHandle)
         {
             return typeHandle.ToEETypePtr().IsGenericTypeDefinition;

--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -213,9 +213,6 @@
   <data name="ArgumentException_InvalidArrayElementType" xml:space="preserve">
     <value>The type '{0}' may not be used as an array element type.</value>
   </data>
-  <data name="PlatformNotSupported_NoTypeHandleForByRef" xml:space="preserve">
-    <value>TypeHandles are not supported for types that return true for IsByRef.</value>
-  </data>
   <data name="PlatformNotSupported_NoTypeHandleForOpenTypes" xml:space="preserve">
     <value>TypeHandles are not supported for types that return true for ContainsGenericParameters.</value>
   </data>

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -543,9 +543,6 @@ namespace System.Reflection.Runtime.TypeInfos
                 if (!typeHandle.IsNull())
                     return typeHandle;
 
-                if (IsByRef)
-                    throw new PlatformNotSupportedException(SR.PlatformNotSupported_NoTypeHandleForByRef);
-
                 // If a constructed type doesn't have an type handle, it's either because the reducer tossed it (in which case,
                 // we would thrown a MissingMetadataException when attempting to construct the type) or because one of
                 // component types contains open type parameters. Since we eliminated the first case, it must be the second.

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -319,13 +319,7 @@ namespace Internal.Reflection.Execution
         //
         public unsafe sealed override bool TryGetByRefTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle byRefTypeHandle)
         {
-#if CORERT
-            throw new NotImplementedException();
-#else
-            // Project N is not capable of emitting EETypes for ByRefs.
-            byRefTypeHandle = default(RuntimeTypeHandle);
-            return false;
-#endif
+            return TypeLoaderEnvironment.Instance.TryGetByRefTypeForTargetType(targetTypeHandle, out byRefTypeHandle);
         }
 
         //

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -568,7 +568,8 @@ namespace Internal.Runtime.TypeLoader
                     }
                     else if (TypeBeingBuilt.RetrieveRuntimeTypeHandleIfPossible() ||
                              TypeBeingBuilt.IsTemplateCanonical() ||
-                             (TypeBeingBuilt is PointerType))
+                             (TypeBeingBuilt is PointerType) ||
+                             (TypeBeingBuilt is ByRefType))
                     {
                         _instanceGCLayout = s_emptyLayout;
                     }
@@ -969,7 +970,7 @@ namespace Internal.Runtime.TypeLoader
                         return (ushort)arrayType.Context.Target.PointerSize;
                     }
                 }
-                else if (TypeBeingBuilt is PointerType)
+                else if (TypeBeingBuilt is PointerType || TypeBeingBuilt is ByRefType)
                 {
                     return (ushort)TypeBeingBuilt.Context.Target.PointerSize;
                 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -424,6 +424,22 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
+        public bool TryGetByRefTypeForTargetType(RuntimeTypeHandle pointeeTypeHandle, out RuntimeTypeHandle byRefTypeHandle)
+        {
+            // There are no lookups for ByRefs in static modules. All ByRef EETypes will be created at this level.
+            // It's possible to have multiple ByRef EETypes representing the same ByRef type with the same element type
+            // The caching of ByRef types is done at the reflection layer (in the RuntimeTypeUnifier) and
+            // here in the TypeSystemContext layer
+
+            if (TypeSystemContext.ByRefTypesCache.TryGetValue(pointeeTypeHandle, out byRefTypeHandle))
+                return true;
+
+            using (LockHolder.Hold(_typeLoaderLock))
+            {
+                return TypeBuilder.TryBuildByRefType(pointeeTypeHandle, out byRefTypeHandle);
+            }
+        }
+
         public int GetCanonicalHashCode(RuntimeTypeHandle typeHandle, CanonicalFormKind kind)
         {
             TypeSystemContext context = TypeSystemContextFactory.Create();

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeDesc.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeDesc.Runtime.cs
@@ -167,15 +167,11 @@ namespace Internal.TypeSystem
                           (TypeLoaderEnvironment.Instance.TryGetArrayTypeForElementType_LookupOnly(typeAsParameterType.ParameterType.RuntimeTypeHandle, type.IsMdArray, type.IsMdArray ? ((ArrayType)type).Rank : -1, out rtth) ||
                            TypeLoaderEnvironment.Instance.TryGetArrayTypeHandleForNonDynamicArrayTypeFromTemplateTable(type as ArrayType, out rtth)))
                            ||
-                        (type is PointerType && TypeSystemContext.PointerTypesCache.TryGetValue(typeAsParameterType.ParameterType.RuntimeTypeHandle, out rtth)))
+                        (type is PointerType && TypeSystemContext.PointerTypesCache.TryGetValue(typeAsParameterType.ParameterType.RuntimeTypeHandle, out rtth))
+                           ||
+                        (type is ByRefType && TypeSystemContext.ByRefTypesCache.TryGetValue(typeAsParameterType.ParameterType.RuntimeTypeHandle, out rtth)))
                     {
                         typeAsParameterType.SetRuntimeTypeHandleUnsafe(rtth);
-                        return true;
-                    }
-                    else if (type is ByRefType)
-                    {
-                        // Byref types don't have any associated type handles, so return success at this point
-                        // since we were able to resolve the typehandle of the element type
                         return true;
                     }
                 }

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -96,6 +96,12 @@ namespace Internal.TypeSystem
         internal static RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable PointerTypesCache { get; } =
             new RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable();
 
+        /// <summary>
+        /// Cache of ByRef types created by the builder to prevent duplication
+        /// </summary>
+        internal static RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable ByRefTypesCache { get; } =
+            new RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable();
+
         internal TypeDesc GetTypeFromCorElementType(CorElementType corElementType)
         {
             switch (corElementType)
@@ -260,6 +266,12 @@ namespace Internal.TypeSystem
                 RuntimeTypeHandle targetTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(rtth);
                 TypeDesc targetType = ResolveRuntimeTypeHandle(targetTypeHandle);
                 returnedType = GetPointerType(targetType);
+            }
+            else if (RuntimeAugments.IsByRefType(rtth))
+            {
+                RuntimeTypeHandle targetTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(rtth);
+                TypeDesc targetType = ResolveRuntimeTypeHandle(targetTypeHandle);
+                returnedType = GetByRefType(targetType);
             }
             else
             {

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -177,14 +177,13 @@ public class ReflectionTest
                 return Fail;
         }
 
-        // TODO: Can't be tested temporarily since it would end up calling into type loader to load a ByRef type.
-        //{
-        //    MethodInfo helloByRefMethod = typeof(InvokeTests).GetTypeInfo().GetDeclaredMethod("GetHelloByRef");
-        //    object[] args = new object[] { "world", null };
-        //    helloByRefMethod.Invoke(null, args);
-        //    if ((string)args[1] != "Hello world")
-        //        return Fail;
-        //}
+        {
+            MethodInfo helloByRefMethod = typeof(InvokeTests).GetTypeInfo().GetDeclaredMethod("GetHelloByRef");
+            object[] args = new object[] { "world", null };
+            helloByRefMethod.Invoke(null, args);
+            if ((string)args[1] != "Hello world")
+                return Fail;
+        }
 
         return Pass;
     }


### PR DESCRIPTION
The CoreRT compiler and runtime have been able to handle this for a
while. The only thing missing (that required us to throw from a place)
was the type loader support.

This adds support for building ByRef types at runtime. I'm not
introducing a native layout representation though, so things like `T&`
won't compile still.