### PR TITLE
Do not use VirtualMethodUseNode for GVMs

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -78,6 +78,10 @@ namespace ILCompiler.DependencyAnalysis
                             if (interfaceMethod.Signature.IsStatic)
                                 continue;
 
+                            // Generic virtual methods are tracked by an orthogonal mechanism.
+                            if (interfaceMethod.HasInstantiation)
+                                continue;
+
                             MethodDesc implMethod = closestDefType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod);
                             if (implMethod != null)
                             {
@@ -141,6 +145,7 @@ namespace ILCompiler.DependencyAnalysis
 
             foreach (MethodDesc decl in defType.EnumAllVirtualSlots())
             {
+                // Generic virtual methods are tracked by an orthogonal mechanism.
                 if (decl.HasInstantiation)
                     continue;
 
@@ -167,6 +172,10 @@ namespace ILCompiler.DependencyAnalysis
                 foreach (MethodDesc interfaceMethod in interfaceType.GetAllMethods())
                 {
                     if (interfaceMethod.Signature.IsStatic)
+                        continue;
+
+                    // Generic virtual methods are tracked by an orthogonal mechanism.
+                    if (interfaceMethod.HasInstantiation)
                         continue;
 
                     MethodDesc implMethod = defType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -170,6 +170,10 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (!method.IsVirtual)
                     continue;
+                
+                // Generic virtual methods are tracked by an orthogonal mechanism.
+                if (method.HasInstantiation)
+                    continue;
 
                 yield return new CombinedDependencyListEntry(
                     factory.VirtualMethodUse(method),

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -8,6 +8,8 @@ using ILCompiler.DependencyAnalysisFramework;
 
 using Internal.TypeSystem;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace ILCompiler.DependencyAnalysis
 {
     // This node represents the concept of a virtual method being used.
@@ -22,6 +24,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public VirtualMethodUseNode(MethodDesc decl)
         {
+            // Generic virtual methods are tracked by an orthogonal mechanism.
+            Debug.Assert(!decl.HasInstantiation);
             _decl = decl;
         }
 


### PR DESCRIPTION
Generic virtual methods are tracked orthogonally. This was already
filtered in some places, but inconsistently.