### PR TITLE
Fix mangling of generic and instantiated methods

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CoreRTNameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CoreRTNameMangler.cs
@@ -322,10 +322,11 @@ namespace ILCompiler
 
             string mangledName;
 
-            var methodDefinition = method.GetTypicalMethodDefinition();
+            var methodDefinition = method.GetMethodDefinition();
             if (methodDefinition != method)
             {
-                mangledName = GetMangledMethodName(methodDefinition.GetMethodDefinition()).ToString();
+                // Instantiated generic method
+                mangledName = GetMangledMethodName(methodDefinition).ToString();
 
                 var inst = method.Instantiation;
                 string mangledInstantiation = "";
@@ -342,12 +343,21 @@ namespace ILCompiler
             }
             else
             {
-                // Assume that Name is unique for all other methods
-                mangledName = SanitizeName(method.Name);
-            }
+                var typicalMethodDefinition = method.GetTypicalMethodDefinition();
+                if (typicalMethodDefinition != method)
+                {
+                    // Method on an instantiated type
+                    mangledName = GetMangledMethodName(typicalMethodDefinition).ToString();
+                }
+                else
+                {
+                    // Assume that Name is unique for all other methods
+                    mangledName = SanitizeName(method.Name);
+                }
 
-            if (prependTypeName != null)
-                mangledName = prependTypeName + "__" + mangledName;
+                if (prependTypeName != null)
+                    mangledName = prependTypeName + "__" + mangledName;
+            }
 
             Utf8String utf8MangledName = new Utf8String(mangledName);
 


### PR DESCRIPTION
* Methods on instantiated types were taking the same path as generic
methods unnecessarily (this will be a small improvement in terms of
string allocations)
* Generic method definitions were attempting to include mangled names of
their generic parameters. (This is the main reason why I looked into it - I hit this while running tests for #3152.)