### PR TITLE
Enable shared generics by default for RyuJIT backend

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -210,7 +210,7 @@ namespace ILCompiler
             // Initialize type system context
             //
 
-            SharedGenericsMode genericsMode = _useSharedGenerics ?
+            SharedGenericsMode genericsMode = _useSharedGenerics || !_isCppCodegen ?
                 SharedGenericsMode.CanonicalReferenceTypes : SharedGenericsMode.Disabled;
 
             var typeSystemContext = new CompilerTypeSystemContext(new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT), genericsMode);

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -127,17 +127,11 @@ if /i "%__BuildType%"=="Debug" (
 
 echo. > %__CoreRTTestBinDir%\testResults.tmp
 
-rem Hacky filtering to prevent shared generics and unshared generics from mixing
-set __Filter=
-if /i "%CoreRT_MultiFileConfiguration%" == "MultiModule" (
-    set __Filter=^^^| findstr /V Generics
-)
-
 set /a __CppTotalTests=0
 set /a __CppPassedTests=0
 set /a __JitTotalTests=0
 set /a __JitPassedTests=0
-for /f "delims=" %%a in ('cmd /c dir /s /aD /b %CoreRT_TestRoot%\src\%CoreRT_TestName% %__Filter%') do (
+for /f "delims=" %%a in ('dir /s /aD /b %CoreRT_TestRoot%\src\%CoreRT_TestName%') do (
     set __SourceFolder=%%a
     set __SourceFileName=%%~na
     set __RelativePath=!__SourceFolder:%CoreRT_TestRoot%=!

--- a/tests/src/Simple/Generics/Generics.csproj
+++ b/tests/src/Simple/Generics/Generics.csproj
@@ -1,9 +1,5 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <IlcArg Include="--usesharedgenerics" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Adding proper tracking of virtual method reflection use in multifile
mode (#3437) was the last thing blocking this. Let's see if we can get
away with enabling this by default.