### PR TITLE
Fix casing in "signature type" error text.

### DIFF
--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2621,6 +2621,6 @@
     <value>This operation is only valid on generic types.</value>
   </data>
   <data name="NotSupported_SignatureType" xml:space="preserve">
-    <value>This method is not supported on Signature Types.</value>
+    <value>This method is not supported on signature types.</value>
   </data>
 </root>


### PR DESCRIPTION
Small piece of codeflow feedback that CodeFlow
email naturally neglected to tell me about.