### PR TITLE
Put field metadata on the same plan as metods

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FieldMetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FieldMetadataNode.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+using EcmaField = Internal.TypeSystem.Ecma.EcmaField;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a field that has metadata generated in the current compilation.
+    /// </summary>
+    /// <remarks>
+    /// Only expected to be used during ILScanning when scanning for reflection.
+    /// </remarks>
+    internal class FieldMetadataNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly FieldDesc _field;
+
+        public FieldMetadataNode(FieldDesc field)
+        {
+            Debug.Assert(field.IsTypicalFieldDefinition);
+            _field = field;
+        }
+
+        public FieldDesc Field => _field;
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            DependencyList dependencies = new DependencyList();
+            dependencies.Add(factory.TypeMetadata((MetadataType)_field.OwningType), "Owning type metadata");
+
+            CustomAttributeBasedDependencyAlgorithm.AddDependenciesDueToCustomAttributes(ref dependencies, factory, ((EcmaField)_field));
+
+            return dependencies;
+        }
+        protected override string GetName(NodeFactory factory)
+        {
+            return "Reflectable field: " + _field.ToString();
+        }
+
+        protected override void OnMarked(NodeFactory factory)
+        {
+            Debug.Assert(!factory.MetadataManager.IsReflectionBlocked(_field));
+            Debug.Assert(factory.MetadataManager.CanGenerateMetadata(_field));
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -445,6 +445,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new MethodMetadataNode(method);
             });
 
+            _fieldsWithMetadata = new NodeCache<FieldDesc, FieldMetadataNode>(field =>
+            {
+                return new FieldMetadataNode(field);
+            });
+
             _modulesWithMetadata = new NodeCache<ModuleDesc, ModuleMetadataNode>(module =>
             {
                 return new ModuleMetadataNode(module);
@@ -881,6 +886,13 @@ namespace ILCompiler.DependencyAnalysis
         internal MethodMetadataNode MethodMetadata(MethodDesc method)
         {
             return _methodsWithMetadata.GetOrAdd(method);
+        }
+
+        private NodeCache<FieldDesc, FieldMetadataNode> _fieldsWithMetadata;
+
+        internal FieldMetadataNode FieldMetadata(FieldDesc field)
+        {
+            return _fieldsWithMetadata.GetOrAdd(field);
         }
 
         private NodeCache<ModuleDesc, ModuleMetadataNode> _modulesWithMetadata;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
@@ -35,6 +35,22 @@ namespace ILCompiler.DependencyAnalysis
 
         private static Utf8String s_NativeLayoutSignaturePrefix = new Utf8String("__RFHSignature_");
 
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            // TODO: https://github.com/dotnet/corert/issues/3224
+            // We should figure out reflectable fields when scanning for reflection
+            FieldDesc fieldDefinition = _targetField.GetTypicalFieldDefinition();
+            if (!factory.MetadataManager.CanGenerateMetadata(fieldDefinition))
+            {
+                return new DependencyList
+                {
+                    new DependencyListEntry(factory.FieldMetadata(fieldDefinition), "LDTOKEN")
+                };
+            }
+
+            return null;
+        }
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory, relocsOnly);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -44,6 +44,14 @@ namespace ILCompiler.DependencyAnalysis
             else
                 dependencies.Add(factory.ModuleMetadata(_type.Module), "Containing module of a reflectable type");
 
+            // TODO: https://github.com/dotnet/corert/issues/3224
+            // We don't currently track the exact list of fields used - assume all are used
+            foreach (FieldDesc field in _type.GetFields())
+            {
+                if (factory.MetadataManager.CanGenerateMetadata(field))
+                    dependencies.Add(factory.FieldMetadata(field), "Field of a reflectable type");
+            }
+
             return dependencies;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -657,6 +657,12 @@ namespace ILCompiler
             return (GetMetadataCategory(method) & MetadataCategory.Description) != 0;
         }
 
+        public bool CanGenerateMetadata(FieldDesc field)
+        {
+            Debug.Assert(field.IsTypicalFieldDefinition);
+            return (GetMetadataCategory(field) & MetadataCategory.Description) != 0;
+        }
+
         /// <summary>
         /// Gets the metadata category for a compiled method body in the current compilation.
         /// The method will only get called with '<paramref name="method"/>' that has a compiled method body

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.Mangling.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.Sorting.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CustomAttributeBasedDependencyAlgorithm.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\FieldMetadataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ILScanNodeFactory.cs" />
     <Compile Include="Compiler\PreInitFieldInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenArrayNode.cs" />


### PR DESCRIPTION
* Add a `FieldMetadataNode` node to track metadata generation for fields
* Since we don't generate runtime artifacts related to fields, we
allocate a node for each field on all reflectable types
* Allocate a field metadata node for RuntimeFieldHandle to fix rolling
build. This will be eventually moved to the scanner.
* A couple perf tweaks.