### PR TITLE
Teach InvokeUtil about Pointers

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/Pointer.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Pointer.cs
@@ -46,6 +46,6 @@ namespace System.Reflection
         }
 
         internal Type GetPointerType() => _ptrType;
-        internal object GetPointerValue() => (IntPtr)_ptr;
+        internal IntPtr GetPointerValue() => (IntPtr)_ptr;
     }
 }


### PR DESCRIPTION
Partial fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/478298

Right now, this is testable through FieldInfo.SetValue().
Method invocations will still fail because the toolchain turns all
pointer EETypes into "IntPtr" before we get called.

Logic inspired from
 https://github.com/dotnet/coreclr/blob/b24d46b2fed0166cfe3bc2ae39e95b6a049f52fe/src/vm/reflectioninvocation.cpp#L227