### PR TITLE
Fix a couple of things in the Unix corerun script

### DIFF
--- a/tests/CoreCLR/corerun
+++ b/tests/CoreCLR/corerun
@@ -14,9 +14,6 @@ __msbuild_dir=${CoreRT_TestRoot}/../Tools
 echo ${__msbuild_dir}/msbuild.sh /m /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} Test.csproj
 ${__msbuild_dir}/msbuild.sh /m /p:IlcPath=${CoreRT_ToolchainDir} /p:Configuration=${CoreRT_BuildType} Test.csproj
 
-# Some tests (interop) have native artifacts they depend on. Copy all DLLs to be sure we have them.
-cp *.dll native/ 2>/dev/null
-
 # Remove the test executable from the arg list so it isn't passed to test execution
 shift
 

--- a/tests/CoreCLR/corerun
+++ b/tests/CoreCLR/corerun
@@ -20,7 +20,7 @@ cp *.dll native/ 2>/dev/null
 # Remove the test executable from the arg list so it isn't passed to test execution
 shift
 
-native/${TestFileName} $*
+native/${TestFileName} "$@"
 
 testScriptExitCode=$?
 


### PR DESCRIPTION
Fix a couple of issues:
- We were trying to copy *.dll for each test into the 'native' directory next to the executable. The comment said this was to ensure we have all the native components required, but the native components are not going to be DLLs on the Unix platforms where this script runs. Moreover, the drop that we're grabbing the IL binaries from doesn't have the Unix native components anyway.

- Test arguments were being passed with `$*` which will cause word splitting issues for any tests which have multi-word arguments. Passing them with `"$@"` will do the right thing.

@nattress