### PR TITLE
Verify lock is held in ClrThreadPool.AdjustMaxWorkersActive.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.cs
@@ -211,6 +211,7 @@ namespace System.Threading
         //
         private void AdjustMaxWorkersActive()
         {
+            _hillClimbingThreadAdjustmentLock.VerifyIsLocked();
             int currentTicks = Environment.TickCount;
             int totalNumCompletions = Volatile.Read(ref _completionCount);
             int numCompletions = totalNumCompletions - _separated.priorCompletionCount;


### PR DESCRIPTION
Add in a debug check to ensure the lock is held in `ClrThreadPool.AdjustMaxWorkersActive`.