### PR TITLE
Port MethodInfo.GetBaseDefinition() quirks. 

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
@@ -195,6 +195,18 @@ namespace System.Reflection.Runtime.MethodInfos
             return _genericMethodDefinition.GetRuntimeParameters(this, out returnParameter);
         }
 
+        internal sealed override RuntimeMethodInfo WithReflectedTypeSetToDeclaringType
+        {
+            get
+            {
+                if (_genericMethodDefinition.ReflectedType.Equals(_genericMethodDefinition.DeclaringType))
+                    return this;
+
+                RuntimeNamedMethodInfo newGenericMethodDefinition = (RuntimeNamedMethodInfo)(_genericMethodDefinition.WithReflectedTypeSetToDeclaringType);
+                return RuntimeConstructedGenericMethodInfo.GetRuntimeConstructedGenericMethodInfo(newGenericMethodDefinition, _genericTypeArguments);
+            }
+        }
+
         private readonly RuntimeNamedMethodInfo _genericMethodDefinition;
         private readonly RuntimeTypeInfo[] _genericTypeArguments;
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeDummyMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeDummyMethodInfo.cs
@@ -43,7 +43,7 @@ namespace System.Reflection.Runtime.MethodInfos
         protected internal sealed override string ComputeToString(RuntimeMethodInfo contextMethod) { throw NotImplemented.ByDesign; }
         internal sealed override MethodInvoker GetUncachedMethodInvoker(RuntimeTypeInfo[] methodArguments, MemberInfo exceptionPertainant) { throw NotImplemented.ByDesign; }
         internal sealed override RuntimeMethodHandle GetRuntimeMethodHandle(Type[] genericArgs) { throw NotImplemented.ByDesign; }
-
+        internal sealed override RuntimeMethodInfo WithReflectedTypeSetToDeclaringType { get { throw NotImplemented.ByDesign; } }
         public static readonly RuntimeDummyMethodInfo Instance = new RuntimeDummyMethodInfo();
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -242,6 +242,17 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
+        internal sealed override RuntimeMethodInfo WithReflectedTypeSetToDeclaringType
+        {
+            get
+            {
+                if (_reflectedType.Equals(_common.DefiningTypeInfo))
+                    return this;
+
+                return RuntimeNamedMethodInfo<TRuntimeMethodCommon>.GetRuntimeNamedMethodInfo(_common, _common.DefiningTypeInfo);
+            }
+        }
+
         private RuntimeTypeInfo[] GenericTypeParameters
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -148,7 +148,7 @@ namespace System.Reflection.Runtime.MethodInfos
         {
             get
             {
-                return RuntimeNamedMethodInfo<TRuntimeMethodCommon>.GetRuntimeNamedMethodInfo(_common.RuntimeMethodCommonOfUninstantiatedMethod, _common.DefiningTypeInfo);
+                return RuntimeNamedMethodInfo<TRuntimeMethodCommon>.GetRuntimeNamedMethodInfo(_common.RuntimeMethodCommonOfUninstantiatedMethod, _common.ContextTypeInfo);
             }
         }
 
@@ -249,7 +249,7 @@ namespace System.Reflection.Runtime.MethodInfos
                 if (_reflectedType.Equals(_common.DefiningTypeInfo))
                     return this;
 
-                return RuntimeNamedMethodInfo<TRuntimeMethodCommon>.GetRuntimeNamedMethodInfo(_common, _common.DefiningTypeInfo);
+                return RuntimeNamedMethodInfo<TRuntimeMethodCommon>.GetRuntimeNamedMethodInfo(_common, _common.ContextTypeInfo);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
@@ -212,6 +212,15 @@ namespace System.Reflection.Runtime.MethodInfos
             return parameters;
         }
 
+        internal sealed override RuntimeMethodInfo WithReflectedTypeSetToDeclaringType
+        {
+            get
+            {
+                Debug.Assert(ReflectedType.Equals(DeclaringType));
+                return this;
+            }
+        }
+
         private readonly String _name;
         private readonly SyntheticMethodId _syntheticMethodId;
         private readonly RuntimeTypeInfo _declaringType;


### PR DESCRIPTION
MethodInfo.GetBaseDefinition() on CoreCLR
produces a MethodHandle internally and
rehydrates it into a MethodInfo only at the end.

(That is, unless the original argument was
declared on an interface type or was non-virtual.)

This had the side effect of removing any generic
method instantation and resetting the ReflectedType
property back to the DeclaredType.

Which the corefx BaseDefinition test was (unwittingly)
relying upon.