### PR TITLE
Remove most of the usages of static name mangler

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -176,7 +176,7 @@ namespace ILCompiler
         {
             using (FileStream dgmlOutput = new FileStream(fileName, FileMode.Create))
             {
-                DgmlWriter.WriteDependencyGraphToStream(dgmlOutput, _dependencyGraph);
+                DgmlWriter.WriteDependencyGraphToStream(dgmlOutput, _dependencyGraph, _nodeFactory);
                 dgmlOutput.Flush();
             }
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedDataNode.cs
@@ -52,7 +52,7 @@ namespace ILCompiler.DependencyAnalysis
             return _nestedNodesList.IndexOf(symbol);
         }
 
-        protected override string GetName() => $"Region {_startSymbol.GetMangledName()}";
+        protected override string GetName(NodeFactory factory) => $"Region {_startSymbol.GetMangledName(factory.NameMangler)}";
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
         public override bool IsShareable => false;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayOfEmbeddedPointersNode.cs
@@ -79,7 +79,7 @@ namespace ILCompiler.DependencyAnalysis
                 _parentNode = futureParent;
             }
 
-            protected override string GetName() => $"Embedded pointer to {Target.GetMangledName()}";
+            protected override string GetName(NodeFactory factory) => $"Embedded pointer to {Target.GetMangledName(factory.NameMangler)}";
 
             protected override void OnMarked(NodeFactory factory)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlobNode.cs
@@ -38,6 +38,6 @@ namespace ILCompiler.DependencyAnalysis
             return new ObjectData(_data, Array.Empty<Relocation>(), _alignment, new ISymbolNode[] { this });
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlockReflectionTypeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/BlockReflectionTypeMapNode.cs
@@ -37,7 +37,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClassConstructorContextMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClassConstructorContextMap.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ClonedConstructedEETypeNode.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.DependencyAnalysis
         {
         }
 
-        protected override string GetName() => this.GetMangledName() + " cloned";
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler) + " cloned";
 
         // Cloned EEType does not have its own interface dispatch map. The runtime dispatching
         // routine will use its primary type's dispatch map instead.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -21,7 +21,7 @@ namespace ILCompiler.DependencyAnalysis
             CheckCanGenerateConstructedEEType(factory, type);
         }
 
-        protected override string GetName() => this.GetMangledName() + " constructed";
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler) + " constructed";
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory) => false;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
@@ -48,7 +48,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override bool StaticDependenciesAreComputed => _methodCode != null;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DelegateMarshallingStubMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DelegateMarshallingStubMapNode.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -99,7 +99,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName() => $"Dictionary layout for {_owningMethodOrType.ToString()}";
+        protected override string GetName(NodeFactory factory) => $"Dictionary layout for {_owningMethodOrType.ToString()}";
 
         public override bool HasConditionalStaticDependencies => false;
         public override bool HasDynamicDependencies => false;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -81,7 +81,7 @@ namespace ILCompiler.DependencyAnalysis
             CheckCanGenerateEEType(factory, type);
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.DependencyAnalysis
         public int Offset => 0;
         public override bool IsShareable => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
@@ -35,7 +35,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool IsShareable => false;
         public override ObjectNodeSection Section => _externalReferences.Section;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis
             _name = name;
         }
 
-        protected override string GetName() => $"ExternSymbol {_name.ToString()}";
+        protected override string GetName(NodeFactory factory) => $"ExternSymbol {_name.ToString()}";
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
@@ -81,7 +81,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
@@ -50,7 +50,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenStringNode.cs
@@ -74,7 +74,7 @@ namespace ILCompiler.DependencyAnalysis
 
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticDescNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticDescNode.cs
@@ -26,7 +26,7 @@ namespace ILCompiler.DependencyAnalysis
             _isThreadStatic = isThreadStatic;
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
             _target = target;
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectNodeSection Section
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool HasConditionalStaticDependencies => false;
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => "__GVMDependenciesNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected override string GetName(NodeFactory factory) => "__GVMDependenciesNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericCompositionNode.cs
@@ -98,7 +98,7 @@ namespace ILCompiler.DependencyAnalysis
             return builder.ToObjectData();
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
     }
 
     internal struct GenericCompositionDetails : IEquatable<GenericCompositionDetails>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -85,9 +85,9 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected sealed override string GetName()
+        protected sealed override string GetName(NodeFactory factory)
         {
-            return this.GetMangledName();
+            return this.GetMangledName(factory.NameMangler);
         }
     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -234,7 +234,7 @@ namespace ILCompiler.DependencyAnalysis
             else
             {
                 MethodDesc instantiatedMethod = _method.InstantiateSignature(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
-                return factory.InterfaceDispatchCell(instantiatedMethod, dictionary.GetMangledName());
+                return factory.InterfaceDispatchCell(instantiatedMethod, dictionary.GetMangledName(factory.NameMangler));
             }
         }
 
