### PR TITLE
Fix GVM Method Pointer Lookup Failure

### DIFF
--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
@@ -470,7 +470,12 @@ namespace Internal.Runtime.TypeLoader
 
                     Debug.Assert(targetMethodNameAndSignature != null);
 
-                    return TryGetGenericVirtualMethodPointer(targetTypeHandle, targetMethodNameAndSignature, genericArguments, out methodPointer, out dictionaryPointer);
+                    if (!TryGetGenericVirtualMethodPointer(targetTypeHandle, targetMethodNameAndSignature, genericArguments, out methodPointer, out dictionaryPointer))
+                    {
+                        Environment.FailFast("GVM method pointer lookup failure");
+                    }
+
+                    return true;
                 }
             }
 


### PR DESCRIPTION
Failure to find a method pointer for a resolved GVM target should fail fast and not attempt to resolve the GVM on a base type (this could lead to calling the incorrect method just because we can't find an entrypoint for the correct one).