### PR TITLE
Stop using InstantiateSignature to convert RDT's to concrete types

### DIFF
--- a/src/Common/src/TypeSystem/RuntimeDetermined/ArrayType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/ArrayType.RuntimeDetermined.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class ArrayType
+    {
+        public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            TypeDesc parameterTypeConverted = ParameterType.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
+            if (ParameterType != parameterTypeConverted)
+            {
+                return Context.GetArrayType(parameterTypeConverted, _rank);
+            }
+
+            return this;
+        }
+    }
+
+    partial class ArrayMethod
+    {
+        public override MethodDesc GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            TypeDesc owningType = this.OwningType;
+            TypeDesc instantiatedOwningType = owningType.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
+
+            if (owningType != instantiatedOwningType)
+                return ((ArrayType)instantiatedOwningType).GetArrayMethod(_kind);
+            else
+                return this;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/RuntimeDetermined/ByRefType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/ByRefType.RuntimeDetermined.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class ByRefType
+    {
+        public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            TypeDesc parameterTypeConverted = ParameterType.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
+            if (ParameterType != parameterTypeConverted)
+            {
+                return Context.GetByRefType(parameterTypeConverted);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/RuntimeDetermined/DefType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/DefType.RuntimeDetermined.cs
@@ -44,5 +44,40 @@ namespace Internal.TypeSystem
 
             return this;
         }
+
+        public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            TypeDesc typeDefinition = GetTypeDefinition();
+            if (this == typeDefinition)
+                return this;
+
+            Instantiation instantiation = Instantiation;
+            TypeDesc[] clone = null;
+
+            for (int i = 0; i < instantiation.Length; i++)
+            {
+                TypeDesc uninst = instantiation[i];
+                TypeDesc inst = uninst.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
+                if (inst != uninst)
+                {
+                    if (clone == null)
+                    {
+                        clone = new TypeDesc[instantiation.Length];
+                        for (int j = 0; j < clone.Length; j++)
+                        {
+                            clone[j] = instantiation[j];
+                        }
+                    }
+                    clone[i] = inst;
+                }
+            }
+
+            if (clone != null)
+            {
+                return Context.GetInstantiatedType((MetadataType)typeDefinition, new Instantiation(clone));
+            }
+
+            return this;
+        }
     }
 }

--- a/src/Common/src/TypeSystem/RuntimeDetermined/FieldDesc.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/FieldDesc.RuntimeDetermined.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class FieldDesc
+    {
+        public FieldDesc GetNonRuntimeDeterminedFieldFromRuntimeDeterminedFieldViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            DefType owningType = OwningType;
+            TypeDesc owningTypeInstantiated = owningType.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
+            if (owningTypeInstantiated != owningType)
+            {
+                return Context.GetFieldForInstantiatedType(GetTypicalFieldDefinition(), (InstantiatedType)owningTypeInstantiated);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/RuntimeDetermined/FunctionPointerType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/FunctionPointerType.RuntimeDetermined.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Debug = System.Diagnostics.Debug;
+
 namespace Internal.TypeSystem
 {
     partial class FunctionPointerType
@@ -19,6 +21,12 @@ namespace Internal.TypeSystem
 
                 return false;
             }
+        }
+
+        public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            Debug.Assert(false);
+            return this;
         }
     }
 }

--- a/src/Common/src/TypeSystem/RuntimeDetermined/GenericParameterDesc.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/GenericParameterDesc.RuntimeDetermined.cs
@@ -16,5 +16,11 @@ namespace Internal.TypeSystem
                 return false;
             }
         }
+
+        public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            Debug.Assert(false);
+            return this;
+        }
     }
 }

