### PR TITLE
Make it possible to provide generic dictionary layout externally

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -25,6 +25,7 @@ namespace ILCompiler
         protected bool _generateDebugInfo = false;
         protected MetadataManager _metadataManager;
         protected VTableSliceProvider _vtableSliceProvider = new LazyVTableSliceProvider();
+        protected DictionaryLayoutProvider _dictionaryLayoutProvider = new LazyDictionaryLayoutProvider();
 
         public CompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup compilationGroup, NameMangler nameMangler)
         {
@@ -67,6 +68,12 @@ namespace ILCompiler
         public CompilationBuilder UseVTableSliceProvider(VTableSliceProvider provider)
         {
             _vtableSliceProvider = provider;
+            return this;
+        }
+
+        public CompilationBuilder UseGenericDictionaryLayoutProvider(DictionaryLayoutProvider provider)
+        {
+            _dictionaryLayoutProvider = provider;
             return this;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -139,9 +139,6 @@ namespace ILCompiler.DependencyAnalysis
                 conditionalDependencies.Add(new CombinedDependencyListEntry(lookupSignature.TemplateDictionaryNode(factory),
                                                                 templateLayout,
                                                                 "Type loader template"));
-
-                // TODO: if the dictionary entry is a GC static base or thread static base, we also need the non-GC static
-                // base because the cctor context is there.
             }
 
             return conditionalDependencies;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -55,9 +55,44 @@ namespace ILCompiler.DependencyAnalysis
             get;
         }
 
-        public abstract ICollection<NativeLayoutVertexNode> GetTemplateEntries(NodeFactory factory);
+        public TypeSystemEntity OwningMethodOrType => _owningMethodOrType;
 
-        public abstract void EmitDictionaryData(ref ObjectDataBuilder builder, NodeFactory factory, GenericDictionaryNode dictionary);
+        /// <summary>
+        /// Gets a value indicating whether the slot assignment is determined at the node creation time.
+        /// </summary>
+        public abstract bool HasFixedSlots
+        {
+            get;
+        }
+
+        public virtual ICollection<NativeLayoutVertexNode> GetTemplateEntries(NodeFactory factory)
+        {
+            ArrayBuilder<NativeLayoutVertexNode> templateEntries = new ArrayBuilder<NativeLayoutVertexNode>();
+            foreach (var entry in Entries)
+            {
+                templateEntries.Add(entry.TemplateDictionaryNode(factory));
+            }
+
+            return templateEntries.ToArray();
+        }
+
+        public virtual void EmitDictionaryData(ref ObjectDataBuilder builder, NodeFactory factory, GenericDictionaryNode dictionary)
+        {
+            var context = new GenericLookupResultContext(dictionary.OwningEntity, dictionary.TypeInstantiation, dictionary.MethodInstantiation);
+
+            foreach (GenericLookupResult lookupResult in Entries)
+            {
+#if DEBUG
+                int offsetBefore = builder.CountBytes;
+#endif
+
+                lookupResult.EmitDictionaryEntry(ref builder, factory, context);
+
+#if DEBUG
+                Debug.Assert(builder.CountBytes - offsetBefore == factory.Target.PointerSize);
+#endif
+            }
+        }
 
         protected override string GetName(NodeFactory factory) => $"Dictionary layout for {_owningMethodOrType.ToString()}";
 
@@ -69,6 +104,38 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+    }
+
+    public sealed class PrecomputedDictionaryLayoutNode : DictionaryLayoutNode
+    {
+        private readonly GenericLookupResult[] _layout;
+
+        public override bool HasFixedSlots => true;
+
+        public PrecomputedDictionaryLayoutNode(TypeSystemEntity owningMethodOrType, IEnumerable<GenericLookupResult> layout)
+            : base(owningMethodOrType)
+        {
+            ArrayBuilder<GenericLookupResult> l = new ArrayBuilder<GenericLookupResult>();
+            foreach (var entry in layout)
+                l.Add(entry);
+
+            _layout = l.ToArray();
+        }
+
+        public override int GetSlotForEntry(GenericLookupResult entry)
+        {
+            int index = Array.IndexOf(_layout, entry);
+            Debug.Assert(index >= 0);
+            return index;
+        }
+
+        public override IEnumerable<GenericLookupResult> Entries
+        {
+            get
+            {
+                return _layout;
+            }
+        }
     }
 
     public sealed class LazilyBuiltDictionaryLayoutNode : DictionaryLayoutNode
