### PR TITLE
Miscellaneous interop changes

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -462,7 +462,7 @@ namespace Internal.TypeSystem.Ecma
                 MetadataReader metadataReader = MetadataReader;
                 BlobReader marshalAsReader = metadataReader.GetBlobReader(parameter.GetMarshallingDescriptor());
                 EcmaSignatureParser parser = new EcmaSignatureParser(Module, marshalAsReader);
-                MarshalAsDescriptor marshalAs = parser.ParseMarshalAsDescriptor(isParameter:true);
+                MarshalAsDescriptor marshalAs = parser.ParseMarshalAsDescriptor();
                 Debug.Assert(marshalAs != null);
                 return marshalAs;
             }

--- a/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -289,35 +289,69 @@ namespace Internal.TypeSystem.Ecma
             return arguments;
         }
 
-        public MarshalAsDescriptor ParseMarshalAsDescriptor(bool isParameter)
+        public MarshalAsDescriptor ParseMarshalAsDescriptor()
         {
             Debug.Assert(_reader.RemainingBytes != 0);
 
             NativeTypeKind type = (NativeTypeKind)_reader.ReadByte();
             NativeTypeKind arraySubType = NativeTypeKind.Invalid;
-            uint? paramNum = null , numElem = null;
-            
-            if (type == NativeTypeKind.Array)
+            uint? paramNum = null, numElem = null;
+
+            switch (type)
             {
-                if (_reader.RemainingBytes != 0)
-                {
-                   arraySubType = (NativeTypeKind)_reader.ReadByte();
-                }
+                case NativeTypeKind.Array:
+                    {
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            arraySubType = (NativeTypeKind)_reader.ReadByte();
+                        }
+
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            paramNum = (uint)_reader.ReadCompressedInteger();
+                        }
+
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            numElem = (uint)_reader.ReadCompressedInteger();
+                        }
+
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            int flag = _reader.ReadCompressedInteger();
+                            if (flag == 0)
+                            {
+                                paramNum = null; //paramNum is just a place holder so that numElem can be present
+                            }
+                        }
+
+                    }
+                    break;
+                case NativeTypeKind.ByValArray:
+                    {
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            numElem = (uint)_reader.ReadCompressedInteger();
+                        }
+
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            arraySubType = (NativeTypeKind)_reader.ReadByte();
+                        }
+                    }
+                    break;
+                case NativeTypeKind.ByValTStr:
+                    {
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            numElem = (uint)_reader.ReadCompressedInteger();
+                        }
+                    }
+                    break;
+                default:
+                    break;
             }
 
-            if (isParameter)
-            {
-                if (_reader.RemainingBytes != 0)
-                {
-                    paramNum = (uint)_reader.ReadCompressedInteger();
-                }
-            }
-
-            if (_reader.RemainingBytes != 0)
-            {
-                numElem = (uint)_reader.ReadCompressedInteger();
-            }
-            
             Debug.Assert(_reader.RemainingBytes == 0);
 
             return new MarshalAsDescriptor(type, arraySubType, paramNum, numElem);

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -524,7 +524,7 @@ namespace Internal.TypeSystem.Ecma
                 MetadataReader metadataReader = MetadataReader;
                 BlobReader marshalAsReader = metadataReader.GetBlobReader(fieldDefinition.GetMarshallingDescriptor());
                 EcmaSignatureParser parser = new EcmaSignatureParser(EcmaModule, marshalAsReader);
-                MarshalAsDescriptor marshalAs =  parser.ParseMarshalAsDescriptor(isParameter:false);
+                MarshalAsDescriptor marshalAs =  parser.ParseMarshalAsDescriptor();
                 Debug.Assert(marshalAs != null);
                 return marshalAs;
             }

--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -107,8 +107,13 @@ namespace Internal.IL.Stubs
                             Debug.Assert(sequence == parameterMetadataArray[parameterIndex].Index);
                             marshalAs = parameterMetadataArray[parameterIndex++].MarshalAsDescriptor;
                         }
+                        bool isByRefType = delegateSignature[i].IsByRef;
 
