### PR TITLE
Add String.Contains overload with StringComparison

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/src/System/String.Searching.cs
@@ -13,6 +13,11 @@ namespace System
             return (IndexOf(value, StringComparison.Ordinal) >= 0);
         }
 
+        public bool Contains(string value, StringComparison comparisonType)
+        {
+            return (IndexOf(value, comparisonType) >= 0);
+        }
+
         // Returns the index of the first occurrence of value in the current instance.
         // The search starts at startIndex and runs thorough the next count characters.
         //


### PR DESCRIPTION
API change for [CoreFX #20846](https://github.com/dotnet/corefx/issues/20846)