### PR TITLE
Enabling static fields access for Reflection

### DIFF
--- a/src/Common/src/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormatWriter.cs
@@ -661,6 +661,8 @@ namespace Internal.NativeFormat
             }
             writer.WriteUnsigned((uint)BagElementKind.End);
         }
+
+        public int ElementsCount => _elements.Count;
     }
 
 #if NATIVEFORMAT_PUBLICWRITER

--- a/src/Common/src/Internal/Runtime/MappingTableFlags.cs
+++ b/src/Common/src/Internal/Runtime/MappingTableFlags.cs
@@ -50,5 +50,6 @@ namespace Internal.Runtime
         IsUniversalCanonicalEntry = 0x04,
         HasMetadataHandle = 0x08,
         IsGcSection = 0x10,
+        FieldOffsetEncodedDirectly = 0x20
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -123,6 +123,15 @@ namespace ILCompiler
                 if (eetypeGenerated.IsGenericDefinition)
                     continue;
 
+                if (eetypeGenerated.HasInstantiation)
+                {
+                    // Collapsing of field map entries based on canonicalization, to avoid redundant equivalent entries
+
+                    TypeDesc canonicalType = eetypeGenerated.ConvertToCanonForm(CanonicalFormKind.Specific);
+                    if (canonicalType != eetypeGenerated && TypeGeneratesEEType(canonicalType))
+                        continue;
+                }
+
                 foreach (FieldDesc field in eetypeGenerated.GetFields())
                 {
                     Field record = transformed.GetTransformedFieldDefinition(field.GetTypicalFieldDefinition());

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -131,6 +131,39 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(new DependencyListEntry(factory.TypeNonGCStaticsSymbol((MetadataType)_type), "Class constructor"));
             }
 
+            // Dependencies of the StaticsInfoHashTable and the ReflectionFieldAccessMap
+            if (_type is MetadataType)
+            {
+                MetadataType metadataType = (MetadataType)_type;
+
+                // NOTE: The StaticsInfoHashtable entries need to reference the gc and non-gc static nodes through an indirection cell.
+                // The StaticsInfoHashtable entries only exist for static fields on generic types.
+
+                if (metadataType.GCStaticFieldSize.AsInt > 0)
+                {
+                    ISymbolNode gcStatics = factory.TypeGCStaticsSymbol(metadataType);
+                    dependencyList.Add(_type.HasInstantiation ? factory.Indirection(gcStatics) : gcStatics, "GC statics indirection for StaticsInfoHashtable");
+                }
+                if (metadataType.NonGCStaticFieldSize.AsInt > 0)
+                {
+                    ISymbolNode nonGCStatic = factory.TypeNonGCStaticsSymbol(metadataType);
+                    if (_type.HasInstantiation)
+                    {
+                        // The entry in the StaticsInfoHashtable points at the begining of the static fields data, so we need to add
+                        // the cctor context offset to the indirection cell.
+
+                        int cctorOffset = 0;
+                        if (factory.TypeSystemContext.HasLazyStaticConstructor(metadataType))
+                            cctorOffset += NonGCStaticsNode.GetClassConstructorContextStorageSize(factory.TypeSystemContext.Target, metadataType);
+
+                        nonGCStatic = factory.Indirection(nonGCStatic, cctorOffset);
+                    }
+                    dependencyList.Add(nonGCStatic, "Non-GC statics indirection for StaticsInfoHashtable");
+                }
+
+                // TODO: TLS dependencies
+            }
+
             return dependencyList;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionNode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 using Internal.Text;
 using Internal.TypeSystem;
 
@@ -13,11 +15,13 @@ namespace ILCompiler.DependencyAnalysis
     public class IndirectionNode : ObjectNode, ISymbolNode
     {
         private ISymbolNode _indirectedNode;
+        private int _offsetDelta;
         private TargetDetails _target;
 
-        public IndirectionNode(TargetDetails target, ISymbolNode indirectedNode)
+        public IndirectionNode(TargetDetails target, ISymbolNode indirectedNode, int offsetDelta)
         {
             _indirectedNode = indirectedNode;
+            _offsetDelta = offsetDelta;
             _target = target;
         }
 
@@ -25,6 +29,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             sb.Append("__indirection");
             _indirectedNode.AppendMangledName(nameMangler, sb);
+            sb.Append("_" + _offsetDelta);
         }
         public int Offset => 0;
 
@@ -51,7 +56,7 @@ namespace ILCompiler.DependencyAnalysis
             builder.RequireInitialPointerAlignment();
             builder.AddSymbol(this);
 
