### PR TITLE
Fix 28 System.Runtime.Extensions test failures.

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.FreeEnvironmentStrings.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.FreeEnvironmentStrings.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, EntryPoint = "FreeEnvironmentStringsW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        internal static extern unsafe bool FreeEnvironmentStrings(char* lpszEnvironmentBlock);
+    }
+}

--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetEnvironmentStrings.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetEnvironmentStrings.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, EntryPoint = "GetEnvironmentStringsW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        internal static extern unsafe char* GetEnvironmentStrings();
+    }
+}

--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.SetEnvironmentVariable.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.SetEnvironmentVariable.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, EntryPoint = "SetEnvironmentVariableW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        internal static extern bool SetEnvironmentVariable(string lpName, string lpValue);
+    }
+}

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -479,7 +479,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.FindFirstFileEx.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.FlushFileBuffers.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.FormatMessage.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.FreeEnvironmentStrings.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetCPInfo.cs" /> 
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetEnvironmentStrings.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetFileAttributesEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetFileInformationByHandleEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetFileType_SafeHandle.cs"/>
@@ -495,6 +497,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SecurityOptions.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SetEndOfFile.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SetEnvironmentVariable.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SetThreadErrorMode.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SetFilePointerEx.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.WideCharToMultiByte.cs"/>

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.CoreRT.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+
+namespace Internal.Runtime.Augments
+{
+    /// <summary>For internal use only.  Exposes runtime functionality to the Environments implementation in corefx.</summary>
+    public static partial class EnvironmentAugments
+    {
+        public static int CurrentManagedThreadId => System.Threading.ManagedThreadId.Current;
+        public static void FailFast(string message, Exception error) => RuntimeExceptionHelpers.FailFast(message, error);
+
+        public static void Exit(int exitCode)
+        {
+#if CORERT
+            s_latchedExitCode = exitCode;
+
+            ShutdownCore();
+
+            RuntimeImports.RhpShutdown();
+
+            Interop.ExitProcess(s_latchedExitCode);
+#else
+            // This needs to be implemented for ProjectN.
+            throw new PlatformNotSupportedException();
+#endif
+        }
+
+        internal static void ShutdownCore()
+        {
+            // Here we'll handle AppDomain.ProcessExit, shut down threading etc.
+        }
+
+        private static int s_latchedExitCode;
+        public static int ExitCode
+        {
+            get
+            {
+                return s_latchedExitCode;
+            }
+            set
+            {
+                s_latchedExitCode = value;
+            }
+        }
+
+        private static string[] s_commandLineArgs;
+
+        internal static void SetCommandLineArgs(string[] args)
+        {
+            s_commandLineArgs = args;
+        }
+
+        public static string[] GetCommandLineArgs()
+        {
+            return (string[])s_commandLineArgs?.Clone();
+        }
+
+        public static bool HasShutdownStarted => false; // .NET Core does not have shutdown finalization
+
+        public static string StackTrace
+        {
+            // Disable inlining to have predictable stack frame to skip
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get
+            {
+                // RhGetCurrentThreadStackTrace returns the number of frames(cFrames) added to input buffer.
+                // It returns a negative value, -cFrames which is the required array size, if the buffer is too small.
+                // Initial array length is deliberately chosen to be 0 so that we reallocate to exactly the right size
+                // for StackFrameHelper.FormatStackTrace call. If we want to do this optimistically with one call change
+                // FormatStackTrace to accept an explicit length.
+                IntPtr[] frameIPs = Array.Empty<IntPtr>();
+                int cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
+                if (cFrames < 0)
+                {
+                    frameIPs = new IntPtr[-cFrames];
+                    cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
+                    if (cFrames < 0)
+                    {
+                        return "";
+                    }
+                }
+
+                return Internal.Diagnostics.StackTraceHelper.FormatStackTrace(frameIPs, 1, true);
+            }
+        }
+
+        public static int TickCount => Environment.TickCount;
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Unix.cs
@@ -3,36 +3,34 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text;
-using System.Threading;
 using System.Collections;
-using System.Runtime;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
 
 namespace Internal.Runtime.Augments
 {
     /// <summary>For internal use only.  Exposes runtime functionality to the Environments implementation in corefx.</summary>
     public static partial class EnvironmentAugments
     {
-        public static string GetEnvironmentVariable(string variable)
+        private static string GetEnvironmentVariableCore(string variable)
         {
-            if (variable == null)
-                throw new ArgumentNullException(nameof(variable));
-
+            Debug.Assert(variable != null);
             return Marshal.PtrToStringAnsi(Interop.Sys.GetEnv(variable));
         }
 
-        public static IDictionary GetEnvironmentVariables()
+        private static void SetEnvironmentVariableCore(string variable, string value)
         {
-            if ("".Length != 0)
-                throw new NotImplementedException(); // TODO: https://github.com/dotnet/corert/issues/3688 Need to implement GetEnvironmentVariables() properly.
-            return new LowLevelListDictionary();
+            Debug.Assert(variable != null);
+            throw new NotImplementedException();
         }
 
-        public static IDictionary GetEnvironmentVariables(EnvironmentVariableTarget target) { throw new NotImplementedException(); }
-        public static string GetEnvironmentVariable(string variable, EnvironmentVariableTarget target) { throw new NotImplementedException(); }
-        public static void SetEnvironmentVariable(string variable, string value) { throw new NotImplementedException(); }
-        public static void SetEnvironmentVariable(string variable, string value, EnvironmentVariableTarget target) { throw new NotImplementedException(); }
+        public static IEnumerable<KeyValuePair<string,string>> EnumerateEnvironmentVariables()
+        {
+            if ("".Length != 0)
+                throw new NotImplementedException(); // Need to return something better than an empty environment block.
+
+            return Array.Empty<KeyValuePair<string,string>>();
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Windows.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Windows.cs
@@ -5,18 +5,20 @@
 using System;
 using System.Buffers;
 using System.Collections;
-using System.Runtime;
-using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using Win32Marshal = System.IO.Win32Marshal;
 
 namespace Internal.Runtime.Augments
 {
     /// <summary>For internal use only.  Exposes runtime functionality to the Environments implementation in corefx.</summary>
     public static partial class EnvironmentAugments
     {
-        public static string GetEnvironmentVariable(string variable)
+        private static string GetEnvironmentVariableCore(string variable)
         {
-            if (variable == null)
-                throw new ArgumentNullException(nameof(variable));
+            Debug.Assert(variable != null);
 
             // The convention of the API is as follows:
             // You call the API with a buffer of a given size. 
@@ -42,16 +44,115 @@ namespace Internal.Runtime.Augments
             }
         }
 
-        public static IDictionary GetEnvironmentVariables()
+        private static void SetEnvironmentVariableCore(string variable, string value)
         {
-            if ("".Length != 0)
-                throw new NotImplementedException(); // TODO: https://github.com/dotnet/corert/issues/3688 Need to implement GetEnvironmentVariables() properly.
-            return new LowLevelListDictionary();
+            Debug.Assert(variable != null);
+
+            if (!Interop.Kernel32.SetEnvironmentVariable(variable, value))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                switch (errorCode)
+                {
+                    case Interop.Errors.ERROR_ENVVAR_NOT_FOUND:
+                        // Allow user to try to clear a environment variable
+                        return;
+                    case Interop.Errors.ERROR_FILENAME_EXCED_RANGE:
+                        // The error message from Win32 is "The filename or extension is too long",
+                        // which is not accurate.
+                        throw new ArgumentException(SR.Argument_LongEnvVarValue);
+                    default:
+                        throw new ArgumentException(Win32Marshal.GetMessage(errorCode));
+                }
+            }
         }
 
-        public static IDictionary GetEnvironmentVariables(EnvironmentVariableTarget target) { throw new NotImplementedException(); }
-        public static string GetEnvironmentVariable(string variable, EnvironmentVariableTarget target) { throw new NotImplementedException(); }
-        public static void SetEnvironmentVariable(string variable, string value) { throw new NotImplementedException(); }
-        public static void SetEnvironmentVariable(string variable, string value, EnvironmentVariableTarget target) { throw new NotImplementedException(); }
+        public static IEnumerable<KeyValuePair<string,string>> EnumerateEnvironmentVariables()
+        {
+            unsafe
+            {
+                char* unsafeBlock = Interop.Kernel32.GetEnvironmentStrings();
+                if (unsafeBlock == (char*)0)
+                    throw new OutOfMemoryException();
+                try
+                {
+                    // Format for GetEnvironmentStrings is:
+                    // [=HiddenVar=value\0]* [Variable=value\0]* \0
+                    // See the description of Environment Blocks in MSDN's
+                    // CreateProcess page (null-terminated array of null-terminated strings).
+
+                    // Search for terminating \0\0 (two unicode \0's).
+                    char* p = unsafeBlock;
+                    while (!(*p == '\0' && *(p + 1) == '\0'))
+                    {
+                        p++;
+                    }
+
+                    int len = checked((int)(p - unsafeBlock + 1));
+                    // TODO Perf: Change "block" from char[] to ReadOnlySpan<char> once that becomes available in Project N.
+                    char[] block = new char[len];
+                    for (int i = 0; i < len; i++)
+                    {
+                        block[i] = unsafeBlock[i];
+                    }
+                    return EnumerateEnvironmentVariables(block);
+                }
+                finally
+                {
+                    bool success = Interop.Kernel32.FreeEnvironmentStrings(unsafeBlock);
+                    Debug.Assert(success);
+                }
+            }
+        }
+
+        // Format for GetEnvironmentStrings is:
+        // (=HiddenVar=value\0 | Variable=value\0)* \0
+        // See the description of Environment Blocks in MSDN's
+        // CreateProcess page (null-terminated array of null-terminated strings).
+        // Note the =HiddenVar's aren't always at the beginning.
+
+        // Copy strings out, parsing into pairs.
+        // The first few environment variable entries start with an '='.
+        // The current working directory of every drive (except for those drives
+        // you haven't cd'ed into in your DOS window) are stored in the 
+        // environment block (as =C:=pwd) and the program's exit code is 
+        // as well (=ExitCode=00000000).
+        private static IEnumerable<KeyValuePair<string, string>> EnumerateEnvironmentVariables(char[] block)
+        {
+            // To maintain complete compatibility with prior versions we need to return a Hashtable.
+            // We did ship a prior version of Core with LowLevelDictionary, which does iterate the
+            // same (e.g. yields DictionaryEntry), but it is not a public type.
+            //
+            // While we could pass Hashtable back from CoreCLR the type is also defined here. We only
+            // want to surface the local Hashtable.
+            for (int i = 0; i < block.Length; i++)
+            {
+                int startKey = i;
+
+                // Skip to key. On some old OS, the environment block can be corrupted.
+                // Some will not have '=', so we need to check for '\0'. 
+                while (block[i] != '=' && block[i] != '\0')
+                    i++;
+                if (block[i] == '\0')
+                    continue;
+
+                // Skip over environment variables starting with '='
+                if (i - startKey == 0)
+                {
+                    while (block[i] != 0)
+                        i++;
+                    continue;
+                }
+
+                string key = new string(block, startKey, i - startKey);
+                i++;  // skip over '='
+
+                int startValue = i;
+                while (block[i] != 0)
+                    i++; // Read to end of this entry 
+                string value = new string(block, startValue, i - startValue); // skip over 0 handled by for loop's i++
+
+                yield return new KeyValuePair<string, string>(key, value);
+            }
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 
@@ -12,84 +13,80 @@ namespace Internal.Runtime.Augments
     /// <summary>For internal use only.  Exposes runtime functionality to the Environments implementation in corefx.</summary>
     public static partial class EnvironmentAugments
     {
-        public static int CurrentManagedThreadId => System.Threading.ManagedThreadId.Current;
-        public static void FailFast(string message, Exception error) => RuntimeExceptionHelpers.FailFast(message, error);
-
-        public static void Exit(int exitCode)
+        public static string GetEnvironmentVariable(string variable)
         {
-#if CORERT
-            s_latchedExitCode = exitCode;
-
-            ShutdownCore();
-
-            RuntimeImports.RhpShutdown();
-
-            Interop.ExitProcess(s_latchedExitCode);
-#else
-            // This needs to be implemented for ProjectN.
-            throw new PlatformNotSupportedException();
-#endif
+            if (variable == null)
+                throw new ArgumentNullException(nameof(variable));
+            return GetEnvironmentVariableCore(variable);
         }
 
-        internal static void ShutdownCore()
+        public static void SetEnvironmentVariable(string variable, string value)
         {
-            // Here we'll handle AppDomain.ProcessExit, shut down threading etc.
+            ValidateVariableAndValue(variable, ref value);
+            SetEnvironmentVariableCore(variable, value);
         }
 
-        private static int s_latchedExitCode;
-        public static int ExitCode
+        private static void ValidateVariableAndValue(string variable, ref string value)
         {
-            get
+            const int MaxEnvVariableValueLength = 32767;
+
+            if (variable == null)
+                throw new ArgumentNullException(nameof(variable));
+
+            if (variable.Length == 0)
+                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(variable));
+
+            if (variable[0] == '\0')
+                throw new ArgumentException(SR.Argument_StringFirstCharIsZero, nameof(variable));
+
+            if (variable.Length >= MaxEnvVariableValueLength)
+                throw new ArgumentException(SR.Argument_LongEnvVarValue, nameof(variable));
+
+            if (variable.IndexOf('=') != -1)
+                throw new ArgumentException(SR.Argument_IllegalEnvVarName, nameof(variable));
+
+            if (string.IsNullOrEmpty(value) || value[0] == '\0')
             {
-                return s_latchedExitCode;
+                // Explicitly null out value if it's empty
+                value = null;
             }
-            set
+            else if (value.Length >= MaxEnvVariableValueLength)
             {
-                s_latchedExitCode = value;
-            }
-        }
-
-        private static string[] s_commandLineArgs;
-
-        internal static void SetCommandLineArgs(string[] args)
-        {
-            s_commandLineArgs = args;
-        }
-
-        public static string[] GetCommandLineArgs()
-        {
-            return (string[])s_commandLineArgs?.Clone();
-        }
-
-        public static bool HasShutdownStarted => false; // .NET Core does not have shutdown finalization
-
-        public static string StackTrace
-        {
-            // Disable inlining to have predictable stack frame to skip
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                // RhGetCurrentThreadStackTrace returns the number of frames(cFrames) added to input buffer.
-                // It returns a negative value, -cFrames which is the required array size, if the buffer is too small.
-                // Initial array length is deliberately chosen to be 0 so that we reallocate to exactly the right size
-                // for StackFrameHelper.FormatStackTrace call. If we want to do this optimistically with one call change
-                // FormatStackTrace to accept an explicit length.
-                IntPtr[] frameIPs = Array.Empty<IntPtr>();
-                int cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
-                if (cFrames < 0)
-                {
-                    frameIPs = new IntPtr[-cFrames];
-                    cFrames = RuntimeImports.RhGetCurrentThreadStackTrace(frameIPs);
-                    if (cFrames < 0)
-                    {
-                        return "";
-                    }
-                }
-
-                return Internal.Diagnostics.StackTraceHelper.FormatStackTrace(frameIPs, 1, true);
+                throw new ArgumentException(SR.Argument_LongEnvVarValue, nameof(value));
             }
         }
 
-        public static int TickCount => Environment.TickCount;
+        // TODO Perf: Once CoreCLR gets PopulateEnvironmentVariables(), get rid of GetEnvironmentVariables() and have 
+        // corefx call PopulateEnvironmentVariables() instead so we don't have to create a dictionary just to copy it into
+        // another dictionary.
+        public static IDictionary GetEnvironmentVariables()
+        {
+            IDictionary dictionary = new Dictionary<string, string>(EnumerateEnvironmentVariables());
+            return dictionary;
+        }
+
+        public static string GetEnvironmentVariable(string variable, EnvironmentVariableTarget target)
+        {
+            if (target == EnvironmentVariableTarget.Process)
+                return GetEnvironmentVariable(variable);
+            throw new NotImplementedException();
+        }
+
+        public static void SetEnvironmentVariable(string variable, string value, EnvironmentVariableTarget target)
+        {
+            if (target == EnvironmentVariableTarget.Process)
+            {
+                SetEnvironmentVariable(variable, value);
+                return;
+            }
+            throw new NotImplementedException();
+        }
+
+        public static IDictionary GetEnvironmentVariables(EnvironmentVariableTarget target)
+        {
+            if (target == EnvironmentVariableTarget.Process)
+                return GetEnvironmentVariables();
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Internal\Runtime\Augments\DynamicDelegateAugments.cs" />
     <Compile Include="Internal\Runtime\Augments\EnumInfo.cs" />
     <Compile Include="Internal\Runtime\Augments\EnvironmentAugments.cs" />
+    <Compile Include="Internal\Runtime\Augments\EnvironmentAugments.CoreRT.cs" />
     <Compile Condition="'$(TargetsWindows)'=='true'" Include="Internal\Runtime\Augments\EnvironmentAugments.Windows.cs" />
     <Compile Condition="'$(TargetsUnix)'=='true'" Include="Internal\Runtime\Augments\EnvironmentAugments.Unix.cs" />
     <Compile Include="Internal\Runtime\Augments\RuntimeThread.cs" />


### PR DESCRIPTION
  SetEnvironmentVariable(string, string)
  GetEnvironmentVariables()

  GetEnvironmentVariable(string, target)
  SetEnvironmentVariable(string, string, target)
  GetEnvironmentVariables(target)

   Where target = Target.Process.

   Target.Machine/User will come up next...

Code is mostly cribbed from CoreCLR with some
minor call tree reorg with an eye towards
optimizing out the copies upon copies in
the GetEnvironmentStrings() path.

Code is written with an eye towards
moving to shared partition (though I don't
have time budgeted for that myself.)

Am not doing the Unix versions on CoreRT.
Focus is on getting tests on Project N up.