### PR TITLE
Rearrange the deck chairs on metadata generation

### DIFF
--- a/src/Common/src/TypeSystem/Canon/TypeSystemContext.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/TypeSystemContext.Canon.cs
@@ -66,7 +66,16 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Converts the instantiation into a canonical form. Returns the canonical instantiation. The '<paramref name="changed"/>'
+        /// Converts an instantiation into its canonical form.
+        /// </summary>
+        public Instantiation ConvertInstantiationToCanonForm(Instantiation instantiation, CanonicalFormKind kind)
+        {
+            bool changed;
+            return ConvertInstantiationToCanonForm(instantiation, kind, out changed);
+        }
+
+        /// <summary>
+        /// Converts an instantiation into its canonical form. Returns the canonical instantiation. The '<paramref name="changed"/>'
         /// parameter indicates whether the returned canonical instantiation is different from the specific instantiation
         /// passed as the input.
         /// </summary>

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -179,7 +179,7 @@ namespace ILCompiler
         /// <summary>
         /// Gets a stub that can be used to reflection-invoke a method with a given signature.
         /// </summary>
-        public override MethodDesc GetReflectionInvokeStub(MethodDesc method)
+        public override MethodDesc GetCanonicalReflectionInvokeStub(MethodDesc method)
         {
             TypeSystemContext context = method.Context;
             var sig = method.Signature;
@@ -193,7 +193,7 @@ namespace ILCompiler
                 _dynamicInvokeThunks.Add(lookupSig, thunk);
             }
 
-            return InstantiateDynamicInvokeMethodForMethod(thunk, method);
+            return InstantiateCanonicalDynamicInvokeMethodForMethod(thunk, method);
         }
 
         private struct GeneratedTypesAndCodeMetadataPolicy : IMetadataPolicy

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -30,53 +30,14 @@ namespace ILCompiler
             _metadataPolicy = new GeneratedTypesAndCodeMetadataPolicy(this);
         }
 
-        private HashSet<MetadataType> _typeDefinitionsGenerated = new HashSet<MetadataType>();
-        private HashSet<MethodDesc> _methodDefinitionsGenerated = new HashSet<MethodDesc>();
+        private HashSet<MetadataType> _typeDefinitionsToGenerate = new HashSet<MetadataType>();
+        private HashSet<MethodDesc> _methodDefinitionsToGenerate = new HashSet<MethodDesc>();
         private HashSet<ModuleDesc> _modulesSeen = new HashSet<ModuleDesc>();
         private Dictionary<DynamicInvokeMethodSignature, MethodDesc> _dynamicInvokeThunks = new Dictionary<DynamicInvokeMethodSignature, MethodDesc>();
-
-        protected override void AddGeneratedType(TypeDesc type)
-        {
-            if (type.IsDefType && type.IsTypeDefinition)
-            {
-                var mdType = type as MetadataType;
-                if (mdType != null)
-                {
-                    _modulesSeen.Add(mdType.Module);
-                    _typeDefinitionsGenerated.Add(mdType);
-                }
-            }
-
-            base.AddGeneratedType(type);
-        }
 
         public override IEnumerable<ModuleDesc> GetCompilationModulesWithMetadata()
         {
             return _modulesSeen;
-        }
-
-        protected override void AddGeneratedMethod(MethodDesc method)
-        {
-            AddGeneratedType(method.OwningType);
-            _methodDefinitionsGenerated.Add(method.GetTypicalMethodDefinition());
-            base.AddGeneratedMethod(method);
-        }
-
-        private void AddMetadataOnlyType(TypeDesc type)
-        {
-            if (type is MetadataType)
-            {
-                var mdType = (MetadataType)type.GetTypeDefinition();
-                _modulesSeen.Add(mdType.Module);
-                _typeDefinitionsGenerated.Add(mdType);
-            }
-        }
-
-        protected override void AddMetadataOnlyMethod(MethodDesc method)
-        {
-            MethodDesc typicalMethod = method.GetTypicalMethodDefinition();
-            AddMetadataOnlyType(typicalMethod.OwningType);
-            _methodDefinitionsGenerated.Add(typicalMethod);
         }
 
         public override bool IsReflectionBlocked(MetadataType type)
