### PR TITLE
Treat the `<Module>` type as not having a lazy constructor

### DIFF
--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -300,6 +300,15 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool IsModuleType
+        {
+            get
+            {
+                // The global module type cannot be generic.
+                return false;
+            }
+        }
+
         public override bool IsSealed
         {
             get

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -51,7 +51,7 @@ namespace Internal.TypeSystem
         /// If true, this is the special &lt;Module&gt; type that contains the definitions
         /// of global fields and methods in the module.
         /// </summary>
-        public bool IsModuleType
+        public virtual bool IsModuleType
         {
             get
             {

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using Debug = System.Diagnostics.Debug;
 
@@ -552,6 +553,14 @@ namespace Internal.TypeSystem.Ecma
             get
             {
                 return (_typeDefinition.Attributes & TypeAttributes.BeforeFieldInit) != 0;
+            }
+        }
+
+        public override bool IsModuleType
+        {
+            get
+            {
+                return _handle.Equals(MetadataTokens.TypeDefinitionHandle(0x00000001 /* COR_GLOBAL_PARENT_TOKEN */));
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.TypeInit.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.TypeInit.cs
@@ -26,7 +26,8 @@ namespace ILCompiler
         /// </summary>
         public bool HasLazyStaticConstructor(TypeDesc type)
         {
-            return type.HasStaticConstructor && !HasEagerConstructorAttribute(type) && _supportsLazyCctors;
+            return type.HasStaticConstructor && !HasEagerConstructorAttribute(type) && _supportsLazyCctors &&
+                (!(type is MetadataType) || !((MetadataType)type).IsModuleType);
         }
 
         /// <summary>

--- a/src/ILCompiler.TypeSystem/tests/WellKnownTypeTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/WellKnownTypeTests.cs
@@ -100,5 +100,11 @@ namespace TypeSystemTests
             Assert.Equal(4, _context.GetWellKnownType(WellKnownType.Single).InstanceFieldSize.AsInt);
             Assert.Equal(8, _context.GetWellKnownType(WellKnownType.Double).InstanceFieldSize.AsInt);
         }
+
+        [Fact]
+        public void TestModuleType()
+        {
+            Assert.True(_testModule.GetGlobalModuleType().IsModuleType);
+        }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1491,16 +1491,10 @@ namespace Internal.JitInterface
                 return CorInfoInitClassResult.CORINFO_INITCLASS_NOT_REQUIRED;
             }
 
-            MetadataType typeToInit = (MetadataType)type;
-
-            if (typeToInit.IsModuleType)
-            {
-                // For both jitted and ngen code the global class is always considered initialized
-                return CorInfoInitClassResult.CORINFO_INITCLASS_NOT_REQUIRED;
-            }
-
             if (fd == null)
             {
+                MetadataType typeToInit = (MetadataType)type;
+
                 if (typeToInit.IsBeforeFieldInit)
                 {
                     // We can wait for field accesses to run .cctor


### PR DESCRIPTION
This was special cased in CorInfoImpl because that's where CoreCLR
special cases it, but the entire system should consider these not having
a lazy cctor. This cctor is triggered differently.

Noticed while working on the IL scanner. Also made this check faster
while I was at it.