### PR TITLE
[ILVerify] added cgt.un to the list of allowed instructions for comparing two object refs

### DIFF
--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -360,6 +360,10 @@ namespace Internal.IL
                     switch (dst.Kind)
                     {
                         case StackValueKind.ObjRef:
+                            // ECMA-335 III.1.5 Operand type table, P. 303:
+                            // __cgt.un__ is allowed and verifiable on ObjectRefs (O). This is commonly used when 
+                            // comparing an ObjectRef with null(there is no "compare - not - equal" instruction, which 
+                            // would otherwise be a more obvious solution)
                             return op == ILOpcode.beq || op == ILOpcode.beq_s ||
                                    op == ILOpcode.bne_un || op == ILOpcode.bne_un_s ||
                                    op == ILOpcode.ceq || op == ILOpcode.cgt_un;

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -362,8 +362,7 @@ namespace Internal.IL
                         case StackValueKind.ObjRef:
                             return op == ILOpcode.beq || op == ILOpcode.beq_s ||
                                    op == ILOpcode.bne_un || op == ILOpcode.bne_un_s ||
-                                   op == ILOpcode.ceq || 
-                                   op == ILOpcode.cgt_un;
+                                   op == ILOpcode.ceq || op == ILOpcode.cgt_un;
                         default:
                             return false;
                     }

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -362,7 +362,8 @@ namespace Internal.IL
                         case StackValueKind.ObjRef:
                             return op == ILOpcode.beq || op == ILOpcode.beq_s ||
                                    op == ILOpcode.bne_un || op == ILOpcode.bne_un_s ||
-                                   op == ILOpcode.ceq;
+                                   op == ILOpcode.ceq || 
+                                   op == ILOpcode.cgt_un;
                         default:
                             return false;
                     }

--- a/src/ILVerify/tests/ILTests/ComparisonTests.il
+++ b/src/ILVerify/tests/ILTests/ComparisonTests.il
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly Comparison
+{
+}
+
+.class public auto ansi beforefieldinit ComparisonTestsType
+       extends [System.Runtime]System.Object
+{
+    .method static public hidebysig void Comparison.NullWithObjRef_Valid() cil managed
+    {
+        .locals init (
+            class [System.Runtime]System.Object V_0
+        )
+        ldnull
+        ldloc.0
+        cgt.un
+        pop
+        ret
+    }
+
+    .method static public hidebysig void Comparison.ObjRefWithNull_Valid() cil managed
+    {
+        .locals init (
+            class [System.Runtime]System.Object V_0
+        )
+        ldloc.0
+        ldnull
+        cgt.un
+        pop
+        ret
+    }
+}


### PR DESCRIPTION
As described in ECMA-335:
> cgt.un is allowed and verifiable on ObjectRefs (O). This is commonly used when
comparing an ObjectRef with null (there is no “compare-not-equal” instruction, which
would otherwise be a more obvious solution)