### PR TITLE
Fix AppDomain test on CoreRT

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1687,9 +1687,6 @@
   <data name="InvalidOperation_SendNotSupportedOnWindowsRTSynchronizationContext" xml:space="preserve">
     <value>Send is not supported in the Windows Runtime SynchronizationContext</value>
   </data>
-  <data name="InvalidOperation_SetData_OnlyOnce" xml:space="preserve">
-    <value>SetData can only be used to set the value of a given name once.</value>
-  </data>
   <data name="SemaphoreSlim_Disposed" xml:space="preserve">
     <value>The semaphore has been disposed.</value>
   </data>

--- a/src/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/System.Private.CoreLib/src/System/AppContext.cs
@@ -65,17 +65,6 @@ namespace System
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
 
-            // SetData should only be used to set values that don't already exist.
-            object currentVal;
-            lock (((ICollection)s_localStore).SyncRoot)
-            {
-                s_localStore.TryGetValue(name, out currentVal);
-            }
-            if (currentVal != null)
-            {
-                throw new InvalidOperationException(SR.InvalidOperation_SetData_OnlyOnce);
-            }
-
             lock (((ICollection)s_localStore).SyncRoot)
             {
                 s_localStore[name] = data;


### PR DESCRIPTION
Part of https://github.com/dotnet/corefx/issues/21680

CoreCLR does not police setting a variable
only once. Why do we?