### PR TITLE
Mark the new ThrowHelpers DebuggerHidden

### DIFF
--- a/src/Common/src/TypeSystem/Common/ThrowHelper.Common.cs
+++ b/src/Common/src/TypeSystem/Common/ThrowHelper.Common.cs
@@ -11,31 +11,37 @@ namespace Internal.TypeSystem
 {
     public static partial class ThrowHelper
     {
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowTypeLoadException(string nestedTypeName, ModuleDesc module)
         {
             ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, nestedTypeName, Format.Module(module));
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowTypeLoadException(string @namespace, string name, ModuleDesc module)
         {
             ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, Format.Type(@namespace, name), Format.Module(module));
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowTypeLoadException(TypeDesc type)
         {
             ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, Format.Type(type), Format.OwningModule(type));
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowTypeLoadException(ExceptionStringID id, MethodDesc method)
         {
             ThrowTypeLoadException(id, Format.Type(method.OwningType), Format.OwningModule(method), Format.Method(method));
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowTypeLoadException(ExceptionStringID id, TypeDesc type, string messageArg)
         {
             ThrowTypeLoadException(id, Format.Type(type), Format.OwningModule(type), messageArg);
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowTypeLoadException(ExceptionStringID id, TypeDesc type)
         {
             ThrowTypeLoadException(id, Format.Type(type), Format.OwningModule(type));

--- a/src/Common/src/TypeSystem/Common/ThrowHelper.cs
+++ b/src/Common/src/TypeSystem/Common/ThrowHelper.cs
@@ -6,41 +6,49 @@ namespace Internal.TypeSystem
 {
     public static partial class ThrowHelper
     {
+        [System.Diagnostics.DebuggerHidden]
         private static void ThrowTypeLoadException(ExceptionStringID id, string typeName, string assemblyName, string messageArg)
         {
             throw new TypeSystemException.TypeLoadException(id, typeName, assemblyName, messageArg);
         }
 
+        [System.Diagnostics.DebuggerHidden]
         private static void ThrowTypeLoadException(ExceptionStringID id, string typeName, string assemblyName)
         {
             throw new TypeSystemException.TypeLoadException(id, typeName, assemblyName);
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowMissingMethodException(TypeDesc owningType, string methodName, MethodSignature signature)
         {
             throw new TypeSystemException.MissingMethodException(ExceptionStringID.MissingMethod, Format.Method(owningType, methodName, signature));
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowMissingFieldException(TypeDesc owningType, string fieldName)
         {
             throw new TypeSystemException.MissingFieldException(ExceptionStringID.MissingField, Format.Field(owningType, fieldName));
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowFileNotFoundException(ExceptionStringID id, string fileName)
         {
             throw new TypeSystemException.FileNotFoundException(id, fileName);
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowInvalidProgramException()
         {
             throw new TypeSystemException.InvalidProgramException();
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowInvalidProgramException(ExceptionStringID id, MethodDesc method)
         {
             throw new TypeSystemException.InvalidProgramException(id, Format.Method(method));
         }
 
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowBadImageFormatException()
         {
             throw new TypeSystemException.BadImageFormatException();


### PR DESCRIPTION
The throw helpers result in a rather poor debugging experience when
debugging first chance exceptions - the debugger breaks in the helper,
requiring the user to manually go up the stack frame to see interesting
bits. Marking them `DebuggerHidden` seems to do the trick.