### PR TITLE
Delete stale lines from dir.targets

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -66,16 +66,4 @@
     </PropertyGroup>
   </Target>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder that exists to skip
-         the GenerateReferenceAssemblyPaths task (not target) and to prevent it from outputting a warning (MSB3644). -->
-    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)/Documentation</_TargetFrameworkDirectories>
-    <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)/Documentation</_FullFrameworkReferenceAssemblyPaths>
-    <!-- We do not want to target a portable profile.
-         TODO: Make this the default in buildtools so this is not necessary. -->
-    <TargetFrameworkProfile></TargetFrameworkProfile>
-    <!-- We set this property to avoid MSBuild errors regarding not setting TargetFrameworkProfile (see above line) -->
-    <PortableNuGetMode>true</PortableNuGetMode>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
I was looking at diagnostic logs trying to decypher why I'm getting
warnings about some loose *.dll files I have at the root of my drive
that has CoreRT repo, but got distracted by seeing attempts to resolve
things in the /Documentation directory.

This is a set of some old workarounds that used to be in the CoreFX repo
too, but are no longer there. Maybe we don't need them anymore?