### PR TITLE
Fix overzealous IL validation

### DIFF
--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -885,11 +885,6 @@ namespace Internal.IL
                     _dependencies.Add(_factory.ReadyToRunHelper(helperId, owningType), reason);
                 }
             }
-            else
-            {
-                if (field.IsStatic)
-                    ThrowHelper.ThrowInvalidProgramException();
-            }
         }
 
         private void ImportLoadField(int token, bool isStatic)

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -844,9 +844,11 @@ namespace Internal.IL
         {
             var field = (FieldDesc)_methodIL.GetObject(token);
 
-            if (isStatic)
+            // Covers both ldsfld/ldsflda and ldfld/ldflda with a static field
+            if (isStatic || field.IsStatic)
             {
-                if (!field.IsStatic)
+                // ldsfld/ldsflda with an instance field is invalid IL
+                if (isStatic && !field.IsStatic)
                     ThrowHelper.ThrowInvalidProgramException();
 
                 // References to literal fields from IL body should never resolve.


### PR DESCRIPTION
I need to read the spec before writing code. Apparently, `ldfld` is
allowed with static fields if `this` is null.