### PR TITLE
NS2.0 AssemblyName.ReferenceMatchesDefinition()

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -225,7 +225,27 @@ namespace System.Reflection
         }
 
         public static AssemblyName GetAssemblyName(string assemblyFile) { throw new NotImplementedException(); } // TODO: https://github.com/dotnet/corert/issues/3253
-        public static bool ReferenceMatchesDefinition(AssemblyName reference, AssemblyName definition) { throw new NotImplementedException(); } // TODO: https://github.com/dotnet/corert/issues/1861
+
+        /// <summary>
+        /// Compares the simple names disregarding Version, Culture and PKT. While this clearly does not
+        /// match the intent of this api, this api has been broken this way since its debut and we cannot
+        /// change its behavior now.
+        /// </summary>
+        public static bool ReferenceMatchesDefinition(AssemblyName reference, AssemblyName definition)
+        {
+            if (object.ReferenceEquals(reference, definition))
+                return true;
+
+            if (reference == null)
+                throw new ArgumentNullException(nameof(reference));
+
+            if (definition == null)
+                throw new ArgumentNullException(nameof(definition));
+
+            string refName = reference.Name ?? string.Empty;
+            string defName = definition.Name ?? string.Empty;
+            return refName.Equals(defName, StringComparison.OrdinalIgnoreCase);
+        }
 
         internal static string EscapeCodeBase(string codebase) { throw new PlatformNotSupportedException(); }
 


### PR DESCRIPTION
Fix: https://github.com/dotnet/corert/issues/1861

This is the CoreRT half of https://github.com/dotnet/coreclr/pull/10919
and reconciles the two implementations of this
remarkably stupid api.

(Excerpted from that PR)

This api was broken from its debut in 2.0 (and yet somehow
scored a 2.9% on .NET api catalog)

 https://connect.microsoft.com/VisualStudio/feedback/details/752902/assemblyname-referencematchesdefinition-returns-true-even-though-the-parameters-dont-match

In 2012, the MSDN docs were changed to match its broken behavior:

   Return Value
   Type: System.Boolean
   true if the simple assembly names are the same; otherwise, false.

   Remarks

   The comparison depends only on the simple assembly name. It ignores version, culture, and public key token.


A more accurate description would be:

   This api takes the simple names of the ref and def.
   Then it parses the simple names *as if they were*
   full-blown assembly names with optional Version, Culture
   and PKT (!)

   Then it applies a RefToDef test to that name using a test
   that's quite separate from the one used by the actual
   CoreCLR loader (so any similarities between
   it and the actual binding rules is purely coincidental.)

   Oh, and that code assumes the Def name came from trusted
   sources so if it's has a null Culture property, it NULL-AV's.

We could replicate this behavior on CoreRT (relying on
its own AssemblyBinder) but the more I progressed, the
more the venture failed to pass the laugh test (though
at least we got a nice AssemblyBinder cleanup
as a side effect.)

So what we'll do is make the api behavior match the
MSDN description (and likely come close enough to the compat bar)
but in a more straightforward fashion.