### PR TITLE
Pass -coredumps option to runtest for CI jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -41,7 +41,7 @@ def osList = ['Ubuntu', 'OSX', 'Windows_NT']
             }
             else {
                 buildString = "./build.sh ${lowercaseConfiguration}"
-                testScriptString = "tests/runtest.sh ${configuration} -coreclr "
+                testScriptString = "tests/runtest.sh ${configuration} -coredumps -coreclr "
             }
 
             // Create a new job with the specified name.  The brace opens a new closure


### PR DESCRIPTION
As the title says, this modifies netci.groovy so that CI jobs enable coredump generation/handling in test runs.

@sergiy-k PTAL