### PR TITLE
Hook up target architecture to MSBuild

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -96,6 +96,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Include="@(IlcCompileInput)" />
       <IlcArg Include="-o:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)" />
       <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
+      <IlcArg Include="--targetarch:$(Platform)" />
       <IlcArg Condition="$(IlcGenerateMetadataLog) == 'true'" Include="--metadatalog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).metadata.csv" />
       <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />


### PR DESCRIPTION
On @sandreenko's machine when running the `desktop` project, `RuntimeInformation.ProcessArchitecture` (that we use to match CPU architecture of the host) reports x86 and then it goes ahead and loads an x64 RyuJIT DLL into the process without any problems. Looks like `ProcessArchitecture` is a lie on desktop CLR.