### PR TITLE
Remove p/invoke calls from the Lock class

### DIFF
--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -1223,6 +1223,16 @@ COOP_PINVOKE_HELPER(Boolean, RhSetThreadStaticStorageForModule, (Array * pStorag
     Thread * pCurrentThread = ThreadStore::RawGetCurrentThread();
     return pCurrentThread->SetThreadStaticStorageForModule((Object*)pStorage, moduleIndex);
 }
+
+// This is function is used to quickly query a value that can uniquely identify a thread
+COOP_PINVOKE_HELPER(UInt8*, RhCurrentNativeThreadId, ())
+{
+#ifndef PLATFORM_UNIX
+    return PalNtCurrentTeb();
+#else
+    return (UInt8*)ThreadStore::RawGetCurrentThread();
+#endif // PLATFORM_UNIX
+}
 #endif // CORERT
 
 // Standard calling convention variant and actual implementation for RhpReversePInvokeAttachOrTrapThread

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -572,6 +572,10 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhSetThreadStaticStorageForModule")]
         internal static unsafe extern bool RhSetThreadStaticStorageForModule(Array storage, Int32 moduleIndex);
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhCurrentNativeThreadId")]
+        internal static unsafe extern IntPtr RhCurrentNativeThreadId();
 #endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime;
 using System.Runtime.CompilerServices;
 using Internal.Runtime.Augments;
 
@@ -40,8 +41,8 @@ namespace System.Threading
 
         private volatile int _state;
 
-        private int _owningThreadId;
         private uint _recursionCount;
+        private IntPtr _owningThreadId;
         private volatile AutoResetEvent _lazyEvent;
 
         private AutoResetEvent Event
@@ -59,6 +60,13 @@ namespace System.Threading
             }
         }
 
+#if CORERT
+        private static IntPtr CurrentNativeThreadId => (IntPtr)RuntimeImports.RhCurrentNativeThreadId();
+#else
+        // Use a compiler intrinsic for .NET Native
+        private static IntPtr CurrentNativeThreadId => (IntPtr)Environment.CurrentNativeThreadId;
+#endif // CORERT
+
         // On platforms where CurrentNativeThreadId redirects to ManagedThreadId.Current the inlined
         // version of Lock.Acquire has the ManagedThreadId.Current call not inlined, while the non-inlined
         // version has it inlined.  So it saves code to keep this function not inlined while having
@@ -66,14 +74,14 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Acquire()
         {
-            int currentThreadId = Environment.CurrentNativeThreadId;
+            IntPtr currentThreadId = CurrentNativeThreadId;
 
             //
             // Make one quick attempt to acquire an uncontended lock
             //
             if (Interlocked.CompareExchange(ref _state, Locked, Uncontended) == Uncontended)
             {
-                Debug.Assert(_owningThreadId == 0);
+                Debug.Assert(_owningThreadId == IntPtr.Zero);
                 Debug.Assert(_recursionCount == 0);
                 _owningThreadId = currentThreadId;
                 return;
@@ -96,14 +104,14 @@ namespace System.Threading
             if (millisecondsTimeout < -1)
                 throw new ArgumentOutOfRangeException(nameof(millisecondsTimeout), SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
 
-            int currentThreadId = Environment.CurrentNativeThreadId;
+            IntPtr currentThreadId = CurrentNativeThreadId;
 
             //
             // Make one quick attempt to acquire an uncontended lock
             //
             if (Interlocked.CompareExchange(ref _state, Locked, Uncontended) == Uncontended)
             {
-                Debug.Assert(_owningThreadId == 0);
+                Debug.Assert(_owningThreadId == IntPtr.Zero);
                 Debug.Assert(_recursionCount == 0);
                 _owningThreadId = currentThreadId;
                 return true;
@@ -115,7 +123,7 @@ namespace System.Threading
             return TryAcquireContended(currentThreadId, millisecondsTimeout);
         }
 
-        private bool TryAcquireContended(int currentThreadId, int millisecondsTimeout)
+        private bool TryAcquireContended(IntPtr currentThreadId, int millisecondsTimeout)
         {
             //
             // If we already own the lock, just increment the recursion count.
@@ -221,7 +229,7 @@ namespace System.Threading
 
         GotTheLock:
             Debug.Assert((_state | Locked) != 0);
-            Debug.Assert(_owningThreadId == 0);
+            Debug.Assert(_owningThreadId == IntPtr.Zero);
             Debug.Assert(_recursionCount == 0);
             _owningThreadId = currentThreadId;
             return true;
@@ -250,7 +258,7 @@ namespace System.Threading
                 // because while we're doing this check the current thread is definitely still
                 // alive.
                 //
-                int currentThreadId = Environment.CurrentNativeThreadId;
+                IntPtr currentThreadId = CurrentNativeThreadId;
                 bool acquired = (currentThreadId == _owningThreadId);
                 if (acquired)
                     Debug.Assert((_state & Locked) != 0);
@@ -286,7 +294,7 @@ namespace System.Threading
         private void ReleaseCore()
         {
             Debug.Assert(_recursionCount == 0);
-            _owningThreadId = 0;
+            _owningThreadId = IntPtr.Zero;
 
             //
             // Make one quick attempt to release an uncontended lock
@@ -303,7 +311,7 @@ namespace System.Threading
         private void ReleaseContended()
         {
             Debug.Assert(_recursionCount == 0);
-            Debug.Assert(_owningThreadId == 0);
+            Debug.Assert(_owningThreadId == IntPtr.Zero);
 
             while (true)
             {


### PR DESCRIPTION
In .NET Native, the Lock class uses a compiler intrinsic to quickly obtain an identifier for the current thread. In CoreRT, such calls are regular p/invokes to OS API, which is obviously bad for Lock performance. This change mitigates the problem by replacing the p/invokes with internal calls to the runtime.

