### PR TITLE
Fix MdArray Rank 1 regressions

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -131,6 +131,14 @@ namespace ILCompiler.DependencyAnalysis
                 // Array EEType depends on System.Array's virtuals. Array EETypes don't point to
                 // their base type (i.e. there's no reloc based dependency making this "just work").
                 dependencyList.Add(factory.ConstructedTypeSymbol(_type.BaseType), "Array base type");
+
+                ArrayType arrayType = (ArrayType)_type;
+                if (arrayType.IsMdArray && arrayType.Rank == 1)
+                {
+                    // Allocating an MDArray of Rank 1 with zero lower bounds results in allocating
+                    // an SzArray instead. Make sure the type loader can find the SzArray type.
+                    dependencyList.Add(factory.ConstructedTypeSymbol(arrayType.ElementType.MakeArrayType()), "Rank 1 array");
+                }
             }
 
             dependencyList.Add(factory.VTable(_type), "VTable");

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ArrayHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ArrayHelpers.cs
@@ -41,13 +41,6 @@ namespace Internal.Runtime.CompilerHelpers
 
                 return ret;
             }
-            else if (nDimensions == 1)
-            {
-                // Multidimensional array of rank 1 with 0 lower bounds gets actually allocated
-                // as an SzArray. SzArray is castable to MdArray rank 1.
-                RuntimeTypeHandle elementTypeHandle = new RuntimeTypeHandle(eeType.ArrayElementType);
-                return Array.CreateInstance(Type.GetTypeFromHandle(elementTypeHandle), pDimensions[0]);
-            }
             else
             {
                 // Multidimensional arrays have two ctors, one with and one without lower bounds
@@ -63,6 +56,21 @@ namespace Internal.Runtime.CompilerHelpers
 
                         pDimensions[i] = pDimensions[2 * i + 1];
                     }
+                }
+
+                if (rank == 1)
+                {
+                    // Multidimensional array of rank 1 with 0 lower bounds gets actually allocated
+                    // as an SzArray. SzArray is castable to MdArray rank 1.
+                    int length = pDimensions[0];
+                    if (length < 0)
+                    {
+                        // Compat: we need to throw OverflowException. Array.CreateInstance would throw ArgumentOutOfRange
+                        throw new OverflowException();
+                    }
+
+                    RuntimeTypeHandle elementTypeHandle = new RuntimeTypeHandle(eeType.ArrayElementType);
+                    return Array.CreateInstance(Type.GetTypeFromHandle(elementTypeHandle), length);
                 }
 
                 return Array.NewMultiDimArray(eeType, pDimensions, rank);


### PR DESCRIPTION
* Make calling Rank 1 MdArray ctor more reliable. This is not a great
fix (great fix would be one of the two options I enumerated in #3610),
but at least makes the problem go away. It's unlikely anyone is going to
use this anyway.
* Fix exception types we throw.