### PR TITLE
Generate stable generic dictionaries in multifile builds

### DIFF
--- a/src/Common/src/TypeSystem/Sorting/TypeSystemComparer.cs
+++ b/src/Common/src/TypeSystem/Sorting/TypeSystemComparer.cs
@@ -33,12 +33,13 @@ namespace Internal.TypeSystem
                 return 0;
             }
 
-            int result = x.ClassCode - y.ClassCode;
-            if (result == 0)
+            int codeX = x.ClassCode;
+            int codeY = y.ClassCode;
+            if (codeX == codeY)
             {
                 Debug.Assert(x.GetType() == y.GetType());
 
-                result = x.CompareToImpl(y, this);
+                int result = x.CompareToImpl(y, this);
 
                 // We did a reference equality check above so an "Equal" result is not expected
                 Debug.Assert(result != 0);
@@ -48,7 +49,7 @@ namespace Internal.TypeSystem
             else
             {
                 Debug.Assert(x.GetType() != y.GetType());
-                return result;
+                return codeX > codeY ? -1 : 1;
             }
         }
 
@@ -74,12 +75,13 @@ namespace Internal.TypeSystem
                 return 0;
             }
 
-            int result = x.ClassCode - y.ClassCode;
-            if (result == 0)
+            int codeX = x.ClassCode;
+            int codeY = y.ClassCode;
+            if (codeX == codeY)
             {
                 Debug.Assert(x.GetType() == y.GetType());
 
-                result = x.CompareToImpl(y, this);
+                int result = x.CompareToImpl(y, this);
 
                 // We did a reference equality check above so an "Equal" result is not expected
                 Debug.Assert(result != 0);
@@ -89,7 +91,7 @@ namespace Internal.TypeSystem
             else
             {
                 Debug.Assert(x.GetType() != y.GetType());
-                return result;
+                return codeX > codeY ? -1 : 1;
             }
         }
 
@@ -100,12 +102,13 @@ namespace Internal.TypeSystem
                 return 0;
             }
 
