### PR TITLE
Simple fix for recursive class definitions.

### DIFF
--- a/src/Common/src/TypeSystem/TypesDebugInfoWriter/TypesDebugInfoWriter.cs
+++ b/src/Common/src/TypeSystem/TypesDebugInfoWriter/TypesDebugInfoWriter.cs
@@ -12,9 +12,9 @@ namespace Internal.TypeSystem.TypesDebugInfo
 
         uint GetClassTypeIndex(ClassTypeDescriptor classTypeDescriptor);
 
-        void CompleteClassDescription(ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptior classFieldsTypeDescriptior, DataFieldDescriptor[] fields);
+        uint GetCompleteClassTypeIndex(ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptior classFieldsTypeDescriptior, DataFieldDescriptor[] fields);
 
-        uint GetVariableTypeIndex(TypeDesc type);
+        uint GetVariableTypeIndex(TypeDesc type, bool needsCompleteType);
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -29,7 +29,7 @@
 
             <MicrosoftNetCoreNativePackageVersion>2.0.0-beta-25021-03</MicrosoftNetCoreNativePackageVersion>
 
-            <ObjectWriterPackageVersion>1.0.17-prerelease-00001</ObjectWriterPackageVersion>
+            <ObjectWriterPackageVersion>1.0.17-prerelease-00002</ObjectWriterPackageVersion>
             <ObjectWriterNuPkgRid Condition="'$(OSGroup)'=='Linux'">ubuntu.14.04-x64</ObjectWriterNuPkgRid>
             <ObjectWriterNuPkgRid Condition="'$(ObjectWriterNuPkgRid)'==''">$(NuPkgRid)</ObjectWriterNuPkgRid>
         </PropertyGroup>

--- a/src/packaging/project.json
+++ b/src/packaging/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Jit": "2.0.0-beta-25117-06",
-    "Microsoft.DotNet.ObjectWriter": "1.0.17-prerelease-00001"
+    "Microsoft.DotNet.ObjectWriter": "1.0.17-prerelease-00002"
   },
   "frameworks": {
     "dnxcore50": { }


### PR DESCRIPTION
Clean ubuntu crap in output.
Complete class now returns value that is used in symbol records.
Type records should contain only forward declarations.
Enums have the same forward and complete type index.

Recursive class works better then before, but it still worse then ProjectN.