### PR TITLE
Add some capabilities to the Unix wait subsystem

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Unix.cs
@@ -64,10 +64,14 @@ namespace Internal.Runtime.Augments
         [NativeCallable]
         private static void OnThreadExit()
         {
-            // Set the Stopped bit and signal the current thread as stopped
             RuntimeThread currentThread = t_currentThread;
             if (currentThread != null)
             {
+                // Inform the wait subsystem that the thread is exiting. For instance, this would abandon any mutexes locked by
+                // the thread.
+                WaitSubsystem.OnThreadExiting(currentThread);
+
+                // Set the Stopped bit and signal the current thread as stopped
                 int state = currentThread._threadState;
                 if ((state & (int)(ThreadState.Stopped | ThreadState.Aborted)) == 0)
                 {

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
@@ -65,6 +65,18 @@ namespace System.Threading
             GC.SuppressFinalize(this);
         }
 
+#if DEBUG
+        public bool IsLocked
+        {
+            get
+            {
+                bool isLocked = _ownerThread == RuntimeThread.CurrentThread;
+                Debug.Assert(!isLocked || (_state & LockedMask) != 0);
+                return isLocked;
+            }
+        }
+#endif
+
         public void VerifyIsLocked()
         {
 #if DEBUG

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Unix.cs
@@ -52,17 +52,21 @@ namespace System.Threading
             GC.SuppressFinalize(this);
         }
 
+#if DEBUG
+        public bool IsLocked => _ownerThread == RuntimeThread.CurrentThread;
+#endif
+
         public void VerifyIsLocked()
         {
 #if DEBUG
-            Debug.Assert(_ownerThread == RuntimeThread.CurrentThread);
+            Debug.Assert(IsLocked);
 #endif
         }
 
         public void VerifyIsNotLocked()
         {
 #if DEBUG
-            Debug.Assert(_ownerThread != RuntimeThread.CurrentThread);
+            Debug.Assert(!IsLocked);
 #endif
         }
 

--- a/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
@@ -64,6 +64,18 @@ namespace System.Threading
             /// </summary>
             private WaitHandleArray<WaitedListNode> _waitedListNodes;
 
+            /// <summary>
+            /// Indicates whether the next wait should be interrupted.
+            /// 
+            /// Synchronization:
+            /// - In most cases, reads and writes are synchronized with <see cref="s_lock"/>
+            /// - Sleep(nonzero) intentionally does not acquire <see cref="s_lock"/>, but it must acquire
+            ///   <see cref="_waitMonitor"/> to do the wait. To support this case, a pending interrupt is recorded while
+            ///   <see cref="s_lock"/> and <see cref="_waitMonitor"/> are locked, and the read and reset for Sleep(nonzero) are
+            ///   done while <see cref="_waitMonitor"/> is locked.
+            /// - Sleep(0) intentionally does not acquire any lock, so it uses an interlocked compare-exchange for the read and
+            ///   reset, see <see cref="CheckAndResetPendingInterrupt_NotLocked"/>
+            /// </summary>
             private int _isPendingInterrupt;
 
             ////////////////////////////////////////////////////////////////
@@ -81,12 +93,22 @@ namespace System.Threading
 
                 _thread = thread;
                 _waitMonitor = new LowLevelMonitor();
+                _waitSignalState = WaitSignalState.NotWaiting;
                 _waitedObjectIndexThatSatisfiedWait = -1;
                 _waitedObjects = new WaitHandleArray<WaitableObject>(elementInitializer: null);
                 _waitedListNodes = new WaitHandleArray<WaitedListNode>(i => new WaitedListNode(this, i));
             }
 
             public RuntimeThread Thread => _thread;
+
+            private bool IsWaiting
+            {
+                get
+                {
+                    _waitMonitor.VerifyIsLocked();
+                    return _waitSignalState < WaitSignalState.NotWaiting;
+                }
+            }
 
             /// <summary>
             /// Callers must ensure to clear the array after use. Once <see cref="RegisterWait(int, bool)"/> is called (followed
@@ -114,7 +136,7 @@ namespace System.Threading
             /// <summary>
             /// The caller is expected to populate <see cref="WaitedObjects"/> and pass in the number of objects filled
             /// </summary>
-            public void RegisterWait(int waitedCount, bool isWaitForAll)
+            public void RegisterWait(int waitedCount, bool prioritize, bool isWaitForAll)
             {
                 s_lock.VerifyIsLocked();
                 Debug.Assert(_thread == RuntimeThread.CurrentThread);
@@ -158,9 +180,19 @@ namespace System.Threading
 
                 _isWaitForAll = isWaitForAll;
                 _waitedCount = waitedCount;
-                for (int i = 0; i < waitedCount; ++i)
+                if (prioritize)
                 {
-                    waitedListNodes[i].RegisterWait(waitedObjects[i]);
+                    for (int i = 0; i < waitedCount; ++i)
+                    {
+                        waitedListNodes[i].RegisterPrioritizedWait(waitedObjects[i]);
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < waitedCount; ++i)
+                    {
+                        waitedListNodes[i].RegisterWait(waitedObjects[i]);
+                    }
                 }
             }
 
@@ -177,7 +209,7 @@ namespace System.Threading
                 _waitedCount = 0;
             }
 
