### PR TITLE
Generate a constructed EEType for interfaces implemented by constructed types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -249,6 +249,12 @@ namespace ILCompiler.DependencyAnalysis
             return _type.BaseType != null ? factory.ConstructedTypeSymbol(_type.BaseType) : null;
         }
 
+        protected override IEETypeNode GetInterfaceTypeNode(NodeFactory factory, TypeDesc interfaceType)
+        {
+            // The interface type will be visible to reflection and should be considered constructed.
+            return factory.ConstructedTypeSymbol(interfaceType);
+        }
+
         protected override int GCDescSize => GCDescEncoder.GetGCDescSize(_type);
 
         protected override void OutputGCDesc(ref ObjectDataBuilder builder)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -477,13 +477,18 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
         
+        protected virtual IEETypeNode GetInterfaceTypeNode(NodeFactory factory, TypeDesc interfaceType)
+        {
+            return factory.NecessaryTypeSymbol(interfaceType);
+        }
+
         protected virtual void OutputInterfaceMap(NodeFactory factory, ref ObjectDataBuilder objData)
         {
             Debug.Assert(EmitVirtualSlotsAndInterfaces);
 
             foreach (var itf in _type.RuntimeInterfaces)
             {
-                objData.EmitPointerRelocOrIndirectionReference(factory.NecessaryTypeSymbol(itf));
+                objData.EmitPointerRelocOrIndirectionReference(GetInterfaceTypeNode(factory, itf));
             }
         }
 


### PR DESCRIPTION
These are visible to reflection: things visible to reflection need to be
considered fully constructed because we can't predict how the code will
use them.