### PR TITLE
[WIP] Unify API between StackFrameIterator and various special addresses

### DIFF
--- a/src/Native/Runtime/StackFrameIterator.cpp
+++ b/src/Native/Runtime/StackFrameIterator.cpp
@@ -52,21 +52,21 @@ GVAL_IMPL_INIT(PTR_VOID, g_ReturnFromCallDescrThunkAddr, PointerToReturnFromCall
 #endif
 
 #ifdef _TARGET_X86_
-EXTERN_C void * RhpCallFunclet2;
-GVAL_IMPL_INIT(PTR_VOID, g_RhpCallFunclet2Addr, &RhpCallFunclet2);
+EXTERN_C void * PointerToRhpCallFunclet2;
+GVAL_IMPL_INIT(PTR_VOID, g_RhpCallFunclet2Addr, PointerToRhpCallFunclet2);
 #endif
-EXTERN_C void * RhpCallCatchFunclet2;
-GVAL_IMPL_INIT(PTR_VOID, g_RhpCallCatchFunclet2Addr, &RhpCallCatchFunclet2);
-EXTERN_C void * RhpCallFinallyFunclet2;
-GVAL_IMPL_INIT(PTR_VOID, g_RhpCallFinallyFunclet2Addr, &RhpCallFinallyFunclet2);
-EXTERN_C void * RhpCallFilterFunclet2;
-GVAL_IMPL_INIT(PTR_VOID, g_RhpCallFilterFunclet2Addr, &RhpCallFilterFunclet2);
-EXTERN_C void * RhpThrowEx2;
-GVAL_IMPL_INIT(PTR_VOID, g_RhpThrowEx2Addr, &RhpThrowEx2);
-EXTERN_C void * RhpThrowHwEx2;
-GVAL_IMPL_INIT(PTR_VOID, g_RhpThrowHwEx2Addr, &RhpThrowHwEx2);
-EXTERN_C void * RhpRethrow2;
-GVAL_IMPL_INIT(PTR_VOID, g_RhpRethrow2Addr, &RhpRethrow2);
+EXTERN_C void * PointerToRhpCallCatchFunclet2;
+GVAL_IMPL_INIT(PTR_VOID, g_RhpCallCatchFunclet2Addr, PointerToRhpCallCatchFunclet2);
+EXTERN_C void * PointerToRhpCallFinallyFunclet2;
+GVAL_IMPL_INIT(PTR_VOID, g_RhpCallFinallyFunclet2Addr, PointerToRhpCallFinallyFunclet2);
+EXTERN_C void * PointerToRhpCallFilterFunclet2;
+GVAL_IMPL_INIT(PTR_VOID, g_RhpCallFilterFunclet2Addr, PointerToRhpCallFilterFunclet2);
+EXTERN_C void * PointerToRhpThrowEx2;
+GVAL_IMPL_INIT(PTR_VOID, g_RhpThrowEx2Addr, PointerToRhpThrowEx2);
+EXTERN_C void * PointerToRhpThrowHwEx2;
+GVAL_IMPL_INIT(PTR_VOID, g_RhpThrowHwEx2Addr, PointerToRhpThrowHwEx2);
+EXTERN_C void * PointerToRhpRethrow2;
+GVAL_IMPL_INIT(PTR_VOID, g_RhpRethrow2Addr, PointerToRhpRethrow2);
 #endif // !defined(USE_PORTABLE_HELPERS)
 
 // Addresses of functions in the DAC won't match their runtime counterparts so we
@@ -78,10 +78,8 @@ GVAL_IMPL_INIT(PTR_VOID, g_RhpRethrow2Addr, &RhpRethrow2);
 // ingest the updated DIA, we're instead exposing a global void * variable
 // holding the return address.
 #ifdef DACCESS_COMPILE
-#define EQUALS_CODE_ADDRESS(x, func_name) ((x) == g_ ## func_name ## Addr)
-#define EQUALS_RETURN_ADDRESS(x, func_name) EQUALS_CODE_ADDRESS((x), func_name)
+#define EQUALS_RETURN_ADDRESS(x, func_name) ((x) == g_ ## func_name ## Addr)
 #else
-#define EQUALS_CODE_ADDRESS(x, func_name) ((x) == &func_name)
 #define EQUALS_RETURN_ADDRESS(x, func_name) (((x)) == (PointerTo ## func_name))
 #endif
 
@@ -583,13 +581,13 @@ void StackFrameIterator::UnwindFuncletInvokeThunk()
     m_ControlPC = dac_cast<PTR_VOID>(*(m_RegDisplay.pIP));
 
     ASSERT(
-        EQUALS_CODE_ADDRESS(m_ControlPC, RhpCallCatchFunclet2) ||
-        EQUALS_CODE_ADDRESS(m_ControlPC, RhpCallFinallyFunclet2) ||
-        EQUALS_CODE_ADDRESS(m_ControlPC, RhpCallFilterFunclet2)
+        EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallCatchFunclet2) ||
+        EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallFinallyFunclet2) ||
+        EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallFilterFunclet2)
         );
 #endif
 