@@ -84,6 +151,8 @@ namespace ILCompiler.DependencyAnalysis
 
         private EntryHashTable _entries = new EntryHashTable();
         private volatile GenericLookupResult[] _layout;
+
+        public override bool HasFixedSlots => false;
 
         public LazilyBuiltDictionaryLayoutNode(TypeSystemEntity owningMethodOrType)
             : base(owningMethodOrType)
@@ -130,38 +199,6 @@ namespace ILCompiler.DependencyAnalysis
                     ComputeLayout();
 
                 return _layout;
-            }
-        }
-
-        public override ICollection<NativeLayoutVertexNode> GetTemplateEntries(NodeFactory factory)
-        {
-            if (_layout == null)
-                ComputeLayout();
-
-            ArrayBuilder<NativeLayoutVertexNode> templateEntries = new ArrayBuilder<NativeLayoutVertexNode>();
-            for (int i = 0; i < _layout.Length; i++)
-            {
-                templateEntries.Add(_layout[i].TemplateDictionaryNode(factory));
-            }
-
-            return templateEntries.ToArray();
-        }
-
-        public override void EmitDictionaryData(ref ObjectDataBuilder builder, NodeFactory factory, GenericDictionaryNode dictionary)
-        {
-            var context = new GenericLookupResultContext(dictionary.OwningEntity, dictionary.TypeInstantiation, dictionary.MethodInstantiation);
-
-            foreach (GenericLookupResult lookupResult in Entries)
-            {
-#if DEBUG
-                int offsetBefore = builder.CountBytes;
-#endif
-
-                lookupResult.EmitDictionaryEntry(ref builder, factory, context);
-
-#if DEBUG
-                Debug.Assert(builder.CountBytes - offsetBefore == factory.Target.PointerSize);
-#endif
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -53,10 +53,13 @@ namespace ILCompiler.DependencyAnalysis
 
             DictionaryLayoutNode layout = GetDictionaryLayout(factory);
 
-            // Node representing the generic dictionary doesn't have any dependencies for
-            // dependency analysis purposes. The dependencies are tracked as dependencies of the
-            // concrete method bodies. When we reach the object data emission phase, the dependencies
-            // should all already have been marked.
+            // Node representing the generic dictionary layout might be one of two kinds:
+            // With fixed slots, or where slots are added as we're expanding the graph.
+            // If it's the latter, we can't touch the collection of slots before the graph expansion
+            // is complete (relocsOnly == false). It's someone else's responsibility
+            // to make sure the dependencies are properly generated.
+            // If this is a dictionary layout with fixed slots, it's the responsibility of
+            // each dictionary to ensure the targets are marked.
             if (layout.HasFixedSlots || !relocsOnly)
             {
                 // TODO: pass the layout we already have to EmitDataInternal

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -37,14 +37,6 @@ namespace ILCompiler.DependencyAnalysis
 
         int ISymbolNode.Offset => 0;
 
-        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
-        {
-            return new DependencyList
-            {
-                new DependencyListEntry(GetDictionaryLayout(factory), "Dictionary layout"),
-            };
-        }
-
         public abstract bool IsExported(NodeFactory factory);
 
         public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
@@ -135,12 +127,12 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            DependencyList result = null;
+            DependencyList result = result = new DependencyList();
+
+            result.Add(GetDictionaryLayout(factory), "Layout");
 
             if (factory.CompilationModuleGroup.ShouldPromoteToFullType(_owningType))
             {
-                result = new DependencyList();
-
                 // If the compilation group wants this type to be fully promoted, it means the EEType is going to be
                 // COMDAT folded with other EETypes generated in a different object file. This means their generic
                 // dictionaries need to have identical contents. The only way to achieve that is by generating

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -124,6 +124,22 @@ namespace ILCompiler.DependencyAnalysis
         public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
         public abstract override string ToString();
         protected abstract int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer);
+        protected abstract bool EqualsImpl(GenericLookupResult obj);
+        protected abstract int GetHashCodeImpl();
+
+        public sealed override bool Equals(object obj)
+        {
+            GenericLookupResult other = obj as GenericLookupResult;
+            if (obj == null)
+                return false;
+
+            return ClassCode == other.ClassCode && EqualsImpl(other);
+        }
+
+        public sealed override int GetHashCode()
+        {
+            return ClassCode * 31 + GetHashCodeImpl();
+        }
 
         public virtual void EmitDictionaryEntry(ref ObjectDataBuilder builder, NodeFactory factory, GenericLookupResultContext dictionary)
         {
@@ -247,6 +263,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_type, ((TypeHandleGenericLookupResult)other)._type);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((TypeHandleGenericLookupResult)obj)._type == _type;
+        }
     }
 
 
@@ -311,6 +337,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_type, ((UnwrapNullableTypeHandleGenericLookupResult)other)._type);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((UnwrapNullableTypeHandleGenericLookupResult)obj)._type == _type;
+        }
     }
 
     /// <summary>
