### PR TITLE
Fix tracking non-GC statics in StaticsInfoHashTable

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -76,13 +76,8 @@ namespace ILCompiler.DependencyAnalysis
 
             if (method.HasInstantiation)
             {
-                var exactMethodInstantiationDependencies = ExactMethodInstantiationsNode.GetExactMethodInstantiationDependenciesForMethod(factory, method);
-                if (exactMethodInstantiationDependencies != null)
-                {
-                    dependencies = dependencies ?? new DependencyList();
-                    dependencies.AddRange(exactMethodInstantiationDependencies);
-                }
-
+                ExactMethodInstantiationsNode.GetExactMethodInstantiationDependenciesForMethod(ref dependencies, factory, method);
+                
                 if (method.IsVirtual)
                 {
                     // Generic virtual methods dependency tracking
@@ -90,12 +85,7 @@ namespace ILCompiler.DependencyAnalysis
                     dependencies.Add(new DependencyListEntry(factory.GVMDependencies(method), "GVM Dependencies Support"));
                 }
 
-                var templateMethodDependencies = GenericMethodsTemplateMap.GetTemplateMethodDependencies(factory, method);
-                if (templateMethodDependencies != null)
-                {
-                    dependencies = dependencies ?? new DependencyList();
-                    dependencies.AddRange(templateMethodDependencies);
-                }
+                GenericMethodsTemplateMap.GetTemplateMethodDependencies(ref dependencies, factory, method);
             }
             else
             {
@@ -105,12 +95,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (factory.TypeSystemContext.IsSpecialUnboxingThunk(method))
                     owningTemplateType = factory.TypeSystemContext.GetTargetOfSpecialUnboxingThunk(method).OwningType;
 
-                var templateTypeDepedencies = GenericTypesTemplateMap.GetTemplateTypeDependencies(factory, owningTemplateType);
-                if (templateTypeDepedencies != null)
-                {
-                    dependencies = dependencies ?? new DependencyList();
-                    dependencies.AddRange(templateTypeDepedencies);
-                }
+                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningTemplateType);
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -161,8 +161,8 @@ namespace ILCompiler.DependencyAnalysis
             // emitting it.
             dependencies.Add(new DependencyListEntry(_optionalFieldsNode, "Optional fields"));
 
-            dependencies.AddRange(StaticsInfoHashtableNode.GetStaticsInfoDependencies(factory, _type));
-            dependencies.AddRange(ReflectionFieldMapNode.GetReflectionFieldMapEntryDependencies(factory, _type));
+            StaticsInfoHashtableNode.AddStaticsInfoDependencies(ref dependencies, factory, _type);
+            ReflectionFieldMapNode.AddReflectionFieldMapEntryDependencies(ref dependencies, factory, _type);
 
             return dependencies;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -161,52 +161,8 @@ namespace ILCompiler.DependencyAnalysis
             // emitting it.
             dependencies.Add(new DependencyListEntry(_optionalFieldsNode, "Optional fields"));
 
