### PR TITLE
Throw an exception when vararg signature is detected

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -170,6 +170,10 @@ namespace Internal.TypeSystem.Ecma
                 Debug.Assert((int)MethodSignatureFlags.UnmanagedCallingConventionStdCall == (int)SignatureCallingConvention.StdCall);
                 Debug.Assert((int)MethodSignatureFlags.UnmanagedCallingConventionThisCall == (int)SignatureCallingConvention.ThisCall);
 
+                // Vararg methods are not supported in .NET Core
+                if (signatureCallConv == SignatureCallingConvention.VarArgs)
+                    throw new TypeSystemException.BadImageFormatException();
+
                 flags = (MethodSignatureFlags)signatureCallConv;
             }
 


### PR DESCRIPTION
We don't report this properly to RyuJIT and end up asserting it every
time we compile System.Console.dll (in multifile mode). The version of
System.Console.dll we have has an unfortunate varargs method in it.