### PR TITLE
Delete ContainsGenericVariables

### DIFF
--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -141,13 +141,6 @@ namespace Internal.TypeSystem
         {
             TypeFlags flags = _rank == -1 ? TypeFlags.SzArray : TypeFlags.Array;
 
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-                if (this.ParameterType.ContainsGenericVariables)
-                    flags |= TypeFlags.ContainsGenericVariables;
-            }
-
             flags |= TypeFlags.HasGenericVarianceComputed;
 
             return flags;

--- a/src/Common/src/TypeSystem/Common/ByRefType.cs
+++ b/src/Common/src/TypeSystem/Common/ByRefType.cs
@@ -33,13 +33,6 @@ namespace Internal.TypeSystem
         {
             TypeFlags flags = TypeFlags.ByRef;
 
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-                if (this.ParameterType.ContainsGenericVariables)
-                    flags |= TypeFlags.ContainsGenericVariables;
-            }
-
             flags |= TypeFlags.HasGenericVarianceComputed;
 
             return flags;

--- a/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
+++ b/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
@@ -63,25 +63,6 @@ namespace Internal.TypeSystem
         {
             TypeFlags flags = TypeFlags.FunctionPointer;
 
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-
-                if (_signature.ReturnType.ContainsGenericVariables)
-                    flags |= TypeFlags.ContainsGenericVariables;
-                else
-                {
-                    for (int i = 0; i < _signature.Length; i++)
-                    {
-                        if (_signature[i].ContainsGenericVariables)
-                        {
-                            flags |= TypeFlags.ContainsGenericVariables;
-                            break;
-                        }
-                    }
-                }
-            }
-
             flags |= TypeFlags.HasGenericVarianceComputed;
 
             return flags;

