### PR TITLE
Add back four more NS2.0 apis.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -124,6 +124,10 @@ namespace System.Reflection
         public virtual Assembly GetSatelliteAssembly(CultureInfo culture) { throw NotImplemented.ByDesign; }
         public virtual Assembly GetSatelliteAssembly(CultureInfo culture, Version version) { throw NotImplemented.ByDesign; }
 
+        public virtual FileStream GetFile(string name) { throw NotImplemented.ByDesign; }
+        public virtual FileStream[] GetFiles() => GetFiles(getResourceModules: false);
+        public virtual FileStream[] GetFiles(bool getResourceModules) { throw NotImplemented.ByDesign; }
+
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context) { throw NotImplemented.ByDesign; }
 
         public override string ToString()

--- a/src/System.Private.CoreLib/src/System/Reflection/StrongNameKeyPair.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/StrongNameKeyPair.cs
@@ -14,7 +14,7 @@
 **
 ===========================================================*/
 
-using System;
+using System.IO;
 using System.Runtime.Serialization;
 
 namespace System.Reflection
@@ -26,6 +26,19 @@ namespace System.Reflection
         private byte[] _keyPairArray;
         private String _keyPairContainer;
         private byte[] _publicKey;
+
+        // Build key pair from file.
+        public StrongNameKeyPair(FileStream keyPairFile)
+        {
+            if (keyPairFile == null)
+                throw new ArgumentNullException(nameof(keyPairFile));
+
+            int length = (int)keyPairFile.Length;
+            _keyPairArray = new byte[length];
+            keyPairFile.Read(_keyPairArray, 0, length);
+
+            _keyPairExported = true;
+        }
 
         // Build key pair from byte array in memory.
         public StrongNameKeyPair(byte[] keyPairArray)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
@@ -75,7 +75,6 @@ namespace System.Reflection.Runtime.Assemblies
             }
         }
 
-
         public sealed override Type GetType(String name, bool throwOnError, bool ignoreCase)
         {
 #if ENABLE_REFLECTION_TRACE
@@ -215,6 +214,16 @@ namespace System.Reflection.Runtime.Assemblies
         }
 
         public sealed override Module LoadModule(string moduleName, byte[] rawModule, byte[] rawSymbolStore)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public sealed override FileStream GetFile(string name)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public sealed override FileStream[] GetFiles(bool getResourceModules)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -11,7 +11,7 @@
 // but since it doesn't, we'll make do with this instead.
 //
 // In DEBUG builds, we'll add a base-delegating override so that it's clear we made an explicit decision
-// to accept the base class's implemention. In RELEASE builds, we'll #if'd these out to avoid the extra metadata and runtime
+// to accept the base class's implementation. In RELEASE builds, we'll #if'd these out to avoid the extra metadata and runtime
 // cost. That way, every overridable member is accounted for (i.e. the codebase should always be kept in a state
 // where hitting "override" + SPACE never brings up additional suggestions in Intellisense.)
 //
@@ -38,6 +38,7 @@ namespace System.Reflection.Runtime.Assemblies
         public sealed override bool IsDynamic => base.IsDynamic;
         public sealed override string ToString() => base.ToString();
         public sealed override string EscapedCodeBase => base.EscapedCodeBase;
+        public sealed override FileStream[] GetFiles() => base.GetFiles();
 #endif //DEBUG
     }
 }


### PR DESCRIPTION
Assembly.GetFiles()
Assembly.GetFiles(bool)
Assembly.GetFile(string)
StrongNameKeyPair..ctor(FileStream)


StrongNameKeyPair.cs is now sharable with CoreClr
but with the mirror bot up and running, I'm going
to defer the actual move to its own commit.
