### PR TITLE
Only index Product symbols, not extra packages.

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Windows.json
+++ b/buildpipeline/DotNet-CoreRT-Windows.json
@@ -176,7 +176,7 @@
       "inputs": {
         "SymbolsPath": "\\\\cpvsbuild\\drops\\DotNetCore\\$(Build.DefinitionName)\\$(Build.BuildNumber)\\symbols",
         "SearchPattern": "**\\*.pdb",
-        "SymbolsFolder": "",
+        "SymbolsFolder": "$(Build.SourcesDirectory)\\$(SourceFolder)\\bin\\Product",
         "SkipIndexing": "false",
         "TreatNotIndexedAsWarning": "false",
         "SymbolsMaximumWaitTime": "",


### PR DESCRIPTION
Symbol indexing has been failing in the nightly builds; this fixes it by only indexing the actual product symbols and not the symbols from packages we download.