### PR TITLE
Removing the special handling for atan2(±∞, ±∞) and pow(-1.0, ±∞)

### DIFF
--- a/src/System.Private.CoreLib/src/System/Math.cs
+++ b/src/System.Private.CoreLib/src/System/Math.cs
@@ -257,23 +257,6 @@ namespace System
         [Intrinsic]
         public static double Pow(double x, double y)
         {
-            if (Double.IsNaN(y))
-                return y;
-            if (Double.IsNaN(x))
-                return x;
-
-            if (Double.IsInfinity(y))
-            {
-                if (x == 1.0)
-                {
-                    return x;
-                }
-                if (x == -1.0)
-                {
-                    return Double.NaN;
-                }
-            }
-
             return RuntimeImports.pow(x, y);
         }
 

--- a/src/System.Private.CoreLib/src/System/Math.cs
+++ b/src/System.Private.CoreLib/src/System/Math.cs
@@ -54,9 +54,7 @@ namespace System
 
         [Intrinsic]
         public static double Atan2(double y, double x)
-        {
-            if (Double.IsInfinity(x) && Double.IsInfinity(y))
-                return Double.NaN;
+        {          
             return RuntimeImports.atan2(y, x);
         }
 


### PR DESCRIPTION
The coreclr S.P.CoreLIB do not have this check and return -2.3561... for  call like Math.Atan2(double.NegativeInfinity, double.NegativeInfinity) but on CoreRT / N 
this return NaN because of this check. This check has been there for ever , for reasons that
i don't know of.

@danmosemsft @joshfree @AtsushiKan @jkotas 