### PR TITLE
Move Type.cs and Module.cs to Shared Partition.

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -161,6 +161,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MemberInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MethodInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MethodBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\Module.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ObfuscateAssemblyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ObfuscationAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\PropertyInfo.cs" />
@@ -211,6 +212,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeoutException.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneNotFoundException.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\TupleExtensions.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)System\Type.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)System\Type.Enum.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)System\Type.Helpers.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\TypeAccessException.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\TypeCode.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\TypeInitializationException.cs"/>

--- a/src/System.Private.CoreLib/shared/System/Type.Enum.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.Enum.cs
@@ -171,16 +171,16 @@ namespace System
 
         internal static bool IsIntegerType(Type t)
         {
-            return (t == CommonRuntimeTypes.Int32 ||
-                    t == CommonRuntimeTypes.Int16 ||
-                    t == CommonRuntimeTypes.UInt16 ||
-                    t == CommonRuntimeTypes.Byte ||
-                    t == CommonRuntimeTypes.SByte ||
-                    t == CommonRuntimeTypes.UInt32 ||
-                    t == CommonRuntimeTypes.Int64 ||
-                    t == CommonRuntimeTypes.UInt64 ||
-                    t == CommonRuntimeTypes.Char ||
-                    t == CommonRuntimeTypes.Boolean);
+            return (t == typeof(int) ||
+                    t == typeof(short) ||
+                    t == typeof(ushort) ||
+                    t == typeof(byte) ||
+                    t == typeof(sbyte) ||
+                    t == typeof(uint) ||
+                    t == typeof(long) ||
+                    t == typeof(ulong) ||
+                    t == typeof(char) ||
+                    t == typeof(bool));
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Type.Helpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.Helpers.cs
@@ -2,15 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.IO;
 using System.Reflection;
-using System.Globalization;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
-
-using Internal.Reflection.Core.NonPortable;
 
 namespace System
 {
@@ -41,7 +33,7 @@ namespace System
             }
         }
 
