### PR TITLE
[WIP] Speed up string allocations

### DIFF
--- a/src/Native/Runtime/amd64/AllocFast.asm
+++ b/src/Native/Runtime/amd64/AllocFast.asm
@@ -110,18 +110,9 @@ LEAF_ENTRY RhNewString, _TEXT
         cmp         rdx, 07fffffffh
         ja          StringSizeOverflow
 
-        ; save element count
-        mov         r8, rdx
-
         ; Compute overall allocation size (align(base size + (element size * elements), 8)).
-        movzx       eax, word ptr [rcx + OFFSETOF__EEType__m_usComponentSize]
-        mul         rdx
-        mov         edx, [rcx + OFFSETOF__EEType__m_uBaseSize]
-        add         rax, rdx
-        add         rax, 7
+        lea         rax, [rdx * 2 + (2 * 8 + 4 + 2) + 7]
         and         rax, -8
-
-        mov         rdx, r8
 
         ; rax == array size
         ; rcx == EEType

--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -110,6 +110,13 @@ COOP_PINVOKE_HELPER(Object *, RhpNewFinalizable, (EEType* pEEType))
     return pObject;
 }
 
+COOP_PINVOKE_HELPER(Array *, RhNewString, (EEType * pArrayEEType, int numElements))
+{
+    Array * pObject = nullptr;
+    /* TODO */ ASSERT_UNCONDITIONALLY("NYI");
+    return pObject;
+}
+
 COOP_PINVOKE_HELPER(Array *, RhpNewArray, (EEType * pArrayEEType, int numElements))
 {
     ASSERT_MSG(!pArrayEEType->RequiresAlign8(), "NYI");

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -313,10 +313,9 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhNewArray")]
         internal static extern Array RhNewArray(EETypePtr pEEType, int length);
 
-        // @todo: Should we just have a proper export for this?
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhNewArray")]
-        internal static extern String RhNewArrayAsString(EETypePtr pEEType, int length);
+        [RuntimeImport(RuntimeLibrary, "RhNewString")]
+        internal static extern String RhNewString(EETypePtr pEEType, int length);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhBox")]

--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -586,19 +586,12 @@ namespace System
 
         internal static String FastAllocateString(int length)
         {
-            try
-            {
-                // We allocate one extra char as an interop convenience so that our strings are null-
-                // terminated, however, we don't pass the extra +1 to the array allocation because the base
-                // size of this object includes the _firstChar field.
-                string newStr = RuntimeImports.RhNewArrayAsString(EETypePtr.EETypePtrOf<string>(), length);
-                Debug.Assert(newStr._stringLength == length);
-                return newStr;
-            }
-            catch (OverflowException)
-            {
-                throw new OutOfMemoryException();
-            }
+            // We allocate one extra char as an interop convenience so that our strings are null-
+            // terminated, however, we don't pass the extra +1 to the array allocation because the base
+            // size of this object includes the _firstChar field.
+            string newStr = RuntimeImports.RhNewString(EETypePtr.EETypePtrOf<string>(), length);
+            Debug.Assert(newStr._stringLength == length);
+            return newStr;
         }
 
         internal static unsafe void wstrcpy(char* dmem, char* smem, int charCount)


### PR DESCRIPTION
I was looking at how much the `@todo: Should we just have a proper export for this?` is costing us for string allocations.

(`FastAllocateString` is showing up hot in the benchmarks we've been running.)

@dotnet-bot skip CI please