### PR TITLE
Make CppCodegen honor size specification for explicit layout

### DIFF
--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
@@ -535,6 +535,11 @@ namespace ILCompiler.CppCodeGen
 
             if (explicitLayout)
             {
+                if (classLayoutMetadata.Size > 0)
+                {
+                    sb.AppendLine();
+                    sb.Append("struct { char __sizePadding[" + classLayoutMetadata.Size + "]; };");
+                }
                 sb.Exdent();
                 sb.AppendLine();
                 sb.Append("};");


### PR DESCRIPTION
Before this change, CppCodegen for
```
[StructLayout(LayoutKind.Explicit, Size = 16)]
private struct Block16 { }
```
looked like this:
```
namespace System_Private_CoreLib { namespace System { class Block16 {
        public:
            static MethodTable * __getMethodTable();
};
};};
```

Now it looks like this:
```
namespace System_Private_CoreLib { namespace System { class Block16 {
        public:
            static MethodTable * __getMethodTable();
            union {
                struct { char __sizePadding[16]; };
            };
};
};};
```

