### PR TITLE
Support GC Statics in type loader

### DIFF
--- a/src/Common/src/Internal/NativeFormat/NativeFormat.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormat.cs
@@ -58,6 +58,7 @@ namespace Internal.NativeFormat
         BaseTypeSize                = 0x4f,
         GenericVarianceInfo         = 0x50,
         DelegateInvokeSignature     = 0x51,
+        GcStaticEEType              = 0x52,
 
         // Add new custom bag elements that don't match to something you'd find in the ECMA metadata here.
     }

--- a/src/Common/src/Internal/Runtime/EEType.Constants.cs
+++ b/src/Common/src/Internal/Runtime/EEType.Constants.cs
@@ -208,6 +208,9 @@ namespace Internal.Runtime
         ETF_DynamicModule,
         ETF_GenericDefinition,
         ETF_GenericComposition,
+        ETF_DynamicGcStatics,
+        ETF_DynamicNonGcStatics,
+        ETF_DynamicThreadStaticOffset,
     }
 
     internal enum CorElementType

--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -1358,7 +1358,7 @@ namespace Internal.Runtime
                 Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithGcStatics) != 0);
                 return cbOffset;
             }
-            if (IsGeneric)
+            if ((RareFlags & EETypeRareFlags.IsDynamicTypeWithGcStatics) != 0)
                 cbOffset += (UInt32)IntPtr.Size;
 
             if (eField == EETypeField.ETF_DynamicNonGcStatics)
@@ -1366,7 +1366,7 @@ namespace Internal.Runtime
                 Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithNonGcStatics) != 0);
                 return cbOffset;
             }
-            if (IsGeneric)
+            if ((RareFlags & EETypeRareFlags.IsDynamicTypeWithNonGcStatics) != 0)
                 cbOffset += (UInt32)IntPtr.Size;
 
             if (eField == EETypeField.ETF_DynamicThreadStaticOffset)
@@ -1374,7 +1374,7 @@ namespace Internal.Runtime
                 Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithThreadStatics) != 0);
                 return cbOffset;
             }
-            if (IsGeneric)
+            if ((RareFlags & EETypeRareFlags.IsDynamicTypeWithThreadStatics) != 0)
                 cbOffset += 4;
 
             Debug.Assert(false, "Unknown EEType field type");

--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -1084,6 +1084,54 @@ namespace Internal.Runtime
 #endif
         }
 
+        internal IntPtr DynamicGcStaticsData
+        {
+            get
+            {
+                Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithGcStatics) != 0);
+                UInt32 cbOffset = GetFieldOffset(EETypeField.ETF_DynamicGcStatics);
+                fixed (EEType* pThis = &this)
+                {
+                    return *(IntPtr*)((byte*)pThis + cbOffset);
+                }
+            }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithGcStatics) != 0);
+                UInt32 cbOffset = GetFieldOffset(EETypeField.ETF_DynamicGcStatics);
+                fixed (EEType* pThis = &this)
+                {
+                    *(IntPtr*)((byte*)pThis + cbOffset) = value;
+                }
+            }
+#endif
+        }
+
+        internal IntPtr DynamicNonGcStaticsData
+        {
+            get
+            {
+                Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithNonGcStatics) != 0);
+                UInt32 cbOffset = GetFieldOffset(EETypeField.ETF_DynamicNonGcStatics);
+                fixed (EEType* pThis = &this)
+                {
+                    return *(IntPtr*)((byte*)pThis + cbOffset);
+                }
+            }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithNonGcStatics) != 0);
+                UInt32 cbOffset = GetFieldOffset(EETypeField.ETF_DynamicNonGcStatics);
+                fixed (EEType* pThis = &this)
+                {
+                    *(IntPtr*)((byte*)pThis + cbOffset) = value;
+                }
+            }
+#endif
+        }
+
         internal DynamicModule* DynamicModule
         {
             get
@@ -1302,8 +1350,32 @@ namespace Internal.Runtime
                 Debug.Assert(IsDynamicType);
                 return cbOffset;
             }