-        private Type GetRootElementType()
+        internal Type GetRootElementType()
         {
             Type rootElementType = this;
 
@@ -55,6 +47,12 @@ namespace System
         {
             get
             {
+#if CORECLR
+                RuntimeType rt = this as RuntimeType;
+                if (rt != null)
+                    return RuntimeTypeHandle.IsVisible(rt);
+#endif //CORECLR
+
                 if (IsGenericParameter)
                     return true;
 
@@ -450,7 +448,7 @@ namespace System
         private static bool FilterNameImpl(MemberInfo m, object filterCriteria)
         {
             // Check that the criteria object is a String object
-            if (filterCriteria == null || !(filterCriteria is String))
+            if (filterCriteria == null || !(filterCriteria is string))
                 throw new InvalidFilterCriteriaException(SR.InvalidFilterCriteriaException_CritString);
 
             // At the moment this fails if its done on a single line....

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/ReflectionCoreNonPortable.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/ReflectionCoreNonPortable.cs
@@ -23,12 +23,6 @@ namespace Internal.Reflection.Core.NonPortable
         {
             return RuntimeTypeUnifier.GetTypeForRuntimeTypeHandle(new RuntimeTypeHandle(eeType));
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsRuntimeImplemented(this Type type)
-        {
-            return type is IRuntimeImplementedType;
-        }
     }
 }
 

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -200,7 +200,6 @@
     <Compile Include="System\Reflection\MethodBase.CoreRT.cs" />
     <Compile Include="System\Reflection\MethodBody.cs" />
     <Compile Include="System\Reflection\MethodImplAttributes.cs" />
-    <Compile Include="System\Reflection\Module.cs" />
     <Compile Include="System\Reflection\ModuleResolveEventHandler.cs" />
     <Compile Include="System\Reflection\ParameterAttributes.cs" />
     <Compile Include="System\Reflection\ParameterInfo.cs" />
@@ -596,9 +595,7 @@
     <Compile Include="System\TimeSpan.cs" />
     <Compile Include="System\TimeZoneInfo.cs" />
     <Compile Include="System\Tuple.cs" />
-    <Compile Include="System\Type.cs" />
-    <Compile Include="System\Type.Enum.cs" />
-    <Compile Include="System\Type.Helpers.cs" />
+    <Compile Include="System\Type.CoreRT.cs" />
     <Compile Include="System\Type.Internal.cs" />
     <Compile Condition="'$(TargetsWindows)'=='true' and '$(EnableWinRT)'=='true'" Include="System\Type.WinRt.cs" />
     <Compile Condition="'$(TargetsWindows)'=='true' and '$(EnableWinRT)'!='true'" Include="System\Type.Win32.cs" />

--- a/src/System.Private.CoreLib/src/System/ModuleHandle.cs
+++ b/src/System.Private.CoreLib/src/System/ModuleHandle.cs
@@ -14,7 +14,8 @@ namespace System
 
         internal Module AssociatedModule => _ptr;
 
-        internal ModuleHandle(Module module)
+        // Not an api but has to be public because of the Reflection.Core/CoreLib divide.
+        public ModuleHandle(Module module)
         {
             _ptr = module;
         }

--- a/src/System.Private.CoreLib/src/System/Type.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Type.CoreRT.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Internal.Runtime.Augments;
+using Internal.Reflection.Augments;
+using Internal.Reflection.Core.NonPortable;
+
+namespace System
+{
+    public abstract partial class Type : MemberInfo, IReflect
+    {
+        public bool IsInterface => (GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface;
+        public virtual bool IsSerializable => (GetAttributeFlagsImpl() & TypeAttributes.Serializable) != 0;
+
+        public virtual bool IsMultiDimensionalArray { get { throw NotImplemented.ByDesign; } }
+
+        [Intrinsic]
+        public static Type GetTypeFromHandle(RuntimeTypeHandle handle) => ReflectionCoreNonPortable.GetTypeForRuntimeTypeHandle(handle);
+
+        [Intrinsic]
+        public static Type GetType(string typeName) => GetType(typeName, throwOnError: false, ignoreCase: false);
+        [Intrinsic]
+        public static Type GetType(string typeName, bool throwOnError) => GetType(typeName, throwOnError: throwOnError, ignoreCase: false);
+        [Intrinsic]
+        public static Type GetType(string typeName, bool throwOnError, bool ignoreCase) => GetType(typeName, null, null, throwOnError: throwOnError, ignoreCase: ignoreCase);
+
+        [Intrinsic]
+        public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver) => GetType(typeName, assemblyResolver, typeResolver, throwOnError: false, ignoreCase: false);
+        [Intrinsic]
+        public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError) => GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: false);
+        [Intrinsic]
+        public static Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase) => RuntimeAugments.Callbacks.GetType(typeName, assemblyResolver, typeResolver, throwOnError: throwOnError, ignoreCase: ignoreCase, defaultAssembly: null);
+
+        public static Type GetTypeFromCLSID(Guid clsid, string server, bool throwOnError) => ReflectionAugments.ReflectionCoreCallbacks.GetTypeFromCLSID(clsid, server, throwOnError);
+
+        public static Type GetTypeFromProgID(string progID, string server, bool throwOnError)
+        {
+            if (progID == null)
+                throw new ArgumentNullException(nameof(progID));
+
+            Guid clsid;
+            Exception exception = GetCLSIDFromProgID(progID, out clsid);
+            if (exception != null)
+            {
+                if (throwOnError)
+                    throw exception;
+                return null;
+            }
+            return Type.GetTypeFromCLSID(clsid, server, throwOnError);
+        }
+
+        public static bool operator ==(Type left, Type right)
+        {
+            if (object.ReferenceEquals(left, right))
+                return true;
+
+            if ((object)left == null || (object)right == null)
+                return false;
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Type left, Type right) => !(left == right);
+
+        public static Binder DefaultBinder => s_defaultBinder ?? (s_defaultBinder = ReflectionAugments.ReflectionCoreCallbacks.CreateDefaultBinder());
+        private static volatile Binder s_defaultBinder;
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool IsRuntimeImplemented() => this is IRuntimeImplementedType;
+    }
+}
+

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -126,6 +126,8 @@ namespace System.Reflection.Runtime.Modules
         public sealed override string ResolveString(int metadataToken) { throw new PlatformNotSupportedException(); }
         public sealed override Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
 
+        protected sealed override ModuleHandle GetModuleHandleImpl() => new ModuleHandle(this);
+
         private readonly Assembly _assembly;
     }
 }


### PR DESCRIPTION
Types.cs is split into the main file, Type.Helpers.cs and Type.Enum.cs.
All three will be shared.

- GenericTypeArguments - reconcile with CoreClr
  (the code is identical provided that the underlying
  Type provider implemented IsConstructedGenericType
  correctly. But we can't assume that for third party types.)

- IsInterface and IsSerializable has some CoreClr
  specific logic for RuntimeTypes - moving this out
  to the unshared space for now.

- IsContextFulImpl()/IsMarshalByRefImpl() - corrected
  implemention to match CoreClr.

- IsIntegerType - no CommonRuntimeTypes in CoreClr
  so going back to typeof() checks - the runtime implemented
  types override all this enum code anyway on both runtimes.

- GetRootElementType() - upgraded visibility to "internal"
  as a concession to CoreClr.

- CoreCLR's IsVisible has a fast path - we'll keep that.

- Moved IsRuntimeImplemented() out of Internal.Reflection.Core.NonPortable
  namespace so calls to it can be more easily shared.

- Module.MethodHandle was not implemented correctly for
  non-runtime modules (it's supposed to return default(ModuleHandle)).
  This makes it behave correctly and reconciles Module.cs
  with the CoreCLR version.