### PR TITLE
Fix test BinaryReaderTests.Read_InvalidEncoding() on ILC

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -139,6 +139,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\InvalidOperationException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\InvalidProgramException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\InvalidTimeZoneException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\BinaryWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DirectoryNotFoundException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\EncodingCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\EndOfStreamException.cs" />

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -222,7 +222,6 @@
     <Compile Include="System\Globalization\TimeSpanParse.cs" />
     <Compile Include="System\InvokeUtils.cs" />
     <Compile Include="System\IO\BinaryReader.cs" />
-    <Compile Include="System\IO\BinaryWriter.cs" />
     <Compile Include="System\IO\InternalFile.cs" />
     <Compile Include="System\IO\InternalFile.Windows.cs" Condition="'$(TargetsWindows)'=='true'" />
     <Compile Include="System\IO\InternalFile.Unix.cs" Condition="'$(TargetsUnix)'=='true'" />

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -574,6 +575,30 @@ namespace System
         public static int[] GetBits(Decimal d)
         {
             return new int[] { d.lo, d.mid, d.hi, d.flags };
+        }
+
+        internal static void GetBytes(Decimal d, byte[] buffer)
+        {
+            Debug.Assert((buffer != null && buffer.Length >= 16), "[GetBytes]buffer != null && buffer.Length >= 16");
+            buffer[0] = (byte)d.lo;
+            buffer[1] = (byte)(d.lo >> 8);
+            buffer[2] = (byte)(d.lo >> 16);
+            buffer[3] = (byte)(d.lo >> 24);
+
+            buffer[4] = (byte)d.mid;
+            buffer[5] = (byte)(d.mid >> 8);
+            buffer[6] = (byte)(d.mid >> 16);
+            buffer[7] = (byte)(d.mid >> 24);
+
+            buffer[8] = (byte)d.hi;
+            buffer[9] = (byte)(d.hi >> 8);
+            buffer[10] = (byte)(d.hi >> 16);
+            buffer[11] = (byte)(d.hi >> 24);
+
+            buffer[12] = (byte)d.flags;
+            buffer[13] = (byte)(d.flags >> 8);
+            buffer[14] = (byte)(d.flags >> 16);
+            buffer[15] = (byte)(d.flags >> 24);
         }
 
         // Returns the larger of two Decimal values.

--- a/src/System.Private.CoreLib/src/System/IO/BinaryReader.cs
+++ b/src/System.Private.CoreLib/src/System/IO/BinaryReader.cs
@@ -422,7 +422,25 @@ namespace System.IO
                 }
 
                 Debug.Assert(byteBuffer != null, "expected byteBuffer to be non-null");
-                charsRead = _decoder.GetChars(byteBuffer, position, numBytes, buffer, index, flush: false);
+                checked
+                {
+                    if (position < 0 || numBytes < 0 || position > byteBuffer.Length - numBytes)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(numBytes));
+                    }
+                    if (index < 0 || charsRemaining < 0 || index > buffer.Length - charsRemaining)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(charsRemaining));
+                    }
+                    unsafe
+                    {
+                        fixed (byte* pBytes = byteBuffer)
+                        fixed (char* pChars = buffer)
+                        {
+                            charsRead = _decoder.GetChars(pBytes + position, numBytes, pChars + index, charsRemaining, flush: false);
+                        }
+                    }
+                }
 
                 charsRemaining -= charsRead;
                 index += charsRead;


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/21645

(issue needs to stay open until we remove the ActiveIssue
from test).


Brought over the changes introduced in

  https://github.com/dotnet/coreclr/pull/7778

Moved BinaryWriter.cs to shared partition.

Leaving BinaryReader.cs in place for now.
CoreCLR needs to gets rid of those "m_" names before
we can do this confidently.