### PR TITLE
Preparing *Info files for migration to shared partition.

### DIFF
--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -175,6 +175,7 @@
     <Compile Include="System\Reflection\ExceptionHandlingClauseOptions.cs" />
     <Compile Include="System\Reflection\FieldAttributes.cs" />
     <Compile Include="System\Reflection\FieldInfo.cs" />
+    <Compile Include="System\Reflection\FieldInfo.CoreRT.cs" />
     <Compile Include="System\Reflection\GenericParameterAttributes.cs" />
     <Compile Include="System\Reflection\ICustomAttributeProvider.cs" />
     <Compile Include="System\Reflection\ImageFileMachine.cs" />
@@ -192,6 +193,7 @@
     <Compile Include="System\Reflection\MemberTypes.cs" />
     <Compile Include="System\Reflection\MethodAttributes.cs" />
     <Compile Include="System\Reflection\MethodBase.cs" />
+    <Compile Include="System\Reflection\MethodBase.CoreRT.cs" />
     <Compile Include="System\Reflection\MethodBody.cs" />
     <Compile Include="System\Reflection\MethodImplAttributes.cs" />
     <Compile Include="System\Reflection\MethodInfo.cs" />

--- a/src/System.Private.CoreLib/src/System/Reflection/ConstructorInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/ConstructorInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
 
 namespace System.Reflection
@@ -12,6 +13,8 @@ namespace System.Reflection
 
         public override MemberTypes MemberType => MemberTypes.Constructor;
 
+        [DebuggerHidden]
+        [DebuggerStepThrough]
         public object Invoke(object[] parameters) => Invoke(BindingFlags.Default, binder: null, parameters: parameters, culture: null);
         public abstract object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture);
 

--- a/src/System.Private.CoreLib/src/System/Reflection/EventInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/EventInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using EventRegistrationToken = System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken;
 
 namespace System.Reflection
@@ -57,6 +58,8 @@ namespace System.Reflection
             }
         }
 
+        [DebuggerHidden]
+        [DebuggerStepThrough]
         public virtual void AddEventHandler(object target, Delegate handler)
         {
             MethodInfo addMethod = GetAddMethod(nonPublic: false);
@@ -70,6 +73,8 @@ namespace System.Reflection
             addMethod.Invoke(target, new object[] { handler });
         }
 
