### PR TITLE
Return null from mincore.Interop.GetLocaleInfoEx

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.Globalization.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Globalization.cs
@@ -89,7 +89,7 @@ internal static partial class Interop
                 return new String(pBuffer);
             }
 
-            return "";
+            return null;
         }
 
         internal static unsafe int GetLocaleInfoExInt(String localeName, uint field)

--- a/src/System.Private.CoreLib/src/System/Globalization/CalendarData.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CalendarData.Windows.cs
@@ -318,7 +318,7 @@ namespace System.Globalization
                     string res = Interop.mincore.GetLocaleInfoEx(localeName, lcType);
 
                     // if it succeeded remember the override for the later callers
-                    if (res != "")
+                    if (res != null)
                     {
                         // Remember this was the override (so we can look for duplicates later in the enum function)
                         context.userOverride = res;


### PR DESCRIPTION
AFAIK, the only caller of this function is [here](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Windows.cs#L38), and this is checking for `null`, not for an empty string!

So makes sense to me that this should always return `null`, or change the caller to check for `null` AND empty string.

Changing it here seemed more appropriate though!