### PR TITLE
Make Environment.GetCommandLineArgs() PNSE on Project N

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.ProjectN.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.ProjectN.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime;
 
 namespace Internal.Runtime.Augments
 {
@@ -12,25 +11,13 @@ namespace Internal.Runtime.Augments
     {
         public static void Exit(int exitCode)
         {
-            s_latchedExitCode = exitCode;
-
-            ShutdownCore();
-
-            RuntimeImports.RhpShutdown();
-
-            Interop.ExitProcess(s_latchedExitCode);
-        }
-
-        private static string[] s_commandLineArgs;
-
-        internal static void SetCommandLineArgs(string[] args)
-        {
-            s_commandLineArgs = args;
+            // This needs to be implemented for ProjectN.
+            throw new PlatformNotSupportedException();
         }
 
         public static string[] GetCommandLineArgs()
         {
-            return (string[])s_commandLineArgs.Clone();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_GetCommandLineArgs);
         }
     }
 }

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2449,4 +2449,7 @@
   <data name="Arg_OpenType" xml:space="preserve">
     <value>Cannot create an instance of {0} as it is an open type.</value>
   </data>
+  <data name="PlatformNotSupported_GetCommandLineArgs" xml:space="preserve">
+    <value>Environment.GetCommandLineArgs() is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -116,7 +116,8 @@
     <Compile Include="Internal\Runtime\Augments\DynamicDelegateAugments.cs" />
     <Compile Include="Internal\Runtime\Augments\EnumInfo.cs" />
     <Compile Include="Internal\Runtime\Augments\EnvironmentAugments.cs" />
-    <Compile Include="Internal\Runtime\Augments\EnvironmentAugments.CoreRT.cs" />
+    <Compile Condition="'$(IsProjectNLibrary)' != 'true'" Include="Internal\Runtime\Augments\EnvironmentAugments.CoreRT.cs" />
+    <Compile Condition="'$(IsProjectNLibrary)' == 'true'" Include="Internal\Runtime\Augments\EnvironmentAugments.ProjectN.cs" />
     <Compile Condition="'$(TargetsWindows)'=='true'" Include="Internal\Runtime\Augments\EnvironmentAugments.Windows.cs" />
     <Compile Condition="'$(TargetsUnix)'=='true'" Include="Internal\Runtime\Augments\EnvironmentAugments.Unix.cs" />
     <Compile Include="Internal\Runtime\Augments\RuntimeThread.cs" />


### PR DESCRIPTION
As opposed to NRE'ing due to using the result of a startup
helper that doesn't exist on the N toolchain...