### PR TITLE
LoadLibrary for Lazy P/Invoke Improvements

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.ExePath.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.ExePath.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal static partial class Interop
+{
+    internal unsafe partial class Sys
+    {
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetEntrypointExecutableAbsolutePath")]
+        internal static extern bool GetEntrypointExecutableAbsolutePath(out string path);
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -428,7 +428,15 @@ namespace Internal.TypeSystem.Ecma
             Debug.Assert((int)MethodImportAttributes.CharSetUnicode == (int)PInvokeAttributes.CharSetUnicode);
             Debug.Assert((int)MethodImportAttributes.SetLastError == (int)PInvokeAttributes.SetLastError);
 
-            return new PInvokeMetadata(moduleName, name, (PInvokeAttributes)import.Attributes);
+            DllImportSearchPath dllImportSearchPath = this.GetDllImportSearchPath();
+
+            // if DefaultDllImportSearchPathAttribute is not assigned on the method
+            // check to see whether it is assigned on the containing assembly
+            if (dllImportSearchPath == DllImportSearchPath.None)
+            {
+                dllImportSearchPath = ((EcmaAssembly)Module).GetDllImportSearchPath();
+            }
+            return new PInvokeMetadata(moduleName, name, (PInvokeAttributes)import.Attributes, dllImportSearchPath);
         }
 
         public override ParameterMetadata[] GetParameterMetadata()

--- a/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
@@ -101,6 +101,18 @@ namespace Internal.TypeSystem
         ThrowOnUnmappableCharMask = 12288
     }
 
+    public enum DllImportSearchPath : int
+    {
+        LegacyBehavior = 0x0,
+        None = 0x1,
+        AssemblyDirectory = 0x2,
+        UseDllDirectoryForDependencies = 0x100,
+        ApplicationDirectory = 0x200,
+        UserDirectories = 0x400,
+        System32 = 0x800,
+        SafeDirectories = 0x1000
+    }
+
     public struct PInvokeFlags
     {
         private PInvokeAttributes _attributes;
@@ -293,18 +305,22 @@ namespace Internal.TypeSystem
 
         public readonly PInvokeFlags Flags;
 
-        public PInvokeMetadata(string module, string entrypoint, PInvokeAttributes attributes)
+        public readonly DllImportSearchPath DllImportSearchPath;
+
+        public PInvokeMetadata(string module, string entrypoint, PInvokeAttributes attributes, DllImportSearchPath dllImageSearchPath)
         {
             Name = entrypoint;
             Module = module;
             Flags = new PInvokeFlags(attributes);
+            DllImportSearchPath = dllImageSearchPath;
         }
 
-        public PInvokeMetadata(string module, string entrypoint, PInvokeFlags flags)
+        public PInvokeMetadata(string module, string entrypoint, PInvokeFlags flags, DllImportSearchPath dllImageSearchPath)
         {
             Name = entrypoint;
             Module = module;
             Flags = flags;
+            DllImportSearchPath = dllImageSearchPath;
         }
     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -97,7 +97,7 @@ namespace ILCompiler
             {
                 var pInvokeFixup = (PInvokeLazyFixupField)field;
                 PInvokeMetadata metadata = pInvokeFixup.PInvokeMetadata;
-                return NodeFactory.PInvokeMethodFixup(metadata.Module, metadata.Name);
+                return NodeFactory.PInvokeMethodFixup(metadata.Module, metadata.Name, metadata.DllImportSearchPath);
             }
             else
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -262,14 +262,14 @@ namespace ILCompiler.DependencyAnalysis
                 return new ExternSymbolNode(name);
             });
 
