### PR TITLE
Fix thread state corruption in EH leading to GC issues on Unix

### DIFF
--- a/src/Native/Runtime/amd64/ExceptionHandling.S
+++ b/src/Native/Runtime/amd64/ExceptionHandling.S
@@ -486,7 +486,7 @@ ALTERNATE_ENTRY RhpCallFinallyFunclet2
         mov     [rax]                            , r15
 
         mov     rax, [rsp + locThread]                               // rax <- Thread*
-   lock or      dword ptr [rax + OFFSETOF__Thread__m_ThreadStateFlags], ~TSF_DoNotTriggerGc
+   lock or      dword ptr [rax + OFFSETOF__Thread__m_ThreadStateFlags], TSF_DoNotTriggerGc
 
         FUNCLET_CALL_EPILOGUE
 


### PR DESCRIPTION
Exception handling code on Unix incorrectly updates the thread state of
the native thread object which causes the thread to be marked as a special
GC thread. As a result, the stack of the thread is not scan for GC roots,
which leads to various random corruptions.