### PR TITLE
Define BIT64 in TypeLoader builds

### DIFF
--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -22,7 +22,7 @@
     <DefineConstants Condition="'$(METADATA_TYPE_LOADER)' != ''">SUPPORTS_NATIVE_METADATA_TYPE_LOADING;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsProjectNLibrary)' != 'true'">
-    <DefineConstants>CORERT;EETYPE_TYPE_MANAGER;AMD64;$(DefineConstants)</DefineConstants>
+    <DefineConstants>CORERT;EETYPE_TYPE_MANAGER;AMD64;BIT64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(JitSupport)' == 'true'">
     <DefineConstants>SUPPORT_JIT;$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
This is required to get correct pointer size during type layout