### PR TITLE
Array.CreateInstance validation checks.

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2455,4 +2455,10 @@
   <data name="Arg_PlatformNotSupported_AssemblyName_GetAssemblyName" xml:space="preserve">
     <value>AssemblyName.GetAssemblyName() is not supported on this platform.</value>
   </data>
+  <data name="NotSupported_OpenType" xml:space="preserve">
+    <value>Cannot create arrays of open type.</value>
+  </data>
+  <data name="NotSupported_ByRefLikeArray" xml:space="preserve">
+    <value>Cannot create arrays of ByRef-like values.</value>
+  </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -281,8 +281,6 @@ namespace System.Reflection.Runtime.TypeInfos
 
             if (elementType.IsByRef)
                 throw new TypeLoadException(SR.Format(SR.ArgumentException_InvalidArrayElementType, elementType));
-            if (elementType.IsGenericTypeDefinition)
-                throw new ArgumentException(SR.Format(SR.ArgumentException_InvalidArrayElementType, elementType));
 
             // We only permit creating parameterized types if the pay-for-play policy specifically allows them *or* if the result
             // type would be an open type.


### PR DESCRIPTION
Array.CreateInstance() has a separate battery of acceptance
checks on the element type that Type.MakeArrayType() doesn't.
This fixes some corefx tests we're about to reenable
(https://github.com/dotnet/corefx/issues/18584)

Original CoreCLR inspiration:
  https://github.com/dotnet/coreclr/blob/17b815123a609a4c326875ff845a8e70aaab278c/src/classlibnative/bcltype/arraynative.cpp#L1117

Also fixes TFS 451290 (Array.CreateInstance throws wrong exception
 on receiving non-runtime type)

Note that the IsByRef() check should be IsByRefLike() but
attempting to start on that opened up a heapload of issues, like:

 - EEType.IsByRefLike doesn't return true is IsByRef types.
   Should it?

 - Is it still even possible to get a type with metadata but
   no TypeHandle (simple experiment suggests no but
   RuntimeNamedTypeInfo factory still assumes it can happen.)

 - If so, how do I do this check safely and without ridiculous
   overhead?

Since we have only a week+1/2 left on ZBB and we have
post-ZBB issue open already (https://github.com/dotnet/corert/issues/3080)
on IsByRefLike checks, I'm punting on this issue until we have
time to look at this holistically.