### PR TITLE
Make Compilation roots understand canonicalization

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -215,7 +215,17 @@ namespace ILCompiler
 
             public void AddCompilationRoot(MethodDesc method, string reason, string exportName = null)
             {
-                var methodEntryPoint = _factory.MethodEntrypoint(method);
+                MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                IMethodNode methodEntryPoint;
+
+                if (canonMethod != method)
+                {
+                    methodEntryPoint = _factory.ShadowConcreteMethod(method);
+                }
+                else
+                {
+                    methodEntryPoint = _factory.MethodEntrypoint(method);
+                }
 
                 _graph.AddRoot(methodEntryPoint, reason);
 


### PR DESCRIPTION
MethodCodeNode expects canonicalized methods when compiling with shared generics. When rooting methods (i.e, via an rd.xml file), use the canon method target for MethodEntryPoint.