### PR TITLE
Implemented verification for binary comparison and branching instructions

### DIFF
--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -332,6 +332,69 @@ namespace Internal.IL
 #endif 
         }
 
+
+        bool IsBinaryComparable(StackValue src, StackValue dst, ILOpcode op)
+        {
+            if (src.Kind == dst.Kind && src.Type == dst.Type)
+                return true;
+
+            switch (src.Kind)
+            {
+                case StackValueKind.ObjRef:
+                    switch (dst.Kind)
+                    {
+                        case StackValueKind.ObjRef:
+                            return op == ILOpcode.beq || op == ILOpcode.beq_s ||
+                                   op == ILOpcode.bne_un || op == ILOpcode.bne_un_s ||
+                                   op == ILOpcode.ceq;
+                        default:
+                            return false;
+                    }
+
+                case StackValueKind.ValueType:
+                    return false;
+
+                case StackValueKind.ByRef:
+                    switch (dst.Kind)
+                    {
+                        case StackValueKind.ByRef:
+                            return true;
+                        case StackValueKind.NativeInt:
+                            return op == ILOpcode.beq || op == ILOpcode.beq_s ||
+                                   op == ILOpcode.bne_un || op == ILOpcode.bne_un_s ||
+                                   op == ILOpcode.ceq;
+                        default:
+                            return false;
+                    }
+
+                case StackValueKind.Int32:
+                    return (dst.Kind == StackValueKind.Int64 || dst.Kind == StackValueKind.NativeInt);
+
+                case StackValueKind.Int64:
+                    return (dst.Kind == StackValueKind.Int64);
+
+                case StackValueKind.NativeInt:
+                    switch (dst.Kind)
+                    {
+                        case StackValueKind.Int32:
+                        case StackValueKind.NativeInt:
+                            return true;
+                        case StackValueKind.ByRef:
+                            return op == ILOpcode.beq || op == ILOpcode.beq_s ||
+                                   op == ILOpcode.bne_un || op == ILOpcode.bne_un_s ||
+                                   op == ILOpcode.ceq;
+                        default:
+                            return false;
+                    }
+
+                case StackValueKind.Float:
+                    return dst.Kind == StackValueKind.Float;
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
         bool IsByRefLike(StackValue value)
         {
             if (value.Kind == StackValueKind.ByRef)

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -959,7 +959,8 @@ namespace Internal.IL
         {
             switch (opcode)
             {
-                case ILOpcode.br: break;
+                case ILOpcode.br:
+                    break;
                 case ILOpcode.brfalse:
                 case ILOpcode.brtrue:
                     {
@@ -978,12 +979,15 @@ namespace Internal.IL
                 case ILOpcode.ble_un:
                 case ILOpcode.blt_un:
                     {
-                        var value1 = Pop();
-                        var value2 = Pop();
+                        StackValue value1 = Pop();
+                        StackValue value2 = Pop();
 
                         CheckIsComparable(value1, value2, opcode);
-                        break;
                     }
+                    break;
+                default:
+                    Debug.Assert(false, "Unexpected branch opcode");
+                    break;
             }
 
             ImportFallthrough(target);

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -336,6 +336,14 @@ namespace Internal.IL
             }
         }
 
+        void CheckIsComparable(StackValue a, StackValue b, ILOpcode op)
+        {
+            if (!IsBinaryComparable(a, b, op))
+            {
+                VerificationError(VerifierError.StackUnexpected, a, b);
+            }
+        }
+
         void Unverifiable()
         {
             VerificationError(VerifierError.Unverifiable);
@@ -949,7 +957,34 @@ namespace Internal.IL
 
         void ImportBranch(ILOpcode opcode, BasicBlock target, BasicBlock fallthrough)
         {
-            // TODO: Verification rules
+            switch (opcode)
+            {
+                case ILOpcode.br: break;
+                case ILOpcode.brfalse:
+                case ILOpcode.brtrue:
+                    {
+                        StackValue value = Pop();
+                        Check(value.Kind >= StackValueKind.Int32 && value.Kind <= StackValueKind.NativeInt || value.Kind == StackValueKind.ObjRef || value.Kind == StackValueKind.ByRef, VerifierError.StackUnexpected);
+                    }
+                    break;
+                case ILOpcode.beq:
+                case ILOpcode.bge:
+                case ILOpcode.bgt:
+                case ILOpcode.ble:
+                case ILOpcode.blt:
+                case ILOpcode.bne_un:
+                case ILOpcode.bge_un:
+                case ILOpcode.bgt_un:
+                case ILOpcode.ble_un:
+                case ILOpcode.blt_un:
+                    {
+                        var value1 = Pop();
+                        var value2 = Pop();
+
+                        CheckIsComparable(value1, value2, opcode);
+                        break;
+                    }
+            }
 
             ImportFallthrough(target);
 
@@ -1013,7 +1048,12 @@ namespace Internal.IL
 
         void ImportCompareOperation(ILOpcode opcode)
         {
-            throw new NotImplementedException();
+            var value1 = Pop();
+            var value2 = Pop();
+
+            CheckIsComparable(value1, value2, opcode);
+
+            Push(StackValue.CreatePrimitive(StackValueKind.Int32));
         }
 
         void ImportConvert(WellKnownType wellKnownType, bool checkOverflow, bool unsigned)


### PR DESCRIPTION
As the title says I implemented verification for binary comparison and branching instructions according to ECMA-335.

I plan to do further development of ILVerify, so that I can use it to verify rewritten IL code as described in https://github.com/dotnet/coreclr/issues/11173.