### PR TITLE
CoreFx Test Burndown: Assembly.Location

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
@@ -63,10 +63,11 @@ namespace System.Reflection.Runtime.Assemblies
             return GetManifestResourceStream(sb.ToString());
         }
 
+        public sealed override string Location => string.Empty;
+
         public sealed override string CodeBase { get { throw new PlatformNotSupportedException(); } }
         public sealed override Assembly GetSatelliteAssembly(CultureInfo culture) { throw new PlatformNotSupportedException(); }
         public sealed override Assembly GetSatelliteAssembly(CultureInfo culture, Version version) { throw new PlatformNotSupportedException(); }
-        public sealed override string Location { get { throw new PlatformNotSupportedException(); } }
         public sealed override string ImageRuntimeVersion { get { throw new PlatformNotSupportedException(); } }
         public sealed override AssemblyName[] GetReferencedAssemblies() { throw new PlatformNotSupportedException(); }
         public sealed override Module GetModule(string name) { throw new PlatformNotSupportedException(); }


### PR DESCRIPTION
While we can't return a path to a file with IL, this will
satisfy the apps that use this api to get the exe's install
directory or a name to display in help text (or use
some library that caches this stuff at the start.)