@@ -363,6 +399,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_field, ((FieldOffsetGenericLookupResult)other)._field);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _field.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((FieldOffsetGenericLookupResult)obj)._field == _field;
         }
     }
 
@@ -429,6 +475,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_method, ((VTableOffsetGenericLookupResult)other)._method);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _method.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((VTableOffsetGenericLookupResult)obj)._method == _method;
+        }
     }
 
     /// <summary>
@@ -474,6 +530,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_method, ((MethodHandleGenericLookupResult)other)._method);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _method.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((MethodHandleGenericLookupResult)obj)._method == _method;
+        }
     }
 
     /// <summary>
@@ -518,6 +584,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_field, ((FieldHandleGenericLookupResult)other)._field);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _field.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((FieldHandleGenericLookupResult)obj)._field == _field;
         }
     }
 
@@ -575,6 +651,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_method, ((MethodDictionaryGenericLookupResult)other)._method);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _method.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((MethodDictionaryGenericLookupResult)obj)._method == _method;
         }
     }
 
@@ -635,6 +721,17 @@ namespace ILCompiler.DependencyAnalysis
 
             return comparer.Compare(_method, otherEntry._method);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _method.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((MethodEntryGenericLookupResult)obj)._method == _method &&
+                ((MethodEntryGenericLookupResult)obj)._isUnboxingThunk == _isUnboxingThunk;
+        }
     }
 
     /// <summary>
@@ -690,6 +787,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_method, ((VirtualDispatchCellGenericLookupResult)other)._method);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _method.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((VirtualDispatchCellGenericLookupResult)obj)._method == _method;
+        }
     }
 
     /// <summary>
@@ -741,6 +848,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_type, ((TypeNonGCStaticBaseGenericLookupResult)other)._type);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((TypeNonGCStaticBaseGenericLookupResult)obj)._type == _type;
+        }
     }
 
     /// <summary>
@@ -787,6 +904,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_type, ((TypeThreadStaticBaseIndexGenericLookupResult)other)._type);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((TypeThreadStaticBaseIndexGenericLookupResult)obj)._type == _type;
         }
     }
 
@@ -839,6 +966,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_type, ((TypeGCStaticBaseGenericLookupResult)other)._type);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((TypeGCStaticBaseGenericLookupResult)obj)._type == _type;
+        }
     }
 
     /// <summary>
