### PR TITLE
Stub Environment from registry apis on N.

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.FromRegistry.Win32.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.FromRegistry.Win32.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32;
+
+namespace Internal.Runtime.Augments
+{
+    /// <summary>For internal use only.  Exposes runtime functionality to the Environments implementation in corefx.</summary>
+    public static partial class EnvironmentAugments
+    {
+        private static string GetEnvironmentVariableFromRegistry(string variable, bool fromMachine)
+        {
+            Debug.Assert(variable != null);
+            using (RegistryKey environmentKey = OpenEnvironmentKeyIfExists(fromMachine: fromMachine, writable: false))
+            {
+                return environmentKey?.GetValue(variable) as string;
+            }
+        }
+
+        private static void SetEnvironmentVariableFromRegistry(string variable, string value, bool fromMachine)
+        {
+            Debug.Assert(variable != null);
+
+            // User-wide environment variables stored in the registry are limited to 255 chars for the environment variable name.
+            const int MaxUserEnvVariableLength = 255;
+            if (variable.Length >= MaxUserEnvVariableLength)
+                throw new ArgumentException(SR.Argument_LongEnvVarValue, nameof(variable));
+
+            using (RegistryKey environmentKey = OpenEnvironmentKeyIfExists(fromMachine: fromMachine, writable: true))
+            {
+                if (environmentKey != null)
+                {
+                    if (value == null)
+                    {
+                        environmentKey.DeleteValue(variable, throwOnMissingValue: false);
+                    }
+                    else
+                    {
+                        environmentKey.SetValue(variable, value);
+                    }
+                }
+            }
+
+            // send a WM_SETTINGCHANGE message to all windows
+            IntPtr r = Interop.User32.SendMessageTimeout(new IntPtr(Interop.User32.HWND_BROADCAST), Interop.User32.WM_SETTINGCHANGE, IntPtr.Zero, "Environment", 0, 1000, IntPtr.Zero);
+            if (r == IntPtr.Zero)
+                Debug.Assert(false, "SetEnvironmentVariable failed: " + Marshal.GetLastWin32Error());
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> EnumerateEnvironmentVariablesFromRegistry(bool fromMachine)
+        {
+            using (RegistryKey environmentKey = OpenEnvironmentKeyIfExists(fromMachine: fromMachine, writable: false))
+            {
+                if (environmentKey != null)
+                {
+                    foreach (string name in environmentKey.GetValueNames())
+                    {
+                        string value = environmentKey.GetValue(name, string.Empty).ToString();
+                        yield return new KeyValuePair<string, string>(name, value);
+                    }
+                }
+            }
+        }
+
+        private static RegistryKey OpenEnvironmentKeyIfExists(bool fromMachine, bool writable)
+        {
+            RegistryKey baseKey;
+            string keyName;
+
+            if (fromMachine)
+            {
+                baseKey = Registry.LocalMachine;
+                keyName = @"System\CurrentControlSet\Control\Session Manager\Environment";
+            }
+            else
+            {
+                baseKey = Registry.CurrentUser;
+                keyName = "Environment";
+            }
+
+            return baseKey.OpenSubKey(keyName, writable: writable);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.FromRegistry.WithoutRegistry.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.FromRegistry.WithoutRegistry.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Internal.Runtime.Augments
+{
+    /// <summary>For internal use only.  Exposes runtime functionality to the Environments implementation in corefx.</summary>
+    public static partial class EnvironmentAugments
+    {
+        private static string GetEnvironmentVariableFromRegistry(string variable, bool fromMachine)
+        {
+            Debug.Assert(variable != null);
+            return null; // Systems without registries pretend that the registry environment subkeys are empty lists.
+        }
+
+        private static void SetEnvironmentVariableFromRegistry(string variable, string value, bool fromMachine)
+        {
+            Debug.Assert(variable != null);
+            return;  // Systems without registries pretend that the registry environment subkeys are empty lists that throw all write requests into a black hole.
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> EnumerateEnvironmentVariablesFromRegistry(bool fromMachine)
+        {
+            return Array.Empty<KeyValuePair<string, string>>();  // Systems without registries pretend that the registry environment subkeys are empty lists.
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Unix.cs
@@ -32,22 +32,5 @@ namespace Internal.Runtime.Augments
 
             return Array.Empty<KeyValuePair<string,string>>();
         }
-
-        private static string GetEnvironmentVariableFromRegistry(string variable, bool fromMachine)
-        {
-            Debug.Assert(variable != null);
-            return null; // Unix systems pretend that the registry environment subkeys are empty lists.
-        }
-
-        private static void SetEnvironmentVariableFromRegistry(string variable, string value, bool fromMachine)
-        {
-            Debug.Assert(variable != null);
-            return;  // Unix systems pretend that the registry environment subkeys are empty lists that throw all write requests into a black hole.
-        }
-
-        private static IEnumerable<KeyValuePair<string, string>> EnumerateEnvironmentVariablesFromRegistry(bool fromMachine)
-        {
-            return Array.Empty<KeyValuePair<string, string>>();  // Unix systems pretend that the registry environment subkeys are empty lists.
-        }
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Windows.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Windows.cs
@@ -9,8 +9,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-using Microsoft.Win32;
-
 using Win32Marshal = System.IO.Win32Marshal;
 
 namespace Internal.Runtime.Augments
@@ -155,79 +153,6 @@ namespace Internal.Runtime.Augments
 
                 yield return new KeyValuePair<string, string>(key, value);
             }
-        }
-
-        private static string GetEnvironmentVariableFromRegistry(string variable, bool fromMachine)
-        {
-            Debug.Assert(variable != null);
-            using (RegistryKey environmentKey = OpenEnvironmentKeyIfExists(fromMachine: fromMachine, writable: false))
-            {
-                return environmentKey?.GetValue(variable) as string;
-            }
-        }
-
-        private static void SetEnvironmentVariableFromRegistry(string variable, string value, bool fromMachine)
-        {
-            Debug.Assert(variable != null);
-
-            // User-wide environment variables stored in the registry are limited to 255 chars for the environment variable name.
-            const int MaxUserEnvVariableLength = 255;
-            if (variable.Length >= MaxUserEnvVariableLength)
-                throw new ArgumentException(SR.Argument_LongEnvVarValue, nameof(variable));
-
-            using (RegistryKey environmentKey = OpenEnvironmentKeyIfExists(fromMachine: fromMachine, writable: true))
-            {
-                if (environmentKey != null)
-                {
-                    if (value == null)
-                    {
-                        environmentKey.DeleteValue(variable, throwOnMissingValue: false);
-                    }
-                    else
-                    {
-                        environmentKey.SetValue(variable, value);
-                    }
-                }
-            }
-
-            // send a WM_SETTINGCHANGE message to all windows
-            IntPtr r = Interop.User32.SendMessageTimeout(new IntPtr(Interop.User32.HWND_BROADCAST), Interop.User32.WM_SETTINGCHANGE, IntPtr.Zero, "Environment", 0, 1000, IntPtr.Zero);
-            if (r == IntPtr.Zero)
-                Debug.Assert(false, "SetEnvironmentVariable failed: " + Marshal.GetLastWin32Error());
-        }
-
-        private static IEnumerable<KeyValuePair<string, string>> EnumerateEnvironmentVariablesFromRegistry(bool fromMachine)
-        {
-            using (RegistryKey environmentKey = OpenEnvironmentKeyIfExists(fromMachine: fromMachine, writable: false))
-            {
-                if (environmentKey != null)
-                {
-                    foreach (string name in environmentKey.GetValueNames())
-                    {
-                        string value = environmentKey.GetValue(name, string.Empty).ToString();
-                        yield return new KeyValuePair<string, string>(name, value);
-                    }
-                }
-            }
-        }
-
-        private static RegistryKey OpenEnvironmentKeyIfExists(bool fromMachine, bool writable)
-        {
-            RegistryKey baseKey;
-            string keyName;
-
-            if (fromMachine)
-            {
-                baseKey = Registry.LocalMachine;
-                keyName = @"System\CurrentControlSet\Control\Session Manager\Environment";
-            }
-            else
-            {
-                baseKey = Registry.CurrentUser;
-                keyName = "Environment";
-            }
-
-            return baseKey.OpenSubKey(keyName, writable: writable);
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -120,6 +120,8 @@
     <Compile Condition="'$(IsProjectNLibrary)' == 'true'" Include="Internal\Runtime\Augments\EnvironmentAugments.ProjectN.cs" />
     <Compile Condition="'$(TargetsWindows)'=='true'" Include="Internal\Runtime\Augments\EnvironmentAugments.Windows.cs" />
     <Compile Condition="'$(TargetsUnix)'=='true'" Include="Internal\Runtime\Augments\EnvironmentAugments.Unix.cs" />
+    <Compile Condition="'$(TargetsWindows)'=='true' and '$(EnableWinRT)' != 'true'" Include="Internal\Runtime\Augments\EnvironmentAugments.FromRegistry.Win32.cs" />
+    <Compile Condition="'$(TargetsUnix)'=='true' or '$(EnableWinRT)'=='true'" Include="Internal\Runtime\Augments\EnvironmentAugments.FromRegistry.WithoutRegistry.cs" />
     <Compile Include="Internal\Runtime\Augments\RuntimeThread.cs" />
     <Compile Include="Internal\Runtime\Augments\TaskTraceCallbacks.cs" />
   </ItemGroup>
@@ -447,8 +449,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true' and '$(EnableWinRT)'!='true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs" />
     <Compile Include="Microsoft\Win32\Registry.cs" />
@@ -494,9 +494,6 @@
     <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.RegQueryValueEx.cs">
       <Link>Interop\Windows\mincore\Interop.RegQueryValueEx.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\kernel32\Interop.ExpandEnvironmentStrings.cs">
-      <Link>Interop\Windows\kernel32\Interop.ExpandEnvironmentStrings.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Compile Include="Internal\Runtime\Augments\RuntimeThread.Windows.cs" />
@@ -509,6 +506,9 @@
     <Compile Include="System\Globalization\FormatProvider.FormatAndParse.Windows.cs" />
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Windows.cs" />
     <Compile Include="System\Runtime\MemoryFailPoint.cs" />
+    <Compile Include="..\..\Common\src\Interop\Windows\kernel32\Interop.ExpandEnvironmentStrings.cs">
+      <Link>Interop\Windows\kernel32\Interop.ExpandEnvironmentStrings.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\Interop\Windows\kernel32\Interop.Memory.cs">
       <Link>Interop\Windows\kernel32\Interop.Memory.cs</Link>
     </Compile>


### PR DESCRIPTION
We're not going to get exemptions for these inside appcontainers
so we'll change them to behave as they do on Unix (present
an empty reg key that eats writes requests.)