### PR TITLE
Fixed casting logic with generic types for stfld, ldfld, call

### DIFF
--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -227,14 +227,7 @@ namespace Internal.IL
                 if (src.Type == null)
                     return true;
 
-                TypeDesc srcType = src.Type;
-
-                if (srcType.IsGenericDefinition)
-                    srcType = srcType.InstantiateAsOpen();
-
-                Debug.Assert(!dst.Type.IsGenericDefinition);
-
-                return CastingHelper.CanCastTo(srcType, dst.Type);
+                return CastingHelper.CanCastTo(src.Type, dst.Type);
 
             case StackValueKind.ValueType:
 

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -227,7 +227,14 @@ namespace Internal.IL
                 if (src.Type == null)
                     return true;
 
-                return CastingHelper.CanCastTo(src.Type, dst.Type);
+                TypeDesc srcType = src.Type;
+
+                if (srcType.IsGenericDefinition)
+                    srcType = srcType.InstantiateAsOpen();
+
+                Debug.Assert(!dst.Type.IsGenericDefinition);
+
+                return CastingHelper.CanCastTo(srcType, dst.Type);
 
             case StackValueKind.ValueType:
 

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -123,7 +123,7 @@ namespace Internal.IL
             _typeSystemContext = method.Context;
 
             if (!_methodSignature.IsStatic)
-                _thisType = method.OwningType;
+                _thisType = method.OwningType.InstantiateAsOpen();
 
             _methodIL = methodIL;
 

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -10,7 +10,8 @@
 {
 }
 
-.class public auto ansi beforefieldinit CastingTestsType
+// Provides tests for casting arrays
+.class public auto ansi beforefieldinit ArrayCastingTestsType
        extends [System.Runtime]System.Object
 {
     // Array<T> tests
@@ -101,6 +102,110 @@
         )
         ldarg.0
         stloc.0
+        ret
+    }
+}
+
+.class public sequential ansi beforefieldinit GenericOtherFieldsType`1<T>
+       extends [System.Runtime]System.ValueType
+{
+    .field public !T GenericField;
+    .field int32 IntField;
+}
+
+// Provides casting logic tests for stfld, ldfld, call, callvirt
+.class public auto ansi beforefieldinit GenericCastingTestsType`1<T>
+       extends [System.Runtime]System.Object
+{
+    .field private int32 ThisIntField
+    .method public hidebysig  instance void Casting.StorePlainFieldInThisGenericType_Valid(int32 v) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        stfld int32 class GenericCastingTestsType`1<!T>::ThisIntField
+        ret
+    }
+
+    .method public hidebysig  instance void Casting.StorePlainFieldInOtherGenericType_Valid(int32 v) cil managed
+    {
+		.locals init (
+			class GenericOtherFieldsType`1<!T> V_0
+		)
+
+        ldloc.0
+        ldarg.1
+        stfld !0 class GenericOtherFieldsType`1<!T>::IntField
+        ret
+    }
+
+    .field private !T ThisGenericField
+    .method public hidebysig  instance void Casting.StoreGenericFieldInThisGenericType_Valid(!T v) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        stfld !0 class GenericCastingTestsType`1<!T>::ThisGenericField
+        ret
+    }
+
+    .method public hidebysig  instance void Casting.StoreGenericFieldInOtherGenericType_Valid(!T v) cil managed
+    {
+		.locals init (
+			class GenericOtherFieldsType`1<!T> V_0
+		)
+        ldloc.0
+        ldarg.1
+        stfld !0 class GenericOtherFieldsType`1<!T>::GenericField
+        ret
+    }
+
+    .method public hidebysig  instance void Casting.CallPlainFunctionFromThisGenericType_Valid(int32 v) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        callvirt instance void class GenericCastingTestsType`1<!T>::Casting.StorePlainFieldInThisGenericType_Valid(int32)
+        ret
+    }
+
+    .method public hidebysig  instance void Casting.CallGenericFunctionFromThisGenericType_Valid(!T v) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        callvirt instance void class GenericCastingTestsType`1<!T>::Casting.CallGenericFunctionFromOtherGenericType_Valid(!0)
+        ret
+    }
+
+    .method public hidebysig  instance void Casting.CallGenericFunctionFromOtherGenericType_Valid(!T v) cil managed
+    {
+		.locals init (
+			class [System.Runtime]System.Func`1<!T> V_0
+		)
+        
+        ldarg.0
+        ldloc.0
+        callvirt  instance !0 class [System.Runtime]System.Func`1<!T>::Invoke()
+        ret
+    }
+
+    .method public hidebysig instance void Casting.AssignThisToSameTypeWithOtherGenericArgs_Invalid_StackUnexpected() cil managed
+    {
+		.locals init (
+			class GenericCastingTestsType`1<int32> V_0
+		)
+        
+        ldarg.0
+        stloc.0
+        ret
+    }
+
+    .method public hidebysig static void Casting.AssignToSameTypeWithOtherGenericArgs_Invalid_StackUnexpected() cil managed
+    {
+		.locals init (
+			class GenericCastingTestsType`1<int32> V_0,
+            class GenericCastingTestsType`1<string> V_1
+		)
+        
+        ldloc.0
+        stloc.1
         ret
     }
 }


### PR DESCRIPTION
The instructions `ldfld`, `stfld` and `call` perform a check, if the type of the _actual this_ value on the stack can be assign to the _declared this_ type of a method/field, where the assignment is in the direction
```
declaredThis = actualThis
```

Having a generic type and using the above instructions on fields/methods within this generic type, then the _actual this_ value on the stack will be an **uninstantiated** generic type definition while the _declared this_ is an **instantiated** generic type, e.g:
```
.class public auto ansi beforefieldinit GenericCastingTestsType`1<T>
       extends [System.Runtime]System.Object
{
    .field private int32 ThisIntField
    .method public hidebysig  instance void Casting.StorePlainFieldInThisGenericType_Valid(int32 v) cil managed
    {
        ldarg.0
        ldarg.1
        stfld int32 class GenericCastingTestsType`1<!T>::ThisIntField
        ret
    }
}
```

I fixed this by calling `TypeSystemHelper.InstantiateAsOpen` on actual this, if it is an uninstantiated generic type definition.