### PR TITLE
Replace some runtime asserts with better type declarations.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -148,7 +148,7 @@ namespace System.Reflection.Runtime.MethodInfos
     //-----------------------------------------------------------------------------------------------------------
     internal sealed partial class RuntimeSyntheticConstructorInfo : RuntimeConstructorInfo
     {
-        internal static RuntimeSyntheticConstructorInfo GetRuntimeSyntheticConstructorInfo(SyntheticMethodId syntheticMethodId, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypes, InvokerOptions options, Func<Object, Object[], Object> invoker)
+        internal static RuntimeSyntheticConstructorInfo GetRuntimeSyntheticConstructorInfo(SyntheticMethodId syntheticMethodId, RuntimeArrayTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypes, InvokerOptions options, Func<Object, Object[], Object> invoker)
         {
             return new RuntimeSyntheticConstructorInfo(syntheticMethodId, declaringType, runtimeParameterTypes, options, invoker);
         }
@@ -194,7 +194,7 @@ namespace System.Reflection.Runtime.MethodInfos
     //-----------------------------------------------------------------------------------------------------------
     internal sealed partial class RuntimeSyntheticMethodInfo : RuntimeMethodInfo
     {
-        internal static RuntimeMethodInfo GetRuntimeSyntheticMethodInfo(SyntheticMethodId syntheticMethodId, String name, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypes, RuntimeTypeInfo returnType, InvokerOptions options, Func<Object, Object[], Object> invoker)
+        internal static RuntimeMethodInfo GetRuntimeSyntheticMethodInfo(SyntheticMethodId syntheticMethodId, String name, RuntimeArrayTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypes, RuntimeTypeInfo returnType, InvokerOptions options, Func<Object, Object[], Object> invoker)
         {
             return new RuntimeSyntheticMethodInfo(syntheticMethodId, name, declaringType, runtimeParameterTypes, returnType, options, invoker).WithDebugName();
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.Ecma.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.Ecma.cs
@@ -41,7 +41,7 @@ namespace System.Reflection.Runtime.General
     internal static partial class TypeUnifier
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static RuntimeTypeInfo GetNamedType(this TypeDefinitionHandle typeDefinitionHandle, MetadataReader reader)
+        public static RuntimeTypeDefinitionTypeInfo GetNamedType(this TypeDefinitionHandle typeDefinitionHandle, MetadataReader reader)
         {
             return typeDefinitionHandle.GetNamedType(reader, default(RuntimeTypeHandle));
         }
@@ -52,7 +52,7 @@ namespace System.Reflection.Runtime.General
         // waste cycles looking up the handle again from the mapping tables.)
         //======================================================================================================
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static RuntimeTypeInfo GetNamedType(this TypeDefinitionHandle typeDefinitionHandle, MetadataReader reader, RuntimeTypeHandle precomputedTypeHandle)
+        public static RuntimeTypeDefinitionTypeInfo GetNamedType(this TypeDefinitionHandle typeDefinitionHandle, MetadataReader reader, RuntimeTypeHandle precomputedTypeHandle)
         {
             return EcmaFormatRuntimeNamedTypeInfo.GetRuntimeNamedTypeInfo(reader, typeDefinitionHandle, precomputedTypeHandle: precomputedTypeHandle);
         }
@@ -113,7 +113,7 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
         {
             protected sealed override EcmaFormatRuntimeGenericParameterTypeInfoForTypes Factory(UnificationKey key)
             {
-                RuntimeTypeInfo typeOwner = key.TypeDefinitionHandle.GetNamedType(key.Reader);
+                RuntimeTypeDefinitionTypeInfo typeOwner = key.TypeDefinitionHandle.GetNamedType(key.Reader);
                 return new EcmaFormatRuntimeGenericParameterTypeInfoForTypes(key.Reader, key.GenericParameterHandle, typeOwner);
             }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.NativeFormat.cs
@@ -40,7 +40,7 @@ namespace System.Reflection.Runtime.General
     internal static partial class TypeUnifier
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static RuntimeTypeInfo GetNamedType(this TypeDefinitionHandle typeDefinitionHandle, MetadataReader reader)
+        public static RuntimeTypeDefinitionTypeInfo GetNamedType(this TypeDefinitionHandle typeDefinitionHandle, MetadataReader reader)
         {
             return typeDefinitionHandle.GetNamedType(reader, default(RuntimeTypeHandle));
         }
@@ -51,7 +51,7 @@ namespace System.Reflection.Runtime.General
         // waste cycles looking up the handle again from the mapping tables.)
         //======================================================================================================
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static RuntimeTypeInfo GetNamedType(this TypeDefinitionHandle typeDefinitionHandle, MetadataReader reader, RuntimeTypeHandle precomputedTypeHandle)
+        public static RuntimeTypeDefinitionTypeInfo GetNamedType(this TypeDefinitionHandle typeDefinitionHandle, MetadataReader reader, RuntimeTypeHandle precomputedTypeHandle)
         {
             return NativeFormatRuntimeNamedTypeInfo.GetRuntimeNamedTypeInfo(reader, typeDefinitionHandle, precomputedTypeHandle: precomputedTypeHandle);
         }
@@ -112,7 +112,7 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
         {
             protected sealed override NativeFormatRuntimeGenericParameterTypeInfoForTypes Factory(UnificationKey key)
             {
-                RuntimeTypeInfo typeOwner = key.TypeDefinitionHandle.GetNamedType(key.Reader);
+                RuntimeTypeDefinitionTypeInfo typeOwner = key.TypeDefinitionHandle.GetNamedType(key.Reader);
                 return new NativeFormatRuntimeGenericParameterTypeInfoForTypes(key.Reader, key.GenericParameterHandle, typeOwner);
             }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
@@ -20,10 +20,8 @@ namespace System.Reflection.Runtime.MethodInfos
     //
     internal sealed partial class RuntimeSyntheticConstructorInfo : RuntimeConstructorInfo, IRuntimeMemberInfoWithNoMetadataDefinition
     {
-        private RuntimeSyntheticConstructorInfo(SyntheticMethodId syntheticMethodId, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypes, InvokerOptions options, Func<Object, Object[], Object> invoker)
+        private RuntimeSyntheticConstructorInfo(SyntheticMethodId syntheticMethodId, RuntimeArrayTypeInfo declaringType, RuntimeTypeInfo[] runtimeParameterTypes, InvokerOptions options, Func<Object, Object[], Object> invoker)
         {
-            Debug.Assert(declaringType.IsArray);
-
             _syntheticMethodId = syntheticMethodId;
             _declaringType = declaringType;
             _options = options;
@@ -185,7 +183,7 @@ namespace System.Reflection.Runtime.MethodInfos
         private volatile RuntimeParameterInfo[] _lazyParameters;
 
         private readonly SyntheticMethodId _syntheticMethodId;
-        private readonly RuntimeTypeInfo _declaringType;
+        private readonly RuntimeArrayTypeInfo _declaringType;
         private readonly RuntimeTypeInfo[] _runtimeParameterTypes;
         private readonly InvokerOptions _options;
         private readonly Func<Object, Object[], Object> _invoker;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
@@ -19,10 +19,8 @@ namespace System.Reflection.Runtime.MethodInfos
     //
     internal sealed partial class RuntimeSyntheticMethodInfo : RuntimeMethodInfo, IRuntimeMemberInfoWithNoMetadataDefinition
     {
-        private RuntimeSyntheticMethodInfo(SyntheticMethodId syntheticMethodId, String name, RuntimeTypeInfo declaringType, RuntimeTypeInfo[] parameterTypes, RuntimeTypeInfo returnType, InvokerOptions options, Func<Object, Object[], Object> invoker)
+        private RuntimeSyntheticMethodInfo(SyntheticMethodId syntheticMethodId, String name, RuntimeArrayTypeInfo declaringType, RuntimeTypeInfo[] parameterTypes, RuntimeTypeInfo returnType, InvokerOptions options, Func<Object, Object[], Object> invoker)
         {
-            Debug.Assert(declaringType.IsArray);
-
             _syntheticMethodId = syntheticMethodId;
             _name = name;
             _declaringType = declaringType;
@@ -234,7 +232,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
         private readonly String _name;
         private readonly SyntheticMethodId _syntheticMethodId;
-        private readonly RuntimeTypeInfo _declaringType;
+        private readonly RuntimeArrayTypeInfo _declaringType;
         private readonly RuntimeTypeInfo[] _runtimeParameterTypes;
         private readonly RuntimeTypeInfo _returnType;
         private readonly InvokerOptions _options;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeGenericParameterTypeInfoForMethods.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeGenericParameterTypeInfoForMethods.cs
@@ -23,6 +23,7 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
         private EcmaFormatRuntimeGenericParameterTypeInfoForMethods(MetadataReader reader, GenericParameterHandle genericParameterHandle, RuntimeNamedMethodInfo declaringRuntimeNamedMethodInfo)
            : base(reader, genericParameterHandle, reader.GetGenericParameter(genericParameterHandle))
         {
+            Debug.Assert(declaringRuntimeNamedMethodInfo.DeclaringType.IsTypeDefinition);
             _declaringRuntimeNamedMethodInfo = declaringRuntimeNamedMethodInfo;
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeGenericParameterTypeInfoForTypes.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeGenericParameterTypeInfoForTypes.cs
@@ -17,10 +17,10 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
 {
     internal sealed partial class EcmaFormatRuntimeGenericParameterTypeInfoForTypes : EcmaFormatRuntimeGenericParameterTypeInfo
     {
-        private EcmaFormatRuntimeGenericParameterTypeInfoForTypes(MetadataReader reader, GenericParameterHandle genericParameterHandle, RuntimeTypeInfo declaringRuntimeNamedTypeInfo)
+        private EcmaFormatRuntimeGenericParameterTypeInfoForTypes(MetadataReader reader, GenericParameterHandle genericParameterHandle, RuntimeTypeDefinitionTypeInfo declaringType)
            : base(reader, genericParameterHandle, reader.GetGenericParameter(genericParameterHandle))
         {
-            _declaringRuntimeNamedTypeInfo = declaringRuntimeNamedTypeInfo;
+            _declaringType = declaringType;
         }
 
         public sealed override MethodBase DeclaringMethod
@@ -39,7 +39,7 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
         {
             get
             {
-                return _declaringRuntimeNamedTypeInfo;
+                return _declaringType;
             }
         }
 
@@ -47,11 +47,11 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
         {
             get
             {
-                return _declaringRuntimeNamedTypeInfo.TypeContext;
+                return _declaringType.TypeContext;
             }
         }
 
-        private readonly RuntimeTypeInfo _declaringRuntimeNamedTypeInfo;
+        private readonly RuntimeTypeDefinitionTypeInfo _declaringType;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfoForMethods.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfoForMethods.cs
@@ -23,6 +23,7 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
         private NativeFormatRuntimeGenericParameterTypeInfoForMethods(MetadataReader reader, GenericParameterHandle genericParameterHandle, RuntimeNamedMethodInfo declaringRuntimeNamedMethodInfo)
            : base(reader, genericParameterHandle, genericParameterHandle.GetGenericParameter(reader))
         {
+            Debug.Assert(declaringRuntimeNamedMethodInfo.DeclaringType.IsTypeDefinition);
             _declaringRuntimeNamedMethodInfo = declaringRuntimeNamedMethodInfo;
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfoForTypes.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfoForTypes.cs
@@ -17,11 +17,10 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
 {
     internal sealed partial class NativeFormatRuntimeGenericParameterTypeInfoForTypes : NativeFormatRuntimeGenericParameterTypeInfo
     {
-        private NativeFormatRuntimeGenericParameterTypeInfoForTypes(MetadataReader reader, GenericParameterHandle genericParameterHandle, RuntimeTypeInfo declaringRuntimeNamedTypeInfo)
+        private NativeFormatRuntimeGenericParameterTypeInfoForTypes(MetadataReader reader, GenericParameterHandle genericParameterHandle, RuntimeTypeDefinitionTypeInfo declaringType)
            : base(reader, genericParameterHandle, genericParameterHandle.GetGenericParameter(reader))
         {
-            Debug.Assert(declaringRuntimeNamedTypeInfo.IsTypeDefinition);
-            _declaringRuntimeNamedTypeInfo = declaringRuntimeNamedTypeInfo;
+            _declaringType = declaringType;
         }
 
         public sealed override MethodBase DeclaringMethod
@@ -40,7 +39,7 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
         {
             get
             {
-                return _declaringRuntimeNamedTypeInfo;
+                return _declaringType;
             }
         }
 
@@ -48,11 +47,11 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
         {
             get
             {
-                return _declaringRuntimeNamedTypeInfo.TypeContext;
+                return _declaringType.TypeContext;
             }
         }
 
-        private readonly RuntimeTypeInfo _declaringRuntimeNamedTypeInfo;
+        private readonly RuntimeTypeDefinitionTypeInfo _declaringType;
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeArrayTypeInfo.cs
@@ -51,7 +51,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 bool multiDim = this.IsVariableBoundArray;
                 int rank = this.GetArrayRank();
 
-                RuntimeTypeInfo arrayType = this;
+                RuntimeArrayTypeInfo arrayType = this;
                 RuntimeTypeInfo countType = CommonRuntimeTypes.Int32.CastToRuntimeTypeInfo();
 
                 {
@@ -170,7 +170,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 int rank = this.GetArrayRank();
 
                 RuntimeTypeInfo indexType = CommonRuntimeTypes.Int32.CastToRuntimeTypeInfo();
-                RuntimeTypeInfo arrayType = this;
+                RuntimeArrayTypeInfo arrayType = this;
                 RuntimeTypeInfo elementType = arrayType.InternalRuntimeElementType;
                 RuntimeTypeInfo voidType = CommonRuntimeTypes.Void.CastToRuntimeTypeInfo();
 


### PR DESCRIPTION
The prior commit added some runtime assertions for
conditions that we were taking new dependencies on.

This commits replaces those assertions with more
specific type declarations so all this can be enforced
at compile-time.