### PR TITLE
Delete reflection workaround in ShadowConcreteMethod

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -28,7 +28,8 @@ namespace ILCompiler.DependencyAnalysis
                 if (dependencies == null)
                     dependencies = new DependencyList();
 
-                if (factory.MetadataManager.HasReflectionInvokeStubForInvokableMethod(method) && !method.IsCanonicalMethod(CanonicalFormKind.Any) /* Shared generics handled in the shadow concrete method node */)
+                if (factory.MetadataManager.HasReflectionInvokeStubForInvokableMethod(method)
+                    && (factory.Target.Abi != TargetAbi.ProjectN) || !method.IsCanonicalMethod(CanonicalFormKind.Any))
                 {
                     MethodDesc canonInvokeStub = factory.MetadataManager.GetCanonicalReflectionInvokeStub(method);
                     if (canonInvokeStub.IsSharedByGenericInstantiations)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -78,26 +78,6 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            if (factory.Target.Abi == TargetAbi.CoreRT)
-            {
-                // TODO: https://github.com/dotnet/corert/issues/3224
-                // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
-                // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
-                // we even start the compilation process (with the invocation stubs being compilation roots like any other).
-                // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
-                if (factory.MetadataManager.HasReflectionInvokeStub(Method))
-                {
-                    MethodDesc canonInvokeStub = factory.MetadataManager.GetCanonicalReflectionInvokeStub(Method);
-                    if (canonInvokeStub.IsSharedByGenericInstantiations)
-                    {
-                        dependencies.Add(new DependencyListEntry(factory.MetadataManager.DynamicInvokeTemplateData, "Reflection invoke template data"));
-                        factory.MetadataManager.DynamicInvokeTemplateData.AddDependenciesDueToInvokeTemplatePresence(ref dependencies, factory, canonInvokeStub);
-                    }
-                    else
-                        dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(canonInvokeStub), "Reflection invoke"));
-                }
-            }
-
             if (Method.HasInstantiation)
             {
                 if (Method.IsVirtual)


### PR DESCRIPTION
This was needed when we weren't using the type loader to load invoke
stub dictionaries. This hasn't been needed for months.