### PR TITLE
Report Span/ReadOnlySpan intrinsics to RyuJIT

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
+++ b/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
@@ -124,8 +124,8 @@ namespace Internal.JitInterface
             // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetManagedThreadId, "get_ManagedThreadId", "System", "Thread"); // not in .NET Core
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Ctor, ".ctor", "System", "ByReference`1");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Value, "get_Value", "System", "ByReference`1");
-            // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_Span_GetItem, "get_Item", "System", "Span`1"); // not handled
-            // table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_ReadOnlySpan_GetItem, "get_Item", "System", "ReadOnlySpan`1"); // not handled
+            table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_Span_GetItem, "get_Item", "System", "Span`1"); // not handled
+            table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_ReadOnlySpan_GetItem, "get_Item", "System", "ReadOnlySpan`1"); // not handled
 
             // If this assert fails, make sure to add the new intrinsics to the table above and update the expected count below.
             Debug.Assert((int)CorInfoIntrinsics.CORINFO_INTRINSIC_Count == 49);

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2966,6 +2966,20 @@ namespace Internal.JitInterface
 
             pResult.methodFlags = getMethodAttribsInternal(targetMethod);
             Get_CORINFO_SIG_INFO(targetMethod, out pResult.sig, targetIsFatFunctionPointer);
+            if (targetMethod.IsIntrinsic)
+            {
+                // We only populate sigInst for intrinsic methods because most of the time,
+                // JIT doesn't care what the instantiation is and this is expensive.
+                Instantiation owningTypeInst = targetMethod.OwningType.Instantiation;
+                pResult.sig.sigInst.classInstCount = (uint)owningTypeInst.Length;
+                if (owningTypeInst.Length > 0)
+                {
+                    var classInst = new IntPtr[owningTypeInst.Length];
+                    for (int i = 0; i < owningTypeInst.Length; i++)
+                        classInst[i] = (IntPtr)ObjectToHandle(owningTypeInst[i]);
+                    pResult.sig.sigInst.classInst = (CORINFO_CLASS_STRUCT_**)GetPin(classInst);
+                }
+            }
 
             if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_VERIFICATION) != 0)
             {

--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.cs
@@ -174,6 +174,9 @@ namespace System
                 return Unsafe.Add(ref _pointer.Value, index);
             }
 #else
+#if CORERT
+            [Intrinsic]
+#endif
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {

--- a/src/System.Private.CoreLib/shared/System/Span.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.cs
@@ -189,6 +189,9 @@ namespace System
                 return ref Unsafe.Add(ref _pointer.Value, index);
             }
 #else
+#if CORERT
+            [Intrinsic]
+#endif
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {


### PR DESCRIPTION
This lets RyuJIT optimize range checks on Span same way as it does for
arrays.

* Annotate the intrinsics
* Uncomment them in the table
* Report `sigInst` for all intrinsics