### PR TITLE
Add new member to RuntimeThread for shared changes in CoreCLR

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
@@ -371,6 +371,15 @@ namespace Internal.Runtime.Augments
         }
 
         public static void Sleep(int millisecondsTimeout) => SleepInternal(VerifyTimeoutMilliseconds(millisecondsTimeout));
+
+        /// <summary>
+        /// Max value to be passed into <see cref="SpinWait(int)"/> for optimal delaying. Currently, the value comes from
+        /// defaults in CoreCLR's Thread::InitializeYieldProcessorNormalized(). This value is supposed to be normalized to be
+        /// appropriate for the processor.
+        /// TODO: See issue https://github.com/dotnet/corert/issues/4430
+        /// </summary>
+        internal static readonly int OptimalMaxSpinWaitsPerSpinIteration = 64;
+
         public static void SpinWait(int iterations) => RuntimeImports.RhSpinWait(iterations);
         public static bool Yield() => RuntimeImports.RhYield();
 


### PR DESCRIPTION
PR https://github.com/dotnet/coreclr/pull/13670 adds a new member to RuntimeThread is that used by SpinWait. SpinWait is shared, so this PR is adding the new member to CoreRT first to avoid a break.