### PR TITLE
IsSzArray => IsSZArray

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/MemberSerializationStringGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MemberSerializationStringGenerator.cs
@@ -110,12 +110,13 @@ namespace System
             if (type.HasElementType)
             {
                 sb.AppendSerializationString(type.GetElementType(), withinGenericTypeArgument);
-                if (type.IsSzArray)
+                if (type.IsSZArray)
                 {
                     sb.Append("[]");
                 }
-                else if (type.IsArray)
+                else if (type.IsMultiDimensionalArray)
                 {
+                    sb.Append('[');
                     int rank = type.GetArrayRank();
                     if (rank == 1)
                     {
@@ -123,10 +124,9 @@ namespace System
                     }
                     else
                     {
-                        sb.Append('[');
                         sb.Append(',', rank - 1);
-                        sb.Append(']');
                     }
+                    sb.Append(']');
                 }
                 else if (type.IsByRef)
                 {

--- a/src/System.Private.CoreLib/src/System/Type.cs
+++ b/src/System.Private.CoreLib/src/System/Type.cs
@@ -49,8 +49,8 @@ namespace System
         public virtual bool IsGenericType => false;
         public virtual bool IsGenericTypeDefinition => false;
 
-        // Not an api but can't be declared "internal" because of Corelib/Reflection.Core divide. Returns true if and only if type is a vector (not a multidim array of rank 1.)
-        public virtual bool IsSzArray { get { throw NotImplemented.ByDesign; } }
+        public virtual bool IsSZArray { get { throw NotImplemented.ByDesign; } }
+        public virtual bool IsMultiDimensionalArray { get { throw NotImplemented.ByDesign; } }
 
         public bool HasElementType => HasElementTypeImpl();
         protected abstract bool HasElementTypeImpl();

--- a/src/System.Private.CoreLib/src/System/UnitySerializationHolder.cs
+++ b/src/System.Private.CoreLib/src/System/UnitySerializationHolder.cs
@@ -44,7 +44,7 @@ namespace System
             List<int> elementTypes = new List<int>();
             while (type.HasElementType)
             {
-                if (type.IsSzArray)
+                if (type.IsSZArray)
                 {
                     elementTypes.Add(SzArray);
                 }

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Internal.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Internal.cs
@@ -155,7 +155,7 @@ namespace Internal.Reflection.Tracing
                 {
                     int rank = runtimeType.GetArrayRank();
                     if (rank == 1)
-                        suffix = "[" + (runtimeType.InternalIsMultiDimArray ? "*" : "") + "]";
+                        suffix = "[" + (runtimeType.IsMultiDimensionalArray ? "*" : "") + "]";
                     else
                         suffix = "[" + new String(',', rank - 1) + "]";
                 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
@@ -143,7 +143,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
             if ((t1.IsArray && t2.IsArray) || (t1.IsByRef && t2.IsByRef) || (t1.IsPointer && t2.IsPointer))
             {
-                if (t1.IsSzArray != t2.IsSzArray)
+                if (t1.IsSZArray != t2.IsSZArray)
                     return false;
 
                 if (t1.IsArray && (t1.GetArrayRank() != t2.GetArrayRank()))

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Assignability.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Assignability.cs
@@ -74,8 +74,8 @@ namespace System.Reflection.Runtime.General
                 if (rank != toTypeInfo.GetArrayRank())
                     return false;
 
-                bool fromTypeIsSzArray = fromTypeInfo.IsSzArray;
-                bool toTypeIsSzArray = toTypeInfo.IsSzArray;
+                bool fromTypeIsSzArray = fromTypeInfo.IsSZArray;
+                bool toTypeIsSzArray = toTypeInfo.IsSZArray;
                 if (fromTypeIsSzArray != toTypeIsSzArray)
                 {
                     // T[] is assignable to T[*] but not vice-versa.

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
@@ -35,12 +35,15 @@ namespace System.Reflection.Runtime.TypeInfos
             return _rank;
         }
 
-        protected sealed override TypeAttributes GetAttributeFlagsImpl()
+        public sealed override bool IsSZArray
         {
-            return TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Serializable;
+            get
+            {
+                return !_multiDim;
+            }
         }
 
-        internal sealed override bool InternalIsMultiDimArray
+        public sealed override bool IsMultiDimensionalArray
         {
             get
             {
@@ -48,11 +51,16 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        protected sealed override TypeAttributes GetAttributeFlagsImpl()
+        {
+            return TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Serializable;
+        }
+
         internal sealed override IEnumerable<RuntimeConstructorInfo> SyntheticConstructors
         {
             get
             {
-                bool multiDim = this.InternalIsMultiDimArray;
+                bool multiDim = this.IsMultiDimensionalArray;
                 int rank = this.GetArrayRank();
 
                 RuntimeTypeInfo arrayType = this;
@@ -266,7 +274,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                if (this.InternalIsMultiDimArray)
+                if (this.IsMultiDimensionalArray)
                     return Array.Empty<QTypeDefRefOrSpec>();
                 else
                     return TypeDefInfoProjectionForArrays.TypeRefDefOrSpecsForDirectlyImplementedInterfaces;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -347,11 +347,25 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
-        public sealed override bool IsSzArray
+        //
+        // Left unsealed as array types must override.
+        //
+        public override bool IsSZArray
         {
             get
             {
-                return IsArrayImpl() && !InternalIsMultiDimArray;
+                return false;
+            }
+        }
+
+        //
+        // Left unsealed as array types must override.
+        //
+        public override bool IsMultiDimensionalArray
+        {
+            get
+            {
+                return false;
             }
         }
 
@@ -669,15 +683,6 @@ namespace System.Reflection.Runtime.TypeInfos
         internal abstract string InternalFullNameOfAssembly { get; }
 
         public abstract override string InternalGetNameIfAvailable(ref Type rootCauseForFailure);
-
-        // Left unsealed so that multidim arrays can override.
-        internal virtual bool InternalIsMultiDimArray
-        {
-            get
-            {
-                return false;
-            }
-        }
 
         //
         // Left unsealed as HasElement types must override this.


### PR DESCRIPTION
We finally got approval for Type.IsSZArray
so changing the capitalization inside corert
so it matches the future api.

Also, made the implementation faster and more
consistent with how CoreRt implements other type
dissectors.

Also, optimistically betting IsMultiDimensionalArray()
will get approved too so standardizing on that name
as well.

Finally fixed a bug I happened on while testing this:
Methods with parameters of type T[*] were getting
serialized wrong. (Easy to miss given that C#
doesn't have a syntax for T[*]).