@@ -290,7 +290,7 @@ namespace ILCompiler.DependencyAnalysis
             else
             {
                 MethodDesc instantiatedMethod = _method.InstantiateSignature(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
-                return factory.InterfaceDispatchCell(instantiatedMethod, dictionary.GetMangledName());
+                return factory.InterfaceDispatchCell(instantiatedMethod, dictionary.GetMangledName(factory.NameMangler));
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsHashtableNode.cs
@@ -35,7 +35,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool IsShareable => false;
         public override ObjectNodeSection Section => _externalReferences.Section;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
@@ -35,7 +35,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool IsShareable => false;
         public override ObjectNodeSection Section => _externalReferences.Section;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesHashtableNode.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool IsShareable => false;
         public override ObjectNodeSection Section => _externalReferences.Section;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesTemplateMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesTemplateMap.cs
@@ -35,7 +35,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool IsShareable => false;
         public override ObjectNodeSection Section => _externalReferences.Section;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool IsShareable => false;
         public override ObjectNodeSection Section => _externalReferences.Section;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         /// <summary>
         /// Helper method to compute the dependencies that would be needed by a hashtable entry for a GVM call.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISymbolNode.cs
@@ -26,13 +26,13 @@ namespace ILCompiler.DependencyAnalysis
         [ThreadStatic]
         static Utf8StringBuilder s_cachedUtf8StringBuilder;
 
-        public static string GetMangledName(this ISymbolNode symbolNode)
+        public static string GetMangledName(this ISymbolNode symbolNode, NameMangler nameMangler)
         {
             Utf8StringBuilder sb = s_cachedUtf8StringBuilder;
             if (sb == null)
                 sb = new Utf8StringBuilder();
 
-            symbolNode.AppendMangledName(NodeFactory.NameManglerDoNotUse, sb);
+            symbolNode.AppendMangledName(nameMangler, sb);
             string ret = sb.ToString();
 
             sb.Clear();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
@@ -43,7 +43,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -44,7 +44,7 @@ namespace ILCompiler.DependencyAnalysis
             return name;
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis
             _dispatchMapTableIndex = IndexNotSet;
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool IsShareable => false;
         public override ObjectNodeSection Section => _externalReferences.Section;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         /// <summary>
         /// Helper method to compute the dependencies that would be needed by a hashtable entry for an interface GVM call.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MetadataNode.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public MethodDesc Method =>  _method;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectNodeSection Section
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ModulesSectionNode.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override bool StaticDependenciesAreComputed => true;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutInfoNode.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool IsShareable => false;
         public override ObjectNodeSection Section => _externalReferences.Section;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public Section LdTokenInfoSection => _ldTokenInfoSection;
         public Section SignaturesSection => _signaturesSection;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutSignatureNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutSignatureNode.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append(nameMangler.CompilationUnitPrefix).Append("__NativeLayoutSignature_" + _id);
         }
         public int Offset => 0;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
         public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
         public override bool IsShareable => false;
         public override bool StaticDependenciesAreComputed => true;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -222,7 +222,7 @@ namespace ILCompiler.DependencyAnalysis
 
     internal sealed class NativeLayoutMethodLdTokenVertexNode : NativeLayoutMethodEntryVertexNode
     {
-        protected override string GetName() => "NativeLayoutMethodLdTokenVertexNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected override string GetName(NodeFactory factory) => "NativeLayoutMethodLdTokenVertexNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
         public NativeLayoutMethodLdTokenVertexNode(NodeFactory factory, MethodDesc method)
             : base(factory, method, 0)
@@ -249,7 +249,7 @@ namespace ILCompiler.DependencyAnalysis
             _containingTypeSig = factory.NativeLayout.TypeSignatureVertex(field.OwningType);
         }
 
-        protected override string GetName() => "NativeLayoutFieldLdTokenVertexNode_" + NodeFactory.NameManglerDoNotUse.GetMangledFieldName(_field);
+        protected override string GetName(NodeFactory factory) => "NativeLayoutFieldLdTokenVertexNode_" + factory.NameMangler.GetMangledFieldName(_field);
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
@@ -277,7 +277,7 @@ namespace ILCompiler.DependencyAnalysis
         private NativeLayoutTypeSignatureVertexNode _returnTypeSig;
         private NativeLayoutTypeSignatureVertexNode[] _parametersSig;
 
-        protected override string GetName() => "NativeLayoutMethodSignatureVertexNode" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected override string GetName(NodeFactory factory) => "NativeLayoutMethodSignatureVertexNode" + factory.NameMangler.GetMangledMethodName(_method);
 
         public NativeLayoutMethodSignatureVertexNode(NodeFactory factory, MethodDesc method)
         {
@@ -327,7 +327,7 @@ namespace ILCompiler.DependencyAnalysis
         private MethodDesc _method;
         private NativeLayoutMethodSignatureVertexNode _methodSig;
 
-        protected override string GetName() => "NativeLayoutMethodNameAndSignatureVertexNode" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected override string GetName(NodeFactory factory) => "NativeLayoutMethodNameAndSignatureVertexNode" + factory.NameMangler.GetMangledMethodName(_method);
 
         public NativeLayoutMethodNameAndSignatureVertexNode(NodeFactory factory, MethodDesc method)
         {
@@ -356,7 +356,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName() => "NativeLayoutTypeSignatureVertexNode: " + _type.ToString();
+        protected override string GetName(NodeFactory factory) => "NativeLayoutTypeSignatureVertexNode: " + _type.ToString();
 
         public static NativeLayoutTypeSignatureVertexNode NewTypeSignatureVertexNode(NodeFactory factory, TypeDesc type)
         {
@@ -531,7 +531,7 @@ namespace ILCompiler.DependencyAnalysis
             _symbol = symbol;
         }
 
-        protected override string GetName() => "NativeLayoutISymbolNodeReferenceVertexNode " + _symbol.GetMangledName();
+        protected override string GetName(NodeFactory factory) => "NativeLayoutISymbolNodeReferenceVertexNode " + _symbol.GetMangledName(factory.NameMangler);
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
@@ -554,7 +554,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         private NativeLayoutVertexNode _signatureToBePlaced;
 
-        protected override string GetName() => "NativeLayoutPlacedSignatureVertexNode";
+        protected override string GetName(NodeFactory factory) => "NativeLayoutPlacedSignatureVertexNode";
 
         public NativeLayoutPlacedSignatureVertexNode(NativeLayoutVertexNode signatureToBePlaced)
         {
@@ -583,7 +583,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         private List<NativeLayoutVertexNode> _vertices;
 
-        protected override string GetName() => "NativeLayoutPlacedVertexSequenceVertexNode";
+        protected override string GetName(NodeFactory factory) => "NativeLayoutPlacedVertexSequenceVertexNode";
         public NativeLayoutPlacedVertexSequenceVertexNode(List<NativeLayoutVertexNode> vertices)
         {
             _vertices = vertices;
@@ -620,7 +620,7 @@ namespace ILCompiler.DependencyAnalysis
 
     internal sealed class NativeLayoutTemplateMethodSignatureVertexNode : NativeLayoutMethodEntryVertexNode
     {
-        protected override string GetName() => "NativeLayoutTemplateMethodSignatureVertexNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected override string GetName(NodeFactory factory) => "NativeLayoutTemplateMethodSignatureVertexNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
         public NativeLayoutTemplateMethodSignatureVertexNode(NodeFactory factory, MethodDesc method)
             : base(factory, method, MethodEntryFlags.CreateInstantiatedSignature | MethodEntryFlags.SaveEntryPoint)
@@ -641,7 +641,7 @@ namespace ILCompiler.DependencyAnalysis
         private MethodDesc _method;
         private Dictionary<int, NativeLayoutVertexNode> _genericDictionaryEntries = new Dictionary<int, NativeLayoutVertexNode>();
 
-        protected override string GetName() => "NativeLayoutTemplateMethodLayoutVertexNode" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected override string GetName(NodeFactory factory) => "NativeLayoutTemplateMethodLayoutVertexNode" + factory.NameMangler.GetMangledMethodName(_method);
 
         public NativeLayoutTemplateMethodLayoutVertexNode(NodeFactory factory, MethodDesc method)
         {
@@ -721,7 +721,7 @@ namespace ILCompiler.DependencyAnalysis
         private bool _isUniversalCanon;
         Dictionary<int, NativeLayoutVertexNode> _genericDictionaryEntries = new Dictionary<int, NativeLayoutVertexNode>();
 
-        protected override string GetName() => "NativeLayoutTemplateTypeLayoutVertexNode_" + NodeFactory.NameManglerDoNotUse.GetMangledTypeName(_type);
+        protected override string GetName(NodeFactory factory) => "NativeLayoutTemplateTypeLayoutVertexNode_" + factory.NameMangler.GetMangledTypeName(_type);
 
         public NativeLayoutTemplateTypeLayoutVertexNode(NodeFactory factory, DefType type)
         {
@@ -1011,7 +1011,7 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         protected abstract string NodeTypeName { get; }
-        protected sealed override string GetName() => NodeTypeName + NodeFactory.NameManglerDoNotUse.GetMangledTypeName(_type);
+        protected sealed override string GetName(NodeFactory factory) => NodeTypeName + factory.NameMangler.GetMangledTypeName(_type);
 
         public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
@@ -1127,7 +1127,7 @@ namespace ILCompiler.DependencyAnalysis
         protected abstract StaticDataKind StaticDataKindFlag { get; }
         protected abstract string NodeTypeName { get; }
 
-        protected sealed override string GetName() => NodeTypeName + NodeFactory.NameManglerDoNotUse.GetMangledTypeName(_type);
+        protected sealed override string GetName(NodeFactory factory) => NodeTypeName + factory.NameMangler.GetMangledTypeName(_type);
 
         protected sealed override FixupSignatureKind SignatureKind => FixupSignatureKind.StaticData;
         public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
@@ -1170,7 +1170,7 @@ namespace ILCompiler.DependencyAnalysis
             _method = method;
         }
 
-        protected sealed override string GetName() => "NativeLayoutInterfaceDispatchGenericDictionarySlotNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected sealed override string GetName(NodeFactory factory) => "NativeLayoutInterfaceDispatchGenericDictionarySlotNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
         protected sealed override FixupSignatureKind SignatureKind => FixupSignatureKind.InterfaceCall;
         public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
@@ -1203,7 +1203,7 @@ namespace ILCompiler.DependencyAnalysis
                 throw new NotSupportedException();
             }
 
-            protected sealed override string GetName() => "WrappedMethodEntryVertexNodeForDictionarySlot_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+            protected sealed override string GetName(NodeFactory factory) => "WrappedMethodEntryVertexNodeForDictionarySlot_" + factory.NameMangler.GetMangledMethodName(_method);
         }
 
 
@@ -1214,7 +1214,7 @@ namespace ILCompiler.DependencyAnalysis
             _wrappedNode = new WrappedMethodDictionaryVertexNode(factory, method);
         }
 
-        protected sealed override string GetName() => "NativeLayoutMethodDictionaryGenericDictionarySlotNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected sealed override string GetName(NodeFactory factory) => "NativeLayoutMethodDictionaryGenericDictionarySlotNode_" + factory.NameMangler.GetMangledMethodName(_method);
         protected sealed override FixupSignatureKind SignatureKind => FixupSignatureKind.MethodDictionary;
         public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
@@ -1236,7 +1236,7 @@ namespace ILCompiler.DependencyAnalysis
             _field = field;
         }
 
-        protected sealed override string GetName() => "NativeLayoutFieldLdTokenGenericDictionarySlotNode_" + NodeFactory.NameManglerDoNotUse.GetMangledFieldName(_field);
+        protected sealed override string GetName(NodeFactory factory) => "NativeLayoutFieldLdTokenGenericDictionarySlotNode_" + factory.NameMangler.GetMangledFieldName(_field);
 
         protected sealed override FixupSignatureKind SignatureKind => FixupSignatureKind.FieldLdToken;
 
@@ -1260,7 +1260,7 @@ namespace ILCompiler.DependencyAnalysis
             _method = method;
         }
 
-        protected sealed override string GetName() => "NativeLayoutMethodLdTokenGenericDictionarySlotNode_" + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected sealed override string GetName(NodeFactory factory) => "NativeLayoutMethodLdTokenGenericDictionarySlotNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
         protected sealed override FixupSignatureKind SignatureKind => FixupSignatureKind.FieldLdToken;
 
@@ -1298,7 +1298,7 @@ namespace ILCompiler.DependencyAnalysis
                 return _functionPointerNode;
             }
 
-            protected sealed override string GetName() => "WrappedMethodEntryVertexNodeForDictionarySlot_" + (_unboxingStub ? "Unboxing_" : "") + NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+            protected sealed override string GetName(NodeFactory factory) => "WrappedMethodEntryVertexNodeForDictionarySlot_" + (_unboxingStub ? "Unboxing_" : "") + factory.NameMangler.GetMangledMethodName(_method);
         }
 
 
@@ -1308,7 +1308,7 @@ namespace ILCompiler.DependencyAnalysis
             _wrappedNode = new WrappedMethodEntryVertexNode(factory, method, unboxingStub, functionPointerNode);
         }
 
