### PR TITLE
Implement Unicode and Ansi StringBuilder Marshalling

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -6,7 +6,6 @@ using System;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
-
 using Interlocked = System.Threading.Interlocked;
 
 namespace Internal.Runtime.CompilerHelpers
@@ -16,74 +15,27 @@ namespace Internal.Runtime.CompilerHelpers
     /// </summary>
     internal static class InteropHelpers
     {
-        private static unsafe byte* CharArrayToAnsi(char* pStr, int stringLength)
+        internal static unsafe byte* StringToAnsiString(String str, bool bestFit, bool throwOnUnmappableChar)
         {
-            // CORERT-TODO: Use same encoding as the rest of the interop
-            var encoding = Encoding.UTF8;
-            int bufferLength = encoding.GetByteCount(pStr, stringLength);
-            byte* buffer = (byte*)PInvokeMarshal.CoTaskMemAlloc((UIntPtr)(void*)(bufferLength + 1)).ToPointer();
-
-            encoding.GetBytes(pStr, stringLength, buffer, bufferLength);
-            *(buffer + bufferLength) = 0;
-            return buffer;
-        }
-
-        internal static unsafe byte* StringToAnsi(String str)
-        {
-            if (str == null)
-                return null;
-
-            fixed (char* pStr = str)
-            {
-                return CharArrayToAnsi(pStr, str.Length);
-            }
-        }
-        internal static unsafe void StringToAnsiFixedArray(String str, byte* buffer, int length)
-        {
-            if (buffer == null)
-                return;
-
-            Debug.Assert(str.Length >= length);
-
-            var encoding = Encoding.UTF8;
-            fixed (char* pStr = str)
-            {
-                int bufferLength = encoding.GetByteCount(pStr, length);
-                encoding.GetBytes(pStr, length, buffer, bufferLength);
-                *(buffer + bufferLength) = 0;
-            }
+            return PInvokeMarshal.StringToAnsiString(str, bestFit, throwOnUnmappableChar);
         }
 
         public static unsafe string AnsiStringToString(byte* buffer)
         {
-            if (buffer == null)
-                return String.Empty;
-
-            int length = strlen(buffer);
-
-            return AnsiStringToStringFixedArray(buffer, length);
-
+            return PInvokeMarshal.AnsiStringToString(buffer);
         }
 
-        public static unsafe string AnsiStringToStringFixedArray(byte* buffer, int length)
+
+        internal static unsafe void StringToByValAnsiString(string str, byte* pNative, int charCount, bool bestFit, bool throwOnUnmappableChar)
         {
-            if (buffer == null)
-                return String.Empty;
+            // In CoreRT charCount = Min(SizeConst, str.Length). So we don't need to truncate again.
+            PInvokeMarshal.StringToByValAnsiString(str, pNative, charCount, bestFit, throwOnUnmappableChar, truncate: false);
+        }
 
-            string result = String.Empty;
 
-            if (length > 0)
-            {
-                result = new String(' ', length);
-
-                fixed (char* pTemp = result)
-                {
-                    int charCount = Encoding.UTF8.GetCharCount(buffer, length);
-                    // TODO: support ansi semantics in windows
-                    Encoding.UTF8.GetChars(buffer, charCount, pTemp, length);
-                }
-            }
-            return result;
+        public static unsafe string ByValAnsiStringToString(byte* buffer, int length)
+        {
+            return PInvokeMarshal.ByValAnsiStringToString(buffer, length);
         }
 
         internal static unsafe void StringToUnicodeFixedArray(String str, UInt16* buffer, int length)
@@ -144,95 +96,56 @@ namespace Internal.Runtime.CompilerHelpers
             return new String(buffer);
         }
 
-        public static unsafe char* StringBuilderToUnicode(StringBuilder sb)
+        public static unsafe byte* AllocMemoryForAnsiStringBuilder(StringBuilder sb)
         {
             if (sb == null)
             {
                 return null;
             }
-
-            char* buffer = (char*)PInvokeMarshal.CoTaskMemAlloc((UIntPtr)(sizeof(char) * (sb.Capacity + 1))).ToPointer();
-            sb.UnsafeCopyTo(buffer);
-            return buffer;
+            return (byte *)CoTaskMemAllocAndZeroMemory(new IntPtr(checked((sb.Capacity + 2) * PInvokeMarshal.GetSystemMaxDBCSCharSize())));
         }
 
