### PR TITLE
Fix custom modifiers on Reflection

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -152,7 +152,7 @@ namespace System.Reflection.Runtime.General
                 if (optional == modifiedType.IsOptional)
                 {
                     Type customModifier = modifiedType.ModifierType.Resolve(reader, typeContext);
-                    customModifiers.Add(customModifier);
+                    customModifiers.Insert(0, customModifier);
                 }
 
                 handle = modifiedType.Type;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.NativeFormat.cs
@@ -20,11 +20,11 @@ namespace System.Reflection.Runtime.General
         {
             if (!skipCheck)
             {
-                if (!handle.IsTypeDefRefOrSpecHandle(reader))
+                if (!handle.IsTypeDefRefSpecOrModifiedTypeHandle(reader))
                     throw new BadImageFormatException();
             }
             
-            Debug.Assert(handle.IsTypeDefRefOrSpecHandle(reader));
+            Debug.Assert(handle.IsTypeDefRefSpecOrModifiedTypeHandle(reader));
             _reader = reader;
             _handle = handle;
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/MetadataReaderExtensions.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/MetadataReaderExtensions.cs
@@ -77,6 +77,15 @@ namespace System.Reflection.Runtime.General
                 handleType == HandleType.TypeSpecification;
         }
 
+        public static bool IsTypeDefRefSpecOrModifiedTypeHandle(this Handle handle, MetadataReader reader)
+        {
+            HandleType handleType = handle.HandleType;
+            return handleType == HandleType.TypeDefinition ||
+                handleType == HandleType.TypeReference ||
+                handleType == HandleType.TypeSpecification ||
+                handleType == HandleType.ModifiedType;
+        }
+
         public static RuntimeAssemblyName ToRuntimeAssemblyName(this ScopeDefinitionHandle scopeDefinitionHandle, MetadataReader reader)
         {
             ScopeDefinition scopeDefinition = scopeDefinitionHandle.GetScopeDefinition(reader);


### PR DESCRIPTION
- Make the guard check ModifiedType aware
  so it doesn't block custom modifiers
  on parameters.

- Sort modifiers in the same way the full
  framework does. Order matters in custom modifiers.