### PR TITLE
Add custom attribute type name formatter

### DIFF
--- a/src/Common/src/TypeSystem/Common/Utilities/CustomAttributeTypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/CustomAttributeTypeNameFormatter.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Formats type names in the 'SerString' format as defined by the ECMA-335 standard.
+    /// This is the inverse of what <see cref="CustomAttributeTypeNameParser.GetTypeByCustomAttributeTypeName(ModuleDesc, string, bool)"/> does.
+    /// </summary>
+    public sealed class CustomAttributeTypeNameFormatter : TypeNameFormatter<IAssemblyDesc, bool>
+    {
+        private readonly IAssemblyDesc _relativeHomeAssembly;
+
+        public CustomAttributeTypeNameFormatter()
+        {
+        }
+
+        public CustomAttributeTypeNameFormatter(IAssemblyDesc relativeHomeAssembly)
+        {
+            _relativeHomeAssembly = relativeHomeAssembly;
+        }
+
+        private void AppendAssemblyName(StringBuilder sb, IAssemblyDesc assembly)
+        {
+            if (assembly == _relativeHomeAssembly || assembly == null)
+                return;
+
+            sb.Append(',');
+            AppendEscapedIdentifier(sb, assembly.GetName().Name);
+        }
+
+        public override IAssemblyDesc AppendName(StringBuilder sb, ArrayType type, bool assemblyQualify)
+        {
+            IAssemblyDesc homeAssembly = AppendName(sb, type.ElementType, false);
+
+            if (type.IsSzArray)
+            {
+                sb.Append("[]");
+            }
+            else if (type.Rank == 1)
+            {
+                sb.Append("[*]");
+            }
+            else
+            {
+                sb.Append('[');
+                sb.Append(',', type.Rank);
+                sb.Append(']');
+            }
+
+            if (assemblyQualify)
+                AppendAssemblyName(sb, homeAssembly);
+
+            return homeAssembly;
+        }
+
+        public override IAssemblyDesc AppendName(StringBuilder sb, ByRefType type, bool assemblyQualify)
+        {
+            IAssemblyDesc homeAssembly = AppendName(sb, type.ParameterType, false);
+
+            sb.Append('&');
+
+            if (assemblyQualify)
+                AppendAssemblyName(sb, homeAssembly);
+
+            return homeAssembly;
+        }
+
+        public override IAssemblyDesc AppendName(StringBuilder sb, PointerType type, bool assemblyQualify)
+        {
+            IAssemblyDesc homeAssembly = AppendName(sb, type.ParameterType, false);
+
+            sb.Append('*');
+
+            if (assemblyQualify)
+                AppendAssemblyName(sb, homeAssembly);
+
+            return homeAssembly;
+        }
+
+        public override IAssemblyDesc AppendName(StringBuilder sb, FunctionPointerType type, bool assemblyQualify)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override IAssemblyDesc AppendName(StringBuilder sb, GenericParameterDesc type, bool assemblyQualify)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override IAssemblyDesc AppendName(StringBuilder sb, SignatureMethodVariable type, bool assemblyQualify)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override IAssemblyDesc AppendName(StringBuilder sb, SignatureTypeVariable type, bool assemblyQualify)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override IAssemblyDesc AppendNameForInstantiatedType(StringBuilder sb, DefType type, bool assemblyQualify)
+        {
+            IAssemblyDesc homeAssembly = AppendName(sb, type.GetTypeDefinition(), false);
+
+            sb.Append('[');
+
+            for (int i = 0; i < type.Instantiation.Length; i++)
+            {
+                sb.Append('[');
+
+                if (i != 0)
+                    sb.Append(',');
+
+                AppendName(sb, type.Instantiation[i], true);
+
+                sb.Append(']');
+            }
+
+            sb.Append(']');
+
+            if (assemblyQualify)
+                AppendAssemblyName(sb, homeAssembly);
+
+            return homeAssembly;
+        }
+
+        protected override IAssemblyDesc AppendNameForNamespaceType(StringBuilder sb, DefType type, bool assemblyQualify)
+        {
+            string ns = type.Namespace;
+            if (ns.Length > 0)
+            {
+                AppendEscapedIdentifier(sb, ns);
+                sb.Append('.');
+            }
+            AppendEscapedIdentifier(sb, type.Name);
+
+            if (type is MetadataType mdType)
+            {
+                Debug.Assert(mdType.Module is IAssemblyDesc, "Multi-module?");
+
+                if (assemblyQualify)
+                    AppendAssemblyName(sb, (IAssemblyDesc)mdType.Module);
+
+                return (IAssemblyDesc)mdType.Module;
+            }
+
+            return null;
+        }
+
+        protected override IAssemblyDesc AppendNameForNestedType(StringBuilder sb, DefType nestedType, DefType containingType, bool assemblyQualify)
+        {
+            IAssemblyDesc homeAssembly = AppendName(sb, containingType, false);
+
+            sb.Append('+');
+
+            AppendEscapedIdentifier(sb, nestedType.Name);
+
+            if (assemblyQualify)
+                AppendAssemblyName(sb, homeAssembly);
+
+            return homeAssembly;
+        }
+
+        private static char[] s_escapedChars = new char[] { ',', '=', '"', ']', '[', '*', '&', '+', '\\' };
+        private void AppendEscapedIdentifier(StringBuilder sb, string identifier)
+        {
+            if (identifier.IndexOfAny(s_escapedChars) < 0)
+            {
+                string escapedIdentifier = identifier;
+                foreach (char escapedChar in s_escapedChars)
+                {
+                    string escapedCharString = new string(escapedChar, 1);
+                    escapedIdentifier = escapedIdentifier.Replace(escapedCharString, "\\" + escapedCharString);
+                }
+                sb.Append(escapedIdentifier);
+            }
+            else
+            {
+                sb.Append(identifier);
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/Utilities/CustomAttributeTypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/CustomAttributeTypeNameFormatter.cs
@@ -50,7 +50,7 @@ namespace Internal.TypeSystem
             else
             {
                 sb.Append('[');
-                sb.Append(',', type.Rank);
+                sb.Append(',', type.Rank - 1);
                 sb.Append(']');
             }
 
@@ -112,13 +112,11 @@ namespace Internal.TypeSystem
 
             for (int i = 0; i < type.Instantiation.Length; i++)
             {
-                sb.Append('[');
-
                 if (i != 0)
                     sb.Append(',');
 
+                sb.Append('[');
                 AppendName(sb, type.Instantiation[i], true);
-
                 sb.Append(']');
             }
 

--- a/src/Common/src/TypeSystem/Common/Utilities/CustomAttributeTypeNameParser.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/CustomAttributeTypeNameParser.cs
@@ -20,6 +20,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Parses the string '<paramref name="name"/>' and returns the type corresponding to the parsed type name.
         /// The type name string should be in the 'SerString' format as defined by the ECMA-335 standard.
+        /// This is the inverse of what <see cref="CustomAttributeTypeNameFormatter"/> does.
         /// </summary>
         public static TypeDesc GetTypeByCustomAttributeTypeName(this ModuleDesc module, string name, bool throwIfNotFound = true)
         {

--- a/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/TypeNameFormatter.cs
@@ -75,71 +75,74 @@ namespace Internal.TypeSystem
         protected abstract void AppendNameForNamespaceType(StringBuilder sb, DefType type);
         protected abstract void AppendNameForInstantiatedType(StringBuilder sb, DefType type);
 
-        #region Convenience methods
-
         public string FormatName(TypeDesc type)
         {
             StringBuilder sb = new StringBuilder();
             AppendName(sb, type);
             return sb.ToString();
         }
+    }
 
-        public string FormatName(DefType type)
+    public abstract class TypeNameFormatter<TState, TOptions>
+    {
+        public TState AppendName(StringBuilder sb, TypeDesc type, TOptions options)
         {
-            StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
-            return sb.ToString();
+            switch (type.Category)
+            {
+                case TypeFlags.Array:
+                case TypeFlags.SzArray:
+                    return AppendName(sb, (ArrayType)type, options);
+                case TypeFlags.ByRef:
+                    return AppendName(sb, (ByRefType)type, options);
+                case TypeFlags.Pointer:
+                    return AppendName(sb, (PointerType)type, options);
+                case TypeFlags.FunctionPointer:
+                    return AppendName(sb, (FunctionPointerType)type, options);
+                case TypeFlags.GenericParameter:
+                    return AppendName(sb, (GenericParameterDesc)type, options);
+                case TypeFlags.SignatureTypeVariable:
+                    return AppendName(sb, (SignatureTypeVariable)type, options);
+                case TypeFlags.SignatureMethodVariable:
+                    return AppendName(sb, (SignatureMethodVariable)type, options);
+                default:
+                    Debug.Assert(type.IsDefType);
+                    return AppendName(sb, (DefType)type, options);
+            }
         }
 
-        public string FormatName(ArrayType type)
+        public TState AppendName(StringBuilder sb, DefType type, TOptions options)
         {
-            StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
-            return sb.ToString();
+            if (!type.IsTypeDefinition)
+            {
+                return AppendNameForInstantiatedType(sb, type, options);
+            }
+            else
+            {
+                DefType containingType = type.ContainingType;
+                if (containingType != null)
+                    return AppendNameForNestedType(sb, type, containingType, options);
+                else
+                    return AppendNameForNamespaceType(sb, type, options);
+            }
         }
 
-        public string FormatName(ByRefType type)
+        public abstract TState AppendName(StringBuilder sb, ArrayType type, TOptions options);
+        public abstract TState AppendName(StringBuilder sb, ByRefType type, TOptions options);
+        public abstract TState AppendName(StringBuilder sb, PointerType type, TOptions options);
+        public abstract TState AppendName(StringBuilder sb, FunctionPointerType type, TOptions options);
+        public abstract TState AppendName(StringBuilder sb, GenericParameterDesc type, TOptions options);
+        public abstract TState AppendName(StringBuilder sb, SignatureMethodVariable type, TOptions options);
+        public abstract TState AppendName(StringBuilder sb, SignatureTypeVariable type, TOptions options);
+
+        protected abstract TState AppendNameForNestedType(StringBuilder sb, DefType nestedType, DefType containingType, TOptions options);
+        protected abstract TState AppendNameForNamespaceType(StringBuilder sb, DefType type, TOptions options);
+        protected abstract TState AppendNameForInstantiatedType(StringBuilder sb, DefType type, TOptions options);
+
+        public string FormatName(TypeDesc type)
         {
             StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
+            AppendName(sb, type, default(TOptions));
             return sb.ToString();
         }
-
-        public string FormatName(PointerType type)
-        {
-            StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
-            return sb.ToString();
-        }
-
-        public string FormatName(InstantiatedType type)
-        {
-            StringBuilder sb = new StringBuilder();
-            AppendNameForInstantiatedType(sb, type);
-            return sb.ToString();
-        }
-
-        public string FormatName(GenericParameterDesc type)
-        {
-            StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
-            return sb.ToString();
-        }
-
-        public string FormatName(SignatureMethodVariable type)
-        {
-            StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
-            return sb.ToString();
-        }
-
-        public string FormatName(SignatureTypeVariable type)
-        {
-            StringBuilder sb = new StringBuilder();
-            AppendName(sb, type);
-            return sb.ToString();
-        }
-
-        #endregion
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CodeGenerationFailedException.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CodeGenerationFailedException.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    public class CodeGenerationFailedException : Exception
+    {
+        private const string MessageText = "Code generation failed";
+
+        public MethodDesc Method { get; }
+
+        public CodeGenerationFailedException(MethodDesc method)
+            : this(method, null)
+        {
+        }
+
+        public CodeGenerationFailedException(MethodDesc method, Exception inner)
+            : base(MessageText, inner)
+        {
+            Method = method;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -89,6 +89,7 @@
       <Link>JitInterface\TypeString.cs</Link>
     </Compile>
     <Compile Include="Compiler\BlockedInternalsBlockingPolicy.cs" />
+    <Compile Include="Compiler\CodeGenerationFailedException.cs" />
     <Compile Include="Compiler\CompilerGeneratedType.cs" />
     <Compile Include="Compiler\CompilerGeneratedType.Sorting.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.BoxedTypes.cs" />

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -112,6 +112,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\ThrowHelper.Common.cs">
       <Link>TypeSystem\Common\ThrowHelper.Common.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\CustomAttributeTypeNameFormatter.cs">
+      <Link>Utilities\CustomAttributeTypeNameFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\CustomAttributeTypeNameParser.cs">
       <Link>Utilities\CustomAttributeTypeNameParser.cs</Link>
     </Compile>

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -500,10 +500,34 @@ namespace ILCompiler
             return method;
         }
 
+        private static bool DumpReproArguments(CodeGenerationFailedException ex)
+        {
+            Console.WriteLine("To repro, add following arguments to the command line:");
+
+            MethodDesc failingMethod = ex.Method;
+
+            var formatter = new CustomAttributeTypeNameFormatter((IAssemblyDesc)failingMethod.Context.SystemModule);
+
+            Console.Write($"--singlemethodtypename {formatter.FormatName(failingMethod.OwningType)}");
+            Console.Write($" --singlemethodname {failingMethod.Name}");
+
+            for (int i = 0; i < failingMethod.Instantiation.Length; i++)
+                Console.Write($" --singlemethodgenericarg {formatter.FormatName(failingMethod.Instantiation[i])}");
+
+            return false;
+        }
+
         private static int Main(string[] args)
         {
 #if DEBUG
-            return new Program().Run(args);
+            try
+            {
+                return new Program().Run(args);
+            }
+            catch (CodeGenerationFailedException ex) when (DumpReproArguments(ex))
+            {
+                throw new NotSupportedException(); // Unreachable
+            }
 #else
             try
             {

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -167,7 +167,20 @@ namespace Internal.JitInterface
                         // If we captured a managed exception, rethrow that.
                         // TODO: might not actually be the real reason. It could be e.g. a JIT failure/bad IL that followed
                         // an inlining attempt with a type system problem in it...
+#if SUPPORT_JIT
                         _lastException.Throw();
+#else
+                        if (_lastException.SourceException is TypeSystemException)
+                        {
+                            // Type system exceptions can be turned into code that throws the exception at runtime.
+                            _lastException.Throw();
+                        }
+                        else
+                        {
+                            // This is just a bug somewhere.
+                            throw new CodeGenerationFailedException(_methodCodeNode.Method, _lastException.SourceException);
+                        }
+#endif
                     }
 
                     // This is a failure we don't know much about.
@@ -181,7 +194,12 @@ namespace Internal.JitInterface
                 }
                 if (result != CorJitResult.CORJIT_OK)
                 {
-                    throw new Exception("JIT Failed");
+#if SUPPORT_JIT
+                    // FailFast?
+                    throw new Exception("JIT failed");
+#else
+                    throw new CodeGenerationFailedException(_methodCodeNode.Method);
+#endif
                 }
 
                 PublishCode();


### PR DESCRIPTION
...and use it to generate repro command line arguments to repro compilation failures in a single method mode.

I spent way too much time in the past formatting these by hand...