@@ -100,6 +61,27 @@ namespace ILCompiler
                                                 out List<MetadataMapping<MethodDesc>> methodMappings,
                                                 out List<MetadataMapping<FieldDesc>> fieldMappings)
         {
+            foreach (var type in factory.MetadataManager.GetTypesWithEETypes())
+            {
+                var definition = type.GetTypeDefinition() as Internal.TypeSystem.Ecma.EcmaType;
+                if (definition == null)
+                    continue;
+                _typeDefinitionsToGenerate.Add(definition);
+                _modulesSeen.Add(definition.Module);
+            }
+
+            foreach (var method in GetCompiledMethods())
+            {
+                var typicalMethod = method.GetTypicalMethodDefinition() as Internal.TypeSystem.Ecma.EcmaMethod;
+                if (typicalMethod != null)
+                {
+                    var owningType = (MetadataType)typicalMethod.OwningType;
+                    _typeDefinitionsToGenerate.Add(owningType);
+                    _modulesSeen.Add(owningType.Module);
+                    _methodDefinitionsToGenerate.Add(typicalMethod);
+                }
+            }
+
             var transformed = MetadataTransform.Run(new GeneratedTypesAndCodeMetadataPolicy(this), _modulesSeen);
 
             // TODO: DeveloperExperienceMode: Use transformed.Transform.HandleType() to generate
@@ -118,8 +100,12 @@ namespace ILCompiler
             fieldMappings = new List<MetadataMapping<FieldDesc>>();
 
             // Generate type definition mappings
-            foreach (var definition in _typeDefinitionsGenerated)
+            foreach (var type in factory.MetadataManager.GetTypesWithEETypes())
             {
+                MetadataType definition = type.IsTypeDefinition ? type as MetadataType : null;
+                if (definition == null)
+                    continue;
+
                 MetadataRecord record = transformed.GetTransformedTypeDefinition(definition);
 
                 // Reflection requires that we maintain type identity. Even if we only generated a TypeReference record,
@@ -215,12 +201,12 @@ namespace ILCompiler
 
             public bool GeneratesMetadata(FieldDesc fieldDef)
             {
-                return _parent._typeDefinitionsGenerated.Contains((MetadataType)fieldDef.OwningType);
+                return _parent._typeDefinitionsToGenerate.Contains((MetadataType)fieldDef.OwningType);
             }
 
             public bool GeneratesMetadata(MethodDesc methodDef)
             {
-                return _parent._methodDefinitionsGenerated.Contains(methodDef);
+                return _parent._methodDefinitionsToGenerate.Contains(methodDef);
             }
 
             public bool GeneratesMetadata(MetadataType typeDef)
@@ -242,7 +228,7 @@ namespace ILCompiler
                         return true;
                 }
 
-                return _parent._typeDefinitionsGenerated.Contains(typeDef);
+                return _parent._typeDefinitionsToGenerate.Contains(typeDef);
             }
 
             public bool IsBlocked(MetadataType typeDef)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -173,6 +173,7 @@ namespace ILCompiler
         /// </summary>
         public override bool HasReflectionInvokeStubForInvokableMethod(MethodDesc method)
         {
+            Debug.Assert(IsReflectionInvokable(method));
             return true;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -6,6 +6,7 @@ using System;
 
 using Internal.NativeFormat;
 using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -50,13 +51,12 @@ namespace ILCompiler.DependencyAnalysis
             Section hashTableSection = writer.NewSection();
             hashTableSection.Place(typeMapHashTable);
 
-            foreach (var arrayType in factory.MetadataManager.GetArrayTypeMapping())
+            foreach (var type in factory.MetadataManager.GetTypesWithEETypes())
             {
-                if (!arrayType.IsSzArray)
+                if (!type.IsSzArray)
                     continue;
 
-                if (!factory.MetadataManager.TypeGeneratesEEType(arrayType))
-                    continue;
+                var arrayType = (ArrayType)type;
 
                 if (!arrayType.ElementType.IsValueType)
                     continue;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -30,15 +30,14 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (factory.MetadataManager.HasReflectionInvokeStubForInvokableMethod(method) && !method.IsCanonicalMethod(CanonicalFormKind.Any) /* Shared generics handled in the shadow concrete method node */)
                 {
-                    MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(method);
-                    MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                    if (invokeStub != canonInvokeStub)
+                    MethodDesc canonInvokeStub = factory.MetadataManager.GetCanonicalReflectionInvokeStub(method);
+                    if (canonInvokeStub.IsSharedByGenericInstantiations)
                     {
                         dependencies.Add(new DependencyListEntry(factory.MetadataManager.DynamicInvokeTemplateData, "Reflection invoke template data"));
                         factory.MetadataManager.DynamicInvokeTemplateData.AddDependenciesDueToInvokeTemplatePresence(ref dependencies, factory, canonInvokeStub);
                     }
                     else
-                        dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke"));
+                        dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(canonInvokeStub), "Reflection invoke"));
                 }
 
                 bool skipUnboxingStubDependency = false;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.DependencyAnalysis
 {
     public static class CodeBasedDependencyAlgorithm
     {
-        public static void AddDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        public static void AddDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             // TODO: https://github.com/dotnet/corert/issues/3224
             // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
@@ -68,6 +68,11 @@ namespace ILCompiler.DependencyAnalysis
 
                 dependencies.AddRange(ReflectionVirtualInvokeMapNode.GetVirtualInvokeMapDependencies(factory, method));
             }
+        }
+
+        public static void AddDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            AddDependenciesDueToReflectability(ref dependencies, factory, method);
 
             if (method.HasInstantiation)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -39,29 +39,12 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
             // TODO: https://github.com/dotnet/corert/issues/3224
