### PR TITLE
Restore support for delegates to GVMs created from unshared code

### DIFF
--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -182,6 +182,35 @@ namespace System
             }
         }
 
+        // This function is known to the compiler.
+        protected void InitializeClosedInstanceWithGVMResolution(object firstParameter, RuntimeMethodHandle tokenOfGenericVirtualMethod)
+        {
+            if (firstParameter == null)
+                throw new ArgumentException(SR.Arg_DlgtNullInst);
+
+            IntPtr functionResolution = TypeLoaderExports.GVMLookupForSlot(firstParameter, tokenOfGenericVirtualMethod);
+
+            if (functionResolution == IntPtr.Zero)
+            {
+                // TODO! What to do when GVM resolution fails. Should never happen
+                throw new InvalidOperationException();
+            }
+            if (!FunctionPointerOps.IsGenericMethodPointer(functionResolution))
+            {
+                m_functionPointer = functionResolution;
+                m_firstParameter = firstParameter;
+            }
+            else
+            {
+                m_firstParameter = this;
+                m_functionPointer = GetThunk(ClosedInstanceThunkOverGenericMethod);
+                m_extraFunctionPointerOrData = functionResolution;
+                m_helperObject = firstParameter;
+            }
+
+            return;
+        }
+
         private void InitializeClosedInstanceToInterface(object firstParameter, IntPtr dispatchCell)
         {
             if (firstParameter == null)


### PR DESCRIPTION
This used to work but it's now failing in the rolling build. It's easy
enough to restore enough of the functionality to get the tests passing
again.

The rest of the work (creating the delegate from shared code) is tracked
in #2796 (uncomment the commented out test line to hit a failure in the
JIT).