-            int result = x.ClassCode - y.ClassCode;
-            if (result == 0)
+            int codeX = x.ClassCode;
+            int codeY = y.ClassCode;
+            if (codeX == codeY)
             {
                 Debug.Assert(x.GetType() == y.GetType());
 
-                result = x.CompareToImpl(y, this);
+                int result = x.CompareToImpl(y, this);
 
                 // We did a reference equality check above so an "Equal" result is not expected
                 Debug.Assert(result != 0);
@@ -115,7 +118,7 @@ namespace Internal.TypeSystem
             else
             {
                 Debug.Assert(x.GetType() != y.GetType());
-                return result;
+                return codeX > codeY ? -1 : 1;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -51,13 +51,15 @@ namespace ILCompiler.DependencyAnalysis
 
         private void ComputeLayout()
         {
-            // TODO: deterministic ordering
             GenericLookupResult[] layout = new GenericLookupResult[_entries.Count];
             int index = 0;
             foreach (GenericLookupResult entry in EntryHashTable.Enumerator.Get(_entries))
             {
                 layout[index++] = entry;
             }
+
+            var comparer = new GenericLookupResult.Comparer(new TypeSystemComparer());
+            Array.Sort(layout, comparer.Compare);
 
             // Only publish after the full layout is computed. Races are fine.
             _layout = layout;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -103,6 +103,49 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool HasConditionalStaticDependencies => true;
 
+        private static bool ContributesToDictionaryLayout(MethodDesc method)
+        {
+            // Generic methods have their own generic dictionaries
+            if (method.HasInstantiation)
+                return false;
+
+            // Abstract methods don't have a body
+            if (method.IsAbstract)
+                return false;
+
+            // PInvoke methods, runtime imports, etc. are not permitted on generic types,
+            // but let's not crash the compilation because of that.
+            if (method.IsPInvoke || method.IsRuntimeImplemented)
+                return false;
+
+            return true;
+        }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            DependencyList result = null;
+
+            if (factory.CompilationModuleGroup.ShouldPromoteToFullType(_owningType))
+            {
+                result = new DependencyList();
+
+                // If the compilation group wants this type to be fully promoted, it means the EEType is going to be
+                // COMDAT folded with other EETypes generated in a different object file. This means their generic
+                // dictionaries need to have identical contents. The only way to achieve that is by generating
+                // the entries for all methods that contribute to the dictionary, and sorting the dictionaries.
+                foreach (var method in _owningType.GetAllMethods())
+                {
+                    if (!ContributesToDictionaryLayout(method))
+                        continue;
+
+                    result.Add(factory.MethodEntrypoint(method.GetCanonMethodTarget(CanonicalFormKind.Specific)),
+                        "Cross-objectfile equivalent dictionary");
+                }
+            }
+
+            return result;
+        }
+
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             // The generic dictionary layout is shared between all the canonically equivalent
@@ -110,12 +153,7 @@ namespace ILCompiler.DependencyAnalysis
             // that use the same dictionary layout.
             foreach (var method in _owningType.GetAllMethods())
             {
-                // Generic methods have their own generic dictionaries
-                if (method.HasInstantiation)
-                    continue;
-
-                // Abstract methods don't have a body
-                if (method.IsAbstract)
+                if (!ContributesToDictionaryLayout(method))
                     continue;
 
                 // If a canonical method body was compiled, we need to track the dictionary

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -32,9 +32,11 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     public abstract class GenericLookupResult
     {
+        protected abstract int ClassCode { get; }
         public abstract ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary);
         public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
         public abstract override string ToString();
+        protected abstract int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer);
 
         public virtual void EmitDictionaryEntry(ref ObjectDataBuilder builder, NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
@@ -61,6 +63,43 @@ namespace ILCompiler.DependencyAnalysis
         {
             return Array.Empty<DependencyNodeCore<NodeFactory>>();
         }
+
+        public class Comparer
+        {
+            private TypeSystemComparer _comparer;
+
+            public Comparer(TypeSystemComparer comparer)
+            {
+                _comparer = comparer;
+            }
+
+            public int Compare(GenericLookupResult x, GenericLookupResult y)
+            {
+                if (x == y)
+                {
+                    return 0;
+                }
+
+                int codeX = x.ClassCode;
+                int codeY = y.ClassCode;
+                if (codeX == codeY)
+                {
+                    Debug.Assert(x.GetType() == y.GetType());
+
+                    int result = x.CompareToImpl(y, _comparer);
+
+                    // We did a reference equality check above so an "Equal" result is not expected
+                    Debug.Assert(result != 0);
+
+                    return result;
+                }
+                else
+                {
+                    Debug.Assert(x.GetType() != y.GetType());
+                    return codeX > codeY ? -1 : 1;
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -69,6 +108,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class TypeHandleGenericLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
+
+        protected override int ClassCode => 1623839081;
 
         public TypeHandleGenericLookupResult(TypeDesc type)
         {
@@ -107,15 +148,22 @@ namespace ILCompiler.DependencyAnalysis
                 return GenericLookupResultReferenceType.Direct;
             }
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((TypeHandleGenericLookupResult)other)._type);
+        }
     }
 
 
     /// <summary>
-    /// Generic lookup result that points to an EEType where if the type is Nullable<X> the EEType is X
+    /// Generic lookup result that points to an EEType where if the type is Nullable&lt;X&gt; the EEType is X
     /// </summary>
     internal sealed class UnwrapNullableTypeHandleGenericLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
+
+        protected override int ClassCode => 53521918;
 
         public UnwrapNullableTypeHandleGenericLookupResult(TypeDesc type)
         {
@@ -159,6 +207,11 @@ namespace ILCompiler.DependencyAnalysis
                 return GenericLookupResultReferenceType.Direct;
             }
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((UnwrapNullableTypeHandleGenericLookupResult)other)._type);
+        }
     }
 
     /// <summary>