-        protected sealed override string GetName() => "NativeLayoutMethodEntrypointGenericDictionarySlotNode_" + (_wrappedNode._unboxingStub ? "Unboxing_" : "")+ NodeFactory.NameManglerDoNotUse.GetMangledMethodName(_method);
+        protected sealed override string GetName(NodeFactory factory) => "NativeLayoutMethodEntrypointGenericDictionarySlotNode_" + (_wrappedNode._unboxingStub ? "Unboxing_" : "") + factory.NameMangler.GetMangledMethodName(_method);
         protected sealed override FixupSignatureKind SignatureKind => FixupSignatureKind.Method;
         public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectAndOffsetSymbolNode.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.DependencyAnalysis
             _includeCompilationUnitPrefix = includeCompilationUnitPrefix;
         }
 
-        protected override string GetName() => $"Symbol {_name.ToString()} at offset {_offset.ToStringInvariant()}";
+        protected override string GetName(NodeFactory factory) => $"Symbol {_name.ToString()} at offset {_offset.ToStringInvariant()}";
 
         public override bool HasConditionalStaticDependencies => false;
         public override bool HasDynamicDependencies => false;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -461,7 +461,7 @@ namespace ILCompiler.DependencyAnalysis
                 ObjectNodeSection lsdaSection = LsdaSection;
                 if (ShouldShareSymbol(node))
                 {
-                    lsdaSection = lsdaSection.GetSharedSection(((ISymbolNode)node).GetMangledName());
+                    lsdaSection = lsdaSection.GetSharedSection(((ISymbolNode)node).GetMangledName(_nodeFactory.NameMangler));
                 }
                 SwitchSection(_nativeObjectWriter, lsdaSection.Name, GetCustomSectionAttributes(lsdaSection), lsdaSection.ComdatName);
 
