### PR TITLE
Update buildtools to 2.0.0-prerelease-01726-03

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01702-02
+2.0.0-prerelease-01726-03


### PR DESCRIPTION
This update reduces the buildtools footprint by ~3GB. Thanks @weshaggard !