### PR TITLE
Handle spurious wakeups in LowLevelLock

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
@@ -182,7 +182,6 @@ namespace System.Threading
                 _monitor.Wait();
 
                 /// Indicate to <see cref="SignalWaiter"/> that the signaled thread has woken up
-                Debug.Assert(_isAnyWaitingThreadSignaled);
                 _isAnyWaitingThreadSignaled = false;
 
                 state = _state;


### PR DESCRIPTION
- The assert is invalid for spurious wakeups. Since spurious wakeups should be rare, it would just try for the lock upon waking up for any reason.