### PR TITLE
Make EETypePtrOf a MustExpand intrinsic

### DIFF
--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -402,6 +402,19 @@ namespace Internal.IL
                 {
                     return;
                 }
+
+                if (IsEETypePtrOf(method))
+                {
+                    if (runtimeDeterminedMethod.IsRuntimeDeterminedExactMethod)
+                    {
+                        _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandle, runtimeDeterminedMethod.Instantiation[0]), reason);
+                    }
+                    else
+                    {
+                        _dependencies.Add(_factory.ConstructedTypeSymbol(method.Instantiation[0]), reason);
+                    }
+                    return;
+                }
             }
 
             TypeDesc exactType = method.OwningType;
@@ -1065,6 +1078,20 @@ namespace Internal.IL
                 if (owningType != null)
                 {
                     return owningType.Name == "Activator" && owningType.Namespace == "System";
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsEETypePtrOf(MethodDesc method)
+        {
+            if (method.IsIntrinsic && method.Name == "EETypePtrOf" && method.Instantiation.Length == 1)
+            {
+                MetadataType owningType = method.OwningType as MetadataType;
+                if (owningType != null)
+                {
+                    return owningType.Name == "EETypePtr" && owningType.Namespace == "System";
                 }
             }
 

--- a/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
+++ b/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
@@ -206,7 +206,7 @@ namespace Internal.JitInterface
                     break;
 
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle:
-                    pMustExpand = method.Name == "DefaultConstructorOf";
+                    pMustExpand = true;
                     break;
 
                 default:


### PR DESCRIPTION
`EETypePtrOf` is the one case where expanding the intrinsic allows
inlining a method with genericness in it. This causes differences in how
generic dictionaries look like. Instead of teaching ILScanner about
optimized and unoptimized builds, let's expand this unconditionally in
both RyuJIT and ILScanner.