### PR TITLE
NS2.0 Complete the 3 remaining System.Exception methods.

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2335,4 +2335,7 @@
   <data name="Overflow_Currency" xml:space="preserve">
     <value>Value was either too large or too small for a Currency.</value>
   </data>
+  <data name="PlatformNotSupported_SecureBinarySerialization" xml:space="preserve">
+    <value>Secure binary serialization is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.IO;
-using System.Text;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.Serialization;
 using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
+
+using MethodBase = System.Reflection.MethodBase;
 
 using Internal.Diagnostics;
-using Internal.Runtime.Augments;
 
 namespace System
 {
@@ -70,6 +66,8 @@ namespace System
             }
         }
 
+        public new Type GetType() => base.GetType();
+
         public virtual IDictionary Data
         {
             get
@@ -79,6 +77,16 @@ namespace System
 
                 return _data;
             }
+        }
+
+        // TargetSite is not supported on CoreRT. Because it's likely use is diagnostic logging, returning null (a permitted return value)
+        // seems more useful than throwing a PlatformNotSupportedException here.
+        public MethodBase TargetSite => null;
+
+        protected event EventHandler<SafeSerializationEventArgs> SerializeObjectState
+        {
+            add { throw new PlatformNotSupportedException(SR.PlatformNotSupported_SecureBinarySerialization); }
+            remove { throw new PlatformNotSupportedException(SR.PlatformNotSupported_SecureBinarySerialization); }
         }
 
         #region Interop Helpers


### PR DESCRIPTION
The secure binary serialization hack from the days
where SecurityCritical actually meant something
is PNSE (following CoreCLR's lead.)

The "why does this even exist" GetType() method speaks
for itself.

TargetSite is iffy even on the full framework -
I don't think it merits work to attempt it on
CoreRT. Since diagnostic logging is the only
really defensible use of this api, returning
null is likely more useful than throwing a PNSE here.