### PR TITLE
Fix to not reuse cached handle arrays for reentrant waits on Windows

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Unix.cs
@@ -31,6 +31,26 @@ namespace Internal.Runtime.Augments
             _stopped = new ManualResetEvent(false);
         }
 
+        /// <summary>
+        /// Callers must ensure to clear and return the array after use
+        /// </summary>
+        internal SafeWaitHandle[] RentWaitedSafeWaitHandleArray(int requiredCapacity)
+        {
+            Debug.Assert(this == CurrentThread);
+            Debug.Assert(!ReentrantWaitsEnabled); // due to this, no need to actually rent and return the array
+
+            _waitedSafeWaitHandles.VerifyElementsAreDefault();
+            _waitedSafeWaitHandles.EnsureCapacity(requiredCapacity);
+            return _waitedSafeWaitHandles.Items;
+        }
+
+        internal void ReturnWaitedSafeWaitHandleArray(SafeWaitHandle[] waitedSafeWaitHandles)
+        {
+            Debug.Assert(this == CurrentThread);
+            Debug.Assert(!ReentrantWaitsEnabled); // due to this, no need to actually rent and return the array
+            Debug.Assert(waitedSafeWaitHandles == _waitedSafeWaitHandles.Items);
+        }
+
         private ThreadPriority GetPriorityLive()
         {
             return ThreadPriority.Normal;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
@@ -64,18 +64,6 @@ namespace Internal.Runtime.Augments
             _managedThreadId = new ManagedThreadId();
         }
 
-        /// <summary>
-        /// Callers must ensure to clear the array after use
-        /// </summary>
-        internal SafeWaitHandle[] GetWaitedSafeWaitHandleArray(int requiredCapacity)
-        {
-            Debug.Assert(this == CurrentThread);
-
-            _waitedSafeWaitHandles.VerifyElementsAreDefault();
-            _waitedSafeWaitHandles.EnsureCapacity(requiredCapacity);
-            return _waitedSafeWaitHandles.Items;
-        }
-
         public static RuntimeThread Create(ThreadStart start) => new RuntimeThread(start, 0);
         public static RuntimeThread Create(ThreadStart start, int maxStackSize) => new RuntimeThread(start, maxStackSize);
 

--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandleArray.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandleArray.cs
@@ -38,13 +38,27 @@ namespace System.Threading
             }
         }
 
-        public T[] Items
+        public T[] Items => _items;
+
+        public T[] RentItems()
         {
-            get
-            {
-                Debug.Assert(_items != null);
-                return _items;
-            }
+            Debug.Assert(_items != null);
+
+            T[] items = _items;
+            _items = null;
+            return items;
+        }
+
+        public void ReturnItems(T[] items)
+        {
+            Debug.Assert(items != null);
+            Debug.Assert(items.Length >= InitialCapacity);
+            Debug.Assert(items.Length <= MaximumCapacity);
+            Debug.Assert((items.Length & (items.Length - 1)) == 0); // is a power of 2
+
+            Debug.Assert(_items == null);
+
+            _items = items;
         }
 
         [Conditional("DEBUG")]


### PR DESCRIPTION
Fixes #3174