### PR TITLE
Use 32bit relative pointers in ExternalReferenceTable

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DynamicInvokeTemplateDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DynamicInvokeTemplateDataNode.cs
@@ -97,7 +97,7 @@ namespace ILCompiler.DependencyAnalysis
             objData.RequireInitialPointerAlignment();
             objData.AddSymbol(this);
 
-            objData.EmitReloc(factory.NecessaryTypeSymbol(_dynamicInvokeMethodContainerType), RelocType.IMAGE_REL_BASED_REL32);
+            objData.EmitReloc(factory.NecessaryTypeSymbol(_dynamicInvokeMethodContainerType), RelocType.IMAGE_REL_BASED_RELPTR32);
 
             List<KeyValuePair<MethodDesc, int>> sortedList = new List<KeyValuePair<MethodDesc, int>>(_methodToTemplateIndex);
             sortedList.Sort((firstEntry, secondEntry) => firstEntry.Value.CompareTo(secondEntry.Value));
@@ -108,7 +108,7 @@ namespace ILCompiler.DependencyAnalysis
                 var nameAndSig = factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.MethodNameAndSignatureVertex(sortedList[i].Key));
 
                 objData.EmitInt(nameAndSig.SavedVertex.VertexOffset);
-                objData.EmitReloc(factory.MethodEntrypoint(sortedList[i].Key), RelocType.IMAGE_REL_BASED_REL32);
+                objData.EmitReloc(factory.MethodEntrypoint(sortedList[i].Key), RelocType.IMAGE_REL_BASED_RELPTR32);
             }
 
             _endSymbol.SetSymbolOffset(objData.CountBytes);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
