### PR TITLE
Replace call to GetDynamicTimeZoneInformation with NYI on Unix

### DIFF
--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -231,6 +231,9 @@ namespace System
 
         internal static bool GetTimeZoneInfo(out TimeZoneInformation timeZoneInfo)
         {
+#if PLATFORM_UNIX
+            throw new NotImplementedException();
+#else
             TIME_DYNAMIC_ZONE_INFORMATION dtzi = new TIME_DYNAMIC_ZONE_INFORMATION();
             long result = Interop.mincore.GetDynamicTimeZoneInformation(out dtzi);
             if (result == Interop.mincore.TIME_ZONE_ID_INVALID)
@@ -242,6 +245,7 @@ namespace System
             timeZoneInfo = new TimeZoneInformation(dtzi);
 
             return true;
+#endif
         }
 
         private class OffsetAndRule


### PR DESCRIPTION
Needed to unblock #3527. Alternatively, we could keep this API in `platform.unix.cpp` under `#if CppCodegen`. I don't know what's better.

Fully implementing TimeZoneInfo on Unix seems like a bunch of work.