### PR TITLE
Implement Type.IsTypeDefinition property on CoreRT

### DIFF
--- a/src/System.Private.CoreLib/src/System/Type.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Type.CoreRT.cs
@@ -14,6 +14,9 @@ namespace System
 {
     public abstract partial class Type : MemberInfo, IReflect
     {
+        //@todo: Move to shared Type.cs once CoreCLR side is done.
+        public virtual bool IsTypeDefinition { get { throw NotImplemented.ByDesign; } }
+
         public bool IsInterface => (GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface;
 
         [Intrinsic]

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -173,6 +173,7 @@
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeNoMetadataNamedTypeInfo.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimePointerTypeInfo.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeBlockedTypeInfo.cs" />
+    <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeDefinitionTypeInfo.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.GetMember.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeTypeInfo.BindingFlags.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -117,7 +117,7 @@ namespace System.Reflection.Runtime.TypeInfos
     //-----------------------------------------------------------------------------------------------------------
     // TypeInfos for type definitions (i.e. "Foo" and "Foo<>" but not "Foo<int>") that aren't opted into metadata.
     //-----------------------------------------------------------------------------------------------------------
-    internal sealed partial class RuntimeNoMetadataNamedTypeInfo : RuntimeTypeInfo
+    internal sealed partial class RuntimeNoMetadataNamedTypeInfo
     {
         internal static RuntimeNoMetadataNamedTypeInfo GetRuntimeNoMetadataNamedTypeInfo(RuntimeTypeHandle typeHandle, bool isGenericTypeDefinition)
         {
@@ -155,7 +155,7 @@ namespace System.Reflection.Runtime.TypeInfos
     // TypeInfos that represent type definitions (i.e. Foo or Foo<>) or constructed generic types (Foo<int>)
     // that can never be reflection-enabled due to the framework Reflection block.
     //-----------------------------------------------------------------------------------------------------------
-    internal sealed partial class RuntimeBlockedTypeInfo : RuntimeTypeInfo
+    internal sealed partial class RuntimeBlockedTypeInfo
     {
         internal static RuntimeBlockedTypeInfo GetRuntimeBlockedTypeInfo(RuntimeTypeHandle typeHandle, bool isGenericTypeDefinition)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
@@ -33,21 +33,11 @@ namespace System.Reflection.Runtime.TypeInfos
             return _rank;
         }
 
-        public sealed override bool IsSZArray
-        {
-            get
-            {
-                return !_multiDim;
-            }
-        }
-
-        public sealed override bool IsVariableBoundArray
-        {
-            get
-            {
-                return _multiDim;
-            }
-        }
+        protected sealed override bool IsArrayImpl() => true;
+        public sealed override bool IsSZArray => !_multiDim;
+        public sealed override bool IsVariableBoundArray => _multiDim;
+        protected sealed override bool IsByRefImpl() => false;
+        protected sealed override bool IsPointerImpl() => false;
 
         protected sealed override TypeAttributes GetAttributeFlagsImpl()
         {
@@ -288,11 +278,6 @@ namespace System.Reflection.Runtime.TypeInfos
             {
                 return new TypeContext(new RuntimeTypeInfo[] { this.InternalRuntimeElementType }, null);
             }
-        }
-
-        protected sealed override bool IsArrayImpl()
-        {
-            return true;
         }
 
         protected sealed override string Suffix

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -30,7 +30,7 @@ namespace System.Reflection.Runtime.TypeInfos
     //
     // Since these represent "internal framework types", the app cannot prove we are lying.
     // 
-    internal sealed partial class RuntimeBlockedTypeInfo : RuntimeTypeInfo
+    internal sealed partial class RuntimeBlockedTypeInfo : RuntimeTypeDefinitionTypeInfo
     {
         private RuntimeBlockedTypeInfo(RuntimeTypeHandle typeHandle, bool isGenericTypeDefinition)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeByRefTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeByRefTypeInfo.cs
@@ -20,10 +20,11 @@ namespace System.Reflection.Runtime.TypeInfos
         {
         }
 
-        protected sealed override bool IsByRefImpl()
-        {
-            return true;
-        }
+        protected sealed override bool IsArrayImpl() => false;
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+        protected sealed override bool IsByRefImpl() => true;
+        protected sealed override bool IsPointerImpl() => false;
 
         protected sealed override string Suffix
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeClsIdTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeClsIdTypeInfo.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.Runtime.TypeInfos
     // TypeInfos returned by the Type.GetTypeFromCLSID() api. These "types" are little more than mules that hold a CLSID
     // and optional remote server name. The only useful thing to do with them is to pass them to Activator.CreateInstance().
     // 
-    internal sealed partial class RuntimeCLSIDTypeInfo : RuntimeTypeInfo, IKeyedItem<RuntimeCLSIDTypeInfo.UnificationKey>
+    internal sealed partial class RuntimeCLSIDTypeInfo : RuntimeTypeDefinitionTypeInfo, IKeyedItem<RuntimeCLSIDTypeInfo.UnificationKey>
     {
         private RuntimeCLSIDTypeInfo(Guid clsid, string server)
         {
@@ -30,6 +30,7 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override string FullName => BaseType.FullName;
         public sealed override Guid GUID => _key.ClsId;
         public sealed override string InternalGetNameIfAvailable(ref Type rootCauseForFailure) => BaseType.InternalGetNameIfAvailable(ref rootCauseForFailure);
+        public sealed override bool IsGenericTypeDefinition => false;
         public sealed override int MetadataToken => BaseType.MetadataToken;
         public sealed override string Namespace => BaseType.Namespace;
         public sealed override StructLayoutAttribute StructLayoutAttribute => BaseType.StructLayoutAttribute;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -29,6 +29,17 @@ namespace System.Reflection.Runtime.TypeInfos
             _key = key;
         }
 
+        public sealed override bool IsTypeDefinition => false;
+        public sealed override bool IsGenericTypeDefinition => false;
+        protected sealed override bool HasElementTypeImpl() => false;
+        protected sealed override bool IsArrayImpl() => false;
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+        protected sealed override bool IsByRefImpl() => false;
+        protected sealed override bool IsPointerImpl() => false;
+        public sealed override bool IsConstructedGenericType => true;
+        public sealed override bool IsGenericParameter => false;
+
         //
         // Implements IKeyedItem.PrepareKey.
         // 
@@ -133,14 +144,6 @@ namespace System.Reflection.Runtime.TypeInfos
                         return true;
                 }
                 return false;
-            }
-        }
-
-        public sealed override bool IsConstructedGenericType
-        {
-            get
-            {
-                return true;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -25,6 +25,17 @@ namespace System.Reflection.Runtime.TypeInfos
             _position = position;
         }
 
+        public sealed override bool IsTypeDefinition => false;
+        public sealed override bool IsGenericTypeDefinition => false;
+        protected sealed override bool HasElementTypeImpl() => false;
+        protected sealed override bool IsArrayImpl() => false;
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+        protected sealed override bool IsByRefImpl() => false;
+        protected sealed override bool IsPointerImpl() => false;
+        public sealed override bool IsConstructedGenericType => false;
+        public sealed override bool IsGenericParameter => true;
+
         public sealed override Assembly Assembly
         {
             get
@@ -67,14 +78,6 @@ namespace System.Reflection.Runtime.TypeInfos
             get
             {
                 return _position;
-            }
-        }
-
-        public sealed override bool IsGenericParameter
-        {
-            get
-            {
-                return true;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
@@ -26,6 +26,17 @@ namespace System.Reflection.Runtime.TypeInfos
             _key = key;
         }
 
+        public sealed override bool IsTypeDefinition => false;
+        public sealed override bool IsGenericTypeDefinition => false;
+        protected sealed override bool HasElementTypeImpl() => true;
+        protected abstract override bool IsArrayImpl();
+        public abstract override bool IsSZArray { get; }
+        public abstract override bool IsVariableBoundArray { get; }
+        protected abstract override bool IsByRefImpl();
+        protected abstract override bool IsPointerImpl();
+        public sealed override bool IsConstructedGenericType => false;
+        public sealed override bool IsGenericParameter => false;
+
         //
         // Implements IKeyedItem.PrepareKey.
         // 
@@ -125,11 +136,6 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             Debug.Assert(IsByRef || IsPointer);
             return TypeAttributes.AnsiClass;
-        }
-
-        protected sealed override bool HasElementTypeImpl()
-        {
-            return true;
         }
 
         protected sealed override int InternalGetHashCode()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -28,7 +28,7 @@ namespace System.Reflection.Runtime.TypeInfos
     // TypeInfos that represent type definitions (i.e. Foo or Foo<>, but not Foo<int> or arrays/pointers/byrefs.)
     // 
     //
-    internal abstract partial class RuntimeNamedTypeInfo : RuntimeTypeInfo, IEquatable<RuntimeNamedTypeInfo>
+    internal abstract partial class RuntimeNamedTypeInfo : RuntimeTypeDefinitionTypeInfo, IEquatable<RuntimeNamedTypeInfo>
     {
         protected RuntimeNamedTypeInfo(RuntimeTypeHandle typeHandle)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNoMetadataNamedTypeInfo.cs
@@ -23,7 +23,7 @@ namespace System.Reflection.Runtime.TypeInfos
     // TypeInfos that represent type definitions (i.e. Foo or Foo<>, but not Foo<int> or arrays/pointers/byrefs.)
     // that not opted into pay-for-play metadata.
     // 
-    internal sealed partial class RuntimeNoMetadataNamedTypeInfo : RuntimeTypeInfo
+    internal sealed partial class RuntimeNoMetadataNamedTypeInfo : RuntimeTypeDefinitionTypeInfo
     {
         private RuntimeNoMetadataNamedTypeInfo(RuntimeTypeHandle typeHandle, bool isGenericTypeDefinition)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimePointerTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimePointerTypeInfo.cs
@@ -20,10 +20,11 @@ namespace System.Reflection.Runtime.TypeInfos
         {
         }
 
-        protected sealed override bool IsPointerImpl()
-        {
-            return true;
-        }
+        protected sealed override bool IsArrayImpl() => false;
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+        protected sealed override bool IsByRefImpl() => false;
+        protected sealed override bool IsPointerImpl() => true;
 
         protected sealed override string Suffix
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeDefinitionTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeDefinitionTypeInfo.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reflection.Runtime.TypeInfos
+{
+    //
+    // TypeInfos that represent non-constructed types (IsTypeDefinition == true)
+    // 
+    internal abstract class RuntimeTypeDefinitionTypeInfo : RuntimeTypeInfo
+    {
+        public sealed override bool IsTypeDefinition => true;
+        public abstract override bool IsGenericTypeDefinition { get; }
+        protected sealed override bool HasElementTypeImpl() => false;
+        protected sealed override bool IsArrayImpl() => false;
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+        protected sealed override bool IsByRefImpl() => false;
+        protected sealed override bool IsPointerImpl() => false;
+        public sealed override bool IsConstructedGenericType => false;
+        public sealed override bool IsGenericParameter => false;
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -42,6 +42,17 @@ namespace System.Reflection.Runtime.TypeInfos
         {
         }
 
+        public abstract override bool IsTypeDefinition { get; }
+        public abstract override bool IsGenericTypeDefinition { get; }
+        protected abstract override bool HasElementTypeImpl();
+        protected abstract override bool IsArrayImpl();
+        public abstract override bool IsSZArray { get; }
+        public abstract override bool IsVariableBoundArray { get; }
+        protected abstract override bool IsByRefImpl();
+        protected abstract override bool IsPointerImpl();
+        public abstract override bool IsGenericParameter { get; }
+        public abstract override bool IsConstructedGenericType { get; }
+
         public abstract override Assembly Assembly { get; }
 
         public sealed override string AssemblyQualifiedName
@@ -306,66 +317,11 @@ namespace System.Reflection.Runtime.TypeInfos
             return Assignability.IsAssignableFrom(this, typeInfo);
         }
 
-        //
-        // Left unsealed as constructed generic types must override.
-        //
-        public override bool IsConstructedGenericType
-        {
-            get
-            {
-                return false;
-            }
-        }
-
         public sealed override bool IsEnum
         {
             get
             {
                 return 0 != (Classification & TypeClassification.IsEnum);
-            }
-        }
-
-        //
-        // Left unsealed as generic parameter types must override.
-        //
-        public override bool IsGenericParameter
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        //
-        // Left unsealed as generic type definitions must override.
-        //
-        public override bool IsGenericTypeDefinition
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        //
-        // Left unsealed as array types must override.
-        //
-        public override bool IsSZArray
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        //
-        // Left unsealed as array types must override.
-        //
-        public override bool IsVariableBoundArray
-        {
-            get
-            {
-                return false;
             }
         }
 
@@ -592,44 +548,12 @@ namespace System.Reflection.Runtime.TypeInfos
 
         protected abstract override TypeAttributes GetAttributeFlagsImpl();
 
-        //
-        // Left unsealed so that RuntimeHasElementTypeInfo can override.
-        //
-        protected override bool HasElementTypeImpl()
-        {
-            return false;
-        }
-
         protected sealed override TypeCode GetTypeCodeImpl()
         {
             return ReflectionAugments.GetRuntimeTypeCode(this);
         }
 
         protected abstract int InternalGetHashCode();
-
-        //
-        // Left unsealed since array types must override.
-        //
-        protected override bool IsArrayImpl()
-        {
-            return false;
-        }
-
-        //
-        // Left unsealed since byref types must override.
-        //
-        protected override bool IsByRefImpl()
-        {
-            return false;
-        }
-
-        //
-        // Left unsealed since pointer types must override.
-        //
-        protected override bool IsPointerImpl()
-        {
-            return false;
-        }
 
         protected sealed override bool IsCOMObjectImpl()
         {


### PR DESCRIPTION
This api was just approved.

https://github.com/dotnet/corefx/issues/17345

This was also a good opportunity to get all our
non-constructed RuntimeType classes under one
umbrella base class and reorganize our type dissector
apis so they're more auditable.