### PR TITLE
Fix an issue in the spinning logic of the Lock.TryAcquireContended method

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -167,7 +167,7 @@ namespace System.Threading
                     RuntimeThread.SpinWait(spins);
                     spins *= 2;
                 }
-                else
+                else if (oldState != 0)
                 {
                     //
                     // We reached our spin limit, and need to wait.  Increment the waiter count.


### PR DESCRIPTION
This change fixes a problem where a thread can get into the blocked state even when the lock is available. As a result, the thread can end up waiting indefinitely unless another thread acquires the lock and wakes up the waiting thread.

This problem happens under the following conditions:
1. The current thread A reaches the allowed spinning limit (https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Threading/Lock.cs#L165)

2. The lock becomes available. As a result, the value of ```oldState``` is set to 0
```int oldState = _state;``` (https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Threading/Lock.cs#L158)

3. Another thread B acquires the lock. As a result, Interlocked.CompareExchange on line 159 fails and the thread A attempts to spin again but gets interrupted by the scheduler.

4. Thread B release the lock (the _state field becomes 0 again).

5. Thread A starts running again and reaches Line 178 to enter the wait
state because it reached its spinning limit. Since both ```oldState``` and ```_state``` are 0, the thread successfully marks its self as a waiter (i.e. Interlocked.CompareExchange succeeds) and proceeds further where it waits on the event even though the lock is not held by anyone. Thread A will remain in the blocked state waiting for the event to be signaled until another thread acquires the lock and then signals the even while releasing the lock.

The fix is to not enter the wait state if oldState is 0 (i.e. Uncontended) and to retry the loop instead.
