### PR TITLE
Move CoreRT specific CopyTo code to .CoreRT file

### DIFF
--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -872,18 +872,6 @@ namespace System
             }
         }
 
-        // CopyTo copies a collection into an Array, starting at a particular
-        // index into the array.
-        // 
-        // This method is to support the ICollection interface, and calls
-        // Array.Copy internally.  If you aren't using ICollection explicitly,
-        // call Array.Copy to avoid an extra indirection.
-        internal void CopyTo<T>(T[] thatArray, int index)
-        {
-            T[] thisArray = (T[])this;
-            Array.Copy(thisArray, 0, thatArray, index, Length);
-        }
-
         public static void Clear(Array array, int index, int length)
         {
             if (!RuntimeImports.TryArrayClear(array, index, length))

--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -872,6 +872,18 @@ namespace System
             }
         }
 
+        // CopyTo copies a collection into an Array, starting at a particular
+        // index into the array.
+        // 
+        // This method is to support the ICollection interface, and calls
+        // Array.Copy internally.  If you aren't using ICollection explicitly,
+        // call Array.Copy to avoid an extra indirection.
+        internal void CopyTo<T>(T[] thatArray, int index)
+        {
+            T[] thisArray = (T[])this;
+            Array.Copy(thisArray, 0, thatArray, index, Length);
+        }
+
         public static void Clear(Array array, int index, int length)
         {
             if (!RuntimeImports.TryArrayClear(array, index, length))

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -1167,18 +1167,6 @@ namespace System
             }
         }
 
-        // CopyTo copies a collection into an Array, starting at a particular
-        // index into the array.
-        // 
-        // This method is to support the ICollection interface, and calls
-        // Array.Copy internally.  If you aren't using ICollection explicitly,
-        // call Array.Copy to avoid an extra indirection.
-        internal void CopyTo<T>(T[] thatArray, int index)
-        {
-            T[] thisArray = (T[])this;
-            Array.Copy(thisArray, 0, thatArray, index, Length);
-        }
-
         public static bool Exists<T>(T[] array, Predicate<T> match)
         {
             return Array.FindIndex(array, match) != -1;


### PR DESCRIPTION
I am not sure if it should go to Array<T> as it does `(T[])this;` which throws for not matching source arrays (e.g. object[])