### PR TITLE
Fix assert generating dependency log

### DIFF
--- a/src/ILCompiler.DependencyAnalysisFramework/src/FirstMarkLogStrategy.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/FirstMarkLogStrategy.cs
@@ -89,6 +89,7 @@ namespace ILCompiler.DependencyAnalysisFramework
                         if (!combinedNodesReported.Contains(combinedNode))
                         {
                             logNodeVisitor.VisitCombinedNode(combinedNode);
+                            combinedNodesReported.Add(combinedNode);
                         }
                     }
                 }


### PR DESCRIPTION
FirstMarkLogStrategy.VisitLogNodes contains a HashSet,
combinedNodesReporting, that ensures we only report duplicate combined
dependencies once. We were checking the HashSet didn't already contain
an entry but failing to add the entry after visiting the node.