### PR TITLE
Hoist common field accessor properties into base classes.

### DIFF
--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/InstanceFieldAccessor.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/InstanceFieldAccessor.cs
@@ -2,24 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Threading;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
 
-using global::Internal.Runtime.Augments;
-using global::Internal.Reflection.Execution;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Runtime.Augments;
+using Internal.Reflection.Core.Execution;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
     internal abstract class InstanceFieldAccessor : FieldAccessor
     {
-        public InstanceFieldAccessor(RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle)
+        public InstanceFieldAccessor(RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle, int offsetPlusHeader)
         {
             this.DeclaringTypeHandle = declaringTypeHandle;
             this.FieldTypeHandle = fieldTypeHandle;
+            this.OffsetPlusHeader = offsetPlusHeader;
         }
 
         public abstract override int Offset { get; }
@@ -97,7 +94,8 @@ namespace Internal.Reflection.Execution.FieldAccessors
         protected abstract Object UncheckedGetField(Object obj);
         protected abstract void UncheckedSetField(Object obj, Object value);
 
-        protected RuntimeTypeHandle DeclaringTypeHandle { get; private set; }
-        protected RuntimeTypeHandle FieldTypeHandle { get; private set; }
+        protected int OffsetPlusHeader { get; }
+        protected RuntimeTypeHandle DeclaringTypeHandle { get; }
+        protected RuntimeTypeHandle FieldTypeHandle { get; }
     }
 }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/LiteralFieldAccessor.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/LiteralFieldAccessor.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Reflection;
-using System.Diagnostics;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForInstanceFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForInstanceFields.cs
@@ -2,33 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Threading;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-
-using global::Internal.Runtime.Augments;
-using global::Internal.Reflection.Execution;
-using global::Internal.Reflection.Core.Execution;
+using System;
+using Internal.Runtime.Augments;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
     internal sealed class ReferenceTypeFieldAccessorForInstanceFields : InstanceFieldAccessor
     {
-        private int _offset;
-
-        public ReferenceTypeFieldAccessorForInstanceFields(int offset, RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle)
-            : base(declaringTypeHandle, fieldTypeHandle)
+        public ReferenceTypeFieldAccessorForInstanceFields(int offsetPlusHeader, RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle)
+            : base(declaringTypeHandle, fieldTypeHandle, offsetPlusHeader)
         {
-            _offset = offset;
         }
 
-        public sealed override int Offset => _offset - RuntimeAugments.ObjectHeaderSize;
+        public sealed override int Offset => OffsetPlusHeader - RuntimeAugments.ObjectHeaderSize;
 
         protected sealed override Object UncheckedGetField(Object obj)
         {
-            return RuntimeAugments.LoadReferenceTypeField(obj, _offset);
+            return RuntimeAugments.LoadReferenceTypeField(obj, OffsetPlusHeader);
         }
 
         protected sealed override object UncheckedGetFieldDirectFromValueType(TypedReference typedReference)
@@ -38,7 +28,7 @@ namespace Internal.Reflection.Execution.FieldAccessors
 
         protected sealed override void UncheckedSetField(Object obj, Object value)
         {
-            RuntimeAugments.StoreReferenceTypeField(obj, _offset, value);
+            RuntimeAugments.StoreReferenceTypeField(obj, OffsetPlusHeader, value);
         }
 
         protected sealed override void UncheckedSetFieldDirectIntoValueType(TypedReference typedReference, object value)

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForStaticFields.cs
@@ -2,57 +2,46 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Runtime.CompilerServices;
-using global::System.Runtime.InteropServices;
-
-using global::Internal.Runtime.Augments;
+using System;
+using Internal.Runtime.Augments;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
-    internal sealed class ReferenceTypeFieldAccessorForStaticFields : WritableStaticFieldAccessor
+    internal sealed class ReferenceTypeFieldAccessorForStaticFields : RegularStaticFieldAccessor
     {
-        private IntPtr _staticsBase;
-        private bool _isGcStaticsBase;
-        private int _fieldOffset;
-
         public ReferenceTypeFieldAccessorForStaticFields(IntPtr cctorContext, IntPtr staticsBase, int fieldOffset, bool isGcStatic, RuntimeTypeHandle fieldTypeHandle)
-            : base(cctorContext, fieldTypeHandle)
+            : base(cctorContext, staticsBase, fieldOffset, isGcStatic, fieldTypeHandle)
         {
-            _staticsBase = staticsBase;
-            _isGcStaticsBase = isGcStatic;
-            _fieldOffset = fieldOffset;
         }
 
         unsafe protected sealed override Object GetFieldBypassCctor()
         {
 #if CORERT
-            if (_isGcStaticsBase)
+            if (IsGcStatic)
             {
                 // The _staticsBase variable points to a GC handle, which points at the GC statics base of the type.
                 // We need to perform a double indirection in a GC-safe manner.
-                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)_staticsBase);
-                return RuntimeAugments.LoadReferenceTypeField(gcStaticsRegion, _fieldOffset);
+                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)StaticsBase);
+                return RuntimeAugments.LoadReferenceTypeField(gcStaticsRegion, FieldOffset);
             }
 #endif
