### PR TITLE
Update CoreCLR.issues.targets

### DIFF
--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -1096,6 +1096,10 @@
     <!-- NetStandard2: System.Type.GetInterfaceMap -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M01\b12425\b12425\b12425.*" />
 
+    <!-- NetStandard2: System.TypedReference in the System.Runtime facade -->
+    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgstress2\_il_dbgstress2.*" />
+    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relstress2\_il_relstress2.*" />
+
     <!-- NetStandard2: PlatformID enum -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgformat\_il_dbgformat.*" />
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbglongsig\_il_dbglongsig.*" />


### PR DESCRIPTION
My previous change errorneously marked these two tests as working
because I had a local hack in place that made TypeRefs to
`TypedReference` always resolve to CoreLib (makes testing possible
without fighting the build system too hard).

Turns out these two tests import `TypedReference` from System.Runtime.
Our System.Runtime doesn't have a forward for that yet.

@dotnet-bot skip ci please