### PR TITLE
Emit IsByRefLike flag on generic definitions

### DIFF
--- a/src/Common/src/TypeSystem/Canon/CanonTypes.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.cs
@@ -124,6 +124,7 @@ namespace Internal.TypeSystem
             }
 
             flags |= TypeFlags.HasFinalizerComputed;
+            flags |= TypeFlags.IsByRefLikeComputed;
 
             return flags;
         }
@@ -213,6 +214,7 @@ namespace Internal.TypeSystem
             }
 
             flags |= TypeFlags.HasFinalizerComputed;
+            flags |= TypeFlags.IsByRefLikeComputed;
 
             return flags;
         }

--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -145,6 +145,8 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasFinalizerComputed;
 
+            flags |= TypeFlags.IsByRefLikeComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/ByRefType.cs
+++ b/src/Common/src/TypeSystem/Common/ByRefType.cs
@@ -37,6 +37,8 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasFinalizerComputed;
 
+            flags |= TypeFlags.IsByRefLikeComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/DefType.FieldLayout.cs
@@ -49,16 +49,6 @@ namespace Internal.TypeSystem
             /// True if information about the shape of value type has been computed.
             /// </summary>
             public const int ComputedValueTypeShapeCharacteristics = 0x40;
-
-            /// <summary>
-            /// True if <see cref="IsByRefLike"/> has been computed.
-            /// </summary>
-            public const int ComputedIsByRefLike = 0x80;
-
-            /// <summary>
-            /// True if this is a byref-like type.
-            /// </summary>
-            public const int IsByRefLike = 0x100;
         }
 
         private class StaticBlockInfo
@@ -297,22 +287,6 @@ namespace Internal.TypeSystem
             }
         }
 
-        /// <summary>
-        /// Gets a value indicating whether this is a byref-like type
-        /// (a <code>TypedReference</code>, <code>Span&lt;T&gt;</code>, etc.).
-        /// </summary>
-        public bool IsByRefLike
-        {
-            get
-            {
-                if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedIsByRefLike))
-                {
-                    ComputeIsByRefLike();
-                }
-                return _fieldLayoutFlags.HasFlags(FieldLayoutFlags.IsByRefLike);
-            }
-        }
-
         private void ComputeValueTypeShapeCharacteristics()
         {
             _valueTypeShapeCharacteristics = this.Context.GetLayoutAlgorithmForType(this).ComputeValueTypeShapeCharacteristics(this);
@@ -398,21 +372,5 @@ namespace Internal.TypeSystem
 
             _fieldLayoutFlags.AddFlags(flagsToAdd);
         }
-
-        public void ComputeIsByRefLike()
-        {
-            if (_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedIsByRefLike))
-                return;
-
-            int flagsToAdd = FieldLayoutFlags.ComputedIsByRefLike;
-
-            if (this.Context.GetLayoutAlgorithmForType(this).ComputeIsByRefLike(this))
-            {
-                flagsToAdd |= FieldLayoutFlags.IsByRefLike;
-            }
-
-            _fieldLayoutFlags.AddFlags(flagsToAdd);
-        }
     }
-
 }

--- a/src/Common/src/TypeSystem/Common/FieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/FieldLayoutAlgorithm.cs
@@ -43,11 +43,6 @@ namespace Internal.TypeSystem
         /// the element type of the homogenous float aggregate. This will either be System.Double or System.Float.
         /// </summary>
         public abstract DefType ComputeHomogeneousFloatAggregateElementType(DefType type);
-
-        /// <summary>
-        /// Compute whether '<paramref name="type"/>' is a ByRef-like value type (TypedReference, Span&lt;T&gt;, etc.).
-        /// </summary>
-        public abstract bool ComputeIsByRefLike(DefType type);
     }
 
     /// <summary>

--- a/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
+++ b/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
@@ -67,6 +67,8 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasFinalizerComputed;
 
+            flags |= TypeFlags.IsByRefLikeComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
+++ b/src/Common/src/TypeSystem/Common/GenericParameterDesc.cs
@@ -164,6 +164,8 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasGenericVarianceComputed;
 
+            flags |= TypeFlags.IsByRefLikeComputed;
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -104,6 +104,14 @@ namespace Internal.TypeSystem
                     flags |= TypeFlags.HasFinalizer;
             }
 
+            if ((mask & TypeFlags.IsByRefLikeComputed) != 0)
+            {
+                flags |= TypeFlags.IsByRefLikeComputed;
+
+                if (_typeDef.IsByRefLike)
+                    flags |= TypeFlags.IsByRefLike;
+            }
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -37,12 +37,9 @@ namespace Internal.TypeSystem
                 if (fieldType.IsByRef)
                     ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
 
