### PR TITLE
Implement Unsafe.AreSame

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs
@@ -43,6 +43,12 @@ namespace Internal.IL.Stubs
                     return EmitReadWrite(method, write: false, unaligned: true);
                 case "WriteUnaligned":
                     return EmitReadWrite(method, write: true, unaligned: true);
+                case "AreSame":
+                    return new ILStubMethodIL(method, new byte[]
+                    {
+                        (byte)ILOpcode.ldarg_0, (byte)ILOpcode.ldarg_1,
+                        (byte)ILOpcode.prefix1, unchecked((byte)ILOpcode.ceq),
+                        (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
             }
 
             return null;


### PR DESCRIPTION
This fixes the 8 rolling build failures.