### PR TITLE
Optimize VerifyGenericParamConstraint

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemConstaintsHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemConstaintsHelpers.cs
@@ -11,22 +11,24 @@ namespace Internal.TypeSystem
     {
         private static bool VerifyGenericParamConstraint(Instantiation typeInstantiation, Instantiation methodInstantiation, GenericParameterDesc genericParam, TypeDesc instantiationParam)
         {
+            GenericConstraints constraints = genericParam.Constraints;
+
             // Check class constraint
-            if (genericParam.HasReferenceTypeConstraint)
+            if ((constraints & GenericConstraints.ReferenceTypeConstraint) != 0)
             {
                 if (!instantiationParam.IsGCPointer)
                     return false;
             }
 
             // Check default constructor constraint
-            if (genericParam.HasDefaultConstructorConstraint)
+            if ((constraints & GenericConstraints.DefaultConstructorConstraint) != 0)
             {
                 if (!instantiationParam.HasExplicitOrImplicitDefaultConstructor())
                     return false;
             }
 
             // Check struct constraint
-            if (genericParam.HasNotNullableValueTypeConstraint)
+            if ((constraints & GenericConstraints.NotNullableValueTypeConstraint) != 0)
             {
                 if (!instantiationParam.IsValueType)
                     return false;


### PR DESCRIPTION
A tiny performance boost to constraint checking. Building ASP.NET 2.0
benchmark makes constraint checking extremely hot (due to GVM analysis)
and we spend more than 6% of time in it.