### PR TITLE
Fix failing System.Runtime.Tests on ILC (Sort_Array_Array_NonGeneric)

### DIFF
--- a/src/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -380,10 +380,11 @@ namespace System.Collections.Generic
         private static void SwapIfGreaterWithItems(TKey[] keys, TValue[] values, IComparer<TKey> comparer, int a, int b)
         {
             Debug.Assert(keys != null);
-            Debug.Assert(values == null || values.Length >= keys.Length);
             Debug.Assert(comparer != null);
             Debug.Assert(0 <= a && a < keys.Length);
             Debug.Assert(0 <= b && b < keys.Length);
+            Debug.Assert(values == null || (0 <= a && a < values.Length));
+            Debug.Assert(values == null || (0 <= b && b < values.Length));
 
             if (a != b)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/17450

This test got reenabled recently though the underlying
bug wasn't fixed. The test was still hitting an assert in CoreLib.

Fixing this now.

It's perfectly legal for the keys and values arrays passed to Array.Sort()
to be of different sizes. All that's required is that offset/range you're
sorting fits within both.

So the "clever" shortcut this assertion rack uses to avoid writing
a proper range check against the "values" array is not valid.