### PR TITLE
Use new string constructor in startup code

### DIFF
--- a/src/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using Debug = Internal.Runtime.CompilerHelpers.StartupDebug;
@@ -158,14 +157,6 @@ namespace Internal.Runtime.CompilerHelpers
                     *pBlock = RuntimeImports.RhHandleAlloc(obj, GCHandleType.Normal);
                 }
             }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe int CStrLen(byte* str)
-        {
-            int len = 0;
-            for (; str[len] != 0; len++) { }
-            return len;
         }
     }
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text;
 
 using Internal.Runtime.Augments;
 
@@ -23,14 +22,12 @@ namespace Internal.Runtime.CompilerHelpers
             EnvironmentAugments.SetCommandLineArgs(args);
         }
 
-        internal static unsafe void InitializeCommandLineArgs(int argc, byte** argv)
+        internal static unsafe void InitializeCommandLineArgs(int argc, sbyte** argv)
         {
             string[] args = new string[argc];
             for (int i = 0; i < argc; ++i)
             {
-                byte* argval = argv[i];
-                int len = CStrLen(argval);
-                args[i] = Encoding.UTF8.GetString(argval, len);
+                args[i] = new string(argv[i]);
             }
             EnvironmentAugments.SetCommandLineArgs(args);
         }


### PR DESCRIPTION
When startup code was written, the string constructor that takes an
`sbyte*` and interprets it as a null-terminated UTF8 string on Unix
didn't exist yet and we rolled our own. We have it now.