### PR TITLE
Cache HasFinalizer

### DIFF
--- a/src/Common/src/TypeSystem/Canon/CanonTypes.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.cs
@@ -123,6 +123,8 @@ namespace Internal.TypeSystem
                 flags |= TypeFlags.HasGenericVarianceComputed;
             }
 
+            flags |= TypeFlags.HasFinalizerComputed;
+
             return flags;
         }
 
@@ -210,6 +212,8 @@ namespace Internal.TypeSystem
                 // It's the closest logical thing and avoids special casing around it.
                 flags |= TypeFlags.ValueType;
             }
+
+            flags |= TypeFlags.HasFinalizerComputed;
 
             return flags;
         }

--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -143,6 +143,8 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasGenericVarianceComputed;
 
+            flags |= TypeFlags.HasFinalizerComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/ByRefType.cs
+++ b/src/Common/src/TypeSystem/Common/ByRefType.cs
@@ -35,6 +35,8 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasGenericVarianceComputed;
 
+            flags |= TypeFlags.HasFinalizerComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
+++ b/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
@@ -65,6 +65,8 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasGenericVarianceComputed;
 
+            flags |= TypeFlags.HasFinalizerComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -96,6 +96,14 @@ namespace Internal.TypeSystem
                     flags |= TypeFlags.HasGenericVariance;
             }
 
+            if ((mask & TypeFlags.HasFinalizerComputed) != 0)
+            {
+                flags |= TypeFlags.HasFinalizerComputed;
+
+                if (_typeDef.HasFinalizer)
+                    flags |= TypeFlags.HasFinalizer;
+            }
+
             return flags;
         }
 
@@ -174,14 +182,6 @@ namespace Internal.TypeSystem
             {
                 Debug.Assert(typeInHierarchy is InstantiatedType);
                 return _typeDef.Context.GetMethodForInstantiatedType(typicalFinalizer.GetTypicalMethodDefinition(), (InstantiatedType)typeInHierarchy);
-            }
-        }
-
-        public override bool HasFinalizer
-        {
-            get
-            {
-                return _typeDef.HasFinalizer;
             }
         }
 

--- a/src/Common/src/TypeSystem/Common/MetadataType.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.cs
@@ -12,14 +12,6 @@ namespace Internal.TypeSystem
     /// </summary>
     public abstract partial class MetadataType : DefType
     {
-        public override bool HasFinalizer
-        {
-            get
-            {
-                return GetFinalizer() != null;
-            }
-        }
-
         public abstract override string Name { get; }
 
         public abstract override string Namespace { get; }

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -454,7 +454,9 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return OwningType.GetFinalizer() == this || OwningType.IsObject && Name == "Finalize";
+                TypeDesc owningType = OwningType;
+                return owningType.HasFinalizer && 
+                    (owningType.GetFinalizer() == this || owningType.IsObject && Name == "Finalize");
             }
         }
 

--- a/src/Common/src/TypeSystem/Common/PointerType.cs
+++ b/src/Common/src/TypeSystem/Common/PointerType.cs
@@ -34,6 +34,7 @@ namespace Internal.TypeSystem
             TypeFlags flags = TypeFlags.Pointer;
 
             flags |= TypeFlags.HasGenericVarianceComputed;
+            flags |= TypeFlags.HasFinalizerComputed;
 
             return flags;
         }

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -577,11 +577,11 @@ namespace Internal.TypeSystem
         /// Gets a value indicating whether this type has a finalizer method.
         /// Use <see cref="GetFinalizer"/> to retrieve the method.
         /// </summary>
-        public virtual bool HasFinalizer
+        public bool HasFinalizer
         {
             get
             {
-                return false;
+                return (GetTypeFlags(TypeFlags.HasFinalizer | TypeFlags.HasFinalizerComputed) & TypeFlags.HasFinalizer) != 0;
             }
         }
 

--- a/src/Common/src/TypeSystem/Common/TypeFlags.cs
+++ b/src/Common/src/TypeSystem/Common/TypeFlags.cs
@@ -53,5 +53,8 @@ namespace Internal.TypeSystem
 
         HasStaticConstructor         = 0x400,
         HasStaticConstructorComputed = 0x800,
+
+        HasFinalizerComputed = 0x1000,
+        HasFinalizer         = 0x2000,
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -233,6 +233,14 @@ namespace Internal.TypeSystem.Ecma
                 }
             }
 
+            if ((mask & TypeFlags.HasFinalizerComputed) != 0)
+            {
+                flags |= TypeFlags.HasFinalizerComputed;
+
+                if (GetFinalizer() != null)
+                    flags |= TypeFlags.HasFinalizer;
+            }
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -218,6 +218,8 @@ namespace Internal.TypeSystem.Interop
                 flags |= TypeFlags.ValueType;
             }
 
+            flags |= TypeFlags.HasFinalizerComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
@@ -282,6 +282,8 @@ namespace Internal.TypeSystem.Interop
                 flags |= TypeFlags.ValueType;
             }
 
+            flags |= TypeFlags.HasFinalizerComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
@@ -203,6 +203,8 @@ namespace Internal.TypeSystem.Interop
                 flags |= TypeFlags.Class;
             }
 
+            flags |= TypeFlags.HasFinalizerComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
@@ -279,6 +279,14 @@ namespace Internal.TypeSystem.NativeFormat
                 }
             }
 
+            if ((mask & TypeFlags.HasFinalizerComputed) != 0)
+            {
+                flags |= TypeFlags.HasFinalizerComputed;
+
+                if (GetFinalizer() != null)
+                    flags |= TypeFlags.HasFinalizer;
+            }
+
             return flags;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedType.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedType.cs
@@ -76,7 +76,8 @@ namespace ILCompiler
         {
             return TypeFlags.Class |
                 TypeFlags.HasGenericVarianceComputed |
-                TypeFlags.HasStaticConstructorComputed;
+                TypeFlags.HasStaticConstructorComputed |
+                TypeFlags.HasFinalizerComputed;
         }
 
         public override ClassLayoutMetadata GetClassLayout()

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -267,6 +267,8 @@ namespace ILCompiler
                     flags |= TypeFlags.Class;
                 }
 
+                flags |= TypeFlags.HasFinalizerComputed;
+
                 return flags;
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -484,10 +484,9 @@ namespace ILCompiler.DependencyAnalysis
 
         private void OutputFinalizerMethod(NodeFactory factory, ref ObjectDataBuilder objData)
         {
-            MethodDesc finalizerMethod = _type.GetFinalizer();
-
-            if (finalizerMethod != null)
+            if (_type.HasFinalizer)
             {
+                MethodDesc finalizerMethod = _type.GetFinalizer();
                 MethodDesc canonFinalizerMethod = finalizerMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
                 objData.EmitPointerReloc(factory.MethodEntrypoint(canonFinalizerMethod));
             }


### PR DESCRIPTION
With some changes I have in flight `GetFinalizer` in compiler traces
went from "might be worth looking into making this faster" to "we spend
15% of compilation time here".

The answer to `HasFinalizer` is cheap to cache and reduces the pressure
on `GetFinalizer` significantly.