### PR TITLE
Add a few stubbed out methods to the AssemblyLoadContext class

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -17,5 +17,27 @@ namespace System.Runtime.Loader
         public static event ResolveEventHandler TypeResolve;
         public static event ResolveEventHandler ResourceResolve;
         public static event ResolveEventHandler AssemblyResolve;
+
+        public event Func<AssemblyLoadContext, AssemblyName, Assembly> Resolving;
+        public event Action<AssemblyLoadContext> Unloading;
+
+        private static AssemblyLoadContext s_defaultContext = new DefaultAssemblyLoadContext();
+        public static AssemblyLoadContext GetLoadContext(Assembly assembly)
+        {
+            return s_defaultContext;
+        }
+
+        public Assembly LoadFromAssemblyPath(string assemblyPath)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+
+    /// <summary>
+    /// AssemblyLoadContext is not supported in .NET Native. This is
+    /// just a dummy class to make applications compile.
+    /// </summary>
+    class DefaultAssemblyLoadContext : AssemblyLoadContext
+    {
     }
 }

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -21,10 +21,11 @@ namespace System.Runtime.Loader
         public event Func<AssemblyLoadContext, AssemblyName, Assembly> Resolving;
         public event Action<AssemblyLoadContext> Unloading;
 
-        private static AssemblyLoadContext s_defaultContext = new DefaultAssemblyLoadContext();
+        public static AssemblyLoadContext Default { get; } = new DefaultAssemblyLoadContext();
+
         public static AssemblyLoadContext GetLoadContext(Assembly assembly)
         {
-            return s_defaultContext;
+            return Default;
         }
 
         public Assembly LoadFromAssemblyPath(string assemblyPath)
@@ -37,7 +38,7 @@ namespace System.Runtime.Loader
     /// AssemblyLoadContext is not supported in .NET Native. This is
     /// just a dummy class to make applications compile.
     /// </summary>
-    class DefaultAssemblyLoadContext : AssemblyLoadContext
+    internal class DefaultAssemblyLoadContext : AssemblyLoadContext
     {
     }
 }


### PR DESCRIPTION
This is needed to be able to compile ASN.NET and Roslyn.
