### PR TITLE
Fix for issue 3248

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -67,6 +67,15 @@ namespace ILCompiler.DependencyAnalysis
                         "UniversalCanon signature of method"));
                 }
 
+                if (method.IsVirtual && !method.HasInstantiation)
+                {
+                    int hierarchyDistance;
+                    MethodDesc declaringMethodForSlot = ReflectionVirtualInvokeMapNode.GetDeclaringVirtualMethodAndHierarchyDistance(method, out hierarchyDistance);
+
+                    if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(declaringMethodForSlot.OwningType))
+                        dependencies.Add(new DependencyListEntry(factory.VirtualMethodUse(declaringMethodForSlot), "Reflection virtual invoke VTable entry"));
+                }
+
                 dependencies.AddRange(ReflectionVirtualInvokeMapNode.GetVirtualInvokeMapDependencies(factory, method));
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -67,15 +67,6 @@ namespace ILCompiler.DependencyAnalysis
                         "UniversalCanon signature of method"));
                 }
 
-                if (method.IsVirtual && !method.HasInstantiation)
-                {
-                    int hierarchyDistance;
-                    MethodDesc declaringMethodForSlot = ReflectionVirtualInvokeMapNode.GetDeclaringVirtualMethodAndHierarchyDistance(method, out hierarchyDistance);
-
-                    if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(declaringMethodForSlot.OwningType))
-                        dependencies.Add(new DependencyListEntry(factory.VirtualMethodUse(declaringMethodForSlot), "Reflection virtual invoke VTable entry"));
-                }
-
                 dependencies.AddRange(ReflectionVirtualInvokeMapNode.GetVirtualInvokeMapDependencies(factory, method));
             }
 


### PR DESCRIPTION
Fix for issue #3248 

1) Fix logic to get declaring method on an instantiated type (call to .GetMethod was incorrect. Replaced with call to context.GetMethodForInstantiatedType.
2) Refactoring the logic that computes the declaring methoddesc + hierarchy distance into a helper function
3) Fix dependency analysis issue with methods that do not produce vtable entries in compilation.