### PR TITLE
Split RuntimeModule into Ecma/Native flavors the proper way.

### DIFF
--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -45,6 +45,7 @@
     <Compile Include="System\Reflection\Runtime\EventInfos\EcmaFormat\EcmaFormatRuntimeEventInfo.cs" />
     <Compile Include="System\Reflection\Runtime\FieldInfos\EcmaFormat\EcmaFormatRuntimeFieldInfo.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\EcmaFormat\EcmaFormatMethodCommon.cs" />
+    <Compile Include="System\Reflection\Runtime\Modules\EcmaFormat\EcmaFormatRuntimeModule.cs" />
     <Compile Include="System\Reflection\Runtime\ParameterInfos\EcmaFormat\EcmaFormatMethodParameterInfo.cs" />
     <Compile Include="System\Reflection\Runtime\PropertyInfos\EcmaFormat\EcmaFormatRuntimePropertyInfo.cs" />
     <Compile Include="System\Reflection\Runtime\TypeInfos\EcmaFormat\EcmaFormatRuntimeGenericParameterTypeInfo.cs" />
@@ -144,6 +145,7 @@
     <Compile Include="System\Reflection\Runtime\MethodInfos\SyntheticMethodId.cs" />
     <Compile Include="System\Reflection\Runtime\MethodInfos\VirtualRuntimeParameterInfoArray.cs" />
     <Compile Include="System\Reflection\Runtime\Modules\RuntimeModule.cs" />
+    <Compile Include="System\Reflection\Runtime\Modules\NativeFormat\NativeFormatRuntimeModule.cs" />
     <Compile Include="System\Reflection\Runtime\ParameterInfos\NativeFormat\NativeFormatMethodParameterInfo.cs" />
     <Compile Include="System\Reflection\Runtime\ParameterInfos\RuntimeMethodParameterInfo.cs" />
     <Compile Include="System\Reflection\Runtime\ParameterInfos\RuntimeParameterInfo.cs" />

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/EcmaFormat/EcmaFormatRuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/EcmaFormat/EcmaFormatRuntimeAssembly.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.Modules;
+using System.Reflection.Runtime.Modules.EcmaFormat;
 using System.Reflection.Runtime.MethodInfos;
 using System.Reflection.Runtime.MethodInfos.EcmaFormat;
 using System.Reflection.Runtime.TypeInfos;
@@ -228,6 +229,14 @@ namespace System.Reflection.Runtime.Assemblies.EcmaFormat
                     // TODO Implement linked resources, when FileStream, and CodeBase are fully implemented
                     throw new NotImplementedException();
                 }
+            }
+        }
+
+        public sealed override Module ManifestModule
+        {
+            get
+            {
+                return EcmaFormatRuntimeModule.GetRuntimeModule(this);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.cs
@@ -11,6 +11,7 @@ using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.MethodInfos;
 using System.Reflection.Runtime.MethodInfos.NativeFormat;
 using System.Reflection.Runtime.Modules;
+using System.Reflection.Runtime.Modules.NativeFormat;
 using System.Reflection.Runtime.TypeInfos;
 using System.Reflection.Runtime.TypeInfos.NativeFormat;
 using System.Reflection.Runtime.TypeParsing;
@@ -20,7 +21,6 @@ using System.Collections.Generic;
 using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
 using Internal.Metadata.NativeFormat;
-
 using Internal.Reflection.Tracing;
 
 namespace System.Reflection.Runtime.Assemblies.NativeFormat
@@ -133,6 +133,14 @@ namespace System.Reflection.Runtime.Assemblies.NativeFormat
         public sealed override Stream GetManifestResourceStream(String name)
         {
             return ReflectionCoreExecution.ExecutionEnvironment.GetManifestResourceStream(this, name);
+        }
+
+        public sealed override Module ManifestModule
+        {
+            get
+            {
+                return NativeFormatRuntimeModule.GetRuntimeModule(this);
+            }
         }
 
         internal sealed override RuntimeAssemblyName RuntimeAssemblyName

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
@@ -59,13 +59,7 @@ namespace System.Reflection.Runtime.Assemblies
             UnitySerializationHolder.GetUnitySerializationInfo(info, UnitySerializationHolder.AssemblyUnity, FullName, this);
         }
 
-        public sealed override Module ManifestModule
-        {
-            get
-            {
-                return RuntimeModule.GetRuntimeModule(this);
-            }
-        }
+        public abstract override Module ManifestModule { get; }
 
         public sealed override IEnumerable<Module> Modules
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.Ecma.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.Ecma.cs
@@ -104,6 +104,21 @@ namespace System.Reflection.Runtime.FieldInfos.EcmaFormat
     }
 }
 
