### PR TITLE
[ubuntu 16.04] fixed NuPkgRid for objectwriter

### DIFF
--- a/src/ILCompiler/ObjectWriter/ObjectWriter.depproj
+++ b/src/ILCompiler/ObjectWriter/ObjectWriter.depproj
@@ -8,6 +8,7 @@
     <NuGetTargetMoniker>.NETCoreApp,Version=v2.0</NuGetTargetMoniker>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('ubuntu.'))">ubuntu.14.04-x64</RuntimeIdentifiers>
     <RidSpecificAssets>true</RidSpecificAssets>
   </PropertyGroup>
 


### PR DESCRIPTION
build.sh on ubuntu 16.04 x64 with this fix is executed successfully