### PR TITLE
[ILVerify]Convert _thisType to managed pointer, if it is a value type

### DIFF
--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -38,18 +38,18 @@ namespace Internal.IL
 
     partial class ILImporter
     {
-        MethodDesc _method;
-        MethodSignature _methodSignature;
-        TypeSystemContext _typeSystemContext;
+        readonly MethodDesc _method;
+        readonly MethodSignature _methodSignature;
+        readonly TypeSystemContext _typeSystemContext;
 
-        TypeDesc _thisType;
+        readonly TypeDesc _thisType;
 
-        MethodIL _methodIL;
-        byte[] _ilBytes;
-        LocalVariableDefinition[] _locals;
+        readonly MethodIL _methodIL;
+        readonly byte[] _ilBytes;
+        readonly LocalVariableDefinition[] _locals;
 
-        bool _initLocals;
-        int _maxStack;
+        readonly bool _initLocals;
+        readonly int _maxStack;
 
         bool[] _instructionBoundaries; // For IL verification
 
@@ -123,13 +123,17 @@ namespace Internal.IL
             _typeSystemContext = method.Context;
 
             if (!_methodSignature.IsStatic)
-                _thisType = method.OwningType.InstantiateAsOpen();
+            {
+                var thisType = method.OwningType.InstantiateAsOpen();
 
-            // ECMA-335 II.13.3 Methods of value types, P. 164:
-            // ... By contrast, instance and virtual methods of value types shall be coded to expect a
-            // managed pointer(see Partition I) to an unboxed instance of the value type. ...
-            if (_thisType != null && _thisType.IsValueType)
-                _thisType = _thisType.MakeByRefType();
+                // ECMA-335 II.13.3 Methods of value types, P. 164:
+                // ... By contrast, instance and virtual methods of value types shall be coded to expect a
+                // managed pointer(see Partition I) to an unboxed instance of the value type. ...
+                if (thisType.IsValueType)
+                    thisType = thisType.MakeByRefType();
+
+                _thisType = thisType;
+            }
 
             _methodIL = methodIL;
 

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -125,6 +125,12 @@ namespace Internal.IL
             if (!_methodSignature.IsStatic)
                 _thisType = method.OwningType.InstantiateAsOpen();
 
+            // ECMA-335 II.13.3 Methods of value types, P. 164:
+            // ... By contrast, instance and virtual methods of value types shall be coded to expect a
+            // managed pointer(see Partition I) to an unboxed instance of the value type. ...
+            if (_thisType != null && _thisType.IsValueType)
+                _thisType = _thisType.MakeByRefType();
+
             _methodIL = methodIL;
 
             _initLocals = _methodIL.IsInitLocals;

--- a/src/ILVerify/tests/ILTests/ValueTypeTests.il
+++ b/src/ILVerify/tests/ILTests/ValueTypeTests.il
@@ -13,7 +13,7 @@
 .class public sequential ansi sealed beforefieldinit ValueTypeTests
        extends [System.Runtime]System.ValueType
 {
-    .field public int32 counter
+    .size 1
     .method public instance void CallThis() cil managed
     {
         ret

--- a/src/ILVerify/tests/ILTests/ValueTypeTests.il
+++ b/src/ILVerify/tests/ILTests/ValueTypeTests.il
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly ValueType
+{
+}
+
+.class public sequential ansi sealed beforefieldinit ValueTypeTests
+       extends [System.Runtime]System.ValueType
+{
+    .field public int32 counter
+    .method public instance void CallThis() cil managed
+    {
+        ret
+    }
+
+    .method public instance void ValueType.CallMethod_Valid() cil managed
+    {
+        ldarg.0
+        call instance void ValueTypeTests::CallThis()
+        ret
+    }
+}
+


### PR DESCRIPTION
As described in  ECMA-335 II.13.3 Methods of value types, P. 164:
> ... By contrast, instance and virtual methods of value types shall be coded to expect a
> managed pointer(see Partition I) to an unboxed instance of the value type. ...

So _thisType is converted to a managed pointer, if it is a value type.
