### PR TITLE
Remove [Serializable] and ISerializable from internal Reflection types

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
@@ -27,8 +27,7 @@ namespace System.Reflection.Runtime.Assemblies
     //
     // The runtime's implementation of an Assembly. 
     //
-    [Serializable]
-    internal abstract partial class RuntimeAssembly : Assembly, IEquatable<RuntimeAssembly>, ISerializable
+    internal abstract partial class RuntimeAssembly : Assembly, IEquatable<RuntimeAssembly>
     {
         public bool Equals(RuntimeAssembly other)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -6,7 +6,6 @@ using System;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
@@ -21,9 +20,8 @@ namespace System.Reflection.Runtime.EventInfos
     //
     // The runtime's implementation of EventInfo's
     //
-    [Serializable]
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimeEventInfo : EventInfo, ISerializable, ITraceableTypeMember
+    internal abstract partial class RuntimeEventInfo : EventInfo, ITraceableTypeMember
     {
         protected RuntimeEventInfo(RuntimeTypeInfo contextTypeInfo, RuntimeTypeInfo reflectedType)
         {
@@ -64,11 +62,6 @@ namespace System.Reflection.Runtime.EventInfos
 
                 return ContextTypeInfo;
             }
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
         }
 
         public sealed override MethodInfo[] GetOtherMethods(bool nonPublic)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 
 using System.Reflection.Runtime.General;
@@ -25,9 +24,8 @@ namespace System.Reflection.Runtime.FieldInfos
     //
     // The Runtime's implementation of fields.
     //
-    [Serializable]
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimeFieldInfo : FieldInfo, ISerializable, ITraceableTypeMember
+    internal abstract partial class RuntimeFieldInfo : FieldInfo, ITraceableTypeMember
     {
         //
         // contextType    - the type that supplies the type context (i.e. substitutions for generic parameters.) Though you
@@ -71,11 +69,6 @@ namespace System.Reflection.Runtime.FieldInfos
             {
                 return this.FieldRuntimeType;
             }
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
         }
 
         public abstract override Type[] GetOptionalCustomModifiers();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
@@ -8,15 +8,10 @@
 // keep the main files less cluttered.
 //
 
-using System;
 using System.IO;
 using System.Text;
-using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Runtime.InteropServices;
 using System.Reflection.Runtime.General;
 
 using Internal.LowLevelLinq;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
 using System.Reflection.Runtime.ParameterInfos;
@@ -21,8 +20,7 @@ namespace System.Reflection.Runtime.MethodInfos
     //
     // The runtime's implementation of ConstructorInfo.
     //
-    [Serializable]
-    internal abstract partial class RuntimeConstructorInfo : ConstructorInfo, ISerializable
+    internal abstract partial class RuntimeConstructorInfo : ConstructorInfo
     {
         public abstract override MethodAttributes Attributes { get; }
 
@@ -47,11 +45,6 @@ namespace System.Reflection.Runtime.MethodInfos
         }
 
         public sealed override MethodBody GetMethodBody()
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
@@ -23,7 +22,7 @@ namespace System.Reflection.Runtime.MethodInfos
     // Abstract base class for RuntimeNamedMethodInfo, RuntimeConstructedGenericMethodInfo.
     //
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimeMethodInfo : MethodInfo, ISerializable, ITraceableTypeMember
+    internal abstract partial class RuntimeMethodInfo : MethodInfo, ITraceableTypeMember
     {
         protected RuntimeMethodInfo()
         {
@@ -151,11 +150,6 @@ namespace System.Reflection.Runtime.MethodInfos
         }
 
         public abstract override MethodInfo GetGenericMethodDefinition();
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
 
         public sealed override MethodBody GetMethodBody()
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -15,7 +15,6 @@ namespace System.Reflection.Runtime.Modules
     // Modules are quite meaningless in ProjectN but we have to keep up the appearances since they still exist in Win8P's surface area.
     // As far as ProjectN is concerned, each Assembly has one module.
     //
-    [Serializable]
     internal abstract partial class RuntimeModule : Module
     {
         protected RuntimeModule()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
@@ -6,15 +6,13 @@ using System;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {
     //
     // Abstract base for all ParameterInfo objects created by the Runtime.
     //
-    [Serializable]
-    internal abstract partial class RuntimeParameterInfo : ParameterInfo, ISerializable
+    internal abstract partial class RuntimeParameterInfo : ParameterInfo
     {
         protected RuntimeParameterInfo(MemberInfo member, int position)
         {
@@ -41,20 +39,6 @@ namespace System.Reflection.Runtime.ParameterInfos
         public sealed override int GetHashCode()
         {
             return _member.GetHashCode();
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            if (info == null)
-                throw new ArgumentNullException(nameof(info));
-
-            // Setting the ObjectType to ParameterInfo is partly tradition (CLR has always done this) and mostly because RuntimeParameterInfo
-            // is not discoverable via Reflection.
-            info.SetType(typeof(ParameterInfo));
-
-            // Compat note: Choosing not to serialize legacy fields such as "AttrsImpl" and "NameImpl" as they've been ignored by deserialization since CLR 4.0.
-            info.AddValue("MemberImpl", Member);
-            info.AddValue("PositionImpl", Position);
         }
 
         public abstract override Type[] GetOptionalCustomModifiers();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
@@ -28,7 +27,7 @@ namespace System.Reflection.Runtime.PropertyInfos
     // The runtime's implementation of PropertyInfo's
     //
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimePropertyInfo : PropertyInfo, ISerializable, ITraceableTypeMember
+    internal abstract partial class RuntimePropertyInfo : PropertyInfo, ITraceableTypeMember
     {
         //
         // propertyHandle - the "tkPropertyDef" that identifies the property.
@@ -119,11 +118,6 @@ namespace System.Reflection.Runtime.PropertyInfos
                 result[i] = indexParameters[i];
             }
             return result;
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
         }
 
         public sealed override MethodInfo GetMethod

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.MethodInfos;
 
@@ -34,9 +33,8 @@ namespace System.Reflection.Runtime.TypeInfos
     //   - Overrides many "NotImplemented" members in TypeInfo with abstracts so failure to implement
     //     shows up as build error.
     //
-    [Serializable]
     [DebuggerDisplay("{_debugName}")]
-    internal abstract partial class RuntimeTypeInfo : TypeInfo, ISerializable, ITraceableTypeMember, ICloneable, IRuntimeImplementedType
+    internal abstract partial class RuntimeTypeInfo : TypeInfo, ITraceableTypeMember, ICloneable, IRuntimeImplementedType
     {
         protected RuntimeTypeInfo()
         {
@@ -207,11 +205,6 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override InterfaceMapping GetInterfaceMap(Type interfaceType)
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_InterfaceMap);
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
         }
 
         //


### PR DESCRIPTION
The presence of [Serializable] was making these internal types
reflectable. Internal types do not need to implement ISerializable
on their own - that's for reflection providers that choose
to make their implementations serializable. We do not.