### PR TITLE
Fix casting arrays to non-variant interfaces

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -71,7 +71,9 @@ namespace ILCompiler.DependencyAnalysis
                     // could result in interface methods of this type being used (e.g. IEnumberable<object>.GetEnumerator()
                     // can dispatch to an implementation of IEnumerable<string>.GetEnumerator()).
                     // For now, we will not try to optimize this and we will pretend all interface methods are necessary.
-                    if (implementedInterface.HasVariance)
+                    // NOTE: we need to also do this for generic interfaces on arrays because they have a weird casting rule
+                    // that doesn't require the implemented interface to be variant to consider it castable.
+                    if (implementedInterface.HasVariance || (_type.IsArray && implementedInterface.HasInstantiation))
                     {
                         foreach (var interfaceMethod in implementedInterface.GetAllMethods())
                         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -256,7 +256,7 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (UInt16)EETypeFlags.GenericVarianceFlag;
             }
 
-            if (IsGenericInterfaceImplementedByArray(_type))
+            if (factory.TypeSystemContext.IsGenericArrayInterfaceType(_type))
             {
                 // Runtime casting logic relies on all interface types implemented on arrays
                 // to have the variant flag set (even if all the arguments are non-variant).
@@ -491,25 +491,6 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        /// <summary>
-        /// Returns true if <paramref name="type"/> is an interface type that could be implemented by an array.
-        /// </summary>
-        private static bool IsGenericInterfaceImplementedByArray(TypeDesc type)
-        {
-            // As a quick test we can use the fact that interfaces implemented by array are all non-generic.
-            if (!type.IsInterface || type.Instantiation.Length != 1)
-                return false;
-
-            TypeDesc elementType = type.Instantiation[0];
-            foreach (var interfaceType in elementType.MakeArrayType().RuntimeInterfaces)
-            {
-                if (interfaceType == type)
-                    return true;
-            }
-
-            return false;
-        }
-
         private void OutputGenericInstantiationDetails(NodeFactory factory, ref ObjectDataBuilder objData)
         {
             if (_type.HasInstantiation && !_type.IsTypeDefinition)
@@ -522,7 +503,7 @@ namespace ILCompiler.DependencyAnalysis
                     // Generic array enumerators use special variance rules recognized by the runtime
                     details = new GenericCompositionDetails(_type.Instantiation, new[] { GenericVariance.ArrayCovariant });
                 }
-                else if (IsGenericInterfaceImplementedByArray(_type))
+                else if (factory.TypeSystemContext.IsGenericArrayInterfaceType(_type))
                 {
                     // Runtime casting logic relies on all interface types implemented on arrays
                     // to have the variant flag set (even if all the arguments are non-variant).

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -256,6 +256,14 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (UInt16)EETypeFlags.GenericVarianceFlag;
             }
 
+            if (IsGenericInterfaceImplementedByArray(_type))
+            {
+                // Runtime casting logic relies on all interface types implemented on arrays
+                // to have the variant flag set (even if all the arguments are non-variant).
+                // This supports e.g. casting uint[] to ICollection<int>
+                flags |= (UInt16)EETypeFlags.GenericVarianceFlag;
+            }
+
             ISymbolNode relatedTypeNode = GetRelatedTypeNode(factory);
 
             // If the related type (base type / array element type / pointee type) is not part of this compilation group, and
@@ -483,6 +491,25 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        /// <summary>
+        /// Returns true if <paramref name="type"/> is an interface type that could be implemented by an array.
+        /// </summary>
+        private static bool IsGenericInterfaceImplementedByArray(TypeDesc type)
+        {
+            // As a quick test we can use the fact that interfaces implemented by array are all non-generic.
+            if (!type.IsInterface || type.Instantiation.Length != 1)
+                return false;
+
+            TypeDesc elementType = type.Instantiation[0];
+            foreach (var interfaceType in elementType.MakeArrayType().RuntimeInterfaces)
+            {
+                if (interfaceType == type)
+                    return true;
+            }
+
+            return false;
+        }
+
         private void OutputGenericInstantiationDetails(NodeFactory factory, ref ObjectDataBuilder objData)
         {
             if (_type.HasInstantiation && !_type.IsTypeDefinition)
@@ -494,6 +521,13 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     // Generic array enumerators use special variance rules recognized by the runtime
                     details = new GenericCompositionDetails(_type.Instantiation, new[] { GenericVariance.ArrayCovariant });
+                }
+                else if (IsGenericInterfaceImplementedByArray(_type))
+                {
+                    // Runtime casting logic relies on all interface types implemented on arrays
+                    // to have the variant flag set (even if all the arguments are non-variant).
+                    // This supports e.g. casting uint[] to ICollection<int>
+                    details = new GenericCompositionDetails(_type, forceVarianceInfo: true);
                 }
                 else
                     details = new GenericCompositionDetails(_type);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text;
 
 using Internal.Text;
 using Internal.TypeSystem;
@@ -30,17 +29,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             sb.Append("__GenericInstance");
 
-            bool hasVariance = false;
-
             for (int i = 0; i < _details.Instantiation.Length; i++)
             {
                 sb.Append('_');
                 sb.Append(nameMangler.GetMangledTypeName(_details.Instantiation[i]));
-
-                hasVariance |= _details.Variance[i] != 0;
             }
 
-            if (hasVariance)
+            if (_details.Variance != null)
             {
                 for (int i = 0; i < _details.Variance.Length; i++)
                 {
@@ -75,15 +70,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            bool hasVariance = false;
-            foreach (var argVariance in _details.Variance)
-            {
-                if (argVariance != 0)
-                {
-                    hasVariance = true;
-                    break;
-                }
-            }
+            bool hasVariance = _details.Variance != null;
 
             var builder = new ObjectDataBuilder(factory);
             builder.AddSymbol(this);
@@ -120,28 +107,48 @@ namespace ILCompiler.DependencyAnalysis
 
         public readonly GenericVariance[] Variance;
 
-        public GenericCompositionDetails(TypeDesc genericTypeInstance)
+        public GenericCompositionDetails(TypeDesc genericTypeInstance, bool forceVarianceInfo = false)
         {
             Debug.Assert(!genericTypeInstance.IsTypeDefinition);
-
-            Debug.Assert((byte)Internal.TypeSystem.GenericVariance.Contravariant == (byte)GenericVariance.Contravariant);
-            Debug.Assert((byte)Internal.TypeSystem.GenericVariance.Covariant == (byte)GenericVariance.Covariant);
-
+            
             Instantiation = genericTypeInstance.Instantiation;
 
-            Variance = new GenericVariance[Instantiation.Length];
-            int i = 0;
-            foreach (GenericParameterDesc param in genericTypeInstance.GetTypeDefinition().Instantiation)
+            bool emitVarianceInfo = forceVarianceInfo;
+            if (!emitVarianceInfo)
             {
-                Variance[i++] = (GenericVariance)param.Variance;
+                foreach (GenericParameterDesc param in genericTypeInstance.GetTypeDefinition().Instantiation)
+                {
+                    if (param.Variance != Internal.TypeSystem.GenericVariance.None)
+                    {
+                        emitVarianceInfo = true;
+                        break;
+                    }
+                }
+            }
+
+            if (emitVarianceInfo)
+            {
+                Debug.Assert((byte)Internal.TypeSystem.GenericVariance.Contravariant == (byte)GenericVariance.Contravariant);
+                Debug.Assert((byte)Internal.TypeSystem.GenericVariance.Covariant == (byte)GenericVariance.Covariant);
+
+                Variance = new GenericVariance[Instantiation.Length];
+                int i = 0;
+                foreach (GenericParameterDesc param in genericTypeInstance.GetTypeDefinition().Instantiation)
+                {
+                    Variance[i++] = (GenericVariance)param.Variance;
+                }
+            }
+            else
+            {
+                Variance = null;
             }
         }
 
         public GenericCompositionDetails(Instantiation instantiation, GenericVariance[] variance)
         {
+            Debug.Assert(variance == null || instantiation.Length == variance.Length);
             Instantiation = instantiation;
             Variance = variance;
-            Debug.Assert(Instantiation.Length == Variance.Length);
         }
 
         public bool Equals(GenericCompositionDetails other)
@@ -149,13 +156,19 @@ namespace ILCompiler.DependencyAnalysis
             if (Instantiation.Length != other.Instantiation.Length)
                 return false;
 
+            if ((Variance == null) != (other.Variance == null))
+                return false;
+
             for (int i = 0; i < Instantiation.Length; i++)
             {
                 if (Instantiation[i] != other.Instantiation[i])
                     return false;
 
-                if (Variance[i] != other.Variance[i])
-                    return false;
+                if (Variance != null)
+                {
+                    if (Variance[i] != other.Variance[i])
+                        return false;
+                }
             }
 
             return true;
@@ -169,10 +182,14 @@ namespace ILCompiler.DependencyAnalysis
         public override int GetHashCode()
         {
             int hashCode = 13;
-            foreach (var element in Variance)
+
+            if (Variance != null)
             {
-                int value = (int)element * 0x5498341 + 0x832424;
-                hashCode = hashCode * 31 + value;
+                foreach (var element in Variance)
+                {
+                    int value = (int)element * 0x5498341 + 0x832424;
+                    hashCode = hashCode * 31 + value;
+                }
             }
 
             return Instantiation.ComputeGenericInstanceHashCode(hashCode);

--- a/tests/src/Simple/Interfaces/Interfaces.cs
+++ b/tests/src/Simple/Interfaces/Interfaces.cs
@@ -25,6 +25,9 @@ public class BringUpTest
         if (TestVariantInterfaces() == Fail)
             return Fail;
 
+        if (TestSpecialArrayInterfaces() == Fail)
+            return Fail;
+
         return Pass;
     }
 
@@ -332,6 +335,24 @@ public class BringUpTest
             sum += e;
 
         if (sum != 30)
+            return Fail;
+
+        return Pass;
+    }
+
+    class SpecialArrayBase { }
+    class SpecialArrayDerived : SpecialArrayBase { }
+
+    // NOTE: ICollection is not a variant interface, but arrays can cast with it as if it was
+    static ICollection<SpecialArrayBase> s_specialDerived = new SpecialArrayDerived[42];
+    static ICollection<uint> s_specialInt = (ICollection<uint>)(object)new int[85];
+
+    private static int TestSpecialArrayInterfaces()
+    {
+        if (s_specialDerived.Count != 42)
+            return Fail;
+
+        if (s_specialInt.Count != 85)
             return Fail;
 
         return Pass;


### PR DESCRIPTION
The runtime has a special set of rules for casting array types. Array
can be cast to various non-variant generic interfaces without triggering
an exception. Note this does not violate type safety because the safety
is enforced at the array store operation level.

The fix is twofold:
* Dependency tracking: methods implementing generic interfaces on arrays
should be always considered used (same as we do for variant interfaces).
This has a pretty negative size on disk impact. The work to see if we
can do something about it without adversely affecting compilation
throughput is tracked in #1198.
* EEType emission - this is a separate issue, but related: generic
interface types that can potentially be implemented by an array need to
have the GenericVariance flag set (even if all the parameters turn out
to be non-variant). This is to make casting take a slower path at
runtime that can handle special array casts.

There is one more issue that I discovered while looking at this in
`CanCastTo`. I'm not fixing it now. Tracked by #2871.