@@ -810,13 +810,13 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         try
                         {
-                            _previouslyWrittenNodeNames.Add(definedSymbol.GetMangledName(), definedSymbol);
+                            _previouslyWrittenNodeNames.Add(definedSymbol.GetMangledName(factory.NameMangler), definedSymbol);
                         }
                         catch (ArgumentException)
                         {
-                            ISymbolNode alreadyWrittenSymbol = _previouslyWrittenNodeNames[definedSymbol.GetMangledName()];
+                            ISymbolNode alreadyWrittenSymbol = _previouslyWrittenNodeNames[definedSymbol.GetMangledName(factory.NameMangler)];
                             Debug.Assert(false, "Duplicate node name emitted to file",
-                            $"Symbol {definedSymbol.GetMangledName()} has already been written to the output object file {objectFilePath} with symbol {alreadyWrittenSymbol}");
+                            $"Symbol {definedSymbol.GetMangledName(factory.NameMangler)} has already been written to the output object file {objectFilePath} with symbol {alreadyWrittenSymbol}");
                         }
                     }
 #endif
@@ -825,7 +825,7 @@ namespace ILCompiler.DependencyAnalysis
                     ObjectNodeSection section = node.Section;
                     if (objectWriter.ShouldShareSymbol(node))
                     {
-                        section = section.GetSharedSection(((ISymbolNode)node).GetMangledName());
+                        section = section.GetSharedSection(((ISymbolNode)node).GetMangledName(factory.NameMangler));
                     }
 
                     // Ensure section and alignment for the node.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -32,7 +32,7 @@ namespace ILCompiler.DependencyAnalysis
         public int Offset => 0;
         public override bool IsShareable => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
@@ -26,7 +26,7 @@ namespace ILCompiler.DependencyAnalysis
         public int Offset => 0;
         public override bool IsShareable => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -55,7 +55,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected sealed override string GetName() => this.GetMangledName();
+        protected sealed override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
         public override bool IsShareable => true;
 
         protected sealed override void OnMarked(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHeaderNode.cs
@@ -49,7 +49,7 @@ namespace ILCompiler.DependencyAnalysis
         public int Offset => 0;
         public override bool IsShareable => false;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override bool StaticDependenciesAreComputed => true;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -87,7 +87,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public ReadyToRunHelperId Id => _id;
         public Object Target =>  _target;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
@@ -40,7 +40,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -46,7 +46,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ResourceDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ResourceDataNode.cs
@@ -47,7 +47,7 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append(nameMangler.CompilationUnitPrefix).Append("__embedded_resourcedata");
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ResourceIndexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ResourceIndexNode.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append(nameMangler.CompilationUnitPrefix).Append("__embedded_resourceindex");
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
@@ -46,7 +46,7 @@ namespace ILCompiler.DependencyAnalysis
             yield return new DependencyListEntry(_canonicalMethodNode, "Canonical body");
         }
 
