### PR TITLE
Update CoreCLR.issues.targets

### DIFF
--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -10,6 +10,7 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\intrinsic_cs_do\intrinsic_cs_do.*" />
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow1\pow1.*" />
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\intrinsic_cs_r\intrinsic_cs_r.*" />
+    <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Samples\gc\gc.*" />
 
     <!-- Infinite generic expansion -->
     <!-- https://github.com/dotnet/corert/issues/363 -->


### PR DESCRIPTION
Turns out in #3837 I was overly eager with re-enabling the GC tests. I should have stuck to the list from issue #2782, but I re-enabled one more test that I didn't remember why we disabled. Turns out this one is a non-deterministic failure. Updated test in the CoreCLR should fix it, so I added it to the bucket of tests waiting for test assets update.