### PR TITLE
Make it possible to use RD.XML for interface methods

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -236,7 +236,11 @@ namespace ILCompiler
                         _graph.AddRoot(_factory.TypeNonGCStaticsSymbol(metadataType), reason);
                     }
                 }
+            }
 
+            public void RootVirtualMethodUse(MethodDesc method, string reason)
+            {
+                _graph.AddRoot(_factory.VirtualMethodUse(method), reason);
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -230,8 +230,7 @@ namespace ILCompiler.DependencyAnalysis
                     MethodDesc implMethod = defType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod);
                     if (implMethod != null)
                     {
-                        yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.ReadyToRunHelper(ReadyToRunHelperId.VirtualCall, interfaceMethod), "Interface method");
-                        yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.ReadyToRunHelper(ReadyToRunHelperId.ResolveVirtualFunction, interfaceMethod), "Interface method address");
+                        yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method");
                     }
                 }
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -151,7 +151,6 @@ namespace ILCompiler.DependencyAnalysis
             {
                 DependencyList dependencyList = new DependencyList();
                 dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Call");
-                dependencyList.Add(factory.VTable(((MethodDesc)_target).OwningType), "ReadyToRun Virtual Method Call Target VTable");
                 return dependencyList;
             }
             else if (_id == ReadyToRunHelperId.ResolveVirtualFunction)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -82,6 +82,8 @@ namespace ILCompiler.DependencyAnalysis
             if (canonDecl != _decl)
                 dependencies.Add(new DependencyListEntry(factory.VirtualMethodUse(canonDecl), "Canonical method"));
 
+            dependencies.Add(new DependencyListEntry(factory.VTable(_decl.OwningType), "VTable of a VirtualMethodUse"));
+
             return dependencies;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
@@ -14,5 +14,6 @@ namespace ILCompiler
         void AddCompilationRoot(MethodDesc method, string reason, string exportName = null);
         void AddCompilationRoot(TypeDesc type, string reason);
         void RootStaticBasesForType(TypeDesc type, string reason);
+        void RootVirtualMethodUse(MethodDesc method, string reason);
     }
 }

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -106,7 +106,19 @@ namespace ILCompiler
             {
                 foreach (var method in type.GetMethods())
                 {
-                    if (method.IsAbstract || method.HasInstantiation)
+                    // We don't know what to instantiate generic methods over
+                    if (method.HasInstantiation)
+                        continue;
+
+                    // Virtual methods should be rooted as if they were called virtually
+                    if (method.IsVirtual)
+                    {
+                        MethodDesc slotMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                        rootProvider.RootVirtualMethodUse(slotMethod, "RD.XML root");
+                    }
+
+                    // Abstract methods have no entrypoints
+                    if (method.IsAbstract)
                         continue;
 
                     rootProvider.AddCompilationRoot(method, "RD.XML root");


### PR DESCRIPTION
* Make it possible to add virtual method use as a compilation root
* Change a condition in ConstructedEETypeNode to depend on the presence
of `VirtualMethodUse` instead of `ReadyToRun` helper. The helper depends
on `VirtualMethodUse` so this will still do the right thing, but it will
also work for calls that don't go through the helper (reflection
calls...)