### PR TITLE
Port recent AssemblyName parsing/binder  changes from CoreCLR

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2611,4 +2611,7 @@
   <data name="StackTrace_EndStackTraceFromPreviousThrow" xml:space="preserve">
     <value>--- End of stack trace from previous location where exception was thrown ---</value>
   </data>
+  <data name="InvalidAssemblyName" xml:space="preserve">
+    <value>The given assembly name or codebase was invalid</value>
+  </data>
 </root>

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
@@ -175,8 +175,7 @@ namespace Internal.Reflection.Execution
 
             if (refName.Version != null)
             {
-                int compareResult = refName.Version.CompareTo(defName.Version);
-                if (compareResult > 0)
+                if (!AssemblyVersionMatches(refVersion: refName.Version, defVersion: defName.Version))
                     return false;
             }
 
@@ -202,6 +201,33 @@ namespace Internal.Reflection.Execution
                 if (!ArePktsEqual(refPublicKeyToken, defPublicKeyToken))
                     return false;
             }
+
+            return true;
+        }
+
+        private static bool AssemblyVersionMatches(Version refVersion, Version defVersion)
+        {
+            if (defVersion.Major < refVersion.Major)
+                return false;
+            if (defVersion.Major > refVersion.Major)
+                return true;
+
+            if (defVersion.Minor < refVersion.Minor)
+                return false;
+            if (defVersion.Minor > refVersion.Minor)
+                return true;
+
+            if (refVersion.Build == -1)
+                return true;
+            if (defVersion.Build < refVersion.Build)
+                return false;
+            if (defVersion.Build > refVersion.Build)
+                return true;
+
+            if (refVersion.Revision == -1)
+                return true;
+            if (defVersion.Revision < refVersion.Revision)
+                return false;
 
             return true;
         }


### PR DESCRIPTION
Makes two of the recently added tests pass on ILC. 

-method System.Reflection.Tests.AssemblyNameTests.Constructor_String_InvalidVersionTest
-method System.Reflection.Tests.AssemblyNameTests.Constructor_String_VersionTest

The third one will require some more extensive replumbing so
I'm splitting that one off for a future PR. (Assembly name failing due to
too late a version expected to trigger a FileLoadException(RefDefMismatch)
rather than a FileNotFoundException.)

Changes are:

- Missing or 65535 Major and Minor version numbers no longer accepted.

- "Empty string" version numbers no longer accepted.

- A 65535 version component causes subsequent version components
  to be treated as 65535 (though still parsed and validated
  as numbers.)

- 65535 in the stringified assembly name converted to -1
  in the System.Version object.

- A missing Build or Revision is now treated as "match anything"
  in the binder.