### PR TITLE
Add support for generating metadata logs

### DIFF
--- a/src/BuildIntegration/BuildFrameworkNativeObjects.proj
+++ b/src/BuildIntegration/BuildFrameworkNativeObjects.proj
@@ -32,6 +32,9 @@
   </Target>
 
   <Target Name="BuildOneFrameworkLibrary">
+    <PropertyGroup>
+        <IlcGenerateMetadataLog>true</IlcGenerateMetadataLog>
+    </PropertyGroup>
     <ItemGroup>
         <ManagedBinary Include="$(LibraryToCompile)" />
         <IlcCompileInput Include="@(ManagedBinary)" />

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -97,6 +97,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Include="@(IlcCompileInput)" />
       <IlcArg Include="-o:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)" />
       <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
+      <IlcArg Condition="$(IlcGenerateMetadataLog) == 'true'" Include="--metadatalog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).metadata.csv" />
       <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -106,7 +106,7 @@ namespace ILCompiler
             // .NET metadata is UTF-16 and UTF-16 contains code points that don't translate to UTF-8.
             var noThrowUtf8Encoding = new UTF8Encoding(false, false);
 
-            using (var logWriter = _metadataLogFile != null ? new StreamWriter(File.Open(_metadataLogFile, FileMode.Create, FileAccess.Write), noThrowUtf8Encoding) : null)
+            using (var logWriter = _metadataLogFile != null ? new StreamWriter(File.Open(_metadataLogFile, FileMode.Create, FileAccess.Write, FileShare.Read), noThrowUtf8Encoding) : null)
             {
                 writer.LogWriter = logWriter;
                 writer.Write(ms);

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Text;
 
 using Internal.IL.Stubs;
 using Internal.TypeSystem;
@@ -24,10 +25,13 @@ namespace ILCompiler
     public class CompilerGeneratedMetadataManager : MetadataManager
     {
         private GeneratedTypesAndCodeMetadataPolicy _metadataPolicy;
+        private string _metadataLogFile;
 
-        public CompilerGeneratedMetadataManager(CompilationModuleGroup group, CompilerTypeSystemContext typeSystemContext) : base(group, typeSystemContext)
+        public CompilerGeneratedMetadataManager(CompilationModuleGroup group, CompilerTypeSystemContext typeSystemContext, string logFile)
+            : base(group, typeSystemContext)
         {
             _metadataPolicy = new GeneratedTypesAndCodeMetadataPolicy(this);
+            _metadataLogFile = logFile;
         }
 
         private HashSet<MetadataType> _typeDefinitionsToGenerate = new HashSet<MetadataType>();
@@ -66,8 +70,11 @@ namespace ILCompiler
                 var definition = type.GetTypeDefinition() as Internal.TypeSystem.Ecma.EcmaType;
                 if (definition == null)
                     continue;
-                _typeDefinitionsToGenerate.Add(definition);
-                _modulesSeen.Add(definition.Module);
+                if (factory.CompilationModuleGroup.ContainsType(definition))
+                {
+                    _typeDefinitionsToGenerate.Add(definition);
+                    _modulesSeen.Add(definition.Module);
+                }
             }
 
             foreach (var method in GetCompiledMethods())
@@ -76,9 +83,12 @@ namespace ILCompiler
                 if (typicalMethod != null)
                 {
                     var owningType = (MetadataType)typicalMethod.OwningType;
-                    _typeDefinitionsToGenerate.Add(owningType);
-                    _modulesSeen.Add(owningType.Module);
-                    _methodDefinitionsToGenerate.Add(typicalMethod);
+                    if (factory.CompilationModuleGroup.ContainsType(owningType))
+                    {
+                        _typeDefinitionsToGenerate.Add(owningType);
+                        _modulesSeen.Add(owningType.Module);
+                        _methodDefinitionsToGenerate.Add(typicalMethod);
+                    }
                 }
             }
 
@@ -92,7 +102,16 @@ namespace ILCompiler
             var writer = new MetadataWriter();
             writer.ScopeDefinitions.AddRange(transformed.Scopes);
             var ms = new MemoryStream();
-            writer.Write(ms);
+
+            // .NET metadata is UTF-16 and UTF-16 contains code points that don't translate to UTF-8.
+            var noThrowUtf8Encoding = new UTF8Encoding(false, false);
+
+            using (var logWriter = _metadataLogFile != null ? new StreamWriter(File.Open(_metadataLogFile, FileMode.Create, FileAccess.Write), noThrowUtf8Encoding) : null)
+            {
+                writer.LogWriter = logWriter;
+                writer.Write(ms);
+            }
+
             metadataBlob = ms.ToArray();
 
             typeMappings = new List<MetadataMapping<MetadataType>>();

