### PR TITLE
Make Assembly.Load() throw same exception as CoreCLR

### DIFF
--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.Ecma.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.Ecma.cs
@@ -86,14 +86,14 @@ namespace Internal.Reflection.Execution
             }
         }
 
-        partial void BindEcmaAssemblyName(RuntimeAssemblyName refName, ref AssemblyBindResult result, ref Exception exception, ref bool foundMatch)
+        partial void BindEcmaAssemblyName(RuntimeAssemblyName refName, ref AssemblyBindResult result, ref Exception exception, ref Exception preferredException, ref bool foundMatch)
         {
             lock(s_ecmaLoadedAssemblies)
             {
                 for (int i = 0; i < s_ecmaLoadedAssemblies.Count; i++)
                 {
                     PEInfo info = s_ecmaLoadedAssemblies[i];
-                    if (AssemblyNameMatches(refName, info.Name))
+                    if (AssemblyNameMatches(refName, info.Name, ref preferredException))
                     {
                         if (foundMatch)
                         {
@@ -146,7 +146,7 @@ namespace Internal.Reflection.Execution
                                 RuntimeAssemblyName runtimeAssemblyName = reader.GetAssemblyDefinition().ToRuntimeAssemblyName(reader).CanonicalizePublicKeyToken();
 
                                 // If assembly name doesn't match, it isn't the one we're looking for. Continue to look for more assemblies
-                                if (!AssemblyNameMatches(refName, runtimeAssemblyName))
+                                if (!AssemblyNameMatches(refName, runtimeAssemblyName, ref preferredException))
                                     continue;
 
                                 // This is the one we are looking for, add it to the list of loaded assemblies

--- a/src/System.Private.TypeLoader/src/Resources/Strings.resx
+++ b/src/System.Private.TypeLoader/src/Resources/Strings.resx
@@ -126,4 +126,7 @@
   <data name="FileNotFound_AssemblyNotFound" xml:space="preserve">
     <value>Cannot load assembly '{0}'. No metadata found for this assembly.</value>
   </data>
+  <data name="FileLoadException_RefDefMismatch" xml:space="preserve">
+    <value>Cannot load assembly '{0}'. The assembly exists but its version {1} is lower than the requested version {2}.</value>
+  </data>
 </root>


### PR DESCRIPTION
When an assembly matching the simple name is found
but the version is wrong, Assembly.Load throws
a FileLoadException with a ref-def mismatch string.

This change makes Project N match that behavior as
well as separating the notion of a preferred exception
(the most informative exception to throw if no
matching candidate has found later in the search)
and the actual exception (used to signal that load
as a whole has failed.)