### PR TITLE
TimeSpan.FromMilliseconds(TimeSpan.MaxValue.TotalMilliseconds) exception

### DIFF
--- a/src/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -245,10 +245,10 @@ namespace System
                 throw new ArgumentException(SR.Arg_CannotBeNaN);
             Contract.EndContractBlock();
             double tmp = value * scale;
-            double millis = tmp + (value >= 0 ? 0.5 : -0.5);
-            if ((millis > Int64.MaxValue / TicksPerMillisecond) || (millis < Int64.MinValue / TicksPerMillisecond))
+            double ticks = Math.Round(tmp * TicksPerMillisecond, 0);
+            if ((ticks > Int64.MaxValue) || (ticks < Int64.MinValue))
                 throw new OverflowException(SR.Overflow_TimeSpanTooLong);
-            return new TimeSpan((long)millis * TicksPerMillisecond);
+            return new TimeSpan((long)ticks);            
         }
 
         public static TimeSpan FromMilliseconds(double value)


### PR DESCRIPTION
fixes #3137
There is a committed pull request in coreclr: dotnet/coreclr#10352.