### PR TITLE
Skip debug directory entries that are not of the CodeView type

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -411,6 +411,9 @@ namespace ILCompiler
                 // If the file doesn't exist, try the path specified in the CodeView section of the image
                 foreach (DebugDirectoryEntry debugEntry in peReader.ReadDebugDirectory())
                 {
+                    if (debugEntry.Type != DebugDirectoryEntryType.CodeView)
+                        continue;
+
                     string candidateFileName = peReader.ReadCodeViewDebugDirectoryData(debugEntry).Path;
                     if (Path.IsPathRooted(candidateFileName) && File.Exists(candidateFileName))
                     {


### PR DESCRIPTION
The code needs to make sure that a ```DebugDirectoryEntry``` is of ```CodeView``` type before calling ```ReadCodeViewDebugDirectoryData``` to parse it.
The ```ReadCodeViewDebugDirectoryData``` method will simply throw an ArgumentException if it is given an entry of wrong type.