### PR TITLE
Only track virtual method use for types that have a lazy vtable

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -240,7 +240,8 @@ namespace ILCompiler
 
             public void RootVirtualMethodUse(MethodDesc method, string reason)
             {
-                _graph.AddRoot(_factory.VirtualMethodUse(method), reason);
+                if (!_factory.CompilationModuleGroup.ShouldProduceFullVTable(method.OwningType))
+                    _graph.AddRoot(_factory.VirtualMethodUse(method), reason);
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -193,48 +193,48 @@ namespace ILCompiler.DependencyAnalysis
             DefType defType = _type.GetClosestDefType();
 
             // If we're producing a full vtable, none of the dependencies are conditional.
-            if (factory.CompilationModuleGroup.ShouldProduceFullVTable(defType))
-                yield break;
-
-            foreach (MethodDesc decl in defType.EnumAllVirtualSlots())
+            if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(defType))
             {
-                // Generic virtual methods are tracked by an orthogonal mechanism.
-                if (decl.HasInstantiation)
-                    continue;
-
-                MethodDesc impl = defType.FindVirtualFunctionTargetMethodOnObjectType(decl);
-                if (impl.OwningType == defType && !impl.IsAbstract)
+                foreach (MethodDesc decl in defType.EnumAllVirtualSlots())
                 {
-                    MethodDesc canonImpl = impl.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                    yield return new CombinedDependencyListEntry(factory.MethodEntrypoint(canonImpl, _type.IsValueType), factory.VirtualMethodUse(decl), "Virtual method");
-                }
-            }
-
-            Debug.Assert(
-                _type == defType ||
-                ((System.Collections.IStructuralEquatable)defType.RuntimeInterfaces).Equals(_type.RuntimeInterfaces,
-                EqualityComparer<DefType>.Default));
-
-            // Add conditional dependencies for interface methods the type implements. For example, if the type T implements
-            // interface IFoo which has a method M1, add a dependency on T.M1 dependent on IFoo.M1 being called, since it's
-            // possible for any IFoo object to actually be an instance of T.
-            foreach (DefType interfaceType in defType.RuntimeInterfaces)
-            {
-                Debug.Assert(interfaceType.IsInterface);
-
-                foreach (MethodDesc interfaceMethod in interfaceType.GetAllMethods())
-                {
-                    if (interfaceMethod.Signature.IsStatic)
-                        continue;
-
                     // Generic virtual methods are tracked by an orthogonal mechanism.
-                    if (interfaceMethod.HasInstantiation)
+                    if (decl.HasInstantiation)
                         continue;
 
-                    MethodDesc implMethod = defType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod);
-                    if (implMethod != null)
+                    MethodDesc impl = defType.FindVirtualFunctionTargetMethodOnObjectType(decl);
+                    if (impl.OwningType == defType && !impl.IsAbstract)
                     {
-                        yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method");
+                        MethodDesc canonImpl = impl.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                        yield return new CombinedDependencyListEntry(factory.MethodEntrypoint(canonImpl, _type.IsValueType), factory.VirtualMethodUse(decl), "Virtual method");
+                    }
+                }
+
+                Debug.Assert(
+                    _type == defType ||
+                    ((System.Collections.IStructuralEquatable)defType.RuntimeInterfaces).Equals(_type.RuntimeInterfaces,
+                    EqualityComparer<DefType>.Default));
+
+                // Add conditional dependencies for interface methods the type implements. For example, if the type T implements
+                // interface IFoo which has a method M1, add a dependency on T.M1 dependent on IFoo.M1 being called, since it's
+                // possible for any IFoo object to actually be an instance of T.
+                foreach (DefType interfaceType in defType.RuntimeInterfaces)
+                {
+                    Debug.Assert(interfaceType.IsInterface);
+
+                    foreach (MethodDesc interfaceMethod in interfaceType.GetAllMethods())
+                    {
+                        if (interfaceMethod.Signature.IsStatic)
+                            continue;
+
+                        // Generic virtual methods are tracked by an orthogonal mechanism.
+                        if (interfaceMethod.HasInstantiation)
+                            continue;
+
+                        MethodDesc implMethod = defType.ResolveInterfaceMethodToVirtualMethodOnType(interfaceMethod);
+                        if (implMethod != null)
+                        {
+                            yield return new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method");
+                        }
                     }
                 }
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -257,8 +257,14 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyNodeCore<NodeFactory>> NonRelocDependenciesFromUsage(NodeFactory factory)
         {
+            MethodDesc canonMethod = _method.GetCanonMethodTarget(CanonicalFormKind.Universal);
+
+            // If we're producing a full vtable for the type, we don't need to report virtual method use.
+            if (factory.CompilationModuleGroup.ShouldProduceFullVTable(canonMethod.OwningType))
+                return Array.Empty<DependencyNodeCore<NodeFactory>>();
+
             return new DependencyNodeCore<NodeFactory>[] {
-                factory.VirtualMethodUse(_method.GetCanonMethodTarget(CanonicalFormKind.Universal))
+                factory.VirtualMethodUse(canonMethod)
             };
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -286,6 +286,10 @@ namespace ILCompiler.DependencyAnalysis
 
             _virtMethods = new NodeCache<MethodDesc, VirtualMethodUseNode>((MethodDesc method) =>
             {
+                // We don't need to track virtual method uses for types that are producing full vtables.
+                // It's a waste of CPU time and memory.
+                Debug.Assert(!CompilationModuleGroup.ShouldProduceFullVTable(method.OwningType));
+
                 return new VirtualMethodUseNode(method);
             });
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -147,22 +147,20 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            if (_id == ReadyToRunHelperId.VirtualCall)
+            if (_id == ReadyToRunHelperId.VirtualCall || _id == ReadyToRunHelperId.ResolveVirtualFunction)
             {
-                DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Call");
-                return dependencyList;
+                var targetMethod = (MethodDesc)_target;
+#if !SUPPORT_JIT
+                if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(targetMethod.OwningType))
+#endif
+                {
+                    DependencyList dependencyList = new DependencyList();
+                    dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Call");
+                    return dependencyList;
+                }
             }
