### PR TITLE
Preserve scratch register r10 in RhpCommonStub

### DIFF
--- a/src/Native/Runtime/amd64/InteropThunksHelpers.S
+++ b/src/Native/Runtime/amd64/InteropThunksHelpers.S
@@ -10,21 +10,21 @@
 LEAF_ENTRY RhpCommonStub, _TEXT
 
     PUSH_ARGUMENT_REGISTERS
+    push_register    r10
 
-    // +8 for alignment
-    alloc_stack    (SIZEOF_MAX_FP_ARG_SPILL + 8)
+    alloc_stack    SIZEOF_FP_REGS 
     SAVE_FLOAT_ARGUMENT_REGISTERS 0 
 
     INLINE_GET_TLS_VAR  tls_thunkData
 
+    RESTORE_FLOAT_ARGUMENT_REGISTERS 0 
+    free_stack    SIZEOF_FP_REGS
+
+    pop_register    r10
+    POP_ARGUMENT_REGISTERS
+
     mov    r11, [r10]
     mov    qword ptr [rax], r11
-
-
-    RESTORE_FLOAT_ARGUMENT_REGISTERS 0 
-    free_stack    (SIZEOF_MAX_FP_ARG_SPILL + 8)
-
-    POP_ARGUMENT_REGISTERS
 
     mov    rax, [r10 + POINTER_SIZE]
     jmp    rax

--- a/src/Native/Runtime/amd64/UniversalTransition.S
+++ b/src/Native/Runtime/amd64/UniversalTransition.S
@@ -16,8 +16,6 @@
 #define SIZEOF_RETURN_BLOCK         0x10    // for 16 bytes of conservatively reported space that the callee can
                                             // use to manage the return value that the call eventually generates
 
-#define SIZEOF_FP_REGS              0x80    // xmm0-7
-
 #define SIZEOF_ARGUMENT_REGISTERS   0x30    // Callee register spill
 
 //

--- a/src/Native/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosamd64.inc
@@ -194,7 +194,7 @@ C_FUNC(\Name):
 
 .endm
 
-#define SIZEOF_MAX_FP_ARG_SPILL  0x80
+#define SIZEOF_FP_REGS 0x80
 
 .macro SAVE_FLOAT_ARGUMENT_REGISTERS ofs
 


### PR DESCRIPTION
INLINE_GET_TLS_VAR can corrupt scratch register r10 which contains the address of thunkData.
This trivial change ensures we preserve it's value.

@jkotas @janvorli 