-        protected override string GetName() => $"{Method.ToString()} backed by {_canonicalMethodNode.GetMangledName()}";
+        protected override string GetName(NodeFactory factory) => $"{Method.ToString()} backed by {_canonicalMethodNode.GetMangledName(factory.NameMangler)}";
 
         public IEnumerable<DependencyListEntry> InstantiateDependencies(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.DependencyAnalysis
               .Append(nameMangler.GetMangledFieldName(_targetField));
         }
         public int Offset => 0;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
         public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
         public override bool IsShareable => false;
         public override bool StaticDependenciesAreComputed => true;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.DependencyAnalysis
               .Append(nameMangler.GetMangledMethodName(_targetMethod));
         }
         public int Offset => 0;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
         public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
         public override bool IsShareable => false;
         public override bool StaticDependenciesAreComputed => true;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -106,7 +106,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override string GetName() => $"{Method.ToString()} backed by {CanonicalMethodNode.GetMangledName()}";
+        protected override string GetName(NodeFactory factory) => $"{Method.ToString()} backed by {CanonicalMethodNode.GetMangledName(factory.NameMangler)}";
 
         public sealed override bool HasConditionalStaticDependencies => false;
         public sealed override bool HasDynamicDependencies => false;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringAllocatorMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StringAllocatorMethodNode.cs
@@ -64,6 +64,6 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMInitialInterfaceDispatchStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMInitialInterfaceDispatchStubNode.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     public partial class InitialInterfaceDispatchStubNode : AssemblyStubNode
     {      
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsIndexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsIndexNode.cs
@@ -41,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public int Offset => 0;
         
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
@@ -104,7 +104,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public int Offset => 0;
 
-        protected override string GetName() => GetMangledName("");
+        protected override string GetName(NodeFactory factory) => GetMangledName("");
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
@@ -188,7 +188,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public int Offset => 0;
 
-        protected override string GetName() => GetMangledName();
+        protected override string GetName(NodeFactory factory) => GetMangledName();
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         protected override void OnMarked(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsOffsetNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsOffsetNode.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.DependencyAnalysis
             _type = type;
         }
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
@@ -44,7 +44,7 @@ namespace ILCompiler.DependencyAnalysis
         public override bool HasDynamicDependencies => false;
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool StaticDependenciesAreComputed => true;
-        protected override string GetName() => "__TypeGVMEntriesNode_" + NodeFactory.NameManglerDoNotUse.GetMangledTypeName(_associatedType);
+        protected override string GetName(NodeFactory factory) => "__TypeGVMEntriesNode_" + factory.NameMangler.GetMangledTypeName(_associatedType);
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)
         {
             return Array.Empty<CombinedDependencyListEntry>();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeManagerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeManagerIndirectionNode.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.DependencyAnalysis
         public int Offset => 0;
         public override bool IsShareable => false;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataMapNode.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.DependencyAnalysis
               .Append(nameMangler.GetMangledTypeName(_type));
         }
         public int Offset => 0;
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
         public override ObjectNodeSection Section
         {
             get

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UnboxingStubNode.cs
@@ -42,6 +42,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool IsShareable => true;
 
-        protected override string GetName() => this.GetMangledName();
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
             get;
         }
 
-        protected override string GetName() => $"__vtable_{NodeFactory.NameManglerDoNotUse.GetMangledTypeName(_type).ToString()}";
+        protected override string GetName(NodeFactory factory) => $"__vtable_{factory.NameMangler.GetMangledTypeName(_type).ToString()}";
 
         public override bool StaticDependenciesAreComputed => true;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
             _decl = decl;
         }
 
