### PR TITLE
[ILVerify] Fixed bugs ImportLoadIndirect/ImportStoreIndirect

### DIFF
--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1265,12 +1265,17 @@ namespace Internal.IL
             ClearPendingPrefix(Prefix.Volatile);
 
             var address = Pop();
+            CheckIsByRef(address);
 
             if (type == null)
+            {
+                CheckIsObjRef(address.Type);
                 type = address.Type;
-
-            CheckIsByRef(address);
-            CheckIsAssignable(address.Type, type);
+            }
+            else
+            {
+                CheckIsAssignable(address.Type, type);
+            }
             Push(StackValue.CreateFromType(type));
         }
 
@@ -1293,10 +1298,13 @@ namespace Internal.IL
             Check(!address.IsReadOnly, VerifierError.ReadOnlyIllegalWrite);
 
             CheckIsByRef(address);
-            if (!value.IsNullReference)
-                CheckIsAssignable(StackValue.CreateFromType(type), StackValue.CreateFromType(address.Type));
 
-            CheckIsAssignable(value, StackValue.CreateFromType(type));
+            var typeVal = StackValue.CreateFromType(type);
+            var addressVal = StackValue.CreateFromType(address.Type);
+            if (!value.IsNullReference)
+                CheckIsAssignable(typeVal, addressVal);
+
+            CheckIsAssignable(value, typeVal);
         }
 
         void ImportThrow()

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1267,7 +1267,7 @@ namespace Internal.IL
             var address = Pop();
 
             if (type == null)
-                type = GetWellKnownType(WellKnownType.Object);
+                type = address.Type;
 
             CheckIsByRef(address);
             CheckIsAssignable(address.Type, type);

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1294,7 +1294,7 @@ namespace Internal.IL
 
             CheckIsByRef(address);
             if (!value.IsNullReference)
-                CheckIsAssignable(type, address.Type);
+                CheckIsAssignable(StackValue.CreateFromType(type), StackValue.CreateFromType(address.Type));
 
             CheckIsAssignable(value, StackValue.CreateFromType(type));
         }

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -13,7 +13,7 @@
 .class public auto ansi beforefieldinit LoadStoreIndirectTestsType
        extends [System.Runtime]System.Object
 {
-    .method static public hidebysig void LoadIndirect.FromStringRef_Valid(string&) cil managed
+    .method static public hidebysig void LoadIndirectRef.FromStringRef_Valid(string&) cil managed
     {
         ldarg.0
         ldind.ref
@@ -34,7 +34,14 @@
         ret
     }
 
-    .method static public hidebysig void LoadIndirect.AssignRefStringToString_Valid(string&) cil managed
+    .method static public hidebysig void LoadIndirectRef.FromInt64Ref_Invalid_StackUnexpected(int64&) cil managed
+    {
+        ldarg.0
+        ldind.ref
+        ret
+    }
+
+    .method static public hidebysig void LoadIndirectRef.AssignRefStringToString_Valid(string&) cil managed
     {
         .locals init (
             string V_0)

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -82,6 +82,14 @@
         ret
     }
 
+    .method static public hidebysig void StoreIndirect.AssignByteToBoolRef_Valid(bool&) cil managed
+    {
+        ldarg.0
+        ldc.i4.0
+        stind.i1
+        ret
+    }
+
     .method static public hidebysig void StoreObject.ValidTypeToken_Valid() cil managed
     {
         .locals init (object V_0)

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -34,6 +34,16 @@
         ret
     }
 
+    .method static public hidebysig void LoadIndirect.AssignRefStringToString_Valid(string&) cil managed
+    {
+        .locals init (
+            string V_0)
+        ldarg.0
+        ldind.ref
+        stloc.0
+        ret
+    }
+
     .method static public hidebysig void StoreIndirect.AssignToInt_Valid(int32&) cil managed
     {
         // arg = 0;


### PR DESCRIPTION
For `ldind.ref` the type is now infered from the address, which was pushed on the stack.
For `stind`  the assignability check is now done with the `intermediate type`.