### PR TITLE
NS2.0 Bring back a bunch of IConvertible methods as methods on type.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Boolean.cs
+++ b/src/System.Private.CoreLib/src/System/Boolean.cs
@@ -91,7 +91,7 @@ namespace System
             return TrueLiteral;
         }
 
-        String IConvertible.ToString(IFormatProvider provider)
+        public String ToString(IFormatProvider provider)
         {
             return ToString();
         }
@@ -120,7 +120,7 @@ namespace System
         // 
         // Returns a value less than zero if this  object
         // 
-        int IComparable.CompareTo(Object obj)
+        public int CompareTo(Object obj)
         {
             if (obj == null)
             {
@@ -247,7 +247,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Boolean;
         }

--- a/src/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/System.Private.CoreLib/src/System/Byte.cs
@@ -40,7 +40,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type byte, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -186,7 +186,7 @@ namespace System
         // IConvertible implementation
         // 
         [Pure]
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Byte;
         }

--- a/src/System.Private.CoreLib/src/System/Char.cs
+++ b/src/System.Private.CoreLib/src/System/Char.cs
@@ -132,7 +132,7 @@ namespace System
         // If object is not of type Char, this method throws an ArgumentException.
         //
         [Pure]
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -161,7 +161,7 @@ namespace System
         }
 
         [Pure]
-        String IConvertible.ToString(IFormatProvider provider)
+        public String ToString(IFormatProvider provider)
         {
             Contract.Ensures(Contract.Result<String>() != null);
             return Char.ToString(m_value);
@@ -457,7 +457,7 @@ namespace System
         // IConvertible implementation
         //    
         [Pure]
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Char;
         }

--- a/src/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/System.Private.CoreLib/src/System/DateTime.cs
@@ -412,7 +412,7 @@ namespace System
         // occurs.  Null is considered less than any instance.
         //
         // Returns a value less than zero if this  object
-        private int CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null) return 1;
             if (!(value is DateTime))
@@ -425,11 +425,6 @@ namespace System
             if (ticks > valueTicks) return 1;
             if (ticks < valueTicks) return -1;
             return 0;
-        }
-
-        int IComparable.CompareTo(Object value)
-        {
-            return this.CompareTo(value);
         }
 
         public int CompareTo(DateTime value)
@@ -1283,7 +1278,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.DateTime;
         }

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -307,7 +307,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type Decimal, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
                 return 1;
@@ -971,7 +971,7 @@ namespace System
         // IConvertible implementation
         //
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Decimal;
         }

--- a/src/System.Private.CoreLib/src/System/Double.cs
+++ b/src/System.Private.CoreLib/src/System/Double.cs
@@ -100,7 +100,7 @@ namespace System
         //
         // Returns a value less than zero if this  object
         //
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -305,7 +305,7 @@ namespace System
         // IConvertible implementation
         //
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Double;
         }

--- a/src/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.cs
@@ -822,13 +822,13 @@ namespace System
             return Format(enumInfo, this, format);
         }
 
-        String IFormattable.ToString(String format, IFormatProvider provider)
+        public String ToString(String format, IFormatProvider provider)
         {
             return ToString(format);
         }
 
         [Obsolete("The provider argument is not used. Please use ToString().")]
-        String IConvertible.ToString(IFormatProvider provider)
+        public String ToString(IFormatProvider provider)
         {
             return ToString();
         }
@@ -1250,7 +1250,7 @@ namespace System
 
 
         #region IConvertible
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             Type enumType = this.GetType();
             Type underlyingType = GetUnderlyingType(enumType);

--- a/src/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/System.Private.CoreLib/src/System/Guid.cs
@@ -1109,7 +1109,7 @@ namespace System
             return 1;
         }
 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -1334,7 +1334,7 @@ namespace System
 
         // IFormattable interface
         // We currently ignore provider