@@ -167,6 +220,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class FieldOffsetGenericLookupResult : GenericLookupResult
     {
         private FieldDesc _field;
+
+        protected override int ClassCode => -1670293557;
 
         public FieldOffsetGenericLookupResult(FieldDesc field)
         {
@@ -200,6 +255,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return factory.NativeLayout.FieldOffsetDictionarySlot(_field);
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_field, ((FieldOffsetGenericLookupResult)other)._field);
+        }
     }
 
     /// <summary>
@@ -208,6 +268,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class VTableOffsetGenericLookupResult : GenericLookupResult
     {
         private MethodDesc _method;
+
+        protected override int ClassCode => 386794182;
 
         public VTableOffsetGenericLookupResult(MethodDesc method)
         {
@@ -253,6 +315,11 @@ namespace ILCompiler.DependencyAnalysis
                 factory.VirtualMethodUse(canonMethod)
             };
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_method, ((VTableOffsetGenericLookupResult)other)._method);
+        }
     }
 
     /// <summary>
@@ -261,6 +328,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class MethodHandleGenericLookupResult : GenericLookupResult
     {
         private MethodDesc _method;
+
+        protected override int ClassCode => 394272689;
 
         public MethodHandleGenericLookupResult(MethodDesc method)
         {
@@ -286,6 +355,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return factory.NativeLayout.MethodLdTokenDictionarySlot(_method);
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_method, ((MethodHandleGenericLookupResult)other)._method);
+        }
     }
 
     /// <summary>
@@ -294,6 +368,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class FieldHandleGenericLookupResult : GenericLookupResult
     {
         private FieldDesc _field;
+
+        protected override int ClassCode => -196995964;
 
         public FieldHandleGenericLookupResult(FieldDesc field)
         {
@@ -319,6 +395,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return factory.NativeLayout.FieldLdTokenDictionarySlot(_field);
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_field, ((FieldHandleGenericLookupResult)other)._field);
+        }
     }
 
     /// <summary>
@@ -327,6 +408,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class MethodDictionaryGenericLookupResult : GenericLookupResult
     {
         private MethodDesc _method;
+
+        protected override int ClassCode => -467418176;
 
         public MethodDictionaryGenericLookupResult(MethodDesc method)
         {
@@ -364,6 +447,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return factory.NativeLayout.MethodDictionaryDictionarySlot(_method);
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_method, ((MethodDictionaryGenericLookupResult)other)._method);
+        }
     }
 
     /// <summary>
@@ -373,6 +461,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private MethodDesc _method;
         private bool _isUnboxingThunk;
+
+        protected override int ClassCode => 1572293098;
 
         public MethodEntryGenericLookupResult(MethodDesc method, bool isUnboxingThunk)
         {
@@ -409,6 +499,16 @@ namespace ILCompiler.DependencyAnalysis
             return factory.NativeLayout.MethodEntrypointDictionarySlot
                         (_method, unboxing: true, functionPointerTarget: factory.MethodEntrypoint(_method.GetCanonMethodTarget(CanonicalFormKind.Specific)));
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            var otherEntry = (MethodEntryGenericLookupResult)other;
+            int result = (_isUnboxingThunk ? 1 : 0) - (otherEntry._isUnboxingThunk ? 1 : 0);
+            if (result != 0)
+                return result;
+
+            return comparer.Compare(_method, otherEntry._method);
+        }
     }
 
     /// <summary>
@@ -417,6 +517,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class VirtualDispatchGenericLookupResult : GenericLookupResult
     {
         private MethodDesc _method;
+
+        protected override int ClassCode => 643566930;
 
         public VirtualDispatchGenericLookupResult(MethodDesc method)
         {
@@ -462,6 +564,11 @@ namespace ILCompiler.DependencyAnalysis
                 return factory.NativeLayout.InterfaceCellDictionarySlot(_method);
             }
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_method, ((VirtualDispatchGenericLookupResult)other)._method);
+        }
     }
 
     /// <summary>
