### PR TITLE
Implement MethodBase.GetCurrentMethod

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.Mangling.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.Mangling.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace Internal.IL.Stubs
+{
+    partial class MethodBaseGetCurrentMethodThunk : IPrefixMangledMethod
+    {
+        MethodDesc IPrefixMangledMethod.BaseMethod
+        {
+            get
+            {
+                return Method;
+            }
+        }
+
+        string IPrefixMangledMethod.Prefix
+        {
+            get
+            {
+                return "GetCurrentMethod";
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Thunk that replaces calls to MethodBase.GetCurrentMethod in user code. The purpose of the thunk
+    /// is to LDTOKEN the method considered "current method" and call into the class library to
+    /// retrieve the associated MethodBase object instance.
+    /// </summary>
+    internal partial class MethodBaseGetCurrentMethodThunk : ILStubMethod
+    {
+        public MethodBaseGetCurrentMethodThunk(MethodDesc method)
+        {
+            Debug.Assert(method.IsTypicalMethodDefinition);
+
+            Method = method;
+            Signature = new MethodSignature(MethodSignatureFlags.Static, 0,
+                Context.SystemModule.GetKnownType("System.Reflection", "MethodBase"), TypeDesc.EmptyTypes);
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return Method.Context;
+            }
+        }
+
+        public MethodDesc Method
+        {
+            get;
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return Method.Name;
+            }
+        }
+
+        public override TypeDesc OwningType
+        {
+            get
+            {
+                return Method.OwningType;
+            }
+        }
+
+        public override MethodSignature Signature
+        {
+            get;
+        }
+
+        public override MethodIL EmitIL()
+        {
+            ILEmitter emit = new ILEmitter();
+            ILCodeStream codeStream = emit.NewCodeStream();
+
+            codeStream.Emit(ILOpcode.ldtoken, emit.NewToken(Method));
+
+            string helperName;
+            if (Method.OwningType.HasInstantiation)
+            {
+                codeStream.Emit(ILOpcode.ldtoken, emit.NewToken(Method.OwningType));
+                helperName = "GetCurrentMethodGeneric";
+            }
+            else
+                helperName = "GetCurrentMethodNonGeneric";
+
+            MethodDesc classlibHelper = Context.GetHelperEntryPoint("ReflectionHelpers", helperName);
+
+            codeStream.Emit(ILOpcode.call, emit.NewToken(classlibHelper));
+            codeStream.Emit(ILOpcode.ret);
+
+            return emit.Link(this);
+        }
+    }
+
+    internal class MethodBaseGetCurrentMethodThunkCache
+    {
+        private Unifier _cache;
+
+        public MethodBaseGetCurrentMethodThunkCache()
+        {
+            _cache = new Unifier();
+        }
+
+        public MethodDesc GetHelper(MethodDesc currentMethod)
+        {
+            return _cache.GetOrCreateValue(currentMethod.GetTypicalMethodDefinition());
+        }
+
+        private class Unifier : LockFreeReaderHashtable<MethodDesc, MethodBaseGetCurrentMethodThunk>
+        {
+            protected override int GetKeyHashCode(MethodDesc key)
+            {
+                return key.GetHashCode();
+            }
+            protected override int GetValueHashCode(MethodBaseGetCurrentMethodThunk value)
+            {
+                return value.Method.GetHashCode();
+            }
+            protected override bool CompareKeyToValue(MethodDesc key, MethodBaseGetCurrentMethodThunk value)
+            {
+                return key == value.Method;
+            }
+            protected override bool CompareValueToValue(MethodBaseGetCurrentMethodThunk value1, MethodBaseGetCurrentMethodThunk value2)
+            {
+                return value1.Method == value2.Method;
+            }
+            protected override MethodBaseGetCurrentMethodThunk CreateValueFromKey(MethodDesc key)
+            {
+                return new MethodBaseGetCurrentMethodThunk(key);
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -68,6 +68,12 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\AssemblyGetExecutingAssemblyMethodThunk.cs">
       <Link>IL\Stubs\AssemblyGetExecutingAssemblyMethodThunk.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\MethodBaseGetCurrentMethodThunk.cs">
+      <Link>IL\Stubs\MethodBaseGetCurrentMethodThunk.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\MethodBaseGetCurrentMethodThunk.Mangling.cs">
+      <Link>IL\Stubs\MethodBaseGetCurrentMethodThunk.Mangling.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateMethodILEmitter.cs">
       <Link>IL\Stubs\DelegateMethodILEmitter.cs</Link>
     </Compile>

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ReflectionHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ReflectionHelpers.cs
@@ -39,18 +39,26 @@ namespace Internal.Runtime.CompilerHelpers
         [System.Runtime.CompilerServices.DependencyReductionRoot]
         public static MethodBase GetCurrentMethodNonGeneric(RuntimeMethodHandle methodHandle)
         {
+#if CORERT
+            return MethodBase.GetMethodFromHandle(methodHandle);
+#else
             // The compiler should ideally provide us with a RuntimeMethodHandle for the uninstantiated thing,
-            // but the file format cannot express a RuntimeMethodHandle for a generic definition of a generic method.
+            // but the Project N toolchain cannot express a RuntimeMethodHandle for a generic definition of a generic method.
             return MethodBase.GetMethodFromHandle(methodHandle).MetadataDefinitionMethod;
+#endif
         }
 
         // This supports MethodBase.GetCurrentMethod() intrinsic expansion in the compiler
         [System.Runtime.CompilerServices.DependencyReductionRoot]
         public static MethodBase GetCurrentMethodGeneric(RuntimeMethodHandle methodHandle, RuntimeTypeHandle typeHandle)
         {
+#if CORERT
+            return MethodBase.GetMethodFromHandle(methodHandle, typeHandle);
+#else
             // The compiler should ideally provide us with a RuntimeMethodHandle for the uninstantiated thing,
-            // but the file format cannot express a RuntimeMethodHandle for a generic definition of a generic method.
+            // but the Project N toolchain cannot express a RuntimeMethodHandle for a generic definition of a generic method.
             return MethodBase.GetMethodFromHandle(methodHandle, typeHandle).MetadataDefinitionMethod;
+#endif
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreRT.cs
@@ -11,7 +11,7 @@ namespace System.Reflection
         public static MethodBase GetMethodFromHandle(RuntimeMethodHandle handle) => ReflectionAugments.ReflectionCoreCallbacks.GetMethodFromHandle(handle);
         public static MethodBase GetMethodFromHandle(RuntimeMethodHandle handle, RuntimeTypeHandle declaringType) => ReflectionAugments.ReflectionCoreCallbacks.GetMethodFromHandle(handle, declaringType);
 
-        // This is actually an ILC intrinsic.
+        [System.Runtime.CompilerServices.Intrinsic]
         public static MethodBase GetCurrentMethod() { throw new NotImplementedException(); }
 
         // This is not an api but needs to be declared public so that System.Private.Reflection.Core can access (and override it)


### PR DESCRIPTION
This is on the same plan as Assembly.GetExecutingAssembly (redirect
calls to this method to call a small thunk that loads what "current"
means and dispatches to the CoreLib to do the rest of the work).

The difference from `GetExecutingAssembly` is that I made the method be
a member of the type that owns the calling method so that we don't have
to come up with weird name manglings.