### PR TITLE
UnmanagedMemoryAccessor throws wrong exceptions on CoreRT

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -409,7 +409,9 @@ namespace System.Runtime.InteropServices
 
         #region "SizeOf Helpers"
         /// <summary>
-        /// Returns the aligned size of an instance of a value type.
+        /// Returns the size that SafeBuffer (and hence, UnmanagedMemoryAccessor) reserves in the unmanaged buffer for each element of an array of T. This is not the same
+        /// value that sizeof(T) returns! Since the primary use case is to parse memory mapped files, we cannot change this algorithm as this defines a de-facto serialization format.
+        /// Throws if T is not blittable.
         /// </summary>
         internal static uint AlignedSizeOf<T>() where T : struct
         {
@@ -418,15 +420,14 @@ namespace System.Runtime.InteropServices
             {
                 return size;
             }
-            if (IntPtr.Size == 8 && size == 4)
-            {
-                return size;
-            }
 
             return (uint)(((size + 3) & (~3)));
         }
 
-        private static uint SizeOf<T>() where T : struct
+        /// <summary>
+        /// Returns same value as sizeof(T) but throws if T is not blittable.
+        /// </summary>
+        internal static uint SizeOf<T>() where T : struct
         {
             RuntimeTypeHandle structureTypeHandle = typeof(T).TypeHandle;
             if (!structureTypeHandle.IsBlittable())


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/20522
 (needs to stay open until we reenable the tests)

Copied over the CoreCLR version, except for

- dropping the Contract stuff.

- Keeping the SizeOf() helpers on SafeBuffer rather than Marshal.
  CoreCLR should move them over to SafeBuffer too - having them
  on Marshal alongside the similarly named but different apis
  is horribly confusing.

- Unlocalized exception messages.

- Type.FullName in exception messages (MissingMetadata exposure.)


Secret decoder ring to the teeming mess of SizeOf's:

CoreCLR                      CoreRT
============                 ===================
Marshal.SizeOfType           SafeBuffer.SizeOf<T>
   same as Unsafe.SizeOf() but throws if not blittable.

Marshal.AlignedSizeOf<T>     SafeBuffer.AlignedSizeOf<T>
   size that SafeBuffer & UnmanagedMemoryAccessor uses for
   reserving element sizes in the unmanaged buffer when 
   ReadArray<T>/WriteArray<T> is used.

   Does *not* always return the same value as UnsafeSizeOf<T>!)

   The (now compatibility-locked) value is:
       if Unsafe.SizeOf() == 1,  return 1;
       if Unsafe.SizeOf() == 2,  return 2;
       else                      return (Unsafe.SafeOf() + 3) & ~3;

   I don't know why SafeBuffer chose to introduce a new meaning of
   "aligned." Neither do these people:

     https://stackoverflow.com/questions/25659651/why-is-marshal-alignedsizeofstructt-being-used-instead-of-marshal-sizeofstruct

   Documentation would be nice...

   Throws if T not blittable.


(not used here but easy to confuse.)
=================================================================
CoreCLR                      CoreRT
============                 ===================
Unsafe.SizeOf<T>             Unsafe.SizeOf<T>
   Returns same size as the IL sizeof instruction. Includes size
   of padding between elements of T[].

Marshal.SizeOf               Marshal.SizeOf
   Api - computes size of what P/Invoke would marshal T to.

Marshal.SizeOf<T>            Marshal.SizeOf<T>
   Api - computes size of what P/Invoke would marshal T to.