-            private int ProcessSignaledWaitState(WaitHandle[] waitHandlesForAbandon, out Exception exception)
+            private int ProcessSignaledWaitState(WaitHandle[] waitHandlesForAbandon)
             {
                 s_lock.VerifyIsNotLocked();
                 _waitMonitor.VerifyIsLocked();
@@ -186,52 +218,53 @@ namespace System.Threading
                 switch (_waitSignalState)
                 {
                     case WaitSignalState.Waiting:
-                        exception = null;
+                    case WaitSignalState.Waiting_Interruptible:
                         return WaitHandle.WaitTimeout;
 
-                    case WaitSignalState.Waiting_SignaledToSatisfyWait:
+                    case WaitSignalState.NotWaiting_SignaledToSatisfyWait:
                         {
                             Debug.Assert(_waitedObjectIndexThatSatisfiedWait >= 0);
                             int waitedObjectIndexThatSatisfiedWait = _waitedObjectIndexThatSatisfiedWait;
                             _waitedObjectIndexThatSatisfiedWait = -1;
-                            exception = null;
                             return waitedObjectIndexThatSatisfiedWait;
                         }
 
-                    case WaitSignalState.Waiting_SignaledToSatisfyWaitWithAbandonedMutex:
+                    case WaitSignalState.NotWaiting_SignaledToSatisfyWaitWithAbandonedMutex:
                         Debug.Assert(_waitedObjectIndexThatSatisfiedWait >= 0);
                         if (waitHandlesForAbandon == null)
                         {
                             _waitedObjectIndexThatSatisfiedWait = -1;
-                            exception = new AbandonedMutexException();
+                            throw new AbandonedMutexException();
                         }
                         else
                         {
                             int waitedObjectIndexThatSatisfiedWait = _waitedObjectIndexThatSatisfiedWait;
                             _waitedObjectIndexThatSatisfiedWait = -1;
-                            exception =
+                            throw
                                 new AbandonedMutexException(
                                     waitedObjectIndexThatSatisfiedWait,
                                     waitHandlesForAbandon[waitedObjectIndexThatSatisfiedWait]);
                         }
-                        return 0;
 
-                    case WaitSignalState.Waiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount:
+                    case WaitSignalState.NotWaiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount:
                         Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
-                        exception = new OverflowException(SR.Overflow_MutexReacquireCount);
-                        return 0;
+                        throw new OverflowException(SR.Overflow_MutexReacquireCount);
 
                     default:
-                        Debug.Assert(_waitSignalState == WaitSignalState.Waiting_SignaledToInterruptWait);
+                        Debug.Assert(_waitSignalState == WaitSignalState.NotWaiting_SignaledToInterruptWait);
                         Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
-                        exception = new ThreadInterruptedException();
-                        return 0;
+                        throw new ThreadInterruptedException();
                 }
             }
 
