### PR TITLE
Fix vtable stability issue with shared code

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -120,7 +120,8 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (_slots == null)
                 {
-                    // Sort the lazily populated slots in metadata order.
+                    // Sort the lazily populated slots in metadata order (the order in which they show up
+                    // in GetAllMethods()).
                     // This ensures that Foo<string> and Foo<object> will end up with the same vtable
                     // no matter the order in which VirtualMethodUse nodes populated it.
                     ArrayBuilder<MethodDesc> slotsBuilder = new ArrayBuilder<MethodDesc>();
@@ -146,12 +147,9 @@ namespace ILCompiler.DependencyAnalysis
             // GVMs are not emitted in the type's vtable.
             Debug.Assert(!virtualMethod.HasInstantiation);
             Debug.Assert(virtualMethod.IsVirtual);
-            Debug.Assert(_slots == null);
+            Debug.Assert(_slots == null && _usedMethods != null);
 
-            if (!_usedMethods.Contains(virtualMethod))
-            {
-                _usedMethods.Add(virtualMethod);
-            }
+            _usedMethods.Add(virtualMethod);
         }
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -106,11 +106,8 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     internal sealed class LazilyBuiltVTableSliceNode : VTableSliceNode
     {
-        private List<MethodDesc> _slots = new List<MethodDesc>();
-
-#if DEBUG
-        bool _slotsCommitted;
-#endif
+        private HashSet<MethodDesc> _usedMethods = new HashSet<MethodDesc>();
+        private MethodDesc[] _slots;
 
         public LazilyBuiltVTableSliceNode(TypeDesc type)
             : base(type)
@@ -121,9 +118,25 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-#if DEBUG
-                _slotsCommitted = true;
-#endif
+                if (_slots == null)
+                {
+                    // Sort the lazily populated slots in metadata order.
+                    // This ensures that Foo<string> and Foo<object> will end up with the same vtable
+                    // no matter the order in which VirtualMethodUse nodes populated it.
+                    ArrayBuilder<MethodDesc> slotsBuilder = new ArrayBuilder<MethodDesc>();
+                    DefType defType = _type.GetClosestDefType();
+                    foreach (var method in defType.GetAllMethods())
+                    {
+                        if (_usedMethods.Contains(method))
+                            slotsBuilder.Add(method);
+                    }
+                    Debug.Assert(_usedMethods.Count == slotsBuilder.Count);
+                    _slots = slotsBuilder.ToArray();
+
+                    // Null out used methods so that we AV if someone tries to add now.
+                    _usedMethods = null;
+                }
+
                 return _slots;
             }
         }
@@ -133,13 +146,11 @@ namespace ILCompiler.DependencyAnalysis
             // GVMs are not emitted in the type's vtable.
             Debug.Assert(!virtualMethod.HasInstantiation);
             Debug.Assert(virtualMethod.IsVirtual);
-#if DEBUG
-            Debug.Assert(!_slotsCommitted);
-#endif
+            Debug.Assert(_slots == null);
 
-            if (!_slots.Contains(virtualMethod))
+            if (!_usedMethods.Contains(virtualMethod))
             {
-                _slots.Add(virtualMethod);
+                _usedMethods.Add(virtualMethod);
             }
         }
 


### PR DESCRIPTION
Pull request #2096 made sure that lazily built vtables of `Foo<X>` and
`Foo<Y>` contain the same entries if their canonical forms are the same,
but didn't make sure the order of the entries is the same. This can lead
to bugs at runtime where the wrong slot is used to dispatch a virtual
method call. To make sure the vtables look the same, we need to also
sort the vtable.