### PR TITLE
Add full support for building with VS 2017

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -8,6 +8,8 @@ Build your repo by issuing the following command at repo root:
 build[.cmd|.sh] clean [Debug|Release]
 ```
 
+If you're using Visual Studio 2017, you need to run the above command from the "Developer Command Prompt for VS 2017". Visual Studio setup puts a shortcut to this in the Start menu.
+
 This will result in the following:
 
 - Restore nuget packages required for building

--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -2,8 +2,8 @@ The following pre-requisites need to be installed for building the repo:
 
 # Windows (Windows 7+)
 
-1. Install [Visual Studio 2015](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), including Visual C++ support. Visual Studio 2017 RC also works, but you will need to pass `vs2017` as a parameter to the build script to build using this version.
-2. Install [CMake](http://www.cmake.org/download/). We use CMake 3.3.2 but any later version should work.
+1. Install [Visual Studio 2017](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), including Visual C++ support. Visual Studio 2015 also works.
+2. Install [CMake](http://www.cmake.org/download/) 3.8.0 or later. Make sure you add it to the PATH in the setup wizard.
 3. (Windows 7 only) Install PowerShell 3.0. It's part of [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Windows 8 or later comes with the right version inbox.
 
 PowerShell also needs to be available from the PATH environment variable (it's the default). Typically it should be %SYSTEMROOT%\System32\WindowsPowerShell\v1.0\.

--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -5,6 +5,7 @@ set __BuildOS=Windows_NT
 
 :: Default to highest Visual Studio version available
 set __VSVersion=vs2015
+if defined VS150COMNTOOLS set __VSVersion=vs2017
 
 :: Set the various build properties here so that CMake and MSBuild can pick them up
 set "__ProjectDir=%~dp0.."
@@ -37,6 +38,7 @@ if /i "%1" == "debug"    (set __BuildType=Debug&shift&goto Arg_Loop)
 if /i "%1" == "release"   (set __BuildType=Release&shift&goto Arg_Loop)
 
 if /i "%1" == "vs2017"   (set __VSVersion=vs2017&shift&goto Arg_Loop)
+if /i "%1" == "vs2015"   (set __VSVersion=vs2015&shift&goto Arg_Loop)
 
 if /i "%1" == "clean"   (set __CleanBuild=1&shift&goto Arg_Loop)
 
@@ -110,14 +112,16 @@ if /i "%__VSVersion%" == "vs2017" set __VSProductVersion=150
 
 :: Check presence of VS
 if defined VS%__VSProductVersion%COMNTOOLS goto CheckVSExistence
-echo Visual Studio 2015 (Community is free) is a pre-requisite to build this repository.
+echo Visual Studio 2015 or 2017 (Community is free) is a pre-requisite to build this repository.
+echo If you're using Visual Studio 2017, make sure to run build.cmd from the "Developer Command Prompt
+echo for VS 2017" (find it in the Start menu).
 echo See: https://github.com/dotnet/corert/blob/master/Documentation/prerequisites-for-building.md
 exit /b 1
 
 :CheckVSExistence
 :: Does VS VS 2015 really exist?
 if exist "!VS%__VSProductVersion%COMNTOOLS!\..\IDE\devenv.exe" goto CheckMSBuild
-echo Visual Studio 2015 (Community is free) is a pre-requisite to build this repository.
+echo Visual Studio not installed in !VS%__VSProductVersion%COMNTOOLS!.
 echo See: https://github.com/dotnet/corert/blob/master/Documentation/prerequisites-for-building.md
 exit /b 1
 
@@ -167,7 +171,7 @@ echo.
 echo./? -? /h -h /help -help: view this message.
 echo Build architecture: one of x64, x86, arm ^(default: x64^).
 echo Build type: one of Debug, Checked, Release ^(default: Debug^).
-echo Visual Studio version: ^(default: VS2015, VS2017 also supported^).
+echo Visual Studio version: vs2015, vs2017 ^(defaults to highest detected^).
 echo clean: force a clean build ^(default is to perform an incremental build^).
 echo skiptests: skip building tests ^(default: tests are built^).
 exit /b 1

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -14,12 +14,19 @@ set CoreRT_CoreCLRTargetsFile=
 set CoreRT_TestLogFileName=testresults.xml
 set CoreRT_TestName=*
 
+:: Default to highest Visual Studio version available
+set CoreRT_VSVersion=vs2015
+if defined VS150COMNTOOLS set CoreRT_VSVersion=vs2017
+
 :ArgLoop
 if "%1" == "" goto :ArgsDone
 if /i "%1" == "/?" goto :Usage
 if /i "%1" == "x64"    (set CoreRT_BuildArch=x64&&shift&goto ArgLoop)
 if /i "%1" == "x86"    (set CoreRT_BuildArch=x86&&shift&goto ArgLoop)
 if /i "%1" == "arm"    (set CoreRT_BuildArch=arm&&shift&goto ArgLoop)
+
+if /i "%1" == "vs2017"   (set CoreRT_VSVersion=vs2017&shift&goto Arg_Loop)
+if /i "%1" == "vs2015"   (set CoreRT_VSVersion=vs2015&shift&goto Arg_Loop)
 
 if /i "%1" == "debug"    (set CoreRT_BuildType=Debug&shift&goto ArgLoop)
 if /i "%1" == "release"  (set CoreRT_BuildType=Release&shift&goto ArgLoop)
@@ -103,7 +110,12 @@ if NOT "%CoreRT_MultiFileConfiguration%" == "" (
 
 set __LogDir=%CoreRT_TestRoot%\..\bin\Logs\%__BuildStr%\tests
 
-call "!VS140COMNTOOLS!\..\..\VC\vcvarsall.bat" %CoreRT_BuildArch%
+:: VS2017 changed the location of vcvarsall.bat.
+if /i "%__VSVersion%" == "vs2017" (
+    call "!VS150COMNTOOLS!\..\..\VC\Auxiliary\Build\vcvarsall.bat" %CoreRT_BuildArch%
+) else (
+    call "!VS140COMNTOOLS!\..\..\VC\vcvarsall.bat" %CoreRT_BuildArch%
+)
 
 if "%CoreRT_RunCoreCLRTests%"=="true" goto :TestExtRepo
 


### PR DESCRIPTION
This is a followup to #2390 that fixes a few things:

* vs2017 no longer needs to be passed to build.cmd (it will be
autodetected)
* Building and running tests now works
* Documentation updates to point out running from Developer Command
prompt is needed.

Fixes #3394.