### PR TITLE
Update Type.GetMethods() to be generics friendly.

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -255,6 +255,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MethodBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MethodImplAttributes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MethodInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MethodInfo.Internal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\Missing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\Module.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ModuleResolveEventHandler.cs" />
@@ -272,6 +273,15 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ReflectionTypeLoadException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ResourceAttributes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ResourceLocation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignatureArrayType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignatureByRefType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignatureConstructedGenericType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignatureGenericMethodParameterType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignatureGenericParameterType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignatureHasElementType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignaturePointerType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignatureType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\SignatureTypeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\StrongNameKeyPair.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\TargetException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\TargetInvocationException.cs" />

--- a/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
+++ b/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
@@ -530,7 +530,7 @@ namespace System
             for (i = 0; i < types.Length; i++)
             {
                 realTypes[i] = types[i].UnderlyingSystemType;
-                if (!(realTypes[i].IsRuntimeImplemented()))
+                if (!(realTypes[i].IsRuntimeImplemented() || realTypes[i] is SignatureType))
                     throw new ArgumentException(SR.Arg_MustBeType, nameof(types));
             }
             types = realTypes;
@@ -552,19 +552,30 @@ namespace System
                 for (j = 0; j < types.Length; j++)
                 {
                     Type pCls = par[j].ParameterType;
-                    if (pCls == types[j])
+                    if (types[j].MatchesParameterTypeExactly(par[j]))
                         continue;
                     if (pCls == typeof(object))
                         continue;
+
+                    Type type = types[j];
+                    if (type is SignatureType signatureType)
+                    {
+                        if (!(candidates[i] is MethodInfo methodInfo))
+                            break;
+                        type = signatureType.TryResolveAgainstGenericMethod(methodInfo);
+                        if (type == null)
+                            break;
+                    }
+
                     if (pCls.IsPrimitive)
                     {
-                        if (!(types[j].UnderlyingSystemType.IsRuntimeImplemented()) ||
-                            !CanChangePrimitive(types[j].UnderlyingSystemType, pCls.UnderlyingSystemType))
+                        if (!(type.UnderlyingSystemType.IsRuntimeImplemented()) ||
+                            !CanChangePrimitive(type.UnderlyingSystemType, pCls.UnderlyingSystemType))
                             break;
                     }
                     else
                     {
-                        if (!pCls.IsAssignableFrom(types[j]))
+                        if (!pCls.IsAssignableFrom(type))
                             break;
                     }
                 }
@@ -918,11 +929,22 @@ namespace System
             if (c1 == c2)
                 return 0;
 
