### PR TITLE
Fix for issue 2855: GVM dependency tracking with shared generics.

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -167,10 +167,11 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (canonMethodTarget != derivedMethodInstantiation)
                 {
-                    // Dependency includes the generic method dictionary of the instantiation
+                    // Dependency includes the generic method dictionary of the instantiation, and all its dependencies. This is done by adding the 
+                    // ShadowConcreteMethod to the list of dynamic dependencies. The generic dictionary will be reported as a dependency of the ShadowConcreteMethod
                     // TODO: detect large recursive generics and fallback to USG templates
                     Debug.Assert(!derivedMethodInstantiation.IsCanonicalMethod(CanonicalFormKind.Any));
-                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.MethodGenericDictionary(derivedMethodInstantiation), null, "DerivedMethodInstantiation dictionary"));
+                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.ShadowConcreteMethod(derivedMethodInstantiation), null, "DerivedMethodInstantiation dictionary"));
                 }
             }
             else

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -25,6 +25,7 @@ class Program
         TestMDArrayAddressMethod.Run();
         TestNameManglingCollisionRegression.Run();
         TestSimpleGVMScenarios.Run();
+        TestGvmDependencies.Run();
 
         return 100;
     }
@@ -902,6 +903,40 @@ class Program
 
             if (s_NumErrors != 0)
                 throw new Exception();
+        }
+    }
+
+    class TestGvmDependencies
+    {
+        class Atom { }
+
+        class Foo
+        {
+            public virtual object Frob<T>()
+            {
+                return new T[0, 0];
+            }
+        }
+
+        class Bar : Foo
+        {
+            public override object Frob<T>()
+            {
+                return new T[0, 0, 0];
+            }
+        }
+
+        public static void Run()
+        {
+            {
+                Foo x = new Foo();
+                x.Frob<Atom>();
+            }
+
+            {
+                Foo x = new Bar();
+                x.Frob<Atom>();
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for #2855. This bug is with shared generics only.

The problem was that we were adding the generic virtual method dictionary to the list of dependencies, but not adding a ShadowConcreteMethod node. This meant that any 'unseen' dependency of the method dictionary would never be rooted, and that produced linker errors.