### PR TITLE
Fix VS project loading on 15.3 preview

### DIFF
--- a/src/dir.props
+++ b/src/dir.props
@@ -1,6 +1,10 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
 
+  <PropertyGroup>
+    <Configurations>Debug;Release</Configurations>
+    <Platforms>AnyCPU;x64;x86;arm;arm64</Platforms>
+  </PropertyGroup>
   <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('System.Private.')) and $(MSBuildProjectDirectory.EndsWith('src'))">
     <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/sdk</OutputPath>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>


### PR DESCRIPTION
Issue https://github.com/dotnet/project-system/issues/2454 is causing
ILCompiler.sln to fail loading due to a bug in the new project system
and there being no defined config / platform for the project. This
work-around lets preview VS load ILCompiler.sln.