-    bool isFilterInvoke = EQUALS_CODE_ADDRESS(m_ControlPC, RhpCallFilterFunclet2);
+    bool isFilterInvoke = EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallFilterFunclet2);
 
 #if defined(UNIX_AMD64_ABI) 
     SP = (PTR_UIntNative)(m_RegDisplay.SP);
@@ -608,7 +606,7 @@ void StackFrameIterator::UnwindFuncletInvokeThunk()
         m_funcletPtrs.pR14 = m_RegDisplay.pR14;
         m_funcletPtrs.pR15 = m_RegDisplay.pR15;
 
-        if (EQUALS_CODE_ADDRESS(m_ControlPC, RhpCallCatchFunclet2))
+        if (EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallCatchFunclet2))
         {
             SP += 6 + 1; // 6 locals and stack alignment
         }
@@ -652,7 +650,7 @@ void StackFrameIterator::UnwindFuncletInvokeThunk()
         m_funcletPtrs.pR14 = m_RegDisplay.pR14;
         m_funcletPtrs.pR15 = m_RegDisplay.pR15;
         
-        if (EQUALS_CODE_ADDRESS(m_ControlPC, RhpCallCatchFunclet2))
+        if (EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallCatchFunclet2))
         {
             SP += 2 + 1; // 2 locals and stack alignment
         }
@@ -703,7 +701,7 @@ void StackFrameIterator::UnwindFuncletInvokeThunk()
     {
         // RhpCallCatchFunclet puts a couple of extra things on the stack that aren't put there by the other two
         // thunks, but we don't need to know what they are here, so we just skip them.
-        SP += EQUALS_CODE_ADDRESS(m_ControlPC, RhpCallCatchFunclet2) ? 3 : 1;
+        SP += EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallCatchFunclet2) ? 3 : 1;
 
         // Save the preserved regs portion of the REGDISPLAY across the unwind through the C# EH dispatch code.
         m_funcletPtrs.pR4  = m_RegDisplay.pR4;
@@ -1623,20 +1621,20 @@ StackFrameIterator::ReturnAddressCategory StackFrameIterator::CategorizeUnadjust
     }
 #endif
 
