### PR TITLE
Cleanup TypeDebugInfoWriter interface

### DIFF
--- a/src/Common/src/TypeSystem/TypesDebugInfoWriter/TypesDebugInfoWriter.cs
+++ b/src/Common/src/TypeSystem/TypesDebugInfoWriter/TypesDebugInfoWriter.cs
@@ -12,9 +12,7 @@ namespace Internal.TypeSystem.TypesDebugInfo
 
         uint GetClassTypeIndex(ClassTypeDescriptor classTypeDescriptor);
 
-        uint GetCompleteClassTypeIndex(ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptior classFieldsTypeDescriptior, DataFieldDescriptor[] fields);
-
-        uint GetVariableTypeIndex(TypeDesc type, bool needsCompleteType);
+        uint GetCompleteClassTypeIndex(ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptor classFieldsTypeDescriptior, DataFieldDescriptor[] fields);
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
@@ -51,7 +49,7 @@ namespace Internal.TypeSystem.TypesDebugInfo
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    public struct ClassFieldsTypeDescriptior
+    public struct ClassFieldsTypeDescriptor
     {
         public int Size;
         public int FieldsCount;

--- a/src/Common/src/TypeSystem/TypesDebugInfoWriter/UserDefinedTypeDescriptor.cs
+++ b/src/Common/src/TypeSystem/TypesDebugInfoWriter/UserDefinedTypeDescriptor.cs
@@ -14,6 +14,21 @@ namespace Internal.TypeSystem.TypesDebugInfo
         {
             _objectWriter = objectWriter;
         }
+
+        public uint GetVariableTypeIndex(TypeDesc type, bool needsCompleteIndex)
+        {
+            uint typeIndex = 0;
+            if (type.IsPrimitive)
+            {
+                typeIndex = PrimitiveTypeDescriptor.GetPrimitiveTypeIndex(type);
+            }
+            else
+            {
+                typeIndex = GetTypeIndex(type, needsCompleteIndex);
+            }
+            return typeIndex;
+        }
+
         public uint GetTypeIndex(TypeDesc type, bool needsCompleteType)
         {
             uint variableTypeIndex = 0;
@@ -58,7 +73,7 @@ namespace Internal.TypeSystem.TypesDebugInfo
                 }
             }
             enumTypeDescriptor.ElementCount = (ulong)fieldsDescriptors.Count;
-            enumTypeDescriptor.ElementType = _objectWriter.GetVariableTypeIndex(defType.UnderlyingType, true);
+            enumTypeDescriptor.ElementType = PrimitiveTypeDescriptor.GetPrimitiveTypeIndex(defType.UnderlyingType);
             enumTypeDescriptor.Name = defType.Name;
             enumTypeDescriptor.UniqueName = defType.GetFullName();
             EnumRecordTypeDescriptor[] typeRecords = new EnumRecordTypeDescriptor[enumTypeDescriptor.ElementCount];
@@ -131,7 +146,7 @@ namespace Internal.TypeSystem.TypesDebugInfo
             classTypeDescriptor.BaseClassId = 0;
             if (type.HasBaseType && !type.IsValueType)
             {
-                classTypeDescriptor.BaseClassId = _objectWriter.GetVariableTypeIndex(defType.BaseType, false);
+                classTypeDescriptor.BaseClassId = GetVariableTypeIndex(defType.BaseType, false);
             }
             uint typeIndex = _objectWriter.GetClassTypeIndex(classTypeDescriptor);
             _knownTypes[type] = typeIndex;
@@ -142,7 +157,7 @@ namespace Internal.TypeSystem.TypesDebugInfo
                 if (fieldDesc.HasRva || fieldDesc.IsLiteral)
                     continue;
                 DataFieldDescriptor field = new DataFieldDescriptor();
-                field.FieldTypeIndex = _objectWriter.GetVariableTypeIndex(fieldDesc.FieldType, false);
+                field.FieldTypeIndex = GetVariableTypeIndex(fieldDesc.FieldType, false);
                 field.Offset = fieldDesc.Offset.AsInt;
                 field.Name = fieldDesc.Name;
                 fieldsDescs.Add(field);
@@ -153,7 +168,7 @@ namespace Internal.TypeSystem.TypesDebugInfo
             {
                 fields[i] = fieldsDescs[i];
             }
-            ClassFieldsTypeDescriptior fieldsDescriptor = new ClassFieldsTypeDescriptior();
+            ClassFieldsTypeDescriptor fieldsDescriptor = new ClassFieldsTypeDescriptor();
             fieldsDescriptor.FieldsCount = fieldsDescs.Count;
             fieldsDescriptor.Size = defType.GetElementSize().AsInt;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -263,30 +263,16 @@ namespace ILCompiler.DependencyAnalysis
         private static extern uint GetClassTypeIndex(IntPtr objWriter, ClassTypeDescriptor classTypeDescriptor);
 
         [DllImport(NativeObjectWriterFileName)]
-        private static extern uint GetCompleteClassTypeIndex(IntPtr objWriter, ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptior classFieldsTypeDescriptior, DataFieldDescriptor[] fields);
+        private static extern uint GetCompleteClassTypeIndex(IntPtr objWriter, ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptor classFieldsTypeDescriptior, DataFieldDescriptor[] fields);
 
         public uint GetClassTypeIndex(ClassTypeDescriptor classTypeDescriptor)
         {
             return GetClassTypeIndex(_nativeObjectWriter, classTypeDescriptor);
         }
 
-        public uint GetCompleteClassTypeIndex(ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptior classFieldsTypeDescriptior, DataFieldDescriptor[] fields)
+        public uint GetCompleteClassTypeIndex(ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptor classFieldsTypeDescriptior, DataFieldDescriptor[] fields)
         {
             return GetCompleteClassTypeIndex(_nativeObjectWriter, classTypeDescriptor, classFieldsTypeDescriptior, fields);
-        }
-
-        public uint GetVariableTypeIndex(TypeDesc type, bool needsCompleteIndex)
-        {
-            uint typeIndex = 0;
-            if (type.IsPrimitive)
-            {
-                typeIndex = PrimitiveTypeDescriptor.GetPrimitiveTypeIndex(type);
-            }
-            else
-            {
-                typeIndex = _userDefinedTypeDescriptor.GetTypeIndex(type, needsCompleteIndex);
-            }
-            return typeIndex;
         }
 
         [DllImport(NativeObjectWriterFileName)]
@@ -295,7 +281,7 @@ namespace ILCompiler.DependencyAnalysis
         public void EmitDebugVar(DebugVarInfo debugVar)
         {
             int rangeCount = debugVar.Ranges.Count;
-            uint typeIndex = GetVariableTypeIndex(debugVar.Type, true);
+            uint typeIndex = _userDefinedTypeDescriptor.GetVariableTypeIndex(debugVar.Type, true);
             EmitDebugVar(_nativeObjectWriter, debugVar.Name, typeIndex, debugVar.IsParam, rangeCount, debugVar.Ranges.ToArray());
         }
 


### PR DESCRIPTION
- Remove GetVariableTypeIndex and move the functionality to UserDefinedTypeDescriptor from ObjectWriter
- Fix misspelling of ClassFieldsTypeDescriptor