-            builder.EmitPointerReloc(_indirectedNode);
+            builder.EmitPointerReloc(_indirectedNode, _offsetDelta);
 
             return builder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -293,9 +293,9 @@ namespace ILCompiler.DependencyAnalysis
                 return new ReadyToRunGenericLookupFromTypeNode(this, data.HelperId, data.Target, data.DictionaryOwner);
             });
 
-            _indirectionNodes = new NodeCache<ISymbolNode, IndirectionNode>(symbol =>
+            _indirectionNodes = new NodeCache<Tuple<ISymbolNode, int>, IndirectionNode>(indirectionData =>
             {
-                return new IndirectionNode(Target, symbol);
+                return new IndirectionNode(Target, indirectionData.Item1, indirectionData.Item2);
             });
 
             _frozenStringNodes = new NodeCache<string, FrozenStringNode>((string data) =>
@@ -729,11 +729,11 @@ namespace ILCompiler.DependencyAnalysis
             return _genericReadyToRunHelpersFromType.GetOrAdd(new ReadyToRunGenericHelperKey(id, target, dictionaryOwner));
         }
 
-        private NodeCache<ISymbolNode, IndirectionNode> _indirectionNodes;
+        private NodeCache<Tuple<ISymbolNode, int>, IndirectionNode> _indirectionNodes;
 
-        public IndirectionNode Indirection(ISymbolNode symbol)
+        public IndirectionNode Indirection(ISymbolNode symbol, int offsetDelta = 0)
         {
-            return _indirectionNodes.GetOrAdd(symbol);
+            return _indirectionNodes.GetOrAdd(new Tuple<ISymbolNode, int>(symbol, offsetDelta));
         }
 
         private NodeCache<string, FrozenStringNode> _frozenStringNodes;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 
 using Internal.Text;
 using Internal.TypeSystem;
@@ -72,10 +73,13 @@ namespace ILCompiler.DependencyAnalysis
 
                     if (field.HasGCStaticBase)
                         flags |= FieldTableFlags.IsGcSection;
+
+                    if (field.OwningType.HasInstantiation)
+                        flags |= FieldTableFlags.FieldOffsetEncodedDirectly;
                 }
                 else
                 {
-                    flags = FieldTableFlags.Instance;
+                    flags = FieldTableFlags.Instance | FieldTableFlags.FieldOffsetEncodedDirectly;
                 }
 
                 // TODO: support emitting field info without a handle for generics in multifile
@@ -113,13 +117,46 @@ namespace ILCompiler.DependencyAnalysis
                     switch (flags & FieldTableFlags.StorageClass)
                     {
                         case FieldTableFlags.ThreadStatic:
-                        case FieldTableFlags.Static:
-                            // TODO: statics and thread statics
+                            // TODO: thread statics
                             continue;
 
+                        case FieldTableFlags.Static:
+                            {
+                                if (field.OwningType.HasInstantiation)
+                                {
+                                    vertex = writer.GetTuple(vertex, writer.GetUnsignedConstant((uint)(field.Offset.AsInt)));
+                                }
+                                else
+                                {
+                                    MetadataType metadataType = (MetadataType)field.OwningType;
+
+                                    int cctorOffset = 0;
+                                    if (!field.HasGCStaticBase && factory.TypeSystemContext.HasLazyStaticConstructor(metadataType))
+                                        cctorOffset += NonGCStaticsNode.GetClassConstructorContextStorageSize(factory.TypeSystemContext.Target, metadataType);
+
+                                    ISymbolNode staticsNode = field.HasGCStaticBase ?
+                                        factory.TypeGCStaticsSymbol(metadataType) :
+                                        factory.TypeNonGCStaticsSymbol(metadataType);
+
+                                    if (!field.HasGCStaticBase || factory.Target.Abi == TargetAbi.ProjectN)
+                                    {
+                                        uint index = _externalReferences.GetIndex(staticsNode, field.Offset.AsInt + cctorOffset);
+                                        vertex = writer.GetTuple(vertex, writer.GetUnsignedConstant(index));
+                                    }
+                                    else
+                                    {
+                                        Debug.Assert(field.HasGCStaticBase && factory.Target.Abi == TargetAbi.CoreRT);
+
+                                        uint index = _externalReferences.GetIndex(staticsNode);
+                                        vertex = writer.GetTuple(vertex, writer.GetUnsignedConstant(index));
+                                        vertex = writer.GetTuple(vertex, writer.GetUnsignedConstant((uint)(field.Offset.AsInt + cctorOffset)));
+                                    }
+                                }
+                            }
+                            break;
+
                         case FieldTableFlags.Instance:
-                            vertex = writer.GetTuple(vertex,
-                                writer.GetUnsignedConstant((uint)field.Offset.AsInt));
+                            vertex = writer.GetTuple(vertex, writer.GetUnsignedConstant((uint)field.Offset.AsInt));
                             break;
                     }
                 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a hashtable with information about all statics regions for all compiled generic types.