-            else if (_id == ReadyToRunHelperId.ResolveVirtualFunction)
-            {
-                DependencyList dependencyList = new DependencyList();
-                dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Address Load");
-                return dependencyList;
-            }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -99,18 +99,15 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            List<DependencyListEntry> dependencies = new List<DependencyListEntry>(_slots.Length + 1);
             if (_type.HasBaseType)
             {
-                dependencies.Add(new DependencyListEntry(factory.VTable(_type.BaseType), "Base type VTable"));
+                return new DependencyListEntry[]
+                {
+                    new DependencyListEntry(factory.VTable(_type.BaseType), "Base type VTable")
+                };
             }
 
-            foreach (MethodDesc method in _slots)
-            {
-                dependencies.Add(new DependencyListEntry(factory.VirtualMethodUse(method), "Full vtable dependency"));
-            }
-
-            return dependencies;
+            return null;
         }
     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -29,8 +29,10 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(decl.IsVirtual);
 
-            // TODO: assert that decl is a slot defining method (either a newslot or a first virtual method
-            // with this name and signature in the inheritance chain).
+            // Virtual method use always represents the slot defining method of the virtual.
+            // Places that might see virtual methods being used through an override need to normalize
+            // to the slot defining method.
+            Debug.Assert(MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(decl) == decl);
 
             // Generic virtual methods are tracked by an orthogonal mechanism.
             Debug.Assert(!decl.HasInstantiation);

--- a/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.Compiler/src/CppCodeGen/ILToCppImporter.cs
@@ -968,7 +968,8 @@ namespace Internal.IL
                     else
                         callViaSlot = true;
 
-                    _dependencies.Add(_nodeFactory.VirtualMethodUse(method));
+                    if (!_nodeFactory.CompilationModuleGroup.ShouldProduceFullVTable(method.OwningType))
+                        _dependencies.Add(_nodeFactory.VirtualMethodUse(method));
                 }
             }
 


### PR DESCRIPTION
It's a waste of CPU time and memory for types that get a full vtable.

With this change, multifile compilation of System.Private.CoreLib gets speeded up by 2% (wallclock time), total GC allocations drop by 5%, peak working set drops by ~2%.