### PR TITLE
Set cache line size in thread pool to 128 bytes on ARM64

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.cs
@@ -32,7 +32,11 @@ namespace System.Threading
         [StructLayout(LayoutKind.Explicit, Size = CacheLineSize * 5)]
         private struct CacheLineSeparated
         {
+#if ARM64
+            private const int CacheLineSize = 128;
+#else
             private const int CacheLineSize = 64;
+#endif
             [FieldOffset(CacheLineSize * 1)]
             public ThreadCounts counts;
             [FieldOffset(CacheLineSize * 2)]


### PR DESCRIPTION
Mirrors [dotnet/coreclr#12801](https://github.com/dotnet/coreclr/pull/12801).

@kouvel