### PR TITLE
Improved System.Decimal performance

### DIFF
--- a/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -73,7 +73,7 @@ namespace System
         /// <summary>
         /// Class that contains all the mathematical calculations for decimal. Most of which have been ported from oleaut32.
         /// </summary>
-        private static unsafe class DecCalc
+        private static class DecCalc
         {
             // Constant representing the negative number that is the closest possible
             // Decimal value to -0m.
@@ -555,7 +555,7 @@ PosRem:
             *   New scale factor returned.
             *
             ***********************************************************************/
-            private static int ScaleResult(Buf24* bufRes, uint iHiRes, int iScale)
+            private static unsafe int ScaleResult(Buf24* bufRes, uint iHiRes, int iScale)
             {
                 Debug.Assert(iHiRes < bufRes->Length);
                 uint* rgulRes = (uint*)bufRes;
@@ -956,7 +956,7 @@ ThrowOverflow:
 
             // DecAddSub adds or subtracts two decimal values.  On return, d1 contains the result
             // of the operation.  Passing in true for bSign means subtract and false means add.
-            private static void DecAddSub(ref Decimal d1, ref Decimal d2, bool bSign)
+            private static unsafe void DecAddSub(ref Decimal d1, ref Decimal d2, bool bSign)
             {
                 ulong low64 = d1.Low64;
                 uint high = d1.High, flags = d1.uflags, d2flags = d2.uflags;
@@ -1299,7 +1299,7 @@ ReturnResult:
 *   None.
 *
 ***********************************************************************/
-            private static uint DecFixInt(ref Decimal input, ref Decimal result)
+            private static unsafe uint DecFixInt(ref Decimal input, ref Decimal result)
             {
                 Buf12 bufNum;
                 _ = &bufNum; // workaround for CS0165
@@ -1560,7 +1560,7 @@ ReturnResult:
             //**********************************************************************
             // VarDecMul - Decimal Multiply
             //**********************************************************************
-            internal static void VarDecMul(ref Decimal pdecL, ref Decimal pdecR)
+            internal static unsafe void VarDecMul(ref Decimal pdecL, ref Decimal pdecR)
             {
                 int iScale = (byte)(pdecL.uflags + pdecR.uflags >> ScaleShift);
 
@@ -2060,7 +2060,7 @@ ReturnZero:
 
             // VarDecDiv divides two decimal values.  On return, d1 contains the result
             // of the operation.
-            internal static void VarDecDiv(ref Decimal d1, ref Decimal d2)
+            internal static unsafe void VarDecDiv(ref Decimal d1, ref Decimal d2)
             {
                 Buf12 bufQuo, bufDivisor;
                 _ = &bufQuo; // workaround for CS0165
@@ -2444,7 +2444,7 @@ ThrowOverflow:
             //**********************************************************************
             // VarDecRound - Decimal Round
             //**********************************************************************
-            internal static void VarDecRound(ref Decimal input, int decimals, ref Decimal result)
+            internal static unsafe void VarDecRound(ref Decimal input, int decimals, ref Decimal result)
             {
                 Buf12 bufNum;
                 _ = &bufNum; // workaround for CS0165

--- a/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -35,14 +35,19 @@ namespace System
 
         internal int Scale
         {
-            get { return (int)((uflags & ScaleMask) >> ScaleShift); }
+            get { return (byte)(uflags >> ScaleShift); }
             set { uflags = (uflags & ~ScaleMask) | ((uint)value << ScaleShift); }
         }
 
         private ulong Low64
         {
+#if BIGENDIAN || DEBUG // On Debug builds, include the big-endian compatible code to help deter bitrot
             get { return ((ulong)umid << 32) | ulo; }
             set { umid = (uint)(value >> 32); ulo = (uint)value; }
+#else
+            get => ulomidLE;
+            set => ulomidLE = value;
+#endif
         }
 
         #region APIs need by number formatting.
@@ -96,7 +101,7 @@ namespace System
             private const Int32 MaxInt32Scale = 9;
 
             // Fast access for 10^n where n is 0-9        
-            private static UInt32[] s_powers10 = new UInt32[] {
+            private static readonly UInt32[] s_powers10 = new UInt32[] {
                 1,
                 10,
                 100,
@@ -109,7 +114,7 @@ namespace System
                 1000000000
             };
 
-            private static double[] s_doublePowers10 = new double[] {
+            private static readonly double[] s_doublePowers10 = new double[] {
                 1, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
                 1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
                 1e20, 1e21, 1e22, 1e23, 1e24, 1e25, 1e26, 1e27, 1e28, 1e29,

--- a/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -1654,20 +1654,20 @@ ReturnResult:
                         tmp += tmp2; // this could generate carry
                         bufProd.U2 = (uint)tmp;
                         if (tmp < tmp2) // detect carry
-                            tmp3 <<= 1;
-                        tmp3 += tmp >> 32;
+                            tmp3 += 1UL << 32;
+                        tmp2 = tmp3 + (tmp >> 32);
 
                         tmp = UInt32x32To64(pdecL.Mid, pdecR.High);
-                        tmp += tmp3; // this could generate carry
+                        tmp += tmp2; // this could generate carry
                         tmp3 = 0;
-                        if (tmp < tmp3) // detect carry
+                        if (tmp < tmp2) // detect carry
                             tmp3 = 1UL << 32;
 
                         tmp2 = UInt32x32To64(pdecL.High, pdecR.Mid);
                         tmp += tmp2; // this could generate carry
                         bufProd.U3 = (uint)tmp;
                         if (tmp < tmp2) // detect carry
-                            tmp3 <<= 1;
+                            tmp3 += 1UL << 32;
                         tmp3 += tmp >> 32;
 
                         tmp = UInt32x32To64(pdecL.High, pdecR.High) + tmp3;

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -123,13 +123,11 @@ namespace System
         [FieldOffset(12), NonSerialized]
         private uint umid;
 
-        // Constructs a zero Decimal.
-        //public Decimal() {
-        //    lo = 0;
-        //    mid = 0;
-        //    hi = 0;
-        //    flags = 0;
-        //}
+        /// <summary>
+        /// The low and mid fields combined in little-endian order
+        /// </summary>
+        [FieldOffset(8), NonSerialized]
+        private ulong ulomidLE;
 
         // Constructs a Decimal from an integer value.
         //
@@ -179,8 +177,7 @@ namespace System
                 uflags = SignMask;
                 value_copy = -value_copy;
             }
-            ulo = (uint)value_copy;
-            umid = (uint)(value_copy >> 32);
+            Low64 = (ulong)value;
             uhi = 0;
         }
 
@@ -190,8 +187,7 @@ namespace System
         public Decimal(ulong value)
         {
             uflags = 0;
-            ulo = (uint)value;
-            umid = (uint)(value >> 32);
+            Low64 = value;
             uhi = 0;
         }
 
@@ -280,10 +276,6 @@ namespace System
         //
         public Decimal(int[] bits)
         {
-            lo = 0;
-            mid = 0;
-            hi = 0;
-            flags = 0;
             SetBits(bits);
         }
 

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -644,9 +644,8 @@ namespace System
         //
         public static Decimal Multiply(Decimal d1, Decimal d2)
         {
-            Decimal decRes;
-            DecCalc.VarDecMul(ref d1, ref d2, out decRes);
-            return decRes;
+            DecCalc.VarDecMul(ref d1, ref d2);
+            return d1;
         }
 
         // Returns the negated value of the given Decimal. If d is non-zero,


### PR DESCRIPTION
As discussed in https://github.com/dotnet/coreclr/issues/10642#issuecomment-321104523, I've done some perf work on core decimal functions. The goal is to get faster than the native (OleAut) implementation currently used in CoreCLR and then move System.Decimal to the shared partition.

Haven't done any 32-bit specific optimizations, so that might need some more work. @jkotas is this approach OK? I added CMP first because I changed it the most. I've been testing it by binary-comparing the results between native/CoreRT/CoreRT2, but I imagine this would be a bit overkill for CoreCLR tests (large parts of Decimal[.DecCalc].cs would have to be included in the tests folder)? For the CoreRT build I used pre-recorded input and expected output files, but for 440 different decimals it's ~9MB. Would it make sense to trim the input set down to for example 100 decimals and include the ~0.5MB reference data file in tests?

---

Perf measured using a weighted [random distribution of decimals](https://gist.github.com/pentp/260d9641ce4490c94f708d64e7fbd7c8) that might better represent real world use (gist is sorted for better overview). A total of 440^2=~190K combinations were tested (excluding overflows/div-by-0).

``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i7-7700K CPU 4.20GHz (Kaby Lake), ProcessorCount=8
.NET Core SDK=
  [Host] : .NET Core ? (Framework 4.6.25731.0), 64bit RyuJIT

EvaluateOverhead=False  Toolchain=InProcessToolchain  WarmupCount=1  
```
### 64-bit
 |  CMP |     Mean |     Error |    StdDev | Scaled |
 |-------- |---------:|----------:|----------:|-------:|
 |  Native | 21.83 ns | 0.0176 ns | 0.0165 ns |   1.00 |
 |  CoreRT | 38.32 ns | 0.0465 ns | 0.0435 ns |   1.75 |
 | CoreRT2 | 11.13 ns | 0.0038 ns | 0.0030 ns |   0.50 |

 |  ADD |     Mean |     Error |    StdDev | Scaled |
 |-------- |---------:|----------:|----------:|-------:|
 |  Native | 28.05 ns | 0.0121 ns | 0.0108 ns |   1.00 |
 |  CoreRT | 50.58 ns | 0.0944 ns | 0.0883 ns |   1.80 |
 | CoreRT2 | 23.99 ns | 0.0184 ns | 0.0172 ns |   0.86 |

 |  MUL |     Mean |     Error |    StdDev | Scaled |
 |-------- |---------:|----------:|----------:|-------:|
 |  Native | 29.86 ns | 0.0063 ns | 0.0056 ns |   1.00 |
 |  CoreRT | 31.38 ns | 0.0348 ns | 0.0326 ns |   1.05 |
 | CoreRT2 | 18.67 ns | 0.0160 ns | 0.0150 ns |   0.62 |

 |  DIV |      Mean |     Error |    StdDev | Scaled |
 |-------- |----------:|----------:|----------:|-------:|
 |  Native | 116.90 ns | 0.3287 ns | 0.2745 ns |   1.00 |
 |  CoreRT | 183.50 ns | 0.2975 ns | 0.2783 ns |   1.57 |
 | CoreRT2 |  78.49 ns | 0.0675 ns | 0.0631 ns |   0.67 |

### 32-bit
 |  CMP |     Mean |     Error |    StdDev | Scaled |
 |-------- |---------:|----------:|----------:|-------:|
 |  Native | 16.53 ns | 0.0087 ns | 0.0078 ns |   1.00 |
 |  CoreRT | 48.12 ns | 0.0387 ns | 0.0362 ns |   2.91 |
 | CoreRT2 | 15.90 ns | 0.0160 ns | 0.0142 ns |   0.96 |

 | ADD |     Mean |     Error |    StdDev | Scaled |
 |-------- |---------:|----------:|----------:|-------:|
 |  Native | 28.84 ns | 0.0097 ns | 0.0091 ns |   1.00 |
 |  CoreRT | 65.52 ns | 0.0695 ns | 0.0650 ns |   2.27 |
 | CoreRT2 | 36.35 ns | 0.0075 ns | 0.0063 ns |   1.26 |

 |  MUL |     Mean |     Error |    StdDev | Scaled |
 |-------- |---------:|----------:|----------:|-------:|
 |  Native | 19.26 ns | 0.0144 ns | 0.0134 ns |   1.00 |
 |  CoreRT | 49.18 ns | 0.0704 ns | 0.0658 ns |   2.55 |
 | CoreRT2 | 28.61 ns | 0.0186 ns | 0.0155 ns |   1.48 |

 |  DIV |     Mean |     Error |    StdDev | Scaled |
 |-------- |---------:|----------:|----------:|-------:|
 |  Native | 121.2 ns | 0.0571 ns | 0.0476 ns |   1.00 |
 |  CoreRT | 236.1 ns | 0.1411 ns | 0.1320 ns |   1.95 |
 | CoreRT2 | 122.5 ns | 0.0959 ns | 0.0897 ns |   1.01 |

### 64-bit CoreRT (same test data, basic measurement code):

 |  Method |     Before |     After |
 |-------- |---------:|---------:|
 |  CMP | 34.1 ns | 12.4 ns |
 |  ADD | 50.0 ns | 25.2 ns |
 |  MUL | 31.9 ns | 19.0 ns |
 |  DIV | 183.3 ns | 79.6 ns |