@@ -97,14 +97,14 @@ namespace ILCompiler.DependencyAnalysis
 
             foreach (SymbolAndDelta symbolAndDelta in _insertedSymbols)
             {
-                if (factory.Target.Abi == Internal.TypeSystem.TargetAbi.CoreRT)
+                if (factory.Target.Abi == TargetAbi.CoreRT)
                 {
                     // TODO: set low bit if the linkage of the symbol is IAT_PVALUE.
-                    builder.EmitPointerReloc(symbolAndDelta.Symbol, symbolAndDelta.Delta);
+                    builder.EmitReloc(symbolAndDelta.Symbol, RelocType.IMAGE_REL_BASED_REL32, symbolAndDelta.Delta);
                 }
                 else
                 {
-                    Debug.Assert(factory.Target.Abi == Internal.TypeSystem.TargetAbi.ProjectN);
+                    Debug.Assert(factory.Target.Abi == TargetAbi.ProjectN);
                     int delta = symbolAndDelta.Delta;
                     if (symbolAndDelta.Symbol.RepresentsIndirectionCell)
                     {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternalReferencesTableNode.cs
@@ -100,7 +100,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (factory.Target.Abi == TargetAbi.CoreRT)
                 {
                     // TODO: set low bit if the linkage of the symbol is IAT_PVALUE.
-                    builder.EmitReloc(symbolAndDelta.Symbol, RelocType.IMAGE_REL_BASED_REL32, symbolAndDelta.Delta);
+                    builder.EmitReloc(symbolAndDelta.Symbol, RelocType.IMAGE_REL_BASED_RELPTR32, symbolAndDelta.Delta);
                 }
                 else
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -184,6 +184,14 @@ namespace ILCompiler.DependencyAnalysis
         private static extern int EmitSymbolRef(IntPtr objWriter, byte[] symbolName, RelocType relocType, int delta);
         public int EmitSymbolRef(Utf8StringBuilder symbolName, RelocType relocType, int delta = 0)
         {
+            // Workaround for ObjectWriter's lack of support for IMAGE_REL_BASED_RELPTR32
+            // https://github.com/dotnet/corert/issues/3278
+            if (relocType == RelocType.IMAGE_REL_BASED_RELPTR32)
+            {
+                relocType = RelocType.IMAGE_REL_BASED_REL32;
+                delta = checked(delta + sizeof(int));
+            }
+
             return EmitSymbolRef(_nativeObjectWriter, symbolName.Append('\0').UnderlyingArray, relocType, delta);
         }
 
@@ -519,7 +527,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (i != 0)
                 {
-                    EmitSymbolRef(_sb.Clear().Append("_lsda0").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_REL32, 4);
+                    EmitSymbolRef(_sb.Clear().Append("_lsda0").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_RELPTR32);
 
                     // emit relative offset from the main function
                     EmitIntValue((ulong)(start - frameInfos[0].StartOffset), 4);
@@ -527,7 +535,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (ehInfo != null)
                 {
-                    EmitSymbolRef(_sb.Clear().Append("_ehInfo").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_REL32, 4);
+                    EmitSymbolRef(_sb.Clear().Append("_ehInfo").Append(_currentNodeZeroTerminatedName), RelocType.IMAGE_REL_BASED_RELPTR32);
                 }
 
                 if (gcInfo != null)

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -451,7 +451,7 @@ namespace Internal.Reflection.Execution
                 if (module.Handle.IsTypeManager)
                 {
                     // CoreRT uses 32bit relative relocs
-                    declaringTypeHandle = RuntimeAugments.CreateRuntimeTypeHandle((IntPtr)((byte*)(&pBlob[1]) + (int)(pBlob[0])));
+                    declaringTypeHandle = RuntimeAugments.CreateRuntimeTypeHandle((IntPtr)(pBlobAsBytes + *(int*)pBlobAsBytes));
                 }
                 else
                 {
@@ -474,7 +474,8 @@ namespace Internal.Reflection.Execution
                 if (module.Handle.IsTypeManager)
                 {
                     // CoreRT uses 32bit relative relocs
-                    dynamicInvokeMethod = (IntPtr)((byte*)(&pBlob[index + 2]) + (int)(pBlob[index + 1]));
+                    int* pRelPtr32 = &((int*)pBlob)[index + 1];
+                    dynamicInvokeMethod = (IntPtr)((byte*)pRelPtr32 + *pRelPtr32);
                 }
                 else
                 {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
@@ -8,11 +8,7 @@ using Internal.Runtime;
 using Internal.Runtime.Augments;
 using Debug = System.Diagnostics.Debug;
 
-#if CORERT
-using TableElement = System.IntPtr;
-#else
 using TableElement = System.UInt32;
-#endif
 
 namespace Internal.Runtime.TypeLoader
 {
@@ -95,8 +91,9 @@ namespace Internal.Runtime.TypeLoader
                 throw new BadImageFormatException();
 
             // TODO: indirection through IAT
+            int* elementsTable = (int*)_elements;
 
-            return ((TableElement*)_elements)[index];
+            return (IntPtr)((byte*)&elementsTable[index + 1] + elementsTable[index]);
 #else
             uint rva = GetRvaFromIndex(index);
             if ((rva & IndirectionConstants.RVAPointsToIndirection) != 0)
@@ -119,7 +116,9 @@ namespace Internal.Runtime.TypeLoader
 
             // TODO: indirection through IAT
 
-            return ((IntPtr*)_elements)[index];
+            int* elementsTable = (int*)_elements;
+
+            return (IntPtr)((byte*)&elementsTable[index + 1] + elementsTable[index]);
 #else
             uint rva = GetRvaFromIndex(index);
 
@@ -152,7 +151,9 @@ namespace Internal.Runtime.TypeLoader
 
             // TODO: indirection through IAT
 
-            return ((IntPtr*)_elements)[index];
+            int* elementsTable = (int*)_elements;
+
+            return (IntPtr)((byte*)&elementsTable[index + 1] + elementsTable[index]);
         }
 #endif
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ExternalReferencesTable.cs
@@ -91,9 +91,8 @@ namespace Internal.Runtime.TypeLoader
                 throw new BadImageFormatException();
 
             // TODO: indirection through IAT
-            int* elementsTable = (int*)_elements;
-
-            return (IntPtr)((byte*)&elementsTable[index + 1] + elementsTable[index]);
+            int* pRelPtr32 = &((int*)_elements)[index];
+            return (IntPtr)((byte*)pRelPtr32 + *pRelPtr32);
 #else
             uint rva = GetRvaFromIndex(index);
             if ((rva & IndirectionConstants.RVAPointsToIndirection) != 0)
@@ -115,10 +114,8 @@ namespace Internal.Runtime.TypeLoader
                 throw new BadImageFormatException();
 
             // TODO: indirection through IAT
-
-            int* elementsTable = (int*)_elements;
-
-            return (IntPtr)((byte*)&elementsTable[index + 1] + elementsTable[index]);
+            int* pRelPtr32 = &((int*)_elements)[index];
+            return (IntPtr)((byte*)pRelPtr32 + *pRelPtr32);
 #else
             uint rva = GetRvaFromIndex(index);
 
@@ -150,10 +147,8 @@ namespace Internal.Runtime.TypeLoader
                 throw new BadImageFormatException();
 
             // TODO: indirection through IAT
-
-            int* elementsTable = (int*)_elements;
-
-            return (IntPtr)((byte*)&elementsTable[index + 1] + elementsTable[index]);
+            int* pRelPtr32 = &((int*)_elements)[index];
+            return (IntPtr)((byte*)pRelPtr32 + *pRelPtr32);
         }
 #endif
 


### PR DESCRIPTION
We can't use IMAGE_REL_BASED_ADDR32NB (because it's Windows only), but
we can use IMAGE_REL_BASED_REL32 which is close enough.

For CppCodegen we'll need to stick to pointer-sized entries (that are
bigger and require an extra reloc), but CppCodegen is not far enough to
use this yet anyway. We can cross that bridge when we get there.

We might also just want to just standardize on IMAGE_REL_BASED_REL32 for
any TypeManager-based modules for simplicity.

This drops the size of HelloWorld.exe with shared generics enabled from 4,390,912 bytes to 4,297,216 bytes.