### PR TITLE
Some improvements for ILVerify

### DIFF
--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -194,7 +194,7 @@ namespace Internal.IL
             }
 
             if (dst.IsInterface || dst.IsArray)
-                throw new NotImplementedException();
+                throw new NotImplementedException($"{nameof(IsAssignable)} is only partially implemented.");
 
             // TODO: Other cases - variance, etc.
 

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -820,7 +820,7 @@ namespace Internal.IL
 
         void ImportCalli(int token)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException($"{nameof(ImportCalli)} not implemented");
         }
 
         void ImportLdFtn(int token, ILOpcode opCode)
@@ -834,7 +834,7 @@ namespace Internal.IL
 
             // TODO
 
-            throw new NotImplementedException();
+            throw new NotImplementedException($"{nameof(ImportLdFtn)} not implemented");
         }
 
         void ImportLoadInt(long value, StackValueKind kind)
@@ -962,7 +962,7 @@ namespace Internal.IL
             if (fallthrough != null)
                 ImportFallthrough(fallthrough);
 
-            throw new NotImplementedException();
+            throw new NotImplementedException($"{nameof(ImportSwitchJump)} not implemented");
         }
 
         void ImportBranch(ILOpcode opcode, BasicBlock target, BasicBlock fallthrough)
@@ -1057,7 +1057,7 @@ namespace Internal.IL
 
         void ImportShiftOperation(ILOpcode opcode)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException($"{nameof(ImportShiftOperation)} not implemented");
         }
 
         void ImportCompareOperation(ILOpcode opcode)
@@ -1213,7 +1213,7 @@ namespace Internal.IL
 
         void ImportStoreIndirect(TypeDesc type)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException($"{nameof(ImportStoreIndirect)} not implemented");
         }
 
         void ImportThrow()
@@ -1418,7 +1418,7 @@ namespace Internal.IL
 
         void ImportUnaryOperation(ILOpcode opCode)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException($"{nameof(ImportUnaryOperation)} not implemented");
         }
 
         void ImportCpOpj(int token)

--- a/src/ILVerify/src/Program.cs
+++ b/src/ILVerify/src/Program.cs
@@ -228,23 +228,14 @@ namespace ILVerify
             _typeSystemContext.InputFilePaths = _inputFilePaths;
             _typeSystemContext.ReferenceFilePaths = _referenceFilePaths;
 
-            EcmaModule systemModule = _typeSystemContext.GetModuleForSimpleName(SystemModuleSimpleName);
-            _typeSystemContext.SetSystemModule(systemModule);
+            _typeSystemContext.SetSystemModule(_typeSystemContext.GetModuleForSimpleName(SystemModuleSimpleName));
 
             foreach (var inputPath in _inputFilePaths.Values)
             {
                 _numErrors = 0;
 
-                EcmaModule module;
-                // special case for verifying mscorlib, which was already loaded
-                string simpleName = Path.GetFileNameWithoutExtension(inputPath);
-                if (simpleName == SystemModuleSimpleName)
-                    module = systemModule;
-                else
-                    module = _typeSystemContext.GetModuleFromPath(inputPath);
+                VerifyModule(_typeSystemContext.GetModuleFromPath(inputPath));
 
-                VerifyModule(module);
-                
                 if (_numErrors > 0)
                     Console.WriteLine(_numErrors + " Error(s) Verifying " + inputPath);
                 else

--- a/src/ILVerify/src/Program.cs
+++ b/src/ILVerify/src/Program.cs
@@ -47,9 +47,9 @@ namespace ILVerify
             Console.WriteLine("--help          Display this usage message (Short form: -?)");
             Console.WriteLine("--reference     Reference metadata from the specified assembly (Short form: -r)");
             Console.WriteLine("--include       Use only methods/types/namespaces, which match the given regular expression(s) (Short form: -i)");
-            Console.WriteLine("--include-file  Same as -include, but the regular expression(s) are declared line by line in the specified file.");
+            Console.WriteLine("--include-file  Same as --include, but the regular expression(s) are declared line by line in the specified file.");
             Console.WriteLine("--exclude       Skip methods/types/namespaces, which match the given regular expression(s) (Short form: -e)");
-            Console.WriteLine("--exclude-file  Same as -exclude, but the regular expression(s) are declared line by line in the specified file.");
+            Console.WriteLine("--exclude-file  Same as --exclude, but the regular expression(s) are declared line by line in the specified file.");
         }
 
         public static IReadOnlyList<Regex> StringPatternsToRegexList(IReadOnlyList<string> patterns)

--- a/src/ILVerify/src/SimpleTypeSystemContext.cs
+++ b/src/ILVerify/src/SimpleTypeSystemContext.cs
@@ -85,6 +85,15 @@ namespace ILVerify
 
         public EcmaModule GetModuleFromPath(string filePath)
         {
+            // This is called once for every assembly that should be verified, so linear search is acceptable.
+            foreach (KeyValuePair<EcmaModule, ModuleData> entry in _moduleData)
+            {
+                EcmaModule curModule = entry.Key;
+                ModuleData curData = entry.Value;
+                if (curData.Path == filePath)
+                    return curModule;
+            }
+            
             PEReader peReader = new PEReader(File.OpenRead(filePath));
             EcmaModule module = EcmaModule.Create(this, peReader);
 


### PR DESCRIPTION
- Added new command line options `--include-file`, `--exclude-file` to specify include/exclude patterns line by line in a file. Example:
```
includes.txt:
-------------
System\.Console\..*
System\.Collections\.*
```

```
ILVerify.exe --include-file:includes.txt mscorlib
```

- Added support for verifying mscorlib. mscorlib was not accepted as input, because it was already loaded. I added a special case for it.
- Verification does not abort anymore when a `NotImplementedException` or `InvalidProgramException` is thrown. This allows collection of verification results for all methods within the specified assemblies.
- Improved error messages for some `NotImplementedException` throw statements

