### PR TITLE
Fix sequence point emission for startup code

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DebuggerSteppingHelpers.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DebuggerSteppingHelpers.cs
@@ -6,7 +6,7 @@ namespace Internal.IL.Stubs
 {
     public static class DebuggerSteppingHelpers
     {
-        public static void BeginDebuggerGuidedStepThroughMethod(this ILCodeStream codeStream)
+        public static void MarkDebuggerStepThroughPoint(this ILCodeStream codeStream)
         {
             codeStream.DefineSequencePoint("", 0xF00F00);
         }

--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -442,6 +442,7 @@ namespace Internal.IL.Stubs
 
         public void DefineSequencePoint(string document, int lineNumber)
         {
+            Debug.Assert(_sequencePoints.Count == 0 || _sequencePoints[_sequencePoints.Count - 1].Offset < _length);
             _sequencePoints.Add(new ILSequencePoint(_length, document, lineNumber));
         }
     }

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -59,7 +59,7 @@ namespace Internal.IL.Stubs.StartupCode
             ILEmitter emitter = new ILEmitter();
             ILCodeStream codeStream = emitter.NewCodeStream();
 
-            codeStream.BeginDebuggerGuidedStepThroughMethod();
+            codeStream.MarkDebuggerStepThroughPoint();
 
             // Allow the class library to run explicitly ordered class constructors first thing in start-up.
             if (_libraryInitializers != null)
@@ -218,7 +218,9 @@ namespace Internal.IL.Stubs.StartupCode
                 ILEmitter emit = new ILEmitter();
                 ILCodeStream codeStream = emit.NewCodeStream();
 
-                codeStream.BeginDebuggerGuidedStepThroughMethod();
+                // We only need the initial step over sequence point if there's any instructions before the call.
+                if (Signature.Length > 0)
+                    codeStream.MarkDebuggerStepThroughPoint();
 
                 for (int i = 0; i < Signature.Length; i++)
                     codeStream.EmitLdArg(i);


### PR DESCRIPTION
If `Main()` doesn't have arguments, the main method wrapper will start
with a call and we were defining two sequence points at offset 0.