### PR TITLE
[ILVerify] Fix for issue #4359

### DIFF
--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -118,15 +118,12 @@ namespace Internal.IL
 
         public ILImporter(MethodDesc method, MethodIL methodIL)
         {
-            _typeSystemContext = method.Context;
-
             _method = method;
-            if (method.HasInstantiation)
-                _method = _typeSystemContext.GetInstantiatedMethod(method.GetMethodDefinition(), method.Instantiation);
+            _typeSystemContext = method.Context;
 
             if (!_method.Signature.IsStatic)
             {
-                if (method.OwningType.HasInstantiation)
+                if (_method.OwningType.HasInstantiation)
                 {
                     _thisType = _typeSystemContext.GetInstantiatedType((MetadataType)_method.OwningType, _method.OwningType.Instantiation);
                     _method = _typeSystemContext.GetMethodForInstantiatedType(_method.GetTypicalMethodDefinition(), (InstantiatedType)_thisType);
@@ -140,6 +137,9 @@ namespace Internal.IL
                 if (_thisType.IsValueType)
                     _thisType = _thisType.MakeByRefType();
             }
+
+            if (_method.HasInstantiation)
+                _method = _typeSystemContext.GetInstantiatedMethod(_method, _method.Instantiation);
 
             _methodSignature = _method.Signature;
             _methodIL = method == _method ? methodIL : new InstantiatedMethodIL(_method, methodIL);

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -113,6 +113,20 @@
     .field int32 IntField;
 }
 
+.class public sequential ansi beforefieldinit GenericTypeWithConstrained<class ([System.Runtime]System.IComparable) TValueType>
+        extends [System.Runtime]System.Object
+{
+    .property !TValueType Value()
+    {
+        .get instance !0 GenericTypeWithConstrained::get_Value()
+    }
+    .method public !TValueType get_Value()
+    {
+        ldc.i4 0x00000000
+        ret
+    }
+}
+
 // Provides casting logic tests for stfld, ldfld, call, callvirt
 .class public auto ansi beforefieldinit GenericCastingTestsType`1<T>
        extends [System.Runtime]System.Object
@@ -218,6 +232,18 @@
         
         ldloc.0
         stloc.1
+        ret
+    }
+
+    .method public static void Casting.AssignReturnValueFromConstrainedProperty_Valid<class ([System.Runtime]System.IComparable) TValueType>(class GenericTypeWithConstrained<!!TValueType> wrapper) cil managed
+    {
+        .locals init (
+            class [System.Runtime]System.IComparable V_0
+        )
+
+        ldarg.0
+        callvirt instance !0 class GenericTypeWithConstrained<!!TValueType>::get_Value()
+        stloc.0
         ret
     }
 }

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -246,4 +246,22 @@
         stloc.0
         ret
     }
+
+
+}
+
+.class public auto ansi beforefieldinit CastingTestsType
+       extends [System.Runtime]System.Object
+{
+    .method public static void Casting.AssignPrimitiveToIComparable_Valid(int32 arg) cil managed
+    {
+        .locals init (
+            class [System.Runtime]System.IComparable
+        )
+
+        ldarg.0
+        box     [System.Runtime]System.Int32
+        stloc.0
+        ret
+    }
 }

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -128,9 +128,9 @@
 
     .method public hidebysig  instance void Casting.StorePlainFieldInOtherGenericType_Valid(int32 v) cil managed
     {
-		.locals init (
-			class GenericOtherFieldsType`1<!T> V_0
-		)
+        .locals init (
+            class GenericOtherFieldsType`1<!T> V_0
+        )
 
         ldloc.0
         ldarg.1
@@ -149,9 +149,9 @@
 
     .method public hidebysig  instance void Casting.StoreGenericFieldInOtherGenericType_Valid(!T v) cil managed
     {
-		.locals init (
-			class GenericOtherFieldsType`1<!T> V_0
-		)
+        .locals init (
+            class GenericOtherFieldsType`1<!T> V_0
+        )
         ldloc.0
         ldarg.1
         stfld !0 class GenericOtherFieldsType`1<!T>::GenericField
@@ -176,9 +176,9 @@
 
     .method public hidebysig  instance void Casting.CallGenericFunctionFromOtherGenericType_Valid(!T v) cil managed
     {
-		.locals init (
-			class [System.Runtime]System.Func`1<!T> V_0
-		)
+        .locals init (
+            class [System.Runtime]System.Func`1<!T> V_0
+        )
         
         ldarg.0
         ldloc.0
@@ -188,21 +188,33 @@
 
     .method public hidebysig instance void Casting.AssignThisToSameTypeWithOtherGenericArgs_Invalid_StackUnexpected() cil managed
     {
-		.locals init (
-			class GenericCastingTestsType`1<int32> V_0
-		)
+        .locals init (
+            class GenericCastingTestsType`1<int32> V_0
+        )
         
         ldarg.0
         stloc.0
         ret
     }
 
+    .method public hidebysig instance void Casting.AssignGenericToObject_Valid(!T v) cil managed
+    {
+        .locals init (
+            object
+        )
+
+        ldarg.1
+        box     !T
+        stloc.0
+        ret
+    }
+
     .method public hidebysig static void Casting.AssignToSameTypeWithOtherGenericArgs_Invalid_StackUnexpected() cil managed
     {
-		.locals init (
-			class GenericCastingTestsType`1<int32> V_0,
+        .locals init (
+            class GenericCastingTestsType`1<int32> V_0,
             class GenericCastingTestsType`1<string> V_1
-		)
+        )
         
         ldloc.0
         stloc.1

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -246,8 +246,6 @@
         stloc.0
         ret
     }
-
-
 }
 
 .class public auto ansi beforefieldinit CastingTestsType


### PR DESCRIPTION
At the moment generic methods/classes are instantiated as open, i.e. their parameters are substituted with `SignatureVariables`. However, for the CastingHelper to be able to compare generic types by their constraints it has to be given a `GenericParameterDesc`.
This causes multiple issues with generics such as #4359 or the issue discussed in #4065.
I changed the `ILImporter.Verify` constructor to instantiate the method to be verified as well as its owning type with the generic instantiation. Therefore any generic arguments are now stored in the method signature and pushed onto the stack as the GenericParameterDesc-type `T`, which is perfectly handled by the `CastingHelper`.
I also added a test case for the particular issue of #4359, for the scenario discussed in #4366 and for the scenario described in #4065 .
This pull request therefore fixes issue #4359 and the issue described in #4065.