### PR TITLE
[Unix/ARM] Fix obtaining of NYI_Assert symbol

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -16,8 +16,7 @@ namespace ILCompiler.DependencyAnalysis
     {       
         protected sealed override void EmitCode(NodeFactory factory, ref ARMEmitter encoder, bool relocsOnly)
         {
-            var NYI_Assert = new ExternSymbolNode("NYI_Assert");
-            encoder.EmitJMP(NYI_Assert);
+            encoder.EmitJMP(factory.ExternSymbol("NYI_Assert"));
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
@@ -16,10 +16,9 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     partial class ReadyToRunHelperNode
     {
-        private ExternSymbolNode NYI_Assert;
         protected override void EmitCode(NodeFactory factory, ref ARMEmitter encoder, bool relocsOnly)
         {
-            NYI_Assert = new ExternSymbolNode("NYI_Assert");
+            ISymbolNode NYI_Assert = factory.ExternSymbol("NYI_Assert");
 
             switch (Id)
             {


### PR DESCRIPTION
Fixes an assertion failure in the checker at [ObjectDataBuilder.cs#L240-L247](https://github.com/dotnet/corert/blob/743a9a1a42b5949446d04ef20c57f0ba03b981de/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs#L240-L247)
```
   at System.Diagnostics.Debug.Assert(Boolean condition, String message, String detailMessage)
   at System.Diagnostics.Debug.Assert(Boolean condition)
   at ILCompiler.DependencyAnalysis.ObjectDataBuilder.EmitReloc(ISymbolNode symbol, RelocType relocType, Int32 delta)
   at ILCompiler.DependencyAnalysis.ARM.ARMEmitter.EmitJMP(ISymbolNode symbol)
   at ILCompiler.DependencyAnalysis.ReadyToRunHelperNode.EmitCode(NodeFactory factory, ARMEmitter& encoder, Boolean relocsOnly)
   at ILCompiler.DependencyAnalysis.AssemblyStubNode.GetData(NodeFactory factory, Boolean relocsOnly)
   at ILCompiler.DependencyAnalysis.ObjectWriter.EmitObject(String objectFilePath, IEnumerable`1 nodes, NodeFactory factory, IObjectDumper dumper)
   at ILCompiler.RyuJitCompilation.CompileInternal(String outputFile, ObjectDumper dumper)
   at ILCompiler.Compilation.ILCompiler.ICompilation.Compile(String outputFile, ObjectDumper dumper)
   at ILCompiler.Program.Run(String[] args)
   at ILCompiler.Program.Main(String[] args)
```