-            public int Wait(int timeoutMilliseconds, WaitHandle[] waitHandlesForAbandon, bool isSleep)
+            public int Wait(int timeoutMilliseconds, bool interruptible, WaitHandle[] waitHandlesForAbandon, bool isSleep)
             {
-                if (!isSleep)
+                if (isSleep)
+                {
+                    s_lock.VerifyIsNotLocked();
+                    Debug.Assert(waitHandlesForAbandon == null);
+                }
+                else
                 {
                     s_lock.VerifyIsLocked();
                 }
@@ -254,54 +287,55 @@ namespace System.Threading
                 Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
                 Debug.Assert(_waitSignalState == WaitSignalState.NotWaiting);
 
-                /// A signaled state may be set only when the thread is in the
-                /// <see cref="WaitSignalState.Waiting"/> state
-                _waitSignalState = WaitSignalState.Waiting;
+                // A signaled state may be set only when the thread is in one of the following states
+                _waitSignalState = interruptible ? WaitSignalState.Waiting_Interruptible : WaitSignalState.Waiting;
 
-                int waitResult;
-                Exception exception;
                 try
                 {
+                    if (isSleep && interruptible && CheckAndResetPendingInterrupt)
+                    {
+                        throw new ThreadInterruptedException();
+                    }
+
                     if (timeoutMilliseconds < 0)
                     {
                         do
                         {
                             _waitMonitor.Wait();
-                        } while (_waitSignalState == WaitSignalState.Waiting);
+                        } while (IsWaiting);
 
-                        waitResult = ProcessSignaledWaitState(waitHandlesForAbandon, out exception);
-                        Debug.Assert(exception != null || waitResult != WaitHandle.WaitTimeout);
+                        int waitResult = ProcessSignaledWaitState(waitHandlesForAbandon);
+                        Debug.Assert(waitResult != WaitHandle.WaitTimeout);
+                        return waitResult;
                     }
-                    else
+
+                    int elapsedMilliseconds = 0;
+                    int startTimeMilliseconds = Environment.TickCount;
+                    while (true)
                     {
-                        int elapsedMilliseconds = 0;
-                        int startTimeMilliseconds = Environment.TickCount;
-                        while (true)
+                        bool monitorWaitResult = _waitMonitor.Wait(timeoutMilliseconds - elapsedMilliseconds);
+
+                        // It's possible for the wait to have timed out, but before the monitor could reacquire the lock, a
+                        // signaler could have acquired it and signaled to satisfy the wait or interrupt the thread. Accept the
+                        // signal and ignore the wait timeout.
+                        int waitResult = ProcessSignaledWaitState(waitHandlesForAbandon);
+                        if (waitResult != WaitHandle.WaitTimeout)
                         {
-                            bool monitorWaitResult = _waitMonitor.Wait(timeoutMilliseconds - elapsedMilliseconds);
-
-                            // It's possible for the wait to have timed out, but before the monitor could reacquire the lock, a
-                            // signaler could have acquired it and signaled to satisfy the wait or interrupt the thread. Accept the
-                            // signal and ignore the wait timeout.
-                            waitResult = ProcessSignaledWaitState(waitHandlesForAbandon, out exception);
-                            if (exception != null || waitResult != WaitHandle.WaitTimeout)
-                            {
-                                break;
-                            }
-
-                            if (monitorWaitResult)
-                            {
-                                elapsedMilliseconds = Environment.TickCount - startTimeMilliseconds;
-                                if (elapsedMilliseconds < timeoutMilliseconds)
-                                {
-                                    continue;
-                                }
-                            }
-
-                            // Timeout
-                            Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
-                            break;
+                            return waitResult;
                         }
+
+                        if (monitorWaitResult)
+                        {
+                            elapsedMilliseconds = Environment.TickCount - startTimeMilliseconds;
+                            if (elapsedMilliseconds < timeoutMilliseconds)
+                            {
+                                continue;
+                            }
+                        }
+
+                        // Timeout
+                        Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
+                        break;
                     }
                 }
                 finally
@@ -312,15 +346,6 @@ namespace System.Threading
                     _thread.ClearWaitSleepJoinState();
                 }
 
-                if (exception != null)
-                {
-                    throw exception;
-                }
-                if (waitResult != WaitHandle.WaitTimeout)
-                {
-                    return waitResult;
-                }
-
                 /// Timeout. It's ok to read <see cref="_waitedCount"/> without acquiring <see cref="s_lock"/> here, because it
                 /// is initially set by this thread, and another thread cannot unregister this thread's wait without first
                 /// signaling this thread, in which case this thread wouldn't be timing out.
@@ -328,20 +353,16 @@ namespace System.Threading
                 if (!isSleep)
                 {
                     s_lock.Acquire();
-                    try
-                    {
-                        UnregisterWait();
-                    }
-                    finally
-                    {
-                        s_lock.Release();
-                    }
+                    UnregisterWait();
+                    s_lock.Release();
                 }
-                return waitResult;
+                return WaitHandle.WaitTimeout;
             }
 
             public static void UninterruptibleSleep0()
             {
+                s_lock.VerifyIsNotLocked();
+
                 // On Unix, a thread waits on a condition variable. The timeout time will have already elapsed at the time
                 // of the call. The documentation does not state whether the thread yields or does nothing before returning
                 // an error, and in some cases, suggests that doing nothing is acceptable. The behavior could also be
@@ -349,20 +370,27 @@ namespace System.Threading
                 RuntimeThread.Yield();
             }
 
