### PR TITLE
Use specialized struct keys instead of Tuple in NodeFactory caches

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -33,10 +33,10 @@ namespace ILCompiler.DependencyAnalysis
             return new UnboxingStubNode(method);
         }
 
-        protected override ISymbolNode CreateReadyToRunHelperNode(Tuple<ReadyToRunHelperId, object> helperCall)
+        protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
         {
             // TODO: this is wrong: this returns an assembly stub node
-            return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
+            return new ReadyToRunHelperNode(this, helperCall.HelperId, helperCall.Target);
         }
 
         protected override IMethodNode CreateShadowConcreteMethodNode(MethodKey methodKey)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -903,7 +903,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 int hashCode = Target.GetHashCode();
                 if (CallsiteId != null)
-                    hashCode = 23 * CallsiteId.GetHashCode();
+                    hashCode = hashCode * 23 + CallsiteId.GetHashCode();
                 return hashCode;
             }
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -220,10 +220,10 @@ namespace ILCompiler.DependencyAnalysis
                 return new GCStaticEETypeNode(Target, gcMap);
             });
 
-            _readOnlyDataBlobs = new NodeCache<Tuple<Utf8String, byte[], int>, BlobNode>((Tuple<Utf8String, byte[], int> key) =>
+            _readOnlyDataBlobs = new NodeCache<ReadOnlyDataBlobKey, BlobNode>(key =>
             {
-                return new BlobNode(key.Item1, ObjectNodeSection.ReadOnlyDataSection, key.Item2, key.Item3);
-            }, new BlobTupleEqualityComparer());
+                return new BlobNode(key.Name, ObjectNodeSection.ReadOnlyDataSection, key.Data, key.Alignment);
+            });
 
             _externSymbols = new NodeCache<string, ExternSymbolNode>((string name) =>
             {
@@ -272,16 +272,16 @@ namespace ILCompiler.DependencyAnalysis
                 return new VirtualMethodUseNode(method);
             });
 
-            _readyToRunHelpers = new NodeCache<Tuple<ReadyToRunHelperId, Object>, ISymbolNode>(CreateReadyToRunHelperNode);
+            _readyToRunHelpers = new NodeCache<ReadyToRunHelperKey, ISymbolNode>(CreateReadyToRunHelperNode);
 
-            _genericReadyToRunHelpersFromDict = new NodeCache<Tuple<ReadyToRunHelperId, object, TypeSystemEntity>, ISymbolNode>(data =>
+            _genericReadyToRunHelpersFromDict = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(data =>
             {
-                return new ReadyToRunGenericLookupFromDictionaryNode(this, data.Item1, data.Item2, data.Item3);
+                return new ReadyToRunGenericLookupFromDictionaryNode(this, data.HelperId, data.Target, data.DictionaryOwner);
             });
 
-            _genericReadyToRunHelpersFromType = new NodeCache<Tuple<ReadyToRunHelperId, object, TypeSystemEntity>, ISymbolNode>(data =>
+            _genericReadyToRunHelpersFromType = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(data =>
             {
-                return new ReadyToRunGenericLookupFromTypeNode(this, data.Item1, data.Item2, data.Item3);
+                return new ReadyToRunGenericLookupFromTypeNode(this, data.HelperId, data.Target, data.DictionaryOwner);
             });
 
             _indirectionNodes = new NodeCache<ISymbolNode, IndirectionNode>(symbol =>
@@ -294,9 +294,9 @@ namespace ILCompiler.DependencyAnalysis
                 return new FrozenStringNode(data, Target);
             });
 
-            _interfaceDispatchCells = new NodeCache<Tuple<MethodDesc, string>, InterfaceDispatchCellNode>((Tuple<MethodDesc, string> callSiteCell) =>
+            _interfaceDispatchCells = new NodeCache<DispatchCellKey, InterfaceDispatchCellNode>(callSiteCell =>
             {
-                return new InterfaceDispatchCellNode(callSiteCell.Item1, callSiteCell.Item2);
+                return new InterfaceDispatchCellNode(callSiteCell.Target, callSiteCell.CallsiteId);
             });
 
             _interfaceDispatchMaps = new NodeCache<TypeDesc, InterfaceDispatchMapNode>((TypeDesc type) =>
@@ -370,7 +370,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected abstract IMethodNode CreateUnboxingStubNode(MethodDesc method);
 
-        protected abstract ISymbolNode CreateReadyToRunHelperNode(Tuple<ReadyToRunHelperId, Object> helperCall);
+        protected abstract ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall);
 
         protected abstract IMethodNode CreateShadowConcreteMethodNode(MethodKey method);
 
@@ -467,11 +467,11 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        private NodeCache<Tuple<MethodDesc, string>, InterfaceDispatchCellNode> _interfaceDispatchCells;
+        private NodeCache<DispatchCellKey, InterfaceDispatchCellNode> _interfaceDispatchCells;
 
         public InterfaceDispatchCellNode InterfaceDispatchCell(MethodDesc method, string callSite = null)
         {
-            return _interfaceDispatchCells.GetOrAdd(new Tuple<MethodDesc, string>(method, callSite));
+            return _interfaceDispatchCells.GetOrAdd(new DispatchCellKey(method, callSite));
         }
 
         private NodeCache<MethodDesc, RuntimeMethodHandleNode> _runtimeMethodHandles;
@@ -488,19 +488,6 @@ namespace ILCompiler.DependencyAnalysis
             return _runtimeFieldHandles.GetOrAdd(field);
         }
 
-        private class BlobTupleEqualityComparer : IEqualityComparer<Tuple<Utf8String, byte[], int>>
-        {
-            bool IEqualityComparer<Tuple<Utf8String, byte[], int>>.Equals(Tuple<Utf8String, byte[], int> x, Tuple<Utf8String, byte[], int> y)
-            {
-                return x.Item1.Equals(y.Item1);
-            }
-
-            int IEqualityComparer<Tuple<Utf8String, byte[], int>>.GetHashCode(Tuple<Utf8String, byte[], int> obj)
-            {
-                return obj.Item1.GetHashCode();
-            }
-        }
-
         private NodeCache<GCPointerMap, GCStaticEETypeNode> _GCStaticEETypes;
 
         public ISymbolNode GCStaticEEType(GCPointerMap gcMap)
@@ -508,11 +495,11 @@ namespace ILCompiler.DependencyAnalysis
             return _GCStaticEETypes.GetOrAdd(gcMap);
         }
 
