### PR TITLE
[armel tizen] Fixed issue #4146

### DIFF
--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -1228,7 +1228,7 @@ namespace Internal.JitInterface
 
         UNKNOWN_ILNUM       = -4, // Unknown variable
 
-        MAX_ILNUM           = -4  // Sentinal value. This should be set to the largest magnitude value in th enum
+        MAX_ILNUM           = -4  // Sentinal value. This should be set to the largest magnitude value in the enum
                                   // so that the compression routines know the enum's range.
     };
 

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -1248,18 +1248,13 @@ namespace Internal.JitInterface
     };
 
     // The following 16 bytes come from coreclr types. See comment below.
+    [StructLayout(LayoutKind.Sequential)]
     public struct VarLoc
     {
-       public int vlType;
-       // The 64bit field is here to keep VarLoc 8byte aligned on Amd64.
-       // For x86, we need to change the VarLoc definition here.
-#if BIT64
-       public long A;
-#else
-       public int A;
-       public int A1;
-#endif
-       public int B;
+        IntPtr A; // vlType + padding
+        int B;
+        int C;
+        int D;
 
         /*
            Changes to the following types may require revisiting the above layout.

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -1220,6 +1220,18 @@ namespace Internal.JitInterface
         // between offsets.
     };
 
+    public enum ILNum
+    {
+        VARARGS_HND_ILNUM   = -1, // Value for the CORINFO_VARARGS_HANDLE varNumber
+        RETBUF_ILNUM        = -2, // Pointer to the return-buffer
+        TYPECTXT_ILNUM      = -3, // ParamTypeArg for CORINFO_GENERICS_CTXT_FROM_PARAMTYPEARG
+
+        UNKNOWN_ILNUM       = -4, // Unknown variable
+
+        MAX_ILNUM           = -4  // Sentinal value. This should be set to the largest magnitude value in th enum
+                                  // so that the compression routines know the enum's range.
+    };
+
     public struct ILVarInfo
     {
         public uint startOffset;
@@ -1241,7 +1253,12 @@ namespace Internal.JitInterface
        public int vlType;
        // The 64bit field is here to keep VarLoc 8byte aligned on Amd64.
        // For x86, we need to change the VarLoc definition here.
-       public long A;   
+#if BIT64
+       public long A;
+#else
+       public int A;
+       public int A1;
+#endif
        public int B;
 
         /*


### PR DESCRIPTION
Before fix 
Info about vars from CoreCLR
```
*************** Variable debug info
8 vars
varNumber:  0 (   UNKNOWN) : From 00000000h to 00000012h, in r0
varNumber:  1 (   UNKNOWN) : From 00000000h to 00000012h, in r1
varNumber:  2 (   UNKNOWN) : From 00000000h to 00000012h, in r2
varNumber:  3 (   UNKNOWN) : From 00000000h to 00000012h, in r3
varNumber:  0 (   UNKNOWN) : From 00000012h to 000000A2h, in r11[-36] (1 slot)
varNumber:  1 (   UNKNOWN) : From 00000012h to 000000A2h, in r11[-12] (1 slot)
varNumber:  2 (   UNKNOWN) : From 00000012h to 000000A2h, in r11[-40] (1 slot)
varNumber:  3 (   UNKNOWN) : From 00000012h to 000000A2h, in r11[-16] (1 slot)
```
Info about these vars from CoreRT
```
varNumber: 0 From 0 to 18
varNumber: -1304079932 From 0 to 1
varNumber: 18 From 0 to 0
varNumber: 11 From 0 to 3
varNumber: 18 From 4294967284 to 8806788
varNumber: 3 From 162 to 3
varNumber: 9306112 From 0 to 0
varNumber: 252 From 15 to 9306112
```
After fix
Info about these vars from CoreRT
```
varNumber: 0 From 0 to 18
varNumber: 1 From 0 to 18
varNumber: 2 From 0 to 18
varNumber: 3 From 0 to 18
varNumber: 0 From 18 to 162
varNumber: 1 From 18 to 162
varNumber: 2 From 18 to 162
varNumber: 3 From 18 to 162
```