### PR TITLE
Add type loader support for building arrays of pointers

### DIFF
--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -226,10 +226,12 @@ namespace Internal.Reflection.Execution
         //
         public unsafe sealed override bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, out RuntimeTypeHandle arrayTypeHandle)
         {
+#if PROJECTN
             if (RuntimeAugments.IsUnmanagedPointerType(elementTypeHandle))
             {
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_PointerArray);
             }
+#endif
 
             if (RuntimeAugments.IsGenericTypeDefinition(elementTypeHandle))
             {
@@ -267,10 +269,12 @@ namespace Internal.Reflection.Execution
         //
         public unsafe sealed override bool TryGetMultiDimArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, int rank, out RuntimeTypeHandle arrayTypeHandle)
         {
+#if PROJECTN
             if (RuntimeAugments.IsUnmanagedPointerType(elementTypeHandle))
             {
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_PointerArray);
             }
+#endif
 
             if (RuntimeAugments.IsGenericTypeDefinition(elementTypeHandle))
             {

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -226,13 +226,6 @@ namespace Internal.Reflection.Execution
         //
         public unsafe sealed override bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, out RuntimeTypeHandle arrayTypeHandle)
         {
-#if PROJECTN
-            if (RuntimeAugments.IsUnmanagedPointerType(elementTypeHandle))
-            {
-                throw new PlatformNotSupportedException(SR.PlatformNotSupported_PointerArray);
-            }
-#endif
-
             if (RuntimeAugments.IsGenericTypeDefinition(elementTypeHandle))
             {
                 throw new NotSupportedException(SR.NotSupported_OpenType);
@@ -269,13 +262,6 @@ namespace Internal.Reflection.Execution
         //
         public unsafe sealed override bool TryGetMultiDimArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, int rank, out RuntimeTypeHandle arrayTypeHandle)
         {
-#if PROJECTN
-            if (RuntimeAugments.IsUnmanagedPointerType(elementTypeHandle))
-            {
-                throw new PlatformNotSupportedException(SR.PlatformNotSupported_PointerArray);
-            }
-#endif
-
             if (RuntimeAugments.IsGenericTypeDefinition(elementTypeHandle))
             {
                 throw new NotSupportedException(SR.NotSupported_OpenType);

--- a/src/System.Private.Reflection.Execution/src/Resources/Resources.resx
+++ b/src/System.Private.Reflection.Execution/src/Resources/Resources.resx
@@ -204,9 +204,6 @@
   <data name="NotSupported_OpenType" xml:space="preserve">
     <value>Cannot create arrays of open type. </value>
   </data>
-  <data name="PlatformNotSupported_PointerArray" xml:space="preserve">
-    <value>Arrays of pointer types are not supported on this platform.</value>
-  </data>
   <data name="PlatformNotSupported_GetMethodInfoForStubDelegate" xml:space="preserve">
     <value>Obtaining a MethodInfo of a reflection-constructed delegate to a virtual method is not supported on this platform.</value>
   </data>

--- a/src/System.Private.Reflection.Execution/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Execution/src/Resources/Strings.resx
@@ -201,9 +201,6 @@
   <data name="NotSupported_OpenType" xml:space="preserve">
     <value>Cannot create arrays of open type. </value>
   </data>
-  <data name="PlatformNotSupported_PointerArray" xml:space="preserve">
-    <value>Arrays of pointer types are not supported on this platform.</value>
-  </data>
   <data name="PlatformNotSupported_GetMethodInfoForStubDelegate" xml:space="preserve">
     <value>Obtaining a MethodInfo of a reflection-constructed delegate to a virtual method is not supported on this platform.</value>
   </data>

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -1058,6 +1058,13 @@ namespace Internal.Runtime.TypeLoader
                 requireVtableSlotMapping = true;
                 pTemplateEEType = null;
             }
+#if !PROJECTN
+            else if (type.IsSzArray && ((ArrayType)type).ElementType.IsPointer)
+            {
+                pTemplateEEType = typeof(void*[]).TypeHandle.ToEETypePtr();
+                requireVtableSlotMapping = false;
+            }
+#endif
             else if (type.IsMdArray)
             {
                 pTemplateEEType = typeof(object[,]).TypeHandle.ToEETypePtr();

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -1058,15 +1058,12 @@ namespace Internal.Runtime.TypeLoader
                 requireVtableSlotMapping = true;
                 pTemplateEEType = null;
             }
-#if !PROJECTN
-            else if (type.IsSzArray && ((ArrayType)type).ElementType.IsPointer)
+            else if (type.IsMdArray || (type.IsSzArray && ((ArrayType)type).ElementType.IsPointer))
             {
-                pTemplateEEType = typeof(void*[]).TypeHandle.ToEETypePtr();
-                requireVtableSlotMapping = false;
-            }
-#endif
-            else if (type.IsMdArray)
-            {
+                // Multidimensional arrays and szarrays of pointers don't implement generic interfaces and
+                // we don't need to do much for them in terms of type building. We can pretty much just take
+                // the EEType for any of those, massage the bits that matter (GCDesc, element type,
+                // component size,...) to be of the right shape and we're done.
                 pTemplateEEType = typeof(object[,]).TypeHandle.ToEETypePtr();
                 requireVtableSlotMapping = false;
             }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -304,7 +304,7 @@ namespace Internal.Runtime.TypeLoader
                 {
                     ArrayType typeAsArrayType = (ArrayType)type;
 
-                    if (typeAsArrayType.IsSzArray)
+                    if (typeAsArrayType.IsSzArray && !typeAsArrayType.ElementType.IsPointer)
                     {
                         typeAsArrayType.ComputeTemplate(state);
                         Debug.Assert(state.TemplateType != null && state.TemplateType is ArrayType && !state.TemplateType.RuntimeTypeHandle.IsNull());
@@ -313,7 +313,7 @@ namespace Internal.Runtime.TypeLoader
                     }
                     else
                     {
-                        Debug.Assert(typeAsArrayType.IsMdArray);
+                        Debug.Assert(typeAsArrayType.IsMdArray || typeAsArrayType.ElementType.IsPointer);
                     }
 
                     // Assert that non-valuetypes are considered to have pointer size
@@ -1342,7 +1342,7 @@ namespace Internal.Runtime.TypeLoader
 
                     FinishInterfaces(type, state);
 
-                    if (typeAsSzArrayType.IsSzArray)
+                    if (typeAsSzArrayType.IsSzArray && !typeAsSzArrayType.ElementType.IsPointer)
                     {
                         FinishTypeDictionary(type, state);
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -382,9 +382,10 @@ namespace Internal.Runtime.TypeLoader
                         }
                     }
                 }
-                else if (TypeBeingBuilt.IsMdArray)
+                else if (TypeBeingBuilt.IsMdArray || (TypeBeingBuilt.IsSzArray && ((ArrayType)TypeBeingBuilt).ElementType.IsPointer))
                 {
-                    // MDArray types have the same vtable as the System.Array type they "derive" from.
+                    // MDArray types and pointer arrays have the same vtable as the System.Array type they "derive" from.
+                    // They do not implement the generic interfaces that make this interesting for normal arrays.
                     unsafe
                     {
                         return TypeBeingBuilt.BaseType.GetRuntimeTypeHandle().ToEETypePtr()->NumVtableSlots;
@@ -855,7 +856,7 @@ namespace Internal.Runtime.TypeLoader
             {
                 ArrayType typeAsArrayType = TypeBeingBuilt as ArrayType;
                 if (typeAsArrayType != null)
-                    return !typeAsArrayType.ParameterType.IsValueType && !typeAsArrayType.IsPointer;
+                    return !typeAsArrayType.ParameterType.IsValueType && !typeAsArrayType.ParameterType.IsPointer;
                 else
                     return false;
             }


### PR DESCRIPTION
This will be taking similar code paths as multidimensional arrays - the
arrays of pointers don't have anything "interesting" in the EEType and
should mostly just pass through.

Checking this in as disabled for PROJECTN since NUTC will blow up if it
sees an array of pointers.