### PR TITLE
Three Interop bug fixes

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -32,6 +32,14 @@ namespace Internal.IL.Stubs
             get;
         }
 
+        public override bool IsPInvoke
+        {
+            get
+            {
+                return Kind == DelegateMarshallingMethodThunkKind.ForwardNativeFunctionWrapper;
+            }
+        }
+
         public MarshalDirection Direction
         {
             get

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -181,8 +181,15 @@ namespace Internal.IL.Stubs
                     nativeParameterTypes[i - 1] = _marshallers[i].NativeParameterType;
                 }
 
+                MethodSignatureFlags flags = MethodSignatureFlags.Static;
+                var delegateType = ((DelegateMarshallingMethodThunk)_targetMethod).DelegateType as EcmaType;
+                if (delegateType != null)
+                {
+                    flags |= delegateType.GetDelegatePInvokeFlags().UnmanagedCallingConvention;
+                }
+
                 MethodSignature nativeSig = new MethodSignature(
-                MethodSignatureFlags.Static, 0, nativeReturnType, nativeParameterTypes);
+                    flags, 0, nativeReturnType, nativeParameterTypes);
 
                 callsiteSetupCodeStream.Emit(ILOpcode.calli, emitter.NewToken(nativeSig));
             }

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -310,7 +310,7 @@ namespace Internal.TypeSystem.Interop
                 // If it is a pointer type we will create InlineArray for IntPtr
                 elementNativeType = (MetadataType)managedElementType.Context.GetWellKnownType(WellKnownType.IntPtr);
             }
-            Debug.Assert(marshalAs.SizeConst.HasValue);
+            Debug.Assert(marshalAs != null && marshalAs.SizeConst.HasValue);
 
             // if SizeConst is not specified, we will default to 1. 
             // the marshaller will throw appropriate exception

--- a/src/Common/src/TypeSystem/Interop/InteropTypes.cs
+++ b/src/Common/src/TypeSystem/Interop/InteropTypes.cs
@@ -8,6 +8,10 @@ namespace Internal.TypeSystem.Interop
 {
     public static class InteropTypes
     {
+        public static MetadataType GetGC(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System", "GC");
+        }
 
         public static MetadataType GetSafeHandleType(TypeSystemContext context)
         {

--- a/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
@@ -162,6 +162,8 @@ namespace Internal.TypeSystem
                         return MethodSignatureFlags.UnmanagedCallingConventionStdCall;
                     case PInvokeAttributes.CallingConventionThisCall:
                         return MethodSignatureFlags.UnmanagedCallingConventionThisCall;
+                    case PInvokeAttributes.None:
+                        return MethodSignatureFlags.None;
                     default:
                         throw new BadImageFormatException();
                 }
@@ -182,7 +184,8 @@ namespace Internal.TypeSystem
                         _attributes |= PInvokeAttributes.CallingConventionThisCall;
                         break;
                     default:
-                        throw new BadImageFormatException();
+                        System.Diagnostics.Debug.Assert(false, "Unexpected Unmanaged Calling Convention.");
+                        break;
                 }
             }
         }


### PR DESCRIPTION
This change contains the following bug fixes:
* Call GC.KeepAlive for delegate marshalling. Sergiy encountered a
scenario where the delegate got collected when we tried to do a reverse
P/Invoke. This change adds a GC.KeepAlive at the end of the marshalling
stub to ensure the delegate is not collected during the duration of the
call.
* For ForwardDelegateCreation Stub set the correct calling convention.
Also set the IsPInvoke property of the ForwardDelegateCreation stub to
be true so that the JIT flag CORJIT_FLAG_IL_STUB is set which is
necessary for RyuJit to inline the call.
* Handle the scenarios when MarshalAs can be null.