### PR TITLE
Add HasFixedSlots API to VTableSlice

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -262,7 +262,7 @@ namespace ILCompiler
             {
                 Debug.Assert(method.IsVirtual);
 
-                if (!_factory.CompilationModuleGroup.ShouldProduceFullVTable(method.OwningType))
+                if (!_factory.VTable(method.OwningType).HasFixedSlots)
                     _graph.AddRoot(_factory.VirtualMethodUse(method), reason);
 
                 if (method.IsAbstract)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(factory.InterfaceDispatchMap(_type), "Interface dispatch map");
             }
 
-            if (_type.RuntimeInterfaces.Length > 0 && !factory.CompilationModuleGroup.ShouldProduceFullVTable(_type))
+            if (_type.RuntimeInterfaces.Length > 0 && !factory.VTable(_type).HasFixedSlots)
             {
                 foreach (var implementedInterface in _type.RuntimeInterfaces)
                 {
@@ -197,7 +197,7 @@ namespace ILCompiler.DependencyAnalysis
             DefType defType = _type.GetClosestDefType();
 
             // If we're producing a full vtable, none of the dependencies are conditional.
-            if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(defType))
+            if (!factory.VTable(defType).HasFixedSlots)
             {
                 foreach (MethodDesc decl in defType.EnumAllVirtualSlots())
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -450,7 +450,7 @@ namespace ILCompiler.DependencyAnalysis
 
             // It's only okay to touch the actual list of slots if we're in the final emission phase
             // or the vtable is not built lazily.
-            if (relocsOnly && !factory.CompilationModuleGroup.ShouldProduceFullVTable(declType))
+            if (relocsOnly && !factory.VTable(declType).HasFixedSlots)
                 return;
 
             // Actual vtable slots follow

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -362,7 +362,7 @@ namespace ILCompiler.DependencyAnalysis
             MethodDesc canonMethod = _method.GetCanonMethodTarget(CanonicalFormKind.Universal);
 
             // If we're producing a full vtable for the type, we don't need to report virtual method use.
-            if (factory.CompilationModuleGroup.ShouldProduceFullVTable(canonMethod.OwningType))
+            if (factory.VTable(canonMethod.OwningType).HasFixedSlots)
                 return Array.Empty<DependencyNodeCore<NodeFactory>>();
 
             return new DependencyNodeCore<NodeFactory>[] {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -1331,7 +1331,7 @@ namespace ILCompiler.DependencyAnalysis
                     break;
 
                 case VTableEntriesToProcess.AllOnTypesThatShouldProduceFullVTables:
-                    if (factory.CompilationModuleGroup.ShouldProduceFullVTable(declType))
+                    if (factory.VTable(declType).HasFixedSlots)
                     {
                         vtableEntriesToProcess = factory.VTable(declType).Slots;
                     }
@@ -1342,7 +1342,7 @@ namespace ILCompiler.DependencyAnalysis
                     break;
 
                 case VTableEntriesToProcess.AllOnTypesThatProducePartialVTables:
-                    if (factory.CompilationModuleGroup.ShouldProduceFullVTable(declType))
+                    if (factory.VTable(declType).HasFixedSlots)
                     {
                         vtableEntriesToProcess = Array.Empty<MethodDesc>();
                     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -327,9 +327,9 @@ namespace ILCompiler.DependencyAnalysis
 
             _virtMethods = new NodeCache<MethodDesc, VirtualMethodUseNode>((MethodDesc method) =>
             {
-                // We don't need to track virtual method uses for types that are producing full vtables.
+                // We don't need to track virtual method uses for types that have a vtable with a known layout.
                 // It's a waste of CPU time and memory.
-                Debug.Assert(!CompilationModuleGroup.ShouldProduceFullVTable(method.OwningType));
+                Debug.Assert(!VTable(method.OwningType).HasFixedSlots);
 
                 return new VirtualMethodUseNode(method);
             });

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -111,7 +111,7 @@ namespace ILCompiler.DependencyAnalysis
                         if (createInfo.NeedsVirtualMethodUseTracking)
                         {
                             MethodDesc instantiatedTargetMethod = createInfo.TargetMethod.GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
-                            if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(instantiatedTargetMethod.OwningType))
+                            if (!factory.VTable(instantiatedTargetMethod.OwningType).HasFixedSlots)
                             {
                                 result.Add(
                                     new DependencyListEntry(
@@ -131,7 +131,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.ResolveVirtualFunction:
                     {
                         MethodDesc instantiatedTarget = ((MethodDesc)_target).GetNonRuntimeDeterminedMethodFromRuntimeDeterminedMethodViaSubstitution(typeInstantiation, methodInstantiation);
-                        if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(instantiatedTarget.OwningType))
+                        if (!factory.VTable(instantiatedTarget.OwningType).HasFixedSlots)
                         {
                             result.Add(
                                 new DependencyListEntry(

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -149,7 +149,7 @@ namespace ILCompiler.DependencyAnalysis
                     dependencyList.Add(factory.ReflectableMethod(targetMethod), "Abstract reflectable method");
                 }
 
-                if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(targetMethod.OwningType))
+                if (!factory.VTable(targetMethod.OwningType).HasFixedSlots)
 
                 {
                     dependencyList.Add(factory.VirtualMethodUse((MethodDesc)_target), "ReadyToRun Virtual Method Call");
@@ -173,7 +173,7 @@ namespace ILCompiler.DependencyAnalysis
                         dependencyList.Add(factory.ReflectableMethod(targetMethod), "Abstract reflectable method");
                     }
 
-                    if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(info.TargetMethod.OwningType))
+                    if (!factory.VTable(info.TargetMethod.OwningType).HasFixedSlots)
                     {
                         dependencyList.Add(factory.VirtualMethodUse(info.TargetMethod), "ReadyToRun Delegate to virtual method");
                     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
@@ -112,7 +112,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (!method.HasInstantiation)
                 {
                     MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
-                    if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(slotDefiningMethod.OwningType))
+                    if (!factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
                     {
                         dependencies.Add(factory.VirtualMethodUse(slotDefiningMethod), "Reflection virtual invoke method");
                     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -29,6 +29,14 @@ namespace ILCompiler.DependencyAnalysis
             get;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the slots are assigned at the beginning of the compilation.
+        /// </summary>
+        public abstract bool HasFixedSlots
+        {
+            get;
+        }
+
         protected override string GetName(NodeFactory factory) => $"__vtable_{factory.NameMangler.GetMangledTypeName(_type).ToString()}";
 
         public override bool StaticDependenciesAreComputed => true;
@@ -97,6 +105,14 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        public override bool HasFixedSlots
+        {
+            get
+            {
+                return true;
+            }
+        }
+
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             if (_type.HasBaseType)
@@ -150,6 +166,14 @@ namespace ILCompiler.DependencyAnalysis
                 }
 
                 return _slots;
+            }
+        }
+
+        public override bool HasFixedSlots
+        {
+            get
+            {
+                return false;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -79,7 +79,7 @@ namespace ILCompiler.DependencyAnalysis
             DefType universalCanonicalOwningType = (DefType)_decl.OwningType.ConvertToCanonForm(CanonicalFormKind.Universal);
             Debug.Assert(universalCanonicalOwningType.IsCanonicalSubtype(CanonicalFormKind.Universal));
 
-            if (!factory.CompilationModuleGroup.ShouldProduceFullVTable(universalCanonicalOwningType))
+            if (!factory.VTable(universalCanonicalOwningType).HasFixedSlots)
             {
                 // This code ensures that in cases where we don't structurally force all universal canonical instantiations
                 // to have full vtables, that we ensure that all vtables are equivalently shaped between universal and non-universal types

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -968,7 +968,7 @@ namespace Internal.IL
                     else
                         callViaSlot = true;
 
-                    if (!_nodeFactory.CompilationModuleGroup.ShouldProduceFullVTable(method.OwningType))
+                    if (!_nodeFactory.VTable(method.OwningType).HasFixedSlots)
                         _dependencies.Add(_nodeFactory.VirtualMethodUse(method));
                 }
             }


### PR DESCRIPTION
This is in preparation for hooking up the ILScanner. The result of IL
scanning will be a precise set of VTable slots to generate that we'll
use to allocate a new descendant of `VTableSliceNode` that reports
`HasFixedSlots` as true, even though `ShouldProduceFullVTable` might
still be false.