-    if (EQUALS_CODE_ADDRESS(returnAddress, RhpThrowEx2) ||
-        EQUALS_CODE_ADDRESS(returnAddress, RhpThrowHwEx2) ||
-        EQUALS_CODE_ADDRESS(returnAddress, RhpRethrow2))
+    if (EQUALS_RETURN_ADDRESS(returnAddress, RhpThrowEx2) ||
+        EQUALS_RETURN_ADDRESS(returnAddress, RhpThrowHwEx2) ||
+        EQUALS_RETURN_ADDRESS(returnAddress, RhpRethrow2))
     {
         return InThrowSiteThunk; 
     }
 
     if (
 #ifdef _TARGET_X86_
-        EQUALS_CODE_ADDRESS(returnAddress, RhpCallFunclet2)
+        EQUALS_RETURN_ADDRESS(returnAddress, RhpCallFunclet2)
 #else
-        EQUALS_CODE_ADDRESS(returnAddress, RhpCallCatchFunclet2) ||
-        EQUALS_CODE_ADDRESS(returnAddress, RhpCallFinallyFunclet2) ||
-        EQUALS_CODE_ADDRESS(returnAddress, RhpCallFilterFunclet2)
+        EQUALS_RETURN_ADDRESS(returnAddress, RhpCallCatchFunclet2) ||
+        EQUALS_RETURN_ADDRESS(returnAddress, RhpCallFinallyFunclet2) ||
+        EQUALS_RETURN_ADDRESS(returnAddress, RhpCallFilterFunclet2)
 #endif
         )
     {

--- a/src/Native/Runtime/amd64/AsmMacros.inc
+++ b/src/Native/Runtime/amd64/AsmMacros.inc
@@ -215,6 +215,24 @@ Name label proc
 PUBLIC Name
         endm
 
+EXPORT_POINTER_TO_ADDRESS macro Name
+
+        local   AddressToExport
+
+AddressToExport  label   proc
+
+        .const
+
+        align   8
+
+Name    dq      offset AddressToExport
+
+        public  Name
+
+        .code
+
+        endm
+
 _tls_array     equ 58h     ;; offsetof(TEB, ThreadLocalStoragePointer)
 
 ;;

--- a/src/Native/Runtime/amd64/CallDescrWorker.S
+++ b/src/Native/Runtime/amd64/CallDescrWorker.S
@@ -6,17 +6,9 @@
 #include <unixasmmacros.inc>
 
 NESTED_ENTRY RhCallDescrWorker, _TEXT, NoHandler
-LOCAL_LABEL(ReturnFromCallDescrThunk):
+
+    EXPORT_POINTER_TO_ADDRESS PointerToReturnFromCallDescrThunk
 
     // UNIXTODO: Implement this function
     int 3
 NESTED_END RhCallDescrWorker, _TEXT
-
-    .text
-
-    .align      8
-
-C_FUNC(PointerToReturnFromCallDescrThunk):
-    .quad       LOCAL_LABEL(ReturnFromCallDescrThunk)
-
-    .global     C_FUNC(PointerToReturnFromCallDescrThunk)

--- a/src/Native/Runtime/amd64/CallDescrWorker.asm
+++ b/src/Native/Runtime/amd64/CallDescrWorker.asm
@@ -57,7 +57,7 @@ StackCopyLoop:                          ; copy the arguments to stack top-down t
 DoCall:
         call    qword ptr [rbx + OFFSETOF__CallDescrData__pTarget]     ; call target function
 
-ReturnFromCallDescrThunk label proc
+        EXPORT_POINTER_TO_ADDRESS PointerToReturnFromCallDescrThunk
 
         ; Symbol used to identify thunk call to managed function so the special 
         ; case unwinder can unwind through this function. Sadly we cannot directly
@@ -102,15 +102,5 @@ ReturnsDouble:
         jmp     Epilog
 
         NESTED_END RhCallDescrWorker, _TEXT
-
-        .const
-
-        align   8
- 
-PointerToReturnFromCallDescrThunk label qword
-
-        dq      offset ReturnFromCallDescrThunk
-
-        public  PointerToReturnFromCallDescrThunk
 
 end

--- a/src/Native/Runtime/amd64/ExceptionHandling.S
+++ b/src/Native/Runtime/amd64/ExceptionHandling.S
@@ -70,7 +70,8 @@ NESTED_ENTRY RhpThrowHwEx, _TEXT, NoHandler
         // rdi still contains the exception code
         // rsi contains the address of the ExInfo
         call    C_FUNC(RhThrowHwEx)
-ALTERNATE_ENTRY RhpThrowHwEx2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowHwEx2
 
         // no return
         int 3
@@ -150,7 +151,8 @@ NESTED_ENTRY RhpThrowEx, _TEXT, NoHandler
         // rdi still contains the exception object
         // rsi contains the address of the ExInfo
         call    C_FUNC(RhThrowEx)
-ALTERNATE_ENTRY RhpThrowEx2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowEx2
 
         // no return
         int 3
@@ -219,7 +221,8 @@ NESTED_ENTRY RhpRethrow, _TEXT, NoHandler
         // rdi contains the currently active ExInfo
         // rsi contains the address of the new ExInfo
         call    C_FUNC(RhRethrow)
-ALTERNATE_ENTRY RhpRethrow2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpRethrow2
 
         // no return
         int 3
@@ -330,7 +333,8 @@ NESTED_ENTRY RhpCallCatchFunclet, _TEXT, NoHandler
         mov     rdi, [rdx + OFFSETOF__REGDISPLAY__SP]               // rdi <- establisher frame
         mov     rsi, [rsp + locArg0]                                // rsi <- exception object
         call    qword ptr [rsp + locArg1]                           // call handler funclet
-ALTERNATE_ENTRY RhpCallCatchFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallCatchFunclet2
 
         mov     rdx, [rsp + locArg2]                                // rdx <- dispatch context
 
@@ -468,7 +472,8 @@ NESTED_ENTRY RhpCallFinallyFunclet, _TEXT, NoHandler
 
         mov     rdi, [rsi + OFFSETOF__REGDISPLAY__SP]                // rdi <- establisher frame
         call    qword ptr [rsp + locArg0]                            // handler funclet address
-ALTERNATE_ENTRY RhpCallFinallyFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallFinallyFunclet2
 
         mov     rsi, [rsp + locArg1]                                 // rsi <- regdisplay
 
@@ -517,7 +522,8 @@ NESTED_ENTRY RhpCallFilterFunclet, _TEXT, NoHandler
         mov     rsi, rdi                                            // rsi <- exception object
         mov     rdi, [rdx + OFFSETOF__REGDISPLAY__SP]               // rdi <- establisher frame
         call    rax
-ALTERNATE_ENTRY RhpCallFilterFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallFilterFunclet2
 
         // RAX contains the result of the filter execution
 

--- a/src/Native/Runtime/amd64/ExceptionHandling.asm
+++ b/src/Native/Runtime/amd64/ExceptionHandling.asm
@@ -92,13 +92,13 @@ NESTED_ENTRY RhpThrowHwEx, _TEXT
         ;; rcx still contains the exception code
         ;; rdx contains the address of the ExInfo
         call    RhThrowHwEx
-ALTERNATE_ENTRY RhpThrowHwEx2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowHwEx2
 
         ;; no return
         int 3
 
 NESTED_END RhpThrowHwEx, _TEXT
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -184,7 +184,8 @@ NESTED_ENTRY RhpThrowEx, _TEXT
         ;; rcx still contains the exception object
         ;; rdx contains the address of the ExInfo
         call    RhThrowEx
-ALTERNATE_ENTRY RhpThrowEx2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowEx2
 
         ;; no return
         int 3
@@ -267,7 +268,8 @@ NESTED_ENTRY RhpRethrow, _TEXT
         ;; rcx contains the currently active ExInfo
         ;; rdx contains the address of the new ExInfo
         call    RhRethrow
-ALTERNATE_ENTRY RhpRethrow2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpRethrow2
 
         ;; no return
         int 3
@@ -425,7 +427,8 @@ else
         mov     rcx, [rsp + rsp_offsetof_arguments + 0h]            ;; rcx <- exception object
 endif
         call    qword ptr [rsp + rsp_offsetof_arguments + 8h]       ;; call handler funclet
-ALTERNATE_ENTRY RhpCallCatchFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallCatchFunclet2
 
         mov     r8, [rsp + rsp_offsetof_arguments + 10h]            ;; r8 <- dispatch context
 
@@ -584,7 +587,8 @@ endif
 
         mov     rcx, [rdx + OFFSETOF__REGDISPLAY__SP]               ;; rcx <- establisher frame
         call    qword ptr [rsp + rsp_offsetof_arguments + 0h]       ;; handler funclet address
-ALTERNATE_ENTRY RhpCallFinallyFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallFinallyFunclet2
 
         mov     rdx, [rsp + rsp_offsetof_arguments + 8h]            ;; rdx <- regdisplay
 
@@ -626,7 +630,6 @@ ALTERNATE_ENTRY RhpCallFinallyFunclet2
 
 NESTED_END RhpCallFinallyFunclet, _TEXT
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; void* FASTCALL RhpCallFilterFunclet(RtuObjectRef exceptionObj, void* pFilterIP, REGDISPLAY* pRegDisplay)
@@ -653,7 +656,8 @@ else
         ;; RCX still contains the exception object
 endif
         call    rax
-ALTERNATE_ENTRY RhpCallFilterFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallFilterFunclet2
 
         ;; RAX contains the result of the filter execution
 

--- a/src/Native/Runtime/amd64/UniversalTransition.S
+++ b/src/Native/Runtime/amd64/UniversalTransition.S
@@ -125,7 +125,7 @@ NESTED_ENTRY Rhp\FunctionName, _TEXT, NoHandler
         lea  rdi, [rsp + DISTANCE_FROM_CHILDSP_TO_RETURN_BLOCK]
         call r10
 
-LOCAL_LABEL(ReturnFrom\FunctionName):
+        EXPORT_POINTER_TO_ADDRESS PointerToReturnFrom\FunctionName
 
         // restore fp argument registers
         movdqa          xmm0, [rsp + DISTANCE_FROM_CHILDSP_TO_FP_REGS + 0x00]
@@ -151,15 +151,6 @@ LOCAL_LABEL(ReturnFrom\FunctionName):
         jmp             rax
 
 NESTED_END Rhp\FunctionName, _TEXT
-
-        .text
-
-        .align          8
-
-C_FUNC(PointerToReturnFrom\FunctionName):
-        .quad           LOCAL_LABEL(ReturnFrom\FunctionName)
-
-        .global         C_FUNC(PointerToReturnFrom\FunctionName)
 
 .endm // UNIVERSAL_TRANSITION
 

--- a/src/Native/Runtime/amd64/UniversalTransition.asm
+++ b/src/Native/Runtime/amd64/UniversalTransition.asm
@@ -127,7 +127,7 @@ endif ; TRASH_SAVED_ARGUMENT_REGISTERS
         lea  rcx, [rsp + DISTANCE_FROM_CHILDSP_TO_RETURN_BLOCK]
         call r10
 
-ReturnFrom&FunctionName label proc
+        EXPORT_POINTER_TO_ADDRESS PointerToReturnFrom&FunctionName
 
         ; We cannot make the label public as that tricks DIA stackwalker into thinking
         ; it's the beginning of a method. For this reason we export the address
@@ -154,18 +154,6 @@ ReturnFrom&FunctionName label proc
         TAILJMP_RAX
 
 NESTED_END Rhp&FunctionName, _TEXT
-
-        .const
-
-        align           8
-
-PointerToReturnFrom&FunctionName label qword
-
-        dq              offset ReturnFrom&FunctionName
-
-        public          PointerToReturnFrom&FunctionName
-
-        .code
 
         endm
 

--- a/src/Native/Runtime/arm/AsmMacros.h
+++ b/src/Native/Runtime/arm/AsmMacros.h
@@ -189,6 +189,25 @@ $Name
 
         MEND
 
+        MACRO
+        EXPORT_POINTER_TO_ADDRESS $Name
+
+1
+
+        AREA        |.rdata|, ALIGN=4, DATA, READONLY
+
+$Name
+
+        DCD         %BT1
+
+        EXPORT      $Name
+
+        TEXTAREA
+
+        ROUT
+
+        MEND
+
 ;-----------------------------------------------------------------------------
 ; Macro used to check (in debug builds only) whether the stack is 64-bit aligned (a requirement before calling
 ; out into C++/OS code). Invoke this directly after your prolog (if the stack frame size is fixed) or directly

--- a/src/Native/Runtime/arm/CallDescrWorker.asm
+++ b/src/Native/Runtime/arm/CallDescrWorker.asm
@@ -59,8 +59,7 @@ LNoFloatingPoint
         ldr     r4, [r5,#OFFSETOF__CallDescrData__pTarget]
         blx     r4
 
-ReturnFromCallDescrThunk
-        rout
+        EXPORT_POINTER_TO_ADDRESS PointerToReturnFromCallDescrThunk
 
         ;; Symbol used to identify thunk call to managed function so the special
         ;; case unwinder can unwind through this function. Sadly we cannot directly
@@ -126,13 +125,5 @@ LReturnDone
         EPILOG_POP              {r4,r5,r7,pc}
 
         NESTED_END RhCallDescrWorker
-
-        AREA        |.rdata|, ALIGN=4, DATA, READONLY
-
-PointerToReturnFromCallDescrThunk
-
-        DCD         ReturnFromCallDescrThunk
-
-        EXPORT      PointerToReturnFromCallDescrThunk
 
         END

--- a/src/Native/Runtime/arm/ExceptionHandling.asm
+++ b/src/Native/Runtime/arm/ExceptionHandling.asm
@@ -70,13 +70,13 @@
         ;; r0: exception code
         ;; r1: ExInfo*
         bl          RhThrowHwEx
-    LABELED_RETURN_ADDRESS RhpThrowHwEx2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowHwEx2
 
         ;; no return
         __debugbreak
 
     NESTED_END RhpThrowHwEx
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -172,13 +172,13 @@ NotHijacked
         ;; r0: exception object
         ;; r1: ExInfo*
         bl          RhThrowEx
-    LABELED_RETURN_ADDRESS RhpThrowEx2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowEx2
 
         ;; no return
         __debugbreak
 
     NESTED_END RhpThrowEx
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -229,7 +229,8 @@ NotHijacked
         ;; r0 contains the currently active ExInfo
         ;; r1 contains the address of the new ExInfo
         bl          RhRethrow
-    LABELED_RETURN_ADDRESS RhpRethrow2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpRethrow2
 
         ;; no return
         __debugbreak
@@ -323,7 +324,8 @@ ClearSuccess_Catch
         ;; 
         ;; r0 still contains the exception object
         blx         r1
-    LABELED_RETURN_ADDRESS RhpCallCatchFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallCatchFunclet2
 
         ;; r0 contains resume IP
 
@@ -354,7 +356,6 @@ DonePopping
         bx          r0
 
     NESTED_END RhpCallCatchFunclet
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -446,7 +447,8 @@ ClearSuccess
         ;; call the funclet
         ;; 
         blx         r0
-    LABELED_RETURN_ADDRESS RhpCallFinallyFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallFinallyFunclet2
 
         ldr         r1, [sp, #rsp_offset_r1]        ;; reload REGDISPLAY pointer
 
@@ -495,7 +497,6 @@ SetSuccess
 
         INLINE_GETTHREAD_CONSTANT_POOL
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; void* FASTCALL RhpCallFilterFunclet(RtuObjectRef exceptionObj, void* pFilterIP, REGDISPLAY* pRegDisplay)
@@ -520,13 +521,12 @@ SetSuccess
         ;; 
         ;; r0 still contains the exception object
         blx         r1
-    LABELED_RETURN_ADDRESS RhpCallFilterFunclet2
 
+        EXPORT_POINTER_TO_ADDRESS PointerToRhpCallFilterFunclet2
 
         EPILOG_VPOP {d8-d15}
         EPILOG_POP {r4-r11,pc}
 
     NESTED_END RhpCallFilterFunclet
-
 
         end

--- a/src/Native/Runtime/arm/UniversalTransition.asm
+++ b/src/Native/Runtime/arm/UniversalTransition.asm
@@ -124,9 +124,7 @@
         add         r0, sp, #DISTANCE_FROM_CHILDSP_TO_RETURN_BLOCK  ;; First parameter to target function is a pointer to the return block
         blx         r12
 
-ReturnFrom$FunctionName
-
-        rout
+        EXPORT_POINTER_TO_ADDRESS PointerToReturnFrom$FunctionName
 
         ; We cannot make the label public as that tricks DIA stackwalker into thinking
         ; it's the beginning of a method. For this reason we export an auxiliary variable
@@ -148,14 +146,6 @@ ReturnFrom$FunctionName
         EPILOG_BRANCH_REG r12
 
         NESTED_END Rhp$FunctionName
-
-        AREA        |.rdata|, ALIGN=4, DATA, READONLY
-
-PointerToReturnFrom$FunctionName
-
-        DCD         ReturnFrom$FunctionName
-
-        EXPORT      PointerToReturnFrom$FunctionName
 
         MEND
 

--- a/src/Native/Runtime/i386/AsmMacros.inc
+++ b/src/Native/Runtime/i386/AsmMacros.inc
@@ -35,6 +35,24 @@ decoratedName label proc
 PUBLIC decoratedName
         endm
 
+EXPORT_POINTER_TO_ADDRESS macro Name
+
+        local   AddressToExport
+
+AddressToExport  label   proc
+
+        .const
+
+        align   4
+
+Name    dd      offset AddressToExport
+
+        public  Name
+
+        .code
+
+        endm
+
 __tls_array     equ 2Ch     ;; offsetof(TEB, ThreadLocalStoragePointer)
 
 ;;

--- a/src/Native/Runtime/i386/CallDescrWorker.asm
+++ b/src/Native/Runtime/i386/CallDescrWorker.asm
@@ -49,7 +49,7 @@ donestack:
         mov     eax,[ebx + OFFSETOF__CallDescrData__pTarget]
         call    eax
 
-ReturnFromCallDescrThunk label proc
+        EXPORT_POINTER_TO_ADDRESS _PointerToReturnFromCallDescrThunk
 
         ; Symbol used to identify thunk call to managed function so the special 
         ; case unwinder can unwind through this function. Sadly we cannot directly
@@ -91,16 +91,6 @@ ReturnsDouble:
         jmp     Epilog
 
 FASTCALL_ENDFUNC
-
-        .const
-
-        align   4
-
-_PointerToReturnFromCallDescrThunk label dword
-
-        dd      offset ReturnFromCallDescrThunk
-
-        public  _PointerToReturnFromCallDescrThunk
 
 endif
 

--- a/src/Native/Runtime/i386/ExceptionHandling.asm
+++ b/src/Native/Runtime/i386/ExceptionHandling.asm
@@ -72,7 +72,8 @@ FASTCALL_FUNC  RhpThrowHwEx, 0
         ;; ecx still contains the exception code
         ;; edx contains the address of the ExInfo
         call    RhThrowHwEx
-ALTERNATE_ENTRY RhpThrowHwEx2
+
+        EXPORT_POINTER_TO_ADDRESS _PointerToRhpThrowHwEx2
 
         ;; no return
         int 3
@@ -148,7 +149,8 @@ FASTCALL_FUNC  RhpThrowEx, 0
         ;; ecx still contains the exception object
         ;; edx contains the address of the ExInfo
         call    RhThrowEx
-ALTERNATE_ENTRY RhpThrowEx2
+
+        EXPORT_POINTER_TO_ADDRESS _PointerToRhpThrowEx2
 
         ;; no return
         int 3
@@ -216,7 +218,8 @@ FASTCALL_FUNC  RhpRethrow, 0
         ;; ecx contains the currently active ExInfo
         ;; edx contains the address of the new ExInfo
         call    RhRethrow
-ALTERNATE_ENTRY RhpRethrow2
+
+        EXPORT_POINTER_TO_ADDRESS _PointerToRhpRethrow2
 
         ;; no return
         int 3
@@ -305,7 +308,8 @@ FASTCALL_FUNC  RhpCallCatchFunclet, 0
         ;; EDX: funclet IP
         ;; EAX: funclet EBP
         call        RhpCallFunclet
-ALTERNATE_ENTRY RhpCallCatchFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS _PointerToRhpCallCatchFunclet2
 
         ;; eax: resume IP
         mov         [esp + esp_offsetof_ResumeIP], eax              ;; save for later
@@ -381,7 +385,8 @@ FASTCALL_FUNC  RhpCallFinallyFunclet, 0
         ;; EDX: funclet IP
         ;; EAX: funclet EBP
         call        RhpCallFunclet
-ALTERNATE_ENTRY RhpCallFinallyFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS _PointerToRhpCallFinallyFunclet2
 
         pop         edx     ;; restore REGDISPLAY*
 
@@ -434,7 +439,8 @@ FASTCALL_FUNC  RhpCallFilterFunclet, 0
         mov         edx, [esp + 0]                  ;; reload filter funclet address
 
         call        RhpCallFunclet
-ALTERNATE_ENTRY RhpCallFilterFunclet2
+
+        EXPORT_POINTER_TO_ADDRESS _PointerToRhpCallFilterFunclet2
 
         ;; EAX contains the result of the filter execution
         mov         edx, [ebp + 8]

--- a/src/Native/Runtime/i386/UniversalTransition.asm
+++ b/src/Native/Runtime/i386/UniversalTransition.asm
@@ -74,7 +74,8 @@ ALTERNATE_ENTRY Rhp&FunctionName&@0
         mov  edx, [ebp-4]    ; Get the extra argument to pass to the callee
         lea  ecx, [ebp-10h]  ; Get pointer to edx value pushed above
         call eax
-ReturnFrom&FunctionName label proc
+
+        EXPORT_POINTER_TO_ADDRESS _PointerToReturnFrom&FunctionName
 
         ; We cannot make the label public as that tricks DIA stackwalker into thinking
         ; it's the beginning of a method. For this reason we export an auxiliary variable
@@ -87,18 +88,6 @@ ReturnFrom&FunctionName label proc
         jmp eax
 
 FASTCALL_ENDFUNC
-
-        .const
-
-        align       4
-
-_PointerToReturnFrom&FunctionName label dword
-
-        dd          offset ReturnFrom&FunctionName 
-
-        public      _PointerToReturnFrom&FunctionName
-
-        .code
 
         endm
         

--- a/src/Native/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosamd64.inc
@@ -224,12 +224,12 @@ C_FUNC(\Name):
 
 .macro EXPORT_POINTER_TO_ADDRESS Name
 
-AddressToExport\@:
+1:
 
         .data
         .align      8
 C_FUNC(\Name):
-        .quad       AddressToExport\@
+        .quad       1b
         .global     C_FUNC(\Name)
         .text
 

--- a/src/Native/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosamd64.inc
@@ -222,6 +222,19 @@ C_FUNC(\Name):
 
 .endm
 
+.macro EXPORT_POINTER_TO_ADDRESS Name
+
+AddressToExport\@:
+
+        .data
+        .align      8
+C_FUNC(\Name):
+        .quad       AddressToExport\@
+        .global     C_FUNC(\Name)
+        .text
+
+.endm
+
 //
 // CONSTANTS -- INTEGER
 //


### PR DESCRIPTION
In .NET Native, we're hitting an issue where DIA gets confused by
public code labels pointing into the middle of methods as it
messes up stack frame layout. I fixed this before for
the UniversalTransitionThunk and for CallDescrWorker. This change
extends the same treatment to ExceptionHandlers and furthermore
introduced a common cross-architecture macro to unify this idiom.

This PR is only intended to trigger lab testing; I need to check the
change into the ProjectN branch as there are two files specific
to .NET Native related to the GenerateDebuggableCallThunk
utility; once these come out of sync with the rest of this change,
ProjectN branch ends up with a global build break.

Thanks

Tomas