### PR TITLE
Account for a null waitHandle array

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
@@ -275,7 +275,7 @@ namespace System.Threading
         ** signalled or timeout milliseonds have elapsed.
         ========================================================================*/
 
-        public static int WaitAny(WaitHandle[] waitHandles, int millisecondsTimeout) => WaitAny(waitHandles, waitHandles.Length, millisecondsTimeout);
+        public static int WaitAny(WaitHandle[] waitHandles, int millisecondsTimeout) => WaitAny(waitHandles, waitHandles?.Length ?? 0, millisecondsTimeout);
 
         internal static int WaitAny(WaitHandle[] waitHandles, int numWaitHandles, int millisecondsTimeout)
         {


### PR DESCRIPTION
When I added this overload I didn't account for a null WaitHandle array. Now it will pass through successfully to the other overload, where it will throw the ArgumentNullException it is supposed to.