### PR TITLE
Add a simple thread pool implementation for Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Threading.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.Threading.cs
@@ -30,7 +30,7 @@ internal static partial class Interop
         [DllImport(Libraries.CoreLibNative, EntryPoint = "CoreLibNative_LowLevelMonitor_Signal_Release")]
         internal static extern void LowLevelMonitor_Signal_Release(IntPtr monitor);
 
-        internal delegate uint ThreadProc(IntPtr parameter);
+        internal delegate IntPtr ThreadProc(IntPtr parameter);
 
         [DllImport(Libraries.CoreLibNative, EntryPoint = "CoreLibNative_RuntimeThread_CreateThread")]
         internal static extern bool RuntimeThread_CreateThread(IntPtr stackSize, IntPtr startAddress, IntPtr parameter);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Unix.cs
@@ -99,7 +99,7 @@ namespace Internal.Runtime.Augments
             _stopped = new ManualResetEvent(false);
 
             if (!Interop.Sys.RuntimeThread_CreateThread((IntPtr)_maxStackSize,
-                AddrofIntrinsics.AddrOf<Interop.Sys.ThreadProc>(StartThread), (IntPtr)thisThreadHandle))
+                AddrofIntrinsics.AddrOf<Interop.Sys.ThreadProc>(ThreadEntryPoint), (IntPtr)thisThreadHandle))
             {
                 return false;
             }
@@ -108,6 +108,16 @@ namespace Internal.Runtime.Augments
             SetPriorityLive(_priority);
 
             return true;
+        }
+
+        /// <summary>
+        /// This an entry point for managed threads created by applicatoin
+        /// </summary>
+        [NativeCallable]
+        private static IntPtr ThreadEntryPoint(IntPtr parameter)
+        {
+            StartThread(parameter);
+            return IntPtr.Zero;
         }
 
         public void Interrupt() => WaitSubsystem.Interrupt(this);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Windows.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Windows.cs
@@ -220,7 +220,7 @@ namespace Internal.Runtime.Augments
 
             uint threadId;
             _osHandle = Interop.mincore.CreateThread(IntPtr.Zero, (IntPtr)stackSize,
-                AddrofIntrinsics.AddrOf<Interop.mincore.ThreadProc>(StartThread), (IntPtr)thisThreadHandle,
+                AddrofIntrinsics.AddrOf<Interop.mincore.ThreadProc>(ThreadEntryPoint), (IntPtr)thisThreadHandle,
                 (uint)(Interop.Constants.CreateSuspended | Interop.Constants.StackSizeParamIsAReservation),
                 out threadId);
 
@@ -234,6 +234,16 @@ namespace Internal.Runtime.Augments
 
             Interop.mincore.ResumeThread(_osHandle);
             return true;
+        }
+
+        /// <summary>
+        /// This an entry point for managed threads created by applicatoin
+        /// </summary>
+        [NativeCallable(CallingConvention = CallingConvention.StdCall)]
+        private static uint ThreadEntryPoint(IntPtr parameter)
+        {
+            StartThread(parameter);
+            return 0;
         }
 
         public ApartmentState GetApartmentState() { throw null; }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
@@ -388,8 +388,7 @@ namespace Internal.Runtime.Augments
             }
         }
 
-        [NativeCallable(CallingConvention = CallingConvention.StdCall)]
-        private static uint StartThread(IntPtr parameter)
+        private static void StartThread(IntPtr parameter)
         {
             GCHandle threadHandle = (GCHandle)parameter;
             RuntimeThread thread = (RuntimeThread)threadHandle.Target;
@@ -410,7 +409,7 @@ namespace Internal.Runtime.Augments
                 thread._stopped.Set();
 #endif
                 // Terminate the current thread. The creator thread will throw a ThreadStartException.
-                return 0;
+                return;
             }
 
             // Report success to the creator thread, which will free threadHandle and _threadStartArg
@@ -441,7 +440,6 @@ namespace Internal.Runtime.Augments
             {
                 thread.SetThreadStateBit(ThreadState.Stopped);
             }
-            return 0;
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Unix.cs
@@ -71,8 +71,8 @@ namespace System.Threading
         /// <summary>
         /// This method is an entry point of a thread pool worker thread.
         /// </summary>
-        [NativeCallable(CallingConvention = CallingConvention.StdCall)]
-        private static uint ThreadPoolDispatchCallback(IntPtr context)
+        [NativeCallable]
+        private static IntPtr ThreadPoolDispatchCallback(IntPtr context)
         {
             RuntimeThread.InitializeThreadPoolThread();
 
@@ -81,23 +81,14 @@ namespace System.Threading
                 // Handle pending requests
                 ThreadPoolWorkQueue.Dispatch();
 
-                try
-                {
-                    // Wait for new requests to arrive
-                    s_semaphore.Wait();
-                }
-                catch (ObjectDisposedException)
-                {
-                    break;
-                }
+                // Wait for new requests to arrive
+                s_semaphore.Wait();
 
             } while (true);
-
-            return 0;
         }
 
