### PR TITLE
Move MemberInfo to shared partition

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -153,6 +153,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\ParamArrayAttribute.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\PlatformNotSupportedException.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\RankException.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MemberInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ObfuscateAssemblyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ObfuscationAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\TypeDelegator.cs" />

--- a/src/System.Private.CoreLib/shared/System/Reflection/MemberInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MemberInfo.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace System.Reflection
 {
-    public abstract class MemberInfo : ICustomAttributeProvider
+    public abstract partial class MemberInfo : ICustomAttributeProvider
     {
         protected MemberInfo() { }
 

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -187,7 +187,6 @@
     <Compile Include="System\Reflection\LocalVariableInfo.cs" />
     <Compile Include="System\Reflection\ManifestResourceInfo.cs" />
     <Compile Include="System\Reflection\MemberFilter.cs" />
-    <Compile Include="System\Reflection\MemberInfo.cs" />
     <Compile Include="System\Reflection\MemberInfoSerializationHolder.cs" />
     <Compile Include="System\Reflection\MemberSerializationStringGenerator.cs" />
     <Compile Include="System\Reflection\MemberTypes.cs" />

--- a/src/System.Private.CoreLib/src/System/Reflection/MemberInfoSerializationHolder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MemberInfoSerializationHolder.cs
@@ -34,7 +34,7 @@ namespace System.Reflection
 
         public static void GetSerializationInfo(SerializationInfo info, MethodInfo m)
         {
-            Type[] genericArguments = (m.IsGenericMethod & !m.IsGenericMethodDefinition) ? m.GetGenericArguments() : null;
+            Type[] genericArguments = m.IsConstructedGenericMethod ? m.GetGenericArguments() : null;
             GetSerializationInfo(info, m.Name, m.ReflectedType, m.ToString(), m.SerializationToString(), MemberTypes.Method, genericArguments);
         }
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
@@ -116,7 +116,7 @@ namespace Internal.Reflection.Execution.PayForPlayExperience
                     bool first = true;
 
                     // write out generic parameters
-                    if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+                    if (method.IsConstructedGenericMethod)
                     {
                         first = true;
                         friendlyName.Append('<');

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
@@ -55,7 +55,7 @@ namespace Internal.Reflection.Execution
             if (pertainant is MethodBase)
             {
                 MethodBase methodBase = (MethodBase)pertainant;
-                resourceName = (methodBase.IsGenericMethod && !methodBase.IsGenericMethodDefinition) ? SR.MakeGenericMethod_NoMetadata : SR.Object_NotInvokable;
+                resourceName = methodBase.IsConstructedGenericMethod ? SR.MakeGenericMethod_NoMetadata : SR.Object_NotInvokable;
                 if (methodBase is ConstructorInfo)
                 {
                     TypeInfo declaringTypeInfo = methodBase.DeclaringType.GetTypeInfo();


### PR DESCRIPTION
There are really two easy changes here, just
to reduce CR overhead.

- CoreRt side of https://github.com/dotnet/coreclr/pull/10167

- Now that we have the shiny new IsConstructedGenericType
  api, let's use it...