-            public void Sleep(int timeoutMilliseconds)
+            public static void Sleep(int timeoutMilliseconds, bool interruptible)
             {
                 s_lock.VerifyIsNotLocked();
-                Debug.Assert(_thread == RuntimeThread.CurrentThread);
-
                 Debug.Assert(timeoutMilliseconds >= -1);
 
                 if (timeoutMilliseconds == 0)
                 {
+                    if (interruptible && RuntimeThread.CurrentThread.WaitInfo.CheckAndResetPendingInterrupt_NotLocked)
+                    {
+                        throw new ThreadInterruptedException();
+                    }
+
                     UninterruptibleSleep0();
                     return;
                 }
 
-                int waitResult = Wait(timeoutMilliseconds, waitHandlesForAbandon: null, isSleep: true);
+                int waitResult =
+                    RuntimeThread
+                        .CurrentThread
+                        .WaitInfo
+                        .Wait(timeoutMilliseconds, interruptible, waitHandlesForAbandon: null, isSleep: true);
                 Debug.Assert(waitResult == WaitHandle.WaitTimeout);
             }
 
@@ -404,7 +432,7 @@ namespace System.Threading
                 // the thread can accept a signal.
                 _waitMonitor.Acquire();
 
-                if (_waitSignalState != WaitSignalState.Waiting)
+                if (!IsWaiting)
                 {
                     _waitMonitor.Release();
                     return false;
@@ -421,15 +449,15 @@ namespace System.Threading
                 Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
                 if (wouldAnyMutexReacquireCountOverflow)
                 {
-                    _waitSignalState = WaitSignalState.Waiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount;
+                    _waitSignalState = WaitSignalState.NotWaiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount;
                 }
                 else
                 {
                     _waitedObjectIndexThatSatisfiedWait = signaledWaitedObjectIndex;
                     _waitSignalState =
                         isAbandonedMutex
-                            ? WaitSignalState.Waiting_SignaledToSatisfyWaitWithAbandonedMutex
-                            : WaitSignalState.Waiting_SignaledToSatisfyWait;
+                            ? WaitSignalState.NotWaiting_SignaledToSatisfyWaitWithAbandonedMutex
+                            : WaitSignalState.NotWaiting_SignaledToSatisfyWait;
                 }
 
                 _waitMonitor.Signal_Release();
@@ -442,10 +470,10 @@ namespace System.Threading
 
                 _waitMonitor.Acquire();
 
-                if (_waitSignalState != WaitSignalState.Waiting)
+                if (_waitSignalState != WaitSignalState.Waiting_Interruptible)
                 {
-                    _waitMonitor.Release();
                     RecordPendingInterrupt();
+                    _waitMonitor.Release();
                     return;
                 }
 
@@ -455,13 +483,46 @@ namespace System.Threading
                 }
 
                 Debug.Assert(_waitedObjectIndexThatSatisfiedWait < 0);
-                _waitSignalState = WaitSignalState.Waiting_SignaledToInterruptWait;
+                _waitSignalState = WaitSignalState.NotWaiting_SignaledToInterruptWait;
 
                 _waitMonitor.Signal_Release();
             }
 
-            private void RecordPendingInterrupt() => Interlocked.Exchange(ref _isPendingInterrupt, 1);
-            public bool CheckAndResetPendingInterrupt => Interlocked.CompareExchange(ref _isPendingInterrupt, 0, 1) != 0;
+            private void RecordPendingInterrupt()
+            {
+                s_lock.VerifyIsLocked();
+                _waitMonitor.VerifyIsLocked();
+
+                _isPendingInterrupt = 1;
+            }
+
+            public bool CheckAndResetPendingInterrupt
+            {
+                get
+                {
+#if DEBUG
+                    Debug.Assert(s_lock.IsLocked || _waitMonitor.IsLocked);
+#endif
+
+                    if (_isPendingInterrupt == 0)
+                    {
+                        return false;
+                    }
+                    _isPendingInterrupt = 0;
+                    return true;
+                }
+            }
+
+            private bool CheckAndResetPendingInterrupt_NotLocked
+            {
+                get
+                {
+                    s_lock.VerifyIsNotLocked();
+                    _waitMonitor.VerifyIsNotLocked();
+
+                    return Interlocked.CompareExchange(ref _isPendingInterrupt, 0, 1) != 0;
+                }
+            }
 
             public WaitableObject LockedMutexesHead
             {
@@ -589,6 +650,29 @@ namespace System.Threading
                     waitableObject.WaitersTail = this;
                 }
 
