### PR TITLE
Add anti-ByRefLike checks in the following apis

### DIFF
--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -221,7 +221,7 @@ namespace System
             {
                 elementType = elementType.GetElementType();
             }
-            if (elementType.IsByRef)
+            if (elementType.IsByRef || elementType.IsByRefLike)
                 throw new NotSupportedException(SR.NotSupported_ByRefLikeArray);
             if (elementType.Equals(CommonRuntimeTypes.Void))
                 throw new NotSupportedException(SR.NotSupported_VoidArray);

--- a/src/System.Private.Reflection.Core/src/Resources/Strings.resx
+++ b/src/System.Private.Reflection.Core/src/Resources/Strings.resx
@@ -370,4 +370,10 @@
   <data name="Arg_EnumLitValueNotFound" xml:space="preserve">
     <value>Literal value was not found.</value>
   </data>
+  <data name="NotSupported_ByRefLike" xml:space="preserve">
+    <value>Cannot create boxed ByRef-like values.</value>
+  </data>
+  <data name="CannotUseByRefLikeTypeInInstantiation" xml:space="preserve">
+    <value>Cannot instantiate a generic type on a byref-like type.</value>
+  </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System/ActivatorImplementation.cs
+++ b/src/System.Private.Reflection.Core/src/System/ActivatorImplementation.cs
@@ -124,6 +124,9 @@ namespace System
             if (type.ContainsGenericParameters)
                 throw new ArgumentException(SR.Format(SR.Acc_CreateGenericEx, type));
 
+            if (type.IsByRefLike)
+                throw new NotSupportedException(SR.NotSupported_ByRefLike);
+
             Type elementType = type;
             while (elementType.HasElementType)
                 elementType = elementType.GetElementType();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -279,7 +279,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             Debug.Assert(multiDim || rank == 1);
 
-            if (elementType.IsByRef)
+            if (elementType.IsByRef || elementType.IsByRefLike)
                 throw new TypeLoadException(SR.Format(SR.ArgumentException_InvalidArrayElementType, elementType));
 
             // We only permit creating parameterized types if the pay-for-play policy specifically allows them *or* if the result

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -129,13 +129,17 @@ namespace System.Reflection.Runtime.MethodInfos
             RuntimeTypeInfo[] genericTypeArguments = new RuntimeTypeInfo[typeArguments.Length];
             for (int i = 0; i < typeArguments.Length; i++)
             {
-                if (typeArguments[i] == null)
+                Type typeArgument = typeArguments[i];
+                if (typeArgument == null)
                     throw new ArgumentNullException();
 
-                if (!typeArguments[i].IsRuntimeImplemented())
+                if (!typeArgument.IsRuntimeImplemented())
                     throw new ArgumentException(SR.Format(SR.Reflection_CustomReflectionObjectsNotSupported, typeArguments[i]), "typeArguments[" + i + "]"); // Not a runtime type.
 
-                genericTypeArguments[i] = typeArguments[i].CastToRuntimeTypeInfo();
+                if (typeArgument.IsByRefLike)
+                    throw new BadImageFormatException(SR.CannotUseByRefLikeTypeInInstantiation);
+
+                genericTypeArguments[i] = typeArgument.CastToRuntimeTypeInfo();
             }
             if (typeArguments.Length != GenericTypeParameters.Length)
                 throw new ArgumentException(SR.Format(SR.Argument_NotEnoughGenArguments, typeArguments.Length, GenericTypeParameters.Length));

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -446,6 +446,9 @@ namespace System.Reflection.Runtime.TypeInfos
                 if (runtimeTypeArgument.IsGenericTypeDefinition)
                     runtimeTypeArgument = runtimeTypeArgument.GetConstructedGenericType(runtimeTypeArgument.RuntimeGenericTypeParameters);
 
+                if (runtimeTypeArgument.IsByRefLike)
+                    throw new TypeLoadException(SR.CannotUseByRefLikeTypeInInstantiation);
+
                 runtimeTypeArguments[i] = runtimeTypeArgument;
             }
             return this.GetConstructedGenericType(runtimeTypeArguments);


### PR DESCRIPTION
Fix https://github.com/dotnet/corert/issues/3080

Type.MakeArrayType()
Array.CreateInstance()
Type.MakeGenericType()
MethodInfo.MakeGenericMethod()
Activator.CreateInstance()
RuntimeHelpers.GetUninitializedObject()

Thrown exception type determined by testing CoreCLR scenario
so point the finger there for all the sad inconsistencies
(looking at you, MakeGenericMethod()).