### PR TITLE
Fix Globalization CompareInfo.Dummy.cs; conditionalize tests in KnownGood

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Dummy.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Dummy.cs
@@ -61,9 +61,13 @@ namespace System.Globalization
             }
         }
 
-        private unsafe int IndexOfCore(string source, string value, int startIndex, int count, CompareOptions options)
+        private unsafe int IndexOfCore(string source, string value, int startIndex, int count, CompareOptions options, int *matchLengthPtr)
         {
-            return IndexOfOrdinal(source, value, startIndex, count, (options & (CompareOptions.IgnoreCase | CompareOptions.OrdinalIgnoreCase)) != 0);
+            int index = IndexOfOrdinal(source, value, startIndex, count, (options & (CompareOptions.IgnoreCase | CompareOptions.OrdinalIgnoreCase)) != 0);
+            if  ((index != -1) && (matchLengthPtr != null))
+                *matchLengthPtr = value.Length;
+
+            return index;
         }
 
         private unsafe int LastIndexOfCore(string source, string value, int startIndex, int count, CompareOptions options)

--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -1415,5 +1415,9 @@
     <!-- Expectations about inlining being enabled -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\87766\ddb87766\ddb87766.*" />
 
+    <!-- These tests use CultureInfo so do not work if we are using dummy globalization -->
+    <ExcludeList Condition="'$(EnableDummyGlobalizationImplementation)' == 'true'" Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b04914\b04914\b04914.*" />
+    <ExcludeList Condition="'$(EnableDummyGlobalizationImplementation)' == 'true'" Include="$(XunitTestBinBase)\Regressions\common\ThreadCulture\ThreadCulture.*" />
+
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit broke the build with EnableDummyGlobalization set:

commit 02194dbca0555c8d5dfce76d07c14e08ce50d3c4
Author: Erti-Chris Eelmaa <chriseelmaa@gmail.com>
Date:   Fri Feb 24 01:42:04 2017 +0000

    Add case-insensitive String.Replace overloads (#2779)

    Added overloads for String.Replace so that they now accept
    StringComparison and CultureInfo as input parameters.

This PR fixes the signatures of CompareInfo.Dummy.cs to match what is now expected, and also conditionalizes the two tests in the KnownGood set that depend upon non-dummy globalization (so a run of KnownGood passes).