### PR TITLE
Pri-0: Fix custom attribute parsing for arrays within arrays.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -86,6 +86,19 @@ namespace System.Reflection.Runtime.General
             return new ReadOnlyCollection<T>(enumeration.ToArray());
         }
 
+        public static T[] ReadOnlyCollectionToArray<T>(this IReadOnlyCollection<T> collection)
+        {
+            int count = collection.Count;
+            T[] result = new T[count];
+            int i = 0;
+            foreach (T element in collection)
+            {
+                result[i++] = element;
+            }
+            Debug.Assert(i == count);
+            return result;
+        }
+
         public static MethodInfo FilterAccessor(this MethodInfo accessor, bool nonPublic)
         {
             if (nonPublic)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -379,7 +379,7 @@ namespace System.Reflection.Runtime.General
             }
         }
 
-        public static IEnumerable TryParseConstantArray(this Handle handle, MetadataReader reader, out Exception exception)
+        public static Array TryParseConstantArray(this Handle handle, MetadataReader reader, out Exception exception)
         {
             exception = null;
 
@@ -387,40 +387,40 @@ namespace System.Reflection.Runtime.General
             switch (handleType)
             {
                 case HandleType.ConstantBooleanArray:
-                    return handle.ToConstantBooleanArrayHandle(reader).GetConstantBooleanArray(reader).Value;
+                    return handle.ToConstantBooleanArrayHandle(reader).GetConstantBooleanArray(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantCharArray:
-                    return handle.ToConstantCharArrayHandle(reader).GetConstantCharArray(reader).Value;
+                    return handle.ToConstantCharArrayHandle(reader).GetConstantCharArray(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantByteArray:
-                    return handle.ToConstantByteArrayHandle(reader).GetConstantByteArray(reader).Value;
+                    return handle.ToConstantByteArrayHandle(reader).GetConstantByteArray(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantSByteArray:
-                    return handle.ToConstantSByteArrayHandle(reader).GetConstantSByteArray(reader).Value;
+                    return handle.ToConstantSByteArrayHandle(reader).GetConstantSByteArray(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantInt16Array:
-                    return handle.ToConstantInt16ArrayHandle(reader).GetConstantInt16Array(reader).Value;
+                    return handle.ToConstantInt16ArrayHandle(reader).GetConstantInt16Array(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantUInt16Array:
-                    return handle.ToConstantUInt16ArrayHandle(reader).GetConstantUInt16Array(reader).Value;
+                    return handle.ToConstantUInt16ArrayHandle(reader).GetConstantUInt16Array(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantInt32Array:
-                    return handle.ToConstantInt32ArrayHandle(reader).GetConstantInt32Array(reader).Value;
+                    return handle.ToConstantInt32ArrayHandle(reader).GetConstantInt32Array(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantUInt32Array:
-                    return handle.ToConstantUInt32ArrayHandle(reader).GetConstantUInt32Array(reader).Value;
+                    return handle.ToConstantUInt32ArrayHandle(reader).GetConstantUInt32Array(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantInt64Array:
-                    return handle.ToConstantInt64ArrayHandle(reader).GetConstantInt64Array(reader).Value;
+                    return handle.ToConstantInt64ArrayHandle(reader).GetConstantInt64Array(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantUInt64Array:
-                    return handle.ToConstantUInt64ArrayHandle(reader).GetConstantUInt64Array(reader).Value;
+                    return handle.ToConstantUInt64ArrayHandle(reader).GetConstantUInt64Array(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantSingleArray:
-                    return handle.ToConstantSingleArrayHandle(reader).GetConstantSingleArray(reader).Value;
+                    return handle.ToConstantSingleArrayHandle(reader).GetConstantSingleArray(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantDoubleArray:
-                    return handle.ToConstantDoubleArrayHandle(reader).GetConstantDoubleArray(reader).Value;
+                    return handle.ToConstantDoubleArrayHandle(reader).GetConstantDoubleArray(reader).Value.ReadOnlyCollectionToArray();
 
                 case HandleType.ConstantStringArray:
                     {


### PR DESCRIPTION
Scenario:

  class MyAttribute
  {
     public MyAttribute(object[] objs) {}
  }


  [My(new object[] { new int[] { 4, 5, 6} }]
  public void Foo() {...}

Trying to read this with Reflection triggers a
BadImageFormatException as the custom attribute parser was
expecting an array of something, not an Int32Collection.

To understand why this is "Pri-0", take that scenario and do
a few renames...

  class InlineData
  {
     public InlineDataAttribute(params object[] objs) {}
  }

  [Theory]
  [InlineData(new int[] { 4, 5, 6})]
  public static void OneOfThousandsOfCoreFxTestsThatAreFailingOnUwpAot(int[] testdata)
  {
     ...
  }


Unfortunately, there's still one case that's broken
(an element is an enum array - what you get back is
an array of the underlying integral type. I don't
think I can fix this without toolchain work...)

However, even this should help the bring down the
failure count.