### PR TITLE
AssemblyBinder cleanup.

### DIFF
--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatMetadataUnit.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatMetadataUnit.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Runtime.Assemblies;
 using System.Runtime;
 using Internal.Metadata.NativeFormat;
 using Internal.Runtime.Augments;
@@ -500,7 +501,7 @@ namespace Internal.TypeSystem.NativeFormat
         public NativeFormatModule GetModuleFromAssemblyName(string assemblyNameString)
         {
             AssemblyBindResult bindResult;
-            AssemblyName assemblyName = new AssemblyName(assemblyNameString);
+            RuntimeAssemblyName assemblyName = AssemblyNameParser.Parse(assemblyNameString);
             Exception failureException;
             if (!AssemblyBinderImplementation.Instance.Bind(assemblyName, out bindResult, out failureException))
             {

--- a/src/System.Private.CoreLib/src/System/Reflection/Runtime/Assemblies/RuntimeAssemblyName.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Runtime/Assemblies/RuntimeAssemblyName.cs
@@ -142,9 +142,9 @@ namespace System.Reflection.Runtime.Assemblies
 
             // Our "Flags" contain both the classic flags and the ProcessorArchitecture + ContentType bits. The public AssemblyName has separate properties for
             // these. The setters for these properties quietly mask out any bits intended for the other one, so we needn't do that ourselves..
-            blank.Flags = AssemblyNameHelpers.ExtractAssemblyNameFlags(this.Flags);
-            blank.ContentType = AssemblyNameHelpers.ExtractAssemblyContentType(this.Flags);
-            blank.ProcessorArchitecture = AssemblyNameHelpers.ExtractProcessorArchitecture(this.Flags);
+            blank.Flags = this.Flags.ExtractAssemblyNameFlags();
+            blank.ContentType = this.Flags.ExtractAssemblyContentType();
+            blank.ProcessorArchitecture = this.Flags.ExtractProcessorArchitecture();
 
             if (this.PublicKeyOrToken != null)
             {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -85,10 +85,9 @@ namespace System.Reflection.Runtime.Assemblies
                 delegate (RuntimeAssemblyName assemblyRefName)
                 {
                     AssemblyBinder binder = ReflectionCoreExecution.ExecutionDomain.ReflectionDomainSetup.AssemblyBinder;
-                    AssemblyName convertedAssemblyRefName = assemblyRefName.ToAssemblyName();
                     AssemblyBindResult bindResult;
                     Exception exception;
-                    if (!binder.Bind(convertedAssemblyRefName, out bindResult, out exception))
+                    if (!binder.Bind(assemblyRefName, out bindResult, out exception))
                         return null;
 
                     return GetRuntimeAssembly(bindResult);

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Internal.Metadata.NativeFormat;
 using System.Reflection.Runtime.General;
-using Internal.Runtime.TypeLoader;
+using System.Reflection.Runtime.Assemblies;
 using System.Runtime.InteropServices;
 
 namespace Internal.Reflection.Core
@@ -31,18 +31,10 @@ namespace Internal.Reflection.Core
     {
         public const String DefaultAssemblyNameForGetType = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
 
-        public abstract bool Bind(AssemblyName refName, out AssemblyBindResult result, out Exception exception);
+        public abstract bool Bind(RuntimeAssemblyName refName, out AssemblyBindResult result, out Exception exception);
 
         public abstract bool Bind(byte[] rawAssembly, byte[] rawSymbolStore, out AssemblyBindResult result, out Exception exception);
 
         public abstract IList<AssemblyBindResult> GetLoadedAssemblies();
-
-        // This helper is a concession to the fact that third-party binders running on top of the Win8P surface area have no sensible way
-        // to perform this task due to the lack of a SetCulture() api on the AssemblyName class. Reflection.Core *is* able to do this 
-        // thanks to the Internal.Reflection.Augment contract so we will expose this helper for the convenience of binders. 
-        protected AssemblyName CreateAssemblyNameFromMetadata(MetadataReader reader, ScopeDefinitionHandle scopeDefinitionHandle)
-        {
-            return scopeDefinitionHandle.ToRuntimeAssemblyName(reader).ToAssemblyName();
-        }
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderTypeSystemContext.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderTypeSystemContext.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Reflection;
 using System.Diagnostics;
+using System.Reflection.Runtime.Assemblies;
+
 using Internal.Metadata.NativeFormat;
 using Internal.Runtime.Augments;
 using Internal.Runtime.CompilerServices;
@@ -193,12 +195,12 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name, bool throwErrorIfNotFound)
+        public override ModuleDesc ResolveAssembly(AssemblyName name, bool throwErrorIfNotFound)
         {
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
             AssemblyBindResult bindResult;
             Exception failureException;
-            if (!AssemblyBinderImplementation.Instance.Bind(name, out bindResult, out failureException))
+            if (!AssemblyBinderImplementation.Instance.Bind(name.ToRuntimeAssemblyName(), out bindResult, out failureException))
             {
                 if (throwErrorIfNotFound)
                     throw failureException;


### PR DESCRIPTION
Use RuntimeAssemblyName rather than AssemblyName as the
exchange and workhorse type to avoid all the back and forth conversion
and working around AssemblyName's deficiencies.

The only reason it was like that before was because
of layering decisions that no longer applied once the NS2.0
effort started.