### PR TITLE
NS2.0 Add back the String constructors taking sbyte*

### DIFF
--- a/src/Common/src/Interop/Windows/kernel32/Interop.MultiByteToWideChar.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.MultiByteToWideChar.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32)]
+        internal static extern unsafe int MultiByteToWideChar(
+            uint CodePage, uint dwFlags,
+            byte* lpMultiByteStr, int cbMultiByte,
+            char* lpWideCharStr, int cchWideChar);
+
+        internal const uint MB_PRECOMPOSED = 0x00000001;
+    }
+}

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2311,4 +2311,10 @@
   <data name="Serialization_DateTimeTicksOutOfRange" xml:space="preserve">
     <value>Invalid serialized DateTime data. Ticks must be between DateTime.MinValue.Ticks and DateTime.MaxValue.Ticks.</value>
   </data>
+  <data name="Arg_InvalidANSIString" xml:space="preserve">
+    <value>The ANSI string passed in could not be converted from the default ANSI code page to Unicode.</value>
+  </data>
+  <data name="Arg_ExpectedNulTermination" xml:space="preserve">
+    <value>The value passed was not NUL terminated.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -634,6 +634,9 @@
     <Compile Include="..\..\Common\src\Interop\Windows\ntdll\Interop.ZeroMemory.cs">
       <Link>Interop\Windows\ntdll\Interop.ZeroMemory.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs">
+      <Link>Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\Interop\Windows\kernel32\Interop.WideCharToMultiByte.cs">
       <Link>Interop\Windows\kernel32\Interop.WideCharToMultiByte.cs</Link>
     </Compile>


### PR DESCRIPTION
Ctor(sbyte*) is a port of

  COMString::StringInitCharPtr
  (https://github.com/dotnet/coreclr/blob/master/src/classlibnative/bcltype/stringnative.cpp#L98)

Ctor(sbyte*, int, int) is a port of

  COMString::StringInitCharPtrPartial
  (https://github.com/dotnet/coreclr/blob/master/src/classlibnative/bcltype/stringnative.cpp#L117)

Ctor(sbyte*, int, int, Encoding) is copied from CoreCLR

  (https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/String.cs#L229)

CreateStringForSByteConstructor() is a rough port of
  StringObject::StringInitCharHelper() (without the "-1" length case and other length checks)

  (https://github.com/dotnet/coreclr/blob/master/src/vm/object.cpp#L2073)