### PR TITLE
Implement BindingFlags.DoNotWrapExceptions on Project N

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/BindingFlags.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/BindingFlags.cs
@@ -46,5 +46,6 @@ namespace System.Reflection
 
         // These are a couple of misc attributes used
         IgnoreReturn = 0x01000000,  // This is used in COM Interop
+        DoNotWrapExceptions = 0x02000000, // Disables wrapping exceptions in TargetInvocationException
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -405,6 +405,7 @@ namespace Internal.Runtime.Augments
             object defaultParametersContext,
             object[] parameters,
             BinderBundle binderBundle,
+            bool wrapInTargetInvocationException,
             bool invokeMethodHelperIsThisCall,
             bool methodToCallIsThisCall)
         {
@@ -417,6 +418,7 @@ namespace Internal.Runtime.Augments
                 defaultParametersContext,
                 parameters,
                 binderBundle,
+                wrapInTargetInvocationException,
                 invokeMethodHelperIsThisCall,
                 methodToCallIsThisCall);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -373,7 +373,7 @@ namespace System
             else
             {
                 IntPtr invokeThunk = this.GetThunk(DelegateInvokeThunk);
-                object result = System.InvokeUtils.CallDynamicInvokeMethod(this.m_firstParameter, this.m_functionPointer, this, invokeThunk, IntPtr.Zero, this, args, binderBundle: null);
+                object result = System.InvokeUtils.CallDynamicInvokeMethod(this.m_firstParameter, this.m_functionPointer, this, invokeThunk, IntPtr.Zero, this, args, binderBundle: null, wrapInTargetInvocationException: true);
                 DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
                 return result;
             }

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/MethodInvoker.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/MethodInvoker.cs
@@ -22,11 +22,12 @@ namespace Internal.Reflection.Core.Execution
         public Object Invoke(Object thisObject, Object[] arguments, Binder binder, BindingFlags invokeAttr, CultureInfo cultureInfo)
         {
             BinderBundle binderBundle = binder.ToBinderBundle(invokeAttr, cultureInfo);
-            Object result = Invoke(thisObject, arguments, binderBundle);
+            bool wrapInTargetInvocationException = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
+            Object result = Invoke(thisObject, arguments, binderBundle, wrapInTargetInvocationException);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
             return result;
         }
-        public abstract Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle);
+        protected abstract Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException);
         public abstract Delegate CreateDelegate(RuntimeTypeHandle delegateType, Object target, bool isStatic, bool isVirtual, bool isOpen);
 
         // This property is used to retrieve the target method pointer. It is used by the RuntimeMethodHandle.GetFunctionPointer API

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/OpenMethodInvoker.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/OpenMethodInvoker.cs
@@ -15,7 +15,7 @@ namespace System.Reflection.Runtime.MethodInfos
 {
     internal sealed class OpenMethodInvoker : MethodInvoker
     {
-        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
+        protected sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             throw new InvalidOperationException(SR.Arg_UnboundGenParam);
         }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/InstanceMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/InstanceMethodInvoker.cs
@@ -28,7 +28,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
         }
 
         [DebuggerGuidedStepThroughAttribute]
-        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
+        protected sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             MethodInvokerUtils.ValidateThis(thisObject, _declaringTypeHandle);
             object result = RuntimeAugments.CallDynamicInvokeMethod(
@@ -40,6 +40,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 MethodInvokeInfo.MethodInfo,
                 arguments,
                 binderBundle,
+                wrapInTargetInvocationException: wrapInTargetInvocationException,
                 invokeMethodHelperIsThisCall: false, 
                 methodToCallIsThisCall: true);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/IntPtrConstructorMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/IntPtrConstructorMethodInvoker.cs
@@ -64,7 +64,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
             }
         }
 
-        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
+        protected sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             switch (_id)
             {
@@ -76,7 +76,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                         {
                             return new IntPtr(value);
                         }
-                        catch (Exception inner)
+                        catch (Exception inner) when (wrapInTargetInvocationException)
                         {
                             throw new TargetInvocationException(inner);
                         }
@@ -90,7 +90,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                         {
                             return new IntPtr(value);
                         }
-                        catch (Exception inner)
+                        catch (Exception inner) when (wrapInTargetInvocationException)
                         {
                             throw new TargetInvocationException(inner);
                         }
@@ -104,7 +104,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                         {
                             return new UIntPtr(value);
                         }
-                        catch (Exception inner)
+                        catch (Exception inner) when (wrapInTargetInvocationException)
                         {
                             throw new TargetInvocationException(inner);
                         }
@@ -118,7 +118,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                         {
                             return new UIntPtr(value);
                         }
-                        catch (Exception inner)
+                        catch (Exception inner) when (wrapInTargetInvocationException)
                         {
                             throw new TargetInvocationException(inner);
                         }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/NullableInstanceMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/NullableInstanceMethodInvoker.cs
@@ -83,7 +83,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
             }
         }
 
-        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
+        protected sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             Object value = thisObject;
             bool hasValue = (thisObject != null);

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StaticMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StaticMethodInvoker.cs
@@ -25,7 +25,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
         }
 
         [DebuggerGuidedStepThroughAttribute]
-        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
+        protected sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             object result = RuntimeAugments.CallDynamicInvokeMethod(
                 thisObject,
@@ -36,6 +36,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 MethodInvokeInfo.MethodInfo,
                 arguments,
                 binderBundle,
+                wrapInTargetInvocationException: wrapInTargetInvocationException,
                 invokeMethodHelperIsThisCall: false,
                 methodToCallIsThisCall: false);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StringConstructorMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StringConstructorMethodInvoker.cs
@@ -58,7 +58,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
             }
         }
 
-        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
+        protected sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             switch (_id)
             {

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/SyntheticMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/SyntheticMethodInvoker.cs
@@ -27,7 +27,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
             _parameterTypes = parameterTypes;
         }
 
-        public override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
+        protected sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             //@todo: This does not handle optional parameters (nor does it need to as today we're only using it for three synthetic array methods.)
             if (!(thisObject == null && 0 != (_options & InvokerOptions.AllowNullThis)))
@@ -46,12 +46,9 @@ namespace Internal.Reflection.Execution.MethodInvokers
             {
                 result = _invoker(thisObject, convertedArguments);
             }
-            catch (Exception e)
+            catch (Exception e) when (wrapInTargetInvocationException && ((_options & InvokerOptions.DontWrapException) == 0))
             {
-                if (0 != (_options & InvokerOptions.DontWrapException))
-                    throw;
-                else
-                    throw new TargetInvocationException(e);
+                throw new TargetInvocationException(e);
             }
             return result;
         }

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
@@ -52,7 +52,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
         }
 
         [DebuggerGuidedStepThroughAttribute]
-        public sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle)
+        protected sealed override Object Invoke(Object thisObject, Object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             MethodInvokerUtils.ValidateThis(thisObject, _declaringTypeHandle);
 
@@ -67,6 +67,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 MethodInvokeInfo.MethodInfo,
                 arguments,
                 binderBundle,
+                wrapInTargetInvocationException: wrapInTargetInvocationException,
                 invokeMethodHelperIsThisCall: false,
                 methodToCallIsThisCall: true);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();


### PR DESCRIPTION
This was approved here.

https://github.com/dotnet/corefx/issues/22866

Ok, this one actually makes the feature work. Turned
out not to be too hard.

There are a couple of drive-by items being done here:

- Since the other Invoke overload on MethodInvoker
  was only for its use, downgraded its visibility.

- Moved the catch in InvokeUtilites before the finally
  that copies back arguments. We don't want to wrap
  any exceptions out of the argument post-processing
  steps.