### PR TITLE
Remove the additional check from Math.Exp()

### DIFF
--- a/src/System.Private.CoreLib/src/System/Math.cs
+++ b/src/System.Private.CoreLib/src/System/Math.cs
@@ -244,13 +244,7 @@ namespace System
 
         [Intrinsic]
         public static double Exp(double d)
-        {
-            if (Double.IsInfinity(d))
-            {
-                if (d < 0)
-                    return +0.0;
-                return d;
-            }
+        {  
             return RuntimeImports.exp(d);
         }
 


### PR DESCRIPTION
Math.Exp() to match dotnet/coreclr#4847.