### PR TITLE
Disable USE_GROWABLE_FUNCTION_TABLE for now

### DIFF
--- a/src/Native/jitinterface/JITCodeManager.h
+++ b/src/Native/jitinterface/JITCodeManager.h
@@ -95,9 +95,10 @@ public:
 
 typedef DPTR(RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
 
-#ifdef _TARGET_AMD64_
-#define USE_GROWABLE_FUNCTION_TABLE 1
-#endif
+// TODO: Not compatible with Windows 7
+// #ifdef _TARGET_AMD64_
+// #define USE_GROWABLE_FUNCTION_TABLE 1
+// #endif
 
 class CodeHeader
 {


### PR DESCRIPTION
The growable function tables do not exist on Windows 7. Fixes #4401.