### PR TITLE
Fix some corefx testing regressions due to multidim rank-1

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -152,7 +152,10 @@ namespace Internal.Runtime.Augments
                 // We just checked above that all lower bounds are zero. In that case, we should actually allocate
                 // a new SzArray instead.
                 RuntimeTypeHandle elementTypeHandle = new RuntimeTypeHandle(typeHandleForArrayType.ToEETypePtr().ArrayElementType);
-                return Array.CreateInstance(Type.GetTypeFromHandle(elementTypeHandle), lengths[0]);
+                int length = lengths[0];
+                if (length < 0)
+                    throw new OverflowException(); // For compat: we need to throw OverflowException(): Array.CreateInstance throws ArgumentOutOfRangeException()
+                return Array.CreateInstance(Type.GetTypeFromHandle(elementTypeHandle), length);
             }
 
             // Create a local copy of the lenghts that cannot be motified by the caller


### PR DESCRIPTION
Passing a negative length to an api that creates multidim
arrays throws OverflowException rather than ArgumentOutOfRangeException
(presumably due to the assumption that we overflowed while computing
the size rather than a specific bad length being passed in.)