### PR TITLE
Fix handling of bad IL in ILScanner

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -204,7 +204,7 @@ namespace Internal.IL
                             if ((uint)target < (uint)_basicBlocks.Length)
                                 CreateBasicBlock(target);
                             else
-                                ReportOutOfRangeBranchTarget(target);
+                                ReportInvalidBranchTarget(target);
                         }
                         break;
                     case ILOpcode.brfalse_s:
@@ -225,7 +225,7 @@ namespace Internal.IL
                             if ((uint)target < (uint)_basicBlocks.Length)
                                 CreateBasicBlock(target);
                             else
-                                ReportOutOfRangeBranchTarget(target);
+                                ReportInvalidBranchTarget(target);
                             CreateBasicBlock(_currentOffset);
                         }
                         break;
@@ -237,7 +237,7 @@ namespace Internal.IL
                             if ((uint)target < (uint)_basicBlocks.Length)
                                 CreateBasicBlock(target);
                             else
-                                ReportOutOfRangeBranchTarget(target);
+                                ReportInvalidBranchTarget(target);
                         }
                         break;
                     case ILOpcode.brfalse:
@@ -258,7 +258,7 @@ namespace Internal.IL
                             if ((uint)target < (uint)_basicBlocks.Length)
                                 CreateBasicBlock(target);
                             else
-                                ReportOutOfRangeBranchTarget(target);
+                                ReportInvalidBranchTarget(target);
                             CreateBasicBlock(_currentOffset);
                         }
                         break;
@@ -273,7 +273,7 @@ namespace Internal.IL
                                 if ((uint)target < (uint)_basicBlocks.Length)
                                     CreateBasicBlock(target);
                                 else
-                                    ReportOutOfRangeBranchTarget(target);
+                                    ReportInvalidBranchTarget(target);
                             }
                             CreateBasicBlock(_currentOffset);
                         }
@@ -901,24 +901,21 @@ namespace Internal.IL
                         return;
                 }
 
+                EndImportingInstruction();
+
                 // Check if control falls through the end of method.
-                if (_currentOffset < _basicBlocks.Length)
+                if (_currentOffset >= _basicBlocks.Length)
                 {
-                    BasicBlock nextBasicBlock = _basicBlocks[_currentOffset];
-                    if (nextBasicBlock != null)
-                    {
-                        ImportFallthrough(nextBasicBlock);
-                        return;
-                    }
-                }
-                else
-                {
-                    ReportFallthrough();
-                    EndImportingInstruction();
+                    ReportFallthroughAtEndOfMethod();
                     return;
                 }
 
-                EndImportingInstruction();
+                BasicBlock nextBasicBlock = _basicBlocks[_currentOffset];
+                if (nextBasicBlock != null)
+                {
+                    ImportFallthrough(nextBasicBlock);
+                    return;
+                }
             }
         }
 

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -914,6 +914,8 @@ namespace Internal.IL
                 else
                 {
                     ReportFallthrough();
+                    EndImportingInstruction();
+                    return;
                 }
 
                 EndImportingInstruction();

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -200,7 +200,11 @@ namespace Internal.IL
                     case ILOpcode.leave_s:
                         {
                             int delta = (sbyte)ReadILByte();
-                            CreateBasicBlock(_currentOffset + delta);
+                            int target = _currentOffset + delta;
+                            if ((uint)target < (uint)_basicBlocks.Length)
+                                CreateBasicBlock(target);
+                            else
+                                ReportOutOfRangeBranchTarget(target);
                         }
                         break;
                     case ILOpcode.brfalse_s:
@@ -217,7 +221,11 @@ namespace Internal.IL
                     case ILOpcode.blt_un_s:
                         {
                             int delta = (sbyte)ReadILByte();
-                            CreateBasicBlock(_currentOffset + delta);
+                            int target = _currentOffset + delta;
+                            if ((uint)target < (uint)_basicBlocks.Length)
+                                CreateBasicBlock(target);
+                            else
+                                ReportOutOfRangeBranchTarget(target);
                             CreateBasicBlock(_currentOffset);
                         }
                         break;
@@ -225,7 +233,11 @@ namespace Internal.IL
                     case ILOpcode.leave:
                         {
                             int delta = (int)ReadILUInt32();
-                            CreateBasicBlock(_currentOffset + delta);
+                            int target = _currentOffset + delta;
+                            if ((uint)target < (uint)_basicBlocks.Length)
+                                CreateBasicBlock(target);
+                            else
+                                ReportOutOfRangeBranchTarget(target);
                         }
                         break;
                     case ILOpcode.brfalse:
