### PR TITLE
NS2.0 - Finish TypeLoadException.cs

### DIFF
--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -524,6 +524,7 @@
     <Compile Include="System\TypedReference.cs" />
     <Compile Include="System\TypeUnificationKey.cs" />
     <Compile Include="System\TypeLoadException.cs" />
+    <Compile Include="System\TypeLoadException.CoreRT.cs" />
     <Compile Include="System\UInt16.cs" />
     <Compile Include="System\UInt32.cs" />
     <Compile Include="System\UInt64.cs" />

--- a/src/System.Private.CoreLib/src/System/TypeLoadException.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/TypeLoadException.CoreRT.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    public partial class TypeLoadException
+    {
+        internal TypeLoadException(string message, string typeName)
+            : base(message)
+        {
+            HResult = __HResults.COR_E_TYPELOAD;
+            _typeName = typeName;
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/TypeLoadException.cs
+++ b/src/System.Private.CoreLib/src/System/TypeLoadException.cs
@@ -2,26 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*=============================================================================
-**
-**
-**
-** Purpose: The exception class for type loading failures.
-**
-**
-=============================================================================*/
-
-using System.Globalization;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
-using System.Security;
-using System.Diagnostics.Contracts;
 
 namespace System
 {
     [Serializable]
-    public class TypeLoadException : SystemException
+    public partial class TypeLoadException : SystemException
     {
         public TypeLoadException()
             : base(SR.Arg_TypeLoadException)
@@ -29,55 +15,50 @@ namespace System
             HResult = __HResults.COR_E_TYPELOAD;
         }
 
-        public TypeLoadException(String message)
+        public TypeLoadException(string message)
             : base(message)
         {
             HResult = __HResults.COR_E_TYPELOAD;
         }
 
-        public TypeLoadException(String message, Exception inner)
+        public TypeLoadException(string message, Exception inner)
             : base(message, inner)
         {
             HResult = __HResults.COR_E_TYPELOAD;
         }
 
-        internal TypeLoadException(String message, String typeName)
-            : base(message)
-        {
-            HResult = __HResults.COR_E_TYPELOAD;
-            _typeName = typeName;
-        }
-
         protected TypeLoadException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            _typeName = info.GetString("TypeLoadClassName");
         }
 
-        public override String Message
+        public override string Message
         {
             get
             {
-                SetMessageField();
+                if (_message == null)
+                    _message = SR.Arg_TypeLoadException;
                 return _message;
             }
         }
 
-        private void SetMessageField()
-        {
-            if (_message == null)
-                _message = SR.Arg_TypeLoadException;
-        }
-
-        public String TypeName
+        public string TypeName
         {
             get
             {
                 if (_typeName == null)
-                    return String.Empty;
+                    return string.Empty;
                 return _typeName;
             }
         }
 
-        private String _typeName;
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("TypeLoadClassName", _typeName, typeof(string));
+        }
+
+        private string _typeName;
     }
 }


### PR DESCRIPTION
This also refactors the file in case we want to share
it with CoreCLR. Still deciding if that's a good idea,
but the cleanup is valid either way.