-            if (c1 == t)
-                return 1;
+            if (t is SignatureType signatureType)
+            {
+                if (signatureType.MatchesExactly(c1))
+                    return 1;
 
-            if (c2 == t)
-                return 2;
+                if (signatureType.MatchesExactly(c2))
+                    return 2;
+            }
+            else
+            {
+                if (c1 == t)
+                    return 1;
+
+                if (c2 == t)
+                    return 2;
+            }
 
             bool c1FromC2;
             bool c2FromC1;

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.Internal.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.Internal.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reflection
+{
+    public abstract partial class MethodInfo : MethodBase
+    {
+#if CORECLR
+        internal
+#else
+        // Not an api but needs to be public so that Reflection.Core can access it.
+        public
+#endif
+        virtual int GenericParameterCount => GetGenericArguments().Length;
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
@@ -4,7 +4,7 @@
 
 namespace System.Reflection
 {
-    public abstract class MethodInfo : MethodBase
+    public abstract partial class MethodInfo : MethodBase
     {
         protected MethodInfo() { }
 

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureArrayType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureArrayType.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Reflection
+{
+    internal sealed class SignatureArrayType : SignatureHasElementType
+    {
+        internal SignatureArrayType(SignatureType elementType, int rank, bool isMultiDim)
+            : base(elementType)
+        {
+            Debug.Assert(rank > 0);
+            Debug.Assert(rank == 1 || isMultiDim);
+    
+            _rank = rank;
+            _isMultiDim = isMultiDim;
+        }
+    
+        protected sealed override bool IsArrayImpl() => true;
+        protected sealed override bool IsByRefImpl() => false;
+        protected sealed override bool IsPointerImpl() => false;
+    
+        public sealed override bool IsSZArray => !_isMultiDim;
+        public sealed override bool IsVariableBoundArray => _isMultiDim;
+    
+        public sealed override int GetArrayRank() => _rank;
+    
+        protected sealed override string Suffix
+        {
+            get
+            {
+                if (!_isMultiDim)
+                    return "[]";
+                else if (_rank == 1)
+                    return "[*]";
+                else
+                    return "[" + new string(',', _rank - 1) + "]";
+            }
+        }
+    
+        private readonly int _rank;
+        private readonly bool _isMultiDim;
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureByRefType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureByRefType.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Reflection
+{
+    internal sealed class SignatureByRefType : SignatureHasElementType
+    {
+        internal SignatureByRefType(SignatureType elementType)
+            : base(elementType)
+        {
+        }
+    
+        protected sealed override bool IsArrayImpl() => false;
+        protected sealed override bool IsByRefImpl() => true;
+        protected sealed override bool IsPointerImpl() => false;
+    
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+    
+        public sealed override int GetArrayRank() => throw new ArgumentException(SR.Argument_HasToBeArrayClass);
+    
+        protected sealed override string Suffix => "&";
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureConstructedGenericType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureConstructedGenericType.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Diagnostics;
+
+namespace System.Reflection
+{
+    internal sealed class SignatureConstructedGenericType : SignatureType
+    {
+        internal SignatureConstructedGenericType(Type genericTypeDefinition, Type[] genericTypeArguments)
+        {
+            Debug.Assert(genericTypeDefinition != null && genericTypeArguments != null);
+            _genericTypeDefinition = genericTypeDefinition;
+            _genericTypeArguments = (Type[])(genericTypeArguments.Clone());
+        }
+    
+        public sealed override bool IsTypeDefinition => false;
+        public sealed override bool IsGenericTypeDefinition => false;
+        protected sealed override bool HasElementTypeImpl() => false;
+        protected sealed override bool IsArrayImpl() => false;
+        protected sealed override bool IsByRefImpl() => false;
+        public sealed override bool IsByRefLike => _genericTypeDefinition.IsByRefLike;
+        protected sealed override bool IsPointerImpl() => false;
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+        public sealed override bool IsConstructedGenericType => true;
+        public sealed override bool IsGenericParameter => false;
+        public sealed override bool IsGenericMethodParameter => false;
+        public sealed override bool ContainsGenericParameters
+        {
+            get
+            {
+                for (int i = 0; i < _genericTypeArguments.Length; i++)
+                {
+                    if (_genericTypeArguments[i].ContainsGenericParameters)
+                        return true;
+                }
+                return false;
+            }
+        }
+    
+        internal sealed override SignatureType ElementType => null;
+        public sealed override int GetArrayRank() => throw new ArgumentException(SR.Argument_HasToBeArrayClass);
+        public sealed override Type GetGenericTypeDefinition() => _genericTypeDefinition;
+        public sealed override Type[] GetGenericArguments() => GenericTypeArguments;
+        public sealed override Type[] GenericTypeArguments => (Type[])(_genericTypeArguments.Clone());
+        public sealed override int GenericParameterPosition => throw new InvalidOperationException(SR.Arg_NotGenericParameter);
+    
+        public sealed override string Name => _genericTypeDefinition.Name;
+        public sealed override string Namespace => _genericTypeDefinition.Namespace;
+    
+        public sealed override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(_genericTypeDefinition.ToString());
+            sb.Append('[');
+            for (int i = 0; i < _genericTypeArguments.Length; i++)
+            {
+                if (i != 0)
+                    sb.Append(',');
+                sb.Append(_genericTypeArguments[i].ToString());
+            }
+            sb.Append(']');
+            return sb.ToString();
+        }
+    
+        private readonly Type _genericTypeDefinition;
+        private readonly Type[] _genericTypeArguments;
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureGenericMethodParameterType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureGenericMethodParameterType.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reflection
+{
+    internal sealed class SignatureGenericMethodParameterType : SignatureGenericParameterType
+    {
+        internal SignatureGenericMethodParameterType(int position)
+            : base(position)
+        {
+        }
+    
+        public sealed override bool IsGenericMethodParameter => true;
+    
+        public sealed override string Name => "!!" + GenericParameterPosition;
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureGenericParameterType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureGenericParameterType.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace System.Reflection
+{
+    internal abstract class SignatureGenericParameterType : SignatureType
+    {
+        protected SignatureGenericParameterType(int position)
+        {
+            Debug.Assert(position >= 0);
+            _position = position;
+        }
+    
+        public sealed override bool IsTypeDefinition => false;
+        public sealed override bool IsGenericTypeDefinition => false;
+        protected sealed override bool HasElementTypeImpl() => false;
+        protected sealed override bool IsArrayImpl() => false;
+        protected sealed override bool IsByRefImpl() => false;
+        public sealed override bool IsByRefLike => false;
+        protected sealed override bool IsPointerImpl() => false;
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+        public sealed override bool IsConstructedGenericType => false;
+        public sealed override bool IsGenericParameter => true;
+        public abstract override bool IsGenericMethodParameter { get; }
+        public sealed override bool ContainsGenericParameters => true;
+    
+        internal sealed override SignatureType ElementType => null;
+        public sealed override int GetArrayRank() => throw new ArgumentException(SR.Argument_HasToBeArrayClass);
+        public sealed override Type GetGenericTypeDefinition() => throw new InvalidOperationException(SR.InvalidOperation_NotGenericType);
+        public sealed override Type[] GetGenericArguments() => Array.Empty<Type>();
+        public sealed override Type[] GenericTypeArguments => Array.Empty<Type>();
+        public sealed override int GenericParameterPosition => _position;
+    
+        public abstract override string Name { get; }
+        public sealed override string Namespace => null;
+    
+        public sealed override string ToString() => Name;
+    
+        private readonly int _position;
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureHasElementType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureHasElementType.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace System.Reflection
+{
+    internal abstract class SignatureHasElementType : SignatureType
+    {
+        protected SignatureHasElementType(SignatureType elementType)
+        {
+            Debug.Assert(elementType != null);  
+            _elementType = elementType;
+        }
+    
+        public sealed override bool IsTypeDefinition => false;
+        public sealed override bool IsGenericTypeDefinition => false;
+        protected sealed override bool HasElementTypeImpl() => true;
+        protected abstract override bool IsArrayImpl();
+        protected abstract override bool IsByRefImpl();
+        public sealed override bool IsByRefLike => false;
+        protected abstract override bool IsPointerImpl();
+        public abstract override bool IsSZArray { get; }
+        public abstract override bool IsVariableBoundArray { get; }
+        public sealed override bool IsConstructedGenericType => false;
+        public sealed override bool IsGenericParameter => false;
+        public sealed override bool IsGenericMethodParameter => false;
+        public sealed override bool ContainsGenericParameters => _elementType.ContainsGenericParameters;
+    
+        internal sealed override SignatureType ElementType => _elementType;
+        public abstract override int GetArrayRank();
+        public sealed override Type GetGenericTypeDefinition() => throw new InvalidOperationException(SR.InvalidOperation_NotGenericType);
+        public sealed override Type[] GetGenericArguments() => Array.Empty<Type>();
+        public sealed override Type[] GenericTypeArguments => Array.Empty<Type>();
+        public sealed override int GenericParameterPosition => throw new InvalidOperationException(SR.Arg_NotGenericParameter);
+    
+        public sealed override string Name => _elementType.Name + Suffix;
+        public sealed override string Namespace => _elementType.Namespace;
+    
+        public sealed override string ToString() => _elementType.ToString() + Suffix;
+    
+        protected abstract string Suffix { get; } 
+    
+        private readonly SignatureType _elementType;
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignaturePointerType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignaturePointerType.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Reflection
+{
+    internal sealed class SignaturePointerType : SignatureHasElementType
+    {
+        internal SignaturePointerType(SignatureType elementType)
+            : base(elementType)
+        {
+        }
+    
+        protected sealed override bool IsArrayImpl() => false;
+        protected sealed override bool IsByRefImpl() => false;
+        protected sealed override bool IsPointerImpl() => true;
+    
+        public sealed override bool IsSZArray => false;
+        public sealed override bool IsVariableBoundArray => false;
+    
+        public sealed override int GetArrayRank() => throw new ArgumentException(SR.Argument_HasToBeArrayClass);
+    
+        protected sealed override string Suffix => "*";
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureType.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace System.Reflection
+{
+    //
+    // Signature Types are highly restricted Type objects that can be passed in the Type[] parameter to Type.GetMethod(). Their primary
+    // use is to pass types representing generic parameters defined by the method, or types composed from them. Passing in the normal
+    // generic parameter Type obtained from MethodInfo.GetGenericArguments() is usually impractical (if you had the method, you wouldn't
+    // be looking for it!)
+    //
+    internal abstract class SignatureType : Type
+    {
+        public sealed override bool IsSignatureType => true;
+
+        // Type flavor predicates
+        public abstract override bool IsTypeDefinition { get; }
+        protected abstract override bool HasElementTypeImpl();
+        protected abstract override bool IsArrayImpl();
+        public abstract override bool IsSZArray { get; }
+        public abstract override bool IsVariableBoundArray { get; }
+        protected abstract override bool IsByRefImpl();
+        public abstract override bool IsByRefLike { get; }
+        protected abstract override bool IsPointerImpl();
+        public sealed override bool IsGenericType => IsGenericTypeDefinition || IsConstructedGenericType;
+        public abstract override bool IsGenericTypeDefinition { get; }
+        public abstract override bool IsConstructedGenericType { get; }
+        public abstract override bool IsGenericParameter { get; }
+        public abstract bool IsGenericMethodParameter { get; }
+        public abstract override bool ContainsGenericParameters { get; }
+        public sealed override MemberTypes MemberType => MemberTypes.TypeInfo;
+
+        // Compositors
+        public sealed override Type MakeArrayType() => new SignatureArrayType(this, rank: 1, isMultiDim: false);
+        public sealed override Type MakeArrayType(int rank)
+        {
+            if (rank <= 0)
+                throw new IndexOutOfRangeException();
+            return new SignatureArrayType(this, rank: rank, isMultiDim: true);
+        }
+        public sealed override Type MakeByRefType() => new SignatureByRefType(this);
+        public sealed override Type MakePointerType() => new SignaturePointerType(this);
+        public sealed override Type MakeGenericType(params Type[] typeArguments) => throw new NotSupportedException(SR.NotSupported_SignatureType); // There is no SignatureType for type definition types so it would never be legal to call this.
+
+        // Dissectors
+        public sealed override Type GetElementType() => ElementType;
+        public abstract override int GetArrayRank();
+        public abstract override Type GetGenericTypeDefinition();
+        public abstract override Type[] GenericTypeArguments { get; }
+        public abstract override Type[] GetGenericArguments();
+        public abstract override int GenericParameterPosition { get; }
+        internal abstract SignatureType ElementType { get; }
+
+        // Identity
+#if DEBUG
+        public sealed override bool Equals(object o) => base.Equals(o);
+        public sealed override bool Equals(Type o) => base.Equals(o);
+        public sealed override int GetHashCode() => base.GetHashCode();
+#endif
+        public sealed override Type UnderlyingSystemType => this;  // Equals(Type) depends on this.
+    
+        // Naming and diagnostics
+        public abstract override string Name { get; }
+        public abstract override string Namespace { get; }
+        public sealed override string FullName => null;
+        public sealed override string AssemblyQualifiedName => null;
+        public abstract override string ToString();
+
+        // Not supported on Signature Types
+        public sealed override Assembly Assembly => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Module Module => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type ReflectedType => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type BaseType => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type[] GetInterfaces() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsAssignableFrom(Type c) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override int MetadataToken => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool HasSameMetadataDefinitionAs(MemberInfo other) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type DeclaringType => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override MethodBase DeclaringMethod => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type[] GetGenericParameterConstraints() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override GenericParameterAttributes GenericParameterAttributes => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsEnumDefined(object value) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override string GetEnumName(object value) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override string[] GetEnumNames() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type GetEnumUnderlyingType() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Array GetEnumValues() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Guid GUID => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override TypeCode GetTypeCodeImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override TypeAttributes GetAttributeFlagsImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override EventInfo GetEvent(string name, BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override EventInfo[] GetEvents(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override FieldInfo GetField(string name, BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override FieldInfo[] GetFields(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override MemberInfo[] GetMembers(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override MethodInfo[] GetMethods(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type GetNestedType(string name, BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type[] GetNestedTypes(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override PropertyInfo[] GetProperties(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override MethodInfo GetMethodImpl(string name, int genericParameterCount, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter filter, object filterCriteria) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override MemberInfo[] GetMember(string name, BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override MemberInfo[] GetDefaultMembers() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override EventInfo[] GetEvents() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override object[] GetCustomAttributes(bool inherit) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override object[] GetCustomAttributes(Type attributeType, bool inherit) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsDefined(Type attributeType, bool inherit) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override IList<CustomAttributeData> GetCustomAttributesData() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type GetInterface(string name, bool ignoreCase) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override bool IsCOMObjectImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override bool IsPrimitiveImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override IEnumerable<CustomAttributeData> CustomAttributes => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type[] FindInterfaces(TypeFilter filter, object filterCriteria) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override InterfaceMapping GetInterfaceMap(Type interfaceType) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override bool IsContextfulImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsEnum => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsEquivalentTo(Type other) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsInstanceOfType(object o) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override bool IsMarshalByRefImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsSecurityCritical => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsSecuritySafeCritical => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsSecurityTransparent => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsSerializable => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override bool IsSubclassOf(Type c) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        protected sealed override bool IsValueTypeImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override StructLayoutAttribute StructLayoutAttribute => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override RuntimeTypeHandle TypeHandle => throw new NotSupportedException(SR.NotSupported_SignatureType);
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureTypeExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureTypeExtensions.cs
@@ -1,0 +1,227 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Diagnostics;
+
+namespace System.Reflection
+{
+#if CORECLR
+    internal
+#else
+    public // Needs to be public so that Reflection.Core can see it.
+#endif
+    static class SignatureTypeExtensions
+    {
+        /// <summary>
+        /// This is semantically identical to 
+        /// 
+        ///      parameter.ParameterType == pattern.TryResolveAgainstGenericMethod(parameter.Member)
+        ///      
+        /// but without the allocation overhead of TryResolve.
+        /// </summary>
+        public static bool MatchesParameterTypeExactly(this Type pattern, ParameterInfo parameter)
+        {
+            if (pattern is SignatureType signatureType)
+                return signatureType.MatchesExactly(parameter.ParameterType);
+            else
+                return pattern == (object)(parameter.ParameterType);
+        }
+
+        /// <summary>
+        /// This is semantically identical to 
+        /// 
+        ///      actual == pattern.TryResolveAgainstGenericMethod(parameterMember)
+        ///      
+        /// but without the allocation overhead of TryResolve.
+        /// </summary>
+        internal static bool MatchesExactly(this SignatureType pattern, Type actual)
+        {
+            if (pattern.IsSZArray)
+            {
+                return actual.IsSZArray && pattern.ElementType.MatchesExactly(actual.GetElementType());
+            }
+            else if (pattern.IsVariableBoundArray)
+            {
+                return actual.IsVariableBoundArray && pattern.GetArrayRank() == actual.GetArrayRank() && pattern.ElementType.MatchesExactly(actual.GetElementType());
+            }
+            else if (pattern.IsByRef)
+            {
+                return actual.IsByRef && pattern.ElementType.MatchesExactly(actual.GetElementType());
+            }
+            else if (pattern.IsPointer)
+            {
+                return actual.IsPointer && pattern.ElementType.MatchesExactly(actual.GetElementType());
+            }
+            else if (pattern.IsConstructedGenericType)
+            {
+                if (!actual.IsConstructedGenericType)
+                    return false;
+                if (!(pattern.GetGenericTypeDefinition() == actual.GetGenericTypeDefinition()))
+                    return false;
+                Type[] patternGenericTypeArguments = pattern.GenericTypeArguments;
+                Type[] actualGenericTypeArguments = actual.GenericTypeArguments;
+                int count = patternGenericTypeArguments.Length;
+                if (count != actualGenericTypeArguments.Length)
+                    return false;
+                for (int i = 0; i < count; i++)
+                {
+                    Type patternGenericTypeArgument = patternGenericTypeArguments[i];
+                    if (patternGenericTypeArgument is SignatureType signatureType)
+                    {
+                        if (!signatureType.MatchesExactly(actualGenericTypeArguments[i]))
+                            return false;
+                    }
+                    else
+                    {
+                        if (patternGenericTypeArgument != actualGenericTypeArguments[i])
+                            return false;
+                    }
+                }
+                return true;
+            }
+            else if (pattern.IsGenericMethodParameter)
+            {
+                if (!(actual.IsGenericParameter && actual.DeclaringMethod != null))
+                    return false;
+                if (pattern.GenericParameterPosition != actual.GenericParameterPosition)
+                    return false;
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Translates a SignatureType into its equivalent resolved Type by recursively substituting all generic parameter references
+        /// with its corresponding generic parameter definition. This is slow so MatchesExactly or MatchesParameterTypeExactly should be
+        /// substituted instead whenever possible. This is only used by the DefaultBinder when its fast-path checks have been exhausted and
+        /// it needs to call non-trivial methods like IsAssignableFrom which SignatureTypes will never support.
+        /// 
+        /// Because this method is used to eliminate method candidates in a GetMethod() lookup, it is entirely possible that the Type
+        /// might not be creatable due to conflicting generic constraints. Since this merely implies that this candidate is not
+        /// the method we're looking for, we return null rather than let the TypeLoadException bubble up. The DefaultBinder will catch
+        /// the null and continue its search for a better candidate.
+        /// </summary>
+        internal static Type TryResolveAgainstGenericMethod(this SignatureType signatureType, MethodInfo genericMethod)
+        {
+            return signatureType.TryResolve(genericMethod.GetGenericArguments());
+        }
+    
+        private static Type TryResolve(this SignatureType signatureType, Type[] genericMethodParameters)
+        {
+            if (signatureType.IsSZArray)
+            {
+                return signatureType.ElementType.TryResolve(genericMethodParameters)?.TryMakeArrayType();
+            }
+            else if (signatureType.IsVariableBoundArray)
+            {
+                return signatureType.ElementType.TryResolve(genericMethodParameters)?.TryMakeArrayType(signatureType.GetArrayRank());
+            }
+            else if (signatureType.IsByRef)
+            {
+                return signatureType.ElementType.TryResolve(genericMethodParameters)?.TryMakeByRefType();
+            }
+            else if (signatureType.IsPointer)
+            {
+                return signatureType.ElementType.TryResolve(genericMethodParameters)?.TryMakePointerType();
+            }
+            else if (signatureType.IsConstructedGenericType)
+            {
+                Type[] genericTypeArguments = signatureType.GenericTypeArguments;
+                int count = genericTypeArguments.Length;
+                Type[] newGenericTypeArguments = new Type[count];
+                for (int i = 0; i < count; i++)
+                {
+                    Type genericTypeArgument = genericTypeArguments[i];
+                    if (genericTypeArgument is SignatureType signatureGenericTypeArgument)
+                    {
+                        newGenericTypeArguments[i] = signatureGenericTypeArgument.TryResolve(genericMethodParameters);
+                        if (newGenericTypeArguments[i] == null)
+                            return null;
+                    }
+                    else
+                    {
+                        newGenericTypeArguments[i] = genericTypeArgument;
+                    }
+                }
+                return signatureType.GetGenericTypeDefinition().TryMakeGenericType(newGenericTypeArguments);
+            }
+            else if (signatureType.IsGenericMethodParameter)
+            {
+                int position = signatureType.GenericParameterPosition;
+                if (position >= genericMethodParameters.Length)
+                    return null;
+                return genericMethodParameters[position];
+            }
+            else
+            {
+                return null;
+            }
+        }
+    
+        private static Type TryMakeArrayType(this Type type)
+        {
+            try
+            {
+                return type.MakeArrayType();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    
+        private static Type TryMakeArrayType(this Type type, int rank)
+        {
+            try
+            {
+                return type.MakeArrayType(rank);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    
+        private static Type TryMakeByRefType(this Type type)
+        {
+            try
+            {
+                return type.MakeByRefType();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    
+        private static Type TryMakePointerType(this Type type)
+        {
+            try
+            {
+                return type.MakePointerType();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    
+        private static Type TryMakeGenericType(this Type type, Type[] instantiation)
+        {
+            try
+            {
+                return type.MakeGenericType(instantiation);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Reflection/TypeDelegator.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/TypeDelegator.cs
@@ -113,6 +113,8 @@ namespace System.Reflection
         public override Type GetElementType() => typeImpl.GetElementType();
         protected override bool HasElementTypeImpl() => typeImpl.HasElementType;
 
+        public override bool IsSignatureType => typeImpl.IsSignatureType;
+
         public override Type UnderlyingSystemType => typeImpl.UnderlyingSystemType;
 
         // ICustomAttributeProvider

--- a/src/System.Private.CoreLib/shared/System/Type.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.cs
@@ -108,6 +108,8 @@ namespace System
         public bool IsValueType => IsValueTypeImpl();
         protected virtual bool IsValueTypeImpl() => IsSubclassOf(typeof(ValueType));
 
+        public virtual bool IsSignatureType => false;
+
         public virtual bool IsSecurityCritical { get { throw NotImplemented.ByDesign; } }
         public virtual bool IsSecuritySafeCritical { get { throw NotImplemented.ByDesign; } }
         public virtual bool IsSecurityTransparent { get { throw NotImplemented.ByDesign; } }
@@ -178,6 +180,27 @@ namespace System
         }
 
         protected abstract MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers);
+
+        public MethodInfo GetMethod(string name, int genericParameterCount, Type[] types) => GetMethod(name, genericParameterCount, types, null);
+        public MethodInfo GetMethod(string name, int genericParameterCount, Type[] types, ParameterModifier[] modifiers) => GetMethod(name, genericParameterCount, Type.DefaultLookup, null, types, modifiers);
+        public MethodInfo GetMethod(string name, int genericParameterCount, BindingFlags bindingAttr, Binder binder, Type[] types, ParameterModifier[] modifiers) => GetMethod(name, genericParameterCount, bindingAttr, binder, CallingConventions.Any, types, modifiers);
+        public MethodInfo GetMethod(string name, int genericParameterCount, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+            if (genericParameterCount < 0)
+                throw new ArgumentException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(genericParameterCount));
+            if (types == null)
+                throw new ArgumentNullException(nameof(types));
+            for (int i = 0; i < types.Length; i++)
+            {
+                if (types[i] == null)
+                    throw new ArgumentNullException(nameof(types));
+            }
+            return GetMethodImpl(name, genericParameterCount, bindingAttr, binder, callConvention, types, modifiers);
+        }
+
+        protected virtual MethodInfo GetMethodImpl(string name, int genericParameterCount, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) => throw new NotSupportedException();
 
         public MethodInfo[] GetMethods() => GetMethods(Type.DefaultLookup);
         public abstract MethodInfo[] GetMethods(BindingFlags bindingAttr);
@@ -318,6 +341,13 @@ namespace System
         public virtual Type MakeByRefType() { throw new NotSupportedException(); }
         public virtual Type MakeGenericType(params Type[] typeArguments) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
         public virtual Type MakePointerType() { throw new NotSupportedException(); }
+
+        public static Type MakeGenericMethodParameter(int position)
+        {
+            if (position < 0)
+                throw new ArgumentException(SR.ArgumentOutOfRange_MustBeNonNegNum, nameof(position));
+            return new SignatureGenericMethodParameterType(position);
+        }
 
         public override string ToString() => "Type: " + Name;  // Why do we add the "Type: " prefix?
 

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -95,6 +95,11 @@ namespace Internal.Reflection.Augments
             return TypeCode.Object;
         }
 
+        public static Type MakeGenericSignatureType(Type genericTypeDefinition, Type[] genericTypeArguments)
+        {
+            return new SignatureConstructedGenericType(genericTypeDefinition, genericTypeArguments);
+        }
+
         internal static ReflectionCoreCallbacks ReflectionCoreCallbacks
         {
             get

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2614,4 +2614,13 @@
   <data name="InvalidAssemblyName" xml:space="preserve">
     <value>The given assembly name or codebase was invalid</value>
   </data>
+  <data name="Argument_HasToBeArrayClass" xml:space="preserve">
+    <value>Must be an array type.</value>
+  </data>
+  <data name="InvalidOperation_NotGenericType" xml:space="preserve">
+    <value>This operation is only valid on generic types.</value>
+  </data>
+  <data name="NotSupported_SignatureType" xml:space="preserve">
+    <value>This method is not supported on Signature Types.</value>
+  </data>
 </root>

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/Shared.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/BindingFlagSupport/Shared.cs
@@ -128,7 +128,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                         for (int i = 0; i < parameterInfos.Length; i++)
                         {
                             // a null argument type implies a null arg which is always a perfect match
-                            if ((object)argumentTypes[i] != null && !parameterInfos[i].ParameterType.Equals(argumentTypes[i]))
+                            if ((object)argumentTypes[i] != null && !argumentTypes[i].MatchesParameterTypeExactly(parameterInfos[i]))
                                 return false;
                         }
                     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NonOverriddenApis.cs
@@ -147,6 +147,7 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override bool IsInstanceOfType(object o) => base.IsInstanceOfType(o);
         public sealed override bool IsSerializable => base.IsSerializable;
         public sealed override bool IsEquivalentTo(Type other) => base.IsEquivalentTo(other); // Note: If we enable COM type equivalence, this is no longer the correct implementation.
+        public sealed override bool IsSignatureType => base.IsSignatureType;
 
         public sealed override IEnumerable<ConstructorInfo> DeclaredConstructors => base.DeclaredConstructors;
         public sealed override IEnumerable<EventInfo> DeclaredEvents => base.DeclaredEvents;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/EcmaFormat/EcmaFormatMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/EcmaFormat/EcmaFormatMethodCommon.cs
@@ -31,13 +31,7 @@ namespace System.Reflection.Runtime.MethodInfos.EcmaFormat
     //
     internal struct EcmaFormatMethodCommon : IRuntimeMethodCommon<EcmaFormatMethodCommon>, IEquatable<EcmaFormatMethodCommon>
     {
-        public bool IsGenericMethodDefinition
-        {
-            get
-            {
-                return _method.GetGenericParameters().Count > 0;
-            }
-        }
+        public bool IsGenericMethodDefinition => GenericParameterCount != 0;
 
         public MethodInvoker GetUncachedMethodInvoker(RuntimeTypeInfo[] methodArguments, MemberInfo exceptionPertainant)
         {
@@ -76,6 +70,8 @@ namespace System.Reflection.Runtime.MethodInfos.EcmaFormat
                         typeContext);
             }
         }
+
+        public int GenericParameterCount => _method.GetGenericParameters().Count;
 
         public RuntimeTypeInfo[] GetGenericTypeParametersWithSpecifiedOwningMethod(RuntimeNamedMethodInfo<EcmaFormatMethodCommon> owningMethod)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/IRuntimeMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/IRuntimeMethodCommon.cs
@@ -49,6 +49,7 @@ namespace System.Reflection.Runtime.MethodInfos
         MethodInvoker GetUncachedMethodInvoker(RuntimeTypeInfo[] methodArguments, MemberInfo exceptionPertainant);
 
         bool IsGenericMethodDefinition { get; }
+        int GenericParameterCount { get; }
 
         bool HasSameMetadataDefinitionAs(TRuntimeMethodCommon other);
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
@@ -28,14 +28,7 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
     //
     internal struct NativeFormatMethodCommon : IRuntimeMethodCommon<NativeFormatMethodCommon>, IEquatable<NativeFormatMethodCommon>
     {
-        public bool IsGenericMethodDefinition
-        {
-            get
-            {
-                Method method = MethodHandle.GetMethod(Reader);
-                return method.GenericParameters.GetEnumerator().MoveNext();
-            }
-        }
+        public bool IsGenericMethodDefinition => GenericParameterCount != 0;
 
         public MethodInvoker GetUncachedMethodInvoker(RuntimeTypeInfo[] methodArguments, MemberInfo exceptionPertainant)
         {
@@ -84,6 +77,8 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
                         typeContext);
             }
         }
+
+        public int GenericParameterCount => MethodHandle.GetMethod(Reader).GenericParameters.Count;
 
         public RuntimeTypeInfo[] GetGenericTypeParametersWithSpecifiedOwningMethod(RuntimeNamedMethodInfo<NativeFormatMethodCommon> owningMethod)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
@@ -76,6 +76,8 @@ namespace System.Reflection.Runtime.MethodInfos
             return _genericMethodDefinition.GetHashCode();
         }
 
+        public sealed override int GenericParameterCount => _genericMethodDefinition.GenericParameterCount;
+
         public sealed override MethodInfo GetGenericMethodDefinition()
         {
             return _genericMethodDefinition;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeDummyMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeDummyMethodInfo.cs
@@ -29,6 +29,7 @@ namespace System.Reflection.Runtime.MethodInfos
         public sealed override bool IsConstructedGenericMethod { get { throw NotImplemented.ByDesign; } }
         public sealed override bool IsGenericMethod { get { throw NotImplemented.ByDesign; } }
         public sealed override bool IsGenericMethodDefinition { get { throw NotImplemented.ByDesign; } }
+        public sealed override int GenericParameterCount { get { throw NotImplemented.ByDesign; } }
         public sealed override bool HasSameMetadataDefinitionAs(MemberInfo other) { throw NotImplemented.ByDesign; }
         public sealed override MethodImplAttributes MethodImplementationFlags { get { throw NotImplemented.ByDesign; } }
         public sealed override Module Module { get { throw NotImplemented.ByDesign; } }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -149,6 +149,8 @@ namespace System.Reflection.Runtime.MethodInfos
             return RuntimeGenericArgumentsOrParameters.CloneTypeArray();
         }
 
+        public abstract override int GenericParameterCount { get; }
+
         public abstract override MethodInfo GetGenericMethodDefinition();
 
         public sealed override MethodBody GetMethodBody()

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -115,6 +115,8 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
+        public sealed override int GenericParameterCount => _common.GenericParameterCount;
+
         public sealed override MethodInfo MakeGenericMethod(params Type[] typeArguments)
         {
 #if ENABLE_REFLECTION_TRACE

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
@@ -109,6 +109,8 @@ namespace System.Reflection.Runtime.MethodInfos
             }
         }
 
+        public sealed override int GenericParameterCount => 0;
+
         public sealed override MethodInfo MakeGenericMethod(params Type[] typeArguments)
         {
             throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericMethodDefinition, this));


### PR DESCRIPTION
The complete specs and rationale are in the
top comment of

https://github.com/dotnet/corefx/issues/16567

but the short version is:

- New Type.GetMethod() overloads with a "genericParameterCount"
  parameter. Only considers methods with that number of generic
  parameters.

- New api: Type.MakeGenericMethodParameter(int position)

  Create a Type representing an unbound generic method parameter
  (just an index, no constraints or container information.)
  Without this, GetMethod() isn't very useable for searching
  for generic methods.

- New api: Type.IsSignatureType

  Indicates whether a Type object was created by
  MakeGenericMethodParameter() or constructed from
  one via MakeArrayType, MakeByRefType, etc.

  

Sample usage:

    class Horror
    {
        public void Moo(int x, int[] y) {}
        public void Moo<T>(T x, T[] y) {}
        public void Moo<T>(int x, int[] y) {}
        public void Moo<T,U>(T x, U[] y) {}  // <-- We want this one.
        public void Moo<T,U>(int x, int[] y) {}
    }


    Type horror = typeof(Horror);
    Type theT = Type.MakeGenericMethodParameter(0);
    Type theU = Type.MakeGenericMethodParameter(1);
    
    MethodInfo moo = horror.GetMethod("Moo", genericParameterCount: 2, new Type[] { theT, theU.MakeArrayType() });