+                public void RegisterPrioritizedWait(WaitableObject waitableObject)
+                {
+                    s_lock.VerifyIsLocked();
+                    Debug.Assert(_waitInfo.Thread == RuntimeThread.CurrentThread);
+
+                    Debug.Assert(waitableObject != null);
+
+                    Debug.Assert(_previous == null);
+                    Debug.Assert(_next == null);
+
+                    WaitedListNode head = waitableObject.WaitersHead;
+                    if (head != null)
+                    {
+                        _next = head;
+                        head._previous = this;
+                    }
+                    else
+                    {
+                        waitableObject.WaitersTail = this;
+                    }
+                    waitableObject.WaitersHead = this;
+                }
+
                 public void UnregisterWait(WaitableObject waitableObject)
                 {
                     s_lock.VerifyIsLocked();
@@ -623,12 +707,13 @@ namespace System.Threading
 
             private enum WaitSignalState : byte
             {
-                NotWaiting,
                 Waiting,
-                Waiting_SignaledToSatisfyWait,
-                Waiting_SignaledToSatisfyWaitWithAbandonedMutex,
-                Waiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount,
-                Waiting_SignaledToInterruptWait
+                Waiting_Interruptible,
+                NotWaiting,
+                NotWaiting_SignaledToSatisfyWait,
+                NotWaiting_SignaledToSatisfyWaitWithAbandonedMutex,
+                NotWaiting_SignaledToAbortWaitDueToMaximumMutexReacquireCount,
+                NotWaiting_SignaledToInterruptWait
             }
         }
     }

--- a/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
@@ -171,7 +171,7 @@ namespace System.Threading
             /// by the thread. See <see cref="ThreadWaitInfo.LockedMutexesHead"/>. So, acquire the lock only after all
             /// possibilities for exceptions have been exhausted.
             ThreadWaitInfo waitInfo = RuntimeThread.CurrentThread.WaitInfo;
-            bool acquiredLock = waitableObject.Wait(waitInfo, 0);
+            bool acquiredLock = waitableObject.Wait(waitInfo, timeoutMilliseconds: 0, interruptible: false, prioritize: false);
             Debug.Assert(acquiredLock);
             return safeWaitHandle;
         }