+    /// </summary>
+    internal sealed class StaticsInfoHashtableNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+        private ExternalReferencesTableNode _nativeStaticsReferences;
+
+        public StaticsInfoHashtableNode(ExternalReferencesTableNode externalReferences, ExternalReferencesTableNode nativeStaticsReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "_StaticsInfoHashtableNode_End", true);
+            _externalReferences = externalReferences;
+            _nativeStaticsReferences = nativeStaticsReferences;
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("_StaticsInfoHashtableNode");
+        }
+
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => _externalReferences.Section;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            NativeWriter writer = new NativeWriter();
+            VertexHashtable hashtable = new VertexHashtable();
+            Section section = writer.NewSection();
+
+            section.Place(hashtable);
+
+            foreach (var type in factory.MetadataManager.GetTypesWithEETypes())
+            {
+                if (!type.HasInstantiation || type.IsCanonicalSubtype(CanonicalFormKind.Any) || type.IsGenericDefinition)
+                    continue;
+
+                MetadataType metadataType = type as MetadataType;
+                if (metadataType == null)
+                    continue;
+
+                VertexBag bag = new VertexBag();
+
+                if (metadataType.GCStaticFieldSize.AsInt > 0)
+                {
+                    ISymbolNode gcStaticIndirection = factory.Indirection(factory.TypeGCStaticsSymbol(metadataType));
+                    bag.AppendUnsigned(BagElementKind.GcStaticData, _nativeStaticsReferences.GetIndex(gcStaticIndirection));
+                }
+                if (metadataType.NonGCStaticFieldSize.AsInt > 0)
+                {
+                    int cctorOffset = 0;
+                    if (factory.TypeSystemContext.HasLazyStaticConstructor(type))
+                        cctorOffset += NonGCStaticsNode.GetClassConstructorContextStorageSize(factory.TypeSystemContext.Target, metadataType);
+
+                    ISymbolNode nonGCStaticIndirection = factory.Indirection(factory.TypeNonGCStaticsSymbol(metadataType), cctorOffset);
+                    bag.AppendUnsigned(BagElementKind.NonGcStaticData, _nativeStaticsReferences.GetIndex(nonGCStaticIndirection));
+                }
+
+                // TODO: TLS
+
+                if (bag.ElementsCount > 0)
+                {
+                    uint typeId = _externalReferences.GetIndex(factory.NecessaryTypeSymbol(type));
+                    Vertex staticsInfo = writer.GetTuple(writer.GetUnsignedConstant(typeId), bag);
+
+                    hashtable.Append((uint)type.GetHashCode(), section.Place(staticsInfo));
+                }
+            }
+
+            byte[] hashTableBytes = writer.Save();
+
+            _endSymbol.SetSymbolOffset(hashTableBytes.Length);
+
+            return new ObjectData(hashTableBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -125,6 +125,9 @@ namespace ILCompiler
             var blockReflectionTypeMapNode = new BlockReflectionTypeMapNode(commonFixupsTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.BlockReflectionTypeMap), blockReflectionTypeMapNode, blockReflectionTypeMapNode, blockReflectionTypeMapNode.EndSymbol);
 
+            var staticsInfoHashtableNode = new StaticsInfoHashtableNode(nativeReferencesTableNode, nativeStaticsTableNode);
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.StaticsInfoHashtable), staticsInfoHashtableNode, staticsInfoHashtableNode, staticsInfoHashtableNode.EndSymbol);
+
             // The external references tables should go last
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.CommonFixupsTable), commonFixupsTableNode, commonFixupsTableNode, commonFixupsTableNode.EndSymbol);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.NativeReferences), nativeReferencesTableNode, nativeReferencesTableNode, nativeReferencesTableNode.EndSymbol);

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -281,6 +281,15 @@ namespace ILCompiler
                 if (eetypeGenerated.IsGenericDefinition)
                     continue;
 