-        public static unsafe void UnicodeToStringBuilder(char* pNative, StringBuilder sb)
-        {
-            if (pNative == null)
-            {
-                sb = null;
-                return;
-            }
-
-            if (sb == null)
-            {
-                sb = new StringBuilder();
-            }
-            sb.ReplaceBuffer(pNative);
-        }
-
-        public static unsafe byte* StringBuilderToAnsi(StringBuilder sb)
+        public static unsafe char* AllocMemoryForUnicodeStringBuilder(StringBuilder sb)
         {
             if (sb == null)
             {
                 return null;
             }
-
-            int len;
-            
-            // Optimize for the most common case. If there is only a single char[] in the StringBuilder,
-            // get it and convert it to ANSI
-            char[] buffer = sb.GetBuffer(out len);
-
-            if (buffer != null)
-            {
-                fixed (char* pManaged = buffer)
-                {
-                    return CharArrayToAnsi(pManaged, len);
-                }
-            }
-            else // Otherwise, convert StringBuilder to string and then convert to ANSI
-            {
-                string str = sb.ToString();
-
-                // Convert UNICODE string to ANSI string
-                fixed (char* pManaged = str)
-                {
-                    return CharArrayToAnsi(pManaged, str.Length);
-                }
-            }
+            return (char *)CoTaskMemAllocAndZeroMemory(new IntPtr(checked((sb.Capacity + 2) * 2)));
         }
 
-        public static unsafe void AnsiToStringBuilder(byte* pNative, StringBuilder sb)
+
+        public static unsafe void AnsiStringToStringBuilder(byte* newBuffer, System.Text.StringBuilder stringBuilder)
+        {
+            if (stringBuilder == null)
+                return;
+
+            PInvokeMarshal.AnsiStringToStringBuilder(newBuffer, stringBuilder);
+        }
+
+        public static unsafe void UnicodeStringToStringBuilder(ushort* newBuffer, System.Text.StringBuilder stringBuilder)
+        {
+            if (stringBuilder == null)
+                return;
+
+            PInvokeMarshal.UnicodeStringToStringBuilder(newBuffer, stringBuilder);
+        }
+
+        public static unsafe void StringBuilderToAnsiString(System.Text.StringBuilder stringBuilder, byte* pNative,
+            bool bestFit, bool throwOnUnmappableChar)
         {
             if (pNative == null)
-            {
-                sb = null;
                 return;
-            }
 
-            if (sb == null)
-            {
-                sb = new StringBuilder();
-            }
+            PInvokeMarshal.StringBuilderToAnsiString(stringBuilder, pNative, bestFit, throwOnUnmappableChar);
+        }
 
-            int length = strlen(pNative);
-            int charCount = Encoding.UTF8.GetCharCount(pNative, length);
+        public static unsafe void StringBuilderToUnicodeString(System.Text.StringBuilder stringBuilder, ushort* destination)
+        {
+            if (destination == null)
+                return;
 
-            if (charCount > 0)
-            {
-                char[] buffer = new char[charCount];
-                fixed (char* pTemp = &buffer[0])
-                {
-                    // TODO: support ansi semantics in windows
-                    Encoding.UTF8.GetChars(pNative, charCount, pTemp, length);
-                }
-                sb.ReplaceBuffer(buffer);
-            }
-            else
-            {
-                sb.Clear();
-            }
+            PInvokeMarshal.StringBuilderToUnicodeString(stringBuilder, destination);
         }
 
         internal static unsafe IntPtr ResolvePInvoke(MethodFixupCell* pCell)

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -73,11 +73,17 @@ namespace PInvokeTests
         [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, EntryPoint = "VerifyUnicodeStringBuilder")]
         private static extern int VerifyUnicodeStringBuilderIn([In]StringBuilder sb);
 
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
+        private static extern int VerifyUnicodeStringBuilderOut([Out]StringBuilder sb);
+
         [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi, EntryPoint = "VerifyAnsiStringBuilder")]
         private static extern int VerifyAnsiStringBuilder(StringBuilder sb);
 
         [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi, EntryPoint = "VerifyAnsiStringBuilder")]
         private static extern int VerifyAnsiStringBuilderIn([In]StringBuilder sb);
+
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        private static extern int VerifyAnsiStringBuilderOut([Out]StringBuilder sb);
 
         [DllImport("*", CallingConvention = CallingConvention.StdCall)]
         public static extern bool SafeHandleTest(SafeMemoryHandle sh1, Int64 sh1Value);
@@ -301,19 +307,26 @@ namespace PInvokeTests
             // Only [In] should change stringbuilder value
             ThrowIfNotEquals("Hello World", sb2.ToString(), "In unicode StringBuilder marshalling failed");
 