@@ -470,6 +577,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class VirtualResolveGenericLookupResult : GenericLookupResult
     {
         private MethodDesc _method;
+
+        protected override int ClassCode => -12619218;
 
         public VirtualResolveGenericLookupResult(MethodDesc method)
         {
@@ -517,6 +626,11 @@ namespace ILCompiler.DependencyAnalysis
                 return factory.NativeLayout.InterfaceCellDictionarySlot(_method);
             }
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_method, ((VirtualResolveGenericLookupResult)other)._method);
+        }
     }
 
     /// <summary>
@@ -525,6 +639,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class TypeNonGCStaticBaseGenericLookupResult : GenericLookupResult
     {
         private MetadataType _type;
+
+        protected override int ClassCode => -328863267;
 
         public TypeNonGCStaticBaseGenericLookupResult(TypeDesc type)
         {
@@ -566,6 +682,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return GenericLookupResultReferenceType.Indirect;
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((TypeNonGCStaticBaseGenericLookupResult)other)._type);
+        }
     }
 
     /// <summary>
@@ -574,6 +695,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class TypeThreadStaticBaseIndexGenericLookupResult : GenericLookupResult
     {
         private MetadataType _type;
+
+        protected override int ClassCode => -177446371;
 
         public TypeThreadStaticBaseIndexGenericLookupResult(TypeDesc type)
         {
@@ -600,6 +723,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return factory.NativeLayout.NotSupportedDictionarySlot;
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((TypeThreadStaticBaseIndexGenericLookupResult)other)._type);
+        }
     }
 
     /// <summary>
@@ -608,6 +736,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class TypeGCStaticBaseGenericLookupResult : GenericLookupResult
     {
         private MetadataType _type;
+
+        protected override int ClassCode => 429225829;
 
         public TypeGCStaticBaseGenericLookupResult(TypeDesc type)
         {
@@ -639,6 +769,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return GenericLookupResultReferenceType.Indirect;
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((TypeGCStaticBaseGenericLookupResult)other)._type);
+        }
     }
 
     /// <summary>
@@ -647,6 +782,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class ObjectAllocatorGenericLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
+
+        protected override int ClassCode => -1671431655;
 
         public ObjectAllocatorGenericLookupResult(TypeDesc type)
         {
@@ -677,6 +814,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return GenericLookupResultReferenceType.Indirect;
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((ObjectAllocatorGenericLookupResult)other)._type);
+        }
     }
 
     /// <summary>
@@ -685,6 +827,8 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class ArrayAllocatorGenericLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
+
+        protected override int ClassCode => -927905284;
 
         public ArrayAllocatorGenericLookupResult(TypeDesc type)
         {
@@ -716,11 +860,18 @@ namespace ILCompiler.DependencyAnalysis
         {
             return GenericLookupResultReferenceType.Indirect;
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((ArrayAllocatorGenericLookupResult)other)._type);
+        }
     }
 
     internal sealed class ThreadStaticIndexLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
+
+        protected override int ClassCode => -25938157;
 
         public ThreadStaticIndexLookupResult(TypeDesc type)
         {
@@ -753,11 +904,18 @@ namespace ILCompiler.DependencyAnalysis
         {
             return GenericLookupResultReferenceType.Indirect;
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((ThreadStaticIndexLookupResult)other)._type);
+        }
     }
 
     internal sealed class ThreadStaticOffsetLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
+
+        protected override int ClassCode => -1678275787;
 
         public ThreadStaticOffsetLookupResult(TypeDesc type)
         {
@@ -791,11 +949,18 @@ namespace ILCompiler.DependencyAnalysis
         {
             return GenericLookupResultReferenceType.Indirect;
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((ThreadStaticOffsetLookupResult)other)._type);
+        }
     }
 
     internal sealed class DefaultConstructorLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
