### PR TITLE
Fix GVM analysis performance

### DIFF
--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
@@ -230,9 +230,13 @@ namespace ILCompiler.DependencyAnalysisFramework
                 if (_newDynamicDependenciesMayHaveAppeared)
                 {
                     _newDynamicDependenciesMayHaveAppeared = false;
-                    foreach (DynamicDependencyNode dynamicNode in _markedNodesWithDynamicDependencies)
+                    for (int i = 0; i < _markedNodesWithDynamicDependencies.Count; i++)
                     {
+                        DynamicDependencyNode dynamicNode = _markedNodesWithDynamicDependencies[i];
                         dynamicNode.MarkNewDynamicDependencies(this);
+
+                        // Update the copy in the list
+                        _markedNodesWithDynamicDependencies[i] = dynamicNode;
                     }
                 }
             } while (_markStack.Count != 0);


### PR DESCRIPTION
Fixing the processing of dynamic dependencies to not recompute already computed results (90% perf improvement on Release builds for the ASPNet benchmark app (22 mins to 2 mins total compile time)