@@ -183,7 +183,13 @@ namespace System.Threading
 
         public static void SetEvent(IntPtr handle)
         {
-            WaitableObject waitableObject = HandleManager.FromHandle(handle);
+            SetEvent(HandleManager.FromHandle(handle));
+        }
+
+        public static void SetEvent(WaitableObject waitableObject)
+        {
+            Debug.Assert(waitableObject != null);
+
             s_lock.Acquire();
             try
             {
@@ -197,7 +203,13 @@ namespace System.Threading
 
         public static void ResetEvent(IntPtr handle)
         {
-            WaitableObject waitableObject = HandleManager.FromHandle(handle);
+            ResetEvent(HandleManager.FromHandle(handle));
+        }
+
+        public static void ResetEvent(WaitableObject waitableObject)
+        {
+            Debug.Assert(waitableObject != null);
+
             s_lock.Acquire();
             try
             {
@@ -212,8 +224,14 @@ namespace System.Threading
         public static int ReleaseSemaphore(IntPtr handle, int count)
         {
             Debug.Assert(count > 0);
+            return ReleaseSemaphore(HandleManager.FromHandle(handle), count);
+        }
 
-            WaitableObject waitableObject = HandleManager.FromHandle(handle);
+        public static int ReleaseSemaphore(WaitableObject waitableObject, int count)
+        {
+            Debug.Assert(waitableObject != null);
+            Debug.Assert(count > 0);
+
             s_lock.Acquire();
             try
             {
@@ -227,7 +245,13 @@ namespace System.Threading
 
         public static void ReleaseMutex(IntPtr handle)
         {
-            WaitableObject waitableObject = HandleManager.FromHandle(handle);
+            ReleaseMutex(HandleManager.FromHandle(handle));
+        }
+
+        public static void ReleaseMutex(WaitableObject waitableObject)
+        {
+            Debug.Assert(waitableObject != null);
+
             s_lock.Acquire();
             try
             {
@@ -242,14 +266,19 @@ namespace System.Threading
         public static bool Wait(IntPtr handle, int timeoutMilliseconds)
         {
             Debug.Assert(timeoutMilliseconds >= -1);
+            return Wait(HandleManager.FromHandle(handle), timeoutMilliseconds);
+        }
 
-            ThreadWaitInfo waitInfo = RuntimeThread.CurrentThread.WaitInfo;
-            if (waitInfo.CheckAndResetPendingInterrupt)
-            {
-                throw new ThreadInterruptedException();
-            }
+        public static bool Wait(
+            WaitableObject waitableObject,
+            int timeoutMilliseconds,
+            bool interruptible = true,
+            bool prioritize = false)
+        {
+            Debug.Assert(waitableObject != null);
+            Debug.Assert(timeoutMilliseconds >= -1);
 
-            return HandleManager.FromHandle(handle).Wait(waitInfo, timeoutMilliseconds);
+            return waitableObject.Wait(RuntimeThread.CurrentThread.WaitInfo, timeoutMilliseconds, interruptible, prioritize);
         }
 
         public static int Wait(
@@ -267,11 +296,6 @@ namespace System.Threading
             Debug.Assert(timeoutMilliseconds >= -1);
 
             ThreadWaitInfo waitInfo = currentThread.WaitInfo;
-            if (waitInfo.CheckAndResetPendingInterrupt)
-            {
-                throw new ThreadInterruptedException();
-            }
-
             int count = waitHandles.Length;
             WaitableObject[] waitableObjects = waitInfo.GetWaitedObjectArray(count);
             bool success = false;
@@ -315,7 +339,10 @@ namespace System.Threading
             {
                 WaitableObject waitableObject = waitableObjects[0];
                 waitableObjects[0] = null;
-                return waitableObject.Wait(waitInfo, timeoutMilliseconds) ? 0 : WaitHandle.WaitTimeout;
+                return
+                    waitableObject.Wait(waitInfo, timeoutMilliseconds, interruptible: true, prioritize : false)
+                        ? 0
+                        : WaitHandle.WaitTimeout;
             }
 
             return
@@ -325,31 +352,82 @@ namespace System.Threading
                     waitForAll,
                     waitInfo,
                     timeoutMilliseconds,
-                    waitHandles);
+                    interruptible: true,
+                    prioritize: false,
+                    waitHandlesForAbandon: waitHandles);
         }
 
-        public static bool SignalAndWait(IntPtr handleToSignal, IntPtr handleToWaitOn, int timeoutMilliseconds)
+        public static int Wait(
+            RuntimeThread currentThread,
+            WaitableObject waitableObject0,
+            WaitableObject waitableObject1,
+            bool waitForAll,
+            int timeoutMilliseconds,
+            bool interruptible = true,
+            bool prioritize = false)
+        {
+            Debug.Assert(currentThread == RuntimeThread.CurrentThread);
+            Debug.Assert(waitableObject0 != null);
+            Debug.Assert(waitableObject1 != null);
+            Debug.Assert(waitableObject1 != waitableObject0);
+            Debug.Assert(timeoutMilliseconds >= -1);
+
+            ThreadWaitInfo waitInfo = currentThread.WaitInfo;
+            int count = 2;
+            WaitableObject[] waitableObjects = waitInfo.GetWaitedObjectArray(count);
+            waitableObjects[0] = waitableObject0;
+            waitableObjects[1] = waitableObject1;
+            return
+                WaitableObject.Wait(
+                    waitableObjects,
+                    count,
+                    waitForAll,
+                    waitInfo,
+                    timeoutMilliseconds,
+                    interruptible,
+                    prioritize,
+                    waitHandlesForAbandon: null);
+        }
+
+        public static bool SignalAndWait(
+            IntPtr handleToSignal,
+            IntPtr handleToWaitOn,
+            int timeoutMilliseconds)
         {
             Debug.Assert(timeoutMilliseconds >= -1);
 
+            return
+                SignalAndWait(
+                    HandleManager.FromHandle(handleToSignal),
+                    HandleManager.FromHandle(handleToWaitOn),
+                    timeoutMilliseconds);
+        }
+
+        public static bool SignalAndWait(
+            WaitableObject waitableObjectToSignal,
+            WaitableObject waitableObjectToWaitOn,
+            int timeoutMilliseconds,
+            bool interruptible = true,
+            bool prioritize = false)
+        {
+            Debug.Assert(waitableObjectToSignal != null);
+            Debug.Assert(waitableObjectToWaitOn != null);
+            Debug.Assert(timeoutMilliseconds >= -1);
+
             ThreadWaitInfo waitInfo = RuntimeThread.CurrentThread.WaitInfo;
-
-            // A pending interrupt does not signal the specified handle
-            if (waitInfo.CheckAndResetPendingInterrupt)
-            {
-                throw new ThreadInterruptedException();
-            }
-
-            WaitableObject waitableObjectToSignal = HandleManager.FromHandle(handleToSignal);
-            WaitableObject waitableObjectToWaitOn = HandleManager.FromHandle(handleToWaitOn);
-
             bool waitCalled = false;
             s_lock.Acquire();
             try
             {
+                // A pending interrupt does not signal the specified handle
+                if (interruptible && waitInfo.CheckAndResetPendingInterrupt)
+                {
+                    throw new ThreadInterruptedException();
+                }
+
                 waitableObjectToSignal.Signal(1);
                 waitCalled = true;
-                return waitableObjectToWaitOn.Wait_Locked(waitInfo, timeoutMilliseconds);
+                return waitableObjectToWaitOn.Wait_Locked(waitInfo, timeoutMilliseconds, interruptible, prioritize);
             }
             finally
             {
@@ -370,17 +448,9 @@ namespace System.Threading
             ThreadWaitInfo.UninterruptibleSleep0();
         }
 
-        public static void Sleep(int timeoutMilliseconds)
+        public static void Sleep(int timeoutMilliseconds, bool interruptible = true)
         {
-            Debug.Assert(timeoutMilliseconds >= -1);
-
-            ThreadWaitInfo waitInfo = RuntimeThread.CurrentThread.WaitInfo;
-            if (waitInfo.CheckAndResetPendingInterrupt)
-            {
-                throw new ThreadInterruptedException();
-            }
-
-            waitInfo.Sleep(timeoutMilliseconds);
+            ThreadWaitInfo.Sleep(timeoutMilliseconds, interruptible);
         }
 
         public static void Interrupt(RuntimeThread thread)
@@ -398,7 +468,6 @@ namespace System.Threading
             }
         }
 
-        // TODO: Call this
         public static void OnThreadExiting(RuntimeThread thread)
         {
             thread.WaitInfo.OnThreadExiting();

--- a/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
@@ -230,19 +230,36 @@ namespace System.Threading
                 }
             }
 
-            public bool Wait(ThreadWaitInfo waitInfo, int timeoutMilliseconds)
+            public bool Wait(ThreadWaitInfo waitInfo, int timeoutMilliseconds, bool interruptible, bool prioritize)
             {
+                Debug.Assert(waitInfo != null);
+                Debug.Assert(waitInfo.Thread == RuntimeThread.CurrentThread);
+
+                Debug.Assert(timeoutMilliseconds >= -1);
+
                 s_lock.Acquire();
-                return Wait_Locked(waitInfo, timeoutMilliseconds);
+
+                if (interruptible && waitInfo.CheckAndResetPendingInterrupt)
+                {
+                    s_lock.Release();
+                    throw new ThreadInterruptedException();
+                }
+
+                return Wait_Locked(waitInfo, timeoutMilliseconds, interruptible, prioritize);
             }
 
-            public bool Wait_Locked(ThreadWaitInfo waitInfo, int timeoutMilliseconds)
+            /// <summary>
+            /// This function does not check for a pending thread interrupt. Callers are expected to do that soon after
+            /// acquiring <see cref="s_lock"/>.
+            /// </summary>
+            public bool Wait_Locked(ThreadWaitInfo waitInfo, int timeoutMilliseconds, bool interruptible, bool prioritize)
             {
                 s_lock.VerifyIsLocked();
                 Debug.Assert(waitInfo != null);
                 Debug.Assert(waitInfo.Thread == RuntimeThread.CurrentThread);
 
                 Debug.Assert(timeoutMilliseconds >= -1);
+                Debug.Assert(!interruptible || !waitInfo.CheckAndResetPendingInterrupt);
 
                 bool needToWait = false;
                 try
@@ -275,7 +292,7 @@ namespace System.Threading
 
                     WaitableObject[] waitableObjects = waitInfo.GetWaitedObjectArray(1);
                     waitableObjects[0] = this;
-                    waitInfo.RegisterWait(1, isWaitForAll: false);
+                    waitInfo.RegisterWait(1, prioritize, isWaitForAll: false);
                     needToWait = true;
                 }
                 finally
@@ -287,7 +304,12 @@ namespace System.Threading
                     }
                 }
 
-                return waitInfo.Wait(timeoutMilliseconds, waitHandlesForAbandon: null, isSleep: false) != WaitHandle.WaitTimeout;
+                return
+                    waitInfo.Wait(
+                        timeoutMilliseconds,
+                        interruptible,
+                        waitHandlesForAbandon: null,
+                        isSleep: false) != WaitHandle.WaitTimeout;
             }
 
             public static int Wait(
@@ -296,6 +318,8 @@ namespace System.Threading
                 bool waitForAll,
                 ThreadWaitInfo waitInfo,
                 int timeoutMilliseconds,
+                bool interruptible,
+                bool prioritize,
                 WaitHandle[] waitHandlesForAbandon)
             {
                 s_lock.VerifyIsNotLocked();
@@ -311,6 +335,11 @@ namespace System.Threading
                 s_lock.Acquire();
                 try
                 {
+                    if (interruptible && waitInfo.CheckAndResetPendingInterrupt)
+                    {
+                        throw new ThreadInterruptedException();
+                    }
+
                     if (!waitForAll)
                     {
                         // Check if any is already signaled
@@ -419,7 +448,7 @@ namespace System.Threading
                     }
 
                     waitableObjects = null; // no need to clear this anymore, RegisterWait / Wait will take over from here
-                    waitInfo.RegisterWait(count, waitForAll);
+                    waitInfo.RegisterWait(count, prioritize, waitForAll);
                     needToWait = true;
                 }
                 finally
@@ -439,7 +468,7 @@ namespace System.Threading
                     }
                 }
 
