### PR TITLE
Fix RhpPInvoke asm helper for arm

### DIFF
--- a/src/Native/Runtime/arm/PInvoke.S
+++ b/src/Native/Runtime/arm/PInvoke.S
@@ -8,18 +8,6 @@
 .syntax unified
 .thumb
 
-.macro INLINE_GET_TLS_VAR Var, trashReg
-	        ldr	         r0, =\Var(tlsgd)
-	        bl	         __tls_get_addr@PLT
-	        ldr	         \trashReg, =\Var(gottpoff)
-	        add	         r0, \trashReg
-.endmacro
-
-.macro INLINE_GETTHREAD trashReg
-	        // Inlined version of call C_FUNC(RhpGetThread)
-	        INLINE_GET_TLS_VAR tls_CurrentThread, \trashReg
-.endmacro
-
 //
 // RhpPInvoke
 //
@@ -29,28 +17,30 @@
 // The codegenerator must treat the callsite of this helper as GC triggering and generate the GC info for it.
 // Also, the codegenerator must ensure that there are no live GC references in callee saved registers.
 //
+
 NESTED_ENTRY RhpPInvoke, _TEXT, NoHandler
-	        PROLOG_PUSH "{r4-r7,lr}"
+        str     lr, [r0, #OFFSETOF__PInvokeTransitionFrame__m_RIP]
+        str     r7, [r0, #OFFSETOF__PInvokeTransitionFrame__m_FramePointer]
+        str     sp, [r0, #OFFSETOF__PInvokeTransitionFrame__m_PreservedRegs]
 
-	        str         lr, [r0, #OFFSETOF__PInvokeTransitionFrame__m_RIP]
-	        str         r7, [r0, #OFFSETOF__PInvokeTransitionFrame__m_FramePointer]
-	        str         sp, [r0, #OFFSETOF__PInvokeTransitionFrame__m_PreservedRegs]
+        PROLOG_PUSH "{r5,lr}"
 
-	        mov	        r5, r0
-	        // R0 = GetThread(), R6 - Trash Register
-	        INLINE_GETTHREAD r6
-	        str         r0, [r5, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
-	        str         r5, [r0, #OFFSETOF__Thread__m_pTransitionFrame]
+        mov   r5, r0
+        // get TLS global variable address
+        INLINE_GETTHREAD
+        str     r0, [r5, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
+        str     r5, [r0, #OFFSETOF__Thread__m_pTransitionFrame]
+        ldr     r3, =C_FUNC(RhpTrapThreads)
+        ldr     r3, [r3]
+        cbnz    r3, LOCAL_LABEL(InvokeRareTrapThread)
 
-	        ldr         r6, =C_FUNC(RhpTrapThreads)
-	        ldr         r6,	[r6]
-	        cbnz        r6, LOCAL_LABEL(InvokeRareTrapThread)
-
-	        EPILOG_POP  "{r4-r7,pc}"
+        EPILOG_POP "{r5,pc}"
 
 LOCAL_LABEL(InvokeRareTrapThread):
-	        b           C_FUNC(RhpWaitForSuspend2)
+        EPILOG_POP "{r5,lr}"
+        b       C_FUNC(RhpWaitForSuspend2)
 NESTED_END RhpPInvoke, _TEXT
+
 
 //
 // RhpPInvokeReturn
@@ -58,18 +48,17 @@ NESTED_END RhpPInvoke, _TEXT
 // IN:  R0: address of pinvoke frame
 //
 LEAF_ENTRY RhpPInvokeReturn, _TEXT
-	        ldr         r3, [r0, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
+        ldr     r3, [r0, #OFFSETOF__PInvokeTransitionFrame__m_pThread]
 
-	        mov         r2, #0
-	        str         r2, [r3, #OFFSETOF__Thread__m_pTransitionFrame]
+        mov     r2, #0
+        str     r2, [r3, #OFFSETOF__Thread__m_pTransitionFrame]
 
-	        ldr         r3, =C_FUNC(RhpTrapThreads)
-	        ldr         r3,	[r3]
-	        cbnz        r3, LOCAL_LABEL(ReturnRareTrapThread)
+        ldr     r3, =C_FUNC(RhpTrapThreads)
+        ldr     r3, [r3]
+        cbnz    r3, LOCAL_LABEL(ReturnRareTrapThread)
 
-	        bx          lr
-
+        bx      lr
 LOCAL_LABEL(ReturnRareTrapThread):
-	        // passing transition frame pointer in r0
-	        b           C_FUNC(RhpWaitForGC2)
+        // passing transition frame pointer in r0
+        b       C_FUNC(RhpWaitForGC2)
 LEAF_END RhpPInvokeReturn, _TEXT

--- a/src/Native/Runtime/unix/unixasmmacrosarm.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm.inc
@@ -170,3 +170,18 @@ C_FUNC(\Name):
         bl C_FUNC(NYI_Assert)
 .endm
 #endif
+
+// thumb with PIC version
+.macro INLINE_GET_TLS_VAR Var
+        ldr     r0, 2f
+1:
+        add     r0, pc, r0
+        bl      __tls_get_addr(PLT)
+2:
+        .4byte  \Var(TLSGD) + (. - 1b - 4)
+.endm
+
+.macro INLINE_GETTHREAD
+        // Inlined version of call C_FUNC(RhpGetThread)
+        INLINE_GET_TLS_VAR tls_CurrentThread
+.endm


### PR DESCRIPTION
	- correct access to tls global variable in arm thumb

Signed-off-by: Petr Bred <bredpetr@gmail.com>