### PR TITLE
Handle exceptions during worker thread creation

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -219,11 +219,11 @@ namespace System.Threading
 
             private static bool TryCreateWorkerThread()
             {
-                RuntimeThread workerThread = RuntimeThread.Create(WorkerThreadStart);
-                workerThread.IsThreadPoolThread = true;
-                workerThread.IsBackground = true;
                 try
                 {
+                    RuntimeThread workerThread = RuntimeThread.Create(WorkerThreadStart);
+                    workerThread.IsThreadPoolThread = true;
+                    workerThread.IsBackground = true;
                     workerThread.Start();
                 }
                 catch (ThreadStartException)

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -148,7 +148,7 @@ namespace System.Threading
 
                 while(toCreate > 0)
                 {
-                    if(CreateWorkerThread())
+                    if(TryCreateWorkerThread())
                     {
                         toCreate--;
                     }
@@ -217,7 +217,7 @@ namespace System.Threading
                 return false;
             }
 
-            private static bool CreateWorkerThread()
+            private static bool TryCreateWorkerThread()
             {
                 RuntimeThread workerThread = RuntimeThread.Create(WorkerThreadStart);
                 workerThread.IsThreadPoolThread = true;

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -146,9 +146,30 @@ namespace System.Threading
                     s_semaphore.Release(toRelease);
                 }
 
-                for (int i = 0; i < toCreate; i++)
+                while(toCreate > 0)
                 {
-                    CreateWorkerThread();
+                    if(CreateWorkerThread())
+                    {
+                        toCreate--;
+                    }
+                    else
+                    {
+                        counts = ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts);
+                        while(true)
+                        {
+                            newCounts = counts;
+                            newCounts.numProcessingWork -= (short)toCreate;
+                            newCounts.numExistingThreads -= (short)toCreate;
+
+                            ThreadCounts oldCounts = ThreadCounts.CompareExchangeCounts(ref ThreadPoolInstance._separated.counts, newCounts, counts);
+                            if(oldCounts == counts)
+                            {
+                                break;
+                            }
+                            counts = oldCounts;
+                        }
+                        toCreate = 0;
+                    }
                 }
             }
 
@@ -196,19 +217,24 @@ namespace System.Threading
                 return false;
             }
 
-            private static void CreateWorkerThread()
+            private static bool CreateWorkerThread()
             {
-                // TODO: Replace RuntimeThread.Create with a more perfomant thread creation
-                // Note: Thread local data is created lazily on CoreRT, so we might get an OOM exception
-                // if we run out of memory when starting this thread.
-                // If we use RuntimeThread.Create, we get the exception on this thread.
-                // If we don't, we will get the exception on our worker thread.
-                // Goal: Figure out how to safely manage the OOM possibility of a worker thread
-                // without perf issues.
                 RuntimeThread workerThread = RuntimeThread.Create(WorkerThreadStart);
                 workerThread.IsThreadPoolThread = true;
                 workerThread.IsBackground = true;
-                workerThread.Start();
+                try
+                {
+                    workerThread.Start();
+                }
+                catch (ThreadStartException)
+                {
+                    return false;
+                }
+                catch (OutOfMemoryException)
+                {
+                    return false;
+                }
+                return true;
             }
         }
     }

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -123,14 +123,14 @@ namespace System.Threading
                     newCounts.numProcessingWork = Math.Max(counts.numProcessingWork, Math.Min((short)(counts.numProcessingWork + 1), counts.numThreadsGoal));
                     newCounts.numExistingThreads = Math.Max(counts.numExistingThreads, newCounts.numProcessingWork);
                     
-                    if(newCounts == counts)
+                    if (newCounts == counts)
                     {
                         return;
                     }
 
                     ThreadCounts oldCounts = ThreadCounts.CompareExchangeCounts(ref ThreadPoolInstance._separated.counts, newCounts, counts);
 
-                    if(oldCounts == counts)
+                    if (oldCounts == counts)
                     {
                         break;
                     }
@@ -141,21 +141,21 @@ namespace System.Threading
                 int toCreate = newCounts.numExistingThreads - counts.numExistingThreads;
                 int toRelease = newCounts.numProcessingWork - counts.numProcessingWork;
 
-                if(toRelease > 0)
+                if (toRelease > 0)
                 {
                     s_semaphore.Release(toRelease);
                 }
 
-                while(toCreate > 0)
+                while (toCreate > 0)
                 {
-                    if(TryCreateWorkerThread())
+                    if (TryCreateWorkerThread())
                     {
                         toCreate--;
                     }
                     else
                     {
                         counts = ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts);
-                        while(true)
+                        while (true)
                         {
                             newCounts = counts;
                             newCounts.numProcessingWork -= (short)toCreate;


### PR DESCRIPTION
Catch exceptions in worker thread creation and update the counts to reflect that the worker thread was not created.