### PR TITLE
Port some changes to runtest from CoreCLR

### DIFF
--- a/tests/CoreCLR/runtest/runtest.sh
+++ b/tests/CoreCLR/runtest/runtest.sh
@@ -118,14 +118,6 @@ case $OSName in
         ;;
 esac
 
-# clean up any existing dumpling remnants from previous runs.
-dumplingsListPath="$PWD/dumplings.txt"
-if [ -f "$dumplingsListPath" ]; then
-    rm "$dumplingsListPath"
-fi
-
-find . -type f -name "local_dumplings.txt" -exec rm {} \;
-
 function xunit_output_begin {
     xunitOutputPath=$__LogDir/testResults.xml
     xunitTestOutputPath=${xunitOutputPath}.test
@@ -601,7 +593,7 @@ function print_info_from_core_file {
 
 function download_dumpling_script {
     echo "Downloading latest version of dumpling script."
-    wget "https://raw.githubusercontent.com/Microsoft/dotnet-reliability/master/src/triage.python/dumpling.py"
+    wget "https://dumpling.azurewebsites.net/api/client/dumpling.py"
 
     local dumpling_script="dumpling.py"
     chmod +x $dumpling_script
@@ -632,8 +624,11 @@ function upload_core_file_to_dumpling {
         paths_to_add=$coreClrBinDir
     fi
 
+    # Ensure the script has Unix line endings
+    perl -pi -e 's/\r\n|\n|\r/\n/g' "$dumpling_script"
+
     # The output from this will include a unique ID for this dump.
-    ./$dumpling_script "--corefile" "$core_file_name" "upload" "--addpaths" $paths_to_add "--squelch" | tee -a $dumpling_file
+    ./$dumpling_script "upload" "--dumppath" "$core_file_name" "--incpaths" $paths_to_add "--properties" "Project=CoreCLR" "--squelch" | tee -a $dumpling_file
 }
 
 function preserve_core_file {
@@ -1203,6 +1198,13 @@ fi
 export __TestEnv=$testEnv
 
 cd "$testRootDir"
+
+dumplingsListPath="$testRootDir/dumplings.txt"
+
+# clean up any existing dumpling remnants from previous runs.
+rm -f "$dumplingsListPath"
+find $testRootDir -type f -name "local_dumplings.txt" -exec rm {} \;
+
 time_start=$(date +"%s")
 if [ -z "$testDirectories" ]
 then
@@ -1224,8 +1226,7 @@ finish_remaining_tests
 
 print_results
 
-echo "constructing $dumplingsListPath"
-find . -type f -name "local_dumplings.txt" -exec cat {} \; > $dumplingsListPath
+find $testRootDir -type f -name "local_dumplings.txt" -exec cat {} \; > $dumplingsListPath
 
 if [ -s $dumplingsListPath ]; then
     cat $dumplingsListPath


### PR DESCRIPTION
The CoreCLR runtest that's checked in here is pretty stale relative to what's in CoreCLR. This brings in some of the changes that occurred in CoreCLR since the script was forked. Specifically, it modifies some dump-handling related stuff that we'll need as we enable dump collection in CoreRT CI.

@nattress 