### PR TITLE
Fix generics with TLS fields in multi-module

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public static string GetMangledName(TypeDesc type, NameMangler nameMangler)
         {
-            return "__ThreadStaticBase_" + nameMangler.GetMangledTypeName(type);
+            return nameMangler.CompilationUnitPrefix + "__ThreadStaticBase_" + nameMangler.GetMangledTypeName(type);
         }
  
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/tests/src/Simple/MultiModule/Library.cs
+++ b/tests/src/Simple/MultiModule/Library.cs
@@ -47,4 +47,16 @@ public class MultiModuleLibrary
     {
         public T Value;
     }
+
+    public class GenericClassWithTLS<T>
+    {
+        [ThreadStatic]
+        public static int ThreadStaticInt;
+    }
+
+    public static bool MethodThatUsesGenericWithTLS()
+    {
+        GenericClassWithTLS<int>.ThreadStaticInt += 1;
+        return GenericClassWithTLS<int>.ThreadStaticInt == 1;
+    }
 }

--- a/tests/src/Simple/MultiModule/MultiModule.cs
+++ b/tests/src/Simple/MultiModule/MultiModule.cs
@@ -20,6 +20,9 @@ public class ReflectionTest
         if (TestSharedGenerics() == Fail)
             return Fail;
 
+        if (TestGenericTLS() == Fail)
+            return Fail;
+
         return Pass;
     }
     
@@ -55,6 +58,20 @@ public class ReflectionTest
             return Fail;
 
         if (!MultiModuleLibrary.MethodThatUsesGenerics())
+            return Fail;
+
+        return Pass;
+    }
+
+    public static int TestGenericTLS()
+    {
+        Console.WriteLine("Testing thread statics on generic types shared between modules are shared properly..");
+
+        if (!MultiModuleLibrary.MethodThatUsesGenericWithTLS())
+            return Fail;
+
+        MultiModuleLibrary.GenericClassWithTLS<int>.ThreadStaticInt += 1;
+        if (MultiModuleLibrary.GenericClassWithTLS<int>.ThreadStaticInt != 2)
             return Fail;
 
         return Pass;


### PR DESCRIPTION
The previous commit to add multi-module support for thread statics
(https://github.com/dotnet/corert/commit/be92d719) has a small issue
causing a link failure if the generic type containing the thread-static
field was instantiated in multiple modules.

That commit changed from referring to the thread static base directly to
referring to the type thread static index, which is looked up on a list
reached through the type manager. This mechanism ensures that even
though we put a copy of the static base in multiple object files, we'll
unify because the thread static index nodes are COMDAT folded. The
ThreadStaticsNodes themselves can't be folded since they're embedded
objects in a list, so change the naming to make them unique across
modules.