### PR TITLE
Add support for arrays of pointer types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 
-using ILCompiler.DependencyAnalysisFramework;
-
 using Internal.IL;
 using Internal.Runtime;
 using Internal.Text;
@@ -277,8 +275,6 @@ namespace ILCompiler.DependencyAnalysis
             {
                 flags |= (UInt16)EETypeFlags.RelatedTypeViaIATFlag;
             }
-
-            // Todo: Generic Type Definition EETypes
 
             if (HasOptionalFields)
             {
@@ -734,9 +730,9 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (parameterizedType.IsArray)
                 {
-                    if (parameterType.IsPointer || parameterType.IsFunctionPointer)
+                    if (parameterType.IsFunctionPointer)
                     {
-                        // Arrays of pointers and function pointers are not currently supported
+                        // Arrays of function pointers are not currently supported
                         throw new TypeSystemException.TypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
                     }
 

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1242,6 +1242,9 @@
   <data name="NotSupported_ByRefLike" xml:space="preserve">
     <value>Cannot create boxed ByRef-like values.</value>
   </data>
+  <data name="NotSupported_Type" xml:space="preserve">
+    <value>Type is not supported.</value>
+  </data>
   <data name="NotSupported_WaitAllSTAThread" xml:space="preserve">
     <value>WaitAll for multiple handles on a STA thread is not supported.</value>
   </data>


### PR DESCRIPTION
Progress towards dotnet/corefx#17480.

On the compiler side:
* Unblock generation of arrays of pointer EETypes. We were already doing
the right thing w.r.t. the interface lists (these *do not* implement the
generic interface: `int*[]` does not implement `IEnumerable<int*>`).
Nothing else was missing.

On the classlib side:
* I groveled through the places where we would box/unbox array element
types, or assume that if the element type is not a value type, it's a
reference type. Hopefully, I didn't miss anything.
* One place that might look like I missed is `GCHandleValidatePinnedObject`,
but it seems like CoreCLR has this missing too and you can't get a pinned
handle to an array of pointers...
* I pre-empted dotnet/coreclr#10646 in my implementation of
`Array.Copy`.

On the runtime side:
* I verified this doesn't affect casting (i.e. we don't allow casting
`uint*[]` to `int*[]`), so no changes should be needed.