### PR TITLE
Fix rules for when metadata token should be used in mapping tables

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -86,16 +86,12 @@ namespace ILCompiler
 
         public override bool WillUseMetadataTokenToReferenceMethod(MethodDesc method)
         {
-            // Until cross module references are understood, and reported by ComputeMetadata
-            // return false here.
-            return false;
+            return _compilationModuleGroup.ContainsType(method.GetTypicalMethodDefinition().OwningType);
         }
 
         public override bool WillUseMetadataTokenToReferenceField(FieldDesc field)
         {
-            // Until cross module references are understood, and reported by ComputeMetadata
-            // return false here.
-            return false;
+            return _compilationModuleGroup.ContainsType(field.GetTypicalFieldDefinition().OwningType);
         }
 
         protected override void ComputeMetadata(NodeFactory factory,

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -214,8 +214,6 @@ namespace ILCompiler
 
         public override bool WillUseMetadataTokenToReferenceField(FieldDesc field)
         {
-            // Until cross module references are understood, and reported by ComputeMetadata
-            // return false here.
             return _compilationModuleGroup.ContainsType(field.GetTypicalFieldDefinition().OwningType);
         }
 


### PR DESCRIPTION
New code from TFS changed the way we refer to members from field/method
reflection mapping tables. It conservatively chose to not use tokens,
but fall back to full signatures at all times (these are normally only
needed for crossmodule references).

Fixing the logic up because this was causing failures in the rolling
build (one of the negative tests that deliberately uses bad types was
crashing the compiler because the bad type can't be used in a native
layout signature).

This fix also recovers a file size/throughput regression.

The bigger picture problem is that we need to do something about
resiliency against bad inputs at the native layout writing phase.