@@ -888,6 +1025,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_type, ((ObjectAllocatorGenericLookupResult)other)._type);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((ObjectAllocatorGenericLookupResult)obj)._type == _type;
         }
     }
 
@@ -940,6 +1087,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_type, ((ArrayAllocatorGenericLookupResult)other)._type);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((ArrayAllocatorGenericLookupResult)obj)._type == _type;
+        }
     }
 
     /// <summary>
@@ -989,6 +1146,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_type, ((CastClassGenericLookupResult)other)._type);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((CastClassGenericLookupResult)obj)._type == _type;
         }
     }
     
@@ -1040,6 +1207,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_type, ((IsInstGenericLookupResult)other)._type);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((IsInstGenericLookupResult)obj)._type == _type;
+        }
     }
 
     internal sealed class ThreadStaticIndexLookupResult : GenericLookupResult
@@ -1088,6 +1265,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_type, ((ThreadStaticIndexLookupResult)other)._type);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((ThreadStaticIndexLookupResult)obj)._type == _type;
         }
     }
 
@@ -1138,6 +1325,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_type, ((ThreadStaticOffsetLookupResult)other)._type);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((ThreadStaticOffsetLookupResult)obj)._type == _type;
         }
     }
 
@@ -1195,6 +1392,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             return comparer.Compare(_type, ((DefaultConstructorLookupResult)other)._type);
         }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((DefaultConstructorLookupResult)obj)._type == _type;
+        }
     }
 
     internal sealed class CallingConventionConverterLookupResult : GenericLookupResult
@@ -1248,6 +1455,16 @@ namespace ILCompiler.DependencyAnalysis
                 return result;
 
             return comparer.Compare(_callingConventionConverter.Signature, otherEntry._callingConventionConverter.Signature);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _callingConventionConverter.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((CallingConventionConverterLookupResult)obj)._callingConventionConverter.Equals(_callingConventionConverter);
         }
     }
 
@@ -1306,6 +1523,16 @@ namespace ILCompiler.DependencyAnalysis
         protected override int CompareToImpl(GenericLookupResult other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_type, ((TypeSizeLookupResult)other)._type);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _type.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            return ((TypeSizeLookupResult)obj)._type == _type;
         }
     }
 
@@ -1382,6 +1609,19 @@ namespace ILCompiler.DependencyAnalysis
                 return result;
 
             return comparer.Compare(_constrainedMethod, otherResult._constrainedMethod);