-                return waitInfo.Wait(timeoutMilliseconds, waitHandlesForAbandon, isSleep: false);
+                return waitInfo.Wait(timeoutMilliseconds, interruptible, waitHandlesForAbandon, isSleep: false);
             }
 
             public static bool WouldWaitForAllBeSatisfiedOrAborted(
@@ -450,6 +479,7 @@ namespace System.Threading
                 ref bool wouldAnyMutexReacquireCountOverflow,
                 ref bool isAnyAbandonedMutex)
             {
+                s_lock.VerifyIsLocked();
                 Debug.Assert(waitingThread != null);
                 Debug.Assert(waitingThread != RuntimeThread.CurrentThread);
                 Debug.Assert(waitedObjects != null);
@@ -504,6 +534,7 @@ namespace System.Threading
                 int waitedCount,
                 int signaledWaitedObjectIndex)
             {
+                s_lock.VerifyIsLocked();
                 Debug.Assert(waitInfo != null);
                 Debug.Assert(waitInfo.Thread != RuntimeThread.CurrentThread);
                 Debug.Assert(waitedObjects != null);
@@ -542,10 +573,12 @@ namespace System.Threading
                 switch (_type)
                 {
                     case WaitableObjectType.ManualResetEvent:
+                        Debug.Assert(count == 1);
                         SignalManualResetEvent();
                         break;
 
                     case WaitableObjectType.AutoResetEvent:
+                        Debug.Assert(count == 1);
                         SignalAutoResetEvent();
                         break;
 
@@ -554,6 +587,7 @@ namespace System.Threading
                         break;
 
                     default:
+                        Debug.Assert(count == 1);
                         SignalMutex();
                         break;
                 }


### PR DESCRIPTION
- Abandon mutexes on thread exit
- Capabilities for thread pool:
  - Added APIs to WaitSubsystem that work directly on WaitableObjects
  - Added ability to do an uninterruptible wait. Thread pool infrastructure waits cannot be interruptible.
  - Added ability to prioritize a wait such that the waiter is registered at the front of the queue of threads to be released. This will be used with a semaphore by the thread pool to release worker threads waiting for work in LIFO order to keep cold threads cold and allow them to time out.
- Fixed the check and reset of a pending interrupt
  - Previously, the checks were done outside the global lock, so a pending interrupt may get recorded for the about-to-wait thread after the check and before it acquires the lock to do the wait. This would result in the waiting thread not being interrupted and it may go into a long wait while an interrupt is pending.
  - The check for a pending interrupt was previously done before any parameter validation to match the exception order in CoreCLR. This is not strictly necessary and it should be fine to do parameter validation first. Now, the synchronization for the pending interrupt is done mostly using the global lock, with Sleep being a special case. See comment on _isPendingInterrupt in ThreadWaitInfo.
- Tests with multiple threads will be coming later