### PR TITLE
TimeZoneInfo binary serialization test failures on uapaot

### DIFF
--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -43,7 +43,7 @@ namespace System
 
 
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     sealed public partial class TimeZoneInfo : IEquatable<TimeZoneInfo>, ISerializable, IDeserializationCallback
     {
         // ---- SECTION:  members for internal support ---------*

--- a/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -43,7 +43,7 @@ namespace System
 
 
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
     sealed public partial class TimeZoneInfo : IEquatable<TimeZoneInfo>, ISerializable, IDeserializationCallback
     {
         // ---- SECTION:  members for internal support ---------*


### PR DESCRIPTION
Fixing the TypeForwardedFrom attribute to correctly point to System.Core instead of mscorlib (like in coreclr and netfx).

I noticed that there are more differences, the code looks like it diverged a lot. @tarekgh is that intentional? E.g. the field `_noDaylightTransitionTime` does not exist in corert but in coreclr. As it is used for serialization and netfx expects it, serialization fails for this type. https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/TimeZoneInfo.AdjustmentRule.cs#L21

These differences resolve in the following serialization errors on uapaot:

1. TimeZoneInfo
```
<test name="System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.ValidateAgainstBlobs(obj: UTC, blobs: [\&quot;AAEAAAD/////AQAAAAAAAAAMAgAAAE5TeXN0ZW0uQ29yZSwgVm\&quot;..., \&quot;AAEAAAD/////AQAAAAAAAAAMAgAAAE5TeXN0ZW0uQ29yZSwgVm\&quot;...])" type="System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests" method="ValidateAgainstBlobs" time="0.0017598" result="Fail">
        <failure exception-type="Xunit.Sdk.TrueException">
          <message><![CDATA[The stored blob for type System.TimeZoneInfo is outdated and needs to be updated.\r\nStored blob: AAEAAAD/////AQAAAAAAAAAMAgAAAE5TeXN0ZW0uQ29yZSwgVmVyc2lvbj0zLjUuMC4wLCBDdWx0dXJlPU5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAABNTeXN0ZW0uVGltZVpvbmVJbmZvBwAAAAJJZAtEaXNwbGF5TmFtZQxTdGFuZGFyZE5hbWUMRGF5bGlnaHROYW1lDUJhc2VVdGNPZmZzZXQPQWRqdXN0bWVudFJ1bGVzGlN1cHBvcnRzRGF5bGlnaHRTYXZpbmdUaW1lAQEBAQACAAwBAgAAAAYDAAAAA1VUQwkDAAAACQMAAAAJAwAAAAAAAAAAAAAACgAL\r\nGenerated runtime blob: AAEAAAD/////AQAAAAAAAAAEAQAAABNTeXN0ZW0uVGltZVpvbmVJbmZvBwAAAAJJZAtEaXNwbGF5TmFtZQxTdGFuZGFyZE5hbWUMRGF5bGlnaHROYW1lDUJhc2VVdGNPZmZzZXQPQWRqdXN0bWVudFJ1bGVzGlN1cHBvcnRzRGF5bGlnaHRTYXZpbmdUaW1lAQEBAQACAAwBBgIAAAADVVRDCQIAAAAJAgAAAAkCAAAAAAAAAAAAAAAKAAs=\r\nExpected: True\r\nActual:   False]]></message>
          <stack-trace><![CDATA[   at System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.SanityCheckBlob(Object obj, String[] blobs)
   at System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.ValidateAgainstBlobs(Object obj, String[] blobs)
   at xunit.console.netcore!<BaseAddress>+0x10d66cf
   at xunit.console.netcore!<BaseAddress>+0x1064945
   at xunit.console.netcore!<BaseAddress>+0x10646d1]]></stack-trace>
        </failure>
      </test>
```

2. TimeZoneInfo+AdjustmentRule

```
<test name="System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.ValidateAgainstBlobs(obj: AdjustmentRule { DateEnd = 1955-12-31T00:00:00.0000000, DateStart = 1900-01-01T00:00:00.0000000, DaylightDelta = 02:00:00, DaylightTransitionEnd = System.TimeZoneInfo+TransitionTime, DaylightTransitionStart = System.TimeZoneInfo+TransitionTime }, blobs: [\&quot;AAEAAAD/////AQAAAAAAAAAEAQAAACJTeXN0ZW0uVGltZVpvbm\&quot;..., \&quot;AAEAAAD/////AQAAAAAAAAAMAgAAAE5TeXN0ZW0uQ29yZSwgVm\&quot;...])" type="System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests" method="ValidateAgainstBlobs" time="0.0013659" result="Fail">
        <failure exception-type="Xunit.Sdk.TrueException">
          <message><![CDATA[The stored blob for type System.TimeZoneInfo+AdjustmentRule is outdated and needs to be updated.\r\nStored blob: AAEAAAD/////AQAAAAAAAAAEAQAAACJTeXN0ZW0uVGltZVpvbmVJbmZvK0FkanVzdG1lbnRSdWxlBwAAAAlEYXRlU3RhcnQHRGF0ZUVuZA1EYXlsaWdodERlbHRhF0RheWxpZ2h0VHJhbnNpdGlvblN0YXJ0FURheWxpZ2h0VHJhbnNpdGlvbkVuZBJCYXNlVXRjT2Zmc2V0RGVsdGEVTm9EYXlsaWdodFRyYW5zaXRpb25zAAAAAwMAAA0NDCJTeXN0ZW0uVGltZVpvbmVJbmZvK1RyYW5zaXRpb25UaW1lIlN5c3RlbS5UaW1lWm9uZUluZm8rVHJhbnNpdGlvblRpbWUMAQBAVyBTBVEIAEDGiJPMjwgA0IjDEAAAAAT+////IlN5c3RlbS5UaW1lWm9uZUluZm8rVHJhbnNpdGlvblRpbWUGAAAACVRpbWVPZkRheQVNb250aARXZWVrA0RheQlEYXlPZldlZWsPSXNGaXhlZERhdGVSdWxlAAAAAAMADQICAhBTeXN0ZW0uRGF5T2ZXZWVrAQDQiMMQAAAAAgEDBP3///8QU3lzdGVtLkRheU9mV2VlawEAAAAHdmFsdWVfXwAIAAAAAAEB/P////7///8A0IjDEAAAAAMBBAH7/////f///wAAAAABAAAAAAAAAAAACw==\r\nGenerated runtime blob: AAEAAAD/////AQAAAAAAAAAEAQAAACJTeXN0ZW0uVGltZVpvbmVJbmZvK0FkanVzdG1lbnRSdWxlBgAAAAlEYXRlU3RhcnQHRGF0ZUVuZA1EYXlsaWdodERlbHRhF0RheWxpZ2h0VHJhbnNpdGlvblN0YXJ0FURheWxpZ2h0VHJhbnNpdGlvbkVuZBJCYXNlVXRjT2Zmc2V0RGVsdGEAAAADAwANDQwiU3lzdGVtLlRpbWVab25lSW5mbytUcmFuc2l0aW9uVGltZSJTeXN0ZW0uVGltZVpvbmVJbmZvK1RyYW5zaXRpb25UaW1lDABAVyBTBVEIAEDGiJPMjwgA0IjDEAAAAAT+////IlN5c3RlbS5UaW1lWm9uZUluZm8rVHJhbnNpdGlvblRpbWUGAAAACVRpbWVPZkRheQVNb250aARXZWVrA0RheQlEYXlPZldlZWsPSXNGaXhlZERhdGVSdWxlAAAAAAMADQICAhBTeXN0ZW0uRGF5T2ZXZWVrAQDQiMMQAAAAAgEDBP3///8QU3lzdGVtLkRheU9mV2VlawEAAAAHdmFsdWVfXwAIAAAAAAEB/P////7///8A0IjDEAAAAAMBBAH7/////f///wAAAAABAAAAAAAAAAAL\r\nExpected: True\r\nActual:   False]]></message>
          <stack-trace><![CDATA[   at System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.SanityCheckBlob(Object obj, String[] blobs)
   at System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.ValidateAgainstBlobs(Object obj, String[] blobs)
   at xunit.console.netcore!<BaseAddress>+0x10d66cf
   at xunit.console.netcore!<BaseAddress>+0x1064945
   at xunit.console.netcore!<BaseAddress>+0x10646d1]]></stack-trace>
        </failure>
      </test>
```

_No Merge until question is answered_