-            return RuntimeAugments.LoadReferenceTypeField(_staticsBase + _fieldOffset);
+            return RuntimeAugments.LoadReferenceTypeField(StaticsBase + FieldOffset);
         }
 
         unsafe protected sealed override void UncheckedSetFieldBypassCctor(Object value)
         {
 
 #if CORERT
-            if (_isGcStaticsBase)
+            if (IsGcStatic)
             {
                 // The _staticsBase variable points to a GC handle, which points at the GC statics base of the type.
                 // We need to perform a double indirection in a GC-safe manner.
-                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)_staticsBase);
-                RuntimeAugments.StoreReferenceTypeField(gcStaticsRegion, _fieldOffset, value);
+                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)StaticsBase);
+                RuntimeAugments.StoreReferenceTypeField(gcStaticsRegion, FieldOffset, value);
                 return;
             }
 #endif
-            RuntimeAugments.StoreReferenceTypeField(_staticsBase + _fieldOffset, value);
+            RuntimeAugments.StoreReferenceTypeField(StaticsBase + FieldOffset, value);
         }
     }
 }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForThreadStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ReferenceTypeFieldAccessorForThreadStaticFields.cs
@@ -2,41 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Threading;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-
-using global::Internal.Runtime.Augments;
-using global::Internal.Reflection.Execution;
-using global::Internal.Reflection.Core.Execution;
+using System;
+using Internal.Runtime.Augments;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
-    internal sealed class ReferenceTypeFieldAccessorForThreadStaticFields : WritableStaticFieldAccessor
+    internal sealed class ReferenceTypeFieldAccessorForThreadStaticFields : ThreadStaticFieldAccessor
     {
-        private int _threadStaticsBlockOffset;
-        private int _fieldOffset;
-        private RuntimeTypeHandle _declaringTypeHandle;
-
         public ReferenceTypeFieldAccessorForThreadStaticFields(IntPtr cctorContext, RuntimeTypeHandle declaringTypeHandle, int threadStaticsBlockOffset, int fieldOffset, RuntimeTypeHandle fieldTypeHandle)
-            : base(cctorContext, fieldTypeHandle)
+            : base(cctorContext, declaringTypeHandle, threadStaticsBlockOffset, fieldOffset, fieldTypeHandle)
         {
-            _threadStaticsBlockOffset = threadStaticsBlockOffset;
-            _fieldOffset = fieldOffset;
-            _declaringTypeHandle = declaringTypeHandle;
         }
 
         protected sealed override Object GetFieldBypassCctor()
         {
-            IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(_declaringTypeHandle, _threadStaticsBlockOffset, _fieldOffset);
+            IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(DeclaringTypeHandle, ThreadStaticsBlockOffset, FieldOffset);
             return RuntimeAugments.LoadReferenceTypeField(fieldAddress);
         }
 
         protected sealed override void UncheckedSetFieldBypassCctor(Object value)
         {
-            IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(_declaringTypeHandle, _threadStaticsBlockOffset, _fieldOffset);
+            IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(DeclaringTypeHandle, ThreadStaticsBlockOffset, FieldOffset);
             RuntimeAugments.StoreReferenceTypeField(fieldAddress, value);
         }
     }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/RegularStaticFieldAccessor.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/RegularStaticFieldAccessor.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Internal.Reflection.Execution.FieldAccessors
+{
+    internal abstract class RegularStaticFieldAccessor : WritableStaticFieldAccessor
+    {
+        protected RegularStaticFieldAccessor(IntPtr cctorContext, IntPtr staticsBase, int fieldOffset, bool isGcStatic, RuntimeTypeHandle fieldTypeHandle)
+            : base(cctorContext, fieldTypeHandle)
+        {
+            StaticsBase = staticsBase;
+            IsGcStatic = isGcStatic;
+            FieldOffset = fieldOffset;
+        }
+
+        protected IntPtr StaticsBase { get; }
+        protected bool IsGcStatic { get; }
+        protected int FieldOffset { get; }
+    }
+}

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/StaticFieldAccessor.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/StaticFieldAccessor.cs
@@ -2,21 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Threading;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
 
