### PR TITLE
Incorporate CR feedback on Marvin hash

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -997,52 +997,7 @@ namespace System
         // they will return the same hash code.
         public override int GetHashCode()
         {
-#if FEATURE_RANDOMIZED_STRING_HASHING
-            return (int)Marvin.ComputeStringHash(ref Unsafe.As<char, byte>(ref _firstChar), (uint)(_stringLength * 2), Marvin.DefaultSeed);
-#else
-            unsafe
-            {
-                fixed (char* src = &_firstChar)
-                {
-#if BIT64
-                    int hash1 = 5381;
-#else
-                    int hash1 = (5381 << 16) + 5381;
-#endif
-                    int hash2 = hash1;
-
-#if BIT64
-                    int c;
-                    char* s = src;
-                    while ((c = s[0]) != 0)
-                    {
-                        hash1 = ((hash1 << 5) + hash1) ^ c;
-                        c = s[1];
-                        if (c == 0)
-                            break;
-                        hash2 = ((hash2 << 5) + hash2) ^ c;
-                        s += 2;
-                    }
-#else
-                    // 32bit machines.
-                    int* pint = (int*)src;
-                    int len = this.Length;
-                    while (len > 0)
-                    {
-                        hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ pint[0];
-                        if (len <= 2)
-                        {
-                            break;
-                        }
-                        hash2 = ((hash2 << 5) + hash2 + (hash2 >> 27)) ^ pint[1];
-                        pint += 2;
-                        len -= 4;
-                    }
-#endif
-                    return hash1 + (hash2 * 1566083941);
-                }
-            }
-#endif // FEATURE_RANDOMIZED_STRING_HASHING
+            return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref _firstChar), _stringLength * 2, Marvin.DefaultSeed);
         }
 
         // Determines whether a specified string is a prefix of the current instance


### PR DESCRIPTION
- String.GetHashCode() now uses Marvin unconditionally.

- Make the Marvin routines more general purpose and
  easier to use.

- Expanded the testing to odd-sized byte arrays (i.e.
  not strings), and fixed the bug found. Original
  data obtained by exporting SymCryptMarvin32() from
  CoreClr.dll and P/Invoking to it from test app.