### PR TITLE
Performance tweaks for Buffer.BlockCopy

### DIFF
--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -247,17 +247,20 @@ namespace System
             public byte Data;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ref byte GetRawSzArrayData()
         {
             Debug.Assert(IsSzArray);
             return ref Unsafe.As<RawData>(this).Data;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ref byte GetRawArrayData()
         {
             return ref Unsafe.Add(ref Unsafe.As<RawData>(this).Data, (int)(EETypePtr.BaseSize - SZARRAY_BASE_SIZE));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ref int GetRawMultiDimArrayBounds()
         {
             Debug.Assert(!IsSzArray);

--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -83,17 +83,20 @@ namespace System
                 throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_MustBeNonNegInt32, nameof(count));
 
             nuint uCount = (nuint)count;
-            if (uSrcLen < ((nuint)srcOffset) + uCount)
+            nuint uSrcOffset = (nuint)srcOffset;
+            nuint uDstOffset = (nuint)dstOffset;
+
+            if (uSrcLen < uSrcOffset + uCount)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
-            if (uDstLen < ((nuint)dstOffset) + uCount)
+            if (uDstLen < uDstOffset + uCount)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            if (uCount == 0)
-                return;
-
-            fixed (byte* pSrc = &src.GetRawArrayData(), pDst = &dst.GetRawArrayData())
+            if (uCount != 0)
             {
-                Buffer.Memmove(pDst + dstOffset, pSrc + srcOffset, uCount);
+                fixed (byte* pSrc = &src.GetRawArrayData(), pDst = &dst.GetRawArrayData())
+                {
+                    Buffer.Memmove(pDst + uDstOffset, pSrc + uSrcOffset, uCount);
+                }
             }
         }
 

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -31,6 +31,11 @@ namespace System
             _value = (EEType*)value;
         }
 
+        internal EETypePtr(EEType* value)
+        {
+            _value = value;
+        }
+
         internal EEType* ToPointer()
         {
             return _value;
@@ -211,7 +216,7 @@ namespace System
         {
             get
             {
-                return new EETypePtr((IntPtr)_value->GenericDefinition);
+                return new EETypePtr(_value->GenericDefinition);
             }
         }
 
@@ -278,7 +283,7 @@ namespace System
         {
             get
             {
-                return new EETypePtr((IntPtr)_value->NullableType);
+                return new EETypePtr(_value->NullableType);
             }
         }
 
@@ -286,7 +291,7 @@ namespace System
         {
             get
             {
-                return new EETypePtr((IntPtr)_value->RelatedParameterType);
+                return new EETypePtr(_value->RelatedParameterType);
             }
         }
 
@@ -316,7 +321,7 @@ namespace System
                 if (IsPointer || IsByRef)
                     return new EETypePtr(default(IntPtr));
 
-                EETypePtr baseEEType = new EETypePtr((IntPtr)_value->NonArrayBaseType);
+                EETypePtr baseEEType = new EETypePtr(_value->NonArrayBaseType);
                 return baseEEType;
             }
         }
@@ -406,8 +411,7 @@ namespace System
                 {
                     Debug.Assert((uint)index < _value->NumInterfaces);
 
-                    EEType* interfaceType = _value->InterfaceMap[index].InterfaceType;
-                    return new EETypePtr((IntPtr)interfaceType);
+                    return new EETypePtr(_value->InterfaceMap[index].InterfaceType);
                 }
             }
         }
@@ -436,7 +440,7 @@ namespace System
                 get
                 {
                     Debug.Assert((uint)index < _argumentCount);
-                    return new EETypePtr((IntPtr)_arguments[index].Value);
+                    return new EETypePtr(_arguments[index].Value);
                 }
             }
         }


### PR DESCRIPTION
- Mark perf critical GetRaw* methods on Array for aggressive inlining
- Added constructor for EETypePtr that takes EEType* and use it as appropriate. It makes properties that return EETypePtr better inlining candidates.
- Rearranged BlockCopy code to reduce register pressure