+            if (IsDynamicType)
+                cbOffset += (UInt32)IntPtr.Size;
 
-            // after this we have statics information for dynamic types
+            if (eField == EETypeField.ETF_DynamicGcStatics)
+            {
+                Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithGcStatics) != 0);
+                return cbOffset;
+            }
+            if (IsGeneric)
+                cbOffset += (UInt32)IntPtr.Size;
+
+            if (eField == EETypeField.ETF_DynamicNonGcStatics)
+            {
+                Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithNonGcStatics) != 0);
+                return cbOffset;
+            }
+            if (IsGeneric)
+                cbOffset += (UInt32)IntPtr.Size;
+
+            if (eField == EETypeField.ETF_DynamicThreadStaticOffset)
+            {
+                Debug.Assert((RareFlags & EETypeRareFlags.IsDynamicTypeWithThreadStatics) != 0);
+                return cbOffset;
+            }
+            if (IsGeneric)
+                cbOffset += 4;
 
             Debug.Assert(false, "Unknown EEType field type");
             return 0;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -645,14 +645,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override NativeLayoutVertexNode TemplateDictionaryNode(NodeFactory factory)
         {
-            if (factory.Target.Abi == TargetAbi.CoreRT)
-            {
-                return factory.NativeLayout.NotSupportedDictionarySlot;
-            }
-            else
-            {
-                return factory.NativeLayout.GcStaticDictionarySlot(_type);
-            }
+            return factory.NativeLayout.GcStaticDictionarySlot(_type);
         }
 
         public override GenericLookupResultReferenceType LookupResultReferenceType(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -854,7 +854,7 @@ namespace ILCompiler.DependencyAnalysis
             else
             {
                 symbol = context.GCStaticEEType(GCPointerMap.FromStaticLayout(_type));
-                staticsBagKind = BagElementKind.GcStaticEEType; // GC static EETypes not yet implemented in type loader
+                staticsBagKind = BagElementKind.GcStaticEEType;
             }
 
             return symbol;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -854,7 +854,7 @@ namespace ILCompiler.DependencyAnalysis
             else
             {
                 symbol = context.GCStaticEEType(GCPointerMap.FromStaticLayout(_type));
-                staticsBagKind = BagElementKind.End; // GC static EETypes not yet implemented in type loader
+                staticsBagKind = BagElementKind.GcStaticEEType; // GC static EETypes not yet implemented in type loader
             }
 
             return symbol;

--- a/src/Native/Runtime/RuntimeInstance.cpp
+++ b/src/Native/Runtime/RuntimeInstance.cpp
@@ -641,6 +641,7 @@ bool RuntimeInstance::CreateGenericAndStaticInfo(EEType *             pEEType,
     }
 
     NewArrayHolder<UInt8> pGcStaticData;
+#ifndef CORERT
     if (gcStaticDataSize > 0)
     {
         // The value of gcStaticDataSize is read from native layout info in the managed layer, where
@@ -653,6 +654,7 @@ bool RuntimeInstance::CreateGenericAndStaticInfo(EEType *             pEEType,
         if (!AddDynamicGcStatics(pGcStaticData, pGcStaticsDesc))
             return false;
     }
+#endif
 
     if (threadStaticOffset != 0)
     {

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -173,7 +173,7 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhpHandleAlloc")]
         private static extern IntPtr RhpHandleAlloc(Object value, GCHandleType type);
 
-        internal static IntPtr RhHandleAlloc(Object value, GCHandleType type)
+        public static IntPtr RhHandleAlloc(Object value, GCHandleType type)
         {
             IntPtr h = RhpHandleAlloc(value, type);
             if (h == IntPtr.Zero)
@@ -210,7 +210,7 @@ namespace System.Runtime
         // Free handle.
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhHandleFree")]
-        internal static extern void RhHandleFree(IntPtr handle);
+        public static extern void RhHandleFree(IntPtr handle);
 
         // Get object reference from handle.
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -512,6 +512,7 @@ namespace Internal.Runtime.TypeLoader
 
         public IntPtr? ClassConstructorPointer;
         public IntPtr GcStaticDesc;
+        public IntPtr GcStaticEEType;
         public IntPtr ThreadStaticDesc;
         public bool AllocatedStaticGCDesc;
         public bool AllocatedThreadStaticGCDesc;
@@ -683,6 +684,10 @@ namespace Internal.Runtime.TypeLoader
 
                             case BagElementKind.ThreadStaticDesc:
                                 ThreadStaticDesc = NativeLayoutInfo.LoadContext.GetGCStaticInfo(typeInfoParser.GetUnsigned());
+                                break;
+
+                            case BagElementKind.GcStaticEEType:
+                                GcStaticEEType = NativeLayoutInfo.LoadContext.GetGCStaticInfo(typeInfoParser.GetUnsigned());
                                 break;
 
                             default:

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -1330,19 +1330,6 @@ class Program
             public object m_objectField;
         }
 
-        // Remove this and use Foo once we have type loader support for all necessary dictionary slots
-        class FooDynamic<T>
-        {
-            static FooDynamic()
-            {
-                Console.WriteLine("FooDynamic<" + typeof(T).Name + "> cctor");
-            }
-
-            public static int s_intField;
-            public static float s_floatField;
-            public static long s_longField1;
-        }
-
         class Bar
         {
             static Bar()
@@ -1383,12 +1370,12 @@ class Program
 
         private static void TestDynamicStaticFields()
         {
-            FooDynamic<object>.s_intField = 1234;
-            FooDynamic<object>.s_floatField = 12.34f;
-            FooDynamic<object>.s_longField1 = 0x1111;
+            Foo<object>.s_intField = 1234;
+            Foo<object>.s_floatField = 12.34f;
+            Foo<object>.s_longField1 = 0x1111;
 
-            var fooDynamicOfClassType = typeof(FooDynamic<>).MakeGenericType(typeof(ClassType)).GetTypeInfo();
-            var fooDynamicOfClassType2 = typeof(FooDynamic<>).MakeGenericType(typeof(ClassType2)).GetTypeInfo();
+            var fooDynamicOfClassType = typeof(Foo<>).MakeGenericType(typeof(ClassType)).GetTypeInfo();
+            var fooDynamicOfClassType2 = typeof(Foo<>).MakeGenericType(typeof(ClassType2)).GetTypeInfo();
             
             FieldInfo fi = fooDynamicOfClassType.GetDeclaredField("s_intField");
             FieldInfo fi2 = fooDynamicOfClassType2.GetDeclaredField("s_intField");
@@ -1410,6 +1397,20 @@ class Program
             fi2.SetValue(null, 0x22222222);
             Verify(0x11111111, (long)fi.GetValue(null));
             Verify(0x22222222, (long)fi2.GetValue(null));
+
+            fi = fooDynamicOfClassType.GetDeclaredField("s_stringField");
+            fi2 = fooDynamicOfClassType2.GetDeclaredField("s_stringField");
+            fi.SetValue(null, "abc123");
+            fi2.SetValue(null, "omgroflpwn");
+            Verify("abc123", (string)fi.GetValue(null));
+            Verify("omgroflpwn", (string)fi2.GetValue(null));
+
+            fi = fooDynamicOfClassType.GetDeclaredField("s_objectField");
+            fi2 = fooDynamicOfClassType2.GetDeclaredField("s_objectField");
+            fi.SetValue(null, "qwerty");
+            fi2.SetValue(null, "ytrewq");
+            Verify("qwerty", (string)fi.GetValue(null));
+            Verify("ytrewq", (string)fi2.GetValue(null));
         }
 
         private static void TestStaticFields()


### PR DESCRIPTION
* Add support for CoreRT-style GC statics when creating new generic types from templates
* Pass new `BagElementKind.GCStaticEEType` through in the template layout so the type's statics can be heap-allocated
* Add managed accessors to the dynamic GC / non-GC data to EEType.cs