### PR TITLE
Generate portable PDBs by default for managed projects

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -104,6 +104,7 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LangVersion>7</LangVersion>
+    <DebugType Condition="'$(IsProjectNLibrary)' != 'true'">portable</DebugType>
   </PropertyGroup>
 
   <!-- Set up handling of build warnings -->

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -5,6 +5,7 @@
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
     <OutputPath>$(MSBuildProjectDirectory)\bin\$(Configuration)\$(Platform)\</OutputPath>
     <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
+    <DebugType Condition="'$(DebugType)' == ''">portable</DebugType>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Single file compilation gets about 8% faster as a result (DIA APIs are super slow), and the PDBs get about 7x smaller.

Line numbers and locals still work fine.

I'm specifically not enabling this for Project N because a Project N debugger person should do that really.