### PR TITLE
Enable IL scanner and use it to provide VTable information

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodBodyNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodBodyNode.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Marker interface that identifies the node representing a compiled method body.
+    /// </summary>
+    public interface IMethodBodyNode : IMethodNode
+    {
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -10,7 +10,7 @@ using Internal.TypeSystem.Interop;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public class MethodCodeNode : ObjectNode, IMethodNode, INodeWithCodeInfo, INodeWithDebugInfo, IMethodCodeNode
+    public class MethodCodeNode : ObjectNode, IMethodBodyNode, INodeWithCodeInfo, INodeWithDebugInfo, IMethodCodeNode
     {
         public static readonly ObjectNodeSection StartSection = new ObjectNodeSection(".managedcode$A", SectionType.Executable);
         public static readonly ObjectNodeSection WindowsContentSection = new ObjectNodeSection(".managedcode$I", SectionType.Executable);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -1585,13 +1585,23 @@ namespace ILCompiler.DependencyAnalysis
         {
             yield return new DependencyListEntry(_signature, "TypeSignature");
 
-            if (!factory.VTable(_method.OwningType).HasFixedSlots)
-                yield return new DependencyListEntry(factory.VirtualMethodUse(_method), "Slot number");
+            MethodDesc method = _method;
+            if (method.IsRuntimeDeterminedExactMethod)
+                method = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
+            if (!factory.VTable(method.OwningType).HasFixedSlots)
+            {
+                yield return new DependencyListEntry(factory.VirtualMethodUse(method), "Slot number");
+            }
         }
 
         protected sealed override Vertex WriteSignatureVertex(NativeWriter writer, NodeFactory factory)
         {
-            int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, _method);
+            MethodDesc method = _method;
+            if (method.IsRuntimeDeterminedExactMethod)
+                method = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
+            int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, method);
 
             return writer.GetMethodSlotSignature(_signature.WriteVertex(factory), checked((uint)slot));
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ScannedMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ScannedMethodNode.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.DependencyAnalysis
     /// Represents a method that should be scanned by an IL scanner and its dependencies
     /// analyzed.
     /// </summary>
-    public class ScannedMethodNode : DependencyNodeCore<NodeFactory>, IMethodNode
+    public class ScannedMethodNode : DependencyNodeCore<NodeFactory>, IMethodBodyNode
     {
         private readonly MethodDesc _method;
         private DependencyList _dependencies;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -27,6 +27,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public VirtualMethodUseNode(MethodDesc decl)
         {
+            Debug.Assert(!decl.IsRuntimeDeterminedExactMethod);
             Debug.Assert(decl.IsVirtual);
 
             // Virtual method use always represents the slot defining method of the virtual.
@@ -66,6 +67,12 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(new DependencyListEntry(factory.VirtualMethodUse(canonDecl), "Canonical method"));
 
             dependencies.Add(new DependencyListEntry(factory.VTable(_decl.OwningType), "VTable of a VirtualMethodUse"));
+
+            // TODO: https://github.com/dotnet/corert/issues/3224
+            if (_decl.IsAbstract)
+            {
+                dependencies.Add(factory.ReflectableMethod(_decl), "Abstract reflectable method");
+            }
 
             return dependencies;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
@@ -121,7 +121,12 @@ namespace ILCompiler
 
             internal override VTableSliceNode GetSlice(TypeDesc type)
             {
-                return new PrecomputedVTableSliceNode(type, _vtableSlices[type]);
+                // TODO: move ownership of compiler-generated entities to CompilerTypeSystemContext.
+                // https://github.com/dotnet/corert/issues/3873
+                if (type.GetTypeDefinition() is Internal.TypeSystem.Ecma.EcmaType)
+                    return new PrecomputedVTableSliceNode(type, _vtableSlices[type]);
+                else
+                    return new LazilyBuiltVTableSliceNode(type);
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
@@ -77,10 +77,7 @@ namespace ILCompiler
         ILScanResults IILScanner.Scan()
         {
             _nodeFactory.NameMangler.CompilationUnitPrefix = "";
-
-            // Touch the MarkedNodeList to trigger dependency analysis.
-            // This really shouldn't be a property...
-            var m = _dependencyGraph.MarkedNodeList;
+            _dependencyGraph.ComputeMarkedNodes();
 
             return new ILScanResults(_dependencyGraph, _nodeFactory);
         }

--- a/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
@@ -77,7 +77,12 @@ namespace ILCompiler
         ILScanResults IILScanner.Scan()
         {
             _nodeFactory.NameMangler.CompilationUnitPrefix = "";
-            return new ILScanResults(_dependencyGraph.MarkedNodeList);
+
+            // Touch the MarkedNodeList to trigger dependency analysis.
+            // This really shouldn't be a property...
+            var m = _dependencyGraph.MarkedNodeList;
+
+            return new ILScanResults(_dependencyGraph, _nodeFactory);
         }
     }
 
@@ -86,18 +91,16 @@ namespace ILCompiler
         ILScanResults Scan();
     }
 
-    public class ILScanResults
+    public class ILScanResults : CompilationResults
     {
-        private readonly ImmutableArray<DependencyNodeCore<NodeFactory>> _markedNodes;
-
-        internal ILScanResults(ImmutableArray<DependencyNodeCore<NodeFactory>> markedNodes)
+        internal ILScanResults(DependencyAnalyzerBase<NodeFactory> graph, NodeFactory factory)
+            : base(graph, factory)
         {
-            _markedNodes = markedNodes;
         }
 
         public VTableSliceProvider GetVTableLayoutInfo()
         {
-            return new ScannedVTableProvider(_markedNodes);
+            return new ScannedVTableProvider(MarkedNodes);
         }
 
         private class ScannedVTableProvider : VTableSliceProvider

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
@@ -42,6 +42,7 @@ namespace ILCompiler
         {
             _corInfo = new CorInfoImpl(this, _jitConfigProvider);
 
+            _dependencyGraph.ComputeMarkedNodes();
             var nodes = _dependencyGraph.MarkedNodeList;
 
             NodeFactory.SetMarkingComplete();

--- a/src/ILCompiler.Compiler/src/Compiler/SimdHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SimdHelper.cs
@@ -13,7 +13,7 @@ namespace ILCompiler
     /// <summary>
     /// Helper type that deals with System.Numerics.Vectors intrinsics.
     /// </summary>
-    internal struct SimdHelper
+    public struct SimdHelper
     {
         private ModuleDesc[] _simdModulesCached;
 

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Compiler\DependencyAnalysis\CustomAttributeBasedDependencyAlgorithm.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FieldMetadataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ILScanNodeFactory.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\IMethodBodyNode.cs" />
     <Compile Include="Compiler\PreInitFieldInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenArrayNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsPreInitDataNode.cs" />

--- a/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilation.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilation.cs
@@ -50,6 +50,8 @@ namespace ILCompiler
         {
             _cppWriter = new CppWriter(this, outputFile);
 
+            _dependencyGraph.ComputeMarkedNodes();
+
             var nodes = _dependencyGraph.MarkedNodeList;
 
             _cppWriter.OutputCode(nodes, NodeFactory);

--- a/src/ILCompiler.CppCodeGen/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/DependencyAnalysis/CppMethodCodeNode.cs
@@ -13,7 +13,7 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    internal class CppMethodCodeNode : DependencyNodeCore<NodeFactory>, IMethodNode
+    internal class CppMethodCodeNode : DependencyNodeCore<NodeFactory>, IMethodBodyNode
     {
         private MethodDesc _method;
         private string _methodCode;

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzer.cs
@@ -87,8 +87,7 @@ namespace ILCompiler.DependencyAnalysisFramework
             {
                 if (!_markingCompleted)
                 {
-                    _markingCompleted = true;
-                    ComputeMarkedNodes();
+                    throw new InvalidOperationException();
                 }
 
                 return _markedNodesFinal;
@@ -242,8 +241,11 @@ namespace ILCompiler.DependencyAnalysisFramework
             } while (_markStack.Count != 0);
         }
 
-        private void ComputeMarkedNodes()
+        public override void ComputeMarkedNodes()
         {
+            if (_markingCompleted)
+                return;
+
             do
             {
                 // Run mark stack algorithm as much as possible
@@ -265,6 +267,7 @@ namespace ILCompiler.DependencyAnalysisFramework
 
             _markedNodesFinal = _markedNodes.ToImmutableArray();
             _markedNodes = null;
+            _markingCompleted = true;
         }
 
         private bool AddToMarkStack(DependencyNodeCore<DependencyContextType> node, string reason, DependencyNodeCore<DependencyContextType> reason1, DependencyNodeCore<DependencyContextType> reason2)

--- a/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzerBase.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/src/DependencyAnalyzerBase.cs
@@ -40,11 +40,18 @@ namespace ILCompiler.DependencyAnalysisFramework
 
         /// <summary>
         /// Return the marked node list. Do not modify this list, as it will cause unexpected behavior.
+        /// Call <see cref="ComputeMarkedNodes"/> to compute the list first.
         /// </summary>
         public abstract ImmutableArray<DependencyNodeCore<DependencyContextType>> MarkedNodeList
         {
             get;
         }
+
+        /// <summary>
+        /// Computes the list of marked nodes. This is a no-op if the marked nodes are already computed.
+        /// The list is available as <see cref="MarkedNodeList"/>.
+        /// </summary>
+        public abstract void ComputeMarkedNodes();
 
         /// <summary>
         /// This event is triggered when a node is added to the graph.

--- a/src/ILCompiler.DependencyAnalysisFramework/tests/TestGraph.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/tests/TestGraph.cs
@@ -163,6 +163,9 @@ namespace ILCompiler.DependencyAnalysisFramework.Tests
             get
             {
                 List<string> liveNodes = new List<string>();
+
+                _analyzer.ComputeMarkedNodes();
+
                 foreach (var node in _analyzer.MarkedNodeList)
                 {
                     liveNodes.Add(((TestNode)node).Data);


### PR DESCRIPTION
This exposes a command line switch to enable IL scanner. When IL scanner is enabled, it determines the shape of all VTables to be used during compilation, allowing codegen to generate inline vtable lookups (instead of calling an assembly helper that does the lookup).

* Factoring of Compilation and ILScanner so that they both can provide lists of compiled methods and generated EETypes
* `IMethodBodyNode` to mark the node that represents a method body in a given compilation.
* Diff the results of scanning and compilation phases to find potential issues in the scanner.
* Native layout is asking for vtables of RuntimeDetermined things. Switching it over to ask for the canon versions.

Known analysis discrepancies:
* SIMD intrinsics not getting recognized as intrinsics in the scanner. There's just too many of them. Worked around by ignoring all scan/compilation diffs in the SIMD module.
* Type system entities injected by interop/reflection not surviving across scan/compile phases. For now, ignoring them under an active issue (#3873)