### PR TITLE
Emit delegate object array thunks

### DIFF
--- a/src/Common/src/TypeSystem/IL/DelegateInfo.cs
+++ b/src/Common/src/TypeSystem/IL/DelegateInfo.cs
@@ -99,6 +99,7 @@ namespace Internal.IL
         private MethodDesc _invokeThunk;
         private MethodDesc _closedInstanceOverGeneric;
         private MethodDesc _reversePInvokeThunk;
+        private MethodDesc _invokeObjectArrayThunk;
 
         internal DelegateThunkCollection(DelegateInfo owningDelegate)
         {
@@ -107,6 +108,7 @@ namespace Internal.IL
             _closedStaticThunk = new DelegateInvokeClosedStaticThunk(owningDelegate);
             _invokeThunk = new DelegateDynamicInvokeThunk(owningDelegate);
             _closedInstanceOverGeneric = new DelegateInvokeInstanceClosedOverGenericMethodThunk(owningDelegate);
+            _invokeObjectArrayThunk = new DelegateInvokeObjectArrayThunk(owningDelegate);
 
             if (!owningDelegate.Type.HasInstantiation && IsNativeCallingConventionCompatible(owningDelegate.Signature))
                 _reversePInvokeThunk = new DelegateReversePInvokeThunk(owningDelegate);
@@ -176,6 +178,8 @@ namespace Internal.IL
                         return _closedInstanceOverGeneric;
                     case DelegateThunkKind.ReversePinvokeThunk:
                         return _reversePInvokeThunk;
+                    case DelegateThunkKind.ObjectArrayThunk:
+                        return _invokeObjectArrayThunk;
                     default:
                         return null;
                 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/DelegateHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/DelegateHelpers.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    /// <summary>
+    /// Delegate helpers for generated code.
+    /// </summary>
+    internal static class DelegateHelpers
+    {
+        private static object[] s_emptyObjectArray = Array.Empty<object>();
+
+        internal static object[] GetEmptyObjectArray()
+        {
+            return s_emptyObjectArray;
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -61,6 +61,7 @@
   <ItemGroup>
     <Compile Include="Internal\Diagnostics\ExceptionExtensions.cs" />
     <Compile Include="Internal\Diagnostics\StackTraceHelper.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\DelegateHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\ReflectionHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\ThreadingHelpers.cs" />


### PR DESCRIPTION
This is a special kind of thunks used to invoke delegates created by the
LINQ expression interpreter.

This is mostly a port from the Project N IL2IL toolchain, but I added the empty
array optimization because it's silly to allocate empty arrays.