### PR TITLE
[ILVerify] Implement stack merging

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -317,7 +317,7 @@ namespace Internal.IL
 
         private void MarkBasicBlock(BasicBlock basicBlock)
         {
-            if (basicBlock.EndOffset == 0 && basicBlock.ErrorCount == 0)
+            if (basicBlock.EndOffset == 0)
             {
                 // Link
                 basicBlock.Next = _pendingBasicBlocks;

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -317,7 +317,7 @@ namespace Internal.IL
 
         private void MarkBasicBlock(BasicBlock basicBlock)
         {
-            if (basicBlock.EndOffset == 0)
+            if (basicBlock.EndOffset == 0 && basicBlock.ErrorCount == 0)
             {
                 // Link
                 basicBlock.Next = _pendingBasicBlocks;

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -129,9 +129,6 @@ namespace Internal.IL
 
         public static bool operator ==(StackValue left, StackValue right)
         {
-            if (left == null)
-                return right == null;
-
             return left.Equals(right);
         }
 
@@ -320,7 +317,7 @@ namespace Internal.IL
                     return true;
 
                 // Merging classes always succeeds since System.Object always works
-                merged = StackValue.CreateFromType(MergeClasses(valueA.Type, valueB.Type)); 
+                merged = StackValue.CreateFromType(MergeObjectReferences(valueA.Type, valueB.Type)); 
                 return true;
             }
 
@@ -328,7 +325,7 @@ namespace Internal.IL
         }
 
         // Used to merge stack states.
-        static TypeDesc MergeClasses(TypeDesc classA, TypeDesc classB)
+        static TypeDesc MergeObjectReferences(TypeDesc classA, TypeDesc classB)
         {
             if (classA == classB)
                 return classA;
@@ -492,7 +489,7 @@ namespace Internal.IL
                      (!arrayTypeB.ElementType.IsValueType && !arrayTypeB.ElementType.IsByRef))
             {
                 // Find common ancestor of the element types
-                mergedElementType = MergeClasses(arrayTypeA.ElementType, arrayTypeB.ElementType);
+                mergedElementType = MergeObjectReferences(arrayTypeA.ElementType, arrayTypeB.ElementType);
             }
             else
             {

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -247,6 +247,217 @@ namespace Internal.IL
             }
         }
 
+        /// <summary>
+        /// Merges two stack values to a common stack value as defined in the ECMA-335 
+        /// standard III.1.8.1.3 (Merging stack states).
+        /// </summary>
+        /// <param name="valueA">The value to be merged with <paramref name="valueB"/>.</param>
+        /// <param name="valueB">The value to be merged with <paramref name="valueA"/>.</param>
+        /// <param name="merged">The resulting type of merging <paramref name="valueA"/> and <paramref name="valueB"/>.</param>
+        /// <returns>True if merge operation was successful, false if the merge operation failed.</returns>
+        public static bool TryMergeStackValues(StackValue valueA, StackValue valueB, out StackValue merged)
+        {
+            merged = valueA;
+
+            if (valueB.IsReadOnly)
+                merged.SetIsReadOnly();
+
+            // Same type
+            if (valueA.Kind == valueB.Kind && valueA.Type == valueB.Type)
+                return true;
+
+            // One of the two types is a (unboxed) generic parameter (only valid if a == b)
+            if ((valueA.Type != null && valueA.Type.IsGenericParameter && valueA.Kind != StackValueKind.ObjRef) ||
+                (valueB.Type != null && valueB.Type.IsGenericParameter && valueB.Kind != StackValueKind.ObjRef))
+                return false;
+
+            if (valueA.IsNullReference)
+            {
+                //Null can be any reference type
+                if (valueB.Kind == StackValueKind.ObjRef)
+                {
+                    merged = valueB;
+                    return true;
+                }
+            }
+            else if (valueA.Kind == StackValueKind.ObjRef)
+            {
+                if (valueB.Kind != StackValueKind.ObjRef)
+                    return false;
+
+                // Null can be any reference type
+                if (valueB.IsNullReference)
+                    return true;
+
+                // Merging classes always succeeds since System.Object always works
+                merged = StackValue.CreateFromType(MergeClasses(valueA.Type, valueB.Type)); 
+                return true;
+            }
+
+            return false;
+        }
+
+        // Used to merge stack states.
+        static TypeDesc MergeClasses(TypeDesc classA, TypeDesc classB)
+        {
+            if (classA == classB)
+                return classA;
+
+            // Array case
+            if (classA.IsArray)
+            {
+                if (classB.IsArray)
+                {
+                    return MergeArrayTypes((ArrayType)classA, (ArrayType)classB);
+                }
+            }
+
+            // Assumes generic parameters are boxed at this point.
+            // Return supertype, if related, otherwhise object
+            if (classA.IsGenericParameter || classB.IsGenericParameter)
+            {
+                if (classA.CanCastTo(classB))
+                    return classB;
+                if (classB.CanCastTo(classA))
+                    return classA;
+
+                return classA.Context.GetWellKnownType(WellKnownType.Object);
+            }
+
+            if (classB.IsInterface)
+            {
+                if (classA.IsInterface)
+                {
+                    foreach (var interf in classA.RuntimeInterfaces)
+                    {
+                        if (interf == classB)
+                            return classB; // Interface A extends interface B
+                    }
+
+                    foreach (var interf in classB.RuntimeInterfaces)
+                    {
+                        if (interf == classA)
+                            return classA; // Interface B extends interface A
+                    }
+
+                    // Get common supertype
+                    foreach (var interfB in classB.RuntimeInterfaces)
+                    {
+                        foreach (var interfA in classA.RuntimeInterfaces)
+                        {
+                            if (interfA == interfB)
+                                return interfA;
+                        }
+                    }
+
+                    // No compatible interface found, return Object
+                    return classA.Context.GetWellKnownType(WellKnownType.Object);
+                }
+                else
+                    return MergeClassWithInterface(classA, classB);
+            }
+            else if (classA.IsInterface)
+                return MergeClassWithInterface(classB, classA);
+
+            // Find class hierarchy depth for both classes
+            int aDepth = 0;
+            int bDepth = 0;
+            TypeDesc curType;
+
+            for (curType = classA; curType != null; curType = curType.BaseType)
+                aDepth++;
+
+            for (curType = classB; curType != null; curType = curType.BaseType)
+                bDepth++;
+
+            // Walk up superclass chain until both classes at same level
+            while (aDepth > bDepth)
+            {
+                classA = classA.BaseType;
+                aDepth--;
+            }
+
+            while (bDepth > aDepth)
+            {
+                classB = classB.BaseType;
+                bDepth--;
+            }
+
+            while (classA != classB)
+            {
+                classA = classA.BaseType;
+                classB = classB.BaseType;
+            }
+
+            // At this point we should either have found a common supertype or end up at System.Object
+            Debug.Assert(classA != null);
+
+            return classA;
+        }
+
+        static TypeDesc MergeClassWithInterface(TypeDesc classType, TypeDesc interfaceType)
+        {
+            // Check if class implements interface
+            foreach (var interf in classType.RuntimeInterfaces)
+            {
+                if (interf == interfaceType)
+                    return interfaceType;
+            }
+
+            // Check if class and interface implement common interface
+            foreach (var iInterf in interfaceType.RuntimeInterfaces)
+            {
+                foreach (var cInterf in classType.RuntimeInterfaces)
+                {
+                    if (iInterf == cInterf)
+                        return iInterf;
+                }
+            }
+
+            // No compatible merge, return Object
+            return classType.Context.GetWellKnownType(WellKnownType.Object);
+        }
+
+        static TypeDesc MergeArrayTypes(ArrayType arrayTypeA, ArrayType arrayTypeB)
+        {
+            if (arrayTypeA == arrayTypeB)
+                return arrayTypeA;
+
+            var basicArrayType = arrayTypeA.Context.GetWellKnownType(WellKnownType.Array);
+
+            if (arrayTypeA == basicArrayType || arrayTypeB == basicArrayType)
+                return basicArrayType;
+
+            // If non matching rank, common ancestor = System.Array
+            var rank = arrayTypeA.Rank;
+            if (rank != arrayTypeB.Rank)
+                return basicArrayType;
+
+            // Determine merged array element type
+            TypeDesc mergedElementType;
+            if (arrayTypeA.ElementType == arrayTypeB.ElementType)
+                mergedElementType = arrayTypeA.ElementType;
+            else if (arrayTypeA.ElementType.IsArray && arrayTypeB.ElementType.IsArray)
+            {
+                // Array of arrays -> find merged type
+                mergedElementType = MergeArrayTypes(arrayTypeA, arrayTypeB);
+            }
+            //Both array element types are ObjRefs
+            else if ((!arrayTypeA.ElementType.IsValueType && !arrayTypeA.ElementType.IsByRef) && 
+                     (!arrayTypeB.ElementType.IsValueType && !arrayTypeB.ElementType.IsByRef))
+            {
+                // Find common ancestor of the element types
+                mergedElementType = MergeClasses(arrayTypeA.ElementType, arrayTypeB.ElementType);
+            }
+            else
+            {
+                // Array element types have nothing in common
+                return basicArrayType;
+            }
+
+            return arrayTypeA.Context.GetArrayType(mergedElementType, rank);
+        }
+
         static bool IsSameReducedType(TypeDesc src, TypeDesc dst)
         {
             return GetReducedType(src) == GetReducedType(dst);
@@ -397,7 +608,7 @@ namespace Internal.IL
     }
 
     return FALSE;
-#endif 
+#endif
         }
 
 

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -335,10 +335,7 @@ namespace Internal.IL
             {
                 if (classB.IsArray)
                     return MergeArrayTypes((ArrayType)classA, (ArrayType)classB);
-                classA = classA.Context.GetWellKnownType(WellKnownType.Array);
             }
