### PR TITLE
Implemented ImportRethrow + Added Rethrow error message

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -117,32 +117,6 @@ namespace Internal.IL
                 _basicBlocks[offset] = basicBlock;
             }
 
-            //find enclosing try
-            for (int i = 0; i < _exceptionRegions.Length; i++)
-            {
-                var r = _exceptionRegions[i].ILRegion;
-
-                if (r.TryOffset <= offset &&
-                    r.TryOffset + r.TryLength >= offset)
-                {
-                    basicBlock.TryIndex = i;
-                    break;
-                }
-            }
-
-            //find enclosing handler
-            for (int i = 0; i < _exceptionRegions.Length; i++)
-            {
-                var r = _exceptionRegions[i].ILRegion;
-
-                if (r.HandlerOffset <= offset &&
-                    r.HandlerOffset + r.HandlerLength >= offset)
-                {
-                    basicBlock.HandlerIndex = i;
-                    break;
-                }
-            }
-
             return basicBlock;
         }
 

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -116,6 +116,33 @@ namespace Internal.IL
                 basicBlock = new BasicBlock() { StartOffset = offset };
                 _basicBlocks[offset] = basicBlock;
             }
+
+            //find enclosing try
+            for (int i = 0; i < _exceptionRegions.Length; i++)
+            {
+                var r = _exceptionRegions[i].ILRegion;
+
+                if (r.TryOffset <= offset &&
+                    r.TryOffset + r.TryLength >= offset)
+                {
+                    basicBlock.TryIndex = i;
+                    break;
+                }
+            }
+
+            //find enclosing handler
+            for (int i = 0; i < _exceptionRegions.Length; i++)
+            {
+                var r = _exceptionRegions[i].ILRegion;
+
+                if (r.HandlerOffset <= offset &&
+                    r.HandlerOffset + r.HandlerLength >= offset)
+                {
+                    basicBlock.HandlerIndex = i;
+                    break;
+                }
+            }
+
             return basicBlock;
         }
 

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -163,30 +163,45 @@ namespace Internal.IL
                 var basicBlock = _basicBlocks[i];
                 var offset = basicBlock.StartOffset;
 
-                //TODO: find faster algorithm doing this.
-                //find enclosing try
                 for (int j = 0; j < _exceptionRegions.Length; j++)
                 {
                     var r = _exceptionRegions[j].ILRegion;
 
-                    if (r.TryOffset <= offset &&
-                        r.TryOffset + r.TryLength >= offset)
+                    if (r.TryOffset <= offset && r.TryOffset + r.TryLength >= offset)
                     {
-                        basicBlock.TryIndex = j;
-                        break;
+                        if (!basicBlock.TryIndex.HasValue)
+                        {
+                            basicBlock.TryIndex = j;
+                        }
+                        else
+                        {
+                            var currentlySelected = _exceptionRegions[basicBlock.TryIndex.Value].ILRegion;
+                            var probeItem = _exceptionRegions[j].ILRegion;
+
+                            if (currentlySelected.TryOffset < probeItem.TryOffset &&
+                                currentlySelected.TryOffset + currentlySelected.TryLength > probeItem.TryOffset + probeItem.TryLength)
+                            {
+                                basicBlock.TryIndex = j;
+                            }
+                        }
                     }
-                }
-
-                //find enclosing handler
-                for (int j = 0; j < _exceptionRegions.Length; j++)
-                {
-                    var r = _exceptionRegions[j].ILRegion;
-
-                    if (r.HandlerOffset <= offset &&
-                        r.HandlerOffset + r.HandlerLength >= offset)
+                    if (r.HandlerOffset <= offset && r.HandlerOffset + r.HandlerLength >= offset)
                     {
-                        basicBlock.HandlerIndex = j;
-                        break;
+                        if (!basicBlock.HandlerIndex.HasValue)
+                        {
+                            basicBlock.HandlerIndex = j;
+                        }
+                        else
+                        {
+                            var currentlySelected = _exceptionRegions[basicBlock.HandlerIndex.Value].ILRegion;
+                            var probeItem = _exceptionRegions[j].ILRegion;
+
+                            if (currentlySelected.HandlerOffset < probeItem.HandlerOffset &&
+                                currentlySelected.HandlerOffset + currentlySelected.HandlerLength > probeItem.HandlerOffset + probeItem.HandlerLength)
+                            {
+                                basicBlock.HandlerIndex = j;
+                            }
+                        }
                     }
                 }
             }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1582,6 +1582,8 @@ namespace Internal.IL
                     return;
                 }
             }