+        }
+
+        protected override int GetHashCodeImpl()
+        {
+            return _constrainedMethod.GetHashCode() * 13 + _constraintType.GetHashCode();
+        }
+
+        protected override bool EqualsImpl(GenericLookupResult obj)
+        {
+            var other = (ConstrainedMethodUseLookupResult)obj;
+            return _constrainedMethod == other._constrainedMethod &&
+                _constraintType == other._constraintType &&
+                _directCall == other._directCall;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ILScanNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ILScanNodeFactory.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class ILScanNodeFactory : NodeFactory
     {
         public ILScanNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager, InteropStubManager interopStubManager, NameMangler nameMangler)
-            : base(context, compilationModuleGroup, metadataManager, interopStubManager, nameMangler, new LazyGenericsDisabledPolicy(), new LazyVTableSliceProvider())
+            : base(context, compilationModuleGroup, metadataManager, interopStubManager, nameMangler, new LazyGenericsDisabledPolicy(), new LazyVTableSliceProvider(), new LazyDictionaryLayoutProvider())
         {
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -797,7 +797,10 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
-            return Array.Empty<DependencyListEntry>();
+            return new DependencyListEntry[]
+            {
+                new DependencyListEntry(context.GenericDictionaryLayout(_method), "Dictionary layout"),
+            };
         }
 
         private int CompareDictionaryEntries(KeyValuePair<int, NativeLayoutVertexNode> left, KeyValuePair<int, NativeLayoutVertexNode> right)
@@ -905,6 +908,8 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
             yield return new DependencyListEntry(context.ConstructedTypeSymbol(_type.ConvertToCanonForm(CanonicalFormKind.Specific)), "Template EEType");
+
+            yield return new DependencyListEntry(context.GenericDictionaryLayout(_type.ConvertToCanonForm(CanonicalFormKind.Specific).GetClosestDefType()), "Dictionary layout");
 
             foreach (TypeDesc iface in _type.RuntimeInterfaces)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -24,15 +24,24 @@ namespace ILCompiler.DependencyAnalysis
         private CompilerTypeSystemContext _context;
         private CompilationModuleGroup _compilationModuleGroup;
         private VTableSliceProvider _vtableSliceProvider;
+        private DictionaryLayoutProvider _dictionaryLayoutProvider;
         private bool _markingComplete;
 
-        public NodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup,
-            MetadataManager metadataManager, InteropStubManager interoptStubManager, NameMangler nameMangler, LazyGenericsPolicy lazyGenericsPolicy, VTableSliceProvider vtableSliceProvider)
+        public NodeFactory(
+            CompilerTypeSystemContext context,
+            CompilationModuleGroup compilationModuleGroup,
+            MetadataManager metadataManager,
+            InteropStubManager interoptStubManager,
+            NameMangler nameMangler,
+            LazyGenericsPolicy lazyGenericsPolicy,
+            VTableSliceProvider vtableSliceProvider,
+            DictionaryLayoutProvider dictionaryLayoutProvider)
         {
             _target = context.Target;
             _context = context;
             _compilationModuleGroup = compilationModuleGroup;
             _vtableSliceProvider = vtableSliceProvider;
+            _dictionaryLayoutProvider = dictionaryLayoutProvider;
             NameMangler = nameMangler;
             InteropStubManager = interoptStubManager;
             CreateNodeCaches();
@@ -462,10 +471,7 @@ namespace ILCompiler.DependencyAnalysis
                 return new ModuleMetadataNode(module);
             });
 
