### PR TITLE
Remove UnNeeded package build Target

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -59,11 +59,4 @@
   <!-- Override corefx multi targeting support -->
   <Target Name="ConvertCommonMetadataToAdditionalProperties" BeforeTargets="AssignProjectConfiguration" />
 
-  <!-- OverrideLicenseUrl is temporary till we update the buildtools to v2 -->  
-  <Target Name="OverrideLicenseUrl" BeforeTargets="GenerateNuSpec">
-    <PropertyGroup>
-      <LicenseUrl>https://github.com/dotnet/corert/blob/master/LICENSE.TXT</LicenseUrl>
-    </PropertyGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
We used this target as a hack till we update the build tools to v2.x and now we updated the build tools so this target is not needed anymore

Fixes https://github.com/dotnet/corert/issues/3583