### PR TITLE
Add support for sorting FieldDescs

### DIFF
--- a/src/Common/src/TypeSystem/Common/FieldForInstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/FieldForInstantiatedType.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Internal.TypeSystem
 {
-    public sealed class FieldForInstantiatedType : FieldDesc
+    public sealed partial class FieldForInstantiatedType : FieldDesc
     {
         private FieldDesc _fieldDef;
         private InstantiatedType _instantiatedType;

--- a/src/Common/src/TypeSystem/Ecma/EcmaField.Sorting.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.Sorting.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection.Metadata.Ecma335;
+
+namespace Internal.TypeSystem.Ecma
+{
+    // Functionality related to deterministic ordering of types and members
+    partial class EcmaField
+    {
+        protected internal override int ClassCode => 44626835;
+
+        protected internal override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+        {
+            var otherField = (EcmaField)other;
+
+            EcmaModule module = _type.EcmaModule;
+            EcmaModule otherModule = otherField._type.EcmaModule;
+
+            int result = module.MetadataReader.GetToken(_handle) - otherModule.MetadataReader.GetToken(otherField._handle);
+            if (result != 0)
+                return result;
+
+            return module.CompareTo(otherModule);
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaField.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.cs
@@ -12,7 +12,7 @@ using Internal.TypeSystem;
 
 namespace Internal.TypeSystem.Ecma
 {
-    public sealed class EcmaField : FieldDesc, EcmaModule.IEntityHandleObject
+    public sealed partial class EcmaField : FieldDesc, EcmaModule.IEntityHandleObject
     {
         private static class FieldFlags
         {

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -170,7 +170,7 @@ namespace Internal.IL.Stubs
             else if (MarshalHelpers.UseLazyResolution(_targetMethod, _importMetadata.Module, _pInvokeILEmitterConfiguration))
             {
                 MetadataType lazyHelperType = _targetMethod.Context.GetHelperType("InteropHelpers");
-                FieldDesc lazyDispatchCell = new PInvokeLazyFixupField((DefType)_targetMethod.OwningType, _importMetadata);
+                FieldDesc lazyDispatchCell = new PInvokeLazyFixupField(_targetMethod);
                 fnptrLoadStream.Emit(ILOpcode.ldsflda, emitter.NewToken(lazyDispatchCell));
                 fnptrLoadStream.Emit(ILOpcode.call, emitter.NewToken(lazyHelperType.GetKnownMethod("ResolvePInvoke", null)));
 
@@ -287,100 +287,6 @@ namespace Internal.IL.Stubs
         {
             Emitter = emitter;
             MarshallingCodeStream = codeStream;
-        }
-    }
-
-    /// <summary>
-    /// Synthetic RVA static field that represents PInvoke fixup cell. The RVA data is
-    /// backed by a small data structure generated on the fly from the <see cref="PInvokeMetadata"/>
-    /// carried by the instance of this class.
-    /// </summary>
-    public sealed class PInvokeLazyFixupField : FieldDesc
-    {
-        private DefType _owningType;
-        private PInvokeMetadata _pInvokeMetadata;
-
-        public PInvokeLazyFixupField(DefType owningType, PInvokeMetadata pInvokeMetadata)
-        {
-            _owningType = owningType;
-            _pInvokeMetadata = pInvokeMetadata;
-        }
-
-        public PInvokeMetadata PInvokeMetadata
-        {
-            get
-            {
-                return _pInvokeMetadata;
-            }
-        }
-
-        public override TypeSystemContext Context
-        {
-            get
-            {
-                return _owningType.Context;
-            }
-        }
-
-        public override TypeDesc FieldType
-        {
-            get
-            {
-                return Context.GetHelperType("InteropHelpers").GetNestedType("MethodFixupCell");
-            }
-        }
-
-        public override bool HasRva
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        public override bool IsInitOnly
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool IsLiteral
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override bool IsStatic
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        public override bool IsThreadStatic
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        public override DefType OwningType
-        {
-            get
-            {
-                return _owningType;
-            }
-        }
-
-        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
-        {
-            return false;
         }
     }
 

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeLazyFixupField.Sorting.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeLazyFixupField.Sorting.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+namespace Internal.IL.Stubs
+{
+    partial class PInvokeLazyFixupField
+    {
+        protected internal override int ClassCode => -1784477702;
+
+        protected internal override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_targetMethod, ((PInvokeLazyFixupField)other)._targetMethod);
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Synthetic RVA static field that represents PInvoke fixup cell. The RVA data is
+    /// backed by a small data structure generated on the fly from the <see cref="PInvokeMetadata"/>
+    /// carried by the instance of this class.
+    /// </summary>
+    public sealed partial class PInvokeLazyFixupField : FieldDesc
+    {
+        private MethodDesc _targetMethod;
+
+        public PInvokeLazyFixupField(MethodDesc targetMethod)
+        {
+            Debug.Assert(targetMethod.IsPInvoke);
+            _targetMethod = targetMethod;
+        }
+
+        public PInvokeMetadata PInvokeMetadata
+        {
+            get
+            {
+                return _targetMethod.GetPInvokeMethodMetadata();
+            }
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return _targetMethod.Context;
+            }
+        }
+
+        public override TypeDesc FieldType
+        {
+            get
+            {
+                return Context.GetHelperType("InteropHelpers").GetNestedType("MethodFixupCell");
+            }
+        }
+
+        public override bool HasRva
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override bool IsInitOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsLiteral
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsStatic
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override bool IsThreadStatic
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override DefType OwningType
+        {
+            get
+            {
+                return (DefType)_targetMethod.OwningType;
+            }
+        }
+
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Interop/IL/NativeStructType.Sorting.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/NativeStructType.Sorting.cs
@@ -13,5 +13,15 @@ namespace Internal.TypeSystem.Interop
         {
             return comparer.Compare(ManagedStructType, ((NativeStructType)other).ManagedStructType);
         }
+
+        partial class NativeStructField
+        {
+            protected internal override int ClassCode => 1580219745;
+
+            protected internal override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+            {
+                return comparer.Compare(_managedField, ((NativeStructField)other)._managedField);
+            }
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
@@ -181,7 +181,7 @@ namespace Internal.TypeSystem.Interop
                     nativeType = managedType;
                 }
 
-                _fields[index++] = new NativeStructField(nativeType, this, field.Name);
+                _fields[index++] = new NativeStructField(nativeType, this, field);
             }
         }
 
@@ -282,11 +282,11 @@ namespace Internal.TypeSystem.Interop
         /// <summary>
         /// Synthetic field on <see cref="NativeStructType"/>.
         /// </summary>
-        private class NativeStructField : FieldDesc
+        private partial class NativeStructField : FieldDesc
         {
             private TypeDesc _fieldType;
             private MetadataType _owningType;
-            private string _name;
+            private FieldDesc _managedField;
 
             public override TypeSystemContext Context
             {
@@ -362,15 +362,15 @@ namespace Internal.TypeSystem.Interop
             {
                 get
                 {
-                    return _name;
+                    return _managedField.Name;
                 }
             }
 
-            public NativeStructField(TypeDesc nativeType, MetadataType owningType, string name)
+            public NativeStructField(TypeDesc nativeType, MetadataType owningType, FieldDesc managedField)
             {
                 _fieldType = nativeType;
                 _owningType = owningType;
-                _name = name;
+                _managedField = managedField;
             }
         }
 

--- a/src/Common/src/TypeSystem/Sorting/FieldDesc.Sorting.cs
+++ b/src/Common/src/TypeSystem/Sorting/FieldDesc.Sorting.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    // Functionality related to deterministic ordering of types and members
+    partial class FieldDesc
+    {
+        /// <summary>
+        /// Gets an identifier that is the same for all instances of this <see cref="FieldDesc"/>
+        /// descendant, but different from the <see cref="ClassCode"/> of any other descendant.
+        /// </summary>
+        /// <remarks>
+        /// This is really just a number, ideally produced by "new Random().Next(int.MinValue, int.MaxValue)".
+        /// If two manage to conflict (which is pretty unlikely), just make a new one...
+        /// </remarks>
+        protected internal abstract int ClassCode { get; }
+
+        // Note to implementers: the type of `other` is actually the same as the type of `this`.
+        protected internal abstract int CompareToImpl(FieldDesc other, TypeSystemComparer comparer);
+    }
+}

--- a/src/Common/src/TypeSystem/Sorting/FieldForInstantiatedType.Sorting.cs
+++ b/src/Common/src/TypeSystem/Sorting/FieldForInstantiatedType.Sorting.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    // Functionality related to deterministic ordering of types and members
+    partial class FieldForInstantiatedType
+    {
+        protected internal override int ClassCode => 1140200283;
+
+        protected internal override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+        {
+            var otherField = (FieldForInstantiatedType)other;
+
+            int result = comparer.CompareWithinClass(_instantiatedType, otherField._instantiatedType);
+            if (result != 0)
+                return result;
+
+            return comparer.Compare(_fieldDef, otherField._fieldDef);
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Sorting/TypeSystemComparer.cs
+++ b/src/Common/src/TypeSystem/Sorting/TypeSystemComparer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem
@@ -70,6 +68,32 @@ namespace Internal.TypeSystem
         }
 
         public int Compare(MethodDesc x, MethodDesc y)
+        {
+            if (x == y)
+            {
+                return 0;
+            }
+
+            int result = x.ClassCode - y.ClassCode;
+            if (result == 0)
+            {
+                Debug.Assert(x.GetType() == y.GetType());
+
+                result = x.CompareToImpl(y, this);
+
+                // We did a reference equality check above so an "Equal" result is not expected
+                Debug.Assert(result != 0);
+
+                return result;
+            }
+            else
+            {
+                Debug.Assert(x.GetType() != y.GetType());
+                return result;
+            }
+        }
+
+        public int Compare(FieldDesc x, FieldDesc y)
         {
             if (x == y)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -286,7 +286,7 @@ namespace ILCompiler
             /// <summary>
             /// Synthetic field on <see cref="BoxedValueType"/>.
             /// </summary>
-            private class BoxedValueField : FieldDesc
+            private partial class BoxedValueField : FieldDesc
             {
                 private BoxedValueType _owningType;
 

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Sorting.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Sorting.cs
@@ -17,6 +17,16 @@ namespace ILCompiler
             {
                 return comparer.Compare(ValueTypeRepresented, ((BoxedValueType)other).ValueTypeRepresented);
             }
+
+            partial class BoxedValueField
+            {
+                protected override int ClassCode => 1765873859;
+
+                protected override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+                {
+                    return comparer.Compare(_owningType, ((BoxedValueField)other)._owningType);
+                }
+            }
         }
 
         partial class GenericUnboxingThunk

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -260,6 +260,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaAssembly.Symbols.cs">
       <Link>Ecma\EcmaAssembly.Symbols.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.Sorting.cs">
+      <Link>Ecma\EcmaField.Sorting.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaGenericParameter.Sorting.cs">
       <Link>Ecma\EcmaGenericParameter.Sorting.cs</Link>
     </Compile>
@@ -334,6 +337,12 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\EnumThunks.Sorting.cs">
       <Link>IL\Stubs\EnumThunks.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\PInvokeLazyFixupField.cs">
+      <Link>IL\Stubs\PInvokeLazyFixupField.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\PInvokeLazyFixupField.Sorting.cs">
+      <Link>IL\Stubs\PInvokeLazyFixupField.Sorting.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\PInvokeTargetNativeMethod.Sorting.cs">
       <Link>IL\Stubs\PInvokeTargetNativeMethod.Sorting.cs</Link>
@@ -418,6 +427,12 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\IL\NativeStructType.cs">
       <Link>TypeSystem\Interop\IL\NativeStructType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Sorting\FieldDesc.Sorting.cs">
+      <Link>TypeSystem\Sorting\FieldDesc.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Sorting\FieldForInstantiatedType.Sorting.cs">
+      <Link>TypeSystem\Sorting\FieldForInstantiatedType.Sorting.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Sorting\InstantiatedMethod.Sorting.cs">
       <Link>TypeSystem\Sorting\InstantiatedMethod.Sorting.cs</Link>

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -77,6 +77,7 @@
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\EETypePtrOfIntrinsic.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\DelegateMethodILEmitter.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\PInvokeILEmitter.cs" />
+    <Compile Include="$(TypeSystemBasePath)\IL\Stubs\PInvokeLazyFixupField.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\PInvokeTargetNativeMethod.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\StructMarshallingThunk.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\TypeGetTypeMethodThunk.cs" />


### PR DESCRIPTION
Follows the same divide and conquer pattern as the code to sort
TypeDescs (#3258 - compare between classes using `ClassCode` and have
the classes handle comparions within the class).