-            // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
-            // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
-            // we even start the compilation process (with the invocation stubs being compilation roots like any other).
-            // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
-            if (context.MetadataManager.IsReflectionInvokable(_method) && _method.IsAbstract)
+            if (_method.IsAbstract)
             {
-                DependencyList dependencies = new DependencyList();
-
-                if (context.MetadataManager.HasReflectionInvokeStubForInvokableMethod(_method) && !_method.IsCanonicalMethod(CanonicalFormKind.Any))
+                return new DependencyListEntry[]
                 {
-                    MethodDesc canonInvokeStub = context.MetadataManager.GetCanonicalReflectionInvokeStub(_method);
-                    if (canonInvokeStub.IsSharedByGenericInstantiations)
-                    {
-                        dependencies.Add(new DependencyListEntry(context.MetadataManager.DynamicInvokeTemplateData, "Reflection invoke template data"));
-                        context.MetadataManager.DynamicInvokeTemplateData.AddDependenciesDueToInvokeTemplatePresence(ref dependencies, context, canonInvokeStub);
-                    }
-                    else
-                        dependencies.Add(new DependencyListEntry(context.MethodEntrypoint(canonInvokeStub), "Reflection invoke"));
-                }
-
-                dependencies.AddRange(ReflectionVirtualInvokeMapNode.GetVirtualInvokeMapDependencies(context, _method));
-
-                return dependencies;
+                    new DependencyListEntry(context.ReflectableMethod(_method), "Abstract reflectable method"),
+                };
             }
 
             return Array.Empty<DependencyListEntry>();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -49,15 +49,14 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (context.MetadataManager.HasReflectionInvokeStubForInvokableMethod(_method) && !_method.IsCanonicalMethod(CanonicalFormKind.Any))
                 {
-                    MethodDesc invokeStub = context.MetadataManager.GetReflectionInvokeStub(_method);
-                    MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                    if (invokeStub != canonInvokeStub)
+                    MethodDesc canonInvokeStub = context.MetadataManager.GetCanonicalReflectionInvokeStub(_method);
+                    if (canonInvokeStub.IsSharedByGenericInstantiations)
                     {
                         dependencies.Add(new DependencyListEntry(context.MetadataManager.DynamicInvokeTemplateData, "Reflection invoke template data"));
                         context.MetadataManager.DynamicInvokeTemplateData.AddDependenciesDueToInvokeTemplatePresence(ref dependencies, context, canonInvokeStub);
                     }
                     else
-                        dependencies.Add(new DependencyListEntry(context.MethodEntrypoint(invokeStub), "Reflection invoke"));
+                        dependencies.Add(new DependencyListEntry(context.MethodEntrypoint(canonInvokeStub), "Reflection invoke"));
                 }
 
                 dependencies.AddRange(ReflectionVirtualInvokeMapNode.GetVirtualInvokeMapDependencies(context, _method));

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -885,6 +885,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
+            yield return new DependencyListEntry(context.ConstructedTypeSymbol(_type.ConvertToCanonForm(CanonicalFormKind.Specific)), "Template EEType");
+
             foreach (TypeDesc iface in _type.RuntimeInterfaces)
             {
                 yield return new DependencyListEntry(context.NativeLayout.TypeSignatureVertex(iface), "template interface list");

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
@@ -16,8 +16,6 @@ namespace ILCompiler.DependencyAnalysis
     {
         public NecessaryCanonicalEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
         {
-            //TODO: This is used temporarily until we switch from STS dependency analysis.
-            Debug.Assert(factory.Target.Abi == TargetAbi.ProjectN);
             Debug.Assert(!type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
             Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
             Debug.Assert(type == type.ConvertToCanonForm(CanonicalFormKind.Specific));

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -290,6 +290,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new TypeGVMEntriesNode(type);
             });
 
+            _reflectableMethods = new NodeCache<MethodDesc, ReflectableMethodNode>(method =>
+            {
+                return new ReflectableMethodNode(method);
+            });
+
             _shadowConcreteMethods = new NodeCache<MethodKey, IMethodNode>(methodKey =>
             {
                 MethodDesc canonMethod = methodKey.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
@@ -668,6 +673,12 @@ namespace ILCompiler.DependencyAnalysis
         internal TypeGVMEntriesNode TypeGVMEntries(TypeDesc type)
         {
             return _gvmTableEntries.GetOrAdd(type);
+        }
+
+        private NodeCache<MethodDesc, ReflectableMethodNode> _reflectableMethods;
+        internal ReflectableMethodNode ReflectableMethod(MethodDesc method)
+        {
+            return _reflectableMethods.GetOrAdd(method);
         }
 
         private NodeCache<MethodKey, IMethodNode> _shadowConcreteMethods;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -148,15 +148,7 @@ namespace ILCompiler.DependencyAnalysis
                     }
                     else if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
                     {
-                        if (Target.Abi == TargetAbi.CoreRT)
-                        {
-                            return new CanonicalEETypeNode(this, type);
-                        }
-                        else
-                        {
-                            // Remove this once we stop using the STS dependency analysis.
-                            return new NecessaryCanonicalEETypeNode(this, type);
-                        }
+                        return new NecessaryCanonicalEETypeNode(this, type);
                     }
                     else
                     {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -118,6 +118,12 @@ namespace ILCompiler.DependencyAnalysis
                                         factory.VirtualMethodUse(createInfo.TargetMethod.InstantiateSignature(typeInstantiation, methodInstantiation)),
                                         "Dictionary dependency"));
                             }
+
+                            // TODO: https://github.com/dotnet/corert/issues/3224 
+                            if (instantiatedTargetMethod.IsAbstract)
+                            {
+                                result.Add(new DependencyListEntry(factory.ReflectableMethod(instantiatedTargetMethod), "Abstract reflectable method"));
+                            }
                         }
                     }
                     break;
