### PR TITLE
Make dispatch map declare dependency on interface vtables

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -62,6 +62,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             var result = new DependencyList();
             result.Add(factory.InterfaceDispatchMapIndirection(_type), "Interface dispatch map indirection node");
+
+            // VTable slots of implemented interfaces are consulted during emission
+            foreach (TypeDesc runtimeInterface in _type.RuntimeInterfaces)
+            {
+                result.Add(factory.VTable(runtimeInterface), "Interface for a dispatch map");
+            }
+
             return result;
         }
 


### PR DESCRIPTION
This showed up as a problem with ILScanner enabled where we couldn't get
the fixed vtable for a canonical interface that wasn't used. ILScanner
only generates vtable information for VTable nodes that were marked
during scanning and nobody made sure this one gets marked.