-            else if (classB.IsArray)
-                classB = classB.Context.GetWellKnownType(WellKnownType.Array);
 
             // Assumes generic parameters are boxed at this point.
             // Return supertype, if related, otherwhise object

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -115,6 +115,41 @@ namespace Internal.IL
             }
         }
 
+        public override bool Equals(object obj)
+        {
+            if (Object.ReferenceEquals(this, obj))
+                return true;
+
+            if (!(obj is StackValue))
+                return false;
+
+            var value = (StackValue)obj;
+            return this.Kind == value.Kind && this.Flags == value.Flags && this.Type == value.Type;
+        }
+
+        public static bool operator ==(StackValue left, StackValue right)
+        {
+            if (left == null)
+                return right == null;
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(StackValue left, StackValue right)
+        {
+            return !(left == right);
+        }
+
+        public override int GetHashCode()
+        {
+                const int prime = 17;
+                int hash = 23;
+                hash = (hash * prime) ^ Type.GetHashCode();
+                hash = (hash * prime) ^ Kind.GetHashCode();
+                hash = (hash * prime) ^ Flags.GetHashCode();
+                return hash;
+        }
+
         // For now, match PEVerify type formating to make it easy to compare with baseline
         static string TypeToStringForByRef(TypeDesc type)
         {

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1142,7 +1142,7 @@ namespace Internal.IL
                                 FatalCheck(false, VerifierError.PathStackUnexpected, entryStack[i], _stack[i]);
 
                             // If merge actually changed entry stack
-                            if (mergedValue.Kind != entryStack[i].Kind || mergedValue.Type != entryStack[i].Type)
+                            if (mergedValue != entryStack[i])
                             {
                                 entryStack[i] = mergedValue;
 

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1145,7 +1145,9 @@ namespace Internal.IL
                             if (mergedValue.Kind != entryStack[i].Kind || mergedValue.Type != entryStack[i].Type)
                             {
                                 entryStack[i] = mergedValue;
-                                next.EndOffset = 0; // Make sure block is reverified
+
+                                if (next.ErrorCount == 0)
+                                    next.EndOffset = 0; // Make sure block is reverified
                             }
                         }
                     }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -400,8 +400,8 @@ namespace Internal.IL
                     VerificationError(VerifierError.BranchOutOfTry);
                 else
                 {
-                    ref ILExceptionRegion srcRegion = ref _exceptionRegions[(int)src.TryIndex].ILRegion;
-                    ref ILExceptionRegion targetRegion = ref _exceptionRegions[(int)target.TryIndex].ILRegion;
+                    ref var srcRegion = ref _exceptionRegions[(int)src.TryIndex].ILRegion;
+                    ref var targetRegion = ref _exceptionRegions[(int)target.TryIndex].ILRegion;
                     // If target is inside source region
                     if (srcRegion.TryOffset <= targetRegion.TryOffset && 
                         target.StartOffset < srcRegion.TryOffset + srcRegion.TryLength)
@@ -423,8 +423,8 @@ namespace Internal.IL
                     VerificationError(VerifierError.BranchOutOfFilter);
                 else
                 {
-                    ref ILExceptionRegion srcRegion = ref _exceptionRegions[(int)src.FilterIndex].ILRegion;
-                    ref ILExceptionRegion targetRegion = ref _exceptionRegions[(int)target.FilterIndex].ILRegion;
+                    ref var srcRegion = ref _exceptionRegions[(int)src.FilterIndex].ILRegion;
+                    ref var targetRegion = ref _exceptionRegions[(int)target.FilterIndex].ILRegion;
                     if (srcRegion.FilterOffset <= targetRegion.FilterOffset)
                         VerificationError(VerifierError.BranchIntoFilter);
                     else
@@ -440,8 +440,8 @@ namespace Internal.IL
                     VerificationError(VerifierError.BranchOutOfHandler);
                 else
                 {
-                    ref ILExceptionRegion srcRegion = ref _exceptionRegions[(int)src.HandlerIndex].ILRegion;
-                    ref ILExceptionRegion targetRegion = ref _exceptionRegions[(int)target.HandlerIndex].ILRegion;
+                    ref var srcRegion = ref _exceptionRegions[(int)src.HandlerIndex].ILRegion;
+                    ref var targetRegion = ref _exceptionRegions[(int)target.HandlerIndex].ILRegion;
                     if (srcRegion.HandlerOffset <= targetRegion.HandlerOffset)
                         VerificationError(VerifierError.BranchIntoHandler);
                     else

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -212,6 +212,29 @@
         ret
     }
 
+    .method static public hidebysig void Branching.UnequalStackMergeGenericArrayConstrain_Valid<(int32[]) T>(!!T generic,
+        int32[] arr) cil managed
+    {
+        .maxstack 1
+        .locals init(
+            [0] int32[] dest
+        )
+
+        ldarg.1
+        brfalse.s   lbl_arr
+
+        ldarg.0
+        box     !!T
+        br.s        lbl_store
+
+    lbl_arr:
+        ldarg.1
+
+    lbl_store:
+        stloc.0
+        ret
+    }
+
     .method static public hidebysig void Branching.InsideTry_Valid() cil managed
     {
         .maxstack 2

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -74,7 +74,7 @@
         IL_0014: ret
     }
 
-    .method static public hidebysig void Branching.NullConditional_Invalid_StackUnexpected.PathStackUnexpected() cil managed
+    .method static public hidebysig void Branching.NullConditional_Invalid_StackUnexpected() cil managed
     {
         //object o = null;
         //Type t = o != null ? o.GetType() : o;
@@ -110,13 +110,37 @@
         )
 
         ldarg.0
-        brfalse.s   lbl_sComp
+        brfalse.s   lbl_cComp
 
         ldarg.0
         br.s        lbl_store
 
-        lbl_sComp:
+        lbl_cComp:
         ldarg.1
+
+        lbl_store:
+        stloc.0
+        ret
+    }
+
+    .method static public hidebysig void Branching.UnequalStackMergeConstrained_Valid<([System.Runtime]System.Collections.IEqualityComparer) T>(class [System.Runtime]System.Collections.IEqualityComparer equalityComparer,
+        !!T customComparer) cil managed
+    {
+        .maxstack 1
+        .locals init(
+            [0] class [System.Runtime]System.Collections.IEqualityComparer
+        )
+
+        ldarg.1
+        box     !!T
+        brfalse.s   lbl_cComp
+
+        ldarg.0
+        br.s        lbl_store
+
+        lbl_cComp:
+        ldarg.1
+        box     !!T
 
         lbl_store:
         stloc.0

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -190,6 +190,28 @@
         ret
     }
 
+    .method static public hidebysig void Branching.UnequalStackMergeGeneric_Invalid_PathStackUnexpected<T>(!!T generic,
+        object obj) cil managed
+    {
+        .maxstack 1
+        .locals init(
+            [0] object obj
+        )
+
+        ldarg.1
+        brfalse.s   lbl_gen
+
+        ldarg.1
+        br.s        lbl_store
+
+    lbl_gen:
+        ldarg.0
+
+    lbl_store:
+        stloc.0
+        ret
+    }
+
     .method static public hidebysig void Branching.InsideTry_Valid() cil managed
     {
         .maxstack 2

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -109,40 +109,83 @@
             [0] class [System.Runtime]System.Collections.IEqualityComparer
         )
 
-        ldarg.0
+        ldc.i4.0
         brfalse.s   lbl_cComp
 
         ldarg.0
         br.s        lbl_store
 
-        lbl_cComp:
+    lbl_cComp:
         ldarg.1
 
-        lbl_store:
+    lbl_store:
         stloc.0
         ret
     }
 
-    .method static public hidebysig void Branching.UnequalStackMergeConstrained_Valid<([System.Runtime]System.Collections.IEqualityComparer) T>(class [System.Runtime]System.Collections.IEqualityComparer equalityComparer,
-        !!T customComparer) cil managed
+    .method static public hidebysig void Branching.UnequalStackMergeConstrained_Valid<([System.Runtime]System.Collections.IEqualityComparer) T>
+        (class [System.Runtime]System.Collections.IEqualityComparer equalityComparer, !!T customComparer) cil managed
     {
         .maxstack 1
         .locals init(
             [0] class [System.Runtime]System.Collections.IEqualityComparer
         )
 
-        ldarg.1
-        box     !!T
+        ldc.i4.0
         brfalse.s   lbl_cComp
 
         ldarg.0
         br.s        lbl_store
 
-        lbl_cComp:
+    lbl_cComp:
         ldarg.1
         box     !!T
 
-        lbl_store:
+    lbl_store:
+        stloc.0
+        ret
+    }
+
+    .method static public hidebysig void Branching.UnequalStackMergeArrays_Valid(class CustomComparer[] comparers,
+        class [System.Runtime]System.Collections.IEqualityComparer[] customComparer) cil managed
+    {
+        .maxstack 1
+        .locals init(
+            [0] class [System.Runtime]System.Collections.IEqualityComparer[]
+        )
+
+        ldarg.0
+        brfalse.s   lbl_cComp
+
+        ldarg.0
+        br.s        lbl_store
+
+    lbl_cComp:
+        ldarg.1
+
+    lbl_store:
+        stloc.0
+        ret
+    }
+
+    .method static public hidebysig void Branching.UnequalStackMergeArrays_Invalid_StackUnexpected(class CustomComparer[] comparers,
+        class [System.Runtime]System.Collections.IEqualityComparer[] customComparer) cil managed
+    {
+        .maxstack 1
+        .locals init(
+            [0] class CustomComparer[]
+        )
+
+        ldarg.0
+        brfalse.s   lbl_cComp
+
+        ldarg.0
+        br.s        lbl_store
+
+    lbl_cComp:
+        ldarg.1
+
+    lbl_store:
         stloc.0
         ret
     }

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -10,6 +10,40 @@
 {
 }
 
+// Custom Comparer class implementing IEqualityComparer for testing
+.class private auto ansi beforefieldinit CustomComparer
+    extends [System.Runtime]System.Object
+    implements [System.Runtime]System.Collections.IEqualityComparer
+{
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor () cil managed 
+    {
+        ldarg.0
+        call      instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+
+    .method public final hidebysig newslot virtual 
+        instance bool Equals (
+            object x,
+            object y
+        ) cil managed 
+    {
+        ldc.i4.0
+        ret
+    }
+
+    .method public final hidebysig newslot virtual 
+        instance int32 GetHashCode (
+            object obj
+        ) cil managed 
+    {
+        ldarg.1
+        callvirt  instance int32 [System.Runtime]System.Object::GetHashCode()
+        ret
+    }
+}
+
 .class public auto ansi beforefieldinit BranchingTestsType
        extends [System.Runtime]System.Object
 {
@@ -65,6 +99,28 @@
         IL_000E: call      valuetype [System.Runtime]System.TypeCode [System.Runtime]System.Type::GetTypeCode(class [System.Runtime]System.Type)
         IL_0013: pop
         IL_0014: ret
+    }
+
+    .method static public hidebysig void Branching.UnequalStackMerge_Valid(class [System.Runtime]System.Collections.IEqualityComparer equalityComparer,
+        class CustomComparer customComparer) cil managed
+    {
+        .maxstack 1
+        .locals init(
+            [0] class [System.Runtime]System.Collections.IEqualityComparer
+        )
+
+        ldarg.0
+        brfalse.s   lbl_sComp
+
+        ldarg.0
+        br.s        lbl_store
+
+        lbl_sComp:
+        ldarg.1
+
+        lbl_store:
+        stloc.0
+        ret
     }
 
     .method static public hidebysig void Branching.InsideTry_Valid() cil managed

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -243,6 +243,7 @@
 
         ldarg.0
         callvirt instance !0 class GenericTypeWithConstrained<!!TValueType>::get_Value()
+        box      !!TValueType
         stloc.0
         ret
     }


### PR DESCRIPTION
As described in the ECMA 335 standard (III.1.8.1.3), the verification algorithm shall merge the simulated stack state with any existing stack state.
At present, ILVerify only checks whether the current stack and the entry stack of the basic block to be verified match, by comparing the types of each stack value and considering one extra rule with nullreferences. This causes some cases of valid IL (see added test cases) to generate verifier errors.

I implemented a stack merging logic very similar to PEVerify's `tiMergeToCommonParent`.
However the stack merging requires basic blocks to be reconsidered for verification, if they have already been verified with another stack-state. Since PEVerify also seems to simply re-verify such blocks, I implemented logic so reset the `EndOffset` attribute, which we use to mark already verified blocks. In order to prevent errors being duplicated by verifying the same block twice, I also added an error count.