### PR TITLE
Fix ToObject on TypedReference

### DIFF
--- a/src/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/System.Private.CoreLib/src/System/TypedReference.cs
@@ -82,6 +82,10 @@ namespace System.Reflection  //@TODO: Intentionally placing TypedReference in th
             {
                 return RuntimeImports.RhBox(eeType, ref value.Value);
             }
+            else if (eeType.IsPointer)
+            {
+                return RuntimeImports.RhBox(EETypePtr.EETypePtrOf<UIntPtr>(), ref value.Value);
+            }
             else
             {
                 return Unsafe.As<byte, object>(ref value.Value);


### PR DESCRIPTION
Pointer types box as `UIntPtr` here. I was considering making RhBox do
this (it already e.g. unwraps nullables), but I'm not sure how
consistent this rule is. Maybe we should just do that.

Regression test in dotnet/corefx#17521.