### PR TITLE
Move AllowUnsafeBlocks where build.cmd will see it

### DIFF
--- a/src/ILCompiler/repro/repro.csproj
+++ b/src/ILCompiler/repro/repro.csproj
@@ -10,16 +10,15 @@
     <AssemblyName>repro</AssemblyName>
     <ExcludeResourcesImport>true</ExcludeResourcesImport>
     <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\Debug</OutputPath>
     <ErrorReport>prompt</ErrorReport>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />


### PR DESCRIPTION
I hit this randomly a couple times. If you have `unsafe` in your repro
project and do a clean build from the command line, the build will fail
because the repro project can't be compiled.