### PR TITLE
Add new Span-based virtual sync Read/Write Stream methods

### DIFF
--- a/src/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -423,6 +423,36 @@ namespace System.IO
             return n;
         }
 
+        public override int Read(Span<byte> destination)
+        {
+            if (GetType() != typeof(MemoryStream))
+            {
+                // MemoryStream is not sealed, and a derived type may have overridden Read(byte[], int, int) prior
+                // to this Read(Span<byte>) overload being introduced.  In that case, this Read(Span<byte>) overload
+                // should use the behavior of Read(byte[],int,int) overload.
+                return base.Read(destination);
+            }
+
+            if (!_isOpen)
+            {
+                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+            }
+
+            int n = Math.Min(_length - _position, destination.Length);
+            if (n <= 0)
+            {
+                return 0;
+            }
+
+            // TODO: Read(byte[], int, int) has an n <= 8 optimization, presumably
+            // based on benchmarking.  Determine if/where such a cut-off is here and
+            // add an equivalent optimization if necessary.
+            new Span<byte>(_buffer, _position, n).CopyTo(destination);
+
+            _position += n;
+            return n;
+        }
+
         public override Task<int> ReadAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             if (buffer == null)
@@ -715,6 +745,52 @@ namespace System.IO
             {
                 Buffer.BlockCopy(buffer, offset, _buffer, _position, count);
             }
+            _position = i;
+        }
+
+        public override void Write(ReadOnlySpan<byte> source)
+        {
+            if (GetType() != typeof(MemoryStream))
+            {
+                // MemoryStream is not sealed, and a derived type may have overridden Write(byte[], int, int) prior
+                // to this Write(Span<byte>) overload being introduced.  In that case, this Write(Span<byte>) overload
+                // should use the behavior of Write(byte[],int,int) overload.
+                base.Write(source);
+                return;
+            }
+
+            if (!_isOpen)
+            {
+                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+            }
+            EnsureWriteable();
+
+            // Check for overflow
+            int i = _position + source.Length;
+            if (i < 0)
+            {
+                throw new IOException(SR.IO_StreamTooLong);
+            }
+
+            if (i > _length)
+            {
+                bool mustZero = _position > _length;
+                if (i > _capacity)
+                {
+                    bool allocatedNewArray = EnsureCapacity(i);
+                    if (allocatedNewArray)
+                    {
+                        mustZero = false;
+                    }
+                }
+                if (mustZero)
+                {
+                    Array.Clear(_buffer, _length, i - _length);
+                }
+                _length = i;
+            }
+
+            source.CopyTo(new Span<byte>(_buffer, _position, source.Length));
             _position = i;
         }
 


### PR DESCRIPTION
Port of https://github.com/dotnet/coreclr/pull/13058 to corert.  The coreclr PR includes UnmanagedMemoryStream changes, which are shared, so this PR doesn't touch that type, but Stream and MemoryStream are both currently outside of the shared partition.

Contributes to dotnet/corefx#22381, dotnet/corefx#22388, and dotnet/corefx#22389.

cc: @jkotas