### PR TITLE
Fix offset bug in TypedReference.MakeTypedReference()

### DIFF
--- a/src/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/System.Private.CoreLib/src/System/TypedReference.cs
@@ -105,7 +105,7 @@ namespace System
                 _offset = offset;
             }
 
-            public ref byte Value => ref Unsafe.Add<byte>(ref Unsafe.As<IntPtr, byte>(ref _target.m_pEEType), _offset);
+            public ref byte Value => ref Unsafe.Add<byte>(ref _target.GetRawData(), _offset);
 
             private readonly object _target;
             private readonly int _offset;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -353,7 +353,7 @@ namespace System.Reflection.Runtime.General
             if (flds.Length == 0)
                 throw new ArgumentException(SR.Arg_ArrayZeroError);
 
-            offset = RuntimeAugments.ObjectHeaderSize;
+            offset = 0;
             Type targetType = target.GetType();
             for (int i = 0; i < flds.Length; i++)
             {


### PR DESCRIPTION
Switch from &m_EEType to Object.GetRawData() was
double-counting the object header size.

Code now computes the offset without the object
header size to begin with.