### PR TITLE
Fix ResourceSet case insensitive get operation.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Resources/ResourceSet.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ResourceSet.cs
@@ -243,8 +243,9 @@ namespace System.Resources
 
             if (copyOfTable == null)
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_ResourceSet);
-
-            return copyOfTable[name];
+            object value;
+            copyOfTable.TryGetValue(name, out value);
+            return value;
         }
 
         private Object GetCaseInsensitiveObjectInternal(String name)
@@ -266,8 +267,9 @@ namespace System.Resources
                 }
                 _caseInsensitiveTable = caseTable;
             }
-
-            return caseTable[name];
+            object value;
+            caseTable.TryGetValue(name, out value);
+            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
Case insensitive get operation throw
KeyNotFoundException since the underlying
implemention use Dictonery instead of
HashTable.
var set = GetSet(StaticResources.WithData);
// this succeed
set.GetString("String"));
// this is supposed to work,but throws
// KeyNotFound
set.GetString("string", true));