+            StringBuilder sb3 = new StringBuilder();
+            ThrowIfNotEquals(1, VerifyUnicodeStringBuilderOut(sb3), "Out Unicode string marshalling failed");
+            ThrowIfNotEquals("Hello World", sb3.ToString(), "Out Unicode StringBuilder marshalling failed");
 
-            StringBuilder sb3 = new StringBuilder("Hello World");
-            ThrowIfNotEquals(1, VerifyAnsiStringBuilder(sb3), "Ansi StringBuilder marshalling failed");
-            ThrowIfNotEquals("HELLO WORLD", sb3.ToString(), "Ansi StringBuilder marshalling failed.");
+            StringBuilder sb4 = new StringBuilder("Hello World");
+            ThrowIfNotEquals(1, VerifyAnsiStringBuilder(sb4), "Ansi StringBuilder marshalling failed");
+            ThrowIfNotEquals("HELLO WORLD", sb4.ToString(), "Ansi StringBuilder marshalling failed.");
 
-            StringBuilder sb4 = null;
+            StringBuilder sb5 = null;
             // for null stringbuilder it should return -1
-            ThrowIfNotEquals(-1, VerifyAnsiStringBuilder(sb4), "Null Ansi StringBuilder marshalling failed");
+            ThrowIfNotEquals(-1, VerifyAnsiStringBuilder(sb5), "Null Ansi StringBuilder marshalling failed");
 
-            StringBuilder sb5 = new StringBuilder("Hello World");
-            ThrowIfNotEquals(1, VerifyAnsiStringBuilderIn(sb5), "In unicode StringBuilder marshalling failed");
+            StringBuilder sb6 = new StringBuilder("Hello World");
+            ThrowIfNotEquals(1, VerifyAnsiStringBuilderIn(sb6), "In unicode StringBuilder marshalling failed");
             // Only [In] should change stringbuilder value
-            ThrowIfNotEquals("Hello World", sb5.ToString(), "In unicode StringBuilder marshalling failed");
+            ThrowIfNotEquals("Hello World", sb6.ToString(), "In unicode StringBuilder marshalling failed");
+
+            StringBuilder sb7 = new StringBuilder();
+            ThrowIfNotEquals(1, VerifyAnsiStringBuilderOut(sb7), "Out Ansi string marshalling failed");
+            ThrowIfNotEquals("Hello World!", sb7.ToString(), "Out Ansi StringBuilder marshalling failed");
         }
 
 

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -67,8 +67,17 @@ namespace PInvokeTests
         private static extern bool VerifySizeParamIndex(
                 [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] out byte[] arrByte, out byte arrSize);
 
-        [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        private static extern int VerifyStringBuilder(StringBuilder sb);
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, EntryPoint = "VerifyUnicodeStringBuilder")]
+        private static extern int VerifyUnicodeStringBuilder(StringBuilder sb);
+
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, EntryPoint = "VerifyUnicodeStringBuilder")]
+        private static extern int VerifyUnicodeStringBuilderIn([In]StringBuilder sb);
+
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi, EntryPoint = "VerifyAnsiStringBuilder")]
+        private static extern int VerifyAnsiStringBuilder(StringBuilder sb);
+
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi, EntryPoint = "VerifyAnsiStringBuilder")]
+        private static extern int VerifyAnsiStringBuilderIn([In]StringBuilder sb);
 
         [DllImport("*", CallingConvention = CallingConvention.StdCall)]
         public static extern bool SafeHandleTest(SafeMemoryHandle sh1, Int64 sh1Value);
