### PR TITLE
Type loader on CoreRT

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -73,7 +73,7 @@ namespace ILCompiler.DependencyAnalysis
             return index;
         }
 
-        public virtual IEnumerable<GenericLookupResult> Entries
+        public virtual ICollection<GenericLookupResult> Entries
         {
             get
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -307,7 +307,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (factory.Target.Abi == TargetAbi.CoreRT)
             {
-                throw new NotImplementedException();
+                return factory.NativeLayout.NotSupportedDictionarySlot;
             }
             else
             {
@@ -363,7 +363,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (factory.Target.Abi == TargetAbi.CoreRT)
             {
-                throw new NotImplementedException();
+                return factory.NativeLayout.NotSupportedDictionarySlot;
             }
             else
             {
@@ -451,7 +451,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override NativeLayoutVertexNode TemplateDictionaryNode(NodeFactory factory)
         {
-            throw new NotImplementedException();
+            return factory.NativeLayout.NotSupportedDictionarySlot;
         }
     }
 
@@ -485,7 +485,14 @@ namespace ILCompiler.DependencyAnalysis
 
         public override NativeLayoutVertexNode TemplateDictionaryNode(NodeFactory factory)
         {
-            return factory.NativeLayout.GcStaticDictionarySlot(_type);
+            if (factory.Target.Abi == TargetAbi.CoreRT)
+            {
+                return factory.NativeLayout.NotSupportedDictionarySlot;
+            }
+            else
+            {
+                return factory.NativeLayout.GcStaticDictionarySlot(_type);
+            }
         }
 
         public override GenericLookupResultReferenceType LookupResultReferenceType(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
@@ -398,6 +398,8 @@ namespace ILCompiler.DependencyAnalysis
                 return _methodDictionary_GenericDictionarySlots.GetOrAdd(method);
             }
 
+            public readonly NativeLayoutNotSupportedDictionarySlotNode NotSupportedDictionarySlot = new NativeLayoutNotSupportedDictionarySlotNode();
+
             private struct MethodEntrypointSlotKey : IEquatable<MethodEntrypointSlotKey>
             {
                 public readonly bool Unboxing;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcDictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcDictionaryLayoutNode.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis
             return index;
         }
 
-        public override IEnumerable<GenericLookupResult> Entries
+        public override ICollection<GenericLookupResult> Entries
         {
             get
             {

--- a/src/ILCompiler/reproNative/reproNative.vcxproj
+++ b/src/ILCompiler/reproNative/reproNative.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>reproNative</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">


### PR DESCRIPTION
* Enable template generation for generic types
* Dictionary slots generated for types / methods cause that type / method to get a type loader template
* Remove the template-specific list of slots and just use the owning type's dictionary layout
* Add not-supported entry for template slots that aren't implemented yet