### PR TITLE
Add IL scanner extensibility points to metadata manager

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedMetadataManager.cs
@@ -59,6 +59,21 @@ namespace ILCompiler
             return _compilationModuleGroup.ContainsType(field.GetTypicalFieldDefinition().OwningType);
         }
 
+        protected override MetadataCategory GetMetadataCategory(FieldDesc field)
+        {
+            return MetadataCategory.RuntimeMapping;
+        }
+
+        protected override MetadataCategory GetMetadataCategory(MethodDesc method)
+        {
+            return MetadataCategory.RuntimeMapping;
+        }
+
+        protected override MetadataCategory GetMetadataCategory(TypeDesc type)
+        {
+            return MetadataCategory.RuntimeMapping;
+        }
+
         protected override void ComputeMetadata(NodeFactory factory,
                                                 out byte[] metadataBlob, 
                                                 out List<MetadataMapping<MetadataType>> typeMappings,

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -72,7 +72,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public static void AddDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            AddDependenciesDueToReflectability(ref dependencies, factory, method);
+            factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencies, factory, method);
 
             if (method.HasInstantiation)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -157,6 +157,9 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(new DependencyListEntry(factory.TypeNonGCStaticsSymbol((MetadataType)_type), "Class constructor"));
             }
 
+            // Ask the metadata manager if we have any dependencies due to reflectability.
+            factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencyList, factory, _type);
+
             return dependencyList;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
@@ -30,7 +30,7 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             DependencyList dependencies = null;
-            CodeBasedDependencyAlgorithm.AddDependenciesDueToReflectability(ref dependencies, factory, _method);
+            factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencies, factory, _method);
             return dependencies;
         }
         protected override string GetName(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
@@ -28,6 +28,21 @@ namespace ILCompiler
             return true;
         }
 
+        protected override MetadataCategory GetMetadataCategory(FieldDesc field)
+        {
+            return MetadataCategory.None;
+        }
+
+        protected override MetadataCategory GetMetadataCategory(MethodDesc method)
+        {
+            return MetadataCategory.None;
+        }
+
+        protected override MetadataCategory GetMetadataCategory(TypeDesc type)
+        {
+            return MetadataCategory.None;
+        }
+
         protected override void ComputeMetadata(NodeFactory factory, out byte[] metadataBlob, out List<MetadataMapping<MetadataType>> typeMappings, out List<MetadataMapping<MethodDesc>> methodMappings, out List<MetadataMapping<FieldDesc>> fieldMappings)
         {
             metadataBlob = Array.Empty<byte>();

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -202,6 +202,24 @@ namespace ILCompiler
             return _compilationModuleGroup.ContainsType(field.GetTypicalFieldDefinition().OwningType);
         }
 
+        protected override MetadataCategory GetMetadataCategory(FieldDesc field)
+        {
+            // Backwards compatible behavior. We might want to tweak this.
+            return MetadataCategory.RuntimeMapping;
+        }
+
+        protected override MetadataCategory GetMetadataCategory(MethodDesc method)
+        {
+            // Backwards compatible behavior. We might want to tweak this.
+            return MetadataCategory.RuntimeMapping;
+        }
+
+        protected override MetadataCategory GetMetadataCategory(TypeDesc type)
+        {
+            // Backwards compatible behavior. We might want to tweak this.
+            return MetadataCategory.RuntimeMapping;
+        }
+
         protected override void ComputeMetadata(NodeFactory factory, out byte[] metadataBlob, out List<MetadataMapping<MetadataType>> typeMappings, out List<MetadataMapping<MethodDesc>> methodMappings, out List<MetadataMapping<FieldDesc>> fieldMappings)
         {
             MetadataLoadedInfo loadedMetadata = _loadedMetadata.Value;


### PR DESCRIPTION
This is so that the `MetadataManager` gets a saying in what dependencies to inject or not to inject.