--- a/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
+++ b/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
@@ -160,8 +160,6 @@ namespace Internal.TypeSystem
         {
             TypeFlags flags = 0;
 
-            flags |= TypeFlags.ContainsGenericVariablesComputed | TypeFlags.ContainsGenericVariables;
-
             flags |= TypeFlags.GenericParameter;
 
             flags |= TypeFlags.HasGenericVarianceComputed;

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -83,20 +83,6 @@ namespace Internal.TypeSystem
         {
             TypeFlags flags = 0;
 
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-
-                for (int i = 0; i < _instantiation.Length; i++)
-                {
-                    if (_instantiation[i].ContainsGenericVariables)
-                    {
-                        flags |= TypeFlags.ContainsGenericVariables;
-                        break;
-                    }
-                }
-            }
-
             if ((mask & TypeFlags.CategoryMask) != 0)
             {
                 flags |= _typeDef.Category;

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -313,26 +313,6 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Gets a value indicating whether the method's <see cref="Instantiation"/>
-        /// contains any generic variables.
-        /// </summary>
-        public bool ContainsGenericVariables
-        {
-            get
-            {
-                // TODO: Cache?
-
-                Instantiation instantiation = this.Instantiation;
-                for (int i = 0; i < instantiation.Length; i++)
-                {
-                    if (instantiation[i].ContainsGenericVariables)
-                        return true;
-                }
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Gets a value indicating whether this method is an instance constructor.
         /// </summary>
         public bool IsConstructor

--- a/src/Common/src/TypeSystem/Common/PointerType.cs
+++ b/src/Common/src/TypeSystem/Common/PointerType.cs
@@ -33,13 +33,6 @@ namespace Internal.TypeSystem
         {
             TypeFlags flags = TypeFlags.Pointer;
 
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-                if (this.ParameterType.ContainsGenericVariables)
-                    flags |= TypeFlags.ContainsGenericVariables;
-            }
-
             flags |= TypeFlags.HasGenericVarianceComputed;
 
             return flags;

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -413,14 +413,6 @@ namespace Internal.TypeSystem
             }
         }
 
-        public bool ContainsGenericVariables
-        {
-            get
-            {
-                return (GetTypeFlags(TypeFlags.ContainsGenericVariables | TypeFlags.ContainsGenericVariablesComputed) & TypeFlags.ContainsGenericVariables) != 0;
-            }
-        }
-
         /// <summary>
         /// Gets the type from which this type derives from, or null if there's no such type.
         /// </summary>

--- a/src/Common/src/TypeSystem/Common/TypeFlags.cs
+++ b/src/Common/src/TypeSystem/Common/TypeFlags.cs
@@ -48,13 +48,10 @@ namespace Internal.TypeSystem
         SignatureTypeVariable   = 0x1D,
         SignatureMethodVariable = 0x1E,
 
-        ContainsGenericVariables         = 0x100,
-        ContainsGenericVariablesComputed = 0x200,
+        HasGenericVariance         = 0x100,
+        HasGenericVarianceComputed = 0x200,
 
-        HasGenericVariance         = 0x400,
-        HasGenericVarianceComputed = 0x800,
-
-        HasStaticConstructor         = 0x1000,
-        HasStaticConstructorComputed = 0x2000,
+        HasStaticConstructor         = 0x400,
+        HasStaticConstructorComputed = 0x800,
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -194,15 +194,6 @@ namespace Internal.TypeSystem.Ecma
         {
             TypeFlags flags = 0;
 
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-
-                // TODO: Do we really want to get the instantiation to figure out whether the type is generic?
-                if (this.HasInstantiation)
-                    flags |= TypeFlags.ContainsGenericVariables;
-            }
-
             if ((mask & TypeFlags.CategoryMask) != 0)
             {
                 TypeDesc baseType = this.BaseType;

--- a/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
@@ -260,10 +260,6 @@ namespace Internal.TypeSystem.Interop
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = 0;
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-            }
 
             if ((mask & TypeFlags.HasGenericVarianceComputed) != 0)
             {

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
@@ -234,15 +234,6 @@ namespace Internal.TypeSystem.NativeFormat
         {
             TypeFlags flags = 0;
 
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-
-                // TODO: Do we really want to get the instantiation to figure out whether the type is generic?
-                if (this.HasInstantiation)
-                    flags |= TypeFlags.ContainsGenericVariables;
-            }
-
             if ((mask & TypeFlags.CategoryMask) != 0 && (flags & TypeFlags.CategoryMask) == 0)
             {
                 TypeDesc baseType = this.BaseType;

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedType.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedType.cs
@@ -75,7 +75,6 @@ namespace ILCompiler
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
             return TypeFlags.Class |
-                TypeFlags.ContainsGenericVariablesComputed |
                 TypeFlags.HasGenericVarianceComputed |
                 TypeFlags.HasStaticConstructorComputed;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -257,11 +257,6 @@ namespace ILCompiler
             {
                 TypeFlags flags = 0;
 
-                if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-                {
-                    flags |= TypeFlags.ContainsGenericVariablesComputed;
-                }
-
                 if ((mask & TypeFlags.HasGenericVarianceComputed) != 0)
                 {
                     flags |= TypeFlags.HasGenericVarianceComputed;

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeNoMetadataType.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeNoMetadataType.cs
@@ -130,20 +130,6 @@ namespace Internal.TypeSystem.NoMetadata
         {
             TypeFlags flags = 0;
 
-            if ((mask & TypeFlags.ContainsGenericVariablesComputed) != 0)
-            {
-                flags |= TypeFlags.ContainsGenericVariablesComputed;
-
-                for (int i = 0; i < _instantiation.Length; i++)
-                {
-                    if (_instantiation[i].ContainsGenericVariables)
-                    {
-                        flags |= TypeFlags.ContainsGenericVariables;
-                        break;
-                    }
-                }
-            }
-
             if ((mask & TypeFlags.CategoryMask) != 0)
             {
                 unsafe


### PR DESCRIPTION
This is not used anywhere, and whenever I saw peoeple using it in the
past, it was for the wrong reason (people tend to use it as a more
expensive version of `IsGenericDefinition`). We don't really instantiate
things over generic parameters anywhere. Better to just delete this and
free up some flags.