-            // Dependencies of the StaticsInfoHashTable and the ReflectionFieldAccessMap
-            if (_type is MetadataType && !_type.IsCanonicalSubtype(CanonicalFormKind.Any))
-            {
-                MetadataType metadataType = (MetadataType)_type;
-
-                // NOTE: The StaticsInfoHashtable entries need to reference the gc and non-gc static nodes through an indirection cell.
-                // The StaticsInfoHashtable entries only exist for static fields on generic types.
-
-                if (metadataType.GCStaticFieldSize.AsInt > 0)
-                {
-                    ISymbolNode gcStatics = factory.TypeGCStaticsSymbol(metadataType);
-                    if (_type.HasInstantiation)
-                    {
-                        dependencies.Add(factory.Indirection(gcStatics), "GC statics indirection for StaticsInfoHashtable");
-                    }
-                    else
-                    {
-                        // TODO: https://github.com/dotnet/corert/issues/3224
-                        // Reflection static field bases handling is here because in the current reflection model we reflection-enable
-                        // all fields of types that are compiled. Ideally the list of reflection enabled fields should be known before
-                        // we even start the compilation process (with the static bases being compilation roots like any other).
-                        dependencies.Add(gcStatics, "GC statics for ReflectionFieldMap entry");
-                    }
-                }
-                if (metadataType.NonGCStaticFieldSize.AsInt > 0)
-                {
-                    ISymbolNode nonGCStatic = factory.TypeNonGCStaticsSymbol(metadataType);
-                    if (_type.HasInstantiation)
-                    {
-                        // The entry in the StaticsInfoHashtable points at the beginning of the static fields data, rather than the cctor 
-                        // context offset.
-                        nonGCStatic = factory.Indirection(nonGCStatic);
-                        dependencies.Add(nonGCStatic, "Non-GC statics indirection for StaticsInfoHashtable");
-                    }
-                    else
-                    {
-                        // TODO: https://github.com/dotnet/corert/issues/3224
-                        // Reflection static field bases handling is here because in the current reflection model we reflection-enable
-                        // all fields of types that are compiled. Ideally the list of reflection enabled fields should be known before
-                        // we even start the compilation process (with the static bases being compilation roots like any other).
-                        dependencies.Add(nonGCStatic, "Non-GC statics for ReflectionFieldMap entry");
-                    }
-                }
-
-                // TODO: TLS dependencies
-            }
+            dependencies.AddRange(StaticsInfoHashtableNode.GetStaticsInfoDependencies(factory, _type));
+            dependencies.AddRange(ReflectionFieldMapNode.GetReflectionFieldMapEntryDependencies(factory, _type));
 
             return dependencies;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
@@ -105,12 +105,12 @@ namespace ILCompiler.DependencyAnalysis
             return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this, _endSymbol });
         }
 
-        public static DependencyList GetExactMethodInstantiationDependenciesForMethod(NodeFactory factory, MethodDesc method)
+        public static void GetExactMethodInstantiationDependenciesForMethod(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             if (!IsMethodEligibleForTracking(method))
-                return null;
+                return;
 
-            DependencyList dependencies = new DependencyList();
+            dependencies = dependencies ?? new DependencyList();
 
             // Method entry point dependency
             bool getUnboxingStub = method.OwningType.IsValueType && !method.Signature.IsStatic;
@@ -127,8 +127,6 @@ namespace ILCompiler.DependencyAnalysis
             // Get native layout dependencies for the method signature.
             NativeLayoutMethodNameAndSignatureVertexNode nameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(method.GetTypicalMethodDefinition());
             dependencies.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(nameAndSig), "Exact method instantiation entry"));
-
-            return dependencies;
         }
 
         private static bool IsMethodEligibleForTracking(MethodDesc method)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -212,7 +212,9 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            return GenericMethodsHashtableNode.GetGenericMethodsHashtableDependenciesForMethod(factory, _owningMethod);
+            DependencyList dependencies = new DependencyList();
+            GenericMethodsHashtableNode.GetGenericMethodsHashtableDependenciesForMethod(ref dependencies, factory, _owningMethod);
+            return dependencies;
         }
 
         public override DictionaryLayoutNode GetDictionaryLayout(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsHashtableNode.cs
@@ -98,12 +98,10 @@ namespace ILCompiler.DependencyAnalysis
             return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this, _endSymbol });
         }
 
-        public static DependencyList GetGenericMethodsHashtableDependenciesForMethod(NodeFactory factory, MethodDesc method)
+        public static void GetGenericMethodsHashtableDependenciesForMethod(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             Debug.Assert(method.HasInstantiation && !method.IsCanonicalMethod(CanonicalFormKind.Any));
-
-            DependencyList dependencies = new DependencyList();
-
+            
             // Method's containing type
             IEETypeNode containingTypeNode = factory.NecessaryTypeSymbol(method.OwningType);
             dependencies.Add(new DependencyListEntry(containingTypeNode, "GenericMethodsHashtable entry containing type"));
@@ -122,8 +120,6 @@ namespace ILCompiler.DependencyAnalysis
 
             ISymbolNode dictionaryNode = factory.MethodGenericDictionary(method);
             dependencies.Add(new DependencyListEntry(dictionaryNode, "GenericMethodsHashtable entry dictionary"));
-
-            return dependencies;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
@@ -80,17 +80,14 @@ namespace ILCompiler.DependencyAnalysis
             return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this, _endSymbol });
         }
 
