### PR TITLE
Remove usage of EqualityComparer.GetHashCode in ValueTuple

### DIFF
--- a/src/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -404,7 +404,7 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return EqualityComparer<T1>.Default.GetHashCode(Item1);
+            return Item1?.GetHashCode() ?? 0;
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -601,8 +601,8 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                EqualityComparer<T2>.Default.GetHashCode(Item2));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                Item2?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -806,9 +806,9 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                EqualityComparer<T3>.Default.GetHashCode(Item3));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                Item2?.GetHashCode() ?? 0,
+                                                Item3?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1028,10 +1028,10 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                EqualityComparer<T4>.Default.GetHashCode(Item4));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                Item2?.GetHashCode() ?? 0,
+                                                Item3?.GetHashCode() ?? 0,
+                                                Item4?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1269,11 +1269,11 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                               EqualityComparer<T5>.Default.GetHashCode(Item5));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0,
+                                               Item4?.GetHashCode() ?? 0,
+                                               Item5?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1529,12 +1529,12 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                EqualityComparer<T6>.Default.GetHashCode(Item6));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                Item2?.GetHashCode() ?? 0,
+                                                Item3?.GetHashCode() ?? 0,
+                                                Item4?.GetHashCode() ?? 0,
+                                                Item5?.GetHashCode() ?? 0,
+                                                Item6?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1808,13 +1808,13 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                EqualityComparer<T7>.Default.GetHashCode(Item7));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                Item2?.GetHashCode() ?? 0,
+                                                Item3?.GetHashCode() ?? 0,
+                                                Item4?.GetHashCode() ?? 0,
+                                                Item5?.GetHashCode() ?? 0,
+                                                Item6?.GetHashCode() ?? 0,
+                                                Item7?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -2116,13 +2116,13 @@ namespace System
             IValueTupleInternal rest = Rest as IValueTupleInternal;
             if (rest == null)
             {
-                return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                    EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                    EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                    EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                    EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                    EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                    EqualityComparer<T7>.Default.GetHashCode(Item7));
+                return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                    Item2?.GetHashCode() ?? 0,
+                                                    Item3?.GetHashCode() ?? 0,
+                                                    Item4?.GetHashCode() ?? 0,
+                                                    Item5?.GetHashCode() ?? 0,
+                                                    Item6?.GetHashCode() ?? 0,
+                                                    Item7?.GetHashCode() ?? 0);
             }
 
             int size = rest.Length;
@@ -2133,47 +2133,47 @@ namespace System
             switch (k)
             {
                 case 1:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 2:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 3:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 4:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 5:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 6:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item2?.GetHashCode() ?? 0,
+                                                       Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 7:
                 case 8:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                       EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                       Item2?.GetHashCode() ?? 0,
+                                                       Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corert/issues/2407, now that the PR to recognize enum.GetHashCode went in. I did a regex find-and-replace to call `GetHashCode` directly on each of the items.

/cc @jcouv, @MichalStrehovsky, @jkotas