### PR TITLE
Add the enum value for BindingFlags.DoNotWrapExceptions

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/BindingFlags.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/BindingFlags.cs
@@ -46,5 +46,6 @@ namespace System.Reflection
 
         // These are a couple of misc attributes used
         IgnoreReturn = 0x01000000,  // This is used in COM Interop
+        DoNotWrapExceptions = 0x02000000, // Disables wrapping exceptions in TargetInvocationException
     }
 }


### PR DESCRIPTION
This was approved here.

https://github.com/dotnet/corefx/issues/22866

This does not implement the feature, it just adds
the member to the enum so that CoreCLR and CoreRT
will agree on the value.