+        [DebuggerHidden]
+        [DebuggerStepThrough]
         public virtual void RemoveEventHandler(object target, Delegate handler)
         {
             MethodInfo removeMethod = GetRemoveMethod(nonPublic: false);

--- a/src/System.Private.CoreLib/src/System/Reflection/FieldInfo.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/FieldInfo.CoreRT.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Reflection.Augments;
+
+namespace System.Reflection
+{
+    public abstract partial class FieldInfo : MemberInfo
+    {
+        public static FieldInfo GetFieldFromHandle(RuntimeFieldHandle handle) => ReflectionAugments.ReflectionCoreCallbacks.GetFieldFromHandle(handle);
+        public static FieldInfo GetFieldFromHandle(RuntimeFieldHandle handle, RuntimeTypeHandle declaringType) => ReflectionAugments.ReflectionCoreCallbacks.GetFieldFromHandle(handle, declaringType);
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Reflection/FieldInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/FieldInfo.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
-
-using Internal.Reflection.Augments;
 
 namespace System.Reflection
 {
-    public abstract class FieldInfo : MemberInfo
+    public abstract partial class FieldInfo : MemberInfo
     {
         protected FieldInfo() { }
 
@@ -37,8 +36,6 @@ namespace System.Reflection
         public virtual bool IsSecurityTransparent => false;
 
         public abstract RuntimeFieldHandle FieldHandle { get; }
-        public static FieldInfo GetFieldFromHandle(RuntimeFieldHandle handle) => ReflectionAugments.ReflectionCoreCallbacks.GetFieldFromHandle(handle);
-        public static FieldInfo GetFieldFromHandle(RuntimeFieldHandle handle, RuntimeTypeHandle declaringType) => ReflectionAugments.ReflectionCoreCallbacks.GetFieldFromHandle(handle, declaringType);
 
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
@@ -58,6 +55,8 @@ namespace System.Reflection
 
         public abstract object GetValue(object obj);
 
+        [DebuggerHidden]
+        [DebuggerStepThrough]
         public void SetValue(object obj, object value) => SetValue(obj, value, BindingFlags.Default, Type.DefaultBinder, null);
         public abstract void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, CultureInfo culture);
 

--- a/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreRT.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Reflection.Augments;
+
+namespace System.Reflection
+{
+    public abstract partial class MethodBase : MemberInfo
+    {
+        public static MethodBase GetMethodFromHandle(RuntimeMethodHandle handle) => ReflectionAugments.ReflectionCoreCallbacks.GetMethodFromHandle(handle);
+        public static MethodBase GetMethodFromHandle(RuntimeMethodHandle handle, RuntimeTypeHandle declaringType) => ReflectionAugments.ReflectionCoreCallbacks.GetMethodFromHandle(handle, declaringType);
+
+        // This is actually an ILC intrinsic.
+        public static MethodBase GetCurrentMethod() { throw new NotImplementedException(); }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -3,12 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using Internal.Reflection.Augments;
 using System.Diagnostics;
 
 namespace System.Reflection
 {
-    public abstract class MethodBase : MemberInfo
+    public abstract partial class MethodBase : MemberInfo
     {
         protected MethodBase() { }
 
@@ -49,15 +48,12 @@ namespace System.Reflection
         public virtual Type[] GetGenericArguments() { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
         public virtual bool ContainsGenericParameters => false;
 
+        [DebuggerHidden]
         [DebuggerStepThrough]
         public object Invoke(object obj, object[] parameters) => Invoke(obj, BindingFlags.Default, binder: null, parameters: parameters, culture: null);
         public abstract object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture);
 
         public abstract RuntimeMethodHandle MethodHandle { get; }
-        public static MethodBase GetMethodFromHandle(RuntimeMethodHandle handle) => ReflectionAugments.ReflectionCoreCallbacks.GetMethodFromHandle(handle);
-        public static MethodBase GetMethodFromHandle(RuntimeMethodHandle handle, RuntimeTypeHandle declaringType) => ReflectionAugments.ReflectionCoreCallbacks.GetMethodFromHandle(handle, declaringType);
-
-        public static MethodBase GetCurrentMethod() { throw new NotImplementedException(); }
 
         public virtual bool IsSecurityCritical { get { throw NotImplemented.ByDesign; } }
         public virtual bool IsSecuritySafeCritical { get { throw NotImplemented.ByDesign; } }

--- a/src/System.Private.CoreLib/src/System/Reflection/PropertyInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/PropertyInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
 
 namespace System.Reflection
@@ -35,14 +36,22 @@ namespace System.Reflection
         public virtual Type[] GetOptionalCustomModifiers() => Array.Empty<Type>();
         public virtual Type[] GetRequiredCustomModifiers() => Array.Empty<Type>();
 
+        [DebuggerHidden]
+        [DebuggerStepThrough]
         public object GetValue(object obj) => GetValue(obj, index: null);
+        [DebuggerHidden]
+        [DebuggerStepThrough]
         public virtual object GetValue(object obj, object[] index) => GetValue(obj, BindingFlags.Default, binder: null, index: index, culture: null);
         public abstract object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture);
 
         public virtual object GetConstantValue() { throw NotImplemented.ByDesign; }
         public virtual object GetRawConstantValue() { throw NotImplemented.ByDesign; }
 
+        [DebuggerHidden]
+        [DebuggerStepThrough]
         public void SetValue(object obj, object value) => SetValue(obj, value, index: null);
+        [DebuggerHidden]
+        [DebuggerStepThrough]
         public virtual void SetValue(object obj, object value, object[] index) => SetValue(obj, value, BindingFlags.Default, binder: null, index: index, culture: null);
         public abstract void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture);
 


### PR DESCRIPTION
This is mostly splitting up files to eliminate roommating
of classes and splitting out inherently nonportable stuff.
There's very little work to do here compared to CoreClr so
combining into one CR.