-                // ByRef-like instance fields on reference types are not allowed.
-                if (fieldType.IsValueType && !type.IsValueType)
-                {
-                    if (((DefType)fieldType).IsByRefLike)
-                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
-                }
+                // ByRef-like instance fields on non-byref-like types are not allowed.
+                if (fieldType.IsByRefLike && !type.IsByRefLike)
+                    ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
 
                 numInstanceFields++;
             }
@@ -621,34 +618,6 @@ namespace Internal.TypeSystem
                         return null;
                 }
             }
-        }
-
-        public override bool ComputeIsByRefLike(DefType type)
-        {
-            // Reference types can never be ByRef-like.
-            if (!type.IsValueType)
-                return false;
-
-            if (type.IsByReferenceOfT)
-                return true;
-
-            foreach (FieldDesc field in type.GetFields())
-            {
-                if (field.IsStatic)
-                    continue;
-
-                TypeDesc fieldType = field.FieldType;
-                if (fieldType.IsValueType && !fieldType.IsPrimitive)
-                {
-                    DefType fieldDefType = (DefType)fieldType;
-                    if (fieldDefType.IsByRefLike)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
         }
 
         private struct SizeAndAlignment

--- a/src/Common/src/TypeSystem/Common/PointerType.cs
+++ b/src/Common/src/TypeSystem/Common/PointerType.cs
@@ -35,6 +35,7 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasGenericVarianceComputed;
             flags |= TypeFlags.HasFinalizerComputed;
+            flags |= TypeFlags.IsByRefLikeComputed;
 
             return flags;
         }

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -617,5 +617,17 @@ namespace Internal.TypeSystem
                 return HasInstantiation && IsTypeDefinition;
             }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether this is a byref-like type
+        /// (a <code>TypedReference</code>, <code>Span&lt;T&gt;</code>, etc.).
+        /// </summary>
+        public bool IsByRefLike
+        {
+            get
+            {
+                return (GetTypeFlags(TypeFlags.IsByRefLike | TypeFlags.IsByRefLikeComputed) & TypeFlags.IsByRefLike) != 0;
+            }
+        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/TypeFlags.cs
+++ b/src/Common/src/TypeSystem/Common/TypeFlags.cs
@@ -56,5 +56,8 @@ namespace Internal.TypeSystem
 
         HasFinalizerComputed = 0x1000,
         HasFinalizer         = 0x2000,
+
+        IsByRefLike          = 0x4000,
+        IsByRefLikeComputed  = 0x8000,
     }
 }

--- a/src/Common/src/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
@@ -22,11 +22,6 @@ namespace Internal.TypeSystem
             throw new NotSupportedException();
         }
 
-        public override bool ComputeIsByRefLike(DefType type)
-        {
-            return false;
-        }
-
         public override DefType ComputeHomogeneousFloatAggregateElementType(DefType type)
         {
             return null;

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -241,6 +241,14 @@ namespace Internal.TypeSystem.Ecma
                     flags |= TypeFlags.HasFinalizer;
             }
 
+            if ((mask & TypeFlags.IsByRefLikeComputed) != 0)
+            {
+                flags |= TypeFlags.IsByRefLikeComputed;
+
+                if (IsValueType && HasCustomAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute"))
+                    flags |= TypeFlags.IsByRefLike;
+            }
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -219,6 +219,7 @@ namespace Internal.TypeSystem.Interop
             }
 
             flags |= TypeFlags.HasFinalizerComputed;
+            flags |= TypeFlags.IsByRefLikeComputed;
 
             return flags;
         }

--- a/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
@@ -301,6 +301,7 @@ namespace Internal.TypeSystem.Interop
             }
 
             flags |= TypeFlags.HasFinalizerComputed;
+            flags |= TypeFlags.IsByRefLikeComputed;
 
             return flags;
         }

--- a/src/Common/src/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
@@ -204,6 +204,7 @@ namespace Internal.TypeSystem.Interop
             }
 
             flags |= TypeFlags.HasFinalizerComputed;
+            flags |= TypeFlags.IsByRefLikeComputed;
 
             return flags;
         }

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
@@ -287,6 +287,14 @@ namespace Internal.TypeSystem.NativeFormat
                     flags |= TypeFlags.HasFinalizer;
             }
 
+            if ((mask & TypeFlags.IsByRefLikeComputed) != 0)
+            {
+                flags |= TypeFlags.IsByRefLikeComputed;
+
+                if (IsValueType && HasCustomAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute"))
+                    flags |= TypeFlags.IsByRefLike;
+            }
+
             return flags;
         }
 

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
@@ -51,14 +51,6 @@ namespace Internal.TypeSystem
             return canonicalType.ContainsGCPointers;
         }
 