-        private String ToString(String format, IFormatProvider provider)
+        public String ToString(String format, IFormatProvider provider)
         {
             if (format == null || format.Length == 0)
                 format = "D";
@@ -1452,11 +1452,6 @@ namespace System
                 }
             }
             return guidString;
-        }
-
-        String IFormattable.ToString(String format, IFormatProvider provider)
-        {
-            return this.ToString(format, provider);
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/System.Private.CoreLib/src/System/Int16.cs
@@ -33,7 +33,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type Int16, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -189,7 +189,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Int16;
         }

--- a/src/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/System.Private.CoreLib/src/System/Int32.cs
@@ -42,7 +42,7 @@ namespace System
         // null is considered to be less than any instance, hence returns positive number
         // If object is not of type Int32, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -179,7 +179,7 @@ namespace System
         // 
 
         [Pure]
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Int32;
         }

--- a/src/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/System.Private.CoreLib/src/System/Int64.cs
@@ -33,7 +33,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type Int64, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -147,7 +147,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Int64;
         }

--- a/src/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/System.Private.CoreLib/src/System/SByte.cs
@@ -28,7 +28,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type SByte, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object obj)
+        public int CompareTo(Object obj)
         {
             if (obj == null)
             {
@@ -190,7 +190,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.SByte;
         }

--- a/src/System.Private.CoreLib/src/System/Single.cs
+++ b/src/System.Private.CoreLib/src/System/Single.cs
@@ -64,7 +64,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type Single, this method throws an ArgumentException.
         //
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -260,7 +260,7 @@ namespace System
         // IConvertible implementation
         //
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.Single;
         }

--- a/src/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -664,7 +664,7 @@ namespace System
         // if this is equal to value, or a value greater than 0 if this is greater than value.
         //
 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {

--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -480,7 +480,7 @@ namespace System
         }
 
         // Returns this string.
-        String IConvertible.ToString(IFormatProvider provider)
+        public String ToString(IFormatProvider provider)
         {
             return this;
         }
@@ -591,7 +591,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.String;
         }

--- a/src/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -178,7 +178,7 @@ namespace System
         }
 
         // Returns a value less than zero if this  object
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null) return 1;
             if (!(value is TimeSpan))

--- a/src/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/System.Private.CoreLib/src/System/UInt16.cs
@@ -35,7 +35,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type UInt16, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -166,7 +166,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.UInt16;
         }

--- a/src/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/System.Private.CoreLib/src/System/UInt32.cs
@@ -36,7 +36,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type UInt32, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -170,7 +170,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.UInt32;
         }

--- a/src/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/System.Private.CoreLib/src/System/UInt64.cs
@@ -34,7 +34,7 @@ namespace System
         // null is considered to be less than any instance.
         // If object is not of type UInt64, this method throws an ArgumentException.
         // 
-        int IComparable.CompareTo(Object value)
+        public int CompareTo(Object value)
         {
             if (value == null)
             {
@@ -149,7 +149,7 @@ namespace System
         // IConvertible implementation
         // 
 
-        TypeCode IConvertible.GetTypeCode()
+        public TypeCode GetTypeCode()
         {
             return TypeCode.UInt64;
         }

--- a/src/System.Private.CoreLib/src/System/Version.cs
+++ b/src/System.Private.CoreLib/src/System/Version.cs
@@ -83,6 +83,12 @@ namespace System
             _Revision = v.Revision;
         }
 
+        public Version()
+        {
+            _Major = 0;
+            _Minor = 0;
+        }
+
         private Version(Version version)
         {
             Debug.Assert(version != null);
@@ -129,7 +135,7 @@ namespace System
             get { return (short)(_Revision & 0xFFFF); }
         }
 
-        int IComparable.CompareTo(Object version)
+        public int CompareTo(Object version)
         {
             if (version == null)
             {


### PR DESCRIPTION
Gets rid of a lot of apicompat noise.

Hope people enjoy knowing that Int32.GetTypeCode() == Int32
and losing any useful compiler type checking
on CompareTo() parameers.