### PR TITLE
Array.Copy() and Array.ConstrainedCopy() fixes.

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2398,4 +2398,7 @@
   <data name="CustomAttributeFormat_InvalidPropertyFail" xml:space="preserve">
     <value>'{0}' property specified was not found.</value>
   </data>
+  <data name="ArrayTypeMismatch_ConstrainedCopy" xml:space="preserve">
+    <value>Array.ConstrainedCopy will only work on array types that are provably compatible, without any form of boxing, unboxing, widening, or casting of each array element.  Change the array types (i.e., copy a Derived[] to a Base[]), or use a mitigation strategy in the CER for Array.Copy's less powerful reliability contract, such as cloning the array or throwing away the potentially corrupt destination array.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -150,6 +150,9 @@ namespace System
             }
         }
 
+        /// <summary>
+        /// Warning! UNLIKE the similarly named Reflection api, this method also returns "true" for Enums.
+        /// </summary>
         internal bool IsPrimitive
         {
             get


### PR DESCRIPTION
Fix another 195 test failures in System.Runtime.Tests

Fix https://github.com/dotnet/corert/issues/3392
Fix https://github.com/dotnet/corert/issues/3391
Fix https://github.com/dotnet/corert/issues/3390
Fix https://github.com/dotnet/corert/issues/3389

50-ft view: Support multidim arrays by not
casting to Object[], and fix up the enforcement
of what type combinations are allowed where
(in particular, our CopyConstrained() implementation
was nowhere near as strict as it was supposed to be.)

In some other PR (not this one), I'll lobby
to have that IsPrimitive() helper renamed to
IsPrimitiveOrEnum() so I don't waste another
half-hour on rabbit holes due to this.