### PR TITLE
Fix Arm relocs

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -968,6 +968,19 @@ namespace ILCompiler.DependencyAnalysis
                             }
                             int size = objectWriter.EmitSymbolReference(reloc.Target, (int)delta, reloc.RelocType);
 
+                            // Emit a copy of original Thumb2 instruction that came from RyuJIT
+                            if (reloc.RelocType == RelocType.IMAGE_REL_BASED_THUMB_MOV32 ||
+                                reloc.RelocType == RelocType.IMAGE_REL_BASED_THUMB_BRANCH24)
+                            {
+                                unsafe
+                                {
+                                    fixed (void* location = &nodeContents.Data[i])
+                                    {
+                                        objectWriter.EmitBytes((IntPtr)location, size);
+                                    }
+                                }
+                            }
+
                             // Update nextRelocIndex/Offset
                             if (++nextRelocIndex < relocs.Length)
                             {


### PR DESCRIPTION
This change makes it possible to fully compile and link (and even run till the first NYI assertion) a tiny executable built against Test.CoreLib on Linux/armel.