### PR TITLE
Generate metadata for standalone generic definitions

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -24,7 +24,12 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            return null;
+            DependencyList dependencyList = null;
+
+            // Ask the metadata manager if we have any dependencies due to reflectability.
+            factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencyList, factory, _type);
+
+            return dependencyList;
         }
 
         protected internal override void ComputeOptionalEETypeFields(NodeFactory factory, bool relocsOnly)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -74,6 +74,7 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         if (mdManager.CanGenerateMetadata((MetadataType)typeDefinition))
                         {
+                            dependencies = dependencies ?? new DependencyList();
                             dependencies.Add(nodeFactory.TypeMetadata((MetadataType)typeDefinition), reason);
                         }
 
@@ -86,6 +87,7 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         if (mdManager.CanGenerateMetadata((MetadataType)type))
                         {
+                            dependencies = dependencies ?? new DependencyList();
                             dependencies.Add(nodeFactory.TypeMetadata((MetadataType)type), reason);
                         }
                     }


### PR DESCRIPTION
`typeof(GenericType<>)` wasn't triggering necessity of metadata for
`GenericType` based on the "what got compiled gets metadata rule". We
would need to see an instantiated type to generate metadata, but that
really shouldn't be needed.