### PR TITLE
Fix debugger stepping into Main method

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DebuggerSteppingHelpers.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DebuggerSteppingHelpers.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.IL.Stubs
+{
+    public static class DebuggerSteppingHelpers
+    {
+        public static void BeginDebuggerGuidedStepThroughMethod(this ILCodeStream codeStream)
+        {
+            codeStream.DefineSequencePoint("", 0xF00F00);
+        }
+
+        public static void MarkDebuggerStepInPoint(this ILCodeStream codeStream)
+        {
+            codeStream.DefineSequencePoint("", 0xFEEFEE);
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -28,6 +28,7 @@ namespace Internal.IL.Stubs
         internal byte[] _instructions;
         internal int _length;
         internal int _startOffsetForLinking;
+        internal ArrayBuilder<ILSequencePoint> _sequencePoints;
 
         private ArrayBuilder<LabelAndOffset> _offsetsNeedingPatching;
 
@@ -438,6 +439,11 @@ namespace Internal.IL.Stubs
                 _instructions[offset + 3] = (byte)(value >> 24);
             }
         }
+
+        public void DefineSequencePoint(string document, int lineNumber)
+        {
+            _sequencePoints.Add(new ILSequencePoint(_length, document, lineNumber));
+        }
     }
 
     /// <summary>
@@ -453,17 +459,22 @@ namespace Internal.IL.Stubs
 
     public class ILStubMethodIL : MethodIL
     {
-        private byte[] _ilBytes;
-        private LocalVariableDefinition[] _locals;
-        private Object[] _tokens;
-        private MethodDesc _method;
+        private readonly byte[] _ilBytes;
+        private readonly LocalVariableDefinition[] _locals;
+        private readonly Object[] _tokens;
+        private readonly MethodDesc _method;
+        private readonly MethodDebugInformation _debugInformation;
 
-        public ILStubMethodIL(MethodDesc owningMethod, byte[] ilBytes, LocalVariableDefinition[] locals, Object[] tokens)
+        public ILStubMethodIL(MethodDesc owningMethod, byte[] ilBytes, LocalVariableDefinition[] locals, Object[] tokens, MethodDebugInformation debugInfo = null)
         {
             _ilBytes = ilBytes;
             _locals = locals;
             _tokens = tokens;
             _method = owningMethod;
+
+            if (debugInfo == null)
+                debugInfo = MethodDebugInformation.None;
+            _debugInformation = debugInfo;
         }
 
         public ILStubMethodIL(ILStubMethodIL methodIL)
@@ -472,6 +483,7 @@ namespace Internal.IL.Stubs
             _locals = methodIL._locals;
             _tokens = methodIL._tokens;
             _method = methodIL._method;
+            _debugInformation = methodIL._debugInformation;
         }
 
         public override MethodDesc OwningMethod
@@ -486,6 +498,12 @@ namespace Internal.IL.Stubs
         {
             return _ilBytes;
         }
