### PR TITLE
Make virtual invoke map report dependency on virtual method slot

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
@@ -108,6 +108,15 @@ namespace ILCompiler.DependencyAnalysis
                 NativeLayoutMethodNameAndSignatureVertexNode nameAndSig = factory.NativeLayout.MethodNameAndSignatureVertex(method.GetTypicalMethodDefinition());
                 NativeLayoutPlacedSignatureVertexNode placedNameAndSig = factory.NativeLayout.PlacedSignatureVertex(nameAndSig);
                 dependencies.Add(placedNameAndSig, "Reflection virtual invoke method signature");
+
+                if (!method.HasInstantiation)
+                {
+                    MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                    if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(slotDefiningMethod.OwningType))
+                    {
+                        dependencies.Add(factory.VirtualMethodUse(slotDefiningMethod), "Reflection virtual invoke method");
+                    }
+                }
             }
         }
 
@@ -207,13 +216,7 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     // Get the declaring method for slot on the instantiated declaring type
                     int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, declaringMethodForSlot, factory.Target.Abi != TargetAbi.ProjectN);
-
-                    if (slot == -1)
-                    {
-                        // This method doesn't have a slot. (At this time, this is only done for the Object.Finalize method)
-                        Debug.Assert(declaringMethodForSlot.Name == "Finalize");
-                        continue;
-                    }
+                    Debug.Assert(slot != -1);
 
                     vertex = writer.GetTuple(
                         writer.GetUnsignedConstant(_externalReferences.GetIndex(containingTypeKeyNode)),

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -717,6 +717,7 @@ class Program
             public virtual string IFaceMethod1(T t) { return "BaseClass.IFaceMethod1"; }
             public virtual string IFaceGVMethod1<U>(T t, U u) { return "BaseClass.IFaceGVMethod1"; }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public virtual string VirtualButNotUsedVirtuallyMethod(T t) { return "BaseClass.VirtualButNotUsedVirtuallyMethod"; }
         }
 

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -716,6 +716,8 @@ class Program
 
             public virtual string IFaceMethod1(T t) { return "BaseClass.IFaceMethod1"; }
             public virtual string IFaceGVMethod1<U>(T t, U u) { return "BaseClass.IFaceGVMethod1"; }
+
+            public virtual string VirtualButNotUsedVirtuallyMethod(T t) { return "BaseClass.VirtualButNotUsedVirtuallyMethod"; }
         }
 
         public class DerivedClass1<T> : BaseClass<T>, IFace<T>
@@ -728,6 +730,12 @@ class Program
             public new virtual string GVMethod3<U>(T t, U u) { return "DerivedClass1.GVMethod3"; }
 
             public override string IFaceMethod1(T t) { return "DerivedClass1.IFaceMethod1"; }
+
+            public string UseVirtualButNotUsedVirtuallyMethod(T t)
+            {
+                // Calling through base produces a `call` instead of `callvirt` instruction.
+                return base.VirtualButNotUsedVirtuallyMethod(t);
+            }
         }
 
         public class DerivedClass2<T> : DerivedClass1<T>, IFace<T>
@@ -801,6 +809,7 @@ class Program
                 new DerivedClass1<string>().GVMethod2<string>("string", "string2");
                 new DerivedClass1<string>().GVMethod3<string>("string", "string2");
                 new DerivedClass1<string>().GVMethod4<string>("string", "string2");
+                new DerivedClass1<string>().UseVirtualButNotUsedVirtuallyMethod("string");
                 new DerivedClass2<string>().Method1("string");
                 new DerivedClass2<string>().Method2("string");
                 new DerivedClass2<string>().Method3("string");
@@ -816,6 +825,7 @@ class Program
                 MethodInfo m2 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("Method2");
                 MethodInfo m3 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("Method3");
                 MethodInfo m4 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("Method4");
+                MethodInfo unusedMethod = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("VirtualButNotUsedVirtuallyMethod");
                 MethodInfo gvm1 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("GVMethod1").MakeGenericMethod(typeof(string));
                 MethodInfo gvm2 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("GVMethod2").MakeGenericMethod(typeof(string));
                 MethodInfo gvm3 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("GVMethod3").MakeGenericMethod(typeof(string));
@@ -824,6 +834,7 @@ class Program
                 Verify("BaseClass.Method2", m2.Invoke(new BaseClass<string>(), new[] { "" }));
                 Verify("BaseClass.Method3", m3.Invoke(new BaseClass<string>(), new[] { "" }));
                 Verify("BaseClass.Method4", m4.Invoke(new BaseClass<string>(), new[] { "" }));
+                Verify("BaseClass.VirtualButNotUsedVirtuallyMethod", unusedMethod.Invoke(new BaseClass<string>(), new[] { "" }));
                 Verify("DerivedClass1.Method1", m1.Invoke(new DerivedClass1<string>(), new[] { "" }));
                 Verify("DerivedClass1.Method2", m2.Invoke(new DerivedClass1<string>(), new[] { "" }));
                 Verify("BaseClass.Method3", m3.Invoke(new DerivedClass1<string>(), new[] { "" }));


### PR DESCRIPTION
Placing a virtual method in the map means that we'll need a slot for it.

I wasn't sure I liked this as a fix in the past, because it makes the
mapping table potentially bring unused methods into the compilation
(e.g. if the method has multiple overrides), but I convinced myself that
doing anything else would result in terrible user experience and
whatever external tool we'll use to determine reflection roots in the
future will need to apply the same rule.