-using global::Internal.Runtime.Augments;
-using global::Internal.Reflection.Execution;
-using global::Internal.Reflection.Core.Execution;
+using Internal.Runtime.Augments;
+using Internal.Reflection.Core.Execution;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
     internal abstract class StaticFieldAccessor : FieldAccessor
     {
-        protected RuntimeTypeHandle FieldTypeHandle { get; private set; }
+        protected RuntimeTypeHandle FieldTypeHandle { get; }
 
         private IntPtr _cctorContext;
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ThreadStaticFieldAccessor.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ThreadStaticFieldAccessor.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Internal.Reflection.Execution.FieldAccessors
+{
+    internal abstract class ThreadStaticFieldAccessor : WritableStaticFieldAccessor
+    {
+        protected ThreadStaticFieldAccessor(IntPtr cctorContext, RuntimeTypeHandle declaringTypeHandle, int threadStaticsBlockOffset, int fieldOffset, RuntimeTypeHandle fieldTypeHandle)
+            : base(cctorContext, fieldTypeHandle)
+        {
+            ThreadStaticsBlockOffset = threadStaticsBlockOffset;
+            FieldOffset = fieldOffset;
+            DeclaringTypeHandle = declaringTypeHandle;
+        }
+
+        protected int ThreadStaticsBlockOffset { get; }
+        protected int FieldOffset { get; }
+        protected RuntimeTypeHandle DeclaringTypeHandle { get; }
+    }
+}

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForInstanceFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForInstanceFields.cs
@@ -2,33 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Threading;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-
-using global::Internal.Runtime.Augments;
-using global::Internal.Reflection.Execution;
-using global::Internal.Reflection.Core.Execution;
+using System;
+using Internal.Runtime.Augments;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
     internal sealed class ValueTypeFieldAccessorForInstanceFields : InstanceFieldAccessor
     {
-        private int _offset;
-
-        public ValueTypeFieldAccessorForInstanceFields(int offset, RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle)
-            : base(declaringTypeHandle, fieldTypeHandle)
+        public ValueTypeFieldAccessorForInstanceFields(int offsetPlusHeader, RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle)
+            : base(declaringTypeHandle, fieldTypeHandle, offsetPlusHeader)
         {
-            _offset = offset;
         }
 
-        public sealed override int Offset => _offset - RuntimeAugments.ObjectHeaderSize;
+        public sealed override int Offset => OffsetPlusHeader - RuntimeAugments.ObjectHeaderSize;
 
         protected sealed override Object UncheckedGetField(Object obj)
         {
-            return RuntimeAugments.LoadValueTypeField(obj, _offset, this.FieldTypeHandle);
+            return RuntimeAugments.LoadValueTypeField(obj, OffsetPlusHeader, this.FieldTypeHandle);
         }
 
         protected sealed override object UncheckedGetFieldDirectFromValueType(TypedReference typedReference)
@@ -38,7 +28,7 @@ namespace Internal.Reflection.Execution.FieldAccessors
 
         protected sealed override void UncheckedSetField(Object obj, Object value)
         {
-            RuntimeAugments.StoreValueTypeField(obj, _offset, value, this.FieldTypeHandle);
+            RuntimeAugments.StoreValueTypeField(obj, OffsetPlusHeader, value, this.FieldTypeHandle);
         }
 
         protected sealed override void UncheckedSetFieldDirectIntoValueType(TypedReference typedReference, object value)

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForStaticFields.cs
@@ -2,56 +2,46 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Runtime.CompilerServices;
-
-using global::Internal.Runtime.Augments;
+using System;
+using Internal.Runtime.Augments;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
-    internal sealed class ValueTypeFieldAccessorForStaticFields : WritableStaticFieldAccessor
+    internal sealed class ValueTypeFieldAccessorForStaticFields : RegularStaticFieldAccessor
     {
-        private IntPtr _staticsBase;
-        private bool _isGcStaticsBase;
-        private int _fieldOffset;
-
         public ValueTypeFieldAccessorForStaticFields(IntPtr cctorContext, IntPtr staticsBase, int fieldOffset, bool isGcStatic, RuntimeTypeHandle fieldTypeHandle)
-            : base(cctorContext, fieldTypeHandle)
+            : base(cctorContext, staticsBase, fieldOffset, isGcStatic, fieldTypeHandle)
         {
-            _staticsBase = staticsBase;
-            _isGcStaticsBase = isGcStatic;
-            _fieldOffset = fieldOffset;
         }
 
         unsafe protected sealed override Object GetFieldBypassCctor()
         {
 #if CORERT
-            if (_isGcStaticsBase)
+            if (IsGcStatic)
             {
                 // The _staticsBase variable points to a GC handle, which points at the GC statics base of the type.
                 // We need to perform a double indirection in a GC-safe manner.
-                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)_staticsBase);
-                return RuntimeAugments.LoadValueTypeField(gcStaticsRegion, _fieldOffset, FieldTypeHandle);
+                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)StaticsBase);
+                return RuntimeAugments.LoadValueTypeField(gcStaticsRegion, FieldOffset, FieldTypeHandle);
             }
 #endif
