### PR TITLE
Block the attaching/detaching threads if GC is in progress

### DIFF
--- a/src/Native/Runtime/RWLock.h
+++ b/src/Native/Runtime/RWLock.h
@@ -6,6 +6,8 @@ class ReaderWriterLock
 {
     volatile Int32  m_RWLock;       // lock used for R/W synchronization
     Int32           m_spinCount;    // spin count for a reader waiting for a writer to release the lock
+    bool            m_fBlockOnGc;   // True if the spinning writers should block when GC is in progress
+
 
 #if 0
     // used to prevent writers from being starved by readers
@@ -36,7 +38,7 @@ public:
         ~WriteHolder();
     };
 
-    ReaderWriterLock();
+    ReaderWriterLock(bool fBlockOnGc = false);
 
     void AcquireReadLock();
     void ReleaseReadLock();


### PR DESCRIPTION
Currently, the threads that are detaching from or attaching to the runtime can end up spinning for a long time in the ThreadStore lock for the entire duration of a GC because the lock is held while GC is in progress. This problem becomes quite visible when Windows thread pool injects a couple
hundreds of worker threads into a process.

This change fixes the problem by adding an option to the lock to block spinning threads on the GC event if GC is in progress.

With this change, I see a couple percent improvement on micro-benchmarks.