### PR TITLE
RuntimeEnvironment.GetSystemVersion() on Project N

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/EcmaFormat/EcmaFormatRuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/EcmaFormat/EcmaFormatRuntimeAssembly.cs
@@ -232,6 +232,14 @@ namespace System.Reflection.Runtime.Assemblies.EcmaFormat
             }
         }
 
+        public sealed override string ImageRuntimeVersion
+        {
+            get
+            {
+                return MetadataReader.MetadataVersion;
+            }
+        }
+
         public sealed override Module ManifestModule
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.cs
@@ -135,6 +135,16 @@ namespace System.Reflection.Runtime.Assemblies.NativeFormat
             return ReflectionCoreExecution.ExecutionEnvironment.GetManifestResourceStream(this, name);
         }
 
+        public sealed override string ImageRuntimeVersion
+        {
+            get
+            {
+                // Needed to make RuntimeEnvironment.GetSystemVersion() work. Will not be correct always but anticipating most callers are not making
+                // actual decisions based on the value.
+                return "v4.0.30319";
+            }
+        }
+
         public sealed override Module ManifestModule
         {
             get

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/RuntimeAssembly.cs
@@ -148,6 +148,7 @@ namespace System.Reflection.Runtime.Assemblies
         public abstract override ManifestResourceInfo GetManifestResourceInfo(String resourceName);
         public abstract override String[] GetManifestResourceNames();
         public abstract override Stream GetManifestResourceStream(String name);
+        public abstract override string ImageRuntimeVersion { get; }
         public abstract override bool Equals(Object obj);
         public abstract override int GetHashCode();
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
@@ -63,7 +63,6 @@ namespace System.Reflection.Runtime.Assemblies
         public sealed override string CodeBase { get { throw new PlatformNotSupportedException(); } }
         public sealed override Assembly GetSatelliteAssembly(CultureInfo culture) { throw new PlatformNotSupportedException(); }
         public sealed override Assembly GetSatelliteAssembly(CultureInfo culture, Version version) { throw new PlatformNotSupportedException(); }
-        public sealed override string ImageRuntimeVersion { get { throw new PlatformNotSupportedException(); } }
         public sealed override AssemblyName[] GetReferencedAssemblies() { throw new PlatformNotSupportedException(); }
         public sealed override Module GetModule(string name) { throw new PlatformNotSupportedException(); }
     }


### PR DESCRIPTION
dotnet/corefx#20600

An api that supposedly returns you the version of the runtime
and is supposedly related to interop but in actually, just
gives you the metadata version string that the assembly
containing System.Object was compiled again.