### PR TITLE
Replace SafeHandle marshaling failure assert with throw

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -1510,8 +1510,12 @@ namespace Internal.TypeSystem.Interop
                 PropagateFromByRefArg(marshallingCodeStream, _managedHome);
             }
 
-            // we don't support [IN,OUT] together yet, either IN or OUT
-            Debug.Assert(!(Out && In));
+            // TODO: https://github.com/dotnet/corert/issues/3291
+            // We don't support [IN,OUT] together yet, either IN or OUT.
+            if (Out && In)
+            {
+                throw new NotImplementedException("Marshalling an argument as both in and out not yet implemented");
+            }
 
             var safeHandleType = InteropTypes.GetSafeHandleType(Context);
 


### PR DESCRIPTION
Throw instead of assert so that we fail creating the interop stub and
replace it at runtime with a throw helper instead of AV'ing in the
compiler.