### PR TITLE
update ObjectWriter

### DIFF
--- a/src/packaging/packages.targets
+++ b/src/packaging/packages.targets
@@ -32,7 +32,7 @@
 
             <MicrosoftNetCoreNativePackageVersion>2.0.0-beta-25021-03</MicrosoftNetCoreNativePackageVersion>
 
-            <ObjectWriterPackageVersion>1.0.18-prerelease-00001</ObjectWriterPackageVersion>
+            <ObjectWriterPackageVersion>1.0.18-prerelease-00002</ObjectWriterPackageVersion>
             <ObjectWriterNuPkgRid Condition="'$(OSGroup)'=='Linux'">ubuntu.14.04-x64</ObjectWriterNuPkgRid>
             <ObjectWriterNuPkgRid Condition="'$(ObjectWriterNuPkgRid)'==''">$(NuPkgRid)</ObjectWriterNuPkgRid>
         </PropertyGroup>

--- a/src/packaging/project.json
+++ b/src/packaging/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Jit": "2.1.0-preview1-25324-01",
-    "Microsoft.DotNet.ObjectWriter": "1.0.18-prerelease-00001"
+    "Microsoft.DotNet.ObjectWriter": "1.0.18-prerelease-00002"
   },
   "frameworks": {
     "dnxcore50": { }


### PR DESCRIPTION
add S_UDT symbols to the object file for all user defined types with names (enum, class, array).
The linker uses this symbols to mark live types.
It fixes #3538.