### PR TITLE
Non-shared CoreRT changes for span-based {Try}Parse methods

### DIFF
--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -511,7 +511,8 @@ namespace System
         //
         public static Decimal Parse(String s)
         {
-            return FormatProvider.ParseDecimal(s, NumberStyles.Number, null);
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return FormatProvider.ParseDecimal(s.AsSpan(), NumberStyles.Number, null);
         }
 
         internal const NumberStyles InvalidNumberStyles = ~(NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite
@@ -537,15 +538,24 @@ namespace System
         public static Decimal Parse(String s, NumberStyles style)
         {
             ValidateParseStyleFloatingPoint(style);
-            return FormatProvider.ParseDecimal(s, style, null);
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return FormatProvider.ParseDecimal(s.AsSpan(), style, null);
         }
 
         public static Decimal Parse(String s, IFormatProvider provider)
         {
-            return FormatProvider.ParseDecimal(s, NumberStyles.Number, provider);
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return FormatProvider.ParseDecimal(s.AsSpan(), NumberStyles.Number, provider);
         }
 
         public static Decimal Parse(String s, NumberStyles style, IFormatProvider provider)
+        {
+            ValidateParseStyleFloatingPoint(style);
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return FormatProvider.ParseDecimal(s.AsSpan(), style, provider);
+        }
+
+        public static Decimal Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider)
         {
             ValidateParseStyleFloatingPoint(style);
             return FormatProvider.ParseDecimal(s, style, provider);
@@ -553,10 +563,18 @@ namespace System
 
         public static Boolean TryParse(String s, out Decimal result)
         {
-            return FormatProvider.TryParseDecimal(s, NumberStyles.Number, null, out result);
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return FormatProvider.TryParseDecimal(s.AsSpan(), NumberStyles.Number, null, out result);
         }
 
         public static Boolean TryParse(String s, NumberStyles style, IFormatProvider provider, out Decimal result)
+        {
+            ValidateParseStyleFloatingPoint(style);
+            if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
+            return FormatProvider.TryParseDecimal(s.AsSpan(), style, provider, out result);
+        }
+
+        public static Boolean TryParse(ReadOnlySpan<char> s, out Decimal result, NumberStyles style = NumberStyles.Integer, IFormatProvider provider = null)
         {
             ValidateParseStyleFloatingPoint(style);
             return FormatProvider.TryParseDecimal(s, style, provider, out result);

--- a/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/FormatProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Globalization
 {
     // Internal Contract for all Globalization APIs that are needed by lower levels of System.Private.CoreLib.
@@ -95,11 +93,11 @@ namespace System.Globalization
         #endregion
 
         #region Parsing
-        public static Decimal ParseDecimal(String value, NumberStyles options, IFormatProvider provider)
+        public static Decimal ParseDecimal(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider)
         {
             return Number.ParseDecimal(value, options, provider);
         }
-        public static Boolean TryParseDecimal(String value, NumberStyles options, IFormatProvider provider, out Decimal result)
+        public static Boolean TryParseDecimal(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider, out Decimal result)
         {
             return Number.TryParseDecimal(value, options, provider, out result);
         }

--- a/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -323,7 +323,7 @@ namespace System.Globalization
             return ChangeCase(str, toUpper: true);
         }
 
-        private static Char ToUpperAsciiInvariant(Char c)
+        internal static Char ToUpperAsciiInvariant(Char c)
         {
             if ((uint)(c - 'a') <= (uint)('z' - 'a'))
             {

--- a/src/System.Private.CoreLib/src/System/Number.FormatAndParse.cs
+++ b/src/System.Private.CoreLib/src/System/Number.FormatAndParse.cs
@@ -287,7 +287,7 @@ namespace System
             return true;
         }
 
-        internal static Decimal ParseDecimal(String value, NumberStyles options, IFormatProvider provider)
+        internal static Decimal ParseDecimal(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider)
         {
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
             NumberBuffer number = new NumberBuffer();
@@ -301,13 +301,8 @@ namespace System
             return result;
         }
 
-        internal static unsafe Double ParseDouble(String value, NumberStyles options, IFormatProvider provider)
+        internal static unsafe Double ParseDouble(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
             NumberBuffer number = new NumberBuffer();
             Double d = 0;
@@ -317,16 +312,16 @@ namespace System
                 //If we failed TryStringToNumber, it may be from one of our special strings.
                 //Check the three with which we're concerned and rethrow if it's not one of
                 //those strings.
-                String sTrim = value.Trim();
-                if (sTrim.Equals(numfmt.PositiveInfinitySymbol))
+                ReadOnlySpan<char> sTrim = StringSpanHelpers.Trim(value);
+                if (StringSpanHelpers.Equals(sTrim, numfmt.PositiveInfinitySymbol))
                 {
                     return Double.PositiveInfinity;
                 }
-                if (sTrim.Equals(numfmt.NegativeInfinitySymbol))
+                if (StringSpanHelpers.Equals(sTrim, numfmt.NegativeInfinitySymbol))
                 {
                     return Double.NegativeInfinity;
                 }
-                if (sTrim.Equals(numfmt.NaNSymbol))
+                if (StringSpanHelpers.Equals(sTrim, numfmt.NaNSymbol))
                 {
                     return Double.NaN;
                 }
@@ -341,7 +336,7 @@ namespace System
             return d;
         }
 
-        internal static unsafe Int32 ParseInt32(String s, NumberStyles style, IFormatProvider provider)
+        internal static unsafe Int32 ParseInt32(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider)
         {
             NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -367,7 +362,7 @@ namespace System
             return i;
         }
 
-        internal static unsafe Int64 ParseInt64(String value, NumberStyles options, IFormatProvider provider)
+        internal static unsafe Int64 ParseInt64(ReadOnlySpan<Char> value, NumberStyles options, IFormatProvider provider)
         {
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -393,13 +388,8 @@ namespace System
             return i;
         }
 
-        internal static unsafe Single ParseSingle(String value, NumberStyles options, IFormatProvider provider)
+        internal static unsafe Single ParseSingle(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
             NumberBuffer number = new NumberBuffer();
             Double d = 0;
@@ -409,16 +399,16 @@ namespace System
                 //If we failed TryStringToNumber, it may be from one of our special strings.
                 //Check the three with which we're concerned and rethrow if it's not one of
                 //those strings.
-                String sTrim = value.Trim();
-                if (sTrim.Equals(numfmt.PositiveInfinitySymbol))
+                ReadOnlySpan<char> sTrim = StringSpanHelpers.Trim(value);
+                if (StringSpanHelpers.Equals(sTrim, numfmt.PositiveInfinitySymbol))
                 {
                     return Single.PositiveInfinity;
                 }
-                if (sTrim.Equals(numfmt.NegativeInfinitySymbol))
+                if (StringSpanHelpers.Equals(sTrim, numfmt.NegativeInfinitySymbol))
                 {
                     return Single.NegativeInfinity;
                 }
-                if (sTrim.Equals(numfmt.NaNSymbol))
+                if (StringSpanHelpers.Equals(sTrim, numfmt.NaNSymbol))
                 {
                     return Single.NaN;
                 }
@@ -437,7 +427,7 @@ namespace System
             return castSingle;
         }
 
-        internal static unsafe UInt32 ParseUInt32(String value, NumberStyles options, IFormatProvider provider)
+        internal static unsafe UInt32 ParseUInt32(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider)
         {
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -464,7 +454,7 @@ namespace System
             return i;
         }
 
-        internal static unsafe UInt64 ParseUInt64(String value, NumberStyles options, IFormatProvider provider)
+        internal static unsafe UInt64 ParseUInt64(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider)
         {
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
             NumberBuffer number = new NumberBuffer();
@@ -488,15 +478,11 @@ namespace System
             return i;
         }
 
-        private static unsafe void StringToNumber(String str, NumberStyles options, ref NumberBuffer number, NumberFormatInfo info, Boolean parseDecimal)
+        private static unsafe void StringToNumber(ReadOnlySpan<char> str, NumberStyles options, ref NumberBuffer number, NumberFormatInfo info, Boolean parseDecimal)
         {
-            if (str == null)
-            {
-                throw new ArgumentNullException("String");
-            }
             Contract.EndContractBlock();
             Debug.Assert(info != null, "");
-            fixed (char* stringPointer = str)
+            fixed (char* stringPointer = &str.DangerousGetPinnableReference())
             {
                 char* p = stringPointer;
                 if (!ParseNumber(ref p, options, ref number, null, info, parseDecimal)
@@ -507,7 +493,7 @@ namespace System
             }
         }
 
-        internal static unsafe Boolean TryParseDecimal(String value, NumberStyles options, IFormatProvider provider, out Decimal result)
+        internal static unsafe Boolean TryParseDecimal(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider, out Decimal result)
         {
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -526,7 +512,7 @@ namespace System
             return true;
         }
 
-        internal static unsafe Boolean TryParseDouble(String value, NumberStyles options, IFormatProvider provider, out Double result)
+        internal static unsafe Boolean TryParseDouble(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider, out Double result)
         {
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
             NumberBuffer number = new NumberBuffer();
@@ -544,7 +530,7 @@ namespace System
             return true;
         }
 
-        internal static unsafe Boolean TryParseInt32(String s, NumberStyles style, IFormatProvider provider, out Int32 result)
+        internal static unsafe Boolean TryParseInt32(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider, out Int32 result)
         {
             NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -573,7 +559,7 @@ namespace System
             return true;
         }
 
-        internal static unsafe Boolean TryParseInt64(String s, NumberStyles style, IFormatProvider provider, out Int64 result)
+        internal static unsafe Boolean TryParseInt64(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider, out Int64 result)
         {
             NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -602,7 +588,7 @@ namespace System
             return true;
         }
 
-        internal static unsafe Boolean TryParseSingle(String value, NumberStyles options, IFormatProvider provider, out Single result)
+        internal static unsafe Boolean TryParseSingle(ReadOnlySpan<char> value, NumberStyles options, IFormatProvider provider, out Single result)
         {
             NumberFormatInfo numfmt = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
             NumberBuffer number = new NumberBuffer();
@@ -627,7 +613,7 @@ namespace System
             return true;
         }
 
-        internal static unsafe Boolean TryParseUInt32(String s, NumberStyles style, IFormatProvider provider, out UInt32 result)
+        internal static unsafe Boolean TryParseUInt32(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider, out UInt32 result)
         {
             NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -656,7 +642,7 @@ namespace System
             return true;
         }
 
-        internal static unsafe Boolean TryParseUInt64(String s, NumberStyles style, IFormatProvider provider, out UInt64 result)
+        internal static unsafe Boolean TryParseUInt64(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider, out UInt64 result)
         {
             NumberFormatInfo info = provider == null ? NumberFormatInfo.CurrentInfo : NumberFormatInfo.GetInstance(provider);
 
@@ -685,7 +671,7 @@ namespace System
             return true;
         }
 
-        internal static Boolean TryStringToNumber(String str, NumberStyles options, ref NumberBuffer number, NumberFormatInfo numfmt, Boolean parseDecimal)
+        internal static Boolean TryStringToNumber(ReadOnlySpan<char> str, NumberStyles options, ref NumberBuffer number, NumberFormatInfo numfmt, Boolean parseDecimal)
         {
             return TryStringToNumber(str, options, ref number, null, numfmt, parseDecimal);
         }

--- a/src/System.Private.CoreLib/src/System/Number.cs
+++ b/src/System.Private.CoreLib/src/System/Number.cs
@@ -541,7 +541,7 @@ namespace System
             return false;
         }
 
-        private static bool TrailingZeros(string s, int index)
+        private static bool TrailingZeros(ReadOnlySpan<char> s, int index)
         {
             // For compatibility, we need to allow trailing zeros at the end of a number string
             for (int i = index; i < s.Length; i++)
@@ -554,15 +554,11 @@ namespace System
             return true;
         }
 
-        internal static unsafe bool TryStringToNumber(string str, NumberStyles options, ref NumberBuffer number, StringBuilder sb, NumberFormatInfo numfmt, bool parseDecimal)
+        internal static unsafe bool TryStringToNumber(ReadOnlySpan<char> str, NumberStyles options, ref NumberBuffer number, StringBuilder sb, NumberFormatInfo numfmt, bool parseDecimal)
         {
-            if (str == null)
-            {
-                return false;
-            }
             Debug.Assert(numfmt != null);
 
-            fixed (char* stringPointer = str)
+            fixed (char* stringPointer = &str.DangerousGetPinnableReference())
             {
                 char* p = stringPointer;
                 if (!ParseNumber(ref p, options, ref number, sb, numfmt, parseDecimal)

--- a/src/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -122,6 +122,8 @@ namespace System
                     return "startIndex";
                 case ExceptionArgument.task:
                     return "task";
+                case ExceptionArgument.s:
+                    return "s";
                 default:
                     Debug.Assert(false,
                         "The enum value is not defined, please check the ExceptionArgument Enum.");
@@ -156,7 +158,8 @@ namespace System
         obj,
         value,
         startIndex,
-        task
+        task,
+        s
     }
 
     //


### PR DESCRIPTION
Additional CoreRT changes to go along with the "shared" changes in https://github.com/dotnet/coreclr/pull/13389.  This will need to be pulled in when those changes are mirrored over.

Contributes to dotnet/corefx#22403
Depends on dotnet/coreclr#13389

skip ci please