### PR TITLE
Ensure Rd.xml rooted virtuals get VTable entries

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -258,8 +258,10 @@ namespace ILCompiler
                 }
             }
             
-            public void RootMethodForReflection(MethodDesc method, string reason)
+            public void RootVirtualMethodForReflection(MethodDesc method, string reason)
             {
+                Debug.Assert(method.IsVirtual);
+
                 if (!_factory.CompilationModuleGroup.ShouldProduceFullVTable(method.OwningType))
                     _graph.AddRoot(_factory.VirtualMethodUse(method), reason);
 

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -257,11 +257,16 @@ namespace ILCompiler
                     }
                 }
             }
-
-            public void RootVirtualMethodUse(MethodDesc method, string reason)
+            
+            public void RootMethodForReflection(MethodDesc method, string reason)
             {
                 if (!_factory.CompilationModuleGroup.ShouldProduceFullVTable(method.OwningType))
                     _graph.AddRoot(_factory.VirtualMethodUse(method), reason);
+
+                if (method.IsAbstract)
+                {
+                    _graph.AddRoot(_factory.ReflectableMethod(method), reason);
+                }
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
@@ -14,6 +14,6 @@ namespace ILCompiler
         void AddCompilationRoot(MethodDesc method, string reason, string exportName = null);
         void AddCompilationRoot(TypeDesc type, string reason);
         void RootStaticBasesForType(TypeDesc type, string reason);
-        void RootVirtualMethodUse(MethodDesc method, string reason);
+        void RootMethodForReflection(MethodDesc method, string reason);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
@@ -14,6 +14,6 @@ namespace ILCompiler
         void AddCompilationRoot(MethodDesc method, string reason, string exportName = null);
         void AddCompilationRoot(TypeDesc type, string reason);
         void RootStaticBasesForType(TypeDesc type, string reason);
-        void RootMethodForReflection(MethodDesc method, string reason);
+        void RootVirtualMethodForReflection(MethodDesc method, string reason);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryRootProvider.cs
@@ -80,7 +80,7 @@ namespace ILCompiler
         /// in its signature. Unresolvable types in a method's signature prevent RyuJIT from generating
         /// even a stubbed out throwing implementation.
         /// </summary>
-        private static void CheckCanGenerateMethod(MethodDesc method)
+        public static void CheckCanGenerateMethod(MethodDesc method)
         {
             MethodSignature signature = method.Signature;
 

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -126,7 +126,7 @@ namespace ILCompiler
                         if (method.IsVirtual)
                         {
                             MethodDesc slotMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
-                            rootProvider.RootMethodForReflection(slotMethod, "RD.XML root");
+                            rootProvider.RootVirtualMethodForReflection(slotMethod, "RD.XML root");
                         }
                         
                         if (!method.IsAbstract)


### PR DESCRIPTION
Virtual methods rooted via rd.xml directives were not getting VTable
slots assigned due to no compiled code virtually calling them. This
makes them available to be called via reflection and causes an assert in
`ReflectionVirtualInvokeMapNode.GetData`.

* Replace the use of `LibraryRootProvider` in `RdXmlRootProvider` with
an implementation that walks all the types in an rd.xml file's
`<Assembly>` directive and ensures virtual methods will be reflectable.
* Replace `IRootingServiceProvider.RootVirtualMethodUse` with
`IRootingServiceProvider.RootMethodForReflection` which specifically
aims to make the method reflectable.