### PR TITLE
Implement Activator.CreateInstance<T> intrinsic

### DIFF
--- a/src/Common/src/TypeSystem/IL/HelperExtensions.cs
+++ b/src/Common/src/TypeSystem/IL/HelperExtensions.cs
@@ -77,6 +77,21 @@ namespace Internal.IL
         }
 
         /// <summary>
+        /// Retrieves a nested type on <paramref name="type"/> that is well known to the compiler.
+        /// Throws an exception if the nested type doesn't exist.
+        /// </summary>
+        public static MetadataType GetKnownNestedType(this MetadataType type, string name)
+        {
+            MetadataType nestedType = type.GetNestedType(name);
+            if (nestedType == null)
+            {
+                throw new InvalidOperationException(String.Format("Expected type '{0}' not found on type '{1}'", name, type));
+            }
+
+            return nestedType;
+        }
+
+        /// <summary>
         /// Retrieves a namespace type in <paramref name= "module" /> that is well known to the compiler.
         /// Throws an exception if the type doesn't exist.
         /// </summary>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -1203,8 +1203,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 // If there isn't a default constructor, use the fallback one.
                 MetadataType missingCtorType = factory.TypeSystemContext.SystemModule.GetKnownType("System", "Activator");
-                missingCtorType = missingCtorType.GetNestedType("ClassWithMissingConstructor");                
-                Debug.Assert(missingCtorType != null);
+                missingCtorType = missingCtorType.GetKnownNestedType("ClassWithMissingConstructor");                
                 defaultCtor = missingCtorType.GetParameterlessConstructor();
             }
             else

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -55,6 +55,8 @@ namespace ILCompiler.DependencyAnalysis
                     return factory.GenericLookup.MethodEntry((MethodDesc)target);
                 case ReadyToRunHelperId.DelegateCtor:
                     return ((DelegateCreationInfo)target).GetLookupKind(factory);
+                case ReadyToRunHelperId.DefaultConstructor:
+                    return factory.GenericLookup.DefaultCtorLookupResult((TypeDesc)target);
                 default:
                     throw new NotImplementedException();
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -30,7 +30,8 @@ namespace ILCompiler.DependencyAnalysis
         MethodHandle,
         FieldHandle,
         MethodDictionary,
-        MethodEntry
+        MethodEntry,
+        DefaultConstructor,
     }
 
     public partial class ReadyToRunHelperNode : AssemblyStubNode

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -210,6 +210,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.VirtualCall:
                 case ReadyToRunHelperId.ResolveVirtualFunction:
                 case ReadyToRunHelperId.MethodEntry:
+                case ReadyToRunHelperId.DefaultConstructor:
                     {
                         EmitDictionaryLookup(factory, ref encoder, contextRegister, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
                         encoder.EmitRET();

--- a/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
+++ b/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
@@ -127,6 +127,7 @@ namespace Internal.JitInterface
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_Span_GetItem, "get_Item", "System", "Span`1");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_ReadOnlySpan_GetItem, "get_Item", "System", "ReadOnlySpan`1");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "EETypePtrOf", "System", "EETypePtr");
+            table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "DefaultConstructorOf", "System", "Activator");
 
             // If this assert fails, make sure to add the new intrinsics to the table above and update the expected count below.
             Debug.Assert((int)CorInfoIntrinsics.CORINFO_INTRINSIC_Count == 50);
@@ -202,6 +203,10 @@ namespace Internal.JitInterface
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Ctor:
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Value:
                     pMustExpand = true;
+                    break;
+
+                case CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle:
+                    pMustExpand = method.Name == "DefaultConstructorOf";
                     break;
 
                 default:

--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -54,8 +54,22 @@ namespace System
 
                 try
                 {
+#if PROJECTN
                     t = CreateInstanceIntrinsic<T>();
-                    System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+                    DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+#else
+                    if (RuntimeHelpers.IsReference<T>())
+                    {
+                        t = (T)(RuntimeImports.RhNewObject(eetype));
+
+                        // Run the default constructor. If the default constructor was missing, codegen
+                        // will expand DefaultConstructorOf to ClassWithMissingConstructor::.ctor
+                        // and we detect that later.
+                        IntPtr defaultConstructor = DefaultConstructorOf<T>();
+                        RawCalliHelper.Call(defaultConstructor, t);
+                        DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+                    }
+#endif
                 }
                 catch (Exception e)
                 {
@@ -81,27 +95,14 @@ namespace System
         }
 
         [Intrinsic]
