### PR TITLE
Make Module.Name work off metadata.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -9,6 +9,9 @@ using System.Runtime.Serialization;
 using System.Reflection.Runtime.Assemblies;
 using System.Collections.Generic;
 
+using Internal.Metadata.NativeFormat;
+using System.Reflection.Runtime.Assemblies.NativeFormat;
+
 namespace System.Reflection.Runtime.Modules
 {
     //
@@ -54,6 +57,13 @@ namespace System.Reflection.Runtime.Modules
         {
             get
             {
+                NativeFormatRuntimeAssembly nativeAssembly = Assembly as NativeFormatRuntimeAssembly;
+                if (nativeAssembly != null)
+                {
+                    string name = nativeAssembly.Scope.ScopeDefinition.ModuleName.GetConstantStringValue(nativeAssembly.Scope.Reader).Value;
+                    if (name != null)
+                        return name;
+                }
                 return this.Assembly.GetName().Name;
             }
         }


### PR DESCRIPTION
This is a quick and dirty version to
unblock ConfigurationManager bringup
as fast as possible.

Will do a proper Ecma/Native refactoring
when I have more time.