### PR TITLE
Emit all methods / data to Comdat sections

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -729,15 +729,14 @@ namespace ILCompiler.DependencyAnalysis
             if (_targetPlatform.OperatingSystem == TargetOS.OSX)
                 return false;
 
-            // Types and methods from the compiler generated assembly are always shareable
-            MetadataType type = (node is EETypeNode ? ((EETypeNode)node).Type : (node as MethodCodeNode)?.Method.OwningType) as MetadataType;
-            if (type != null &&
-                type.Module == _nodeFactory.CompilationModuleGroup.GeneratedAssembly)
-            {
-                return true;
-            }
-            
-            return node.IsShareable;
+            if (!(node is ISymbolNode))
+                return false;
+
+            // These intentionally clash with one another, but are merged with linker directives so should not be Comdat folded
+            if (node is ModulesSectionNode)
+                return false;
+
+            return true;
         }
 
         public static void EmitObject(string objectFilePath, IEnumerable<DependencyNode> nodes, NodeFactory factory, IObjectDumper dumper)

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -25,11 +25,6 @@ namespace ILCompiler
             {
                 try
                 {
-                    // Skip delegates (since their Invoke methods have no IL)
-                    // Note that this check can fail with TypeSystemException as well.
-                    if (type.IsDelegate)
-                        continue;
-
                     rootProvider.AddCompilationRoot(type, "Library module type");
                 }
                 catch (TypeSystemException)


### PR DESCRIPTION
* When linking against a library, if the linker needs any symbols from
an object file in that library, it links in the entire library's
sections. This bloats the final binary image. When opt:ref is used (in
release mode), unreferenced symbols can be discarded if they are in
their own Comdat section.

* Switch to using Comdats for all ISymbolNodes in multi-module mode.

* This change is sufficient to collapse multi-module binaries down to
around 7MB (from 19MB) if metadata is disabled. In the presence of
metadata, all types and methods end up rooted.

* Remove the IsDelegate exclusion in library mode. We can handle rooting
delegates now and we were missing delegate types with metadata disabled.

* ObjectNode.IsShareable could strictly be removed at this point. I want
to let this bake a few days to be sure before doing that work though. We
may still want some of this logic, too; now everything is a global
mergeable comdat. The next step is to properly categorize symbols for
global / private linkage.