### PR TITLE
[ILVerify] Added special handling for null values in ImportStoreIndirect

### DIFF
--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -39,6 +39,11 @@ namespace Internal.IL
             get { return (Flags & StackValueFlags.ReadOnly) == StackValueFlags.ReadOnly; }
         }
 
+        public bool IsNullReference
+        {
+            get { return Kind == StackValueKind.ObjRef && Type == null; }
+        }
+
         public StackValue DereferenceByRef()
         {
             Debug.Assert(Kind == StackValueKind.ByRef && Type != null, "Cannot dereference");
@@ -357,7 +362,7 @@ namespace Internal.IL
                         case StackValueKind.ObjRef:
                             return op == ILOpcode.beq || op == ILOpcode.beq_s ||
                                    op == ILOpcode.bne_un || op == ILOpcode.bne_un_s ||
-                                   op == ILOpcode.ceq;
+                                   op == ILOpcode.ceq || op == ILOpcode.cgt_un;
                         default:
                             return false;
                     }

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -362,7 +362,7 @@ namespace Internal.IL
                         case StackValueKind.ObjRef:
                             return op == ILOpcode.beq || op == ILOpcode.beq_s ||
                                    op == ILOpcode.bne_un || op == ILOpcode.bne_un_s ||
-                                   op == ILOpcode.ceq || op == ILOpcode.cgt_un;
+                                   op == ILOpcode.ceq;
                         default:
                             return false;
                     }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1279,7 +1279,9 @@ namespace Internal.IL
             Check(!address.IsReadOnly, VerifierError.ReadOnlyIllegalWrite);
 
             CheckIsByRef(address);
-            CheckIsAssignable(type, address.Type);
+            if (value.Type != null)
+                CheckIsAssignable(type, address.Type);
+
             CheckIsAssignable(value, StackValue.CreateFromType(type));
         }
 

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1279,7 +1279,7 @@ namespace Internal.IL
             Check(!address.IsReadOnly, VerifierError.ReadOnlyIllegalWrite);
 
             CheckIsByRef(address);
-            if (value.Type != null)
+            if (!value.IsNullReference)
                 CheckIsAssignable(type, address.Type);
 
             CheckIsAssignable(value, StackValue.CreateFromType(type));

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -71,6 +71,17 @@
         ret
     }
 
+    .method static public hidebysig void StoreIndirect.AssignNullToRefString_Valid(string&) cil managed
+    {
+        // ref string x;
+        // x = null;
+
+        ldarg.0
+        ldnull
+        stind.ref
+        ret
+    }
+
     .method static public hidebysig void StoreObject.ValidTypeToken_Valid() cil managed
     {
         .locals init (object V_0)


### PR DESCRIPTION
Following case was not handled correctly
```csharp
ref string x;
x = null;
```
I fixed this by omitting the type assignability check for nullereference values.