-        public static DependencyList GetTemplateMethodDependencies(NodeFactory factory, MethodDesc method)
+        public static void GetTemplateMethodDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             if (!IsEligibleToBeATemplate(method))
-                return null;
+                return;
 
-            DependencyList dependencies = new DependencyList();
-
+            dependencies = dependencies ?? new DependencyList();
             dependencies.Add(new DependencyListEntry(factory.NativeLayout.TemplateMethodEntry(method), "Template Method Entry"));
             dependencies.Add(new DependencyListEntry(factory.NativeLayout.TemplateMethodLayout(method), "Template Method Layout"));
-
-            return dependencies;
         }
 
         private static bool IsEligibleToBeATemplate(MethodDesc method)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesTemplateMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesTemplateMap.cs
@@ -89,27 +89,24 @@ namespace ILCompiler.DependencyAnalysis
             return new ObjectData(streamBytes, Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this, _endSymbol });
         }
         
-        public static DependencyList GetTemplateTypeDependencies(NodeFactory factory, TypeDesc type)
+        public static void GetTemplateTypeDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
             TypeDesc templateType = ConvertArrayOfTToRegularArray(factory, type);
 
             if (!IsEligibleToHaveATemplate(templateType))
-                return null;
+                return;
 
             if (factory.Target.Abi == TargetAbi.ProjectN)
             {
                 // If the type does not have fully constructed type, don't track its dependencies.
                 // TODO: Remove the workaround once we stop using the STS dependency analysis.
                 if (!factory.ConstructedTypeSymbol(templateType).Marked)
-                    return null;
+                    return;
             }
 
-            DependencyList dependencies = new DependencyList();
-
+            dependencies = dependencies ?? new DependencyList();
             dependencies.Add(new DependencyListEntry(factory.NecessaryTypeSymbol(templateType), "Template type"));
             dependencies.Add(new DependencyListEntry(factory.NativeLayout.TemplateTypeLayout(templateType), "Template Type Layout"));
-
-            return dependencies;
         }
 
         /// <summary>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
@@ -47,12 +47,10 @@ namespace ILCompiler.DependencyAnalysis
         /// The dependencies returned from this function will be reported as static dependencies of the TypeGVMEntriesNode,
         /// which we create for each type that has generic virtual methods.
         /// </summary>
-        public static DependencyList GetGenericVirtualMethodImplementationDependencies(NodeFactory factory, MethodDesc callingMethod, MethodDesc implementationMethod)
+        public static void GetGenericVirtualMethodImplementationDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc callingMethod, MethodDesc implementationMethod)
         {
             Debug.Assert(!callingMethod.OwningType.IsInterface);
-
-            DependencyList dependencyNodes = new DependencyList();
-
+            
             // Compute the open method signatures
             MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
             MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
@@ -60,10 +58,8 @@ namespace ILCompiler.DependencyAnalysis
             var openCallingMethodNameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(openCallingMethod);
             var openImplementationMethodNameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(openImplementationMethod);
 
-            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openCallingMethodNameAndSig), "gvm table calling method signature"));
-            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openImplementationMethodNameAndSig), "gvm table implementation method signature"));
-
-            return dependencyNodes;
+            dependencies.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openCallingMethodNameAndSig), "gvm table calling method signature"));
+            dependencies.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openImplementationMethodNameAndSig), "gvm table implementation method signature"));
         }
 
         private void AddGenericVirtualMethodImplementation(NodeFactory factory, MethodDesc callingMethod, MethodDesc implementationMethod)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
@@ -48,12 +48,10 @@ namespace ILCompiler.DependencyAnalysis
         /// The dependencies returned from this function will be reported as static dependencies of the TypeGVMEntriesNode,
         /// which we create for each type that has generic virtual methods.
         /// </summary>