--- a/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CppCodegenCompilationBuilder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysisFramework;
 
 namespace ILCompiler
 {
@@ -16,7 +17,7 @@ namespace ILCompiler
         CppCodegenConfigProvider _config = new CppCodegenConfigProvider(Array.Empty<string>());
 
         public CppCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group)
-            : base(new CppCodegenNodeFactory(context, group))
+            : base(context, group)
         {
         }
 
@@ -28,7 +29,11 @@ namespace ILCompiler
 
         public override ICompilation ToCompilation()
         {
-            return new CppCodegenCompilation(CreateDependencyGraph(), _nodeFactory, _compilationRoots, _logger, _config);
+            MetadataManager metadataManager = CreateMetadataManager();
+            CppCodegenNodeFactory factory = new CppCodegenNodeFactory(_context, _compilationGroup, metadataManager);
+            DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
+
+            return new CppCodegenCompilation(graph, factory, _compilationRoots, _logger, _config);
         }
     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -10,8 +10,8 @@ namespace ILCompiler.DependencyAnalysis
 {
     public sealed class CppCodegenNodeFactory : NodeFactory
     {
-        public CppCodegenNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup)
-            : base(context, compilationModuleGroup, new CompilerGeneratedMetadataManager(compilationModuleGroup, context), new CoreRTNameMangler(true))
+        public CppCodegenNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager)
+            : base(context, compilationModuleGroup, metadataManager, new CoreRTNameMangler(true))
         {
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -12,8 +12,8 @@ namespace ILCompiler.DependencyAnalysis
 {
     public sealed class RyuJitNodeFactory : NodeFactory
     {
-        public RyuJitNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup)
-            : base(context, compilationModuleGroup, new CompilerGeneratedMetadataManager(compilationModuleGroup, context), new CoreRTNameMangler(false))
+        public RyuJitNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager)
+            : base(context, compilationModuleGroup, metadataManager, new CoreRTNameMangler(false))
         {
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysis;
-
+using ILCompiler.DependencyAnalysisFramework;
 using Internal.JitInterface;
 
 namespace ILCompiler
@@ -18,7 +18,7 @@ namespace ILCompiler
         private KeyValuePair<string, string>[] _ryujitOptions = Array.Empty<KeyValuePair<string, string>>();
 
         public RyuJitCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group)
-            : base(new RyuJitNodeFactory(context, group))
+            : base(context, group)
         {
         }
 
@@ -73,8 +73,13 @@ namespace ILCompiler
             if (_generateDebugInfo)
                 jitFlagBuilder.Add(CorJitFlag.CORJIT_FLAG_DEBUG_INFO);
 
+            MetadataManager metadataManager = CreateMetadataManager();
+
+            var factory = new RyuJitNodeFactory(_context, _compilationGroup, metadataManager);
+
             var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);
-            return new RyuJitCompilation(CreateDependencyGraph(), _nodeFactory, _compilationRoots, _logger, jitConfig);
+            DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _logger, jitConfig);
         }
     }
 }

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -37,6 +37,7 @@ namespace ILCompiler
         private bool _multiFile;
         private bool _useSharedGenerics;
         private string _mapFileName;
+        private string _metadataLogFileName;
 
         private string _singleMethodTypeName;
         private string _singleMethodName;
@@ -133,6 +134,7 @@ namespace ILCompiler
                 syntax.DefineOptionList("codegenopt", ref _codegenOptions, "Define a codegen option");
                 syntax.DefineOptionList("rdxml", ref _rdXmlFilePaths, "RD.XML file(s) for compilation");
                 syntax.DefineOption("map", ref _mapFileName, "Generate a map file");
+                syntax.DefineOption("metadatalog", ref _metadataLogFileName, "Generate a metadata log file");
 
                 syntax.DefineOption("targetarch", ref _targetArchitectureStr, "Target architecture for cross compilation");
                 syntax.DefineOption("targetos", ref _targetOSStr, "Target OS for cross compilation");
@@ -340,6 +342,7 @@ namespace ILCompiler
                 .UseCompilationRoots(compilationRoots)
                 .UseOptimizationMode(_optimizationMode)
                 .UseDebugInfo(_enableDebugInfo)
+                .UseMetadataLogFile(_metadataLogFileName)
                 .ToCompilation();
 
             ObjectDumper dumper = _mapFileName != null ? new ObjectDumper(_mapFileName) : null;


### PR DESCRIPTION
* Move creation of `MetadataManager` to `CompilationBuilder`. We'll want
to expose more compilation options in respect to metadata generation in
the future (e.g. satellite assembly metadata), so this is a much better
place to have it.
* Add compilation switch that lets us pass a file name to generate the
log into.
* Enable metadata log generation when building the framework object
files. Diagnostic breadcrumbs are generally useful.