### PR TITLE
Fix delegate creation to shared generic method bodies

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -39,10 +39,12 @@ namespace ILCompiler.DependencyAnalysis
             return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
         }
 
-        protected override IMethodNode CreateShadowConcreteMethodNode(MethodDesc method)
+        protected override IMethodNode CreateShadowConcreteMethodNode(MethodKey methodKey)
         {
-            return new ShadowConcreteMethodNode<CppMethodCodeNode>(method,
-                (CppMethodCodeNode)MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific)));
+            return new ShadowConcreteMethodNode<CppMethodCodeNode>(methodKey.Method,
+                (CppMethodCodeNode)MethodEntrypoint(
+                    methodKey.Method.GetCanonMethodTarget(CanonicalFormKind.Specific),
+                    methodKey.IsUnboxingStub));
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -73,10 +73,12 @@ namespace ILCompiler.DependencyAnalysis
             return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
         }
 
-        protected override IMethodNode CreateShadowConcreteMethodNode(MethodDesc method)
+        protected override IMethodNode CreateShadowConcreteMethodNode(MethodKey methodKey)
         {
-            return new ShadowConcreteMethodNode<MethodCodeNode>(method, 
-                (MethodCodeNode)MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific)));
+            return new ShadowConcreteMethodNode<MethodCodeNode>(methodKey.Method, 
+                (MethodCodeNode)MethodEntrypoint(
+                    methodKey.Method.GetCanonMethodTarget(CanonicalFormKind.Specific),
+                    methodKey.IsUnboxingStub));
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
@@ -168,11 +168,13 @@ namespace ILCompiler
             return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
         }
 
-        protected override IMethodNode CreateShadowConcreteMethodNode(MethodDesc method)
+        protected override IMethodNode CreateShadowConcreteMethodNode(MethodKey methodKey)
         {
             // All methods are modeled as ExternMethodSymbolNode in ProjectX for now.
-            return new ShadowConcreteMethodNode<ExternMethodSymbolNode>(method,
-                (ExternMethodSymbolNode)MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific)));
+            return new ShadowConcreteMethodNode<ExternMethodSymbolNode>(methodKey.Method,
+                (ExternMethodSymbolNode)MethodEntrypoint(
+                    methodKey.Method.GetCanonMethodTarget(CanonicalFormKind.Specific),
+                    methodKey.IsUnboxingStub));
         }
 
         public GCStaticDescRegionNode GCStaticDescRegion = new GCStaticDescRegionNode(

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -14,6 +14,7 @@ class Program
         TestStaticBaseLookups.Run();
         TestInitThisClass.Run();
         TestDelegateFatFunctionPointers.Run();
+        TestDelegateToCanonMethods.Run();
         TestVirtualMethodUseTracking.Run();
         TestSlotsInHierarchy.Run();
         TestReflectionInvoke.Run();
@@ -227,6 +228,151 @@ class Program
                     if (x.Bytes[i] != result.Bytes[i])
                         throw new Exception();
             }
+        }
+    }
+
+    class TestDelegateToCanonMethods
+    {
+        class Foo
+        {
+            public readonly int Value;
+            public Foo(int value)
+            {
+                Value = value;
+            }
+
+            public override string ToString()
+            {
+                return Value.ToString();
+            }
+        }
+
+        class Bar
+        {
+            public readonly int Value;
+            public Bar(int value)
+            {
+                Value = value;
+            }
+
+            public override string ToString()
+            {
+                return Value.ToString();
+            }
+        }
+
+        class GenClass<T>
+        {
+            public readonly T X;
+
+            public GenClass(T x)
+            {
+                X = x;
+            }
+
+            public string MakeString()
+            {
+                // Use a constructed type that is not used elsewhere
+                return typeof(T[,]).GetElementType().Name + ": " + X.ToString();
+            }
+
+            public string MakeGenString<U>()
+            {
+                // Use a constructed type that is not used elsewhere
+                return typeof(T[,,]).GetElementType().Name + ", " + 
+                    typeof(U[,,,]).GetElementType().Name + ": " + X.ToString();
+            }
+        }
+
+        struct GenStruct<T>
+        {
+            public readonly T X;
+
+            public GenStruct(T x)
+            {
+                X = x;
+            }
+
+            public string MakeString()
+            {
+                // Use a constructed type that is not used elsewhere
+                return typeof(T[,]).GetElementType().Name + ": " + X.ToString();
+            }
+
+            public string MakeGenString<U>()
+            {
+                // Use a constructed type that is not used elsewhere
+                return typeof(T[,,]).GetElementType().Name + ", " +
+                    typeof(U[,,,]).GetElementType().Name + ": " + X.ToString();
+            }
+        }
+
+        public static void Run()
+        {
+            // Delegate to a shared nongeneric reference type instance method
+            {
+                GenClass<Foo> g = new GenClass<Foo>(new Foo(42));
+                Func<string> f = g.MakeString;
+                if (f() != "Foo: 42")
+                    throw new Exception();
+            }
+
+            // Delegate to a unshared nongeneric reference type instance method
+            {
+                GenClass<int> g = new GenClass<int>(85);
+                Func<string> f = g.MakeString;
+                if (f() != "Int32: 85")
+                    throw new Exception();
+            }
+
+            // Delegate to a shared generic reference type instance method
+            {
+                GenClass<Foo> g = new GenClass<Foo>(new Foo(42));
+                Func<string> f = g.MakeGenString<Foo>;
+                if (f() != "Foo, Foo: 42")
+                    throw new Exception();
+            }
+
+            // Delegate to a unshared generic reference type instance method
+            {
+                GenClass<int> g = new GenClass<int>(85);
+                Func<string> f = g.MakeGenString<int>;
+                if (f() != "Int32, Int32: 85")
+                    throw new Exception();
+            }
+
+            // Delegate to a shared nongeneric value type instance method
+            /*{
+                GenStruct<Bar> g = new GenStruct<Bar>(new Bar(42));
+                Func<string> f = g.MakeString;
+                if (f() != "Bar: 42")
+                    throw new Exception();
+            }*/
+
+            // Delegate to a unshared nongeneric value type instance method
+            {
+                GenStruct<int> g = new GenStruct<int>(85);
+                Func<string> f = g.MakeString;
+                if (f() != "Int32: 85")
+                    throw new Exception();
+            }
+
+            // Delegate to a shared generic value type instance method
+            /*{
+                GenStruct<Bar> g = new GenStruct<Bar>(new Bar(42));
+                Func<string> f = g.MakeGenString<Bar>;
+                if (f() != "Bar, Bar: 42")
+                    throw new Exception();
+            }*/
+
+            // Delegate to a unshared generic value type instance method
+            {
+                GenStruct<int> g = new GenStruct<int>(85);
+                Func<string> f = g.MakeGenString<int>;
+                if (f() != "Int32, Int32: 85")
+                    throw new Exception();
+            }
+
         }
     }
 


### PR DESCRIPTION
The delegate creation code path wasn't updated for shared generics:

* We need to use canonical entrypoints and fat function pointers where appropriate
* This required adding infrastructure to track unboxing stubs from shared code.

More work will be needed around here to add support for creating delegates *from* shared code.