### PR TITLE
Fix 84 failing tests in System.Data.Common.Tests

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static unsafe partial class Kernel32
+    {
+        internal const int  LOCALE_NAME_MAX_LENGTH      = 85;
+        internal const uint LOCALE_ALLOW_NEUTRAL_NAMES  = 0x08000000; // Flag to allow returning neutral names/lcids for name conversion
+        internal const uint LOCALE_SUPPLEMENTAL         = 0x00000002;
+        internal const uint LOCALE_REPLACEMENT          = 0x00000008;
+        internal const uint LOCALE_NEUTRALDATA          = 0x00000010;
+        internal const uint LOCALE_SPECIFICDATA         = 0x00000020;
+        internal const int  COMPARE_STRING              = 0x0001;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static unsafe int LCIDToLocaleName(int locale, char *pLocaleName, int cchName, uint dwFlags);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static int LocaleNameToLCID(string lpName, uint dwFlags);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static unsafe int LCMapStringEx(
+                    string lpLocaleName,
+                    uint dwMapFlags,
+                    char* lpSrcStr,
+                    int cchSrc,
+                    void* lpDestStr,
+                    int cchDest,
+                    void* lpVersionInformation,
+                    void* lpReserved,
+                    IntPtr sortHandle);
+
+        [DllImport("kernel32.dll", EntryPoint = "FindNLSStringEx")]
+        internal extern static unsafe int FindNLSStringEx(
+                    char* lpLocaleName,
+                    uint dwFindNLSStringFlags,
+                    char* lpStringSource,
+                    int cchSource,
+                    char* lpStringValue,
+                    int cchValue,
+                    int* pcchFound,
+                    void* lpVersionInformation,
+                    void* lpReserved,
+                    IntPtr sortHandle);
+
+        [DllImport("kernel32.dll", EntryPoint = "CompareStringEx")]
+        internal extern static unsafe int CompareStringEx(
+                    char* lpLocaleName,
+                    uint dwCmpFlags,
+                    char* lpString1,
+                    int cchCount1,
+                    char* lpString2,
+                    int cchCount2,
+                    void* lpVersionInformation,
+                    void* lpReserved,
+                    IntPtr lParam);
+
+        [DllImport("kernel32.dll", EntryPoint = "CompareStringOrdinal")]
+        internal extern static unsafe int CompareStringOrdinal(
+                    char* lpString1,
+                    int cchCount1,
+                    char* lpString2,
+                    int cchCount2,
+                    bool bIgnoreCase);
+
+        [DllImport("kernel32.dll", EntryPoint = "FindStringOrdinal")]
+        internal extern static unsafe int FindStringOrdinal(
+                    uint dwFindStringOrdinalFlags,
+                    char* lpStringSource,
+                    int cchSource,
+                    char* lpStringValue,
+                    int cchValue,
+                    int bIgnoreCase);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static unsafe bool IsNLSDefinedString(
+                    int  Function,
+                    uint dwFlags,
+                    IntPtr lpVersionInformation,
+                    char* lpString,
+                    int cchStr);
+
+        [DllImport("Kernel32.dll", CharSet = CharSet.Auto)]
+        internal static extern bool GetUserPreferredUILanguages(uint dwFlags, out uint pulNumLanguages, char [] pwszLanguagesBuffer, ref uint pcchLanguagesBuffer);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal static extern int GetLocaleInfoEx(string lpLocaleName, uint LCType, IntPtr lpLCData, int cchData);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static bool EnumSystemLocalesEx(EnumLocalesProcEx lpLocaleEnumProcEx, uint dwFlags, IntPtr lParam, IntPtr reserved);
+
+        internal delegate BOOL EnumLocalesProcEx(IntPtr lpLocaleString, uint dwFlags, IntPtr lParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static int ResolveLocaleName(string lpNameToResolve, char* lpLocaleName, int cchLocaleName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static bool EnumTimeFormatsEx(EnumTimeFormatsProcEx lpTimeFmtEnumProcEx, string lpLocaleName, uint dwFlags, IntPtr lParam);
+  
+        internal delegate BOOL EnumTimeFormatsProcEx(IntPtr lpTimeFormatString, IntPtr lParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static int GetCalendarInfoEx(string lpLocaleName, uint Calendar, IntPtr lpReserved, uint CalType, IntPtr lpCalData, int cchData, out int lpValue);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static int GetCalendarInfoEx(string lpLocaleName, uint Calendar, IntPtr lpReserved, uint CalType, IntPtr lpCalData, int cchData, IntPtr lpValue);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static bool EnumCalendarInfoExEx(EnumCalendarInfoProcExEx pCalInfoEnumProcExEx, string lpLocaleName, uint Calendar, string lpReserved, uint CalType, IntPtr lParam);
+        
+        internal delegate BOOL EnumCalendarInfoProcExEx(IntPtr lpCalendarInfoString, uint Calendar, IntPtr lpReserved, IntPtr lParam);
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct NlsVersionInfoEx 
+        {
+            internal int dwNLSVersionInfoSize;
+            internal int dwNLSVersion;
+            internal int dwDefinedVersion;
+            internal int dwEffectiveId;
+            internal Guid guidCustomVersion;
+        }
+        
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal extern static unsafe bool GetNLSVersionEx(int function, string localeName, NlsVersionInfoEx* lpVersionInformation);
+    }
+}

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -466,6 +466,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetLongPathNameW.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetTempFileNameW.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetTempPathW.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.Globalization.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.LockFile.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.OutputDebugString.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs"/>

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
@@ -604,9 +604,17 @@ namespace System.Globalization
             return GetLocaleInfo(LocaleNumberData.LanguageId);
         }
 
-        private static string LCIDToLocaleName(int culture)
+        private static unsafe string LCIDToLocaleName(int culture)
         {
-            throw new NotImplementedException();
+            char *pBuffer = stackalloc char[Interop.Kernel32.LOCALE_NAME_MAX_LENGTH + 1]; // +1 for the null termination
+            int length = Interop.Kernel32.LCIDToLocaleName(culture, pBuffer, Interop.Kernel32.LOCALE_NAME_MAX_LENGTH + 1, Interop.Kernel32.LOCALE_ALLOW_NEUTRAL_NAMES);
+
+            if (length > 0)
+            {
+                return new String(pBuffer);
+            }
+
+            return null;
         }
 
         private int GetAnsiCodePage(string cultureName)


### PR DESCRIPTION
Implemented the missing LCIDToLocalName() method.

Both the P/Invoke file and the method implementation
are purloined directly from CoreCLR.