-        protected override string GetName() => $"VirtualMethodUse {_decl.ToString()}";
+        protected override string GetName(NodeFactory factory) => $"VirtualMethodUse {_decl.ToString()}";
 
         protected override void OnMarked(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -741,7 +741,7 @@ namespace ILCompiler.CppCodeGen
             }
             else
             {
-                string mangledName = ((ISymbolNode)node).GetMangledName();
+                string mangledName = ((ISymbolNode)node).GetMangledName(factory.NameMangler);
 
                 // Rename generic composition and optional fields nodes to avoid name clash with types
                 bool shouldReplaceNamespaceQualifier = node is GenericCompositionNode || node is EETypeOptionalFieldsNode;
@@ -820,7 +820,7 @@ namespace ILCompiler.CppCodeGen
             // Node is either an non-emitted type or a generic composition - both are ignored for CPP codegen
             else if ((reloc.Target is TypeManagerIndirectionNode || reloc.Target is InterfaceDispatchMapNode || reloc.Target is EETypeOptionalFieldsNode || reloc.Target is GenericCompositionNode) && !(reloc.Target as ObjectNode).ShouldSkipEmittingObjectNode(factory))
             {
-                string mangledTargetName = reloc.Target.GetMangledName();
+                string mangledTargetName = reloc.Target.GetMangledName(factory.NameMangler);
                 bool shouldReplaceNamespaceQualifier = reloc.Target is GenericCompositionNode || reloc.Target is EETypeOptionalFieldsNode;
                 relocCode.Append(shouldReplaceNamespaceQualifier ? mangledTargetName.Replace("::", "_") : mangledTargetName);
                 relocCode.Append("()");
@@ -950,7 +950,7 @@ namespace ILCompiler.CppCodeGen
                 else if (node is InterfaceDispatchMapNode)
                 {
                     dispatchPointers.Append("(void *)");
-                    dispatchPointers.Append(((ISymbolNode)node).GetMangledName());
+                    dispatchPointers.Append(((ISymbolNode)node).GetMangledName(factory.NameMangler));
                     dispatchPointers.Append("(),");
                     dispatchPointers.AppendLine();
                     dispatchMapCount++;
@@ -1175,7 +1175,7 @@ namespace ILCompiler.CppCodeGen
                 rtrHeader.Append("{ 0x00,0x00,0x00,0x00 },");
             rtrHeader.AppendLine();
             rtrHeader.Append("(void*)");
-            rtrHeader.Append(headerNode.GetMangledName());
+            rtrHeader.Append(headerNode.GetMangledName(factory.NameMangler));
             rtrHeader.Append("(),");
             rtrHeader.AppendLine();
             if (pointerSize == 8)

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
@@ -108,16 +108,16 @@ namespace ILCompiler.DependencyAnalysisFramework
                 return _markedNodes;
         }
 
-        public override sealed void VisitLogNodes(IDependencyAnalyzerLogNodeVisitor logNodeVisitor)
+        public override sealed void VisitLogNodes(IDependencyAnalyzerLogNodeVisitor<DependencyContextType> logNodeVisitor)
         {
-            foreach (DependencyNode node in MarkedNodesEnumerable())
+            foreach (DependencyNodeCore<DependencyContextType> node in MarkedNodesEnumerable())
             {
                 logNodeVisitor.VisitNode(node);
             }
             _marker.VisitLogNodes(MarkedNodesEnumerable(), logNodeVisitor);
         }
 
-        public override sealed void VisitLogEdges(IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor)
+        public override sealed void VisitLogEdges(IDependencyAnalyzerLogEdgeVisitor<DependencyContextType> logEdgeVisitor)
         {
             _marker.VisitLogEdges(MarkedNodesEnumerable(), logEdgeVisitor);
         }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzerBase.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzerBase.cs
@@ -62,12 +62,12 @@ namespace ILCompiler.DependencyAnalysisFramework
         /// Used to walk all nodes that should be emitted to a log. Not intended for other purposes.
         /// </summary>
         /// <param name="logNodeVisitor"></param>
-        public abstract void VisitLogNodes(IDependencyAnalyzerLogNodeVisitor logNodeVisitor);
+        public abstract void VisitLogNodes(IDependencyAnalyzerLogNodeVisitor<DependencyContextType> logNodeVisitor);
 
         /// <summary>
         /// Used to walk the logical edges in the graph as part of log building.
         /// </summary>
         /// <param name="logEdgeVisitor"></param>
-        public abstract void VisitLogEdges(IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor);
+        public abstract void VisitLogEdges(IDependencyAnalyzerLogEdgeVisitor<DependencyContextType> logEdgeVisitor);
     }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNode.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNode.cs
@@ -39,14 +39,6 @@ namespace ILCompiler.DependencyAnalysisFramework
             }
         }
 
-        // Force all non-abstract nodes to provide a name
-        protected internal abstract string GetName();
-
-        public override string ToString()
-        {
-            return GetName();
-        }
-
         public sealed override bool Equals(object obj)
         {
             return Object.ReferenceEquals(this, obj);

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
@@ -138,5 +138,8 @@ namespace ILCompiler.DependencyAnalysisFramework
         {
             // Do nothing by default
         }
+
+        // Force all non-abstract nodes to provide a name
+        protected internal abstract string GetName();
     }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
@@ -140,6 +140,13 @@ namespace ILCompiler.DependencyAnalysisFramework
         }
 
         // Force all non-abstract nodes to provide a name
-        protected internal abstract string GetName(DependencyContextType context);
+        protected abstract string GetName(DependencyContextType context);
+
+        // We would prefer GetName to be "protected internal", but that will break people who want to source
+        // include the dependency analysis framework. When nobody does that, maybe we can get rid of this method.
+        internal string GetNameInternal(DependencyContextType context)
+        {
+            return GetName(context);
+        }
     }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyNodeCore.cs
@@ -140,6 +140,6 @@ namespace ILCompiler.DependencyAnalysisFramework
         }
 
         // Force all non-abstract nodes to provide a name
-        protected internal abstract string GetName();
+        protected internal abstract string GetName(DependencyContextType context);
     }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DgmlWriter.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DgmlWriter.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.DependencyAnalysisFramework
         }
     }
 
-    internal class DgmlWriter<DependencyContextType> : IDisposable, IDependencyAnalyzerLogEdgeVisitor, IDependencyAnalyzerLogNodeVisitor
+    internal class DgmlWriter<DependencyContextType> : IDisposable, IDependencyAnalyzerLogEdgeVisitor<DependencyContextType>, IDependencyAnalyzerLogNodeVisitor<DependencyContextType>
     {
         private XmlWriter _xmlWrite;
         private bool _done = false;
@@ -101,7 +101,7 @@ namespace ILCompiler.DependencyAnalysisFramework
         private Dictionary<object, int> _nodeMappings = new Dictionary<object, int>();
         private int _nodeNextId = 0;
 
-        private void AddNode(DependencyNode node)
+        private void AddNode(DependencyNodeCore<DependencyContextType> node)
         {
             AddNode(node, node.GetName());
         }
@@ -128,7 +128,7 @@ namespace ILCompiler.DependencyAnalysisFramework
             _xmlWrite.WriteEndElement();
         }
 
-        void IDependencyAnalyzerLogEdgeVisitor.VisitEdge(DependencyNode nodeDepender, DependencyNode nodeDependedOn, string reason)
+        void IDependencyAnalyzerLogEdgeVisitor<DependencyContextType>.VisitEdge(DependencyNodeCore<DependencyContextType> nodeDepender, DependencyNodeCore<DependencyContextType> nodeDependedOn, string reason)
         {
             _xmlWrite.WriteStartElement("Link");
             _xmlWrite.WriteAttributeString("Source", _nodeMappings[nodeDepender].ToString());
@@ -138,12 +138,12 @@ namespace ILCompiler.DependencyAnalysisFramework
             _xmlWrite.WriteEndElement();
         }
 
