### PR TITLE
[PAL/ThreadPool] CPU Utilization and High Performance Counter for CLR ThreadPool

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.GetCpuUtilization.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.GetCpuUtilization.cs
@@ -19,6 +19,6 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetCpuUtilization")]
-        internal static extern unsafe IntPtr GetCpuUtilization(ref ProcessCpuInformation previousCpuInfo);
+        internal static extern unsafe int GetCpuUtilization(ref ProcessCpuInformation previousCpuInfo);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.GetCpuUtilization.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.GetCpuUtilization.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal unsafe partial class Sys
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct ProcessCpuInformation
+        {
+            ulong lastRecordedCurrentTime;
+            ulong lastRecordedKernelTime;
+            ulong lastRecordedUserTime;
+        }
+
+        [DllImport(Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetCpuUtilization")]
+        internal static extern unsafe IntPtr GetCpuUtilization(ref ProcessCpuInformation previousCpuInfo);
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.HighPrecisionCounter.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.HighPrecisionCounter.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal unsafe partial class Sys
+    {
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetHighPrecisionCounts")]
+        internal static extern ulong GetHighPrecisionCounts();
+
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetHighPrecisionCounterFrequency")]
+        internal static extern ulong GetHighPrecisionCounterFrequency();
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.HighPrecisionCounter.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.HighPrecisionCounter.cs
@@ -10,8 +10,8 @@ internal static partial class Interop
 {
     internal unsafe partial class Sys
     {
-        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetHighPrecisionCounts")]
-        internal static extern ulong GetHighPrecisionCounts();
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetHighPrecisionCount")]
+        internal static extern ulong GetHighPrecisionCount();
 
         [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetHighPrecisionCounterFrequency")]
         internal static extern ulong GetHighPrecisionCounterFrequency();

--- a/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
@@ -17,53 +17,6 @@ extern "C" char* CoreLibNative_GetEnv(const char* variable)
     return getenv(variable);
 }
 
-#define SECONDS_TO_MILLISECONDS 1000
-#define MILLISECONDS_TO_MICROSECONDS 1000
-#define MILLISECONDS_TO_NANOSECONDS 1000000 // 10^6
-
-// Returns a 64-bit tick count with a millisecond resolution. It tries its best
-// to return monotonically increasing counts and avoid being affected by changes
-// to the system clock (either due to drift or due to explicit changes to system
-// time).
-extern "C" uint64_t CoreLibNative_GetTickCount64()
-{
-    uint64_t retval = 0;
-
-#if HAVE_MACH_ABSOLUTE_TIME
-    {
-        mach_timebase_info_data_t *machTimebaseInfo = GetMachTimebaseInfo();
-        retval = (mach_absolute_time() * machTimebaseInfo->numer / machTimebaseInfo->denom) / MILLISECONDS_TO_NANOSECONDS;
-    }
-#elif HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC
-    {
-        clockid_t clockType =
-#if HAVE_CLOCK_MONOTONIC_COARSE
-            CLOCK_MONOTONIC_COARSE; // good enough resolution, fastest speed
-#else
-            CLOCK_MONOTONIC;
-#endif
-        struct timespec ts;
-        if (clock_gettime(clockType, &ts) != 0)
-        {
-            assert(false);
-            return retval;
-        }
-        retval = (ts.tv_sec * SECONDS_TO_MILLISECONDS) + (ts.tv_nsec / MILLISECONDS_TO_NANOSECONDS);
-    }
-#else
-    {
-        struct timeval tv;    
-        if (gettimeofday(&tv, NULL) == -1)
-        {
-            assert(false);
-            return retval;
-        }
-        retval = (tv.tv_sec * SECONDS_TO_MILLISECONDS) + (tv.tv_usec / MILLISECONDS_TO_MICROSECONDS);
-    }
-#endif
-    return retval;
-}
-
 extern "C" int32_t CoreLibNative_SchedGetCpu()
 {
 #if HAVE_SCHED_GETCPU

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -35,29 +35,7 @@ mach_timebase_info_data_t *InitializeTimebaseInfo()
 }
 #endif
 
-#if HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC
-clockid_t GetMonotonicClockType(bool preferCoarseIfAvailable)
-{
-    clockid_t clockType;
-#if HAVE_CLOCK_MONOTONIC_COARSE && HAVE_CLOCK_MONOTONIC
-    if (preferCoarseIfAvailable)
-    {
-        clockType = CLOCK_MONOTONIC_COARSE;
-    }
-    else
-    {
-        clockType = CLOCK_MONOTONIC;
-    }
-#elif HAVE_CLOCK_MONOTONIC_COARSE
-    clockType = CLOCK_MONOTONIC_COARSE;
-#elif HAVE_CLOCK_MONOTONIC
-    clockType = CLOCK_MONOTONIC;
-#endif
-    return clockType;
-}
-#endif
-
-uint64_t GetHighPrecisionCount(bool preferCoarseIfAvailable)
+extern "C" uint64_t CoreLibNative_GetHighPrecisionCount()
 {
     uint64_t counts = 0;
 
@@ -65,9 +43,9 @@ uint64_t GetHighPrecisionCount(bool preferCoarseIfAvailable)
     {
         counts = mach_absolute_time();
     }
-#elif HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC
+#elif HAVE_CLOCK_MONOTONIC
     {
-        clockid_t clockType = GetMonotonicClockType(preferCoarseIfAvailable);
+        clockid_t clockType = CLOCK_MONOTONIC;
         struct timespec ts;
         if (clock_gettime(clockType, &ts) != 0)
         {
@@ -88,11 +66,6 @@ uint64_t GetHighPrecisionCount(bool preferCoarseIfAvailable)
     }
 #endif
     return counts;
-}
-
-extern "C" uint64_t CoreLibNative_GetHighPrecisionCount()
-{
-    return GetHighPrecisionCount(false);
 }
 
 #if HAVE_MACH_ABSOLUTE_TIME

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -35,10 +35,6 @@ mach_timebase_info_data_t *InitializeTimebaseInfo()
 }
 #endif
 
-uint64_t GetNanoseconds() {
-    return CoreLibNative_GetHighPrecisionCounts() * (NanosecondsPerSecond / CoreLibNative_GetHighPrecisionCounts());
-}
-
 extern "C" uint64_t CoreLibNative_GetHighPrecisionCounts()
 {
     uint64_t counts = 0;
@@ -109,7 +105,7 @@ extern "C" uint64_t CoreLibNative_GetHighPrecisionCounterFrequency()
 // time).
 extern "C" uint64_t CoreLibNative_GetTickCount64()
 {
-    return CoreLibNative_GetHighPrecisionCounts() * (MillisecondsPerSecond / CoreLibNative_GetHighPrecisionCounts());
+    return CoreLibNative_GetHighPrecisionCounts() * (MillisecondsPerSecond / CoreLibNative_GetHighPrecisionCounterFrequency());
 }
 
 
@@ -160,7 +156,7 @@ extern "C" int32_t CoreLibNative_GetCpuUtilization(PROCESS_CPU_INFORMATION* prev
         userTime = TimeValToNanoseconds(resUsage.ru_utime);
     }
 
-    uint64_t currentTime = GetNanoseconds();
+    uint64_t currentTime = CoreLibNative_GetHighPrecisionCounts() * (NanosecondsPerSecond / CoreLibNative_GetHighPrecisionCounterFrequency());
 
     uint64_t lastRecordedCurrentTime = previousCpuInfo->lastRecordedCurrentTime;
     uint64_t lastRecordedKernelTime = previousCpuInfo->lastRecordedKernelTime;

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -58,7 +58,7 @@ extern "C" uint64_t CoreLibNative_GetHighPrecisionCounts()
             assert(false);
             return counts;
         }
-        counts = ts.tv_sec * SecondsToNanoseconds + ts.tv_nsec;
+        counts = ts.tv_sec * NanosecondsPerSecond + ts.tv_nsec;
     }
 #else
     {
@@ -85,11 +85,11 @@ extern "C" uint64_t CoreLibNative_GetHighPrecisionCounterFrequency()
 #if HAVE_MACH_ABSOLUTE_TIME
     {
         mach_timebase_info_data_t *machTimebaseInfo = GetMachTimebaseInfo();
-        frequency = SecondsToNanoseconds * static_cast<uint64_t>(machTimebaseInfo->denom) / machTimebaseInfo->numer;
+        frequency = NanosecondsPerSecond * static_cast<uint64_t>(machTimebaseInfo->denom) / machTimebaseInfo->numer;
     }
 #elif HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC
     {
-        frequency = SecondsToNanoseconds;
+        frequency = NanosecondsPerSecond;
     }
 #else
     {

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -169,7 +169,7 @@ extern "C" int32_t CoreLibNative_GetCpuUtilization(ProcessCpuInformation* previo
     if (numProcessors <= 0)
     {
         numProcessors = sysconf(_SC_NPROCESSORS_ONLN);
-        if (numProcessors < 0)
+        if (numProcessors <= 0)
         {
             return 0;
         }

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -170,12 +170,12 @@ extern "C" uint64_t CoreLibNative_GetTickCount64()
 }
 
 
-typedef struct _PROCESS_CPU_INFORMATION
+struct ProcessCpuInformation
 {
     uint64_t lastRecordedCurrentTime;
     uint64_t lastRecordedKernelTime;
     uint64_t lastRecordedUserTime;
-} PROCESS_CPU_INFORMATION;
+};
 
 
 /*
@@ -189,10 +189,10 @@ from a user process, getrusage and gettimeofday are used to
 compute the current process's CPU utilization instead.
 
 */
-extern "C" int32_t CoreLibNative_GetCpuUtilization(PROCESS_CPU_INFORMATION* previousCpuInfo)
-{
-    static long numProcessors = 0;
 
+static long numProcessors = 0;
+extern "C" int32_t CoreLibNative_GetCpuUtilization(ProcessCpuInformation* previousCpuInfo)
+{
     if (numProcessors <= 0)
     {
         numProcessors = sysconf(_SC_NPROCESSORS_ONLN);

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -6,7 +6,8 @@
 #include "pal_threading.h"
 #include "pal_time.h"
 
-#include <pthread.h>
+#include <unistd.h>
+#include <sys/resource.h>
 
 #if HAVE_MACH_ABSOLUTE_TIME
 static LowLevelMutex s_lock(true /* abortOnFailure */, nullptr /* successRef */);
@@ -33,3 +34,166 @@ mach_timebase_info_data_t *InitializeTimebaseInfo()
     return g_isMachTimebaseInfoInitialized ? &g_machTimebaseInfo : nullptr;
 }
 #endif
+
+uint64_t GetNanoseconds() {
+    return CoreLibNative_GetHighPrecisionCounts() * (NanosecondsPerSecond / CoreLibNative_GetHighPrecisionCounts());
+}
+
+extern "C" uint64_t CoreLibNative_GetHighPrecisionCounts()
+{
+    uint64_t counts = 0;
+
+#if HAVE_MACH_ABSOLUTE_TIME
+    {
+        mach_timebase_info_data_t *machTimebaseInfo = GetMachTimebaseInfo();
+        counts = mach_absolute_time();
+    }
+#elif HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC
+    {
+        clockid_t clockType =
+#if HAVE_CLOCK_MONOTONIC_COARSE
+            CLOCK_MONOTONIC_COARSE; // good enough resolution, fastest speed
+#else
+            CLOCK_MONOTONIC;
+#endif
+        struct timespec ts;
+        if (clock_gettime(clockType, &ts) != 0)
+        {
+            assert(false);
+            return counts;
+        }
+        counts = ts.tv_sec * SecondsToNanoseconds + ts.tv_nsec;
+    }
+#else
+    {
+        struct timeval tv;
+        if (gettimeofday(&tv, nullptr) == -1)
+        {
+            assert(false);
+            return counts;
+        }
+        counts = tv.tv_sec * MicrosecondsPerSecond + tv.tv_usec;
+    }
+#endif
+    return counts;
+}
+
+extern "C" uint64_t CoreLibNative_GetHighPrecisionCounterFrequency()
+{
+    static uint64_t frequency = 0;
+    if (frequency != 0)
+    {
+        return frequency;
+    }
+
+#if HAVE_MACH_ABSOLUTE_TIME
+    {
+        mach_timebase_info_data_t *machTimebaseInfo = GetMachTimebaseInfo();
+        frequency = SecondsToNanoseconds * static_cast<uint64_t>(machTimebaseInfo->denom) / machTimebaseInfo->numer;
+    }
+#elif HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC
+    {
+        frequency = SecondsToNanoseconds;
+    }
+#else
+    {
+        frequency = MicrosecondsPerSecond;
+    }
+#endif
+    return frequency;
+}
+
+// Returns a 64-bit tick count with a millisecond resolution. It tries its best
+// to return monotonically increasing counts and avoid being affected by changes
+// to the system clock (either due to drift or due to explicit changes to system
+// time).
+extern "C" uint64_t CoreLibNative_GetTickCount64()
+{
+    return CoreLibNative_GetHighPrecisionCounts() * (MillisecondsPerSecond / CoreLibNative_GetHighPrecisionCounts());
+}
+
+
+typedef struct _PROCESS_CPU_INFORMATION
+{
+    uint64_t lastRecordedCurrentTime;
+    uint64_t lastRecordedKernelTime;
+    uint64_t lastRecordedUserTime;
+} PROCESS_CPU_INFORMATION;
+
+
+/*
+Function:
+CoreLibNative_GetCpuUtilization
+
+The main purpose of this function is to compute the overall CPU utilization
+for the CLR thread pool to regulate the number of worker threads.
+Since there is no consistent API on Unix to get the CPU utilization
+from a user process, getrusage and gettimeofday are used to
+compute the current process's CPU utilization instead.
+
+*/
+extern "C" int32_t CoreLibNative_GetCpuUtilization(PROCESS_CPU_INFORMATION* previousCpuInfo)
+{
+    static long numProcessors = 0;
+
+    if (numProcessors <= 0)
+    {
+        numProcessors = sysconf(_SC_NPROCESSORS_ONLN);
+        if (numProcessors < 0)
+        {
+            return 0;
+        }
+    }
+
+    uint64_t kernelTime = 0;
+    uint64_t userTime = 0;
+
+    struct rusage resUsage;
+    if (getrusage(RUSAGE_SELF, &resUsage) == -1)
+    {
+        assert(false);
+        return 0;
+    }
+    else
+    {
+        kernelTime = TimeValToNanoseconds(resUsage.ru_stime);
+        userTime = TimeValToNanoseconds(resUsage.ru_utime);
+    }
+
+    uint64_t currentTime = GetNanoseconds();
+
+    uint64_t lastRecordedCurrentTime = previousCpuInfo->lastRecordedCurrentTime;
+    uint64_t lastRecordedKernelTime = previousCpuInfo->lastRecordedKernelTime;
+    uint64_t lastRecordedUserTime = previousCpuInfo->lastRecordedUserTime;
+
+    uint64_t cpuTotalTime = 0;
+    if (currentTime > lastRecordedCurrentTime)
+    {
+        // cpuTotalTime is based on clock time. Since multiple threads can run in parallel,
+        // we need to scale cpuTotalTime cover the same amount of total CPU time.
+        // rusage time is already scaled across multiple processors.
+        cpuTotalTime = (currentTime - lastRecordedCurrentTime);
+        cpuTotalTime *= numProcessors;
+    }
+
+    uint64_t cpuBusyTime = 0;
+    if (userTime >= lastRecordedUserTime && kernelTime >= lastRecordedKernelTime)
+    {
+        cpuBusyTime = (userTime - lastRecordedUserTime) + (kernelTime - lastRecordedKernelTime);
+    }
+
+    int32_t cpuUtilization = 0;
+    if (cpuTotalTime > 0 && cpuBusyTime > 0)
+    {
+        cpuUtilization = static_cast<int32_t>(cpuBusyTime / cpuTotalTime);
+    }
+
+    assert(cpuUtilization >= 0 && cpuUtilization <= 100);
+
+    previousCpuInfo->lastRecordedCurrentTime = currentTime;
+    previousCpuInfo->lastRecordedUserTime = userTime;
+    previousCpuInfo->lastRecordedKernelTime = kernelTime;
+
+    return cpuUtilization;
+}
+

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -41,7 +41,6 @@ extern "C" uint64_t CoreLibNative_GetHighPrecisionCounts()
 
 #if HAVE_MACH_ABSOLUTE_TIME
     {
-        mach_timebase_info_data_t *machTimebaseInfo = GetMachTimebaseInfo();
         counts = mach_absolute_time();
     }
 #elif HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -95,12 +95,12 @@ extern "C" uint64_t CoreLibNative_GetHighPrecisionCount()
     return GetHighPrecisionCount(false);
 }
 
+static uint64_t s_highPrecisionCounterFrequency = 0;
 extern "C" uint64_t CoreLibNative_GetHighPrecisionCounterFrequency()
 {
-    static uint64_t frequency = 0;
-    if (frequency != 0)
+    if (s_highPrecisionCounterFrequency != 0)
     {
-        return frequency;
+        return s_highPrecisionCounterFrequency;
     }
 
 #if HAVE_MACH_ABSOLUTE_TIME
@@ -114,10 +114,10 @@ extern "C" uint64_t CoreLibNative_GetHighPrecisionCounterFrequency()
     }
 #else
     {
-        frequency = MicrosecondsPerSecond;
+        s_highPrecisionCounterFrequency = MicrosecondsPerSecond;
     }
 #endif
-    return frequency;
+    return s_highPrecisionCounterFrequency;
 }
 
 // Returns a 64-bit tick count with a millisecond resolution. It tries its best

--- a/src/Native/System.Private.CoreLib.Native/pal_time.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.cpp
@@ -104,7 +104,7 @@ extern "C" uint64_t CoreLibNative_GetHighPrecisionCounterFrequency()
 // time).
 extern "C" uint64_t CoreLibNative_GetTickCount64()
 {
-    return CoreLibNative_GetHighPrecisionCounts() * (MillisecondsPerSecond / CoreLibNative_GetHighPrecisionCounterFrequency());
+    return CoreLibNative_GetHighPrecisionCounts() * MillisecondsPerSecond / CoreLibNative_GetHighPrecisionCounterFrequency();
 }
 
 
@@ -155,7 +155,7 @@ extern "C" int32_t CoreLibNative_GetCpuUtilization(PROCESS_CPU_INFORMATION* prev
         userTime = TimeValToNanoseconds(resUsage.ru_utime);
     }
 
-    uint64_t currentTime = CoreLibNative_GetHighPrecisionCounts() * (NanosecondsPerSecond / CoreLibNative_GetHighPrecisionCounterFrequency());
+    uint64_t currentTime = CoreLibNative_GetHighPrecisionCounts() * NanosecondsPerSecond / CoreLibNative_GetHighPrecisionCounterFrequency();
 
     uint64_t lastRecordedCurrentTime = previousCpuInfo->lastRecordedCurrentTime;
     uint64_t lastRecordedKernelTime = previousCpuInfo->lastRecordedKernelTime;

--- a/src/Native/System.Private.CoreLib.Native/pal_time.h
+++ b/src/Native/System.Private.CoreLib.Native/pal_time.h
@@ -14,8 +14,11 @@
 #include <mach/mach_time.h>
 #endif
 
-const int32_t MillisecondsToNanoseconds = 1000 * 1000;
-const int32_t SecondsToNanoseconds = 1000 * 1000 * 1000;
+const uint64_t MillisecondsPerSecond = 1000;
+const uint64_t NanosecondsPerSecond = 1000 * 1000 * 1000;
+const uint64_t MicrosecondsPerSecond = 1000 * 1000;
+const uint64_t NanosecondsPerMicrosecond = 1000;
+const uint64_t NanosecondsPerMillisecond = 1000 * 1000;
 
 inline void MillisecondsToTimeSpec(uint32_t milliseconds, timespec *t)
 {
@@ -26,9 +29,9 @@ inline void MillisecondsToTimeSpec(uint32_t milliseconds, timespec *t)
         return;
     }
 
-    uint64_t nanoseconds = milliseconds * static_cast<uint64_t>(MillisecondsToNanoseconds);
-    t->tv_sec = static_cast<time_t>(nanoseconds / SecondsToNanoseconds);
-    t->tv_nsec = static_cast<int32_t>(nanoseconds % SecondsToNanoseconds);
+    uint64_t nanoseconds = milliseconds * NanosecondsPerMillisecond;
+    t->tv_sec = static_cast<time_t>(nanoseconds / NanosecondsPerSecond);
+    t->tv_nsec = static_cast<int32_t>(nanoseconds % NanosecondsPerSecond);
 }
 
 inline void AddMillisecondsToTimeSpec(uint32_t milliseconds, timespec *t)
@@ -38,13 +41,18 @@ inline void AddMillisecondsToTimeSpec(uint32_t milliseconds, timespec *t)
         return;
     }
 
-    uint64_t nanoseconds = milliseconds * static_cast<uint64_t>(MillisecondsToNanoseconds) + t->tv_nsec;
-    if (nanoseconds >= SecondsToNanoseconds)
+    uint64_t nanoseconds = milliseconds * NanosecondsPerMillisecond + t->tv_nsec;
+    if (nanoseconds >= NanosecondsPerSecond)
     {
-        t->tv_sec += static_cast<time_t>(nanoseconds / SecondsToNanoseconds);
-        nanoseconds %= SecondsToNanoseconds;
+        t->tv_sec += static_cast<time_t>(nanoseconds / NanosecondsPerSecond);
+        nanoseconds %= NanosecondsPerSecond;
     }
     t->tv_nsec = static_cast<int32_t>(nanoseconds);
+}
+
+inline uint64_t TimeValToNanoseconds(const struct timeval& t)
+{
+    return t.tv_sec * NanosecondsPerSecond + t.tv_usec * NanosecondsPerMicrosecond;
 }
 
 #if HAVE_MACH_ABSOLUTE_TIME

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -674,11 +674,17 @@
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.Exit.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.Exit.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.GetCpuUtilization.cs">
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.GetCpuUtilization.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.GetEnv.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.GetEnv.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.GetExecutableAbsolutePath.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.GetExecutableAbsolutePath.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.HighPrecisionCounter.cs">
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.HighPrecisionCounter.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.MemAllocFree.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.MemAllocFree.cs</Link>


### PR DESCRIPTION
Updated PAL to have functions for calculating CPU Utilization and using a high-performance counter (both for CLR ThreadPool). Also refactor the code for `CoreLibNative_GetTickCount64` so it uses the counter under the hood.
