### PR TITLE
Improve performance of string.IndexOfCharArray

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/src/System/String.Searching.cs
@@ -180,11 +180,6 @@ namespace System
 
             InitializeProbabilisticMap(charMap, anyOf);
 
-            return IndexOfCharArrayFilter(anyOf, startIndex, charMap, count);
-        }
-
-        private unsafe int IndexOfCharArrayFilter(char[] anyOf, int startIndex, uint* charMap, int count)
-        {
             fixed (char* pChars = &_firstChar)
             {
                 char* pCh = pChars + startIndex;
@@ -467,11 +462,6 @@ namespace System
 
             InitializeProbabilisticMap(charMap, anyOf);
 
-            return LastIndexOfCharArrayFilter(anyOf, startIndex, charMap, count);
-        }
-
-        private unsafe int LastIndexOfCharArrayFilter(char[] anyOf, int startIndex, uint* charMap, int count)
-        {
             fixed (char* pChars = &_firstChar)
             {
                 char* pCh = pChars + startIndex;

--- a/src/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/src/System/String.Searching.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
 
 namespace System
@@ -188,11 +189,11 @@ namespace System
 
                 while (count > 0)
                 {
-                    char thisChar = *pCh;
+                    int thisChar = *pCh;
 
                     if (IsCharBitSet(charMap, (byte)thisChar) &&
                         IsCharBitSet(charMap, (byte)(thisChar >> 8)) &&
-                        ArrayContains(thisChar, anyOf))
+                        ArrayContains((char)thisChar, anyOf))
                     {
                         return (int)(pCh - pChars);
                     }
@@ -222,6 +223,16 @@ namespace System
         private static unsafe void InitializeProbabilisticMap(uint* charMap, char[] anyOf)
         {
             bool hasAscii = false;
+
+            charMap[0] = 0;
+            charMap[1] = 0;
+            charMap[2] = 0;
+            charMap[3] = 0;
+            charMap[4] = 0;
+            charMap[5] = 0;
+            charMap[6] = 0;
+            charMap[7] = 0;
+            Debug.Assert(PROBABILISTICMAP_SIZE == 0x8);
 
             for (int i = 0; i < anyOf.Length; ++i)
             {
@@ -472,11 +483,11 @@ namespace System
 
                 while (count > 0)
                 {
-                    char thisChar = *pCh;
+                    int thisChar = *pCh;
 
                     if (IsCharBitSet(charMap, (byte)thisChar) &&
                         IsCharBitSet(charMap, (byte)(thisChar >> 8)) &&
-                        ArrayContains(thisChar, anyOf))
+                        ArrayContains((char)thisChar, anyOf))
                     {
                         return (int)(pCh - pChars);
                     }


### PR DESCRIPTION
`IndexOfCharArray` is the last holdout before the String.Searching.cs file is common between RT and CLR. While this PR is almost x2 what was there before it is still 15-20% short of the C++ CLR version.

Unconfirmed, but this appears to be due to C++ use of `BTS` and `BT` instructions. `BT` looks like it could be generally useful to JIT? (cc @mikedn)

Any other patterns that might help here that the JIT will recognise? (cc @jkotas @benaadams)

Note the C# code also doesn't have the x86 performance penalty that the C++ version does (cc @davkean) so we really just need to catch up to x64.

**Edit - Final Figures**
_dotnet core 2.0 RTM_
Short no-match 4% faster
Long no-match 12% faster
Short match 4% faster
Mapping false positives 42% faster
eg.
```
public static char[] _array = new char[] { 'a', '\xDE20', '\xDE20', '\xDE20', '\xDE20', '\xDE20', '\xDE20', '\xDE20', '\xDE20' };
private const string LongString = "                                                                                                                                                                                                                                                                                                                                                                            ";
```

_x86 Framework_
Long no-match 42% faster
