### PR TITLE
Filter out non-valuetype arrays from the array map

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -58,7 +58,8 @@ namespace ILCompiler.DependencyAnalysis
                 if (!factory.MetadataManager.TypeGeneratesEEType(arrayType))
                     continue;
 
-                // TODO: This should only be emitted for arrays of value types. The type loader builds everything else.
+                if (!arrayType.ElementType.IsValueType)
+                    continue;
 
                 // Go with a necessary type symbol. It will be upgraded to a constructed one if a constructed was emitted.
                 IEETypeNode arrayTypeSymbol = factory.NecessaryTypeSymbol(arrayType);


### PR DESCRIPTION
These were being added to the table as a workaround for the type loader
trying to build array types. We should let type loader do it's thing and
save the bytes.