+namespace System.Reflection.Runtime.Modules.EcmaFormat
+{
+    //-----------------------------------------------------------------------------------------------------------
+    // Modules (these exist only because Modules still exist in the Win8P surface area. There is a 1-1
+    //          mapping between Assemblies and Modules.)
+    //-----------------------------------------------------------------------------------------------------------
+    internal sealed partial class EcmaFormatRuntimeModule
+    {
+        internal static RuntimeModule GetRuntimeModule(EcmaFormatRuntimeAssembly assembly)
+        {
+            return new EcmaFormatRuntimeModule(assembly);
+        }
+    }
+}
+
 namespace System.Reflection.Runtime.PropertyInfos.EcmaFormat
 {
     //-----------------------------------------------------------------------------------------------------------

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.NativeFormat.cs
@@ -156,6 +156,21 @@ namespace System.Reflection.Runtime.EventInfos.NativeFormat
     }
 }
 
+namespace System.Reflection.Runtime.Modules.NativeFormat
+{
+    //-----------------------------------------------------------------------------------------------------------
+    // Modules (these exist only because Modules still exist in the Win8P surface area. There is a 1-1
+    //          mapping between Assemblies and Modules.)
+    //-----------------------------------------------------------------------------------------------------------
+    internal sealed partial class NativeFormatRuntimeModule
+    {
+        internal static RuntimeModule GetRuntimeModule(NativeFormatRuntimeAssembly assembly)
+        {
+            return new NativeFormatRuntimeModule(assembly);
+        }
+    }
+}
+
 namespace System.Reflection.Runtime.ParameterInfos.NativeFormat
 {
     //-----------------------------------------------------------------------------------------------------------

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -115,21 +115,6 @@ namespace System.Reflection.Runtime.Assemblies
     }
 }
 