+
+        protected override int ClassCode => -1391112482;
 
         public DefaultConstructorLookupResult(TypeDesc type)
         {
@@ -836,11 +1001,18 @@ namespace ILCompiler.DependencyAnalysis
         {
             return factory.NativeLayout.DefaultConstructorDictionarySlot(_type);
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((DefaultConstructorLookupResult)other)._type);
+        }
     }
 
     internal sealed class CallingConventionConverterLookupResult : GenericLookupResult
     {
         private CallingConventionConverterKey _callingConventionConverter;
+
+        protected override int ClassCode => -581806472;
 
         public CallingConventionConverterLookupResult(CallingConventionConverterKey callingConventionConverter)
         {
@@ -872,11 +1044,23 @@ namespace ILCompiler.DependencyAnalysis
         {
             return factory.NativeLayout.CallingConventionConverter(_callingConventionConverter);
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            var otherEntry = (CallingConventionConverterLookupResult)other;
+            int result = (int)(_callingConventionConverter.ConverterKind - otherEntry._callingConventionConverter.ConverterKind);
+            if (result != 0)
+                return result;
+
+            return comparer.Compare(_callingConventionConverter.Signature, otherEntry._callingConventionConverter.Signature);
+        }
     }
 
     internal sealed class TypeSizeLookupResult : GenericLookupResult
     {
         private TypeDesc _type;
+
+        protected override int ClassCode => -367755250;
 
         public TypeSizeLookupResult(TypeDesc type)
         {
@@ -918,6 +1102,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             return factory.NativeLayout.TypeSizeDictionarySlot(_type);
         }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            return comparer.Compare(_type, ((TypeSizeLookupResult)other)._type);
+        }
     }
 
     internal sealed class ConstrainedMethodUseLookupResult : GenericLookupResult
@@ -925,6 +1114,8 @@ namespace ILCompiler.DependencyAnalysis
         MethodDesc _constrainedMethod;
         TypeDesc _constraintType;
         bool _directCall;
+
+        protected override int ClassCode => -1525377658;
 
         public ConstrainedMethodUseLookupResult(MethodDesc constrainedMethod, TypeDesc constraintType, bool directCall)
         {
@@ -984,6 +1175,20 @@ namespace ILCompiler.DependencyAnalysis
         public override NativeLayoutVertexNode TemplateDictionaryNode(NodeFactory factory)
         {
             return factory.NativeLayout.ConstrainedMethodUse(_constrainedMethod, _constraintType, _directCall);
+        }
+
+        protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
+        {
+            var otherResult = (ConstrainedMethodUseLookupResult)other;
+            int result = (_directCall ? 1 : 0) - (otherResult._directCall ? 1 : 0);
+            if (result != 0)
+                return result;
+
+            result = comparer.Compare(_constraintType, otherResult._constraintType);
+            if (result != 0)
+                return result;
+
+            return comparer.Compare(_constrainedMethod, otherResult._constrainedMethod);
         }
     }
 }


### PR DESCRIPTION
In multifile compilation (when we generate multiple OBJ files with
possibly duplicated content for generics), we need to ensure the generic
dictionary layout generated into each OBJ file is the same, so that
COMDAT folding them at link time causes no harm.

We ensure this by doing two things:

* Always compiling all the methods that contribute to the generic
dictionary. Previously, if code in an OBJ file didn't use a method on a
generic type, we wouldn't compile it. This is not correct for multifile
because the method might be contributing slots to the generic dictionary
of the owning type. We need to make sure it's compiled so that the
dictionary looks the same.
* Sorting the dictionary layout before starting to generate
dictionaries. The order of compilation of methods might not be the same
across different compilations, resulting in different order of slots.
Sorting fixes the problem.

This has no effect on Project X dictionary layout since that one
overrides all the methods that would call into `ComputeLayout`. We
should have really made `DictionaryLayoutNode` an abstract class when
Project X diverged, but that can be cleaned up later. I put it on the
list of my pet peeves (#2645).