### PR TITLE
Treat filter funclets the same as others

### DIFF
--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -231,11 +231,11 @@ extern "C" bool REDHAWK_PALAPI PalInit();
 #define DLL_PROCESS_ATTACH      1
 extern "C" BOOL WINAPI RtuDllMain(HANDLE hPalInstance, DWORD dwReason, void* pvReserved);
 
-extern "C" int32_t RhpEnableConservativeStackReporting();
-
 extern "C" void RhpShutdown();
 
-#ifndef CPPCODEGEN
+#ifdef CPPCODEGEN
+extern "C" int32_t RhpEnableConservativeStackReporting();
+#else
 
 extern "C" bool RhpRegisterCoffModule(void * pModule,
     void * pvStartRange, uint32_t cbRange,
@@ -282,10 +282,10 @@ int main(int argc, char* argv[])
     if (!RtuDllMain(NULL, DLL_PROCESS_ATTACH, NULL))
         return -1;
 
+#ifdef CPPCODEGEN
     if (!RhpEnableConservativeStackReporting())
         return -1;
-
-#ifndef CPPCODEGEN
+#else
     void *osModule;
 
 #if defined(_WIN32)


### PR DESCRIPTION
Debugging the issues with enabling precise GC info, I found they are
caused by double reporting of locals by both a filter funclet and the
enclosing method. Our code generator for CoreRT treats all funclets
alike, but the runtime expects filter funclets to be treated specially.

This fix lifts the distinction for CoreRT, i.e. treats all funclets the
same. The interaction of GC with EH is pretty complex though, so this is
just a first attempt.