--- a/src/Common/src/TypeSystem/RuntimeDetermined/PointerType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/PointerType.RuntimeDetermined.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class PointerType
+    {
+        public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            TypeDesc parameterTypeConverted = ParameterType.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
+            if (ParameterType != parameterTypeConverted)
+            {
+                return Context.GetPointerType(parameterTypeConverted);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -156,7 +156,7 @@ namespace Internal.TypeSystem
             return String.Concat(_runtimeDeterminedDetailsType.ToString(), "_", _rawCanonType.ToString());
         }
 
-        public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
             if (_runtimeDeterminedDetailsType.Kind == GenericParameterKind.Type)
             {

--- a/src/Common/src/TypeSystem/RuntimeDetermined/SignatureVariable.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/SignatureVariable.RuntimeDetermined.cs
@@ -16,5 +16,11 @@ namespace Internal.TypeSystem
                 return false;
             }
         }
+
+        public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            Debug.Assert(false);
+            return this;
+        }
     }
 }

--- a/src/Common/src/TypeSystem/RuntimeDetermined/TypeDesc.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/TypeDesc.RuntimeDetermined.cs
@@ -29,5 +29,7 @@ namespace Internal.TypeSystem
                 return this.GetType() == typeof(RuntimeDeterminedType);
             }
         }
+
+        public abstract TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -159,7 +159,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
             // We are getting a constructed type symbol because this might be something passed to newobj.
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.ConstructedTypeSymbol(instantiatedType);
         }
 
@@ -217,7 +217,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
 
             // Unwrap the nullable type if necessary
             if (instantiatedType.IsNullable)
@@ -286,7 +286,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void EmitDictionaryEntry(ref ObjectDataBuilder builder, NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            FieldDesc instantiatedField = _field.InstantiateSignature(typeInstantiation, methodInstantiation);
+            FieldDesc instantiatedField = _field.GetNonRuntimeDeterminedFieldFromRuntimeDeterminedFieldViaSubstitution(typeInstantiation, methodInstantiation);
             int offset = instantiatedField.Offset.AsInt;
             builder.EmitNaturalInt(offset);
         }
@@ -398,7 +398,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            MethodDesc instantiatedMethod = _method.InstantiateSignature(typeInstantiation, methodInstantiation);
+            MethodDesc instantiatedMethod = _method.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.RuntimeMethodHandle(instantiatedMethod);
         }
 
@@ -443,7 +443,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            FieldDesc instantiatedField = _field.InstantiateSignature(typeInstantiation, methodInstantiation);
+            FieldDesc instantiatedField = _field.GetNonRuntimeDeterminedFieldFromRuntimeDeterminedFieldViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.RuntimeFieldHandle(instantiatedField);
         }
 
@@ -488,7 +488,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            MethodDesc instantiatedMethod = _method.InstantiateSignature(typeInstantiation, methodInstantiation);
+            MethodDesc instantiatedMethod = _method.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.MethodGenericDictionary(instantiatedMethod);
         }
 
@@ -547,7 +547,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            MethodDesc instantiatedMethod = _method.InstantiateSignature(typeInstantiation, methodInstantiation);
+            MethodDesc instantiatedMethod = _method.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.FatFunctionPointer(instantiatedMethod, _isUnboxingThunk);
         }
 
@@ -609,12 +609,12 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (factory.Target.Abi == TargetAbi.CoreRT)
             {
-                MethodDesc instantiatedMethod = _method.InstantiateSignature(typeInstantiation, methodInstantiation);
+                MethodDesc instantiatedMethod = _method.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
                 return factory.ReadyToRunHelper(ReadyToRunHelperId.VirtualCall, instantiatedMethod);
             }
             else
             {
-                MethodDesc instantiatedMethod = _method.InstantiateSignature(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
+                MethodDesc instantiatedMethod = _method.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
                 return factory.InterfaceDispatchCell(instantiatedMethod, dictionary.GetMangledName(factory.NameMangler));
             }
         }
@@ -682,12 +682,12 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (factory.Target.Abi == TargetAbi.CoreRT)
             {
-                MethodDesc instantiatedMethod = _method.InstantiateSignature(typeInstantiation, methodInstantiation);
+                MethodDesc instantiatedMethod = _method.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
                 return factory.InterfaceDispatchCell(instantiatedMethod);
             }
             else
             {
-                MethodDesc instantiatedMethod = _method.InstantiateSignature(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
+                MethodDesc instantiatedMethod = _method.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
                 return factory.InterfaceDispatchCell(instantiatedMethod, dictionary.GetMangledName(factory.NameMangler));
             }
         }
