### PR TITLE
Fix interface handling in CorInfoImpl.resolveVirtualMethod

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -849,6 +849,10 @@ namespace Internal.JitInterface
                 }
 
                 impl = implType.ResolveInterfaceMethodTarget(decl);
+                if (impl != null)
+                {
+                    impl = implType.GetClosestDefType().FindVirtualFunctionTargetMethodOnObjectType(impl);
+                }
             }
             else
             {

--- a/tests/src/Simple/Interfaces/Interfaces.cs
+++ b/tests/src/Simple/Interfaces/Interfaces.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 public class BringUpTest
 {
@@ -26,6 +27,9 @@ public class BringUpTest
             return Fail;
 
         if (TestSpecialArrayInterfaces() == Fail)
+            return Fail;
+
+        if (TestIterfaceCallOptimization() == Fail)
             return Fail;
 
         return Pass;
@@ -356,6 +360,36 @@ public class BringUpTest
             return Fail;
 
         return Pass;
+    }
+
+    #endregion
+
+    #region Interface call optimization tests
+
+    public interface ISomeInterface
+    {
+        int SomeValue { get; }
+    }
+
+    public abstract class SomeAbstractBaseClass : ISomeInterface
+    {
+        public abstract int SomeValue { get; }
+    }
+
+    public class SomeClass : SomeAbstractBaseClass
+    {
+        public override int SomeValue
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get { return 14; }
+        }
+    }
+
+    private static int TestIterfaceCallOptimization()
+    {
+        ISomeInterface test = new SomeClass();
+        int v = test.SomeValue;
+        return (v == 14) ? Pass : Fail;
     }
 
     #endregion


### PR DESCRIPTION
Without this fix, the CoreRT compiler generated the following code for the test that I am adding:
```
call Interfaces!_NewHelper_Interfaces_BringUpTest_SomeClass
mov rcx,rax
call Interfaces!Interfaces_BringUpTest_SomeAbstractBaseClass__get_SomeValue
```
As you can see, it ends up calling an abstract method on the base class.

With this fix, the interface call is resolved correctly:
```
call Interfaces!_NewHelper_Interfaces_BringUpTest_SomeClass
mov rcx,rax
call Interfaces!Interfaces_BringUpTest_SomeClass__get_SomeValue
```
@davidwrighton, here is the fix based on you suggestion.