-        void IDependencyAnalyzerLogEdgeVisitor.VisitEdge(string root, DependencyNode dependedOn)
+        void IDependencyAnalyzerLogEdgeVisitor<DependencyContextType>.VisitEdge(string root, DependencyNodeCore<DependencyContextType> dependedOn)
         {
             AddReason(root, dependedOn, null);
         }
 
-        void IDependencyAnalyzerLogNodeVisitor.VisitCombinedNode(Tuple<DependencyNode, DependencyNode> node)
+        void IDependencyAnalyzerLogNodeVisitor<DependencyContextType>.VisitCombinedNode(Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>> node)
         {
             string label1 = node.Item1.GetName();
             string label2 = node.Item2.GetName();
@@ -151,11 +151,11 @@ namespace ILCompiler.DependencyAnalysisFramework
             AddNode(node, string.Concat("(", label1, ", ", label2, ")"));
         }
 
-        private HashSet<Tuple<DependencyNode, DependencyNode>> _combinedNodesEdgeVisited = new HashSet<Tuple<DependencyNode, DependencyNode>>();
+        private HashSet<Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>> _combinedNodesEdgeVisited = new HashSet<Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>>();
 
-        void IDependencyAnalyzerLogEdgeVisitor.VisitEdge(DependencyNode nodeDepender, DependencyNode nodeDependerOther, DependencyNode nodeDependedOn, string reason)
+        void IDependencyAnalyzerLogEdgeVisitor<DependencyContextType>.VisitEdge(DependencyNodeCore<DependencyContextType> nodeDepender, DependencyNodeCore<DependencyContextType> nodeDependerOther, DependencyNodeCore<DependencyContextType> nodeDependedOn, string reason)
         {
-            Tuple<DependencyNode, DependencyNode> combinedNode = new Tuple<DependencyNode, DependencyNode>(nodeDepender, nodeDependerOther);
+            var combinedNode = new Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>(nodeDepender, nodeDependerOther);
             if (!_combinedNodesEdgeVisited.Contains(combinedNode))
             {
                 _combinedNodesEdgeVisited.Add(combinedNode);
@@ -183,12 +183,12 @@ namespace ILCompiler.DependencyAnalysisFramework
             _xmlWrite.WriteEndElement();
         }
 
-        void IDependencyAnalyzerLogNodeVisitor.VisitNode(DependencyNode node)
+        void IDependencyAnalyzerLogNodeVisitor<DependencyContextType>.VisitNode(DependencyNodeCore<DependencyContextType> node)
         {
             AddNode(node);
         }
 
-        void IDependencyAnalyzerLogNodeVisitor.VisitRootNode(string rootName)
+        void IDependencyAnalyzerLogNodeVisitor<DependencyContextType>.VisitRootNode(string rootName)
         {
             AddNode(rootName, rootName);
         }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DgmlWriter.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DgmlWriter.cs
@@ -106,7 +106,7 @@ namespace ILCompiler.DependencyAnalysisFramework
 
         private void AddNode(DependencyNodeCore<DependencyContextType> node)
         {
-            AddNode(node, node.GetName(_context));
+            AddNode(node, node.GetNameInternal(_context));
         }
 
         private void AddNode(object node, string label)
@@ -148,8 +148,8 @@ namespace ILCompiler.DependencyAnalysisFramework
 
         void IDependencyAnalyzerLogNodeVisitor<DependencyContextType>.VisitCombinedNode(Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>> node)
         {
-            string label1 = node.Item1.GetName(_context);
-            string label2 = node.Item2.GetName(_context);
+            string label1 = node.Item1.GetNameInternal(_context);
+            string label2 = node.Item2.GetNameInternal(_context);
 
             AddNode(node, string.Concat("(", label1, ", ", label2, ")"));
         }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/FirstMarkLogStrategy.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/FirstMarkLogStrategy.cs
@@ -64,9 +64,9 @@ namespace ILCompiler.DependencyAnalysisFramework
             return true;
         }
 
