### PR TITLE
Enable array loading via dynamic type loader

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -135,13 +135,13 @@ namespace ILCompiler.DependencyAnalysis
 
             dependencyList.Add(factory.VTable(_type), "VTable");
 
-            if (closestDefType.HasGenericDictionarySlot())
+            if (closestDefType.HasInstantiation)
             {
-                // Add a dependency on the template for this type, if the canonical type should be generated into this binary.
-                DefType templateType = GenericTypesTemplateMap.GetActualTemplateTypeForType(factory, _type.ConvertToCanonForm(CanonicalFormKind.Specific));
+                TypeDesc canonType = _type.ConvertToCanonForm(CanonicalFormKind.Specific);
 
-                if (templateType.IsCanonicalSubtype(CanonicalFormKind.Any) && !factory.NecessaryTypeSymbol(templateType).RepresentsIndirectionCell)
-                    dependencyList.Add(factory.NativeLayout.TemplateTypeLayout(templateType), "Template Type Layout");
+                // Add a dependency on the template for this type, if the canonical type should be generated into this binary.
+                if (canonType.IsCanonicalSubtype(CanonicalFormKind.Any) && !factory.NecessaryTypeSymbol(canonType).RepresentsIndirectionCell)
+                    dependencyList.Add(factory.NativeLayout.TemplateTypeLayout(canonType), "Template Type Layout");
             }
 
             // Generated type contains generic virtual methods that will get added to the GVM tables

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -704,7 +704,10 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override void OnMarked(NodeFactory context)
         {
-            //Debug.Assert(_type.IsTypeDefinition || !_type.HasSameTypeDefinition(context.ArrayOfTClass), "Asking for Array<T> EEType");
+            if (!(context is CppCodegenNodeFactory))
+            { 
+                Debug.Assert(_type.IsTypeDefinition || !_type.HasSameTypeDefinition(context.ArrayOfTClass), "Asking for Array<T> EEType");
+            }
         }
 
         /// <summary>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Internal.Text;
 using Internal.TypeSystem;
@@ -88,7 +89,7 @@ namespace ILCompiler.DependencyAnalysis
                     return new NativeLayoutTemplateMethodLayoutVertexNode(_factory, method);
                 });
 
-                _templateTypeLayouts = new NodeCache<DefType, NativeLayoutTemplateTypeLayoutVertexNode>(type =>
+                _templateTypeLayouts = new NodeCache<TypeDesc, NativeLayoutTemplateTypeLayoutVertexNode>(type =>
                 {
                     return new NativeLayoutTemplateTypeLayoutVertexNode(_factory, type);
                 });
@@ -403,10 +404,10 @@ namespace ILCompiler.DependencyAnalysis
                 return _templateMethodLayouts.GetOrAdd(method);
             }
 
-            private NodeCache<DefType, NativeLayoutTemplateTypeLayoutVertexNode> _templateTypeLayouts;
-            public NativeLayoutTemplateTypeLayoutVertexNode TemplateTypeLayout(DefType type)
+            private NodeCache<TypeDesc, NativeLayoutTemplateTypeLayoutVertexNode> _templateTypeLayouts;
+            public NativeLayoutTemplateTypeLayoutVertexNode TemplateTypeLayout(TypeDesc type)
             {
-                return _templateTypeLayouts.GetOrAdd(type);
+                return _templateTypeLayouts.GetOrAdd(GenericTypesTemplateMap.ConvertArrayOfTToRegularArray(_factory, type));
             }
 
             private NodeCache<TypeDesc, NativeLayoutTypeHandleGenericDictionarySlotNode> _typeHandle_GenericDictionarySlots;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -184,8 +184,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                DefType actualTemplateType = GenericTypesTemplateMap.GetActualTemplateTypeForType(factory, (TypeDesc)_dictionaryOwner);
-                dependencies.Add(factory.NativeLayout.TemplateTypeLayout(actualTemplateType), "Type loader template");
+                dependencies.Add(factory.NativeLayout.TemplateTypeLayout((TypeDesc)_dictionaryOwner), "Type loader template");
             }
 
             return dependencies;
@@ -205,8 +204,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                DefType actualTemplateType = GenericTypesTemplateMap.GetActualTemplateTypeForType(factory, (TypeDesc)_dictionaryOwner);
-                templateLayout = factory.NativeLayout.TemplateTypeLayout(actualTemplateType);
+                templateLayout = factory.NativeLayout.TemplateTypeLayout((TypeDesc)_dictionaryOwner);
                 conditionalDependencies.Add(new CombinedDependencyListEntry(_lookupSignature.TemplateDictionaryNode(factory),
                                                                 templateLayout,
                                                                 "Type loader template"));


### PR DESCRIPTION
* Add canonical templates for arrays to the generic type template map.
* The native layout for array templates uses Array<T>. Remove several places that were getting the Array<T> template and only fetch it when needed in the native layout type template.
* Re-enable the assert for Array<T> EEType detection for RyuJitNodeFactory to keep ourselves honest during type loader bring-up.
* Properly emit variance info for all array interface types in the array template native layout (those interfaces had the variance set on their EEType previously in https://github.com/dotnet/corert/commit/3b66085793b54ae425e4bbebf13706906e857c52 and it was not agreeing during EEType creation at runtime).