-        private NodeCache<Tuple<Utf8String, byte[], int>, BlobNode> _readOnlyDataBlobs;
+        private NodeCache<ReadOnlyDataBlobKey, BlobNode> _readOnlyDataBlobs;
 
         public BlobNode ReadOnlyDataBlob(Utf8String name, byte[] blobData, int alignment)
         {
-            return _readOnlyDataBlobs.GetOrAdd(new Tuple<Utf8String, byte[], int>(name, blobData, alignment));
+            return _readOnlyDataBlobs.GetOrAdd(new ReadOnlyDataBlobKey(name, blobData, alignment));
         }
 
         private NodeCache<TypeDesc, InterfaceDispatchMapNode> _interfaceDispatchMaps;
@@ -712,25 +699,25 @@ namespace ILCompiler.DependencyAnalysis
             return _virtMethods.GetOrAdd(decl);
         }
 
-        private NodeCache<Tuple<ReadyToRunHelperId, Object>, ISymbolNode> _readyToRunHelpers;
+        private NodeCache<ReadyToRunHelperKey, ISymbolNode> _readyToRunHelpers;
 
         public ISymbolNode ReadyToRunHelper(ReadyToRunHelperId id, Object target)
         {
-            return _readyToRunHelpers.GetOrAdd(new Tuple<ReadyToRunHelperId, object>(id, target));
+            return _readyToRunHelpers.GetOrAdd(new ReadyToRunHelperKey(id, target));
         }
 
-        private NodeCache<Tuple<ReadyToRunHelperId, Object, TypeSystemEntity>, ISymbolNode> _genericReadyToRunHelpersFromDict;
+        private NodeCache<ReadyToRunGenericHelperKey, ISymbolNode> _genericReadyToRunHelpersFromDict;
 
         public ISymbolNode ReadyToRunHelperFromDictionaryLookup(ReadyToRunHelperId id, Object target, TypeSystemEntity dictionaryOwner)
         {
-            return _genericReadyToRunHelpersFromDict.GetOrAdd(new Tuple<ReadyToRunHelperId, object, TypeSystemEntity>(id, target, dictionaryOwner));
+            return _genericReadyToRunHelpersFromDict.GetOrAdd(new ReadyToRunGenericHelperKey(id, target, dictionaryOwner));
         }
 
-        private NodeCache<Tuple<ReadyToRunHelperId, Object, TypeSystemEntity>, ISymbolNode> _genericReadyToRunHelpersFromType;
+        private NodeCache<ReadyToRunGenericHelperKey, ISymbolNode> _genericReadyToRunHelpersFromType;
 
         public ISymbolNode ReadyToRunHelperFromTypeLookup(ReadyToRunHelperId id, Object target, TypeSystemEntity dictionaryOwner)
         {
-            return _genericReadyToRunHelpersFromType.GetOrAdd(new Tuple<ReadyToRunHelperId, object, TypeSystemEntity>(id, target, dictionaryOwner));
+            return _genericReadyToRunHelpersFromType.GetOrAdd(new ReadyToRunGenericHelperKey(id, target, dictionaryOwner));
         }
 
         private NodeCache<ISymbolNode, IndirectionNode> _indirectionNodes;