@@ -751,7 +751,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            var instantiatedType = (MetadataType)_type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            var instantiatedType = (MetadataType)_type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.Indirection(factory.TypeNonGCStaticsSymbol(instantiatedType));
         }
 
@@ -802,7 +802,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            var instantiatedType = (MetadataType)_type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            var instantiatedType = (MetadataType)_type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.TypeThreadStaticIndex(instantiatedType);
         }
 
@@ -849,7 +849,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            var instantiatedType = (MetadataType)_type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            var instantiatedType = (MetadataType)_type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.Indirection(factory.TypeGCStaticsSymbol(instantiatedType));
         }
 
@@ -899,7 +899,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.Indirection(factory.ExternSymbol(JitHelper.GetNewObjectHelperForType(instantiatedType)));
         }
 
@@ -949,7 +949,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             Debug.Assert(instantiatedType.IsArray);
             return factory.Indirection(factory.ExternSymbol(JitHelper.GetNewArrayHelperForType(instantiatedType)));
         }
@@ -1000,7 +1000,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.Indirection(factory.ExternSymbol(JitHelper.GetCastingHelperNameForType(instantiatedType, true)));
         }
 
@@ -1050,7 +1050,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.Indirection(factory.ExternSymbol(JitHelper.GetCastingHelperNameForType(instantiatedType, false)));
         }
 
@@ -1099,7 +1099,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             UtcNodeFactory utcNodeFactory = factory as UtcNodeFactory;
             Debug.Assert(utcNodeFactory != null);
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             return factory.Indirection(utcNodeFactory.TypeThreadStaticsIndexSymbol(instantiatedType));
         }
 
@@ -1148,7 +1148,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             UtcNodeFactory utcNodeFactory = factory as UtcNodeFactory;
             Debug.Assert(utcNodeFactory != null);
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             Debug.Assert(instantiatedType is MetadataType);
             return factory.Indirection(utcNodeFactory.TypeThreadStaticsOffsetSymbol((MetadataType)instantiatedType));
         }
@@ -1196,7 +1196,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             MethodDesc defaultCtor = instantiatedType.GetDefaultConstructor();
 
             if (defaultCtor == null)
