### PR TITLE
Fix FirstLevelSpinWaiter's proc count-based spin limiting

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/FirstLevelSpinWaiter.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/FirstLevelSpinWaiter.cs
@@ -27,7 +27,7 @@ namespace System.Threading
 
         private static int s_spinningThreadCount;
 
-        public static bool SpinWaitForCondition(Func<bool> condition)
+        public static bool SpinWaitForCondition<T>(Func<T, bool> condition, T obj)
         {
             Debug.Assert(condition != null);
 
@@ -56,7 +56,7 @@ namespace System.Threading
                     // The caller should check the condition in a fast path before calling this method, so wait first
                     Wait(spinIndex);
 
-                    if (condition())
+                    if (condition(obj))
                     {
                         return true;
                     }

--- a/src/System.Private.CoreLib/src/System/Threading/FirstLevelSpinWaiter.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/FirstLevelSpinWaiter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Internal.Runtime.Augments;
 
 namespace System.Threading
@@ -14,65 +15,62 @@ namespace System.Threading
     /// 
     /// Used by the wait subsystem on Unix, so this class cannot have any dependencies on the wait subsystem.
     /// </summary>
-    internal struct FirstLevelSpinWaiter
+    [EagerStaticClassConstruction] // the spin waiter is used during lazy class construction on Unix
+    internal static class FirstLevelSpinWaiter
     {
         // TODO: Tune these values
         private const int SpinCount = 8;
         private const int SpinYieldThreshold = 4;
         private const int SpinSleep0Threshold = 6;
 
-        private static int s_processorCount;
+        private static readonly int ProcessorCount = Environment.ProcessorCount;
 
-        private int _spinningThreadCount;
+        private static int s_spinningThreadCount;
 
-        public void Initialize()
-        {
-            if (s_processorCount == 0)
-            {
-                s_processorCount = Environment.ProcessorCount;
-            }
-        }
-
-        public bool SpinWaitForCondition(Func<bool> condition)
+        public static bool SpinWaitForCondition(Func<bool> condition)
         {
             Debug.Assert(condition != null);
-            Debug.Assert(s_processorCount > 0);
 
-            int processorCount = s_processorCount;
-            int spinningThreadCount = Interlocked.Increment(ref _spinningThreadCount);
+            Debug.Assert(SpinYieldThreshold > 0);
+            Debug.Assert(SpinYieldThreshold < SpinSleep0Threshold);
+            Debug.Assert(SpinSleep0Threshold < SpinCount);
+
+            Debug.Assert(ProcessorCount > 0);
+
+            int processorCount = ProcessorCount;
+            int spinningThreadCount = Interlocked.Increment(ref s_spinningThreadCount);
             try
             {
                 // Limit the maximum spinning thread count to the processor count to prevent unnecessary context switching
                 // caused by an excessive number of threads spin waiting, perhaps even slowing down the thread holding the
                 // resource being waited upon
-                if (spinningThreadCount <= processorCount)
+                if (spinningThreadCount > processorCount)
                 {
-                    // For uniprocessor systems, start at the yield threshold since the pause instructions used for waiting
-                    // prior to that threshold would not help other threads make progress
-                    for (int spinIndex = processorCount > 1 ? 0 : SpinYieldThreshold; spinIndex < SpinCount; ++spinIndex)
-                    {
-                        // The caller should check the condition in a fast path before calling this method, so wait first
-                        Wait(spinIndex);
+                    return false;
+                }
 
-                        if (condition())
-                        {
-                            return true;
-                        }
+                // For uniprocessor systems, start at the yield threshold since the pause instructions used for waiting
+                // prior to that threshold would not help other threads make progress
+                for (int spinIndex = processorCount > 1 ? 0 : SpinYieldThreshold; spinIndex < SpinCount; ++spinIndex)
+                {
+                    // The caller should check the condition in a fast path before calling this method, so wait first
+                    Wait(spinIndex);
+
+                    if (condition())
+                    {
+                        return true;
                     }
                 }
+                return false;
             }
             finally
             {
-                Interlocked.Decrement(ref _spinningThreadCount);
+                Interlocked.Decrement(ref s_spinningThreadCount);
             }
-
-            return false;
         }
 
         private static void Wait(int spinIndex)
         {
-            Debug.Assert(SpinYieldThreshold < SpinSleep0Threshold);
-
             if (spinIndex < SpinYieldThreshold)
             {
                 RuntimeThread.SpinWait(1 << spinIndex);

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Internal.Runtime.Augments;
 
 namespace System.Threading
@@ -12,12 +13,15 @@ namespace System.Threading
     /// 
     /// Used by the wait subsystem on Unix, so this class cannot have any dependencies on the wait subsystem.
     /// </summary>
+    [EagerStaticClassConstruction] // the lock is used during lazy class construction on Unix
     internal sealed class LowLevelLock : IDisposable
     {
         private const int LockedMask = 1;
         private const int WaiterCountIncrement = 2;
 
         private const int MaximumPreemptingAcquireDurationMilliseconds = 200;
+
+        private static readonly Func<LowLevelLock, bool> SpinWaitTryAcquireDelegate = SpinWaitTryAcquire;
 
         /// <summary>
         /// Layout:
@@ -36,7 +40,6 @@ namespace System.Threading
         /// </summary>
         private bool _isAnyWaitingThreadSignaled;
 
-        private readonly Func<bool> _spinWaitTryAcquireCallback;
         private readonly LowLevelMonitor _monitor;
 
         public LowLevelLock()
@@ -45,7 +48,6 @@ namespace System.Threading
             _ownerThread = null;
 #endif
 
-            _spinWaitTryAcquireCallback = SpinWaitTryAcquireCallback;
             _monitor = new LowLevelMonitor();
         }
 
@@ -141,7 +143,7 @@ namespace System.Threading
             return (state & LockedMask) == 0 && Interlocked.CompareExchange(ref _state, state + LockedMask, state) == state;
         }
 
-        private bool SpinWaitTryAcquireCallback() => TryAcquire_NoFastPath(_state);
+        private static bool SpinWaitTryAcquire(LowLevelLock obj) => obj.TryAcquire_NoFastPath(obj._state);
 
         public void Acquire()
         {
@@ -156,7 +158,7 @@ namespace System.Threading
             VerifyIsNotLocked();
 
             // Spin a bit to see if the lock becomes available, before forcing the thread into a wait state
-            if (FirstLevelSpinWaiter.SpinWaitForCondition(_spinWaitTryAcquireCallback))
+            if (FirstLevelSpinWaiter.SpinWaitForCondition(SpinWaitTryAcquireDelegate, this))
             {
                 Debug.Assert((_state & LockedMask) != 0);
                 SetOwnerThreadToCurrent();

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.Unix.cs
@@ -36,7 +36,6 @@ namespace System.Threading
         /// </summary>
         private bool _isAnyWaitingThreadSignaled;
 
-        private FirstLevelSpinWaiter _spinWaiter;
         private readonly Func<bool> _spinWaitTryAcquireCallback;
         private readonly LowLevelMonitor _monitor;
 
@@ -46,8 +45,6 @@ namespace System.Threading
             _ownerThread = null;
 #endif
 
-            _spinWaiter = new FirstLevelSpinWaiter();
-            _spinWaiter.Initialize();
             _spinWaitTryAcquireCallback = SpinWaitTryAcquireCallback;
             _monitor = new LowLevelMonitor();
         }
@@ -159,7 +156,7 @@ namespace System.Threading
             VerifyIsNotLocked();
 
             // Spin a bit to see if the lock becomes available, before forcing the thread into a wait state
-            if (_spinWaiter.SpinWaitForCondition(_spinWaitTryAcquireCallback))
+            if (FirstLevelSpinWaiter.SpinWaitForCondition(_spinWaitTryAcquireCallback))
             {
                 Debug.Assert((_state & LockedMask) != 0);
                 SetOwnerThreadToCurrent();


### PR DESCRIPTION
I had intended for this limit to apply per process and not per instance, as the purpose of this limit is to limit the total number of spinners. Also made it a static class since it doesn't have any fields anymore.