-        [NativeCallable(CallingConvention = CallingConvention.StdCall)]
-        private static uint LongRunningWorkCallback(IntPtr context)
+        [NativeCallable]
+        private static IntPtr LongRunningWorkCallback(IntPtr context)
         {
             RuntimeThread.InitializeThreadPoolThread();
 
@@ -106,7 +97,7 @@ namespace System.Threading
             gcHandle.Free();
 
             callback();
-            return 0;
+            return IntPtr.Zero;
         }
 
     }

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Unix.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Runtime.Augments;
+using System.Runtime.InteropServices;
+
 namespace System.Threading
 {
     //
@@ -9,16 +12,102 @@ namespace System.Threading
     //
     internal static partial class ThreadPool
     {
+        // TODO: this is a very primitive (temporary) implementation of Thread Pool to allow Tasks to be
+        // used on Unix. All of this code must be replaced with proper implementation.
+
+        /// <summary>
+        /// Max allowed number of thread in the thread pool. This is just arbitrary number
+        /// that is used to prevent unbound creation of threads.
+        /// It should by high enough to provide sufficient number of thread pool workers
+        /// in case if some threads get blocked while running user code.
+        /// </summary>
+        private static readonly int MaxThreadCount = 4 * ThreadPoolGlobals.processorCount;
+
+        /// <summary>
+        /// Semaphore that is used to release waiting thread pool workers when new work becomes available.
+        /// </summary>
+        private static SemaphoreSlim s_semaphore = new SemaphoreSlim(0);
+
+        /// <summary>
+        /// Number of worker threads created by the thread pool.
+        /// </summary>
+        private static volatile int s_workerCount = 0;
+
+        /// <summary>
+        /// This method is called to request a new thread pool worker to handle pending work.
+        /// </summary>
         internal static void QueueDispatch()
         {
-            // UNIXTODO: Threadpool
-            throw new NotImplementedException();
+            // For simplicity of the state management, we pre-create all thread pool workers on the first
+            // request and then use the semaphore to release threads as new requests come in.
+            if ((s_workerCount == 0) && Interlocked.Exchange(ref s_workerCount, MaxThreadCount) == 0)
+            {
+                for (int i = 0; i < MaxThreadCount; i++)
+                {
+                    if (!Interop.Sys.RuntimeThread_CreateThread(IntPtr.Zero /*use default stack size*/,
+                        AddrofIntrinsics.AddrOf<Interop.Sys.ThreadProc>(ThreadPoolDispatchCallback), IntPtr.Zero))
+                    {
+                        throw new OutOfMemoryException();
+                    }
+                }
+            }
+
+            // Release one thread to handle the new request
+            s_semaphore.Release(1);
         }
 
         internal static void QueueLongRunningWork(Action callback)
         {
-            // UNIXTODO: Threadpool
-            throw new NotImplementedException();
+            GCHandle gcHandle = GCHandle.Alloc(callback);
+
+            if (!Interop.Sys.RuntimeThread_CreateThread(IntPtr.Zero /*use default stack size*/,
+                AddrofIntrinsics.AddrOf<Interop.Sys.ThreadProc>(LongRunningWorkCallback), GCHandle.ToIntPtr(gcHandle)))
+            {
+                gcHandle.Free();
+                throw new OutOfMemoryException();
+            }
         }
+
+        /// <summary>
+        /// This method is an entry point of a thread pool worker thread.
+        /// </summary>
+        [NativeCallable(CallingConvention = CallingConvention.StdCall)]
+        private static uint ThreadPoolDispatchCallback(IntPtr context)
+        {
+            RuntimeThread.InitializeThreadPoolThread();
+
+            do
+            {
+                // Handle pending requests
+                ThreadPoolWorkQueue.Dispatch();
+
+                try
+                {
+                    // Wait for new requests to arrive
+                    s_semaphore.Wait();
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+
+            } while (true);
+
+            return 0;
+        }
+
+        [NativeCallable(CallingConvention = CallingConvention.StdCall)]
+        private static uint LongRunningWorkCallback(IntPtr context)
+        {
+            RuntimeThread.InitializeThreadPoolThread();
+
+            GCHandle gcHandle = GCHandle.FromIntPtr(context);
+            Action callback = (Action)gcHandle.Target;
+            gcHandle.Free();
+
+            callback();
+            return 0;
+        }
+
     }
 }

--- a/tests/src/Simple/BasicThreading/BasicThreading.cs
+++ b/tests/src/Simple/BasicThreading/BasicThreading.cs
@@ -28,13 +28,6 @@ class Program
 
         return Pass;
     }
-
-    public static bool IsRunnningOnWindows()
-    {
-        // Note: Environment.OSVersion is not yet available.
-        // This is a temporary hack that allows to skip Task related tests on Unix.
-        return System.IO.Path.DirectorySeparatorChar == '\\';
-    }
 }
 
 class FinalizeTest
@@ -163,12 +156,6 @@ class ThreadStaticsTestWithTasks
 
     public static void Run()
     {
-        if (!Program.IsRunnningOnWindows())
-        {
-            // Tasks are not supported on Unix yet
-            return;
-        }
-
         Task[] tasks = new Task[TotalTaskCount];
         for (int i = 0; i < tasks.Length; ++i)
         {
@@ -340,12 +327,6 @@ class ThreadTest
 
     private static void TestIsBackgroundProperty()
     {
-        if (!Program.IsRunnningOnWindows())
-        {
-            // This test uses tasks which are not supported on Unix yet
-            return;
-        }
-
         // Thread created using Thread.Start
         var t_event = new AutoResetEvent(false);
         var t = new Thread(() => t_event.WaitOne());


### PR DESCRIPTION
This change adds a very primitive (temporary) implementation of Thread Pool to allow Tasks to be used on Unix until a proper implementation is available.

For simplicity of the state management, the thread pool pre-creates all thread pool workers (controlled by the MaxThreadCount const) on the first request and then uses a semaphore to release threads as new requests come in.
I chose not to simply create a new thread for each QueueDispatch call because I noticed on a simple test that thread pool could end up creating thousands of new threads.

In addition, this change enables all test cases in the BasicThreading test.
