### PR TITLE
Switch DotNetCore-Build for macOS Sierra 10.12.

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Mac.json
+++ b/buildpipeline/DotNet-CoreRT-Mac.json
@@ -353,12 +353,12 @@
   "quality": "definition",
   "defaultBranch": "refs/heads/master",
   "queue": {
+    "id": 330,
+    "name": "DotNetCore-Build",
     "pool": {
-      "id": 39,
-      "name": "DotNet-Build"
-    },
-    "id": 36,
-    "name": "DotNet-Build"
+      "id": 97,
+      "name": "DotNetCore-Build"
+    }
   },
   "path": "\\",
   "type": "build",


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/1097
Build agents with macOS Sierra 10.12 are available in DotNetCore-Build. Hence the switch.
