### PR TITLE
Add mangled names for delegate and struct marshalling stubs

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.Mangling.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.Mangling.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// contains functionality related to name mangling
+    /// </summary>
+    public partial class DelegateMarshallingMethodThunk : IPrefixMangledType
+    {
+        TypeDesc IPrefixMangledType.BaseType
+        {
+            get
+            {
+                return _delegateType;
+            }
+        }
+
+        string IPrefixMangledType.Prefix
+        {
+            get
+            {
+                if (IsOpenStaticDelegate)
+                {
+                    return "ReverseOpenStaticDelegateStub";
+                }
+                else
+                {
+                    return "ReverseDelegateStub";
+                }
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -13,7 +13,7 @@ namespace Internal.IL.Stubs
     /// <summary>
     /// Thunk to marshal delegate parameters and invoke the appropriate delegate function pointer
     /// </summary>
-    public class DelegateMarshallingMethodThunk : ILStubMethod
+    public partial class DelegateMarshallingMethodThunk : ILStubMethod
     {
         private readonly TypeDesc _owningType;
         private readonly MetadataType _delegateType;

--- a/src/Common/src/TypeSystem/IL/Stubs/StructMarshallingThunk.Mangling.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/StructMarshallingThunk.Mangling.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace Internal.IL.Stubs
+{
+    public partial class StructMarshallingThunk : IPrefixMangledType
+    {
+        TypeDesc IPrefixMangledType.BaseType
+        {
+            get
+            {
+                return ManagedType;
+            }
+        }
+
+        string IPrefixMangledType.Prefix
+        {
+            get
+            {
+                switch (ThunkType)
+                {
+                    case StructMarshallingThunkType.ManagedToNative:
+                        return "ManagedToNative";
+                    case StructMarshallingThunkType.NativeToManage:
+                        return "NativeToManaged";
+                    case StructMarshallingThunkType.Cleanup:
+                        return "Cleanup";
+                    default:
+                        System.Diagnostics.Debug.Assert(false, "Unexpected Struct marshalling thunk type");
+                        return string.Empty;
+                }
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
@@ -30,7 +30,7 @@ namespace Internal.IL.Stubs
         }
     }
 
-    public class StructMarshallingThunk : ILStubMethod
+    public partial class StructMarshallingThunk : ILStubMethod
     {
         internal readonly MetadataType ManagedType;
         internal readonly NativeStructType NativeType;
@@ -96,17 +96,17 @@ namespace Internal.IL.Stubs
         {
             get
             {
-                if (ThunkType == StructMarshallingThunkType.ManagedToNative)
+                switch (ThunkType)
                 {
-                    return "ManagedToNative__" + ((MetadataType)ManagedType).Name;
-                }
-                else if (ThunkType == StructMarshallingThunkType.NativeToManage)
-                {
-                    return "NativeToManaged__" + ((MetadataType)ManagedType).Name;
-                }
-                else
-                {
-                    return "Cleanup__" + ((MetadataType)ManagedType).Name;
+                    case StructMarshallingThunkType.ManagedToNative:
+                        return "ManagedToNative__" + ((MetadataType)ManagedType).Name;
+                    case StructMarshallingThunkType.NativeToManage:
+                        return "NativeToManaged__" + ((MetadataType)ManagedType).Name;
+                    case StructMarshallingThunkType.Cleanup:
+                        return "Cleanup__" + ((MetadataType)ManagedType).Name;
+                    default:
+                        System.Diagnostics.Debug.Assert(false, "Unexpected Struct marshalling thunk type");
+                        return string.Empty;
                 }
             }
         }

--- a/src/Common/src/TypeSystem/Mangling/IPrefixMangledMethod.cs
+++ b/src/Common/src/TypeSystem/Mangling/IPrefixMangledMethod.cs
@@ -5,7 +5,7 @@
 namespace Internal.TypeSystem
 {
     /// <summary>
-    /// When implemented by a <see cref="MethodDesc"/>, instructs a name mangler to use the same mangled name
+    /// When implemented by a <see cref="TypeDesc"/> or <see cref="MethodDesc"/>, instructs a name mangler to use the same mangled name
     /// as another entity while prepending a specific prefix to that mangled name.
     /// </summary>
     public interface IPrefixMangledMethod

--- a/src/Common/src/TypeSystem/Mangling/IPrefixMangledType.cs
+++ b/src/Common/src/TypeSystem/Mangling/IPrefixMangledType.cs
@@ -5,7 +5,7 @@
 namespace Internal.TypeSystem
 {
     /// <summary>
-    /// When implemented by a <see cref="TypeDesc"/>, instructs a name mangler to use the same mangled name
+    /// When implemented by a <see cref="TypeDesc"/> or <see cref="MethodDesc"/>, instructs a name mangler to use the same mangled name
     /// as another entity while prepending a specific prefix to that mangled name.
     /// </summary>
     public interface IPrefixMangledType

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -368,11 +368,17 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.cs">
       <Link>IL\Stubs\DelegateMarshallingMethodThunk.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.Mangling.cs">
+      <Link>IL\Stubs\DelegateMarshallingMethodThunk.Mangling.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateThunks.cs">
       <Link>IL\Stubs\DelegateThunks.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\StructMarshallingThunk.cs">
       <Link>IL\Stubs\StructMarshallingThunk.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\StructMarshallingThunk.Mangling.cs">
+      <Link>IL\Stubs\StructMarshallingThunk.Mangling.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\IL\NativeStructType.cs">
       <Link>TypeSystem\Interop\IL\NativeStructType.cs</Link>


### PR DESCRIPTION
Michal added concept of prefix mangled type/method couples of
days ago which enables us to add managled name for delegate and struct
marshalling stubs.