### PR TITLE
Work around FormatMessage linker failure

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -105,6 +105,16 @@ namespace Internal.TypeSystem.Interop
                 return true;
             }
 
+            //
+            // https://github.com/dotnet/corert/issues/730
+            // P/Invoke to FormatMessage doesn't specify A/W form and we don't currently perform the lookup
+            // on the user's behalf at compile time.
+            //
+            if (assemblySimpleName == "System.Diagnostics.Tracing")
+            {
+                return true;
+            }
+
             // Determine whether this call should be made through a lazy resolution or a static reference
             // Eventually, this should be controlled by a custom attribute (or an extension to the metadata format).
             if (importModule == "[MRT]" || importModule == "*")


### PR DESCRIPTION
System.Diagnostics.Tracing uses a P/Invoke to FormatMessage without the
A/W character encoding suffix.  Make P/Invokes from that assembly lazily
resolved so the runtime lookup code finds FormatMessageW correctly. This
is due to issue https://github.com/dotnet/corert/issues/730. This fixes an unresolved symbol error in the linker for the ASP.NET Core workloads we're investigating.