@@ -1312,7 +1312,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void EmitDictionaryEntry(ref ObjectDataBuilder builder, NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            TypeDesc instantiatedType = _type.InstantiateSignature(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             int typeSize;
 
             if (_type.IsDefType)
@@ -1371,8 +1371,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation, GenericDictionaryNode dictionary)
         {
-            MethodDesc instantiatedConstrainedMethod = _constrainedMethod.InstantiateSignature(typeInstantiation, methodInstantiation);
-            TypeDesc instantiatedConstraintType = _constraintType.InstantiateSignature(typeInstantiation, methodInstantiation);
+            MethodDesc instantiatedConstrainedMethod = _constrainedMethod.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
+            TypeDesc instantiatedConstraintType = _constraintType.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
 
             MethodDesc implMethod = instantiatedConstraintType.GetClosestDefType().ResolveInterfaceMethodToVirtualMethodOnType(instantiatedConstrainedMethod);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -110,12 +110,12 @@ namespace ILCompiler.DependencyAnalysis
                         DelegateCreationInfo createInfo = (DelegateCreationInfo)_target;
                         if (createInfo.NeedsVirtualMethodUseTracking)
                         {
-                            MethodDesc instantiatedTargetMethod = createInfo.TargetMethod.InstantiateSignature(typeInstantiation, methodInstantiation);
+                            MethodDesc instantiatedTargetMethod = createInfo.TargetMethod.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
                             if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(instantiatedTargetMethod.OwningType))
                             {
                                 result.Add(
                                     new DependencyListEntry(
-                                        factory.VirtualMethodUse(createInfo.TargetMethod.InstantiateSignature(typeInstantiation, methodInstantiation)),
+                                        factory.VirtualMethodUse(instantiatedTargetMethod),
                                         "Dictionary dependency"));
                             }
 
@@ -130,7 +130,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 case ReadyToRunHelperId.ResolveVirtualFunction:
                     {
-                        MethodDesc instantiatedTarget = ((MethodDesc)_target).InstantiateSignature(typeInstantiation, methodInstantiation);
+                        MethodDesc instantiatedTarget = ((MethodDesc)_target).GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
                         if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(instantiatedTarget.OwningType))
                         {
                             result.Add(

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeDeterminedMethodNode.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis
         public IEnumerable<DependencyListEntry> InstantiateDependencies(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
             yield return new DependencyListEntry(
-                factory.ShadowConcreteMethod(Method.InstantiateSignature(typeInstantiation, methodInstantiation)), "concrete method");
+                factory.ShadowConcreteMethod(Method.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation)), "concrete method");
         }
 
         public override bool HasConditionalStaticDependencies => false;

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -503,11 +503,23 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\LocalVariableDefinition.cs">
       <Link>TypeSystem\Common\LocalVariableDefinition.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs">
+      <Link>TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ByRefType.RuntimeDetermined.cs">
+      <Link>TypeSystem\RuntimeDetermined\ByRefType.RuntimeDetermined.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\FieldDesc.RuntimeDetermined.cs">
+      <Link>TypeSystem\RuntimeDetermined\FieldDesc.RuntimeDetermined.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\FunctionPointerType.RuntimeDetermined.cs">
       <Link>TypeSystem\RuntimeDetermined\FunctionPointerType.RuntimeDetermined.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\MethodDesc.RuntimeDetermined.cs">
       <Link>TypeSystem\RuntimeDetermined\MethodDesc.RuntimeDetermined.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\PointerType.RuntimeDetermined.cs">
+      <Link>TypeSystem\RuntimeDetermined\PointerType.RuntimeDetermined.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\RuntimeDeterminedCanonicalizationAlgorithm.cs">
       <Link>TypeSystem\RuntimeDetermined\RuntimeDeterminedCanonicalizationAlgorithm.cs</Link>

--- a/src/ILCompiler.TypeSystem/tests/RuntimeDeterminedTypesTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/RuntimeDeterminedTypesTests.cs
@@ -143,7 +143,7 @@ namespace TypeSystemTests
             // GenericReferenceTypeWithThreeParams<T__Canon, StructType, V__Canon> substituted over
             // an instantiation of <ReferenceType, StructType, OtherReferenceType> is 
             // GenericReferenceTypeWithThreeParams<ReferenceType, StructType, OtherReferenceType>
-            var grtOverRtStRtSharedInstantiated = grtOverRtStRtShared.InstantiateSignature(
+            var grtOverRtStRtSharedInstantiated = grtOverRtStRtShared.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(
                 new Instantiation(_referenceType, _structType, _otherReferenceType),
                 Instantiation.Empty);
 

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -52,11 +52,14 @@
     <NativeFormatCommonPath>..\..\Common\src\Internal\NativeFormat</NativeFormatCommonPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(JitSupport)' == 'true'">
+    <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ByRefType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\DefType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\FunctionPointerType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\GenericParameterDesc.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\MethodDesc.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ParameterizedType.RuntimeDetermined.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\PointerType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\RuntimeDeterminedCanonicalizationAlgorithm.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\RuntimeDeterminedType.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\RuntimeDeterminedTypeUtilities.cs" />


### PR DESCRIPTION
Calling `InstantiateSignature` on `Foo<T__Canon, !0>` should have no
effect on the `T__Canon` part.

I was trying to avoid duplicating code when I was porting
RuntimeDeterminedTypes out of NUTC by reusing `InstantiateSignature` to
also do
`GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution`
but we really need the duplication.