@@ -131,6 +137,12 @@ namespace ILCompiler.DependencyAnalysis
                                 new DependencyListEntry(
                                     factory.VirtualMethodUse(instantiatedTarget),
                                     "Dictionary dependency"));
+                        }
+
+                        // TODO: https://github.com/dotnet/corert/issues/3224 
+                        if (instantiatedTarget.IsAbstract)
+                        {
+                            result.Add(new DependencyListEntry(factory.ReflectableMethod(instantiatedTarget), "Abstract reflectable method"));
                         }
                     }
                     break;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a method that doesn't have a body, but we need to track it because it's reflectable.
+    /// </summary>
+    internal class ReflectableMethodNode : DependencyNodeCore<NodeFactory>
+    {
+        private MethodDesc _method;
+
+        public ReflectableMethodNode(MethodDesc method)
+        {
+            Debug.Assert(method.IsAbstract || method.IsPInvoke);
+            _method = method;
+        }
+
+        public MethodDesc Method => _method;
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            DependencyList dependencies = null;
+            CodeBasedDependencyAlgorithm.AddDependenciesDueToReflectability(ref dependencies, factory, _method);
+            return dependencies;
+        }
+        protected override string GetName(NodeFactory factory)
+        {
+            return "Reflectable method: " + _method.ToString();
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -138,9 +138,8 @@ namespace ILCompiler.DependencyAnalysis
 
                 if ((flags & InvokeTableFlags.NeedsParameterInterpretation) == 0)
                 {
-                    MethodDesc invokeStubMethod = factory.MetadataManager.GetReflectionInvokeStub(method);
-                    MethodDesc canonInvokeStubMethod = invokeStubMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                    if (invokeStubMethod != canonInvokeStubMethod)
+                    MethodDesc canonInvokeStubMethod = factory.MetadataManager.GetCanonicalReflectionInvokeStub(method);
+                    if (canonInvokeStubMethod.IsSharedByGenericInstantiations)
                     {
                         vertex = writer.GetTuple(vertex,
                             writer.GetUnsignedConstant(((uint)factory.MetadataManager.DynamicInvokeTemplateData.GetIdForMethod(canonInvokeStubMethod) << 1) | 1));
@@ -148,7 +147,7 @@ namespace ILCompiler.DependencyAnalysis
                     else
                     {
                         vertex = writer.GetTuple(vertex,
-                            writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.MethodEntrypoint(invokeStubMethod)) << 1));
+                            writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.MethodEntrypoint(canonInvokeStubMethod)) << 1));
                     }
                 }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -87,15 +87,14 @@ namespace ILCompiler.DependencyAnalysis
                 // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
                 if (factory.MetadataManager.HasReflectionInvokeStub(Method))
                 {
-                    MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(Method);
-                    MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                    if (invokeStub != canonInvokeStub)
+                    MethodDesc canonInvokeStub = factory.MetadataManager.GetCanonicalReflectionInvokeStub(Method);
+                    if (canonInvokeStub.IsSharedByGenericInstantiations)
                     {
                         dependencies.Add(new DependencyListEntry(factory.MetadataManager.DynamicInvokeTemplateData, "Reflection invoke template data"));
                         factory.MetadataManager.DynamicInvokeTemplateData.AddDependenciesDueToInvokeTemplatePresence(ref dependencies, factory, canonInvokeStub);
                     }
                     else
-                        dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke"));
+                        dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(canonInvokeStub), "Reflection invoke"));
                 }
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -70,15 +70,14 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (factory.MetadataManager.HasReflectionInvokeStubForInvokableMethod(_decl) && !_decl.IsCanonicalMethod(CanonicalFormKind.Any))
                 {
-                    MethodDesc invokeStub = factory.MetadataManager.GetReflectionInvokeStub(_decl);
-                    MethodDesc canonInvokeStub = invokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                    if (invokeStub != canonInvokeStub)
+                    MethodDesc canonInvokeStub = factory.MetadataManager.GetCanonicalReflectionInvokeStub(_decl);
+                    if (canonInvokeStub.IsSharedByGenericInstantiations)
                     {
                         dependencies.Add(new DependencyListEntry(factory.MetadataManager.DynamicInvokeTemplateData, "Reflection invoke template data"));
                         factory.MetadataManager.DynamicInvokeTemplateData.AddDependenciesDueToInvokeTemplatePresence(ref dependencies, factory, canonInvokeStub);
                     }
                     else
-                        dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(invokeStub), "Reflection invoke"));
+                        dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(canonInvokeStub), "Reflection invoke"));
                 }
 
                 dependencies.AddRange(ReflectionVirtualInvokeMapNode.GetVirtualInvokeMapDependencies(factory, _decl));

