### PR TITLE
Fix emission of unconstructed types declarations in CppCodegen

### DIFF
--- a/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/CppWriter.cs
@@ -1105,24 +1105,24 @@ namespace ILCompiler.CppCodeGen
                     typeDefinitions.AppendLine();
                     typeDefinitions.Append(GetCodeForDelegate(nodeType));
                 }
+            }
 
+            if (nodeType.HasStaticConstructor)
+            {
+                _statics.AppendLine();
+                _statics.Append("bool __cctor_" + GetCppTypeName(nodeType).Replace("::", "__") + ";");
+            }
 
-                if (nodeType.HasStaticConstructor)
+            List<MethodDesc> methodList;
+            if (_methodLists.TryGetValue(nodeType, out methodList))
+            {
+                foreach (var m in methodList)
                 {
-                    _statics.AppendLine();
-                    _statics.Append("bool __cctor_" + GetCppTypeName(nodeType).Replace("::", "__") + ";");
-                }
-
-                List<MethodDesc> methodList;
-                if (_methodLists.TryGetValue(nodeType, out methodList))
-                {
-                    foreach (var m in methodList)
-                    {
-                        typeDefinitions.AppendLine();
-                        AppendCppMethodDeclaration(typeDefinitions, m, false);
-                    }
+                    typeDefinitions.AppendLine();
+                    AppendCppMethodDeclaration(typeDefinitions, m, false);
                 }
             }
+
             typeDefinitions.AppendEmptyLine();
             typeDefinitions.Append("};");
             typeDefinitions.AppendEmptyLine();


### PR DESCRIPTION
If a type is not constructed, we still want the member methods to be
part of the class declaration.