### PR TITLE
[ILVerify] Resolve signature variable to generic parameter type before passing them to CastingHelper

### DIFF
--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -214,7 +214,9 @@ namespace Internal.IL
                 return false;
             }
 
-            return CastingHelper.CanCastTo(src, dst);
+            return CastingHelper.CanCastTo(
+                    src.ResolveSignatureVariable(_method),
+                    dst.ResolveSignatureVariable(_method));
         }
 
         bool IsAssignable(StackValue src, StackValue dst)

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -232,7 +232,9 @@ namespace Internal.IL
                 if (src.Type == null)
                     return true;
 
-                return CastingHelper.CanCastTo(src.Type, dst.Type);
+                return CastingHelper.CanCastTo(
+                    src.Type.ResolveSignatureVariable(_method), 
+                    dst.Type.ResolveSignatureVariable(_method));
 
             case StackValueKind.ValueType:
 

--- a/src/ILVerify/src/ILVerify.csproj
+++ b/src/ILVerify/src/ILVerify.csproj
@@ -15,6 +15,7 @@
     <Compile Include="ILImporter.StackValue.cs" />
     <Compile Include="SimpleArrayOfTRuntimeInterfacesAlgorithm.cs" />
     <Compile Include="SimpleTypeSystemContext.cs" />
+    <Compile Include="TypeDescExtensions.cs" />
     <Compile Include="VerifierError.cs" />
   </ItemGroup>
 

--- a/src/ILVerify/src/TypeDescExtensions.cs
+++ b/src/ILVerify/src/TypeDescExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Internal.TypeSystem
+{
+    public static class TypeDescExtensiosn
+    {
+        public static TypeDesc ResolveSignatureVariable(this TypeDesc t, MethodDesc method)
+        {
+            if (t.IsSignatureVariable)
+            {
+                SignatureVariable sigVar = t as SignatureVariable;
+                if (sigVar.IsMethodSignatureVariable)
+                    return method.Instantiation[sigVar.Index];
+                else
+                    return method.OwningType.Instantiation[sigVar.Index];
+            }
+            return t;
+        }
+    }
+}

--- a/src/ILVerify/src/TypeDescExtensions.cs
+++ b/src/ILVerify/src/TypeDescExtensions.cs
@@ -1,10 +1,14 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Internal.TypeSystem
 {
-    public static class TypeDescExtensiosn
+    public static class TypeDescExtensions
     {
         public static TypeDesc ResolveSignatureVariable(this TypeDesc t, MethodDesc method)
         {

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -106,11 +106,25 @@
     }
 }
 
-.class public sequential ansi beforefieldinit GenericOtherFieldsType`1<T>
+.class public sequential ansi sealed beforefieldinit GenericOtherFieldsType`1<T>
        extends [System.Runtime]System.ValueType
 {
     .field public !T GenericField;
     .field int32 IntField;
+}
+
+.class public sequential ansi beforefieldinit GenericTypeWithConstrained<class ([System.Runtime]System.IComparable) TValueType>
+        extends [System.Runtime]System.Object
+{
+    .property !TValueType Value()
+    {
+        .get instance !0 GenericTypeWithConstrained::get_Value()
+    }
+    .method public !TValueType get_Value()
+    {
+        ldc.i4 0x00000000
+        ret
+    }
 }
 
 // Provides casting logic tests for stfld, ldfld, call, callvirt
@@ -206,6 +220,18 @@
         
         ldloc.0
         stloc.1
+        ret
+    }
+
+    .method public static void Casting.AssignReturnValueFromConstrainedProperty_Valid<class ([System.Runtime]System.IComparable) TValueType>(class GenericTypeWithConstrained<!!TValueType> wrapper) cil managed
+    {
+        .locals init (
+            class [System.Runtime]System.IComparable V_0
+        )
+
+        ldarg.0
+        callvirt instance !0 class GenericTypeWithConstrained<!!TValueType>::get_Value()
+        stloc.0
         ret
     }
 }


### PR DESCRIPTION
When a method/property returns a generic value, then an instance of `SignatureVariable` is on the stack. This instance may be further used for assignability checks, which does not work. So I modified the `StackValue.IsAssignable` method to resolve the `SignatureVariable` to a `GenericParameterDesc`, which is perfectly handled by `CastingHelper` logic.