-            return RuntimeAugments.LoadValueTypeField(_staticsBase + _fieldOffset, FieldTypeHandle);
+            return RuntimeAugments.LoadValueTypeField(StaticsBase + FieldOffset, FieldTypeHandle);
         }
 
         unsafe protected sealed override void UncheckedSetFieldBypassCctor(Object value)
         {
 
 #if CORERT
-            if (_isGcStaticsBase)
+            if (IsGcStatic)
             {
                 // The _staticsBase variable points to a GC handle, which points at the GC statics base of the type.
                 // We need to perform a double indirection in a GC-safe manner.
-                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)_staticsBase);
-                RuntimeAugments.StoreValueTypeField(gcStaticsRegion, _fieldOffset, value, FieldTypeHandle);
+                object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(*(IntPtr*)StaticsBase);
+                RuntimeAugments.StoreValueTypeField(gcStaticsRegion, FieldOffset, value, FieldTypeHandle);
                 return;
             }
 #endif
-            RuntimeAugments.StoreValueTypeField(_staticsBase + _fieldOffset, value, FieldTypeHandle);
+            RuntimeAugments.StoreValueTypeField(StaticsBase + FieldOffset, value, FieldTypeHandle);
         }
     }
 }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForThreadStaticFields.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/ValueTypeFieldAccessorForThreadStaticFields.cs
@@ -2,43 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Threading;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-
-using global::Internal.Runtime.Augments;
-using global::Internal.Reflection.Execution;
-using global::Internal.Reflection.Core.Execution;
-
-using global::Internal.Metadata.NativeFormat;
+using System;
+using Internal.Runtime.Augments;
 
 namespace Internal.Reflection.Execution.FieldAccessors
 {
-    internal sealed class ValueTypeFieldAccessorForThreadStaticFields : WritableStaticFieldAccessor
+    internal sealed class ValueTypeFieldAccessorForThreadStaticFields : ThreadStaticFieldAccessor
     {
-        private int _threadStaticsBlockOffset;
-        private int _fieldOffset;
-        private RuntimeTypeHandle _declaringTypeHandle;
-
         public ValueTypeFieldAccessorForThreadStaticFields(IntPtr cctorContext, RuntimeTypeHandle declaringTypeHandle, int threadStaticsBlockOffset, int fieldOffset, RuntimeTypeHandle fieldTypeHandle)
-            : base(cctorContext, fieldTypeHandle)
+            : base(cctorContext, declaringTypeHandle, threadStaticsBlockOffset, fieldOffset, fieldTypeHandle)
         {
-            _threadStaticsBlockOffset = threadStaticsBlockOffset;
-            _fieldOffset = fieldOffset;
-            _declaringTypeHandle = declaringTypeHandle;
         }
 
         protected sealed override Object GetFieldBypassCctor()
         {
-            IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(_declaringTypeHandle, _threadStaticsBlockOffset, _fieldOffset);
+            IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(DeclaringTypeHandle, ThreadStaticsBlockOffset, FieldOffset);
             return RuntimeAugments.LoadValueTypeField(fieldAddress, FieldTypeHandle);
         }
 
         protected sealed override void UncheckedSetFieldBypassCctor(Object value)
         {
-            IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(_declaringTypeHandle, _threadStaticsBlockOffset, _fieldOffset);
+            IntPtr fieldAddress = RuntimeAugments.GetThreadStaticFieldAddress(DeclaringTypeHandle, ThreadStaticsBlockOffset, FieldOffset);
             RuntimeAugments.StoreValueTypeField(fieldAddress, value, FieldTypeHandle);
         }
     }

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -71,10 +71,12 @@
     <Compile Include="Internal\Reflection\Execution\RuntimeHandlesExtensions.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\InstanceFieldAccessor.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\LiteralFieldAccessor.cs" />
+    <Compile Include="Internal\Reflection\Execution\FieldAccessors\RegularStaticFieldAccessor.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\ReferenceTypeFieldAccessorForInstanceFields.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\ReferenceTypeFieldAccessorForStaticFields.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\ReferenceTypeFieldAccessorForThreadStaticFields.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\StaticFieldAccessor.cs" />
+    <Compile Include="Internal\Reflection\Execution\FieldAccessors\ThreadStaticFieldAccessor.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\ValueTypeFieldAccessorForInstanceFields.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\ValueTypeFieldAccessorForStaticFields.cs" />
     <Compile Include="Internal\Reflection\Execution\FieldAccessors\ValueTypeFieldAccessorForThreadStaticFields.cs" />


### PR DESCRIPTION
We'll be needing to add FieldAccessors for pointer fields
to this hierarchy and in preparing for that, noticed
some DRY in the existing hierarchy that would be
multiplied by 150% if we add field accessors for pointers
without cleaning this up.