### PR TITLE
Fix getClassAlignmentRequirement for arm 32-bit architectures

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1133,7 +1133,10 @@ namespace Internal.JitInterface
         }
 
         private uint getClassAlignmentRequirement(CORINFO_CLASS_STRUCT_* cls, bool fDoubleAlignHint)
-        { throw new NotImplementedException("getClassAlignmentRequirement"); }
+        {
+            DefType type = (DefType)HandleToObject(cls);
+            return (uint)type.InstanceByteAlignment.AsInt;
+        }
 
         private int GatherClassGCLayout(TypeDesc type, byte* gcPtrs)
         {


### PR DESCRIPTION
This change need due to crash on 32-bit ARM architectures.

Backtrace:
```
Unhandled Exception: System.NotImplementedException: getClassAlignmentRequirement
at Internal.JitInterface.CorInfoImpl.getClassAlignmentRequirement(CORINFO_CLASS_STRUCT_* cls, Boolean fDoubleAlignHint)
at Internal.JitInterface.CorInfoImpl._getClassAlignmentRequirement(IntPtr thisHandle, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, Boolean fDoubleAlignHint)
--- End of stack trace from previous location where exception was thrown ---
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at Internal.JitInterface.CorInfoImpl.CompileMethod(IMethodCodeNode methodCodeNodeNeedingCode, MethodIL methodIL)
at ILCompiler.RyuJitCompilation.ComputeDependencyNodeDependencies(List`1 obj)
at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.ComputeDependencies(List`1 deferredStaticDependencies)
at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.ComputeMarkedNodes()
at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.get_MarkedNodeList()
at ILCompiler.RyuJitCompilation.CompileInternal(String outputFile, ObjectDumper dumper)
at ILCompiler.Compilation.ILCompiler.ICompilation.Compile(String outputFile, ObjectDumper dumper)
at ILCompiler.Program.Run(String[] args)
at ILCompiler.Program.Main(String[] args)
```

Signed-off-by: UIDL YGEN <uidlygen@yandex.ru>