### PR TITLE
Correctly mangle names of NativeStructTypes

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.TypeSystem;
-
 using System;
 using System.Collections.Generic;
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Interop
 {
-    public class NativeStructType : MetadataType, IPrefixMangledType
+    public partial class NativeStructType : MetadataType
     {
         // The managed struct that this type will imitate
         public MetadataType ManagedStructType
@@ -126,10 +124,6 @@ namespace Internal.TypeSystem.Interop
                 return ManagedStructType.Context;
             }
         }
-
-        TypeDesc IPrefixMangledType.BaseType => ManagedStructType;
-
-        string IPrefixMangledType.Prefix => "NativeStructType";
 
         private NativeStructField[] _fields;
         private InteropStateManager _interopStateManager;

--- a/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
@@ -2,13 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.TypeSystem;
+
 using System;
 using System.Collections.Generic;
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Interop
 {
-    public class NativeStructType : MetadataType
+    public class NativeStructType : MetadataType, IPrefixMangledType
     {
         // The managed struct that this type will imitate
         public MetadataType ManagedStructType
@@ -124,6 +126,10 @@ namespace Internal.TypeSystem.Interop
                 return ManagedStructType.Context;
             }
         }
+
+        TypeDesc IPrefixMangledType.BaseType => ManagedStructType;
+
+        string IPrefixMangledType.Prefix => "NativeStructType";
 
         private NativeStructField[] _fields;
         private InteropStateManager _interopStateManager;

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -383,6 +383,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Interop\IL\NativeStructType.cs">
       <Link>TypeSystem\Interop\IL\NativeStructType.cs</Link>
     </Compile>
+    <Compile Include="TypeSystem\Interop\IL\NativeStructType.Mangling.cs">
+      <Link>TypeSystem\Interop\IL\NativeStructType.Mangling.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\IL\InlineArrayType.cs">
       <Link>TypeSystem\Interop\IL\InlineArrayType.cs</Link>
     </Compile>

--- a/src/ILCompiler.TypeSystem/src/TypeSystem/Interop/IL/NativeStructType.Mangling.cs
+++ b/src/ILCompiler.TypeSystem/src/TypeSystem/Interop/IL/NativeStructType.Mangling.cs
@@ -4,7 +4,7 @@
 
 namespace Internal.TypeSystem.Interop
 {
-    public partial class NativeStructType : MetadataType, IPrefixMangledType
+    partial class NativeStructType : IPrefixMangledType
     {
         TypeDesc IPrefixMangledType.BaseType => ManagedStructType;
 

--- a/src/ILCompiler.TypeSystem/src/TypeSystem/Interop/IL/NativeStructType.Mangling.cs
+++ b/src/ILCompiler.TypeSystem/src/TypeSystem/Interop/IL/NativeStructType.Mangling.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem.Interop
+{
+    public partial class NativeStructType : MetadataType, IPrefixMangledType
+    {
+        TypeDesc IPrefixMangledType.BaseType => ManagedStructType;
+
+        string IPrefixMangledType.Prefix => "NativeStructType";
+    }
+}

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -66,7 +66,6 @@
     <Compile Include="$(CommonBasePath)\Internal\Text\Utf8String.cs" />
     <Compile Include="$(CommonBasePath)\Internal\Text\Utf8StringBuilder.cs" />
     <Compile Include="$(CommonBasePath)\System\Collections\Generic\ArrayBuilder.cs" />
-    <Compile Include="$(TypeSystemBasePath)\Mangling\IPrefixMangledType.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\EcmaMethodIL.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\ILProvider.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\McgInteropSupport.cs" />

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -66,6 +66,7 @@
     <Compile Include="$(CommonBasePath)\Internal\Text\Utf8String.cs" />
     <Compile Include="$(CommonBasePath)\Internal\Text\Utf8StringBuilder.cs" />
     <Compile Include="$(CommonBasePath)\System\Collections\Generic\ArrayBuilder.cs" />
+    <Compile Include="$(TypeSystemBasePath)\Mangling\IPrefixMangledType.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\EcmaMethodIL.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\ILProvider.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\McgInteropSupport.cs" />


### PR DESCRIPTION
Use the new IPrefixMangledType interface to disambiguate structs with
the same name from different input assemblies.