-namespace System.Reflection.Runtime.Modules
-{
-    //-----------------------------------------------------------------------------------------------------------
-    // Modules (these exist only because Modules still exist in the Win8P surface area. There is a 1-1
-    //          mapping between Assemblies and Modules.)
-    //-----------------------------------------------------------------------------------------------------------
-    internal sealed partial class RuntimeModule
-    {
-        internal static RuntimeModule GetRuntimeModule(RuntimeAssembly assembly)
-        {
-            return new RuntimeModule(assembly);
-        }
-    }
-}
-
 namespace System.Reflection.Runtime.MethodInfos
 {
     //-----------------------------------------------------------------------------------------------------------

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/LegacyCustomAttributeApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/LegacyCustomAttributeApis.cs
@@ -151,7 +151,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
 namespace System.Reflection.Runtime.Modules
 {
-    internal sealed partial class RuntimeModule
+    internal abstract partial class RuntimeModule
     {
         public sealed override IList<CustomAttributeData> GetCustomAttributesData() => CustomAttributes.ToReadOnlyCollection();
         public sealed override object[] GetCustomAttributes(bool inherit) => CustomAttributeExtensions.GetCustomAttributes(this).ToArray();  // inherit is meaningless for Modules

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -102,7 +102,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
 namespace System.Reflection.Runtime.Modules
 {
-    internal sealed partial class RuntimeModule
+    internal abstract partial class RuntimeModule
     {
 #if DEBUG
         public sealed override Type[] FindTypes(TypeFilter filter, object filterCriteria) => base.FindTypes(filter, filterCriteria);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/EcmaFormat/EcmaFormatRuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/EcmaFormat/EcmaFormatRuntimeModule.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.CustomAttributes;
+using System.Collections.Generic;
+
+using Internal.Reflection.Core;
+using System.Reflection.Runtime.Assemblies.EcmaFormat;
+
+namespace System.Reflection.Runtime.Modules.EcmaFormat
+{
+    internal sealed partial class EcmaFormatRuntimeModule : RuntimeModule
+    {
+        private EcmaFormatRuntimeModule(EcmaFormatRuntimeAssembly assembly)
+            : base()
+        {
+            _assembly = assembly;
+        }
+
+        public sealed override Assembly Assembly => _assembly;
+
+        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
+        {
+            get
+            {
+                return Empty<CustomAttributeData>.Enumerable;
+            }
+        }
+
+        public sealed override string Name
+        {
+            get
+            {
+                return _assembly.GetName().Name;
+            }
+        }
+
+        public sealed override int MetadataToken
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public sealed override Guid ModuleVersionId
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private readonly EcmaFormatRuntimeAssembly _assembly;
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/NativeFormat/NativeFormatRuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/NativeFormat/NativeFormatRuntimeModule.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Reflection.Runtime.Assemblies;
+using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.CustomAttributes;
+using System.Collections.Generic;
+
+using Internal.Reflection.Core;
+using Internal.Metadata.NativeFormat;
+using System.Reflection.Runtime.Assemblies.NativeFormat;
+
+namespace System.Reflection.Runtime.Modules.NativeFormat
+{
+    internal sealed partial class NativeFormatRuntimeModule : RuntimeModule
+    {
+        private NativeFormatRuntimeModule(NativeFormatRuntimeAssembly assembly)
+            : base()
+        {
+            _assembly = assembly;
+        }
+
+        public sealed override Assembly Assembly => _assembly;
+
+        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
+        {
+            get
+            {
+                QScopeDefinition scope = _assembly.Scope;
+                return RuntimeCustomAttributeData.GetCustomAttributes(scope.Reader, scope.ScopeDefinition.CustomAttributes);
+            }
+        }
+
+        public sealed override string Name
+        {
+            get
+            {
+                QScopeDefinition scope = _assembly.Scope;
+                MetadataReader reader = scope.Reader;
+                string name = scope.ScopeDefinition.ModuleName.GetConstantStringValue(reader).Value;
+                if (name == null)
+                    return _assembly.GetName().Name + ".dll"; // Workaround for TFS 441076 - Module data not emitted for facade assemblies.
+                return name;
+            }
+        }
+
+        public sealed override int MetadataToken
+        {
+            get
+            {
+                throw new InvalidOperationException(SR.NoMetadataTokenAvailable);
+            }
+        }
+
+        public sealed override Guid ModuleVersionId
+        {
+            get
+            {
+                byte[] mvid = _assembly.Scope.ScopeDefinition.Mvid.ReadOnlyCollectionToArray();
+                if (mvid.Length == 0)
+                    return default(Guid); // Workaround for TFS 441076 - Module data not emitted for facade assemblies.
+                return new Guid(mvid);
+            }
+        }
+
+        private readonly NativeFormatRuntimeAssembly _assembly;
+    }
+}

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -2,15 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Reflection;
 using System.Diagnostics;
 using System.Runtime.Serialization;
 using System.Reflection.Runtime.Assemblies;
 using System.Collections.Generic;
-
-using Internal.Metadata.NativeFormat;
-using System.Reflection.Runtime.Assemblies.NativeFormat;
 
 namespace System.Reflection.Runtime.Modules
 {
@@ -18,34 +13,20 @@ namespace System.Reflection.Runtime.Modules
     // The runtime's implementation of a Module.
     //
     // Modules are quite meaningless in ProjectN but we have to keep up the appearances since they still exist in Win8P's surface area.
-    // As far as ProjectN is concerned, each Assembly has one module whose name is "<Unknown>".
+    // As far as ProjectN is concerned, each Assembly has one module.
     //
     [Serializable]
-    internal sealed partial class RuntimeModule : Module
+    internal abstract partial class RuntimeModule : Module
     {
-        private RuntimeModule(RuntimeAssembly assembly)
+        protected RuntimeModule()
             : base()
-        {
-            _assembly = assembly;
-        }
+        { }
 
-        public sealed override Assembly Assembly
-        {
-            get
-            {
-                return _assembly;
-            }
-        }
+        public abstract override Assembly Assembly { get; }
 
-        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-                return Empty<CustomAttributeData>.Enumerable;
-            }
-        }
+        public abstract override IEnumerable<CustomAttributeData> CustomAttributes { get; }
 
-        public sealed override String FullyQualifiedName
+        public sealed override string FullyQualifiedName
         {
             get
             {
@@ -53,32 +34,19 @@ namespace System.Reflection.Runtime.Modules
             }
         }
 
-        public sealed override String Name
-        {
-            get
-            {
-                NativeFormatRuntimeAssembly nativeAssembly = Assembly as NativeFormatRuntimeAssembly;
-                if (nativeAssembly != null)
-                {
-                    string name = nativeAssembly.Scope.ScopeDefinition.ModuleName.GetConstantStringValue(nativeAssembly.Scope.Reader).Value;
-                    if (name != null)
-                        return name;
-                }
-                return this.Assembly.GetName().Name;
-            }
-        }
+        public abstract override string Name { get; }
 
-        public sealed override bool Equals(Object o)
+        public sealed override bool Equals(object o)
         {
             RuntimeModule other = o as RuntimeModule;
             if (other == null)
                 return false;
-            return _assembly.Equals(other._assembly);
+            return Assembly.Equals(other.Assembly);
         }
 
         public sealed override int GetHashCode()
         {
-            return _assembly.GetHashCode();
+            return Assembly.GetHashCode();
         }
 
         public sealed override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -88,34 +56,22 @@ namespace System.Reflection.Runtime.Modules
             UnitySerializationHolder.GetUnitySerializationInfo(info, UnitySerializationHolder.ModuleUnity, ScopeName, Assembly);
         }
 
-        public sealed override int MetadataToken
-        {
-            get
-            {
-                throw new InvalidOperationException(SR.NoMetadataTokenAvailable);
-            }
-        }
+        public abstract override int MetadataToken { get; }
 
-        public sealed override Type GetType(String name, bool throwOnError, bool ignoreCase)
+        public sealed override Type GetType(string name, bool throwOnError, bool ignoreCase)
         {
-            return _assembly.GetType(name, throwOnError, ignoreCase);
+            return Assembly.GetType(name, throwOnError, ignoreCase);
         }
 
         public sealed override Type[] GetTypes()
         {
-            Debug.Assert(this.Equals(_assembly.ManifestModule)); // We only support single-module assemblies so we have to be the manifest module.
-            return _assembly.GetTypes();
+            Debug.Assert(this.Equals(Assembly.ManifestModule)); // We only support single-module assemblies so we have to be the manifest module.
+            return Assembly.GetTypes();
         }
 
-        public sealed override Guid ModuleVersionId
-        {
-            get
-            {
-                throw new InvalidOperationException(SR.ModuleVersionIdNotSupported);
-            }
-        }
+        public abstract override Guid ModuleVersionId { get; }
 
-        public sealed override String ToString()
+        public sealed override string ToString()
         {
             return "<Unknown>";
         }
@@ -137,8 +93,6 @@ namespace System.Reflection.Runtime.Modules
         public sealed override Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
 
         protected sealed override ModuleHandle GetModuleHandleImpl() => new ModuleHandle(this);
-
-        private readonly Assembly _assembly;
     }
 }
 


### PR DESCRIPTION
Also:

- Implemented Module.ModuleVersionId

  Fixes https://github.com/dotnet/corert/issues/3638

- Implemented Module.CustomAttributes (in case toolchain
  ever starts emitting them.)

- Made Module.Name workaround for facades a little more useful.