### PR TITLE
NS2.0 Add String.Intern

### DIFF
--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -113,9 +113,6 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\GCPointerMap.cs">
       <Link>Utilities\GCPointerMap.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
-      <Link>Utilities\LockFreeReaderHashtable.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\ArrayType.cs">
       <Link>TypeSystem\Common\ArrayType.cs</Link>
     </Compile>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -427,6 +427,7 @@
     <Compile Include="System\Single.cs" />
     <Compile Include="System\String.cs" />
     <Compile Include="System\String.Comparison.cs" />
+    <Compile Include="System\String.Intern.cs" />
     <Compile Include="System\String.Manipulation.cs" />
     <Compile Include="System\String.Searching.cs" />
     <Compile Include="System\Array.cs" />
@@ -872,6 +873,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
+      <Link>Utilities\LockFreeReaderHashtable.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelList.cs">
       <Link>System\Collections\Generic\LowLevelList.cs</Link>
     </Compile>

--- a/src/System.Private.CoreLib/src/System/String.Intern.cs
+++ b/src/System.Private.CoreLib/src/System/String.Intern.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using Internal.TypeSystem;
+
+namespace System
+{
+    public partial class String
+    {
+        public static string Intern(string str)
+        {
+            if (str == null)
+                throw new ArgumentNullException(nameof(str));
+
+            return InternTable.GetOrCreateValue(str);
+        }
+
+        public static string IsInterned(string str)
+        {
+            if (str == null)
+                throw new ArgumentNullException(nameof(str));
+
+            string canonicalString;
+            if (!InternTable.TryGetValue(str, out canonicalString))
+                return null;
+            return canonicalString;
+        }
+
+        private sealed class StringInternTable : LockFreeReaderHashtable<string, string>
+        {
+            protected sealed override bool CompareKeyToValue(string key, string value) => key == value;
+            protected sealed override bool CompareValueToValue(string value1, string value2) => value1 == value2;
+            protected sealed override string CreateValueFromKey(string key) => key;
+            protected sealed override int GetKeyHashCode(string key) => key.GetHashCode();
+            protected sealed override int GetValueHashCode(string value) => value.GetHashCode();
+        }
+
+        private static StringInternTable InternTable
+        {
+            get
+            {
+                if (s_lazyInternTable == null)
+                {
+                    StringInternTable internTable = new StringInternTable();
+                    internTable.AddOrGetExisting(string.Empty);
+                    Interlocked.CompareExchange<StringInternTable>(ref s_lazyInternTable, internTable, null);
+                }
+                return s_lazyInternTable;
+            }
+        }
+
+        private static volatile StringInternTable s_lazyInternTable;
+    }
+}

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -379,9 +379,6 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\UniversalCanonLayoutAlgorithm.cs">
       <Link>UniversalCanonLayoutAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
-      <Link>LockFreeReaderHashtable.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtableOfPointers.cs">
       <Link>LockFreeReaderHashtableOfPointers.cs</Link>
     </Compile>


### PR DESCRIPTION
This won't cover literals but otherwise, gets the
job done.

Note that LockFreeReaderHashTable was declared public
(and so were a ton of classes that derived from it,
so I couldn't just make it private.)

Including it in CoreLib.dll means no one above
CoreLib can include it - they'll just the public
one from CoreLib.dll.