-        public override bool ComputeIsByRefLike(DefType type)
-        {
-            RuntimeDeterminedType runtimeDeterminedType = (RuntimeDeterminedType)type;
-            DefType canonicalType = runtimeDeterminedType.CanonicalType;
-
-            return canonicalType.IsByRefLike;
-        }
-
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
             RuntimeDeterminedType runtimeDeterminedType = (RuntimeDeterminedType)type;

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedType.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedType.cs
@@ -77,7 +77,8 @@ namespace ILCompiler
             return TypeFlags.Class |
                 TypeFlags.HasGenericVarianceComputed |
                 TypeFlags.HasStaticConstructorComputed |
-                TypeFlags.HasFinalizerComputed;
+                TypeFlags.HasFinalizerComputed |
+                TypeFlags.IsByRefLikeComputed;
         }
 
         public override ClassLayoutMetadata GetClassLayout()

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -268,6 +268,7 @@ namespace ILCompiler
                 }
 
                 flags |= TypeFlags.HasFinalizerComputed;
+                flags |= TypeFlags.IsByRefLikeComputed;
 
                 return flags;
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -771,7 +771,7 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (uint)EETypeRareFlags.IsAbstractClassFlag;
             }
 
-            if (metadataType != null && metadataType.IsByRefLike)
+            if (_type.IsByRefLike)
             {
                 flags |= (uint)EETypeRareFlags.IsByRefLikeFlag;
             }
@@ -935,7 +935,7 @@ namespace ILCompiler.DependencyAnalysis
                         || typeArg.IsPointer
                         || typeArg.IsFunctionPointer
                         || typeArg.IsVoid
-                        || (typeArg.IsValueType && ((DefType)typeArg).IsByRefLike))
+                        || typeArg.IsByRefLike)
                     {
                         ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
                     }
@@ -976,7 +976,7 @@ namespace ILCompiler.DependencyAnalysis
                         ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadRankTooLarge, type);
                     }
 
-                    if ((parameterType.IsDefType) && ((DefType)parameterType).IsByRefLike)
+                    if (parameterType.IsByRefLike)
                     {
                         // Arrays of byref-like types are not allowed
                         ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -51,6 +51,8 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (short)EETypeFlags.IsInterfaceFlag;
             if (factory.TypeSystemContext.HasLazyStaticConstructor(_type))
                 rareFlags = rareFlags | EETypeRareFlags.HasCctorFlag;
+            if (_type.IsByRefLike)
+                rareFlags |= EETypeRareFlags.IsByRefLikeFlag;
 
             if (rareFlags != 0)
                 _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldTag.RareFlags, (uint)rareFlags);

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -246,13 +246,13 @@ namespace ILCompiler
             // Methods that return ByRef-like types or take them by reference can't be reflection invoked
             // ----------------------------------------------------------------
 
-            if (signature.ReturnType.IsDefType && ((DefType)signature.ReturnType).IsByRefLike)
+            if (signature.ReturnType.IsByRefLike)
                 return false;
 
             for (int i = 0; i < signature.Length; i++)
             {
                 ByRefType paramType = signature[i] as ByRefType;
-                if (paramType != null && paramType.ParameterType.IsDefType && ((DefType)paramType.ParameterType).IsByRefLike)
+                if (paramType != null && paramType.ParameterType.IsByRefLike)
                     return false;
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/VectorOfTFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/VectorOfTFieldLayoutAlgorithm.cs
@@ -63,11 +63,6 @@ namespace ILCompiler
             return false;
         }
 
-        public override bool ComputeIsByRefLike(DefType type)
-        {
-            return false;
-        }
-
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
             return _fallbackAlgorithm.ComputeValueTypeShapeCharacteristics(type);

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/InstanceFieldLayout.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/InstanceFieldLayout.cs
@@ -148,14 +148,10 @@ namespace Sequential
 
 namespace IsByRefLike
 {
+    [System.Runtime.CompilerServices.IsByRefLike]
     public struct ByRefLikeStruct
     {
         ByReference<object> ByRef;
-    }
-
-    public struct ComposedStruct
-    {
-        ByRefLikeStruct ByRefLike;
     }
 
     public struct NotByRefLike
@@ -163,12 +159,13 @@ namespace IsByRefLike
         int X;
     }
 
-    public class Invalid
+    [System.Runtime.CompilerServices.IsByRefLike]
+    public class InvalidClass
     {
         ByReference<int> ByRef;
     }
 
-    public class ComposedInvalid
+    public struct InvalidStruct
     {
         ByRefLikeStruct ByRefLike;
     }

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/Platform.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/Platform.cs
@@ -67,12 +67,14 @@ namespace System
 
     public class Exception { }
 
