### PR TITLE
Avoid unnecessary intermediate Version allocation

### DIFF
--- a/src/System.Private.CoreLib/src/System/AppContextDefaultValues.cs
+++ b/src/System.Private.CoreLib/src/System/AppContextDefaultValues.cs
@@ -100,7 +100,7 @@ namespace System
                     {
                         value = value.Substring(1);
                     }
-                    Version realVersion = new Version(value);
+                    Version realVersion = Version.Parse(value);
                     // The version class will represent some unset values as -1 internally (instead of 0).
                     version = realVersion.Major * 10000;
                     if (realVersion.Minor > 0)

--- a/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -748,7 +748,7 @@ namespace System.Resources
             Version ver;
             try
             {
-                ver = new Version(v);
+                ver = Version.Parse(v);
             }
             catch (ArgumentOutOfRangeException e)
             {


### PR DESCRIPTION
Just a minor nit: `Version..ctor(string)` is [implemented](https://github.com/dotnet/corert/blob/aed0a825e6e6eb2663c71af1ea2717dc837e816f/src/System.Private.CoreLib/shared/System/Version.cs#L81-L88) by calling `Version.Parse`, which allocates an intermediate `Version` instance. Avoid the unnecessary intermediate allocation by using `Version.Parse` directly.

Related: https://github.com/dotnet/coreclr/pull/13496