-            _genericDictionaryLayouts = new NodeCache<TypeSystemEntity, DictionaryLayoutNode>(methodOrType =>
-            {
-                return new LazilyBuiltDictionaryLayoutNode(methodOrType);
-            });
+            _genericDictionaryLayouts = new NodeCache<TypeSystemEntity, DictionaryLayoutNode>(_dictionaryLayoutProvider.GetLayout);
 
             _stringAllocators = new NodeCache<MethodDesc, IMethodNode>(constructor =>
             {
@@ -687,7 +693,7 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         private NodeCache<TypeSystemEntity, DictionaryLayoutNode> _genericDictionaryLayouts;
-        public virtual DictionaryLayoutNode GenericDictionaryLayout(TypeSystemEntity methodOrType)
+        public DictionaryLayoutNode GenericDictionaryLayout(TypeSystemEntity methodOrType)
         {
             return _genericDictionaryLayouts.GetOrAdd(methodOrType);
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -155,6 +155,9 @@ namespace ILCompiler.DependencyAnalysis
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DependencyList dependencies = new DependencyList();
+
+            dependencies.Add(factory.GenericDictionaryLayout(_dictionaryOwner), "Layout");
+
             foreach (DependencyNodeCore<NodeFactory> dependency in _lookupSignature.NonRelocDependenciesFromUsage(factory))
             {
                 dependencies.Add(new DependencyListEntry(dependency, "GenericLookupResultDependency"));

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -163,17 +163,6 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(new DependencyListEntry(dependency, "GenericLookupResultDependency"));
             }
 
-            // Root the template for the type while we're hitting its dictionary cells. In the future, we may
-            // want to control this via type reflectability instead.
-            if (_dictionaryOwner is MethodDesc)
-            {
-                dependencies.Add(factory.NativeLayout.TemplateMethodLayout((MethodDesc)_dictionaryOwner), "Type loader template");
-            }
-            else
-            {
-                dependencies.Add(factory.NativeLayout.TemplateTypeLayout((TypeDesc)_dictionaryOwner), "Type loader template");
-            }
-
             return dependencies;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -65,16 +65,21 @@ namespace ILCompiler.DependencyAnalysis
 
         protected sealed override void OnMarked(NodeFactory factory)
         {
-            // When the helper call gets marked, ensure the generic layout for the associated dictionaries
-            // includes the signature.
-            ((LazilyBuiltDictionaryLayoutNode)factory.GenericDictionaryLayout(_dictionaryOwner)).EnsureEntry(_lookupSignature);
+            DictionaryLayoutNode layout = factory.GenericDictionaryLayout(_dictionaryOwner);
 
-            if ((_id == ReadyToRunHelperId.GetGCStaticBase || _id == ReadyToRunHelperId.GetThreadStaticBase) &&
-                factory.TypeSystemContext.HasLazyStaticConstructor((TypeDesc)_target))
+            if (!layout.HasFixedSlots)
             {
-                // If the type has a lazy static constructor, we also need the non-GC static base
-                // because that's where the class constructor context is.
-                ((LazilyBuiltDictionaryLayoutNode)factory.GenericDictionaryLayout(_dictionaryOwner)).EnsureEntry(factory.GenericLookup.TypeNonGCStaticBase((TypeDesc)_target));
+                // When the helper call gets marked, ensure the generic layout for the associated dictionaries
+                // includes the signature.
+                ((LazilyBuiltDictionaryLayoutNode)layout).EnsureEntry(_lookupSignature);
+
+                if ((_id == ReadyToRunHelperId.GetGCStaticBase || _id == ReadyToRunHelperId.GetThreadStaticBase) &&
+                    factory.TypeSystemContext.HasLazyStaticConstructor((TypeDesc)_target))
+                {
+                    // If the type has a lazy static constructor, we also need the non-GC static base
+                    // because that's where the class constructor context is.
+                    ((LazilyBuiltDictionaryLayoutNode)layout).EnsureEntry(factory.GenericLookup.TypeNonGCStaticBase((TypeDesc)_target));
+                }
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -13,8 +13,8 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class RyuJitNodeFactory : NodeFactory
     {
         public RyuJitNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager,
-            InteropStubManager interopStubManager, NameMangler nameMangler, VTableSliceProvider vtableSliceProvider)
-            : base(context, compilationModuleGroup, metadataManager, interopStubManager, nameMangler, new LazyGenericsDisabledPolicy(), vtableSliceProvider)
+            InteropStubManager interopStubManager, NameMangler nameMangler, VTableSliceProvider vtableSliceProvider, DictionaryLayoutProvider dictionaryLayoutProvider)
+            : base(context, compilationModuleGroup, metadataManager, interopStubManager, nameMangler, new LazyGenericsDisabledPolicy(), vtableSliceProvider, dictionaryLayoutProvider)
         {
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcDictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcDictionaryLayoutNode.cs
@@ -25,6 +25,14 @@ namespace ILCompiler.DependencyAnalysis
     /// </remarks>
     public partial class UtcDictionaryLayoutNode : DictionaryLayoutNode
     {
+        public override bool HasFixedSlots
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public UtcDictionaryLayoutNode(TypeSystemEntity owningMethodOrType) : base(owningMethodOrType)
         {
 

--- a/src/ILCompiler.Compiler/src/Compiler/DictionaryLayoutProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DictionaryLayoutProvider.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+using ILCompiler.DependencyAnalysis;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Provides generic dictionary layout information for a specific type or method.
+    /// </summary>
+    public abstract class DictionaryLayoutProvider
+    {
+        internal abstract DictionaryLayoutNode GetLayout(TypeSystemEntity methodOrType);
+    }
+
+    /// <summary>
+    /// Provides dictionary layout information that collects data during the compilation to build a dictionary layout
+    /// for a type or method on demand.
+    /// </summary>
+    public sealed class LazyDictionaryLayoutProvider : DictionaryLayoutProvider
+    {
+        internal override DictionaryLayoutNode GetLayout(TypeSystemEntity methodOrType)
+        {
+            return new LazilyBuiltDictionaryLayoutNode(methodOrType);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
@@ -86,7 +86,7 @@ namespace ILCompiler
             }
 
             var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_compilationGroup.GeneratedAssembly));
-            var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider);
+            var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
 
             var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Compiler\DependencyAnalysis\FieldMetadataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ILScanNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IMethodBodyNode.cs" />
+    <Compile Include="Compiler\DictionaryLayoutProvider.cs" />
     <Compile Include="Compiler\EmptyInteropStubManager.cs" />
     <Compile Include="Compiler\PreInitFieldInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenArrayNode.cs" />

--- a/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilationBuilder.cs
@@ -32,7 +32,7 @@ namespace ILCompiler
         public override ICompilation ToCompilation()
         {
             var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_compilationGroup.GeneratedAssembly));
-            CppCodegenNodeFactory factory = new CppCodegenNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider);
+            CppCodegenNodeFactory factory = new CppCodegenNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
 
             return new CppCodegenCompilation(graph, factory, _compilationRoots, _logger, _config);

--- a/src/ILCompiler.CppCodeGen/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -11,8 +11,8 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class CppCodegenNodeFactory : NodeFactory
     {
         public CppCodegenNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager,
-            InteropStubManager interopStubManager, NameMangler nameMangler, VTableSliceProvider vtableSliceProvider)
-            : base(context, compilationModuleGroup, metadataManager, interopStubManager, nameMangler, new LazyGenericsDisabledPolicy(), vtableSliceProvider)
+            InteropStubManager interopStubManager, NameMangler nameMangler, VTableSliceProvider vtableSliceProvider, DictionaryLayoutProvider dictionaryLayoutProvider)
+            : base(context, compilationModuleGroup, metadataManager, interopStubManager, nameMangler, new LazyGenericsDisabledPolicy(), vtableSliceProvider, dictionaryLayoutProvider)
         {
         }
 

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -364,10 +364,16 @@ namespace ILCompiler
                 .UseOptimizationMode(_optimizationMode)
                 .UseDebugInfo(_enableDebugInfo);
 
-            // If we have a scanner, feed the vtable analysis results to the compilation.
-            // This could be a command line switch if we really wanted to.
             if (scanResults != null)
+            {
+                // If we have a scanner, feed the vtable analysis results to the compilation.
+                // This could be a command line switch if we really wanted to.
                 builder.UseVTableSliceProvider(scanResults.GetVTableLayoutInfo());
+
+                // If we have a scanner, feed the generic dictionary results to the compilation.
+                // This could be a command line switch if we really wanted to.
+                builder.UseGenericDictionaryLayoutProvider(scanResults.GetDictionaryLayoutInfo());
+            }
 
             ICompilation compilation = builder.ToCompilation();
 


### PR DESCRIPTION
...and implement a provider in the ILScanner.

This is a prerequisite for getting rid of generic lookup ready to run helpers.

* Add a `DictionaryLayoutProvider` class that provides `DictionaryLayoutNode` for a specified type or method.
* Expose APIs on compilation builder that let user specify a `DictionaryLayoutProvider` to be used for compilation.
* Add an implementation of `DictionaryLayoutProvider` on ILScanner that looks at the marked dictionary layouts in the graph to provide results.
* Make nodes that depend on dictionary layout to declare the dependency (so that it properly shows up in the graph)
* Add a lazy dictionary layout provider that just simulates the existing behavior of dictionary layouts that cannot be queried about slots until after we're done compiling.
* Duplicate dependencies from ReadyToRun generic helpers to dictionary layout/generic dictionaries - these have known dependencies if the slots are known. We'll need them when lookups stop using the ReadyToRun helpers.
* Implement Equals/GetHashCode on GenericLookupResult - these are normally interned, but when we reuse GenericLookupResults across scanning/compilation phase, we need to be able to compare them.