### PR TITLE
Remove unnecessary casts

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -41,8 +41,8 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override IMethodNode CreateShadowConcreteMethodNode(MethodKey methodKey)
         {
-            return new ShadowConcreteMethodNode<CppMethodCodeNode>(methodKey.Method,
-                (CppMethodCodeNode)MethodEntrypoint(
+            return new ShadowConcreteMethodNode(methodKey.Method,
+                MethodEntrypoint(
                     methodKey.Method.GetCanonMethodTarget(CanonicalFormKind.Specific),
                     methodKey.IsUnboxingStub));
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -86,8 +86,8 @@ namespace ILCompiler.DependencyAnalysis
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {
             // If there is a constructed version of this node in the graph, emit that instead
-                if (ConstructedEETypeNode.CreationAllowed(_type))
-                return ((DependencyNode)factory.ConstructedTypeSymbol(_type)).Marked;
+            if (ConstructedEETypeNode.CreationAllowed(_type))
+                return factory.ConstructedTypeSymbol(_type).Marked;
 
             return false;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
@@ -37,7 +37,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(!method.IsSharedByGenericInstantiations);
             Debug.Assert(method.IsRuntimeDeterminedExactMethod);
-            Debug.Assert(canonicalMethod is DependencyNodeCore<NodeFactory>);
             Method = method;
             _canonicalMethodNode = canonicalMethod;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -75,8 +75,8 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override IMethodNode CreateShadowConcreteMethodNode(MethodKey methodKey)
         {
-            return new ShadowConcreteMethodNode<MethodCodeNode>(methodKey.Method, 
-                (MethodCodeNode)MethodEntrypoint(
+            return new ShadowConcreteMethodNode(methodKey.Method, 
+                MethodEntrypoint(
                     methodKey.Method.GetCanonMethodTarget(CanonicalFormKind.Specific),
                     methodKey.IsUnboxingStub));
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -20,13 +20,12 @@ namespace ILCompiler.DependencyAnalysis
     /// method body, as if it was generated. The node acts as a symbol for the canonical
     /// method for convenience.
     /// </summary>
-    internal class ShadowConcreteMethodNode<T> : DependencyNodeCore<NodeFactory>, IMethodNode
-        where T : IMethodNode
+    internal class ShadowConcreteMethodNode : DependencyNodeCore<NodeFactory>, IMethodNode
     {
         /// <summary>
         /// Gets the canonical method body that defines the dependencies of this node.
         /// </summary>
-        public T CanonicalMethodNode { get; }
+        public IMethodNode CanonicalMethodNode { get; }
 
         /// <summary>
         /// Gets the concrete method represented by this node.
@@ -44,7 +43,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool StaticDependenciesAreComputed
             => CanonicalMethodNode.StaticDependenciesAreComputed;
 
-        public ShadowConcreteMethodNode(MethodDesc method, T canonicalMethod)
+        public ShadowConcreteMethodNode(MethodDesc method, IMethodNode canonicalMethod)
         {
             Debug.Assert(!method.IsSharedByGenericInstantiations);
             Debug.Assert(!method.IsRuntimeDeterminedExactMethod);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
@@ -195,7 +195,7 @@ namespace ILCompiler
                     methodKey.Method.GetCanonMethodTarget(CanonicalFormKind.Specific),
                     methodKey.IsUnboxingStub);
 
-            return new ShadowConcreteMethodNode<IMethodNode>(methodKey.Method, methodCodeNode);
+            return new ShadowConcreteMethodNode(methodKey.Method, methodCodeNode);
         }
 
         public GCStaticDescRegionNode GCStaticDescRegion = new GCStaticDescRegionNode(

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -143,7 +143,7 @@ namespace ILCompiler
 
             IMethodNode methodNode = obj as MethodCodeNode;
             if (methodNode == null)
-                methodNode = obj as ShadowConcreteMethodNode<MethodCodeNode>;
+                methodNode = obj as ShadowConcreteMethodNode;
 
             if (methodNode == null)
                 methodNode = obj as NonExternMethodSymbolNode;

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -268,7 +268,7 @@ namespace ILCompiler
                     // See the ProjectN abi specific code in there.
                     if (!method.HasInstantiation && method.OwningType.IsValueType && method.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any) && !method.Signature.IsStatic)
                     {
-                        if (!((DependencyNode)factory.MethodEntrypoint(method, true)).Marked)
+                        if (!factory.MethodEntrypoint(method, true).Marked)
                             continue;
                     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
@@ -57,8 +57,8 @@ namespace ILCompiler
                 {
                     // To compute dependencies of the shadow method that tracks dictionary
                     // dependencies we need to ensure there is code for the canonical method body.
-                    var dependencyMethod = (ShadowConcreteMethodNode<MethodCodeNode>)dependency;
-                    methodCodeNodeNeedingCode = dependencyMethod.CanonicalMethodNode;
+                    var dependencyMethod = (ShadowConcreteMethodNode)dependency;
+                    methodCodeNodeNeedingCode = (MethodCodeNode)dependencyMethod.CanonicalMethodNode;
                 }
 
                 // We might have already compiled this method.


### PR DESCRIPTION
When David made dependency nodes implement an interface and made that
interface required to be implemented by `ISymbolNode` earlier today, it
opened us up to a few cleanups.