### PR TITLE
Fix more CoreFx on ILC tests

### DIFF
--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -602,11 +602,7 @@ namespace System
             nuint srcElementSize = sourceArray.ElementSize;
             nuint destElementSize = destinationArray.ElementSize;
 
-            // Compat: Why this asymmetrical treatment of enums?
-            if (destinationElementEEType.IsEnum)
-                throw new ArrayTypeMismatchException(SR.ArrayTypeMismatch_CantAssignType);
-
-            if (sourceElementEEType.IsEnum && sourceElementType != destElementType)
+            if ((sourceElementEEType.IsEnum || destinationElementEEType.IsEnum) && sourceElementType != destElementType)
                 throw new ArrayTypeMismatchException(SR.ArrayTypeMismatch_CantAssignType);
 
             if (reliable)

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -21,6 +21,7 @@ namespace System.Reflection
         }
 
         public AssemblyName(string assemblyName)
+            : this()
         {
             if (assemblyName == null)
                 throw new ArgumentNullException(nameof(assemblyName));

--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -361,4 +361,10 @@
   <data name="Acc_CreateInterface" xml:space="preserve">
     <value>Cannot create an instance of an interface.</value>
   </data>
+  <data name="CannotCreateByRefOfByRef" xml:space="preserve">
+    <value>Cannot create a byref of a byref: {0}</value>
+  </data>
+  <data name="CannotCreatePointerOfByRef" xml:space="preserve">
+    <value>Cannot create a pointer to a byref: {0}</value>
+  </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -286,7 +286,7 @@ namespace System.Reflection.Runtime.TypeInfos
 
             // We only permit creating parameterized types if the pay-for-play policy specifically allows them *or* if the result
             // type would be an open type.
-            if (typeHandle.IsNull() && !elementType.ContainsGenericParameters)
+            if (typeHandle.IsNull() && !elementType.ContainsGenericParameters && !(elementType is RuntimeCLSIDTypeInfo))
                 throw ReflectionCoreExecution.ExecutionDomain.CreateMissingArrayTypeException(elementType, multiDim, rank);
         }
     }
@@ -321,6 +321,9 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             protected sealed override RuntimeByRefTypeInfo Factory(UnificationKey key)
             {
+                if (key.ElementType.IsByRef)
+                    throw new TypeLoadException(SR.Format(SR.CannotCreateByRefOfByRef, key.ElementType));
+
                 return new RuntimeByRefTypeInfo(key);
             }
 
@@ -358,6 +361,9 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             protected sealed override RuntimePointerTypeInfo Factory(UnificationKey key)
             {
+                if (key.ElementType.IsByRef)
+                    throw new TypeLoadException(SR.Format(SR.CannotCreatePointerOfByRef, key.ElementType));
+
                 return new RuntimePointerTypeInfo(key);
             }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -285,6 +285,11 @@ namespace System.Reflection.Runtime.TypeInfos
             if (c == null)
                 return false;
 
+            if (object.ReferenceEquals(c, this))
+                return true;
+
+            c = c.UnderlyingSystemType;
+
             Type typeInfo = c;
             RuntimeTypeInfo toTypeInfo = this;
 


### PR DESCRIPTION
A bunch of one-bucket items combined into one commit
for efficiency...

- Port over new Array.Copy behavior 
    https://github.com/dotnet/coreclr/pull/11266

- Fix initial value for AssemblyName.VersionCompatibility

- Enforce the traditional restrictions on stacking ByRefs and stacking
  Pointers on ByRefs.

- Remove the restriction on GetTypeFromCLSID().MakeArrayType()
  (https://github.com/dotnet/corert/issues/3522)

- Allow IsAssignable() to take a TypeDelegator (or anything
  else that wraps a runtime type.)