### PR TITLE
Revert "TimeSpan.FromMilliseconds(TimeSpan.MaxValue.TotalMilliseconds) exception"

### DIFF
--- a/src/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -245,10 +245,10 @@ namespace System
                 throw new ArgumentException(SR.Arg_CannotBeNaN);
             Contract.EndContractBlock();
             double tmp = value * scale;
-            double ticks = Math.Round(tmp * TicksPerMillisecond, 0);
-            if ((ticks > Int64.MaxValue) || (ticks < Int64.MinValue))
+            double millis = tmp + (value >= 0 ? 0.5 : -0.5);
+            if ((millis > Int64.MaxValue / TicksPerMillisecond) || (millis < Int64.MinValue / TicksPerMillisecond))
                 throw new OverflowException(SR.Overflow_TimeSpanTooLong);
-            return new TimeSpan((long)ticks);            
+            return new TimeSpan((long)millis * TicksPerMillisecond);
         }
 
         public static TimeSpan FromMilliseconds(double value)


### PR DESCRIPTION
Reverts dotnet/corert#3144