-        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor logNodeVisitor)
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor<DependencyContextType> logNodeVisitor)
         {
-            HashSet<Tuple<DependencyNode, DependencyNode>> combinedNodesReported = new HashSet<Tuple<DependencyNode, DependencyNode>>();
+            var combinedNodesReported = new HashSet<Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>>();
 
             if (_reasonStringOnlyNodes != null)
             {
@@ -84,7 +84,7 @@ namespace ILCompiler.DependencyAnalysisFramework
 
                     if (markData.Reason2 != null)
                     {
-                        Tuple<DependencyNode, DependencyNode> combinedNode = new Tuple<DependencyNode, DependencyNode>(markData.Reason1, markData.Reason2);
+                        var combinedNode = new Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>(markData.Reason1, markData.Reason2);
 
                         if (!combinedNodesReported.Contains(combinedNode))
                         {
@@ -95,7 +95,7 @@ namespace ILCompiler.DependencyAnalysisFramework
             }
         }
 
-        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor)
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor<DependencyContextType> logEdgeVisitor)
         {
             foreach (DependencyNodeCore<DependencyContextType> node in nodeList)
             {

--- a/src/ILCompiler.DependencyAnalysisFramework/src/FullGraphLogStrategy.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/FullGraphLogStrategy.cs
@@ -135,9 +135,9 @@ namespace ILCompiler.DependencyAnalysisFramework
             return newlyMarked;
         }
 
-        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor logNodeVisitor)
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor<DependencyContextType> logNodeVisitor)
         {
-            HashSet<Tuple<DependencyNode, DependencyNode>> combinedNodesReported = new HashSet<Tuple<DependencyNode, DependencyNode>>();
+            var combinedNodesReported = new HashSet<Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>>();
 
             if (_reasonStringOnlyNodes != null)
             {
@@ -156,7 +156,7 @@ namespace ILCompiler.DependencyAnalysisFramework
                     {
                         if (markData.Reason2 != null)
                         {
-                            Tuple<DependencyNode, DependencyNode> combinedNode = new Tuple<DependencyNode, DependencyNode>(markData.Reason1, markData.Reason2);
+                            var combinedNode = new Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>(markData.Reason1, markData.Reason2);
 
                             if (!combinedNodesReported.Contains(combinedNode))
                             {
@@ -168,7 +168,7 @@ namespace ILCompiler.DependencyAnalysisFramework
             }
         }
 
-        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor)
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor<DependencyContextType> logEdgeVisitor)
         {
             foreach (DependencyNodeCore<DependencyContextType> node in nodeList)
             {

--- a/src/ILCompiler.DependencyAnalysisFramework/src/IDependencyAnalysisMarkStrategy.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/IDependencyAnalysisMarkStrategy.cs
@@ -19,8 +19,8 @@ namespace ILCompiler.DependencyAnalysisFramework
         /// <returns>true if the node is newly marked</returns>
         bool MarkNode(DependencyNodeCore<DependencyContextType> node, DependencyNodeCore<DependencyContextType> reasonNode, DependencyNodeCore<DependencyContextType> reasonNode2, string reason);
 
-        void VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor logNodeVisitor);
+        void VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor<DependencyContextType> logNodeVisitor);
 
-        void VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor);
+        void VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor<DependencyContextType> logEdgeVisitor);
     }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/IDependencyAnalyzerLogEdgeVisitor.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/IDependencyAnalyzerLogEdgeVisitor.cs
@@ -10,10 +10,10 @@ using System.Threading.Tasks;
 
 namespace ILCompiler.DependencyAnalysisFramework
 {
-    public interface IDependencyAnalyzerLogEdgeVisitor
+    public interface IDependencyAnalyzerLogEdgeVisitor<DependencyContextType>
     {
-        void VisitEdge(DependencyNode nodeDepender, DependencyNode nodeDependedOn, string reason);
-        void VisitEdge(string root, DependencyNode dependedOn);
-        void VisitEdge(DependencyNode nodeDepender, DependencyNode nodeDependerOther, DependencyNode nodeDependedOn, string reason);
+        void VisitEdge(DependencyNodeCore<DependencyContextType> nodeDepender, DependencyNodeCore<DependencyContextType> nodeDependedOn, string reason);
+        void VisitEdge(string root, DependencyNodeCore<DependencyContextType> dependedOn);
+        void VisitEdge(DependencyNodeCore<DependencyContextType> nodeDepender, DependencyNodeCore<DependencyContextType> nodeDependerOther, DependencyNodeCore<DependencyContextType> nodeDependedOn, string reason);
     }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/IDependencyAnalyzerLogNodeVisitor.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/IDependencyAnalyzerLogNodeVisitor.cs
@@ -6,10 +6,10 @@ using System;
 
 namespace ILCompiler.DependencyAnalysisFramework
 {
-    public interface IDependencyAnalyzerLogNodeVisitor
+    public interface IDependencyAnalyzerLogNodeVisitor<DependencyContextType>
     {
-        void VisitCombinedNode(Tuple<DependencyNode, DependencyNode> node);
-        void VisitNode(DependencyNode node);
+        void VisitCombinedNode(Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>> node);
+        void VisitNode(DependencyNodeCore<DependencyContextType> node);
         void VisitRootNode(string rootName);
     }
 }

--- a/src/ILCompiler.DependencyAnalysisFramework/src/NoLogStrategy.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/NoLogStrategy.cs
@@ -32,13 +32,13 @@ namespace ILCompiler.DependencyAnalysisFramework
             return true;
         }
 
-        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor logEdgeVisitor)
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogEdges(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogEdgeVisitor<DependencyContextType> logEdgeVisitor)
         {
             // This marker does not permit logging.
             return;
         }
 
-        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor logNodeVisitor)
+        void IDependencyAnalysisMarkStrategy<DependencyContextType>.VisitLogNodes(IEnumerable<DependencyNodeCore<DependencyContextType>> nodeList, IDependencyAnalyzerLogNodeVisitor<DependencyContextType> logNodeVisitor)
         {
             // This marker does not permit logging.
             return;

--- a/src/ILCompiler.DependencyAnalysisFramework/tests/DependencyAnalysisFrameworkTests.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/DependencyAnalysisFrameworkTests.cs
@@ -169,7 +169,7 @@ namespace ILCompiler.DependencyAnalysisFramework.Tests
             {
                 BuildGraphUsingAllTypesOfRules(testGraph, analyzer);
                 MemoryStream dgmlOutput = new MemoryStream();
-                DgmlWriter.WriteDependencyGraphToStream(dgmlOutput, analyzer);
+                DgmlWriter.WriteDependencyGraphToStream(dgmlOutput, analyzer, testGraph);
                 dgmlOutput.Seek(0, SeekOrigin.Begin);
                 TextReader tr = new StreamReader(dgmlOutput);
                 dgmlOutputs[analyzer.GetType().FullName] = tr.ReadToEnd();

--- a/src/ILCompiler.DependencyAnalysisFramework/tests/TestGraph.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/TestGraph.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysisFramework.Tests
                 }
             }
 
-            protected override string GetName()
+            protected override string GetName(TestGraph context)
             {
                 return _data;
             }


### PR DESCRIPTION
References to the static name mangler property on `NodeFactory` are problematic from multiple angles (unit testing, hosting more than one compilation in a single process, etc.).

After this change, we're down to one place that still uses the `NameManglerDoNotUse` property. I'll fix that later.