### PR TITLE
Reenable randomized hashing perf mitigation for CoreRT.

### DIFF
--- a/src/Common/src/System/Collections/HashHelpers.cs
+++ b/src/Common/src/System/Collections/HashHelpers.cs
@@ -19,6 +19,8 @@ namespace System.Collections
 {
     internal static class HashHelpers
     {
+        public const int HashCollisionThreshold = 100;
+
         private const Int32 HashPrime = 101;
 
         // Table of prime numbers to use as hash table sizes. 

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -288,7 +288,7 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return this.GetType() == typeof(ArrayType);
+                return this is ArrayType;
             }
         }
 
@@ -323,7 +323,7 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return this.GetType() == typeof(ByRefType);
+                return this is ByRefType;
             }
         }
 
@@ -334,7 +334,7 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return this.GetType() == typeof(PointerType);
+                return this is PointerType;
             }
         }
 
@@ -345,7 +345,7 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return this.GetType() == typeof(FunctionPointerType);
+                return this is FunctionPointerType;
             }
         }
 
@@ -356,7 +356,7 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return this.GetType() == typeof(SignatureTypeVariable) || this.GetType() == typeof(SignatureMethodVariable);
+                return this is SignatureTypeVariable || this is SignatureMethodVariable;
             }
         }
 

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -217,6 +217,7 @@
     <Compile Include="System\Collections\Generic\List.cs" />
     <Compile Include="System\Collections\Generic\Dictionary.cs" />
     <Compile Include="System\Collections\Generic\IDictionaryDebugView.cs" />
+    <Compile Include="System\Collections\Generic\NonRandomizedStringEqualityComparer.cs" />
     <Compile Include="System\Collections\LowLevelListDictionary.cs" />
     <Compile Include="System\Collections\LowLevelComparer.cs" />
     <Compile Include="System\Collections\ObjectEqualityComparer.cs" />

--- a/src/System.Private.CoreLib/src/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Collections.Generic
+{
+    // NonRandomizedStringEqualityComparer is the comparer used by default with the Dictionary<string,...> 
+    // As the randomized string hashing is now turned on with no opt-out, we need to keep the performance not affected 
+    // as much as possible in the main stream scenarios like Dictionary<string,>
+    // We use NonRandomizedStringEqualityComparer as default comparer as it doesnt use the randomized string hashing which 
+    // keep the performance not affected till we hit collision threshold and then we switch to the comparer which is using 
+    // randomized string hashing.
+    [Serializable]
+    internal sealed class NonRandomizedStringEqualityComparer : EqualityComparer<string>
+    {
+        private static volatile IEqualityComparer<string> s_nonRandomizedComparer;
+
+        internal static new IEqualityComparer<string> Default => s_nonRandomizedComparer ?? (s_nonRandomizedComparer = new NonRandomizedStringEqualityComparer());
+
+        public sealed override bool Equals(string x, string y) => string.Equals(x, y);
+
+        public sealed override int GetHashCode(string obj)
+        {
+            if (obj == null)
+                return 0;
+            return obj.GetLegacyNonRandomizedHashCode();
+        }
+    }
+} 


### PR DESCRIPTION
This reenables the FEATURE_RANDOMIZED_STRING_HASHING paths for
Dictionary (without the #if ceremony.) The purpose of this
code is mitigate the perf regression introduced by randomized
string hashing on Dictionaries. Dictionaries only switch
to the randomized hash if they suspect a DOS attack
in progress.

String.GetLegacyNonRandomizedHashCode() is cut-paste directly
from CoreCLR (sans the ThisAssembly.DailyBuildNumber salt
which wasn't doing what it intended anyway since
ThisAssembly.DailyBuildNumber never changes in CoreCLR.)

The part that will look strange are the changes to TypeDesc.cs.
Without this, instantiating a Dictionary triggers this unfortunate
reentrancy.


 EqualityComparerHelpers.GetComparer()

   which triggers

 TryBuildGenericType

   which triggers

 another TryBuildGenericType

   which triggers

 TypeDesc.IsArray => this.GetType() == typeof(ArrayType)

   which triggers

 two Type creations

   which triggers

 RuntimeTypeInfo.EstablishDebugName

   which triggers

 ReflectionTrace.get_Enabled

   which triggers

 ReflectionEventSource class constructor

   which triggers a bunch more EventSource-related stuff
   which eventually triggers

 EqualityComparerHelpers.GetComparer() again,

   which eventually ends up apparently creating/registering
   the very same type that the first GetComparer() was trying to add.

   As a result, this all unwinds and

 RegisterDynamicGenericTypesAndMethods()

   throws an throw new ArgumentException(SR.Argument_AddingDuplicate);


I chose to break this cycle by removing the GetType()/typeof() calls
from the path and replacing them with "is" checks (after checking
that each target type is sealed. Though "is" is still probably
correct even if unsealed.)

Let me know if there's a more holistic solution for this but
in general, not triggering Type creations in low-level code
is a good practice in Project N.