### PR TITLE
Use the PDB path from the executable image as fallback

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
+++ b/src/Common/src/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
@@ -126,7 +126,7 @@ namespace Internal.TypeSystem.Ecma
         private static IMetaDataDispenser s_metadataDispenser;
         private static ISymUnmanagedBinder s_symBinder;
 
-        public static PdbSymbolReader TryOpenSymbolReaderForMetadataFile(string metadataFileName)
+        public static PdbSymbolReader TryOpenSymbolReaderForMetadataFile(string metadataFileName, string searchPath)
         {
             try
             {
@@ -142,7 +142,7 @@ namespace Internal.TypeSystem.Ecma
                     return null;
 
                 ISymUnmanagedReader reader;
-                if (s_symBinder.GetReaderForFile(objImporter, metadataFileName, "", out reader) < 0)
+                if (s_symBinder.GetReaderForFile(objImporter, metadataFileName, searchPath, out reader) < 0)
                     return null;
 
                 return new UnmanagedPdbSymbolReader(reader);

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -207,7 +207,7 @@ namespace ILCompiler
             try
             {
                 PEReader peReader = OpenPEFile(filePath, out mappedViewAccessor);
-                pdbReader = OpenAssociatedSymbolFile(filePath);
+                pdbReader = OpenAssociatedSymbolFile(filePath, peReader);
 
                 EcmaModule module = EcmaModule.Create(this, peReader, pdbReader);
 
@@ -395,20 +395,38 @@ namespace ILCompiler
         // Symbols
         //
 
-        private PdbSymbolReader OpenAssociatedSymbolFile(string peFilePath)
+        private PdbSymbolReader OpenAssociatedSymbolFile(string peFilePath, PEReader peReader)
         {
             // Assume that the .pdb file is next to the binary
             var pdbFilename = Path.ChangeExtension(peFilePath, ".pdb");
+            string searchPath = "";
 
             if (!File.Exists(pdbFilename))
-                return null;
+            {
+                pdbFilename = null;
+
+                // If the file doesn't exist, try the path specified in the CodeView section of the image
+                foreach (DebugDirectoryEntry debugEntry in peReader.ReadDebugDirectory())
+                {
+                    string candidateFileName = peReader.ReadCodeViewDebugDirectoryData(debugEntry).Path;
+                    if (File.Exists(candidateFileName))
+                    {
+                        pdbFilename = candidateFileName;
+                        searchPath = Path.GetDirectoryName(pdbFilename);
+                        break;
+                    }
+                }
+
+                if (pdbFilename == null)
+                    return null;
+            }
 
             // Try to open the symbol file as portable pdb first
             PdbSymbolReader reader = PortablePdbSymbolReader.TryOpen(pdbFilename, GetMetadataStringDecoder());
             if (reader == null)
             {
                 // Fallback to the diasymreader for non-portable pdbs
-                reader = UnmanagedPdbSymbolReader.TryOpenSymbolReaderForMetadataFile(peFilePath);
+                reader = UnmanagedPdbSymbolReader.TryOpenSymbolReaderForMetadataFile(peFilePath, searchPath);
             }
 
             return reader;

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -409,7 +409,7 @@ namespace ILCompiler
                 foreach (DebugDirectoryEntry debugEntry in peReader.ReadDebugDirectory())
                 {
                     string candidateFileName = peReader.ReadCodeViewDebugDirectoryData(debugEntry).Path;
-                    if (File.Exists(candidateFileName))
+                    if (Path.IsPathRooted(candidateFileName) && File.Exists(candidateFileName))
                     {
                         pdbFilename = candidateFileName;
                         searchPath = Path.GetDirectoryName(pdbFilename);


### PR DESCRIPTION
This lets us have proper debugging support for the Simple tests.