+
+        public override MethodDebugInformation GetDebugInfo()
+        {
+            return _debugInformation;
+        }
+
         public override int MaxStack
         {
             get
@@ -617,11 +635,14 @@ namespace Internal.IL.Stubs
         public MethodIL Link(MethodDesc owningMethod)
         {
             int totalLength = 0;
+            int numSequencePoints = 0;
+
             for (int i = 0; i < _codeStreams.Count; i++)
             {
                 ILCodeStream ilCodeStream = _codeStreams[i];
                 ilCodeStream._startOffsetForLinking = totalLength;
                 totalLength += ilCodeStream._length;
+                numSequencePoints += ilCodeStream._sequencePoints.Count;
             }
 
             byte[] ilInstructions = new byte[totalLength];
@@ -634,7 +655,45 @@ namespace Internal.IL.Stubs
                 copiedLength += ilCodeStream._length;
             }
 
-            return new ILStubMethodIL(owningMethod, ilInstructions, _locals.ToArray(), _tokens.ToArray());
+            MethodDebugInformation debugInfo = null;
+            if (numSequencePoints > 0)
+            {
+                ILSequencePoint[] sequencePoints = new ILSequencePoint[numSequencePoints];
+                int copiedSequencePointLength = 0;
+                for (int codeStreamIndex = 0; codeStreamIndex < _codeStreams.Count; codeStreamIndex++)
+                {
+                    ILCodeStream ilCodeStream = _codeStreams[codeStreamIndex];
+
+                    for (int sequencePointIndex = 0; sequencePointIndex < ilCodeStream._sequencePoints.Count; sequencePointIndex++)
+                    {
+                        ILSequencePoint sequencePoint = ilCodeStream._sequencePoints[sequencePointIndex];
+                        sequencePoints[copiedSequencePointLength] = new ILSequencePoint(
+                            ilCodeStream._startOffsetForLinking + sequencePoint.Offset,
+                            sequencePoint.Document,
+                            sequencePoint.LineNumber);
+                        copiedSequencePointLength++;
+                    }
+                }
+
+                debugInfo = new EmittedMethodDebugInformation(sequencePoints);
+            }
+
+            return new ILStubMethodIL(owningMethod, ilInstructions, _locals.ToArray(), _tokens.ToArray(), debugInfo);
+        }
+
+        private class EmittedMethodDebugInformation : MethodDebugInformation
+        {
+            private readonly ILSequencePoint[] _sequencePoints;
+
+            public EmittedMethodDebugInformation(ILSequencePoint[] sequencePoints)
+            {
+                _sequencePoints = sequencePoints;
+            }
+
+            public override IEnumerable<ILSequencePoint> GetSequencePoints()
+            {
+                return _sequencePoints;
+            }
         }
     }
 

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -59,6 +59,8 @@ namespace Internal.IL.Stubs.StartupCode
             ILEmitter emitter = new ILEmitter();
             ILCodeStream codeStream = emitter.NewCodeStream();
 
+            codeStream.BeginDebuggerGuidedStepThroughMethod();
+
             // Allow the class library to run explicitly ordered class constructors first thing in start-up.
             if (_libraryInitializers != null)
             {
@@ -100,6 +102,8 @@ namespace Internal.IL.Stubs.StartupCode
 
                 codeStream.Emit(ILOpcode.call, emitter.NewToken(startup.GetKnownMethod("GetMainMethodArguments", null)));
             }
+
+            codeStream.MarkDebuggerStepInPoint();
             codeStream.Emit(ILOpcode.call, emitter.NewToken(_mainMethod));
 
             MethodDesc setLatchedExitCode = startup.GetMethod("SetLatchedExitCode", null);
@@ -214,8 +218,12 @@ namespace Internal.IL.Stubs.StartupCode
                 ILEmitter emit = new ILEmitter();
                 ILCodeStream codeStream = emit.NewCodeStream();
 
+                codeStream.BeginDebuggerGuidedStepThroughMethod();
+
                 for (int i = 0; i < Signature.Length; i++)
                     codeStream.EmitLdArg(i);
+
+                codeStream.MarkDebuggerStepInPoint();
 
                 codeStream.Emit(ILOpcode.call, emit.NewToken(WrappedMethod));
 

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -421,6 +421,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\ILEmitter.cs">
       <Link>IL\Stubs\ILEmitter.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DebuggerSteppingHelpers.cs">
+      <Link>IL\Stubs\DebuggerSteppingHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.cs">
       <Link>IL\Stubs\DelegateMarshallingMethodThunk.cs</Link>
     </Compile>

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2125,7 +2125,7 @@ namespace Internal.JitInterface
                 SequencePoint s;
                 if (_sequencePoints.TryGetValue((int)ilOffset, out s))
                 {
-                    Debug.Assert(!string.IsNullOrEmpty(s.Document));
+                    Debug.Assert(s.Document != null);
                     DebugLocInfo loc = new DebugLocInfo(nativeOffset, s.Document, s.LineNumber);
                     debugLocInfos.Add(loc);
                     previousNativeOffset = nativeOffset;


### PR DESCRIPTION
This fixes a long standing pet peeve of mine: F11 into the
`__managed_Main` method doesn't work and steps over the method instead.
This adds infrastructure so that we can do `DebuggerGuidedStepThrough`
on generated methods.

A slight annoyance is that for UTC, the FEEFEE sequence point needs to
be on a NOP that precedes the call, and that scheme doesn't work for
RyuJIT. But UTC will need to fix that anyway because we won't be
rewriting IL for them in the future and no-NOP is how
DebuggerGuidedStepThrough methods are in C# when used from within the
BCL.