-        [DebuggerGuidedStepThrough]
-        private static T CreateInstanceIntrinsic<T>()
+        private extern static T CreateInstanceIntrinsic<T>();
+
+        [Intrinsic]
+        private static IntPtr DefaultConstructorOf<T>()
         {
-            // Fallback implementation for codegens that don't support this intrinsic.
-            // This uses the type loader and doesn't have the kind of guarantees about it always working
-            // as the intrinsic expansion has. Also, it's slower.
-
-            EETypePtr eetype = EETypePtr.EETypePtrOf<T>();
-
-            // The default(T) check can be evaluated statically and will result in the body of this method
-            // becoming empty for valuetype Ts. We still need a dynamic IsNullable check to cover Nullables though.
-            // This will obviously need work once we start supporting default valuetype constructors.
-            if (default(T) == null && !eetype.IsNullable)
-            {
-                object o = null;
-                TypeLoaderExports.ActivatorCreateInstanceAny(ref o, eetype.RawValue);
-                System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
-                return (T)o;
-            }
-
-            return default(T);
+            // Codegens must expand this intrinsic.
+            // We could implement a fallback with the type loader if we wanted to, but it will be slow and unreliable.
+            throw new NotSupportedException();
         }
 
         [ThreadStatic]

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -219,6 +219,13 @@ namespace System.Runtime.CompilerServices
             return !pEEType.IsValueType || pEEType.HasPointers;
         }
 
+        [Intrinsic]
+        public static bool IsReference<T>()
+        {
+            var pEEType = EETypePtr.EETypePtrOf<T>();
+            return !pEEType.IsValueType;
+        }
+
         // Constrained Execution Regions APIs are NOP's because we do not support CERs in .NET Core at all.
         public static void ProbeForSufficientStack() { }
         public static void PrepareConstrainedRegions() { }

--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -36,25 +36,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgvtret\_il_dbgvtret.*" />
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_relvtret\_il_relvtret.*" />
     
-    <!-- CreateInstance<T> -->
-    <!-- https://github.com/dotnet/corert/issues/368 -->
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Base_6\Generic_Test_CSharp_Base_6.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Peer_6\Generic_Test_CSharp_Peer_6.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_cs_d\class1_cs_d.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_cs_do\class1_cs_do.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_cs_r\class1_cs_r.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_cs_ro\class1_cs_ro.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_cs_d\class2_cs_d.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_cs_do\class2_cs_do.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_cs_r\class2_cs_r.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_cs_ro\class2_cs_ro.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_cs_d\vt4_cs_d.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_cs_do\vt4_cs_do.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_cs_r\vt4_cs_r.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_cs_ro\vt4_cs_ro.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\341477\Test\Test.*" />
-    <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_568786\4_Misc\SealedTypes\SealedTypes.*" />
-
     <!-- System.Reflection.Emit.Lightweight -->
     <!-- https://github.com/dotnet/corert/issues/370 -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\dynamic_methods\bug_445388\bug_445388.*" />


### PR DESCRIPTION
We previously didn't do an intrinsic expanstion for this and had to fall
back to slow and unreliable type loader. This implements a guaranteed
expansion of `CreateInstance<T>` using the infrastructure built for
`EETypePtrOf<T>`.

* Add `RuntimeHelpers.IsReference<T>` intrinsic that constantly expands
to 0 or 1 at compile time (this gets rid of the `default(T) == null`
workaround that requires special handling for `Nullable<T>`).
* Add `DefaultConstructorOf<T>` that expands to the default constructor
of `T` or a special marker method.
* Rewrite `CreateInstanceIntrinsic` using the new intrinsics.

Fixes #368.