@@ -279,10 +288,32 @@ namespace PInvokeTests
         private static void TestStringBuilder()
         {
             Console.WriteLine("Testing marshalling string builder");
-            StringBuilder sb = new StringBuilder(16);
-            VerifyStringBuilder(sb);
-            bool result = (sb.ToString() == "Hello World");
-            ThrowIfNotEquals(true, result, "Unicode String builder marshalling failed.");
+            StringBuilder sb = new StringBuilder("Hello World");
+            ThrowIfNotEquals(1, VerifyUnicodeStringBuilder(sb), "Unicode StringBuilder marshalling failed");
+            ThrowIfNotEquals("HELLO WORLD", sb.ToString(), "Unicode StringBuilder marshalling failed.");
+
+            StringBuilder sb1 = null;
+            // for null stringbuilder it should return -1
+            ThrowIfNotEquals(-1, VerifyUnicodeStringBuilder(sb1), "Null unicode StringBuilder marshalling failed");
+
+            StringBuilder sb2 = new StringBuilder("Hello World");
+            ThrowIfNotEquals(1, VerifyUnicodeStringBuilderIn(sb2), "In unicode StringBuilder marshalling failed");
+            // Only [In] should change stringbuilder value
+            ThrowIfNotEquals("Hello World", sb2.ToString(), "In unicode StringBuilder marshalling failed");
+
+
+            StringBuilder sb3 = new StringBuilder("Hello World");
+            ThrowIfNotEquals(1, VerifyAnsiStringBuilder(sb3), "Ansi StringBuilder marshalling failed");
+            ThrowIfNotEquals("HELLO WORLD", sb3.ToString(), "Ansi StringBuilder marshalling failed.");
+
+            StringBuilder sb4 = null;
+            // for null stringbuilder it should return -1
+            ThrowIfNotEquals(-1, VerifyAnsiStringBuilder(sb4), "Null Ansi StringBuilder marshalling failed");
+
+            StringBuilder sb5 = new StringBuilder("Hello World");
+            ThrowIfNotEquals(1, VerifyAnsiStringBuilderIn(sb5), "In unicode StringBuilder marshalling failed");
+            // Only [In] should change stringbuilder value
+            ThrowIfNotEquals("Hello World", sb5.ToString(), "In unicode StringBuilder marshalling failed");
         }
 
 

--- a/tests/src/Simple/PInvoke/PInvokeNative.cpp
+++ b/tests/src/Simple/PInvoke/PInvokeNative.cpp
@@ -373,6 +373,27 @@ DLL_EXPORT int __stdcall VerifyUnicodeStringBuilder(unsigned short *val)
     return 1;
 }
 
+DLL_EXPORT int __stdcall VerifyUnicodeStringBuilderOut(unsigned short *val)
+{
+    if (val == NULL)
+        return 0;
+
+    unsigned short src[] = { 'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', 0 };
+    for (int i = 0; i < 12; i++)
+        val[i] = src[i];
+    
+    return 1;
+}
+
+DLL_EXPORT int __stdcall VerifyAnsiStringBuilderOut(char *val)
+{
+    if (val == NULL)
+        return 0;
+
+    CopyAnsiString(val, "Hello World!");
+    return 1;
+}
+
 // returns
 // -1 if val is null
 //  1 if val is "Hello World"

--- a/tests/src/Simple/PInvoke/PInvokeNative.cpp
+++ b/tests/src/Simple/PInvoke/PInvokeNative.cpp
@@ -351,15 +351,49 @@ DLL_EXPORT bool __stdcall Callback(StringFuncPtr *fnPtr)
    return true;
 }
 
-DLL_EXPORT void __stdcall VerifyStringBuilder(unsigned short *val)
+// returns
+// -1 if val is null
+//  1 if val is "Hello World"
+//  0 otherwise
+DLL_EXPORT int __stdcall VerifyUnicodeStringBuilder(unsigned short *val)
 {
-    char str[] = "Hello World";
-    int i;
-    for (i = 0; str[i] != '\0'; i++)
-        val[i] = (unsigned short)str[i];
-    val[i] = 0;
+    if (val == NULL)
+        return -1;
+
+    if (!VerifyUnicodeString(val))
+        return 0;
+
+    for (int i = 0; val[i] != '\0'; i++)
+    {
+        if ((char)val[i] >= 'a' && (char)val[i] <= 'z')
+        {
+            val[i] += 'A' - 'a';
+        }
+    }
+    return 1;
 }
 
+// returns
+// -1 if val is null
+//  1 if val is "Hello World"
+//  0 otherwise
+DLL_EXPORT int __stdcall VerifyAnsiStringBuilder(char *val)
+{
+    if (val == NULL)
+        return -1;
+
+    if (!VerifyAnsiString(val))
+        return 0;
+
+    for (int i = 0; val[i] != '\0'; i++)
+    {
+        if (val[i] >= 'a' && val[i] <= 'z')
+        {
+             val[i] += 'A' - 'a';
+        }
+    }
+    return 1;
+}
 
 DLL_EXPORT int* __stdcall ReversePInvoke_Unused(void(__stdcall *fnPtr) (void))
 {


### PR DESCRIPTION
We previously had only [OUT] UnicodeStringBuilder marshalling support. This change implements support for both Unicode and ANSI StringBuilder. It should also fix issue https://github.com/dotnet/corert/issues/2959 