+    [System.Runtime.CompilerServices.IsByRefLike]
     public struct TypedReference
     {
         private readonly ByReference<byte> _value;
         private readonly RuntimeTypeHandle _typeHandle;
     }
 
+    [System.Runtime.CompilerServices.IsByRefLike]
     public struct ByReference<T> { }
 }
 
@@ -128,3 +130,9 @@ namespace System.Runtime.InteropServices
     }
 }
 
+namespace System.Runtime.CompilerServices
+{
+    public sealed class IsByRefLikeAttribute : Attribute
+    {
+    }
+}

--- a/src/ILCompiler.TypeSystem/tests/InstanceFieldLayoutTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/InstanceFieldLayoutTests.cs
@@ -319,11 +319,6 @@ namespace TypeSystemTests
             }
 
             {
-                DefType type = _testModule.GetType("IsByRefLike", "ComposedStruct");
-                Assert.True(type.IsByRefLike);
-            }
-
-            {
                 DefType type = _testModule.GetType("IsByRefLike", "NotByRefLike");
                 Assert.False(type.IsByRefLike);
             }
@@ -333,12 +328,12 @@ namespace TypeSystemTests
         public void TestInvalidByRefLikeTypes()
         {
             {
-                DefType type = _testModule.GetType("IsByRefLike", "Invalid");
+                DefType type = _testModule.GetType("IsByRefLike", "InvalidClass");
                 Assert.Throws<TypeSystemException.TypeLoadException>(() => type.ComputeInstanceLayout(InstanceLayoutKind.TypeAndFields));
             }
 
             {
-                DefType type = _testModule.GetType("IsByRefLike", "ComposedInvalid");
+                DefType type = _testModule.GetType("IsByRefLike", "InvalidStruct");
                 Assert.Throws<TypeSystemException.TypeLoadException>(() => type.ComputeInstanceLayout(InstanceLayoutKind.TypeAndFields));
             }
         }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1498,7 +1498,7 @@ namespace Internal.JitInterface
 
             // we shouldn't allow boxing of types that contains stack pointers
             // csc and vbc already disallow it.
-            if (type.IsValueType && ((DefType)type).IsByRefLike)
+            if (type.IsByRefLike)
                 ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramSpecific, MethodBeingCompiled);
 
             return type.IsNullable ? CorInfoHelpFunc.CORINFO_HELP_BOX_NULLABLE : CorInfoHelpFunc.CORINFO_HELP_BOX;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutFieldAlgorithm.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutFieldAlgorithm.cs
@@ -37,17 +37,6 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        public unsafe override bool ComputeIsByRefLike(DefType type)
-        {
-            if (type.RetrieveRuntimeTypeHandleIfPossible())
-            {
-                return type.RuntimeTypeHandle.ToEETypePtr()->IsByRefLike;
-            }
-
-            // Being ByRefLike is a property of the uninstantiated form of a type (so its set on all kinds of templates reliably)
-            return type.ComputeTemplate().RuntimeTypeHandle.ToEETypePtr()->IsByRefLike;
-        }
-
         public override ComputedInstanceFieldLayout ComputeInstanceLayout(DefType type, InstanceLayoutKind layoutKind)
         {
             if (!type.IsTemplateUniversal() && (layoutKind == InstanceLayoutKind.TypeOnly))

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NoMetadataFieldLayoutAlgorithm.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NoMetadataFieldLayoutAlgorithm.cs
@@ -23,11 +23,6 @@ namespace Internal.Runtime.TypeLoader
             return type.RuntimeTypeHandle.ToEETypePtr()->HasGCPointers;
         }
 
-        public unsafe override bool ComputeIsByRefLike(DefType type)
-        {
-            return type.RuntimeTypeHandle.ToEETypePtr()->IsByRefLike;
-        }
-
         /// <summary>
         /// Reads the minimal information about type layout encoded in the 
         /// EEType. That doesn't include field information.

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeNoMetadataType.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeNoMetadataType.cs
@@ -195,6 +195,20 @@ namespace Internal.TypeSystem.NoMetadata
                 }
             }
 
+            if ((mask & TypeFlags.IsByRefLikeComputed) != 0)
+            {
+                flags |= TypeFlags.IsByRefLikeComputed;
+
+                unsafe
+                {
+                    EEType* eetype = _genericTypeDefinition.ToEETypePtr();
+                    if (eetype->IsByRefLike)
+                    {
+                        flags |= TypeFlags.IsByRefLike;
+                    }
+                }
+            }
+
             return flags;
         }
 


### PR DESCRIPTION
Also took the opportunity to make the IsByRefLike flag not be a property
of the field layout (but use the newly approved custom attribute that
everyone else uses).

Fixes #4220.