### PR TITLE
[ILVerify] Fix stind to allow storing a string to ref string

### DIFF
--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1362,10 +1362,9 @@ namespace Internal.IL
 
             var typeVal = StackValue.CreateFromType(type);
             var addressVal = StackValue.CreateFromType(address.Type);
-            if (!value.IsNullReference)
-                CheckIsAssignable(typeVal, addressVal);
 
             CheckIsAssignable(value, typeVal);
+            CheckIsAssignable(value, addressVal);
         }
 
         void ImportThrow()
@@ -1375,7 +1374,7 @@ namespace Internal.IL
             if (value.Kind != StackValueKind.ObjRef)
             {
                 VerificationError(VerifierError.StackObjRef);
-            }            
+            }
         }
 
         void ImportLoadString(int token)

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1350,9 +1350,6 @@ namespace Internal.IL
             ClearPendingPrefix(Prefix.Unaligned);
             ClearPendingPrefix(Prefix.Volatile);
 
-            if (type == null)
-                type = GetWellKnownType(WellKnownType.Object);
-
             var value = Pop();
             var address = Pop();
 
@@ -1360,9 +1357,13 @@ namespace Internal.IL
 
             CheckIsByRef(address);
 
+            if (type == null)
+                type = address.Type;
+
             var typeVal = StackValue.CreateFromType(type);
             var addressVal = StackValue.CreateFromType(address.Type);
 
+            CheckIsAssignable(typeVal, addressVal);
             CheckIsAssignable(value, typeVal);
             CheckIsAssignable(value, addressVal);
         }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1365,7 +1365,6 @@ namespace Internal.IL
 
             CheckIsAssignable(typeVal, addressVal);
             CheckIsAssignable(value, typeVal);
-            CheckIsAssignable(value, addressVal);
         }
 
         void ImportThrow()

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -99,6 +99,18 @@
         ret
     }
 
+    .method static public hidebysig void StoreIndirect.AssignStringToRefString_Valid(string&) cil managed
+    {
+        // ref string x;
+        // string y = "a";
+        // x = y;
+
+        ldarg.0
+        ldstr   "a"
+        stind.ref
+        ret
+    }
+
     .method static public hidebysig void StoreIndirect.AssignByteToBoolRef_Valid(bool&) cil managed
     {
         ldarg.0

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -74,7 +74,7 @@
         ret
     }
 
-    .method static public hidebysig void StoreIndirect.AssignToRefString_Invalid_StackUnexpected_StackUnexpected(string&) cil managed
+    .method static public hidebysig void StoreIndirect.AssignToRefString_Invalid_StackUnexpected(string&) cil managed
     {
         .locals init (object V_0)
 

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -111,6 +111,18 @@
         ret
     }
 
+    .method static public hidebysig void StoreObject.AssignStringToRefStringAsObject_Invalid_StackUnexpected(string&) cil managed
+    {
+        // ref string x;
+        // string y = "a";
+        // x = y;
+
+        ldarg.0
+        ldstr   "a"
+        stobj   [System.Runtime]System.Object
+        ret
+    }
+
     .method static public hidebysig void StoreIndirect.AssignByteToBoolRef_Valid(bool&) cil managed
     {
         ldarg.0

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -74,7 +74,7 @@
         ret
     }
 
-    .method static public hidebysig void StoreIndirect.AssignToRefString_Invalid_StackUnexpected(string&) cil managed
+    .method static public hidebysig void StoreIndirect.AssignToRefString_Invalid_StackUnexpected_StackUnexpected(string&) cil managed
     {
         .locals init (object V_0)
 


### PR DESCRIPTION
In order to assign a `string` to a `ref string`, compiler-generated IL calls stind.ref (as a short form of stobj string). Currently ILVerify reports an error because it checks whether the typetoken (in this case `System.Object`) is assignable to the type of the managed pointer (in this case `System.String`). This check however is not required by ECMA and also PEVerify seems to not check for this.
The only checks specified by the ECMA standard are:

> _addr_ shall be a managed pointer, `T&`, and the type of _val_ shall be verifier-assignable-
to T

additionally for stobj:

> _srcType_ shall be verifier-assignable-to _typeTok_

I removed the unnecessary check and added the check of stind.
I also added a test-case for assigning a `string` to a `ref string`.