### PR TITLE
Fix worker thread count tracking when a thread fails to take a request.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -31,9 +31,9 @@ namespace System.Threading
                     // TODO: Event:  Worker thread wait event
                     while (s_semaphore.Wait(TimeoutMs))
                     {
-                        Volatile.Write(ref ThreadPoolInstance._separated.lastDequeueTime, Environment.TickCount);
                         if (TakeActiveRequest())
                         {
+                            Volatile.Write(ref ThreadPoolInstance._separated.lastDequeueTime, Environment.TickCount);
                             if (ThreadPoolWorkQueue.Dispatch())
                             {
                                 // If we ran out of work, we need to update s_separated.counts that we are done working for now
@@ -70,6 +70,31 @@ namespace System.Threading
 
                             CultureInfo.CurrentCulture = CultureInfo.InstalledUICulture;
                             CultureInfo.CurrentUICulture = CultureInfo.InstalledUICulture;
+                        }
+                        else
+                        {
+                            // If we woke up but couldn't find a request, we need to update s_separated.counts that we are done working for now
+                            ThreadCounts currentCounts = ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts);
+                            while (true)
+                            {
+                                ThreadCounts newCounts = currentCounts;
+                                newCounts.numProcessingWork--;
+                                ThreadCounts oldCounts = ThreadCounts.CompareExchangeCounts(ref ThreadPoolInstance._separated.counts, newCounts, currentCounts);
+
+                                if (oldCounts == currentCounts)
+                                {
+                                    break;
+                                }
+                                currentCounts = oldCounts;
+                            }
+                            // It's possible that we decided we had thread requests just before a request came in, 
+                            // but reduced the worker count *after* the request came in.  In this case, we might
+                            // miss the notification of a thread request.  So we wake up a thread (maybe this one!)
+                            // if there is work to do.
+                            if (ThreadPoolInstance._numRequestedWorkers > 0)
+                            {
+                                MaybeAddWorkingWorker();
+                            }
                         }
                     }
 

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -102,6 +102,7 @@ namespace System.Threading
                     }
                     currentCounts = oldCounts;
                 }
+
                 // It's possible that we decided we had thread requests just before a request came in, 
                 // but reduced the worker count *after* the request came in.  In this case, we might
                 // miss the notification of a thread request.  So we wake up a thread (maybe this one!)

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -37,7 +37,7 @@ namespace System.Threading
                             if (ThreadPoolWorkQueue.Dispatch())
                             {
                                 // If the queue runs out of work for us, we need to update the number of working workers to reflect that we are done working for now
-                                MaybeRemoveWorkingWorker();
+                                RemoveWorkingWorker();
                             }
 
                             // Reset thread-local state that we control.
@@ -52,7 +52,7 @@ namespace System.Threading
                         else
                         {
                             // If we woke up but couldn't find a request, we need to update the number of working workers to reflect that we are done working for now
-                            MaybeRemoveWorkingWorker();
+                            RemoveWorkingWorker();
                         }
                     }
 
@@ -85,9 +85,9 @@ namespace System.Threading
             }
 
             /// <summary>
-            /// Reduce the number of working workers by one, but maybe add back a worker if a thread request comes in while we are marking this thread as not working.
+            /// Reduce the number of working workers by one, but maybe add back a worker (possibily this thread) if a thread request comes in while we are marking this thread as not working.
             /// </summary>
-            private static void MaybeRemoveWorkingWorker()
+            private static void RemoveWorkingWorker()
             {
                 ThreadCounts currentCounts = ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts);
                 while (true)


### PR DESCRIPTION
Fix bug where a thread that fails to take an active request didn't decrement the working threads count and threads would not get woken up because the working thread count was inaccurate.