--- a/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
@@ -46,7 +46,7 @@ namespace ILCompiler
         /// <summary>
         /// Gets a stub that can be used to reflection-invoke a method with a given signature.
         /// </summary>
-        public override MethodDesc GetReflectionInvokeStub(MethodDesc method)
+        public override MethodDesc GetCanonicalReflectionInvokeStub(MethodDesc method)
         {
             return null;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysis;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace ILCompiler
 {
     class EmptyMetadataManager : MetadataManager
@@ -40,6 +42,7 @@ namespace ILCompiler
         /// </summary>
         public override bool HasReflectionInvokeStubForInvokableMethod(MethodDesc method)
         {
+            Debug.Assert(IsReflectionInvokable(method));
             return false;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -405,6 +405,8 @@ namespace ILCompiler
         /// </summary>
         public override bool HasReflectionInvokeStubForInvokableMethod(MethodDesc method)
         {
+            Debug.Assert(IsReflectionInvokable(method));
+
             if (method.IsCanonicalMethod(CanonicalFormKind.Any))
                 return false;
 

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -190,8 +190,8 @@ namespace ILCompiler
                 if (!_dynamicInvokeStubs.Value.TryGetValue(reflectableMethod, out typicalDynamicInvokeStub))
                     continue;
 
-                MethodDesc instantiatiatedDynamicInvokeStub = InstantiateDynamicInvokeMethodForMethod(typicalDynamicInvokeStub, reflectableMethod);
-                result.DynamicInvokeCompiledMethods.Add(instantiatiatedDynamicInvokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific));
+                MethodDesc instantiatiatedDynamicInvokeStub = InstantiateCanonicalDynamicInvokeMethodForMethod(typicalDynamicInvokeStub, reflectableMethod);
+                result.DynamicInvokeCompiledMethods.Add(instantiatiatedDynamicInvokeStub);
             }
 
             return result;
@@ -408,14 +408,14 @@ namespace ILCompiler
             if (method.IsCanonicalMethod(CanonicalFormKind.Any))
                 return false;
 
-            MethodDesc reflectionInvokeStub = GetReflectionInvokeStub(method);
+            MethodDesc reflectionInvokeStub = GetCanonicalReflectionInvokeStub(method);
 
             if (reflectionInvokeStub == null)
                 return false;
 
             // TODO: Generate DynamicInvokeTemplateMap dependencies correctly. For now, force all canonical stubs to go through the 
             // calling convention converter interpreter path.
-            if (reflectionInvokeStub.GetCanonMethodTarget(CanonicalFormKind.Specific) != reflectionInvokeStub)
+            if (reflectionInvokeStub.IsSharedByGenericInstantiations)
                 return false;
 
             return true;
@@ -425,7 +425,7 @@ namespace ILCompiler
         /// <summary>
         /// Gets a stub that can be used to reflection-invoke a method with a given signature.
         /// </summary>
-        public override MethodDesc GetReflectionInvokeStub(MethodDesc method)
+        public override MethodDesc GetCanonicalReflectionInvokeStub(MethodDesc method)
         {
             MethodDesc typicalInvokeTarget = method.GetTypicalMethodDefinition();
             MethodDesc typicalDynamicInvokeStub;
@@ -433,16 +433,12 @@ namespace ILCompiler
             if (!_dynamicInvokeStubs.Value.TryGetValue(typicalInvokeTarget, out typicalDynamicInvokeStub))
                 return null;
 
-            MethodDesc dynamicInvokeStubIfItExists = InstantiateDynamicInvokeMethodForMethod(typicalDynamicInvokeStub, method);
+            MethodDesc dynamicInvokeStubCanonicalized = InstantiateCanonicalDynamicInvokeMethodForMethod(typicalDynamicInvokeStub, method);
 
-            if (dynamicInvokeStubIfItExists == null)
+            if (dynamicInvokeStubCanonicalized == null || !_loadedMetadata.Value.DynamicInvokeCompiledMethods.Contains(dynamicInvokeStubCanonicalized))
                 return null;
 
-            MethodDesc dynamicInvokeStubCanonicalized = dynamicInvokeStubIfItExists.GetCanonMethodTarget(CanonicalFormKind.Specific);
-            if (_loadedMetadata.Value.DynamicInvokeCompiledMethods.Contains(dynamicInvokeStubCanonicalized))
-                return dynamicInvokeStubIfItExists;
-            else
-                return null;
+            return dynamicInvokeStubCanonicalized;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.Sorting.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ImportedGenericDictionaryNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\DynamicInvokeTemplateDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReflectableMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ShadowConcreteUnboxingThunkNode.cs" />
     <Compile Include="Compiler\EmptyMetadataManager.cs" />
     <Compile Include="Compiler\ILStreamReader.cs" />


### PR DESCRIPTION
This is a subset of bigger changes we'll need to put metadata generation before the codegen takes place. This is the best we can do given the state of reflection support in TFS-land. I tried to make bigger changes, but hit a bunch of expensive TODOs that would make this utterly unreviewable (Plus, I'm not sure I would actually succeed. Because I tried.).

It's recommended to review the individual commits, as they have a more reviewable size.