+                if (eetypeGenerated.HasInstantiation)
+                {
+                    // Collapsing of field map entries based on canonicalization, to avoid redundant equivalent entries
+
+                    TypeDesc canonicalType = eetypeGenerated.ConvertToCanonForm(CanonicalFormKind.Specific);
+                    if (canonicalType != eetypeGenerated && TypeGeneratesEEType(canonicalType))
+                        continue;
+                }
+
                 foreach (FieldDesc field in eetypeGenerated.GetFields())
                 {
                     int token;

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Compiler\DependencyAnalysis\GCStaticEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticDescNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\StaticsInfoHashtableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\INodeWithCodeInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\INodeWithDebugInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ISymbolNode.cs" />

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForStaticFields.cs
@@ -3,37 +3,56 @@
 // See the LICENSE file in the project root for more information.
 
 using global::System;
-using global::System.Threading;
 using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using global::System.Runtime.CompilerServices;
+using global::System.Runtime.InteropServices;
 
 using global::Internal.Runtime.Augments;
-using global::Internal.Reflection.Execution;
-using global::Internal.Reflection.Core.Execution;
-
-using TargetException = System.ArgumentException;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
     internal sealed class ReferenceTypeFieldAccessorForStaticFields : WritableStaticFieldAccessor
     {
-        private IntPtr _fieldAddress;
+        private IntPtr _staticsBase;
+        private bool _isGcStaticsBase;
+        private int _fieldOffset;
 
-        public ReferenceTypeFieldAccessorForStaticFields(IntPtr cctorContext, IntPtr fieldAddress, RuntimeTypeHandle fieldTypeHandle)
+        public ReferenceTypeFieldAccessorForStaticFields(IntPtr cctorContext, IntPtr staticsBase, int fieldOffset, bool isGcStatic, RuntimeTypeHandle fieldTypeHandle)
             : base(cctorContext, fieldTypeHandle)
         {
-            _fieldAddress = fieldAddress;
+            _staticsBase = staticsBase;
+            _isGcStaticsBase = isGcStatic;
+            _fieldOffset = fieldOffset;
         }
 
-        protected sealed override Object GetFieldBypassCctor()
+        unsafe protected sealed override Object GetFieldBypassCctor()
         {
-            return RuntimeAugments.LoadReferenceTypeField(_fieldAddress);
+#if CORERT
+            if (_isGcStaticsBase)
+            {
+                // The _staticsBase variable points to a GC handle, which points at the GC statics base of the type.
+                // We need to perform a double indirection in a GC-safe manner.
+                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)_staticsBase);
+                return RuntimeAugments.LoadReferenceTypeField(gcStaticsRegion, _fieldOffset);
+            }
+#endif
+            return RuntimeAugments.LoadReferenceTypeField(_staticsBase + _fieldOffset);
         }
 
-        protected sealed override void UncheckedSetFieldBypassCctor(Object value)
+        unsafe protected sealed override void UncheckedSetFieldBypassCctor(Object value)
         {
-            RuntimeAugments.StoreReferenceTypeField(_fieldAddress, value);
+
+#if CORERT
+            if (_isGcStaticsBase)
+            {
+                // The _staticsBase variable points to a GC handle, which points at the GC statics base of the type.
+                // We need to perform a double indirection in a GC-safe manner.
+                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)_staticsBase);
+                RuntimeAugments.StoreReferenceTypeField(gcStaticsRegion, _fieldOffset, value);
+                return;
+            }
+#endif
+            RuntimeAugments.StoreReferenceTypeField(_staticsBase + _fieldOffset, value);
         }
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
@@ -144,6 +144,18 @@ namespace Internal.Runtime.TypeLoader
             return GetIntPtrFromIndex(index);
         }
 
+#if CORERT
+        unsafe public IntPtr GetFieldAddressFromIndex(uint index)
+        {
+            if (index >= _elementsCount)
+                throw new BadImageFormatException();
+
+            // TODO: indirection through IAT
+
+            return ((IntPtr*)_elements)[index];
+        }
+#endif
+
         public uint GetExternalNativeLayoutOffset(uint index)
         {
             // CoreRT is a bit more optimized than ProjectN. In ProjectN, some tables that reference data


### PR DESCRIPTION
1) Adding the StaticsInfoHashtable to track statics regions for compiled types.
2) Writing statics field data to the ReflectionFieldMapNode
3) Improving the IndirectionNode to allow it to point to an inner offset in a target symbol
4) CoreRT runtime support for static fields access
5) Collapsing of field entries in the ReflectionFieldMapNode based on canonicalization
6) Various fixes to enable correct generation of the System.__UniversalCanon type.