### PR TITLE
Implement IsByRefLike on System.Type

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Type.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.cs
@@ -47,6 +47,8 @@ namespace System
         public virtual bool IsSZArray { get { throw NotImplemented.ByDesign; } }
         public virtual bool IsVariableBoundArray => IsArray && !IsSZArray;
 
+        public virtual bool IsByRefLike => throw new NotSupportedException(SR.NotSupported_SubclassOverride);
+
         public bool HasElementType => HasElementTypeImpl();
         protected abstract bool HasElementTypeImpl();
         public abstract Type GetElementType();

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -623,6 +623,8 @@ namespace Internal.Runtime.Augments
             return typeHandle.ToEETypePtr().IsArray;
         }
 
+        public static bool IsByRefLike(RuntimeTypeHandle typeHandle) => typeHandle.ToEETypePtr().IsByRefLike;
+
         public static bool IsDynamicType(RuntimeTypeHandle typeHandle)
         {
             return typeHandle.ToEETypePtr().IsDynamicType;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -39,6 +39,7 @@ namespace System.Reflection.Runtime.TypeInfos
         protected sealed override bool IsPointerImpl() => false;
         public sealed override bool IsConstructedGenericType => true;
         public sealed override bool IsGenericParameter => false;
+        public sealed override bool IsByRefLike => GenericTypeDefinitionTypeInfo.IsByRefLike;
 
         //
         // Implements IKeyedItem.PrepareKey.

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeGenericParameterTypeInfo.cs
@@ -35,6 +35,7 @@ namespace System.Reflection.Runtime.TypeInfos
         protected sealed override bool IsPointerImpl() => false;
         public sealed override bool IsConstructedGenericType => false;
         public sealed override bool IsGenericParameter => true;
+        public sealed override bool IsByRefLike => false;
 
         public sealed override Assembly Assembly
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.cs
@@ -36,6 +36,7 @@ namespace System.Reflection.Runtime.TypeInfos
         protected abstract override bool IsPointerImpl();
         public sealed override bool IsConstructedGenericType => false;
         public sealed override bool IsGenericParameter => false;
+        public sealed override bool IsByRefLike => false;
 
         //
         // Implements IKeyedItem.PrepareKey.

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeDefinitionTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeDefinitionTypeInfo.cs
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+using System.Reflection.Runtime.General;
+
+using Internal.Runtime.Augments;
+
 namespace System.Reflection.Runtime.TypeInfos
 {
     //
@@ -19,6 +24,23 @@ namespace System.Reflection.Runtime.TypeInfos
         protected sealed override bool IsPointerImpl() => false;
         public sealed override bool IsConstructedGenericType => false;
         public sealed override bool IsGenericParameter => false;
+
+        public sealed override bool IsByRefLike
+        {
+            get
+            {
+                RuntimeTypeHandle typeHandle = InternalTypeHandleIfAvailable;
+                if (!typeHandle.IsNull())
+                    return RuntimeAugments.IsByRefLike(typeHandle);
+
+                foreach (CustomAttributeData cad in CustomAttributes)
+                {
+                    if (cad.AttributeType == typeof(IsByRefLikeAttribute))
+                        return true;
+                }
+                return false;
+            }
+        }
 
         // Left unsealed as RuntimeCLSIDTypeInfo has special behavior and needs to override.
         public override bool HasSameMetadataDefinitionAs(MemberInfo other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -52,6 +52,7 @@ namespace System.Reflection.Runtime.TypeInfos
         protected abstract override bool IsPointerImpl();
         public abstract override bool IsGenericParameter { get; }
         public abstract override bool IsConstructedGenericType { get; }
+        public abstract override bool IsByRefLike { get; }
 
         public abstract override Assembly Assembly { get; }
 


### PR DESCRIPTION
This is sitting around in the api review queue
but we don't need to block on that to have an
implementation. We're going to need to start
enforcing this in various apis.

Notes:

  IsByRef != IsByRefLike (this matches
  the EEType property definition and
  avoids overlapping concerns.)

  My read of the Span safety docs
  is that the [IsByRefLike] attribute
  is required before you can embed
  IsByRefLike fields - hence, no need
  for IsByRefLike to check each field.

  There's some inconsistency in the behavior
  regarding [IsByRefLike] attributes applied
  by hand to types that don't actually have
  IsByRefLike behavior. EETypePtr.IsByRefLike
  and MethodTable::IsByRefLike (CoreCLR)
  don't report these as IsByRefLike but
  the metadata fallback for BrowseOnly
  types will.