-            _pInvokeModuleFixups = new NodeCache<string, PInvokeModuleFixupNode>((string name) =>
+            _pInvokeModuleFixups = new NodeCache<Tuple<string, DllImportSearchPath>, PInvokeModuleFixupNode>((Tuple<string, DllImportSearchPath> key) =>
             {
-                return new PInvokeModuleFixupNode(name);
+                return new PInvokeModuleFixupNode(key.Item1, key.Item2);
             });
 
-            _pInvokeMethodFixups = new NodeCache<Tuple<string, string>, PInvokeMethodFixupNode>((Tuple<string, string> key) =>
+            _pInvokeMethodFixups = new NodeCache<Tuple<string, string, DllImportSearchPath>, PInvokeMethodFixupNode>((Tuple<string, string, DllImportSearchPath> key) =>
             {
-                return new PInvokeMethodFixupNode(key.Item1, key.Item2);
+                return new PInvokeMethodFixupNode(key.Item1, key.Item2, key.Item3);
             });
 
             _methodEntrypoints = new NodeCache<MethodDesc, IMethodNode>(CreateMethodEntrypointNode);
@@ -604,18 +604,18 @@ namespace ILCompiler.DependencyAnalysis
             return _externSymbols.GetOrAdd(name);
         }
 
-        private NodeCache<string, PInvokeModuleFixupNode> _pInvokeModuleFixups;
+        private NodeCache<Tuple<string, DllImportSearchPath>, PInvokeModuleFixupNode> _pInvokeModuleFixups;
 
-        public ISymbolNode PInvokeModuleFixup(string moduleName)
+        public ISymbolNode PInvokeModuleFixup(string moduleName, DllImportSearchPath dllImportSearchPath)
         {
-            return _pInvokeModuleFixups.GetOrAdd(moduleName);
+            return _pInvokeModuleFixups.GetOrAdd(new Tuple<string, DllImportSearchPath>(moduleName, dllImportSearchPath));
         }
 
-        private NodeCache<Tuple<string, string>, PInvokeMethodFixupNode> _pInvokeMethodFixups;
+        private NodeCache<Tuple<string, string, DllImportSearchPath>, PInvokeMethodFixupNode> _pInvokeMethodFixups;
 
-        public PInvokeMethodFixupNode PInvokeMethodFixup(string moduleName, string entryPointName)
+        public PInvokeMethodFixupNode PInvokeMethodFixup(string moduleName, string entryPointName, DllImportSearchPath dllImportSearchPath)
         {
-            return _pInvokeMethodFixups.GetOrAdd(new Tuple<string, string>(moduleName, entryPointName));
+            return _pInvokeMethodFixups.GetOrAdd(new Tuple<string, string, DllImportSearchPath>(moduleName, entryPointName, dllImportSearchPath));
         }
 
         private NodeCache<TypeDesc, VTableSliceNode> _vTableNodes;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -5,6 +5,7 @@
 using System;
 
 using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -15,11 +16,13 @@ namespace ILCompiler.DependencyAnalysis
     {
         private string _moduleName;
         private string _entryPointName;
+        private DllImportSearchPath _dllImportSearchPath;
 
-        public PInvokeMethodFixupNode(string moduleName, string entryPointName)
+        public PInvokeMethodFixupNode(string moduleName, string entryPointName, DllImportSearchPath dllImportSearchPath)
         {
             _moduleName = moduleName;
             _entryPointName = entryPointName;
+            _dllImportSearchPath = dllImportSearchPath;
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -69,7 +72,7 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             // Module fixup cell
-            builder.EmitPointerReloc(factory.PInvokeModuleFixup(_moduleName));
+            builder.EmitPointerReloc(factory.PInvokeModuleFixup(_moduleName, _dllImportSearchPath));
 
             return builder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeModuleFixupNode.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -12,10 +13,12 @@ namespace ILCompiler.DependencyAnalysis
     public class PInvokeModuleFixupNode : ObjectNode, ISymbolDefinitionNode
     {
         public string _moduleName;
+        public DllImportSearchPath _dllImportSearchPath;
 
-        public PInvokeModuleFixupNode(string moduleName)
+        public PInvokeModuleFixupNode(string moduleName, DllImportSearchPath dllImportSearchPath)
         {
             _moduleName = moduleName;
+            _dllImportSearchPath = dllImportSearchPath;
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -45,6 +48,7 @@ namespace ILCompiler.DependencyAnalysis
 
             builder.EmitZeroPointer();
             builder.EmitPointerReloc(nameSymbol);
+            builder.EmitInt((int)_dllImportSearchPath);
 
             return builder.ToObjectData();
         }

--- a/src/Native/System.Private.CoreLib.Native/CMakeLists.txt
+++ b/src/Native/System.Private.CoreLib.Native/CMakeLists.txt
@@ -10,6 +10,7 @@ set(NATIVE_SOURCES
     pal_memory.cpp
     pal_threading.cpp
     pal_time.cpp
+    pal_exepath.cpp
 )
 
 add_library(System.Private.CoreLib.Native

--- a/src/Native/System.Private.CoreLib.Native/pal_exepath.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_exepath.cpp
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <cstdlib>
+#include <cstring>
+#include <assert.h>
+#include <dirent.h>
+#include <dlfcn.h>
+#include <limits.h>
+#include <set>
+#include <string>
+#include <string.h>
+#include <sys/stat.h>
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/param.h>
+#endif
+#if defined(HAVE_SYS_SYSCTL_H) || defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#endif
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+#include <unistd.h>
+
+#if defined(__linux__)
+#define symlinkEntrypointExecutable "/proc/self/exe"
+#elif !defined(__APPLE__)
+#define symlinkEntrypointExecutable "/proc/curproc/exe"
+#endif
+
+extern "C" bool CoreLibNative_GetEntrypointExecutableAbsolutePath(char **buf)
+{
+    bool result = false;
+    *buf = NULL;
+    
+    // Get path to the executable for the current process using
+    // platform specific means.
+#if defined(__APPLE__)
+    
+    // On Mac, we ask the OS for the absolute path to the entrypoint executable
+    uint32_t lenActualPath = 0;
+    if (_NSGetExecutablePath(nullptr, &lenActualPath) == -1)
+    {
+        // OSX has placed the actual path length in lenActualPath,
+        // so re-attempt the operation
+        char *pResizedPath = (char *)malloc(sizeof(char) * lenActualPath);
+        if (_NSGetExecutablePath(pResizedPath, &lenActualPath) == 0)
+        {
+            *buf = pResizedPath;
+            result = true;
+        }
+    }
+#elif defined (__FreeBSD__)
+    static const int name[] = {
+        CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1
+    };
+    char *path = (char *)malloc(sizeof(char) * PATH_MAX);
+    size_t len;
+
+    len = sizeof(path);
+    if (sysctl(name, 4, path, &len, nullptr, 0) == 0)
+    {
+        *buf = path;
+        result = true;
+    }
+#elif defined(__NetBSD__) && defined(KERN_PROC_PATHNAME)
+    static const int name[] = {
+        CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME,
+    };
+    char *path = (char *)malloc(sizeof(char) * MAXPATHLEN);
+    size_t len;
+
+    len = sizeof(path);
+    if (sysctl(name, __arraycount(name), path, &len, NULL, 0) != -1)
+    {
+        *buf = path;
+        result = true;
+    }
+#else
+    // On other OSs, return the symlink that will be resolved 
+    // to fetch the entrypoint EXE absolute path, inclusive of filename.
+    char *realPath = (char *)malloc(sizeof(char) * PATH_MAX);
+    if (realpath(symlinkEntrypointExecutable, realPath) != nullptr && realPath[0] != '\0')
+    {
+        *buf = realPath;
+        result = true;
+    }
+#endif 
+
+    return result;
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -682,6 +682,9 @@
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.ErrNo.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.ErrNo.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.ExePath.cs">
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.ExePath.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\Interop\Unix\System.Native\Interop.SysConf.cs">
       <Link>Interop\Unix\System.Native\Interop.SysConf.cs</Link>
     </Compile>

--- a/src/System.Private.CoreLib/src/System/AppContext.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/AppContext.Unix.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace System
 {
@@ -17,7 +16,14 @@ namespace System
         {
             get
             {
-                throw new NotImplementedException();
+                string path;
+                bool found = Interop.Sys.GetEntrypointExecutableAbsolutePath(out path);
+                if (!found)
+                {
+                  // TODO: throw appropriate exception
+                   throw new TypeLoadException("GetEntrypointExecutableAbsolutePath failed");
+                }
+                return path.Substring(0, path.LastIndexOf('/'));
             }
         }
     }

--- a/tests/CoreCLR/corerun
+++ b/tests/CoreCLR/corerun
@@ -33,18 +33,11 @@ nativeArtifactRepo=${testExtRepo}native/
 dirSuffix=$(dirname ${PWD#$testExtRepo})/
 nativeDir=${nativeArtifactRepo}tests/src/${dirSuffix}
 
-# In OSX we copy the native component to the directory where the exectuable resides.
-# However, in Linux dlopen doesn't seem to look for current directory to resolve the dynamic library.
-# So instead we point LD_LIBRARY_PATH to the directory where the native component is.
+# We copy the native component to the directory where the exectuable resides.
 if [ -e ${nativeDir} ]; then
-    if [ "${CoreRT_BuildOS}" == "OSX" ]; then
-        echo "Copying native component from :"${nativeDir}
+	echo "Copying native component from :"${nativeDir}
         cp ${nativeDir}*.dylib  native/ 2>/dev/null
-    fi
-    if [ "${CoreRT_BuildOS}" == "Linux" ]; then
-        LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${nativeDir}
-        export LD_LIBRARY_PATH
-    fi
+        cp ${nativeDir}*.so native/ 2>/dev/null
 fi
 
 if [[ ! -f native/${TestFileName} ]]; then
@@ -52,10 +45,8 @@ if [[ ! -f native/${TestFileName} ]]; then
     exit -1
 fi
 
-pushd native/
-./${TestFileName} "$@"
+native/${TestFileName} "$@"
 testScriptExitCode=$?
-popd
 
 if [[ $CoreRT_EnableCoreDumps == 1 ]]; then
     # Handle any core files generated when running the test.


### PR DESCRIPTION
This change improves the loadlibrary for Lazy P/Invoke by propagating
DllImportSearchPath attribute value to runtime and tries to imitate the
CoreCLR behavior. In particular, this change ensures we look for native
libraries in the directory where the executable resides by default.