### PR TITLE
Remove workaround for EETypePtrOf being slow in Buffer

### DIFF
--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -36,7 +36,8 @@ namespace System
                 throw new ArgumentNullException(nameof(dst));
 
             // Use optimized path for byte arrays since this is the main scenario for Buffer::BlockCopy
-            if (src.EETypePtr.FastEquals(EETypePtr.EETypePtrOf<byte[]>()))
+            // We only need an unreliable comparison since the slow path can handle the byte[] case too.
+            if (src.EETypePtr.FastEqualsUnreliable(EETypePtr.EETypePtrOf<byte[]>()))
             {
                 uSrcLen = (nuint)src.Length;
             }
@@ -50,7 +51,9 @@ namespace System
 
             if (src != dst)
             {
-                if (dst.EETypePtr.FastEquals(EETypePtr.EETypePtrOf<byte[]>()))
+                // Use optimized path for byte arrays since this is the main scenario for Buffer::BlockCopy
+                // We only need an unreliable comparison since the slow path can handle the byte[] case too.
+                if (dst.EETypePtr.FastEqualsUnreliable(EETypePtr.EETypePtrOf<byte[]>()))
                 {
                     uDstLen = (nuint)dst.Length;
                 }

--- a/src/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.cs
@@ -21,15 +21,8 @@ using nuint = System.UInt32;
 
 namespace System
 {
-    [EagerStaticClassConstruction]
     public static class Buffer
     {
-        /// <summary>
-        /// This field is used to quickly check whether an array that is given to the BlockCopy
-        /// method is a byte array and the code can take optimized path.
-        /// </summary>
-        private static readonly EETypePtr s_byteArrayEEType = EETypePtr.EETypePtrOf<byte[]>();
-
         public static unsafe void BlockCopy(Array src, int srcOffset,
                                             Array dst, int dstOffset,
                                             int count)
@@ -43,8 +36,7 @@ namespace System
                 throw new ArgumentNullException(nameof(dst));
 
             // Use optimized path for byte arrays since this is the main scenario for Buffer::BlockCopy
-            EETypePtr byteArrayEEType = s_byteArrayEEType;
-            if (src.EETypePtr.FastEquals(byteArrayEEType))
+            if (src.EETypePtr.FastEquals(EETypePtr.EETypePtrOf<byte[]>()))
             {
                 uSrcLen = (nuint)src.Length;
             }
@@ -58,7 +50,7 @@ namespace System
 
             if (src != dst)
             {
-                if (dst.EETypePtr.FastEquals(byteArrayEEType))
+                if (dst.EETypePtr.FastEquals(EETypePtr.EETypePtrOf<byte[]>()))
                 {
                     uDstLen = (nuint)dst.Length;
                 }

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -90,6 +90,19 @@ namespace System
             return RuntimeImports.AreTypesEquivalent(this, other);
         }
 
+        //
+        // An even faster version of FastEquals that only checks if two EEType pointers are identical.
+        // Note: this method might return false for cases where FastEquals would return true.
+        // Only use if you know what you're doing.
+        //
+        internal bool FastEqualsUnreliable(EETypePtr other)
+        {
+            Debug.Assert(!this.IsNull);
+            Debug.Assert(!other.IsNull);
+
+            return this.RawValue == other.RawValue;
+        }
+
         // Caution: You cannot safely compare RawValue's as RH does NOT unify EETypes. Use the == or Equals() methods exposed by EETypePtr itself.
         internal IntPtr RawValue
         {


### PR DESCRIPTION
EETypePtrOf is more efficient than a cached static now.