### PR TITLE
Fix stringbuilder marshalling

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -1613,10 +1613,18 @@ namespace Internal.TypeSystem.Interop
 
         protected override void TransformNativeToManaged(ILCodeStream codeStream)
         {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            ILCodeLabel lNullStringBuilder = emitter.NewCodeLabel();
+
+            LoadManagedValue(codeStream);
+            codeStream.Emit(ILOpcode.brfalse, lNullStringBuilder);
             LoadManagedValue(codeStream);
             LoadNativeValue(codeStream);
             codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(
                 InteropTypes.GetStringBuilder(Context).GetKnownMethod("ReplaceBuffer", null)));
+
+            codeStream.EmitLabel(lNullStringBuilder);
         }
     }
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -143,6 +143,9 @@ namespace Internal.Runtime.CompilerHelpers
         internal static char[] GetEmptyStringBuilderBuffer(StringBuilder sb)
         {
             // CORERT-TODO: Reuse buffer from string builder where possible?
+            if (sb == null)
+                return null;
+
             return new char[sb.Capacity + 1];
         }
 


### PR DESCRIPTION
A null parameter for StringBuilder (which is possible in various win32
APIs) argument should skip marshalling. Currently,
`GetEmptyStringBuilderBuffer` assumes an instance, as does the reverse
marshalling code after the call. Adjust `GetEmptyStringBuilderBuffer` to
handle a null StringBuilder, and the native to managed marshaller to
skip replacing the StringBuilder's buffer after the p/invoke.