### PR TITLE
Fill in holes in String api support:

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -751,6 +751,43 @@ namespace System.Globalization
             return IndexOfCore(source, value, startIndex, count, options, null);
         }
 
+        // The following IndexOf overload is mainly used by String.Replace. This overload assumes the parameters are already validated
+        // and the caller is passing a valid matchLengthPtr pointer.
+        internal unsafe int IndexOf(string source, string value, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
+        {
+            Debug.Assert(source != null);
+            Debug.Assert(value != null);
+            Debug.Assert(startIndex >= 0);
+            Debug.Assert(matchLengthPtr != null);
+            *matchLengthPtr = 0;
+
+            if (source.Length == 0)
+            {
+                if (value.Length == 0)
+                {
+                    return 0;
+                }
+                return -1;
+            }
+
+            if (startIndex >= source.Length)
+            {
+                return -1;
+            }
+
+            if (options == CompareOptions.OrdinalIgnoreCase)
+            {
+                int res = IndexOfOrdinal(source, value, startIndex, count, ignoreCase: true);
+                if (res >= 0)
+                {
+                    *matchLengthPtr = value.Length;
+                }
+                return res;
+            }
+
+            return IndexOfCore(source, value, startIndex, count, options, matchLengthPtr);
+        }
+
         ////////////////////////////////////////////////////////////////////////
         //
         //  LastIndexOf

--- a/src/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -1026,6 +1026,10 @@ namespace System
             return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref _firstChar), _stringLength * 2, Marvin.DefaultSeed);
         }
 
+        // Gets a hash code for this string and this comparison. If strings A and B and comparition C are such
+        // that String.Equals(A, B, C), then they will return the same hash code with this comparison C.
+        public int GetHashCode(StringComparison comparisonType) => StringComparer.FromComparison(comparisonType).GetHashCode(this);
+
         // Use this if and only if you need the hashcode to not change across app domains (e.g. you have an app domain agile
         // hash table).
         internal int GetLegacyNonRandomizedHashCode()


### PR DESCRIPTION
TFS	451296	Port new overload String.GetHashCode(StringComparison)
TFS	451301	Port String.Replace(String, String, bool, CultureInfo)
TFS	451298	Port String.Replace(String, String, StringComparison)

Copy-pasted from CoreCLR - reactivated the CoreFX tests
that were disabled and verified they pass.