### PR TITLE
VirtualInvokeMap Table

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -48,6 +48,8 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (method.OwningType.IsValueType && !method.Signature.IsStatic && !skipUnboxingStubDependency)
                     dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(method, unboxingStub: true), "Reflection unboxing stub"));
+
+                dependencies.AddRange(ReflectionVirtualInvokeMapNode.GetVirtualInvokeMapDependencies(factory, method));
             }
 
             if (method.HasInstantiation)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -114,7 +114,7 @@ namespace ILCompiler.DependencyAnalysis
                 // Add a dependency on the template for this type, if the canonical type should be generated into this binary.
                 DefType templateType = GenericTypesTemplateMap.GetActualTemplateTypeForType(factory, _type.ConvertToCanonForm(CanonicalFormKind.Specific));
 
-                if (!factory.NecessaryTypeSymbol(templateType).RepresentsIndirectionCell)
+                if (templateType.IsCanonicalSubtype(CanonicalFormKind.Any) && !factory.NecessaryTypeSymbol(templateType).RepresentsIndirectionCell)
                     dependencyList.Add(factory.NativeLayout.TemplateTypeLayout(templateType), "Template Type Layout");
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -408,7 +408,8 @@ namespace ILCompiler.DependencyAnalysis
             if (declType.HasGenericDictionarySlot())
             {
                 // Note: Canonical type instantiations always have a generic dictionary vtable slot, but it's empty
-                if (declType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                // TODO: emit the correction dictionary slot for interfaces (needed when we start supporting static methods on interfaces)
+                if (declType.IsInterface || declType.IsCanonicalSubtype(CanonicalFormKind.Any))
                     objData.EmitZeroPointer();
                 else
                     objData.EmitPointerReloc(factory.TypeGenericDictionary(declType));

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -22,6 +22,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private MethodDesc _method;
 
+        public MethodDesc Method => _method;
+
         public GVMDependenciesNode(MethodDesc method)
         {
             Debug.Assert(!method.IsRuntimeDeterminedExactMethod);
@@ -36,6 +38,29 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
+            // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
+            // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
+            // we even start the compilation process (with the invocation stubs being compilation roots like any other).
+            // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
+            if (context.MetadataManager.IsReflectionInvokable(_method) && _method.IsAbstract)
+            {
+                List<DependencyListEntry> dependencies = new List<DependencyListEntry>();
+
+                if (context.MetadataManager.HasReflectionInvokeStubForInvokableMethod(_method) && !_method.IsCanonicalMethod(CanonicalFormKind.Any))
+                {
+                    MethodDesc invokeStub = context.MetadataManager.GetReflectionInvokeStub(_method);
+                    MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                    if (invokeStub != canonInvokeStub)
+                        dependencies.Add(new DependencyListEntry(context.FatFunctionPointer(invokeStub), "Reflection invoke"));
+                    else
+                        dependencies.Add(new DependencyListEntry(context.MethodEntrypoint(invokeStub), "Reflection invoke"));
+                }
+
+                dependencies.AddRange(ReflectionVirtualInvokeMapNode.GetVirtualInvokeMapDependencies(context, _method));
+
+                return dependencies;
+            }
+
             return Array.Empty<DependencyListEntry>();
         }
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -87,7 +87,7 @@ namespace ILCompiler.DependencyAnalysis
                     if (implMethod != null)
                     {
                         builder.EmitShort(checked((short)interfaceIndex));
-                        builder.EmitShort(checked((short)interfaceMethodSlot));
+                        builder.EmitShort(checked((short)(interfaceMethodSlot + (interfaceType.HasGenericDictionarySlot() ? 1 : 0))));
                         builder.EmitShort(checked((short)VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, implMethod)));
                         entryCount++;
                     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -779,7 +779,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
-
             foreach (TypeDesc iface in _type.RuntimeInterfaces)
             {
                 yield return new DependencyListEntry(context.NativeLayout.TypeSignatureVertex(iface), "template interface list");
@@ -805,7 +804,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            if (_type.BaseType.IsRuntimeDeterminedSubtype)
+            if (_type.BaseType != null && _type.BaseType.IsRuntimeDeterminedSubtype)
             {
                 yield return new DependencyListEntry(context.NativeLayout.PlacedSignatureVertex(context.NativeLayout.TypeSignatureVertex(_type.BaseType)), "template base type");
             }
@@ -1014,7 +1013,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            if (_type.BaseType.IsRuntimeDeterminedSubtype)
+            if (_type.BaseType != null && _type.BaseType.IsRuntimeDeterminedSubtype)
             {
                 layoutInfo.Append(BagElementKind.BaseType, factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.TypeSignatureVertex(_type.BaseType)).WriteVertex(factory));
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -84,7 +84,8 @@ namespace ILCompiler.DependencyAnalysis
                 if (method.IsDefaultConstructor)
                     flags |= InvokeTableFlags.IsDefaultConstructor;
 
-                // TODO: HasVirtualInvoke
+                if (ReflectionVirtualInvokeMapNode.NeedsVirtualInvokeInfo(method))
+                    flags |= InvokeTableFlags.HasVirtualInvoke;
 
                 if (!method.IsAbstract)
                     flags |= InvokeTableFlags.HasEntrypoint;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
@@ -1,0 +1,224 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.NativeFormat;
+
+using VirtualInvokeTableEntry = Internal.Runtime.VirtualInvokeTableEntry;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a map containing the necessary information needed to resolve 
+    /// a virtual method target called through reflection.
+    /// </summary>
+    internal sealed class ReflectionVirtualInvokeMapNode : ObjectNode, ISymbolNode
+    {
+        private ObjectAndOffsetSymbolNode _endSymbol;
+        private ExternalReferencesTableNode _externalReferences;
+
+        public ReflectionVirtualInvokeMapNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__VirtualInvokeMap_End", true);
+            _externalReferences = externalReferences;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__VirtualInvokeMap");
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+        public int Offset => 0;
+        public override bool IsShareable => false;
+        public override ObjectNodeSection Section => _externalReferences.Section;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        public static bool NeedsVirtualInvokeInfo(MethodDesc method)
+        {
+            if (!method.IsVirtual)
+                return false;
+
+            if (method.OwningType.IsInterface)
+                return true;
+
+            if (method.IsFinal)
+                return false;
+
+            if (method.OwningType.IsSealed())
+                return false;
+
+            return true;
+        }
+
+        public static IEnumerable<DependencyListEntry> GetVirtualInvokeMapDependencies(NodeFactory factory, MethodDesc method)
+        {
+            if (NeedsVirtualInvokeInfo(method))
+            {
+                if (factory.Target.Abi == TargetAbi.ProjectN)
+                {
+                    yield return new DependencyListEntry(
+                        factory.NecessaryTypeSymbol(method.OwningType.GetTypeDefinition()),
+                        "Reflection virtual invoke owning type");
+                }
+                else
+                {
+                    yield return new DependencyListEntry(
+                        factory.NecessaryTypeSymbol(method.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific)),
+                        "Reflection virtual invoke owning type");
+                }
+
+                NativeLayoutMethodNameAndSignatureVertexNode nameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(method.GetTypicalMethodDefinition());
+                NativeLayoutPlacedSignatureVertexNode placedNameAndSig = factory.NativeLayout.PlacedSignatureVertex(nameAndSig);
+                yield return new DependencyListEntry(placedNameAndSig, "Reflection virtual invoke method signature");
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolNode[] { this });
+
+            // Ensure the native layout blob has been saved
+            factory.MetadataManager.NativeLayoutInfo.SaveNativeLayoutInfoWriter(factory);
+
+            var writer = new NativeWriter();
+            var typeMapHashTable = new VertexHashtable();
+
+            Section hashTableSection = writer.NewSection();
+            hashTableSection.Place(typeMapHashTable);
+
+            Dictionary<int, HashSet<TypeDesc>> methodsEmitted = new Dictionary<int, HashSet<TypeDesc>>();
+
+            // Get a list of all methods that have a method body and metadata from the metadata manager.
+            foreach (var mappingEntry in factory.MetadataManager.GetMethodMapping(factory))
+            {
+                MethodDesc method = mappingEntry.Entity;
+
+                // The current format requires us to have an EEType for the owning type. We might want to lift this.
+                if (!factory.MetadataManager.TypeGeneratesEEType(method.OwningType))
+                    continue;
+
+                // We have a method body, we have a metadata token, but we can't get an invoke stub. Bail.
+                if (!factory.MetadataManager.IsReflectionInvokable(method))
+                    continue;
+
+                // Only virtual methods are interesting
+                if (!NeedsVirtualInvokeInfo(method))
+                    continue;
+
+                //
+                // When working with the ProjectN ABI, the entries in the map are based on the definition types. All
+                // instantiations of these definition types will have the same vtable method entries.
+                // On CoreRT, the vtable entries for each instantiated type might not necessarily exist.
+                // Example 1: 
+                //      If there's a call to Foo<string>.Method1 and a call to Foo<int>.Method2, Foo<string> will
+                //      not have Method2 in its vtable and Foo<int> will not have Method1.
+                // Example 2:
+                //      If there's a call to Foo<string>.Method1 and a call to Foo<object>.Method2, given that both
+                //      of these instantiations share the same canonical form, Foo<__Canon> will have both method 
+                //      entries, and therefore Foo<string> and Foo<object> will have both entries too.
+                // For this reason, the entries that we write to the map in CoreRT will be based on the canonical form
+                // of the method's containing type instead of the open type definition.
+                //
+                // Similarly, given that we use the open type definition for ProjectN, the slot numbers ignore dictionary
+                // entries in the vtable, and computing the correct slot number in the presence of dictionary entries is 
+                // done at runtime. When working with the CoreRT ABI, the correct slot numbers will be written to the map,
+                // and no adjustments will be performed at runtime.
+                //
+
+                TypeDesc containingTypeKey;
+
+                if (factory.Target.Abi == TargetAbi.ProjectN)
+                    containingTypeKey = method.OwningType.GetTypeDefinition();
+                else
+                    containingTypeKey = method.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
+
+                HashSet<TypeDesc> cache;
+                if (!methodsEmitted.TryGetValue(mappingEntry.MetadataHandle, out cache))
+                    methodsEmitted[mappingEntry.MetadataHandle] = cache = new HashSet<TypeDesc>();
+
+                // Only one record is needed for any instantiation.
+                if (!cache.Add(containingTypeKey))
+                    continue;
+
+                // Grammar of an entry in the hash table:
+                // Virtual Method uses a normal slot 
+                // TypeKey + NameAndSig metadata offset into the native layout metadata + (NumberOfStepsUpParentHierarchyToType << 1) + slot
+                // OR
+                // Generic Virtual Method 
+                // TypeKey + NameAndSig metadata offset into the native layout metadata + (NumberOfStepsUpParentHierarchyToType << 1 + 1)
+
+                MethodDesc declaringMethodForSlot = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method.GetTypicalMethodDefinition());
+                uint parentHierarchyDistance = 0;
+                TypeDesc typeOfDeclaringMethodForSlot = declaringMethodForSlot.OwningType.GetTypeDefinition();
+                TypeDesc currentType = method.OwningType.GetTypeDefinition();
+
+                while (typeOfDeclaringMethodForSlot != currentType)
+                {
+                    parentHierarchyDistance++;
+                    currentType = currentType.BaseType.GetTypeDefinition();
+                }
+
+                Vertex vertex = null;
+
+                ISymbolNode containingTypeKeyNode = factory.NecessaryTypeSymbol(containingTypeKey);
+                NativeLayoutMethodNameAndSignatureVertexNode nameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(method.GetTypicalMethodDefinition());
+                NativeLayoutPlacedSignatureVertexNode placedNameAndSig = factory.NativeLayout.PlacedSignatureVertex(nameAndSig);
+
+                if (method.HasInstantiation)
+                {
+                    vertex = writer.GetTuple(
+                        writer.GetUnsignedConstant(_externalReferences.GetIndex(containingTypeKeyNode)),
+                        writer.GetUnsignedConstant((uint)placedNameAndSig.SavedVertex.VertexOffset),
+                        writer.GetUnsignedConstant((parentHierarchyDistance << 1) + VirtualInvokeTableEntry.GenericVirtualMethod));
+                }
+                else
+                {
+                    // Get the declaring method for slot on the instantiated declaring type
+                    if (method.OwningType.HasInstantiation)
+                    {
+                        TypeDesc containingTypeOfDeclaringMethodForSlot = method.OwningType;
+                        for (int i = 0; i < parentHierarchyDistance; i++)
+                            containingTypeOfDeclaringMethodForSlot = containingTypeOfDeclaringMethodForSlot.BaseType;
+                        declaringMethodForSlot = containingTypeOfDeclaringMethodForSlot.GetMethod(declaringMethodForSlot.Name, declaringMethodForSlot.Signature);
+                    }
+
+                    int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, declaringMethodForSlot, factory.Target.Abi != TargetAbi.ProjectN);
+
+                    if (slot == -1)
+                    {
+                        // This method doesn't have a slot. (At this time, this is only done for the Object.Finalize method)
+                        Debug.Assert(declaringMethodForSlot.Name == "Finalize");
+                        continue;
+                    }
+
+                    vertex = writer.GetTuple(
+                        writer.GetUnsignedConstant(_externalReferences.GetIndex(containingTypeKeyNode)),
+                        writer.GetUnsignedConstant((uint)placedNameAndSig.SavedVertex.VertexOffset));
+
+                    vertex = writer.GetTuple(vertex,
+                        writer.GetUnsignedConstant(parentHierarchyDistance << 1),
+                        writer.GetUnsignedConstant((uint)slot));
+                }
+
+                int hashCode = containingTypeKey.GetHashCode();
+                typeMapHashTable.Append((uint)hashCode, hashTableSection.Place(vertex));
+            }
+
+            byte[] hashTableBytes = writer.Save();
+
+            _endSymbol.SetSymbolOffset(hashTableBytes.Length);
+
+            return new ObjectData(hashTableBytes, Array.Empty<Relocation>(), 1, new ISymbolNode[] { this, _endSymbol });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -129,6 +129,9 @@ namespace ILCompiler
             var staticsInfoHashtableNode = new StaticsInfoHashtableNode(nativeReferencesTableNode, nativeStaticsTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.StaticsInfoHashtable), staticsInfoHashtableNode, staticsInfoHashtableNode, staticsInfoHashtableNode.EndSymbol);
 
+            var virtualInvokeMapNode = new ReflectionVirtualInvokeMapNode(commonFixupsTableNode);
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.VirtualInvokeMap), virtualInvokeMapNode, virtualInvokeMapNode, virtualInvokeMapNode.EndSymbol);
+
             // The external references tables should go last
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.CommonFixupsTable), commonFixupsTableNode, commonFixupsTableNode, commonFixupsTableNode.EndSymbol);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.NativeReferences), nativeReferencesTableNode, nativeReferencesTableNode, nativeReferencesTableNode.EndSymbol);
@@ -182,6 +185,19 @@ namespace ILCompiler
             if (dictionaryNode != null)
             {
                 _genericDictionariesGenerated.Add(dictionaryNode);
+            }
+
+            var virtualMethodUseNode = obj as VirtualMethodUseNode;
+            if (virtualMethodUseNode != null && virtualMethodUseNode.Method.IsAbstract)
+            {
+                AddGeneratedMethod(virtualMethodUseNode.Method);
+                return;
+            }
+
+            var gvmDependenciesNode = obj as GVMDependenciesNode;
+            if(gvmDependenciesNode != null && gvmDependenciesNode.Method.IsAbstract)
+            {
+                AddGeneratedMethod(gvmDependenciesNode.Method);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
@@ -16,15 +16,15 @@ namespace ILCompiler
         /// Given a virtual method decl, return its VTable slot if the method is used on its containing type.
         /// Return -1 if the virtual method is not used.
         /// </summary>
-        public static int GetVirtualMethodSlot(NodeFactory factory, MethodDesc method)
+        public static int GetVirtualMethodSlot(NodeFactory factory, MethodDesc method, bool countDictionarySlots = true)
         {
             // TODO: More efficient lookup of the slot
             TypeDesc owningType = method.OwningType;
-            int baseSlots = GetNumberOfBaseSlots(factory, owningType);
+            int baseSlots = GetNumberOfBaseSlots(factory, owningType, countDictionarySlots);
 
             // For types that have a generic dictionary, the introduced virtual method slots are
             // prefixed with a pointer to the generic dictionary.
-            if (owningType.HasGenericDictionarySlot())
+            if (owningType.HasGenericDictionarySlot() && countDictionarySlots)
                 baseSlots++;
 
             IReadOnlyList<MethodDesc> virtualSlots = factory.VTable(owningType).Slots;
@@ -41,7 +41,7 @@ namespace ILCompiler
             return methodSlot == -1 ? -1 : baseSlots + methodSlot;
         }
 
-        private static int GetNumberOfBaseSlots(NodeFactory factory, TypeDesc owningType)
+        private static int GetNumberOfBaseSlots(NodeFactory factory, TypeDesc owningType, bool countDictionarySlots)
         {
             int baseSlots = 0;
             TypeDesc baseType = owningType.BaseType;
@@ -56,7 +56,7 @@ namespace ILCompiler
 
                 // For types that have a generic dictionary, the introduced virtual method slots are
                 // prefixed with a pointer to the generic dictionary.
-                if (baseType.HasGenericDictionarySlot())
+                if (baseType.HasGenericDictionarySlot() && countDictionarySlots)
                     baseSlots++;
 
                 IReadOnlyList<MethodDesc> baseVirtualSlots = factory.VTable(baseType).Slots;
@@ -74,7 +74,7 @@ namespace ILCompiler
         public static int GetGenericDictionarySlot(NodeFactory factory, TypeDesc type)
         {
             Debug.Assert(type.HasGenericDictionarySlot());
-            return GetNumberOfBaseSlots(factory, type);
+            return GetNumberOfBaseSlots(factory, type, countDictionarySlots: true);
         }
 
         /// <summary>
@@ -83,7 +83,13 @@ namespace ILCompiler
         /// </summary>
         public static bool HasGenericDictionarySlot(this TypeDesc type)
         {
-            return !type.IsInterface && type.HasInstantiation &&
+            // Dictionary slots on generic interfaces are necessary to support static methods on interfaces
+            // The reason behind making this unconditional is simplicity, and keeping method slot indices for methods on IFoo<int> 
+            // and IFoo<string> identical. That won't change.
+            if (type.IsInterface)
+                return type.HasInstantiation;
+
+            return type.HasInstantiation &&
                 (type.ConvertToCanonForm(CanonicalFormKind.Specific) != type || type.IsCanonicalSubtype(CanonicalFormKind.Any));
         }
     }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Compiler\DependencyAnalysis\HelperEntrypoint.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IndirectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionInvokeMapNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReflectionVirtualInvokeMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeDeterminedMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ShadowConcreteMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericDictionaryNode.cs" />
@@ -233,7 +234,7 @@
     <Compile Include="Compiler\MemoryHelper.cs" />
     <Compile Include="Compiler\CompilerGeneratedMetadataManager.cs" />
     <Compile Include="Compiler\MetadataManager.cs" />
-	<Compile Include="Compiler\InteropStubManager.cs" />
+    <Compile Include="Compiler\InteropStubManager.cs" />
     <Compile Include="Compiler\MethodExtensions.cs" />
     <Compile Include="Compiler\MultiFileCompilationModuleGroup.cs" />
     <Compile Include="Compiler\NameMangler.cs" />

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -613,6 +613,8 @@ class Program
 
     class TestReflectionInvoke
     {
+        static int s_NumErrors = 0;
+
         struct Foo<T>
         {
             public int Value;
@@ -622,6 +624,60 @@ class Program
             {
                 Value = value;
                 return check != null && typeof(T) == typeof(U);
+            }
+        }
+
+        public interface IFace<T>
+        {
+            string IFaceMethod1(T t);
+            string IFaceGVMethod1<U>(T t, U u);
+        }
+
+        public class BaseClass<T> : IFace<T>
+        {
+            public virtual string Method1(T t) { return "BaseClass.Method1"; }
+            public virtual string Method2(T t) { return "BaseClass.Method2"; }
+            public virtual string Method3(T t) { return "BaseClass.Method3"; }
+            public virtual string Method4(T t) { return "BaseClass.Method4"; }
+            public virtual string GVMethod1<U>(T t, U u) { return "BaseClass.GVMethod1"; }
+            public virtual string GVMethod2<U>(T t, U u) { return "BaseClass.GVMethod2"; }
+            public virtual string GVMethod3<U>(T t, U u) { return "BaseClass.GVMethod3"; }
+            public virtual string GVMethod4<U>(T t, U u) { return "BaseClass.GVMethod4"; }
+
+            public virtual string IFaceMethod1(T t) { return "BaseClass.IFaceMethod1"; }
+            public virtual string IFaceGVMethod1<U>(T t, U u) { return "BaseClass.IFaceGVMethod1"; }
+        }
+
+        public class DerivedClass1<T> : BaseClass<T>, IFace<T>
+        {
+            public override sealed string Method1(T t) { return "DerivedClass1.Method1"; }
+            public override string Method2(T t) { return "DerivedClass1.Method2"; }
+            public new virtual string Method3(T t) { return "DerivedClass1.Method3"; }
+            public override sealed string GVMethod1<U>(T t, U u) { return "DerivedClass1.GVMethod1"; }
+            public override string GVMethod2<U>(T t, U u) { return "DerivedClass1.GVMethod2"; }
+            public new virtual string GVMethod3<U>(T t, U u) { return "DerivedClass1.GVMethod3"; }
+
+            public override string IFaceMethod1(T t) { return "DerivedClass1.IFaceMethod1"; }
+        }
+
+        public class DerivedClass2<T> : DerivedClass1<T>, IFace<T>
+        {
+            public override string Method3(T t) { return "DerivedClass2.Method3"; }
+            public override string Method4(T t) { return "DerivedClass2.Method4"; }
+            public override string GVMethod3<U>(T t, U u) { return "DerivedClass2.GVMethod3"; }
+            public override string GVMethod4<U>(T t, U u) { return "DerivedClass2.GVMethod4"; }
+
+            string IFace<T>.IFaceMethod1(T t) { return "DerivedClass2.IFaceMethod1"; }
+            public override string IFaceGVMethod1<U>(T t, U u) { return "DerivedClass2.IFaceGVMethod1"; }
+        }
+
+        private static void Verify<T>(T expected, T actual)
+        {
+            if (!actual.Equals(expected))
+            {
+                Console.WriteLine("ACTUAL   : " + actual);
+                Console.WriteLine("EXPECTED : " + expected);
+                s_NumErrors++;
             }
         }
 
@@ -639,22 +695,141 @@ class Program
             {
                 MethodInfo mi = typeof(Foo<string>).GetTypeInfo().GetDeclaredMethod("SetAndCheck").MakeGenericMethod(typeof(string));
                 if (!(bool)mi.Invoke(o, new object[] { 123, "hello" }))
-                    throw new Exception();
+                    s_NumErrors++;
 
                 var foo = (Foo<string>)o;
                 if (foo.Value != 123)
-                    throw new Exception();
+                    s_NumErrors++;
 
                 if ((bool)mi.Invoke(o, new object[] { 123, null }))
-                    throw new Exception();
+                    s_NumErrors++;
             }
 
             // Uncomment when we have the type loader to buld invoke stub dictionaries.
             /*{
                 MethodInfo mi = typeof(Foo<string>).GetTypeInfo().GetDeclaredMethod("SetAndCheck").MakeGenericMethod(typeof(object));
                 if ((bool)mi.Invoke(o, new object[] { 123, new object() }))
-                    throw new Exception();
+                    s_NumErrors++;
             }*/
+
+            // VirtualInvokeMap testing
+            {
+                // Rooting some methods to make them reflectable
+                new BaseClass<string>().Method1("string");
+                new BaseClass<string>().Method2("string");
+                new BaseClass<string>().Method3("string");
+                new BaseClass<string>().Method4("string");
+                new BaseClass<string>().GVMethod1<string>("string", "string2");
+                new BaseClass<string>().GVMethod2<string>("string", "string2");
+                new BaseClass<string>().GVMethod3<string>("string", "string2");
+                new BaseClass<string>().GVMethod4<string>("string", "string2");
+                new DerivedClass1<string>().Method1("string");
+                new DerivedClass1<string>().Method2("string");
+                new DerivedClass1<string>().Method3("string");
+                new DerivedClass1<string>().Method4("string");
+                new DerivedClass1<string>().GVMethod1<string>("string", "string2");
+                new DerivedClass1<string>().GVMethod2<string>("string", "string2");
+                new DerivedClass1<string>().GVMethod3<string>("string", "string2");
+                new DerivedClass1<string>().GVMethod4<string>("string", "string2");
+                new DerivedClass2<string>().Method1("string");
+                new DerivedClass2<string>().Method2("string");
+                new DerivedClass2<string>().Method3("string");
+                new DerivedClass2<string>().Method4("string");
+                new DerivedClass2<string>().GVMethod1<string>("string", "string2");
+                new DerivedClass2<string>().GVMethod2<string>("string", "string2");
+                new DerivedClass2<string>().GVMethod3<string>("string", "string2");
+                new DerivedClass2<string>().GVMethod4<string>("string", "string2");
+                ((IFace<string>)new BaseClass<string>()).IFaceMethod1("string");
+                ((IFace<string>)new BaseClass<string>()).IFaceGVMethod1<string>("string1", "string2");
+
+                MethodInfo m1 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("Method1");
+                MethodInfo m2 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("Method2");
+                MethodInfo m3 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("Method3");
+                MethodInfo m4 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("Method4");
+                MethodInfo gvm1 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("GVMethod1").MakeGenericMethod(typeof(string));
+                MethodInfo gvm2 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("GVMethod2").MakeGenericMethod(typeof(string));
+                MethodInfo gvm3 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("GVMethod3").MakeGenericMethod(typeof(string));
+                MethodInfo gvm4 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("GVMethod4").MakeGenericMethod(typeof(string));
+                Verify("BaseClass.Method1", m1.Invoke(new BaseClass<string>(), new[] { "" }));
+                Verify("BaseClass.Method2", m2.Invoke(new BaseClass<string>(), new[] { "" }));
+                Verify("BaseClass.Method3", m3.Invoke(new BaseClass<string>(), new[] { "" }));
+                Verify("BaseClass.Method4", m4.Invoke(new BaseClass<string>(), new[] { "" }));
+                Verify("DerivedClass1.Method1", m1.Invoke(new DerivedClass1<string>(), new[] { "" }));
+                Verify("DerivedClass1.Method2", m2.Invoke(new DerivedClass1<string>(), new[] { "" }));
+                Verify("BaseClass.Method3", m3.Invoke(new DerivedClass1<string>(), new[] { "" }));
+                Verify("BaseClass.Method4", m4.Invoke(new DerivedClass1<string>(), new[] { "" }));
+                Verify("DerivedClass1.Method1", m1.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("DerivedClass1.Method2", m2.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("BaseClass.Method3", m3.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("DerivedClass2.Method4", m4.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("BaseClass.GVMethod1", gvm1.Invoke(new BaseClass<string>(), new[] { "", "" }));
+                Verify("BaseClass.GVMethod2", gvm2.Invoke(new BaseClass<string>(), new[] { "", "" }));
+                Verify("BaseClass.GVMethod3", gvm3.Invoke(new BaseClass<string>(), new[] { "", "" }));
+                Verify("BaseClass.GVMethod4", gvm4.Invoke(new BaseClass<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.GVMethod1", gvm1.Invoke(new DerivedClass1<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.GVMethod2", gvm2.Invoke(new DerivedClass1<string>(), new[] { "", "" }));
+                Verify("BaseClass.GVMethod3", gvm3.Invoke(new DerivedClass1<string>(), new[] { "", "" }));
+                Verify("BaseClass.GVMethod4", gvm4.Invoke(new DerivedClass1<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.GVMethod1", gvm1.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.GVMethod2", gvm2.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+                Verify("BaseClass.GVMethod3", gvm3.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+                Verify("DerivedClass2.GVMethod4", gvm4.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+
+                m1 = typeof(DerivedClass1<string>).GetTypeInfo().GetDeclaredMethod("Method1");
+                m2 = typeof(DerivedClass1<string>).GetTypeInfo().GetDeclaredMethod("Method2");
+                m3 = typeof(DerivedClass1<string>).GetTypeInfo().GetDeclaredMethod("Method3");
+                gvm1 = typeof(DerivedClass1<string>).GetTypeInfo().GetDeclaredMethod("GVMethod1").MakeGenericMethod(typeof(string));
+                gvm2 = typeof(DerivedClass1<string>).GetTypeInfo().GetDeclaredMethod("GVMethod2").MakeGenericMethod(typeof(string));
+                gvm3 = typeof(DerivedClass1<string>).GetTypeInfo().GetDeclaredMethod("GVMethod3").MakeGenericMethod(typeof(string));
+                Verify("DerivedClass1.Method1", m1.Invoke(new DerivedClass1<string>(), new[] { "" }));
+                Verify("DerivedClass1.Method2", m2.Invoke(new DerivedClass1<string>(), new[] { "" }));
+                Verify("DerivedClass1.Method3", m3.Invoke(new DerivedClass1<string>(), new[] { "" }));
+                Verify("DerivedClass1.Method1", m1.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("DerivedClass1.Method2", m2.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("DerivedClass2.Method3", m3.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("DerivedClass1.GVMethod1", gvm1.Invoke(new DerivedClass1<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.GVMethod2", gvm2.Invoke(new DerivedClass1<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.GVMethod3", gvm3.Invoke(new DerivedClass1<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.GVMethod1", gvm1.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.GVMethod2", gvm2.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+                Verify("DerivedClass2.GVMethod3", gvm3.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+
+                m3 = typeof(DerivedClass2<string>).GetTypeInfo().GetDeclaredMethod("Method3");
+                m4 = typeof(DerivedClass2<string>).GetTypeInfo().GetDeclaredMethod("Method4");
+                gvm3 = typeof(DerivedClass2<string>).GetTypeInfo().GetDeclaredMethod("GVMethod3").MakeGenericMethod(typeof(string));
+                gvm4 = typeof(DerivedClass2<string>).GetTypeInfo().GetDeclaredMethod("GVMethod4").MakeGenericMethod(typeof(string));
+                Verify("DerivedClass2.Method3", m3.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("DerivedClass2.Method4", m4.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("DerivedClass2.GVMethod3", gvm3.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+                Verify("DerivedClass2.GVMethod4", gvm4.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+
+                // BaseClass<int>.Method1 has the same slot as BaseClass<float>.Method3 on CoreRT, because vtable entries
+                // get populated on demand (the first type won't get a Method3 entry, and the latter won't get a Method1 entry)
+                // On ProjectN, both types will get vtable entries for both methods.
+                new BaseClass<int>().Method1(1);
+                m1 = typeof(BaseClass<int>).GetTypeInfo().GetDeclaredMethod("Method1");
+                Verify("BaseClass.Method1", m1.Invoke(new BaseClass<int>(), new object[] { (int)1 }));
+                Verify("DerivedClass1.Method1", m1.Invoke(new DerivedClass1<int>(), new object[] { (int)1 }));
+                Verify("DerivedClass1.Method1", m1.Invoke(new DerivedClass2<int>(), new object[] { (int)1 }));
+
+                new BaseClass<float>().Method3(1);
+                m3 = typeof(BaseClass<float>).GetTypeInfo().GetDeclaredMethod("Method3");
+                Verify("BaseClass.Method3", m3.Invoke(new BaseClass<float>(), new object[] { 1.1f }));
+                Verify("BaseClass.Method3", m3.Invoke(new DerivedClass1<float>(), new object[] { 1.1f }));
+                Verify("BaseClass.Method3", m3.Invoke(new DerivedClass2<float>(), new object[] { 1.1f }));
+
+                m1 = typeof(IFace<string>).GetTypeInfo().GetDeclaredMethod("IFaceMethod1");
+                gvm1 = typeof(IFace<string>).GetTypeInfo().GetDeclaredMethod("IFaceGVMethod1").MakeGenericMethod(typeof(string));
+                Verify("BaseClass.IFaceMethod1", m1.Invoke(new BaseClass<string>(), new[] { "" }));
+                Verify("BaseClass.IFaceGVMethod1", gvm1.Invoke(new BaseClass<string>(), new[] { "", "" }));
+                Verify("DerivedClass1.IFaceMethod1", m1.Invoke(new DerivedClass1<string>(), new[] { "" }));
+                Verify("BaseClass.IFaceGVMethod1", gvm1.Invoke(new DerivedClass1<string>(), new[] { "", "" }));
+                Verify("DerivedClass2.IFaceMethod1", m1.Invoke(new DerivedClass2<string>(), new[] { "" }));
+                Verify("DerivedClass2.IFaceGVMethod1", gvm1.Invoke(new DerivedClass2<string>(), new[] { "", "" }));
+            }
+
+            if (s_NumErrors != 0)
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
Implementation of the VirtualInvokeMap table to enable Reflection invocation to virtual and generic virtual methods.

Implementation supports both CoreRT and ProjectX models.
Fixed interface EEType generation to unconditionally produce a dictionary slot for generic interfaces (to support static interface methods, and enable correct Reflection virtual invoke slot computation on ProjectX).