### PR TITLE
Make VirtualMethodUse nodes only track methods that introduce slot

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -39,6 +39,15 @@ namespace ILCompiler.DependencyAnalysis
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool HasDynamicDependencies => false;
         public override bool HasConditionalStaticDependencies => false;
+
+        protected IEnumerable<MethodDesc> GetAllVirtualMethods()
+        {
+            foreach (MethodDesc method in _type.GetAllMethods())
+            {
+                if (method.IsVirtual)
+                    yield return method;
+            }
+        }
     }
 
     /// <summary>
@@ -54,19 +63,24 @@ namespace ILCompiler.DependencyAnalysis
         {
             var slots = new ArrayBuilder<MethodDesc>();
 
-            MethodDesc finalizerMethod = type.GetFinalizer();
+            bool isObjectType = type.IsObject;
             DefType defType = _type.GetClosestDefType();
-            foreach (var method in defType.GetAllMethods())
-            {
-                if (!method.IsVirtual)
-                    continue;
 
+            IEnumerable<MethodDesc> allSlots = _type.IsInterface ?
+                GetAllVirtualMethods() : defType.EnumAllVirtualSlots();
+
+            foreach (var method in allSlots)
+            {
                 // GVMs are not emitted in the type's vtable.
                 if (method.HasInstantiation)
                     continue;
 
                 // Finalizers are called via a field on the EEType, not through the VTable
-                if (finalizerMethod == method || (type.IsObject && method.Name == "Finalize"))
+                if (isObjectType && method.Name == "Finalize")
+                    continue;
+
+                // Current type doesn't define this slot.
+                if (method.OwningType != defType)
                     continue;
 
                 slots.Add(method);
@@ -175,13 +189,18 @@ namespace ILCompiler.DependencyAnalysis
             // VirtualMethodUse of Foo<SomeType>.Method will bring in VirtualMethodUse
             // of Foo<__Canon>.Method. This in turn should bring in Foo<OtherType>.Method.
             DefType defType = _type.GetClosestDefType();
-            foreach (var method in defType.GetAllMethods())
+
+            IEnumerable<MethodDesc> allSlots = _type.IsInterface ?
+                GetAllVirtualMethods() : defType.EnumAllVirtualSlots();
+
+            foreach (var method in allSlots)
             {
-                if (!method.IsVirtual)
-                    continue;
-                
                 // Generic virtual methods are tracked by an orthogonal mechanism.
                 if (method.HasInstantiation)
+                    continue;
+
+                // Current type doesn't define this slot. Another VTableSlice will take care of this.
+                if (method.OwningType != defType)
                     continue;
 
                 yield return new CombinedDependencyListEntry(

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -24,8 +24,14 @@ namespace ILCompiler.DependencyAnalysis
 
         public VirtualMethodUseNode(MethodDesc decl)
         {
+            Debug.Assert(decl.IsVirtual);
+
+            // TODO: assert that decl is a slot defining method (either a newslot or a first virtual method
+            // with this name and signature in the inheritance chain).
+
             // Generic virtual methods are tracked by an orthogonal mechanism.
             Debug.Assert(!decl.HasInstantiation);
+
             _decl = decl;
         }
 
@@ -36,7 +42,7 @@ namespace ILCompiler.DependencyAnalysis
             // If the VTable slice is getting built on demand, the fact that the virtual method is used means
             // that the slot is used.
             var lazyVTableSlice = factory.VTable(_decl.OwningType) as LazilyBuiltVTableSliceNode;
-            if (lazyVTableSlice != null && !_decl.HasInstantiation)
+            if (lazyVTableSlice != null)
                 lazyVTableSlice.AddEntry(factory, _decl);
         }
 


### PR DESCRIPTION
The rest of the analysis assumes the methods are used through the
declaring slot. We make sure of that when reading inputs (e.g. a
callvirt through the non-declaring method gets normalized to the
declaring slot). We were not enforcing this which resulted in seeing
garbage slots in the vtable.