### PR TITLE
Restrict rule that marks generic interfaces on arrays as always used

### DIFF
--- a/src/Common/src/TypeSystem/Common/CastingHelper.cs
+++ b/src/Common/src/TypeSystem/Common/CastingHelper.cs
@@ -189,6 +189,12 @@ namespace Internal.TypeSystem
             }
         }
 
+        public static bool IsArrayElementTypeCastableBySize(TypeDesc elementType)
+        {
+            TypeDesc underlyingType = elementType.UnderlyingType;
+            return underlyingType.IsPrimitive && GetIntegralTypeMatchSize(underlyingType) != 0;
+        }
+
         private static bool CanCastToClassOrInterface(this TypeDesc thisType, TypeDesc otherType, StackOverflowProtect protect)
         {
             if (otherType.IsInterface)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -76,9 +76,20 @@ namespace ILCompiler.DependencyAnalysis
                     // could result in interface methods of this type being used (e.g. IEnumberable<object>.GetEnumerator()
                     // can dispatch to an implementation of IEnumerable<string>.GetEnumerator()).
                     // For now, we will not try to optimize this and we will pretend all interface methods are necessary.
-                    // NOTE: we need to also do this for generic interfaces on arrays because they have a weird casting rule
-                    // that doesn't require the implemented interface to be variant to consider it castable.
-                    if (implementedInterface.HasVariance || (_type.IsArray && implementedInterface.HasInstantiation))
+                    bool allInterfaceMethodsAreImplicitlyUsed = implementedInterface.HasVariance;
+                    if (!allInterfaceMethodsAreImplicitlyUsed && _type.IsArray && implementedInterface.HasInstantiation)
+                    {
+                        // NOTE: we need to also do this for generic interfaces on arrays because they have a weird casting rule
+                        // that doesn't require the implemented interface to be variant to consider it castable.
+                        // For value types, we only need this when the array is castable by size (int[] and ICollection<uint>),
+                        // or it's a reference type (Derived[] and ICollection<Base>).
+                        TypeDesc elementType = ((ArrayType)_type).ElementType;
+                        allInterfaceMethodsAreImplicitlyUsed =
+                            CastingHelper.IsArrayElementTypeCastableBySize(elementType) ||
+                            (elementType.IsDefType && !elementType.IsValueType);
+                    }
+
+                    if (allInterfaceMethodsAreImplicitlyUsed)
                     {
                         foreach (var interfaceMethod in implementedInterface.GetAllMethods())
                         {


### PR DESCRIPTION
In particular, we don't need to do this for arrays of valuetypes (unless
the "cast by size" rule applies).

This improves single file compilation throughput by 5-7%. Size of a retail single file HelloWorld.exe goes from 5,061,120 bytes to 4,624,896 bytes.

Makes things less terrible until we have a real fix for #1198 (more size/throughput savings are possible there).