-        public static DependencyList GetGenericVirtualMethodImplementationDependencies(NodeFactory factory, MethodDesc callingMethod, TypeDesc implementationType, MethodDesc implementationMethod)
+        public static void GetGenericVirtualMethodImplementationDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc callingMethod, TypeDesc implementationType, MethodDesc implementationMethod)
         {
             Debug.Assert(callingMethod.OwningType.IsInterface);
-
-            DependencyList dependencyNodes = new DependencyList();
-
+            
             // Compute the open method signatures
             MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
             MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
@@ -62,8 +60,8 @@ namespace ILCompiler.DependencyAnalysis
             var openCallingMethodNameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(openCallingMethod);
             var openImplementationMethodNameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(openImplementationMethod);
 
-            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openCallingMethodNameAndSig), "interface gvm table calling method signature"));
-            dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openImplementationMethodNameAndSig), "interface gvm table implementation method signature"));
+            dependencies.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openCallingMethodNameAndSig), "interface gvm table calling method signature"));
+            dependencies.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(openImplementationMethodNameAndSig), "interface gvm table implementation method signature"));
 
             if (!openImplementationType.IsInterface)
             {
@@ -73,12 +71,10 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         TypeDesc currentInterface = openImplementationType.RuntimeInterfaces[index];
                         var currentInterfaceSignature = factory.NativeLayout.TypeSignatureVertex(currentInterface);
-                        dependencyNodes.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(currentInterfaceSignature), "interface gvm table interface signature"));
+                        dependencies.Add(new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(currentInterfaceSignature), "interface gvm table interface signature"));
                     }
                 }
             }
-
-            return dependencyNodes;
         }
 
         private void AddGenericVirtualMethodImplementation(NodeFactory factory, MethodDesc callingMethod, TypeDesc implementationType, MethodDesc implementationMethod)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
@@ -46,10 +46,8 @@ namespace ILCompiler.DependencyAnalysis
         /// <summary>
         /// Helper method to compute the dependencies that would be needed for reflection field lookup.
         /// </summary>
-        public static DependencyList GetReflectionFieldMapEntryDependencies(NodeFactory factory, TypeDesc type)
+        public static void AddReflectionFieldMapEntryDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
-            DependencyList dependencies = new DependencyList();
-
             // TODO: https://github.com/dotnet/corert/issues/3224
             // Reflection static field bases handling is here because in the current reflection model we reflection-enable
             // all fields of types that are compiled. Ideally the list of reflection enabled fields should be known before
@@ -70,8 +68,6 @@ namespace ILCompiler.DependencyAnalysis
 
                 // TODO: TLS dependencies
             }
-
-            return dependencies;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
@@ -46,10 +46,8 @@ namespace ILCompiler.DependencyAnalysis
         /// This helper is used by EETypeNode, which is used by the dependency analysis to compute the statics hashtable
         /// entries for the compiled types.
         /// </summary>
-        public static DependencyList GetStaticsInfoDependencies(NodeFactory factory, TypeDesc type)
+        public static void AddStaticsInfoDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
-            DependencyList dependencies = new DependencyList();
-
             if (type is MetadataType && type.HasInstantiation && !type.IsCanonicalSubtype(CanonicalFormKind.Any))
             {
                 MetadataType metadataType = (MetadataType)type;
@@ -71,8 +69,6 @@ namespace ILCompiler.DependencyAnalysis
 
                 // TODO: TLS dependencies
             }
-            
-            return dependencies;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
@@ -61,10 +61,10 @@ namespace ILCompiler.DependencyAnalysis
                 _staticDependencies = new DependencyList();
 
                 foreach(var entry in ScanForGenericVirtualMethodEntries())
-                    _staticDependencies.AddRange(GenericVirtualMethodTableNode.GetGenericVirtualMethodImplementationDependencies(context, entry.CallingMethod, entry.ImplementationMethod));
+                    GenericVirtualMethodTableNode.GetGenericVirtualMethodImplementationDependencies(ref _staticDependencies, context, entry.CallingMethod, entry.ImplementationMethod);
 
                 foreach (var entry in ScanForInterfaceGenericVirtualMethodEntries())
-                    _staticDependencies.AddRange(InterfaceGenericVirtualMethodTableNode.GetGenericVirtualMethodImplementationDependencies(context, entry.CallingMethod, entry.ImplementationType, entry.ImplementationMethod));
+                    InterfaceGenericVirtualMethodTableNode.GetGenericVirtualMethodImplementationDependencies(ref _staticDependencies, context, entry.CallingMethod, entry.ImplementationType, entry.ImplementationMethod);
             }
 
             return _staticDependencies;


### PR DESCRIPTION
* Add a hash table entry for the non-GC statics of a type which has no
actual non-GC static fields but which does have a lazy class constructor
* Move the dependency computation for `StaticsInfoHashtable` and `ReflectionFieldMapNode` entries to
the right place