### PR TITLE
Removed Dictionary<TKey, TValue>.GetValueOrDefault Methods.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -632,21 +632,6 @@ namespace System.Collections.Generic
             return false;
         }
 
-        // Method similar to TryGetValue that returns the value instead of putting it in an out param.
-        public TValue GetValueOrDefault(TKey key) => GetValueOrDefault(key, default(TValue));
-
-        // Method similar to TryGetValue that returns the value instead of putting it in an out param. If the entry
-        // doesn't exist, returns the defaultValue instead.
-        public TValue GetValueOrDefault(TKey key, TValue defaultValue)
-        {
-            int i = FindEntry(key);
-            if (i >= 0)
-            {
-                return entries[i].value;
-            }
-            return defaultValue;
-        }
-
         public bool TryAdd(TKey key, TValue value) => TryInsert(key, value, InsertionBehavior.None);
 
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly


### PR DESCRIPTION
As Per [dotnet/corefx/#17917](https://github.com/dotnet/corefx/issues/17917)  ,`Dictionary<TKey, TValue>.GetValueOrDefault` Methods have been decided to be removed.As new Extension Methods in the `CollectionExtenstions.cs` are added which do the same job.

@safern Please Review the Changes