### PR TITLE
System.Globalization.Tests now at 5 failures.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureData.Windows.cs
@@ -615,7 +615,7 @@ namespace System.Globalization
 
         private int LocaleNameToLCID(string cultureName)
         {
-            return GetLocaleInfo(LocaleNumberData.LanguageId);
+            return Interop.Kernel32.LocaleNameToLCID(cultureName, Interop.Kernel32.LOCALE_ALLOW_NEUTRAL_NAMES);
         }
 
         private static unsafe string LCIDToLocaleName(int culture)

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2411,7 +2411,7 @@ namespace System.Globalization
             /// <summary>language id (coresponds to LOCALE_ILANGUAGE)</summary>
             LanguageId = 0x00000001,
             /// <summary>geographical location id, (coresponds to LOCALE_IGEOID)</summary>
-            GeoId = 0x00000008,
+            GeoId = 0x0000005B,
             /// <summary>0 = context, 1 = none, 2 = national (coresponds to LOCALE_IDIGITSUBSTITUTION)</summary>
             DigitSubstitution = 0x00001014,
             /// <summary>0 = metric, 1 = US (coresponds to LOCALE_IMEASURE)</summary>

--- a/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -450,6 +450,8 @@ namespace System.Globalization
 
             StringBuilder result = new StringBuilder();
             string lowercaseData = null;
+            // Store if the current culture is Dutch (special case)
+            bool isDutchCulture = CultureName.StartsWith("nl-", StringComparison.OrdinalIgnoreCase);
 
             for (int i = 0; i < str.Length; i++)
             {
@@ -459,8 +461,18 @@ namespace System.Globalization
                 charType = CharUnicodeInfo.InternalGetUnicodeCategory(str, i, out charLen);
                 if (Char.CheckLetter(charType))
                 {
-                    // Do the titlecasing for the first character of the word.
-                    i = AddTitlecaseLetter(ref result, ref str, i, charLen) + 1;
+                    // Special case to check for Dutch specific titlecasing with "IJ" characters 
+                    // at the beginning of a word
+                    if (isDutchCulture && i < str.Length - 1 && (str[i] == 'i' || str[i] == 'I') && (str[i + 1] == 'j' || str[i + 1] == 'J'))
+                    {
+                        result.Append("IJ");
+                        i += 2;
+                    }
+                    else
+                    {
+                        // Do the titlecasing for the first character of the word.
+                        i = AddTitlecaseLetter(ref result, ref str, i, charLen) + 1;
+                    }
 
                     //
                     // Convert the characters until the end of the this word


### PR DESCRIPTION
- Fixed a bad GeoId constant (was fixed in CoreCLR - copied it over)

- Replaced LocaleNameToLCID() implementation with CoreCLR implementation.

- Ported Dutch ToTitleCase() fix from CoreCLR

    (https://github.com/dotnet/coreclr/pull/10195)

The remaining test failures are:

- One Exception.ParamName check.

- Async-friendly CurrentCulture (a feature not yet ported
  from CoreCLR.)

- Project N mangling Unicode strings in [InlineData] custom
  attributes.