### PR TITLE
Fix System.Security.SecureString tests on ILC

### DIFF
--- a/src/System.Private.Interop/src/System.Private.Interop.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.csproj
@@ -234,6 +234,12 @@
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\WriteOnlyArrayAttribute.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(IsProjectKLibrary)' != 'true'">
+    <Compile Include="..\..\System.Private.CoreLib\shared\Interop\Windows\Interop.Libraries.cs">
+      <Link>Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="..\..\System.Private.CoreLib\shared\Interop\Windows\Kernel32\Interop.WideCharToMultiByte.cs">
+      <Link>Interop\Windows\Kernel32\Interop.WideCharToMultiByte.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.MemAllocFree.cs">
       <Link>Interop\Windows\mincore\Interop.MemAllocFree.cs</Link>
     </Compile>

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
@@ -78,7 +78,7 @@ namespace System.Runtime.InteropServices
                 }
                 else
                 {
-                    return ConvertToUnicode(ptr, nb);
+                    return new string((sbyte*)ptr);
                 }
             }
         }
@@ -656,7 +656,7 @@ namespace System.Runtime.InteropServices
             fixed (char* pch = source)
             {
                 int convertedBytes =
-                    PInvokeMarshal.ConvertWideCharToMultiByte(pch, source.Length, (byte*)pbNativeBuffer, cbNativeBuffer);
+                    PInvokeMarshal.ConvertWideCharToMultiByte(pch, source.Length, (byte*)pbNativeBuffer, cbNativeBuffer, Interop.Kernel32.WC_NO_BEST_FIT_CHARS, IntPtr.Zero);
                 ((byte*)pbNativeBuffer)[convertedBytes] = 0;
             }
         }


### PR DESCRIPTION
Make Marshal.PtrToStringAnsi() and StringToCoTaskMemAnsi()
and StringToHGlobalAnsi() work the same way CoreCLR/Desktop
does.