### PR TITLE
Fix more CoreFx on ILC tests

### DIFF
--- a/src/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.cs
@@ -1003,6 +1003,12 @@ namespace System
             if (TryParseAsInteger(enumEEType, value, firstNonWhitespaceIndex, out result))
                 return true;
 
+            if (StillLooksLikeInteger(value, firstNonWhitespaceIndex))
+            {
+                exception = new OverflowException();
+                return false;
+            }
+
             // Parse as string. Now (and only now) do we look for metadata information.
             EnumInfo enumInfo = RuntimeAugments.Callbacks.GetEnumInfoIfAvailable(enumType);
             if (enumInfo == null)
@@ -1173,6 +1179,31 @@ namespace System
                         throw new NotSupportedException();
                 }
             }
+        }
+
+        private static bool StillLooksLikeInteger(String value, int index)
+        {
+            if (index != value.Length && (value[index] == '-' || value[index] == '+'))
+            {
+                index++;
+            }
+
+            if (index == value.Length || !char.IsDigit(value[index]))
+                return false;
+
+            index++;
+
+            while (index != value.Length && char.IsDigit(value[index]))
+            {
+                index++;
+            }
+
+            while (index != value.Length && char.IsWhiteSpace(value[index]))
+            {
+                index++;
+            }
+
+            return index == value.Length;
         }
 
         [Conditional("BIGENDIAN")]

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -268,9 +268,14 @@ namespace Internal.Reflection.Execution
                 return false;
             }
             
+            if (rank == 1)
+            {
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_NoMultiDims_Rank1);
+            }
+
             if ((rank < MDArray.MinRank) || (rank > MDArray.MaxRank))
             {
-                throw new PlatformNotSupportedException(SR.Format(SR.PlatformNotSupported_NoMultiDims, rank));
+                throw new TypeLoadException(SR.Format(SR.MultiDim_Of_This_Rank_Not_Supported, rank));
             }
 
             return TypeLoaderEnvironment.Instance.TryGetArrayTypeForElementType(elementTypeHandle, true, rank, out arrayTypeHandle);

--- a/src/System.Private.Reflection.Execution/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Execution/src/Resources/Strings.resx
@@ -174,8 +174,11 @@
   <data name="MissingConstructor_Name" xml:space="preserve">
     <value>Constructor on type '{0}' not found.</value>
   </data>
-  <data name="PlatformNotSupported_NoMultiDims" xml:space="preserve">
-    <value>Multidimensional arrays of rank {0} are not supported on this runtime.</value>
+  <data name="PlatformNotSupported_NoMultiDims_Rank1" xml:space="preserve">
+    <value>Multidimensional arrays of rank 1 are not supported on this runtime.</value>
+  </data>
+  <data name="MultiDim_Of_This_Rank_Not_Supported" xml:space="preserve">
+    <value>Multidimensional arrays of rank {0} are not supported.</value>
   </data>
   <data name="Object_NotInvokable" xml:space="preserve">
     <value>This object cannot be invoked because it was metadata-enabled for browsing only: '{0}' For more information, please visit  http://go.microsoft.com/fwlink/?LinkID=616867</value>


### PR DESCRIPTION
- Make Enum.Parse() throw OverflowException
  when it's supposed to.

- Now that we support all the multidim array ranks
  that the full framework did, throw the same
  exception it does when you go outside that
  allowance.