@@ -851,6 +838,95 @@ namespace ILCompiler.DependencyAnalysis
             public bool Equals(MethodKey other) => Method == other.Method && IsUnboxingStub == other.IsUnboxingStub;
             public override bool Equals(object obj) => obj is MethodKey && Equals((MethodKey)obj);
             public override int GetHashCode() => Method.GetHashCode();
+        }
+
+        protected struct ReadyToRunHelperKey : IEquatable<ReadyToRunHelperKey>
+        {
+            public readonly object Target;
+            public readonly ReadyToRunHelperId HelperId;
+
+            public ReadyToRunHelperKey(ReadyToRunHelperId helperId, object target)
+            {
+                HelperId = helperId;
+                Target = target;
+            }
+
+            public bool Equals(ReadyToRunHelperKey other) => HelperId == other.HelperId && Target.Equals(other.Target);
+            public override bool Equals(object obj) => obj is ReadyToRunHelperKey && Equals((ReadyToRunHelperKey)obj);
+            public override int GetHashCode()
+            {
+                int hashCode = (int)HelperId * 0x5498341 + 0x832424;
+                hashCode = hashCode * 23 + Target.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        protected struct ReadyToRunGenericHelperKey : IEquatable<ReadyToRunGenericHelperKey>
+        {
+            public readonly object Target;
+            public readonly TypeSystemEntity DictionaryOwner;
+            public readonly ReadyToRunHelperId HelperId;
+
+            public ReadyToRunGenericHelperKey(ReadyToRunHelperId helperId, object target, TypeSystemEntity dictionaryOwner)
+            {
+                HelperId = helperId;
+                Target = target;
+                DictionaryOwner = dictionaryOwner;
+            }
+
+            public bool Equals(ReadyToRunGenericHelperKey other)
+                => HelperId == other.HelperId && DictionaryOwner == other.DictionaryOwner && Target.Equals(other.Target);
+            public override bool Equals(object obj) => obj is ReadyToRunGenericHelperKey && Equals((ReadyToRunGenericHelperKey)obj);
+            public override int GetHashCode()
+            {
+                int hashCode = (int)HelperId * 0x5498341 + 0x832424;
+                hashCode = hashCode * 23 + Target.GetHashCode();
+                hashCode = hashCode * 23 + DictionaryOwner.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        protected struct DispatchCellKey : IEquatable<DispatchCellKey>
+        {
+            public readonly MethodDesc Target;
+            public readonly string CallsiteId;
+
+            public DispatchCellKey(MethodDesc target, string callsiteId)
+            {
+                Target = target;
+                CallsiteId = callsiteId;
+            }
+
+            public bool Equals(DispatchCellKey other) => Target == other.Target && CallsiteId == other.CallsiteId;
+            public override bool Equals(object obj) => obj is DispatchCellKey && Equals((DispatchCellKey)obj);
+            public override int GetHashCode()
+            {
+                int hashCode = Target.GetHashCode();
+                if (CallsiteId != null)
+                    hashCode = 23 * CallsiteId.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        protected struct ReadOnlyDataBlobKey : IEquatable<ReadOnlyDataBlobKey>
+        {
+            public readonly Utf8String Name;
+            public readonly byte[] Data;
+            public readonly int Alignment;
+
+            public ReadOnlyDataBlobKey(Utf8String name, byte[] data, int alignment)
+            {
+                Name = name;
+                Data = data;
+                Alignment = alignment;
+            }
+
+            // The assumption here is that the name of the blob is unique.
+            // We can't emit two blobs with the same name and different contents.
+            // The name is part of the symbolic name and we don't do any mangling on it.
+            public bool Equals(ReadOnlyDataBlobKey other) => Name.Equals(other.Name);
+            public override bool Equals(object obj) => obj is ReadOnlyDataBlobKey && Equals((ReadOnlyDataBlobKey)obj);
+            public override int GetHashCode() => Name.GetHashCode();
         }
     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -68,9 +68,9 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override ISymbolNode CreateReadyToRunHelperNode(Tuple<ReadyToRunHelperId, object> helperCall)
+        protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
         {
-            return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
+            return new ReadyToRunHelperNode(this, helperCall.HelperId, helperCall.Target);
         }
 
         protected override IMethodNode CreateShadowConcreteMethodNode(MethodKey methodKey)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
@@ -184,9 +184,9 @@ namespace ILCompiler
             }
         }
 
-        protected override ISymbolNode CreateReadyToRunHelperNode(Tuple<ReadyToRunHelperId, object> helperCall)
+        protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
         {
-            return new ReadyToRunHelperNode(this, helperCall.Item1, helperCall.Item2);
+            return new ReadyToRunHelperNode(this, helperCall.HelperId, helperCall.Target);
         }
 
         protected override IMethodNode CreateShadowConcreteMethodNode(MethodKey methodKey)


### PR DESCRIPTION
Makes Roslyn compile with ILC about 3% faster on my machine. Also, mild
improvement in readability of the code.