@@ -242,7 +254,11 @@ namespace Internal.IL
                     case ILOpcode.blt_un:
                         {
                             int delta = (int)ReadILUInt32();
-                            CreateBasicBlock(_currentOffset + delta);
+                            int target = _currentOffset + delta;
+                            if ((uint)target < (uint)_basicBlocks.Length)
+                                CreateBasicBlock(target);
+                            else
+                                ReportOutOfRangeBranchTarget(target);
                             CreateBasicBlock(_currentOffset);
                         }
                         break;
@@ -253,7 +269,11 @@ namespace Internal.IL
                             for (uint i = 0; i < count; i++)
                             {
                                 int delta = (int)ReadILUInt32();
-                                CreateBasicBlock(jmpBase + delta);
+                                int target = jmpBase + delta;
+                                if ((uint)target < (uint)_basicBlocks.Length)
+                                    CreateBasicBlock(target);
+                                else
+                                    ReportOutOfRangeBranchTarget(target);
                             }
                             CreateBasicBlock(_currentOffset);
                         }
@@ -876,18 +896,24 @@ namespace Internal.IL
                         ImportReadOnlyPrefix();
                         continue;
                     default:
-                        throw new BadImageFormatException("Invalid opcode");
+                        ReportInvalidInstruction(opCode);
+                        EndImportingInstruction();
+                        return;
                 }
 
                 // Check if control falls through the end of method.
-                if (_currentOffset >= _basicBlocks.Length)
-                    throw new TypeSystemException.InvalidProgramException();
-
-                BasicBlock nextBasicBlock = _basicBlocks[_currentOffset];
-                if (nextBasicBlock != null)
+                if (_currentOffset < _basicBlocks.Length)
                 {
-                    ImportFallthrough(nextBasicBlock);
-                    return;
+                    BasicBlock nextBasicBlock = _basicBlocks[_currentOffset];
+                    if (nextBasicBlock != null)
+                    {
+                        ImportFallthrough(nextBasicBlock);
+                        return;
+                    }
+                }
+                else
+                {
+                    ReportFallthrough();
                 }
 
                 EndImportingInstruction();

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -1014,12 +1014,12 @@ namespace Internal.IL
                 + (_ilBytes[ilOffset + 3] << 24));
         }
 
-        private void ReportOutOfRangeBranchTarget(int targetOffset)
+        private void ReportInvalidBranchTarget(int targetOffset)
         {
             throw new TypeSystemException.InvalidProgramException();
         }
 
-        private void ReportFallthrough()
+        private void ReportFallthroughAtEndOfMethod()
         {
             throw new TypeSystemException.InvalidProgramException();
         }

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2640,12 +2640,12 @@ namespace Internal.IL
             return _writer.GetCppSignatureTypeName(type);
         }
 
-        private void ReportOutOfRangeBranchTarget(int targetOffset)
+        private void ReportInvalidBranchTarget(int targetOffset)
         {
             throw new TypeSystemException.InvalidProgramException();
         }
 
-        private void ReportFallthrough()
+        private void ReportFallthroughAtEndOfMethod()
         {
             throw new TypeSystemException.InvalidProgramException();
         }

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2639,6 +2639,21 @@ namespace Internal.IL
             AddTypeReference(type, constructed);
             return _writer.GetCppSignatureTypeName(type);
         }
+
+        private void ReportOutOfRangeBranchTarget(int targetOffset)
+        {
+            throw new TypeSystemException.InvalidProgramException();
+        }
+
+        private void ReportFallthrough()
+        {
+            throw new TypeSystemException.InvalidProgramException();
+        }
+
+        private void ReportInvalidInstruction(ILOpcode opcode)
+        {
+            throw new TypeSystemException.InvalidProgramException();
+        }
     }
 }
 

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1741,12 +1741,12 @@ namespace Internal.IL
             throw new PlatformNotSupportedException("TypedReference not supported in .NET Core");
         }
 
-        private void ReportOutOfRangeBranchTarget(int targetOffset)
+        private void ReportInvalidBranchTarget(int targetOffset)
         {
             throw new NotImplementedException();
         }
 
-        private void ReportFallthrough()
+        private void ReportFallthroughAtEndOfMethod()
         {
             throw new NotImplementedException();
         }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1740,5 +1740,20 @@ namespace Internal.IL
         {
             throw new PlatformNotSupportedException("TypedReference not supported in .NET Core");
         }
+
+        private void ReportOutOfRangeBranchTarget(int targetOffset)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void ReportFallthrough()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void ReportInvalidInstruction(ILOpcode opcode)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
While the scanner is not trying to be an IL validator, we should at
least not crash.

* Update IL importer to provide hooks for bad IL (this is mostly to
prevent it from crashing with IndexOutOfRangeExceptions).
* Remove exception throwing from the shared ILImporter (while we might
want to throw most of the time, ILVerify probably doesn't want to).
* Do not crash when trying to determine static bases of instance fields.
* Fix constrained method handling.