### PR TITLE
Fix writing object by ObjWriter for arm32

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -921,7 +921,8 @@ namespace ILCompiler.DependencyAnalysis
                     // Build symbol definition map.
                     objectWriter.BuildSymbolDefinitionMap(node, nodeContents.DefinedSymbols);
 
-                    if (!factory.Target.IsWindows)
+                    // The DWARF CFI unwind is implemented for AMD64 only.
+                    if (!factory.Target.IsWindows && (factory.Target.Architecture == TargetArchitecture.X64))
                         objectWriter.BuildCFIMap(factory, node);
 
                     // Build debug location map


### PR DESCRIPTION
	- DWARF CFI unwind is not implemented for arm32 now

Signed-off-by: Petr Bred <bredpetr@gmail.com>