### PR TITLE
Make presence of RuntimeMethodHandle trigger generation of metadata

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -62,6 +62,23 @@ namespace ILCompiler
             base.AddGeneratedMethod(method);
         }
 
+        private void AddMetadataOnlyType(TypeDesc type)
+        {
+            if (type is MetadataType)
+            {
+                var mdType = (MetadataType)type.GetTypeDefinition();
+                _modulesSeen.Add(mdType.Module);
+                _typeDefinitionsGenerated.Add(mdType);
+            }
+        }
+
+        protected override void AddMetadataOnlyMethod(MethodDesc method)
+        {
+            MethodDesc typicalMethod = method.GetTypicalMethodDefinition();
+            AddMetadataOnlyType(typicalMethod.OwningType);
+            _methodDefinitionsGenerated.Add(typicalMethod);
+        }
+
         public override bool IsReflectionBlocked(MetadataType type)
         {
             return _metadataPolicy.IsBlocked(type);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -14,6 +14,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private MethodDesc _targetMethod;
 
+        public MethodDesc Method => _targetMethod;
+
         public RuntimeMethodHandleNode(MethodDesc targetMethod)
         {
             Debug.Assert(!targetMethod.IsSharedByGenericInstantiations);

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -169,6 +169,13 @@ namespace ILCompiler
                 return;
             }
 
+            var runtimeMethodHandleNode = obj as RuntimeMethodHandleNode;
+            if (runtimeMethodHandleNode != null)
+            {
+                AddMetadataOnlyMethod(runtimeMethodHandleNode.Method);
+                return;
+            }
+
             var nonGcStaticSectionNode = obj as NonGCStaticsNode;
             if (nonGcStaticSectionNode != null && _typeSystemContext.HasLazyStaticConstructor(nonGcStaticSectionNode.Type))
             {
@@ -398,6 +405,10 @@ namespace ILCompiler
         {
             Debug.Assert(_metadataBlob == null, "Created a new EEType after metadata generation finished");
             _methodsGenerated.Add(method);
+        }
+
+        protected virtual void AddMetadataOnlyMethod(MethodDesc method)
+        {
         }
 
         private void EnsureMetadataGenerated(NodeFactory factory)


### PR DESCRIPTION
This is just temporary (until we move metadata generation to happen
before we compile), but will help with bringup - `RuntimeMethodHandle`
for something that wasn't metadata enabled will otherwise throw an
unhelpful "Handle is invalid" when fed to `GetMethodFromHandle`.