### PR TITLE
Add ExactCallableAddress/CanonicalEntrypoint helpers to NodeFactory

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -215,18 +215,7 @@ namespace ILCompiler
 
             public void AddCompilationRoot(MethodDesc method, string reason, string exportName = null)
             {
-                MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                IMethodNode methodEntryPoint;
-
-                if (canonMethod != method)
-                {
-                    methodEntryPoint = _factory.ShadowConcreteMethod(method);
-                }
-                else
-                {
-                    methodEntryPoint = _factory.MethodEntrypoint(method);
-                }
-
+                IMethodNode methodEntryPoint = _factory.CanonicalEntrypoint(method);
                 _graph.AddRoot(methodEntryPoint, reason);
 
                 if (exportName != null)

--- a/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DelegateCreationInfo.cs
@@ -111,21 +111,13 @@ namespace ILCompiler
         public ISymbolNode GetTargetNode(NodeFactory factory)
         {
             Debug.Assert(!NeedsRuntimeLookup);
-            MethodDesc canonTargetMethod = TargetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
-
             switch (_targetKind)
             {
                 case TargetKind.CanonicalEntrypoint:
-                    if (TargetMethod != canonTargetMethod)
-                        return factory.ShadowConcreteMethod(TargetMethod, TargetMethodIsUnboxingThunk);
-                    else
-                        return factory.MethodEntrypoint(TargetMethod, TargetMethodIsUnboxingThunk);
+                    return factory.CanonicalEntrypoint(TargetMethod, TargetMethodIsUnboxingThunk);
 
                 case TargetKind.ExactCallableAddress:
-                    if (TargetMethod != canonTargetMethod)
-                        return factory.FatFunctionPointer(TargetMethod, TargetMethodIsUnboxingThunk);
-                    else
-                        return factory.MethodEntrypoint(TargetMethod, TargetMethodIsUnboxingThunk);
+                    return factory.ExactCallableAddress(TargetMethod, TargetMethodIsUnboxingThunk);
 
                 case TargetKind.InterfaceDispatch:
                     return factory.InterfaceDispatchCell(TargetMethod);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -1121,9 +1121,9 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(instantiatedConstraintType.IsValueType);
             Debug.Assert(implMethod.OwningType == instantiatedConstraintType);
 
-            if (implMethod.HasInstantiation && implMethod.GetCanonMethodTarget(CanonicalFormKind.Specific) != implMethod)
+            if (implMethod.HasInstantiation)
             {
-                return factory.FatFunctionPointer(implMethod);
+                return factory.ExactCallableAddress(implMethod);
             }
             else
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -663,6 +663,24 @@ namespace ILCompiler.DependencyAnalysis
             return _fatFunctionPointers.GetOrAdd(new MethodKey(method, isUnboxingStub));
         }
 
+        public IMethodNode ExactCallableAddress(MethodDesc method, bool isUnboxingStub = false)
+        {
+            MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            if (method != canonMethod)
+                return FatFunctionPointer(method, isUnboxingStub);
+            else
+                return MethodEntrypoint(method, isUnboxingStub);
+        }
+
+        public IMethodNode CanonicalEntrypoint(MethodDesc method, bool isUnboxingStub = false)
+        {
+            MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            if (method != canonMethod)
+                return ShadowConcreteMethod(method, isUnboxingStub);
+            else
+                return MethodEntrypoint(method, isUnboxingStub);
+        }
+
         private NodeCache<MethodDesc, GVMDependenciesNode> _gvmDependenciesNode;
         internal GVMDependenciesNode GVMDependencies(MethodDesc method)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -123,11 +123,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 // Emit the actual StaticClassConstructionContext
                 MethodDesc cctorMethod = _type.GetStaticConstructor();
-                MethodDesc canonCctorMethod = cctorMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                if (cctorMethod != canonCctorMethod)
-                    builder.EmitPointerReloc(factory.FatFunctionPointer(cctorMethod));
-                else
-                    builder.EmitPointerReloc(factory.MethodEntrypoint(cctorMethod));
+                builder.EmitPointerReloc(factory.ExactCallableAddress(cctorMethod));
                 builder.EmitZeroPointer();
             }
             else

--- a/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitNodeFactory.cs
+++ b/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitNodeFactory.cs
@@ -86,6 +86,24 @@ namespace ILCompiler.DependencyAnalysis
             return _methodEntrypoints.GetOrAdd(method);
         }
 
+        public IMethodNode ExactCallableAddress(MethodDesc method, bool isUnboxingStub = false)
+        {
+            MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            if (method != canonMethod)
+                return FatFunctionPointer(method, isUnboxingStub);
+            else
+                return MethodEntrypoint(method, isUnboxingStub);
+        }
+
+        public IMethodNode CanonicalEntrypoint(MethodDesc method, bool isUnboxingStub = false)
+        {
+            MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            if (method != canonMethod)
+                return ShadowConcreteMethod(method, isUnboxingStub);
+            else
+                return MethodEntrypoint(method, isUnboxingStub);
+        }
+
         public IMethodNode RuntimeDeterminedMethod(MethodDesc method) { throw new NotImplementedException(); }
         public JitFrozenStringNode SerializedStringObject(string data) { return _frozenStrings.GetOrAdd(data); }
         public JitGenericMethodDictionaryNode MethodGenericDictionary(MethodDesc method) { throw new NotImplementedException(); }


### PR DESCRIPTION
Removes a bit of boilerplate. This is an API @davidwrighton suggested
some time ago. This was blocked until #3423 got implemented.