### PR TITLE
Add support for obscure features in ILScanner

### DIFF
--- a/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
+++ b/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
@@ -27,6 +27,7 @@ namespace Internal.TypeSystem
         FileLoadErrorGeneric,
 
         // InvalidProgramException
+        InvalidProgramDefault,
         InvalidProgramSpecific,
         InvalidProgramVararg,
         InvalidProgramCallVirtFinalize,

--- a/src/Common/src/TypeSystem/Common/TypeSystemException.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemException.cs
@@ -172,6 +172,11 @@ namespace Internal.TypeSystem
                 : base(id, Format.Method(method))
             {
             }
+
+            public InvalidProgramException()
+                : base(ExceptionStringID.InvalidProgramDefault)
+            {
+            }
         }
 
         public class BadImageFormatException : TypeSystemException

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -403,7 +403,7 @@ namespace Internal.IL
                         break;
                     case ILOpcode.jmp:
                         ImportJmp(ReadILToken());
-                        break;
+                        return;
                     case ILOpcode.call:
                         ImportCall(opCode, ReadILToken());
                         break;

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -879,6 +879,10 @@ namespace Internal.IL
                         throw new BadImageFormatException("Invalid opcode");
                 }
 
+                // Check if control falls through the end of method.
+                if (_currentOffset >= _basicBlocks.Length)
+                    throw new TypeSystemException.InvalidProgramException();
+
                 BasicBlock nextBasicBlock = _basicBlocks[_currentOffset];
                 if (nextBasicBlock != null)
                 {

--- a/src/Common/src/TypeSystem/IL/Stubs/TypeSystemThrowingILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/TypeSystemThrowingILEmitter.cs
@@ -51,7 +51,17 @@ namespace Internal.IL.Stubs
             }
             else if (exceptionType == typeof(TypeSystemException.InvalidProgramException))
             {
+                //
+                // There are two ThrowInvalidProgramException helpers. Find the one which matches the number of
+                // arguments "exception" was initialized with.
+                //
+
                 helper = context.GetHelperEntryPoint("ThrowHelpers", "ThrowInvalidProgramException");
+
+                if (helper.Signature.Length != exception.Arguments.Count + 1)
+                {
+                    helper = context.GetHelperEntryPoint("ThrowHelpers", "ThrowInvalidProgramExceptionWithArgument");
+                }
             }
             else if (exceptionType == typeof(TypeSystemException.BadImageFormatException))
             {

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -123,6 +123,22 @@ namespace Internal.IL
                 }
             }
 
+            if (_canonMethod.IsSynchronized)
+            {
+                const string reason = "Synchronized method";
+                if (_canonMethod.Signature.IsStatic)
+                {
+                    _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.MonitorEnterStatic), reason);
+                    _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.MonitorExitStatic), reason);
+                }
+                else
+                {
+                    _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.MonitorEnter), reason);
+                    _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.MonitorExit), reason);
+                }
+                
+            }
+
             FindBasicBlocks();
             ImportBasicBlocks();
 
@@ -193,7 +209,8 @@ namespace Internal.IL
 
         private void ImportJmp(int token)
         {
-            // TODO
+            // JMP is kind of like a tail call (with no arguments pushed on the stack).
+            ImportCall(ILOpcode.call, token);
         }
 
         private void ImportCasting(ILOpcode opcode, int token)
@@ -711,12 +728,12 @@ namespace Internal.IL
 
         private void ImportRefAnyVal(int token)
         {
-            // TODO
+            _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.GetRefAny), "refanyval");
         }
 
         private void ImportMkRefAny(int token)
         {
-            // TODO
+            _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.TypeHandleToRuntimeType), "mkrefany");
         }
 
         private void ImportLdToken(int token)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -177,7 +177,7 @@ namespace Internal.JitInterface
                 }
                 if (result == CorJitResult.CORJIT_BADCODE)
                 {
-                    throw new TypeSystemException.InvalidProgramException(ExceptionStringID.InvalidProgramSpecific, MethodBeingCompiled);
+                    throw new TypeSystemException.InvalidProgramException();
                 }
                 if (result != CorJitResult.CORJIT_OK)
                 {

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -80,7 +80,12 @@ namespace Internal.Runtime.CompilerHelpers
             throw TypeLoaderExceptionHelper.CreateFileNotFoundException(id, fileName);
         }
 
-        public static void ThrowInvalidProgramException(ExceptionStringID id, string methodName)
+        public static void ThrowInvalidProgramException(ExceptionStringID id)
+        {
+            throw TypeLoaderExceptionHelper.CreateInvalidProgramException(id);
+        }
+
+        public static void ThrowInvalidProgramExceptionWithArgument(ExceptionStringID id, string methodName)
         {
             throw TypeLoaderExceptionHelper.CreateInvalidProgramException(id, methodName);
         }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
@@ -48,6 +48,11 @@ namespace Internal.Runtime
             throw new System.IO.FileNotFoundException(SR.Format(GetFormatString(id), fileName), fileName);
         }
 
+        public static Exception CreateInvalidProgramException(ExceptionStringID id)
+        {
+            throw new InvalidProgramException(GetFormatString(id));
+        }
+
         public static Exception CreateInvalidProgramException(ExceptionStringID id, string methodName)
         {
             throw new InvalidProgramException(SR.Format(GetFormatString(id), methodName));
@@ -70,6 +75,8 @@ namespace Internal.Runtime
                     return SR.ClassLoad_ExplicitLayout;
                 case ExceptionStringID.ClassLoadRankTooLarge:
                     return SR.ClassLoad_RankTooLarge;
+                case ExceptionStringID.InvalidProgramDefault:
+                    return SR.InvalidProgram_Default;
                 case ExceptionStringID.InvalidProgramSpecific:
                     return SR.InvalidProgram_Specific;
                 case ExceptionStringID.InvalidProgramVararg:


### PR DESCRIPTION
CoreCLR test suite uses these:

* Synchronized methods depend on a couple helpers.
* MkRefAny/RefAnyVal depends on a couple helpers.
* Jmp instruction handling.