-                        nativeParameterTypes[i] = MarshalHelpers.GetNativeMethodParameterType(delegateSignature[i], marshalAs, _interopStateManager, false, isAnsi);
+                        var managedType = isByRefType ? delegateSignature[i].GetParameterType() : delegateSignature[i];
+
+                        var nativeType = MarshalHelpers.GetNativeMethodParameterType(managedType, marshalAs, _interopStateManager, false, isAnsi);
+
+                        nativeParameterTypes[i] = isByRefType ? nativeType.MakePointerType() : nativeType;
                      }
                     _signature = new MethodSignature(MethodSignatureFlags.Static, 0, nativeReturnType, nativeParameterTypes);
                 }

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -59,7 +59,7 @@ namespace Internal.IL.Stubs
             ParameterMetadata[] parameterMetadataArray = targetMethod.GetParameterMetadata();
             Marshaller[] marshallers = new Marshaller[methodSig.Length + 1];
             int parameterIndex = 0;
-            ParameterMetadata parameterMetadata = new ParameterMetadata();
+            ParameterMetadata parameterMetadata;
 
             for (int i = 0; i < marshallers.Length; i++)
             {
@@ -281,6 +281,12 @@ namespace Internal.IL.Stubs
             CallsiteSetupCodeStream = Emitter.NewCodeStream();
             ReturnValueMarshallingCodeStream = Emitter.NewCodeStream();
             UnmarshallingCodestream = Emitter.NewCodeStream();
+        }
+
+        public PInvokeILCodeStreams(ILEmitter emitter, ILCodeStream codeStream)
+        {
+            Emitter = emitter;
+            MarshallingCodeStream = codeStream;
         }
     }
 

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -159,12 +159,15 @@ namespace Internal.TypeSystem.Interop
                 MarshallerKind kind, 
                 MarshallerKind elementMarshallerKind,
                 InteropStateManager interopStateManager,
-                MarshalAsDescriptor marshalAs)
+                MarshalAsDescriptor marshalAs,
+                bool isArrayElement = false)
         {
             TypeSystemContext context = type.Context;
             NativeTypeKind nativeType = NativeTypeKind.Invalid;
             if (marshalAs != null)
-                nativeType = marshalAs.Type;
+            {
+                nativeType = isArrayElement ? marshalAs.ArraySubType : marshalAs.Type;
+            }
 
             switch (kind)
             {
@@ -199,6 +202,9 @@ namespace Internal.TypeSystem.Interop
 
                 case MarshallerKind.Bool:
                     return context.GetWellKnownType(WellKnownType.Int32);
+
+                case MarshallerKind.CBool:
+                        return context.GetWellKnownType(WellKnownType.Byte);
 
                 case MarshallerKind.Enum:
                 case MarshallerKind.BlittableStruct:
@@ -236,9 +242,6 @@ namespace Internal.TypeSystem.Interop
                 case MarshallerKind.AnsiStringBuilder:
                     return context.GetWellKnownType(WellKnownType.Byte).MakePointerType();
 
-                case MarshallerKind.CBool:
-                    return context.GetWellKnownType(WellKnownType.Byte);
-
                 case MarshallerKind.BlittableArray:
                 case MarshallerKind.Array:
                 case MarshallerKind.AnsiCharArray:
@@ -254,7 +257,8 @@ namespace Internal.TypeSystem.Interop
                             elementMarshallerKind,
                             MarshallerKind.Unknown,
                             interopStateManager,
-                            null);
+                            marshalAs, 
+                            isArrayElement: true);
 
                         return elementNativeType.MakePointerType();
                     }


### PR DESCRIPTION
This contains the following changes:

* Added support for CBool Marshalling
* Parse MarshalAsDescriptor correctly based on native type
* Separate out AllocManagedToNative and TransformManagedToNative from
AllocAndTransformManagedToNative for Array Marshaller so that the
codepath that calls TransformManagedToNative works correctly.
* Handle ByRef type for delegate marshalling

This fixes two CoreCLR tests:

* MarshalBoolArrayTest
* BoolTest