### PR TITLE
Fix ILASM warnings for PreInitDataTest

### DIFF
--- a/tests/src/Simple/PreInitData/PreInitData.ilproj
+++ b/tests/src/Simple/PreInitData/PreInitData.ilproj
@@ -1,12 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="PreInitDataTest.il" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(Platform)'=='x64' or '$(Platform)'=='arm64'">
     <Compile Include="PreInitData64.il" />
   </ItemGroup>
   <ItemGroup Condition="'$(Platform)'=='x86' or '$(Platform)'=='arm'">
     <Compile Include="PreInitData32.il" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="PreInitDataTest.il" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SimpleTest.targets))\SimpleTest.targets" />


### PR DESCRIPTION
Reordering inputs to ILASM silences these warnings:

```
1>PreInitData64.il(11): warning : Reference to undeclared extern
assembly 'mscorlib'. Attempting autodetect
[d:\git\rt\tests\src\Simple\PreInitData\PreInitData.ilproj]
1>PreInitData64.il(15): warning : Reference to undeclared extern
assembly 'System.Private.CoreLib'. Attempting autodetect
[d:\git\rt\tests\src\Simple\PreInitData\PreInitData.ilproj]
1>PreInitData64.il(15): warning : Failed to autodetect assembly
'System.Private.CoreLib'
[d:\git\rt\tests\src\Simple\PreInitData\PreInitData.ilproj]
```