### PR TITLE
Fix two CoreRT issues/

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
@@ -38,7 +38,7 @@ namespace Internal.Reflection.Extensions.NonPortable
             ConstructorInfo matchingCtor = null;
             ParameterInfo[] matchingParameters = null;
             IList<CustomAttributeTypedArgument> constructorArguments = cad.ConstructorArguments;
-            foreach (ConstructorInfo ctor in attributeType.GetConstructors(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            foreach (ConstructorInfo ctor in attributeType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
             {
                 ParameterInfo[] parameters = ctor.GetParametersNoCopy();
                 if (parameters.Length != constructorArguments.Count)
@@ -59,7 +59,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                 }
             }
             if (matchingCtor == null)
-                throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeType); // No matching ctor.
+                throw new MissingMethodException(attributeType.FullName, ConstructorInfo.ConstructorName);
 
             //
             // Found the right constructor. Instantiate the Attribute.
@@ -85,7 +85,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                     // Field
                     for (;;)
                     {
-                        FieldInfo fieldInfo = walk.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
+                        FieldInfo fieldInfo = walk.GetField(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
                         if (fieldInfo != null)
                         {
                             fieldInfo.SetValue(newAttribute, argumentValue);
@@ -93,7 +93,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                         }
                         Type baseType = walk.BaseType;
                         if (baseType == null)
-                            throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeType); // No field matches named argument.
+                            throw new CustomAttributeFormatException(SR.Format(SR.CustomAttributeFormat_InvalidFieldFail, name));
                         walk = baseType;
                     }
                 }
@@ -102,7 +102,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                     // Property
                     for (;;)
                     {
-                        PropertyInfo propertyInfo = walk.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
+                        PropertyInfo propertyInfo = walk.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
                         if (propertyInfo != null)
                         {
                             propertyInfo.SetValue(newAttribute, argumentValue);
@@ -110,7 +110,7 @@ namespace Internal.Reflection.Extensions.NonPortable
                         }
                         Type baseType = walk.BaseType;
                         if (baseType == null)
-                            throw RuntimeAugments.Callbacks.CreateMissingMetadataException(attributeType); // No field matches named argument.
+                            throw new CustomAttributeFormatException(SR.Format(SR.CustomAttributeFormat_InvalidPropertyFail, name));
                         walk = baseType;
                     }
                 }

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2392,4 +2392,10 @@
   <data name="Arg_SurrogatesNotAllowedAsSingleChar" xml:space="preserve">
     <value>Unicode surrogate characters must be written out as pairs together in the same call, not individually. Consider passing in a character array instead.</value>
   </data>
+  <data name="CustomAttributeFormat_InvalidFieldFail" xml:space="preserve">
+    <value>'{0}' field specified was not found.</value>
+  </data>
+  <data name="CustomAttributeFormat_InvalidPropertyFail" xml:space="preserve">
+    <value>'{0}' property specified was not found.</value>
+  </data>
 </root>


### PR DESCRIPTION
https://github.com/dotnet/corert/issues/3063

  CustomAttributeInstantiatior should stop throwing MissingMetadataExceptions


https://github.com/dotnet/corert/issues/2941

  FieldInfo.GetCustomAttributes(bool) shouldn't check if the ctor is public

Note: CoreCLR actually checks visibility relative to the decorated
member, but I'm not going to worry about that now (this is not the
right place in the code to do that anyway - the visibility check
is used to filter the enumeration.) I think we can get away without that.

While researching this, I found out that custom attribute fields
and properties *do* have to be public so I made that fix too.