### PR TITLE
Generate generic dictionary for array templates

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -107,6 +107,7 @@ namespace ILCompiler.DependencyAnalysis
             if (type != null)
             {
                 Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
+                Debug.Assert(type.IsDefType);
             }
             else
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -1057,7 +1057,7 @@ namespace ILCompiler.DependencyAnalysis
 
             VertexBag layoutInfo = new VertexBag();
 
-            DictionaryLayoutNode associatedLayout = factory.GenericDictionaryLayout(_type.ConvertToCanonForm(CanonicalFormKind.Specific));
+            DictionaryLayoutNode associatedLayout = factory.GenericDictionaryLayout(_type.ConvertToCanonForm(CanonicalFormKind.Specific).GetClosestDefType());
             ICollection<NativeLayoutVertexNode> templateLayout = associatedLayout.GetTemplateEntries(factory);
             
             NativeWriter writer = GetNativeWriter(factory);


### PR DESCRIPTION
My previous commit
https://github.com/dotnet/corert/pull/3438/commits/46307aeae6e8ec3161151d139123ca45a30f833b
added support for dynamically loading arrays using the type loader. A
bug in the native layout generation was using the shared runtime
determined form to get generic dictionary information which is incorrect
(there is no generic dictionary on T_System_Canon[]). Fixed to correctly
use the closest DefType when looking up generic dictionary layout.