### PR TITLE
Remove usage of unsafe code in computing static field layouts

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -174,7 +174,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public unsafe override ComputedStaticFieldLayout ComputeStaticFieldLayout(DefType defType, StaticLayoutKind layoutKind)
+        public override ComputedStaticFieldLayout ComputeStaticFieldLayout(DefType defType, StaticLayoutKind layoutKind)
         {
             MetadataType type = (MetadataType)defType;
             int numStaticFields = 0;
@@ -216,18 +216,14 @@ namespace Internal.TypeSystem
                     throw new TypeSystemException.TypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
                 }
 
-                StaticsBlock* block =
-                    field.IsThreadStatic ? &result.ThreadStatics :
-                    field.HasGCStaticBase ? &result.GcStatics :
-                    &result.NonGcStatics;
-
+                ref StaticsBlock block = ref GetStaticsBlockForField(ref result, field);
                 SizeAndAlignment sizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, type.Context.Target.DefaultPackingSize);
 
-                block->Size = LayoutInt.AlignUp(block->Size, sizeAndAlignment.Alignment);
-                result.Offsets[index] = new FieldAndOffset(field, block->Size);
-                block->Size = block->Size + sizeAndAlignment.Size;
+                block.Size = LayoutInt.AlignUp(block.Size, sizeAndAlignment.Alignment);
+                result.Offsets[index] = new FieldAndOffset(field, block.Size);
+                block.Size = block.Size + sizeAndAlignment.Size;
 
-                block->LargestAlignment = LayoutInt.Max(block->LargestAlignment, sizeAndAlignment.Alignment);
+                block.LargestAlignment = LayoutInt.Max(block.LargestAlignment, sizeAndAlignment.Alignment);
 
                 index++;
             }
@@ -235,6 +231,16 @@ namespace Internal.TypeSystem
             FinalizeRuntimeSpecificStaticFieldLayout(type.Context, ref result);
 
             return result;
+        }
+
+        private ref StaticsBlock GetStaticsBlockForField(ref ComputedStaticFieldLayout layout, FieldDesc field)
+        {
+            if (field.IsThreadStatic)
+                return ref layout.ThreadStatics;
+            else if (field.HasGCStaticBase)
+                return ref layout.GcStatics;
+            else
+                return ref layout.NonGcStatics;
         }
 
         public override bool ComputeContainsGCPointers(DefType type)


### PR DESCRIPTION
Ref locals to the rescue. I had to introduce a separate method because
`ref` doesn't seem to be supported as a result of the ternary `?:`
operator.