### PR TITLE
Fix regressions in System.Runtime.Tests on ILC.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.cs
@@ -52,14 +52,6 @@ namespace System.Globalization
         {
             return CompareInfo.CompareOrdinalIgnoreCase(string1, offset1, length1, string2, offset2, length2);
         }
-        public static int IndexOf(String source, String value, int startIndex, int count)
-        {
-            return CultureInfo.CurrentCulture.CompareInfo.IndexOf(source, value, startIndex, count, CompareOptions.None);
-        }
-        public static int IndexOfIgnoreCase(String source, String value, int startIndex, int count)
-        {
-            return CultureInfo.CurrentCulture.CompareInfo.IndexOf(source, value, startIndex, count, CompareOptions.IgnoreCase);
-        }
         public static bool IsPrefix(String source, String prefix)
         {
             return CultureInfo.CurrentCulture.CompareInfo.IsPrefix(source, prefix, CompareOptions.None);
@@ -75,14 +67,6 @@ namespace System.Globalization
         public static bool IsSuffixIgnoreCase(String source, String suffix)
         {
             return CultureInfo.CurrentCulture.CompareInfo.IsSuffix(source, suffix, CompareOptions.IgnoreCase);
-        }
-        public static int LastIndexOf(String source, String value, int startIndex, int count)
-        {
-            return CultureInfo.CurrentCulture.CompareInfo.LastIndexOf(source, value, startIndex, count, CompareOptions.None);
-        }
-        public static int LastIndexOfIgnoreCase(String source, String value, int startIndex, int count)
-        {
-            return CultureInfo.CurrentCulture.CompareInfo.LastIndexOf(source, value, startIndex, count, CompareOptions.IgnoreCase);
         }
         public static int OrdinalIndexOf(String source, String value, int startIndex, int count)
         {

--- a/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -86,7 +86,7 @@ namespace System.Globalization
         // Currently we don't have native functions to do this, so we do it the hard way
         internal static int IndexOfStringOrdinalIgnoreCase(String source, String value, int startIndex, int count)
         {
-            if (count > source.Length || count < 0 || startIndex < 0 || startIndex >= source.Length || startIndex + count > source.Length)
+            if (count > source.Length || count < 0 || startIndex < 0 || startIndex > source.Length - count)
             {
                 return -1;
             }

--- a/src/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/src/System/String.Searching.cs
@@ -230,10 +230,16 @@ namespace System
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    return FormatProvider.IndexOf(this, value, startIndex, count);
+                    return CultureInfo.CurrentCulture.CompareInfo.IndexOf(this, value, startIndex, count, CompareOptions.None);
 
                 case StringComparison.CurrentCultureIgnoreCase:
-                    return FormatProvider.IndexOfIgnoreCase(this, value, startIndex, count);
+                    return CultureInfo.CurrentCulture.CompareInfo.IndexOf(this, value, startIndex, count, CompareOptions.IgnoreCase);
+
+                case StringComparison.InvariantCulture:
+                    return CultureInfo.InvariantCulture.CompareInfo.IndexOf(this, value, startIndex, count, CompareOptions.None);
+
+                case StringComparison.InvariantCultureIgnoreCase:
+                    return CultureInfo.InvariantCulture.CompareInfo.IndexOf(this, value, startIndex, count, CompareOptions.IgnoreCase);
 
                 case StringComparison.Ordinal:
                     return FormatProvider.OrdinalIndexOf(this, value, startIndex, count);
@@ -429,16 +435,23 @@ namespace System
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    return FormatProvider.LastIndexOf(this, value, startIndex, count);
+                    return CultureInfo.CurrentCulture.CompareInfo.LastIndexOf(this, value, startIndex, count, CompareOptions.None);
 
                 case StringComparison.CurrentCultureIgnoreCase:
-                    return FormatProvider.LastIndexOfIgnoreCase(this, value, startIndex, count);
+                    return CultureInfo.CurrentCulture.CompareInfo.LastIndexOf(this, value, startIndex, count, CompareOptions.IgnoreCase);
+
+                case StringComparison.InvariantCulture:
+                    return CultureInfo.InvariantCulture.CompareInfo.LastIndexOf(this, value, startIndex, count, CompareOptions.None);
+
+                case StringComparison.InvariantCultureIgnoreCase:
+                    return CultureInfo.InvariantCulture.CompareInfo.LastIndexOf(this, value, startIndex, count, CompareOptions.IgnoreCase);
 
                 case StringComparison.Ordinal:
                     return FormatProvider.OrdinalLastIndexOf(this, value, startIndex, count);
 
                 case StringComparison.OrdinalIgnoreCase:
                     return FormatProvider.OrdinalLastIndexOfIgnoreCase(this, value, startIndex, count);
+
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }


### PR DESCRIPTION
- InvariantCultures not supported on IndexOf and LastIndexOf.

- Bad range check in TestInfo.IndexOfStringOrdinalIgnoreCase,

  breaks:

     String.Empty.IndexOf(String.Empty.Index, InvariantCulture)

[Discretionaly]
- Started to peel the FormatProvider helpers in these methods
  for a more consistent source but then found that the ones for
  Ordinal cultures don't fit the pattern. So I stopped there
  since the primary mission is fixing the test failures.