+
+            VerificationError(VerifierError.Rethrow);
         }
 
         void ImportSizeOf(int token)

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1523,7 +1523,26 @@ namespace Internal.IL
 
         void ImportRethrow()
         {
-            // TODO:
+            //search for a catch block which begins before rethrow and ends after it
+            bool isContainedInCatchBlock = false;
+
+            for (int i = 0; i < _exceptionRegions.Length; i++)
+            {
+                var r = _exceptionRegions[i].ILRegion;
+
+                if (r.Kind == ILExceptionRegionKind.Catch)
+                {
+                    if (_currentBasicBlock.StartOffset >= r.HandlerOffset && _currentBasicBlock.StartOffset <= r.HandlerOffset + r.HandlerLength)
+                    {
+                        isContainedInCatchBlock = true;
+                    }
+                }
+            }
+
+            if (!isContainedInCatchBlock)
+            {
+                VerificationError(VerifierError.Rethrow);
+            }
         }
 
         void ImportSizeOf(int token)

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -149,8 +149,46 @@ namespace Internal.IL
             _instructionBoundaries = new bool[_ilBytes.Length];
 
             FindBasicBlocks();
-
+            FindEnclosingExceptionRegions();
             ImportBasicBlocks();
+        }
+
+        private void FindEnclosingExceptionRegions()
+        {
+            for (int i = 0; i < _basicBlocks.Length; i++)
+            {
+                if (_basicBlocks[i] == null)
+                    continue;
+
+                var basicBlock = _basicBlocks[i];
+                var offset = basicBlock.StartOffset;
+
+                //find enclosing try
+                for (int j = 0; j < _exceptionRegions.Length; j++)
+                {
+                    var r = _exceptionRegions[j].ILRegion;
+
+                    if (r.TryOffset <= offset &&
+                        r.TryOffset + r.TryLength >= offset)
+                    {
+                        basicBlock.TryIndex = j;
+                        break;
+                    }
+                }
+
+                //find enclosing handler
+                for (int j = 0; j < _exceptionRegions.Length; j++)
+                {
+                    var r = _exceptionRegions[j].ILRegion;
+
+                    if (r.HandlerOffset <= offset &&
+                        r.HandlerOffset + r.HandlerLength >= offset)
+                    {
+                        basicBlock.HandlerIndex = j;
+                        break;
+                    }
+                }
+            }
         }
 
         void AbortBasicBlockVerification()

--- a/src/ILVerify/src/Resources/Strings.resx
+++ b/src/ILVerify/src/Resources/Strings.resx
@@ -168,6 +168,9 @@
   <data name="ReadOnly" xml:space="preserve">
     <value>Missing ldelema or call following readonly prefix.</value>
   </data>
+  <data name="Rethrow" xml:space="preserve">
+    <value>Rethrow from outside a catch handler.</value>
+  </data>
   <data name="StackByRef" xml:space="preserve">
     <value>Expected ByRef on the stack.</value>
   </data>

--- a/src/ILVerify/src/VerifierError.cs
+++ b/src/ILVerify/src/VerifierError.cs
@@ -59,7 +59,7 @@ namespace ILVerify
         //E_FALLTHRU_INTO_HND  "fallthru into an exception handler."
         //E_FALLTHRU_INTO_FIL  "fallthru into an exception filter."
         //E_LEAVE              "Leave from outside a try or catch block."
-        //E_RETHROW            "Rethrow from outside a catch handler."
+        Rethrow,                        //"Rethrow from outside a catch handler."
         //E_ENDFINALLY         "Endfinally from outside a finally handler."
         //E_ENDFILTER          "Endfilter from outside an exception filter block."
         //E_ENDFILTER_MISSING  "Missing Endfilter."


### PR DESCRIPTION
Implemented the verification of rethrow. 
The idea: 
We search for a catch block which begins before rethrow and ends after it (also covers `try{}catch{try{throw;}finally{}}` ). If there is none then the rethrow is not in a catch block -> invalid IL. 