### PR TITLE
Unify pseudo-attribute code between NativeFormat and Ecma

### DIFF
--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -175,17 +175,6 @@ namespace Internal.Reflection.Core.Execution
             }
         }
 
-        //
-        // Get or create a CustomAttributeData object for a specific type and arguments. 
-        //
-        public CustomAttributeData GetCustomAttributeData(Type attributeType, IList<CustomAttributeTypedArgument> constructorArguments, IList<CustomAttributeNamedArgument> namedArguments)
-        {
-            if (!attributeType.IsRuntimeImplemented())
-                throw new InvalidOperationException();
-            RuntimeTypeInfo runtimeAttributeType = attributeType.CastToRuntimeTypeInfo();
-            return new RuntimePseudoCustomAttributeData(runtimeAttributeType, constructorArguments, namedArguments);
-        }
-
         //=======================================================================================
         // This group of methods jointly service the Type.GetTypeFromHandle() path. The caller
         // is responsible for analyzing the RuntimeTypeHandle to figure out which flavor to call.

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -72,17 +72,6 @@ namespace Internal.Reflection.Core.Execution
         public abstract FieldAccessor TryGetFieldAccessor(MetadataReader reader, RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle fieldTypeHandle, FieldHandle fieldHandle);
 
         //==============================================================================================
-        // Pseudo Custom Attributes
-        //==============================================================================================
-        public abstract IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, ScopeDefinitionHandle scopeDefinitionHandle);
-        public abstract IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, TypeDefinitionHandle typeDefinitionHandle);
-        public abstract IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, MethodHandle methodHandle, TypeDefinitionHandle declaringTypeHandle);
-        public abstract IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, ParameterHandle parameterHandle, MethodHandle declaringMethodHandle);
-        public abstract IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, FieldHandle fieldHandle, TypeDefinitionHandle declaringTypeHandle);
-        public abstract IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, PropertyHandle propertyHandle, TypeDefinitionHandle declaringTypeHandle);
-        public abstract IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, EventHandle eventHandle, TypeDefinitionHandle declaringTypeHandle);
-
-        //==============================================================================================
         // RuntimeMethodHandle and RuntimeFieldHandle support.
         //==============================================================================================
         public abstract bool TryGetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out QMethodDefinition methodHandle, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.cs
@@ -46,9 +46,6 @@ namespace System.Reflection.Runtime.Assemblies.NativeFormat
                 {
                     foreach (CustomAttributeData cad in RuntimeCustomAttributeData.GetCustomAttributes(scope.Reader, scope.ScopeDefinition.CustomAttributes))
                         yield return cad;
-
-                    foreach (CustomAttributeData cad in ReflectionCoreExecution.ExecutionEnvironment.GetPseudoCustomAttributes(scope.Reader, scope.Handle))
-                        yield return cad;
                 }
             }
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.Runtime.CustomAttributes
     //
     internal sealed class RuntimePseudoCustomAttributeData : RuntimeCustomAttributeData
     {
-        public RuntimePseudoCustomAttributeData(RuntimeTypeInfo attributeType, IList<CustomAttributeTypedArgument> constructorArguments, IList<CustomAttributeNamedArgument> namedArguments)
+        public RuntimePseudoCustomAttributeData(Type attributeType, IList<CustomAttributeTypedArgument> constructorArguments, IList<CustomAttributeNamedArgument> namedArguments)
         {
             _attributeType = attributeType;
             if (constructorArguments == null)
@@ -74,7 +74,7 @@ namespace System.Reflection.Runtime.CustomAttributes
 
         // Equals/GetHashCode no need to override (they just implement reference equality but desktop never unified these things.)
 
-        private readonly RuntimeTypeInfo _attributeType;
+        private readonly Type _attributeType;
         private readonly ReadOnlyCollection<CustomAttributeTypedArgument> _constructorArguments;
         private readonly ReadOnlyCollection<CustomAttributeNamedArgument> _namedArguments;
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/EcmaFormat/EcmaFormatRuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/EcmaFormat/EcmaFormatRuntimeEventInfo.cs
@@ -108,8 +108,7 @@ namespace System.Reflection.Runtime.EventInfos.EcmaFormat
                     ReflectionTrace.EventInfo_CustomAttributes(this);
 #endif
 
-                foreach (CustomAttributeData cad in RuntimeCustomAttributeData.GetCustomAttributes(_reader, _event.GetCustomAttributes()))
-                    yield return cad;
+                return RuntimeCustomAttributeData.GetCustomAttributes(_reader, _event.GetCustomAttributes());
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/NativeFormat/NativeFormatRuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/NativeFormat/NativeFormatRuntimeEventInfo.cs
@@ -104,10 +104,7 @@ namespace System.Reflection.Runtime.EventInfos.NativeFormat
                     ReflectionTrace.EventInfo_CustomAttributes(this);
 #endif
 
-                foreach (CustomAttributeData cad in RuntimeCustomAttributeData.GetCustomAttributes(_reader, _event.CustomAttributes))
-                    yield return cad;
-                foreach (CustomAttributeData cad in ReflectionCoreExecution.ExecutionEnvironment.GetPseudoCustomAttributes(_reader, _eventHandle, _definingTypeInfo.TypeDefinitionHandle))
-                    yield return cad;
+                return RuntimeCustomAttributeData.GetCustomAttributes(_reader, _event.CustomAttributes);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/EcmaFormat/EcmaFormatRuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/EcmaFormat/EcmaFormatRuntimeFieldInfo.cs
@@ -64,28 +64,6 @@ namespace System.Reflection.Runtime.FieldInfos.EcmaFormat
             _field = _reader.GetFieldDefinition(fieldHandle);
         }
 
-        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-#if ENABLE_REFLECTION_TRACE
-                if (ReflectionTrace.Enabled)
-                    ReflectionTrace.FieldInfo_CustomAttributes(this);
-#endif
-
-                IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(_reader, _field.GetCustomAttributes());
-                foreach (CustomAttributeData cad in customAttributes)
-                    yield return cad;
-                
-                if (_definingTypeInfo.IsExplicitLayout)
-                {
-                    int offset = _field.GetOffset();
-                    CustomAttributeTypedArgument offsetArgument = new CustomAttributeTypedArgument(typeof(Int32), offset);
-                    yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(System.Runtime.InteropServices.FieldOffsetAttribute), new CustomAttributeTypedArgument[] { offsetArgument }, null);
-                }
-            }
-        }
-
         public sealed override FieldAttributes Attributes
         {
             get
@@ -203,6 +181,10 @@ namespace System.Reflection.Runtime.FieldInfos.EcmaFormat
         }
 
         protected sealed override RuntimeTypeInfo DefiningType { get { return _definingTypeInfo; } }
+
+        protected sealed override IEnumerable<CustomAttributeData> TrueCustomAttributes => RuntimeCustomAttributeData.GetCustomAttributes(_reader, _field.GetCustomAttributes());
+
+        protected sealed override int ExplicitLayoutFieldOffsetData => _field.GetOffset();
 
         private readonly EcmaFormatRuntimeNamedTypeInfo _definingTypeInfo;
         private readonly FieldDefinitionHandle _fieldHandle;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
@@ -61,23 +61,6 @@ namespace System.Reflection.Runtime.FieldInfos.NativeFormat
             _field = fieldHandle.GetField(_reader);
         }
 
-        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-#if ENABLE_REFLECTION_TRACE
-                if (ReflectionTrace.Enabled)
-                    ReflectionTrace.FieldInfo_CustomAttributes(this);
-#endif
-
-                IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(_reader, _field.CustomAttributes);
-                foreach (CustomAttributeData cad in customAttributes)
-                    yield return cad;
-                foreach (CustomAttributeData cad in ReflectionCoreExecution.ExecutionEnvironment.GetPseudoCustomAttributes(_reader, _fieldHandle, _definingTypeInfo.TypeDefinitionHandle))
-                    yield return cad;
-            }
-        }
-
         public sealed override FieldAttributes Attributes
         {
             get
@@ -182,6 +165,10 @@ namespace System.Reflection.Runtime.FieldInfos.NativeFormat
 
         protected sealed override RuntimeTypeInfo DefiningType { get { return _definingTypeInfo; } }
 
+        protected sealed override IEnumerable<CustomAttributeData> TrueCustomAttributes => RuntimeCustomAttributeData.GetCustomAttributes(_reader, _field.CustomAttributes);
+  
+        protected sealed override int ExplicitLayoutFieldOffsetData => (int)(_field.Offset);
+ 
         private Handle FieldTypeHandle => _field.Signature.GetFieldSignature(_reader).Type;
 
         private readonly NativeFormatRuntimeNamedTypeInfo _definingTypeInfo;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
 using System.Reflection.Runtime.General;
@@ -48,6 +49,27 @@ namespace System.Reflection.Runtime.FieldInfos
         {
             _contextTypeInfo = contextTypeInfo;
             _reflectedType = reflectedType;
+        }
+
+        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
+        {
+            get
+            {
+#if ENABLE_REFLECTION_TRACE
+                if (ReflectionTrace.Enabled)
+                    ReflectionTrace.FieldInfo_CustomAttributes(this);
+#endif
+
+                foreach (CustomAttributeData cad in TrueCustomAttributes)
+                    yield return cad;
+
+                if (DeclaringType.IsExplicitLayout)
+                {
+                    int offset = ExplicitLayoutFieldOffsetData;
+                    CustomAttributeTypedArgument offsetArgument = new CustomAttributeTypedArgument(typeof(int), offset);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(FieldOffsetAttribute), new CustomAttributeTypedArgument[] { offsetArgument }, null);
+                }
+            }
         }
 
         public sealed override Type DeclaringType
@@ -182,7 +204,6 @@ namespace System.Reflection.Runtime.FieldInfos
         }
 
         // Types that derive from RuntimeFieldInfo must implement the following public surface area members
-        public abstract override IEnumerable<CustomAttributeData> CustomAttributes { get; }
         public abstract override FieldAttributes Attributes { get; }
         public abstract override int MetadataToken { get; }
         public abstract override String ToString();
@@ -257,6 +278,9 @@ namespace System.Reflection.Runtime.FieldInfos
         /// Return the DefiningTypeInfo as a RuntimeTypeInfo (instead of as a format specific type info)
         /// </summary>
         protected abstract RuntimeTypeInfo DefiningType { get; }
+
+        protected abstract IEnumerable<CustomAttributeData> TrueCustomAttributes { get; }
+        protected abstract int ExplicitLayoutFieldOffsetData { get; }
 
         /// <summary>
         /// Returns the field offset (asserts and throws if not an instance field). Does not include the size of the object header.

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/EcmaFormat/EcmaFormatMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/EcmaFormat/EcmaFormatMethodCommon.cs
@@ -157,19 +157,6 @@ namespace System.Reflection.Runtime.MethodInfos.EcmaFormat
             }
         }
 
-        public IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-                IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(_reader, _method.GetCustomAttributes());
-                foreach (CustomAttributeData cad in customAttributes)
-                    yield return cad;
-
-                if (0 != (_method.ImplAttributes & MethodImplAttributes.PreserveSig))
-                    yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(PreserveSigAttribute), null, null);
-            }
-        }
-
         public RuntimeTypeInfo DeclaringType
         {
             get
@@ -316,6 +303,8 @@ namespace System.Reflection.Runtime.MethodInfos.EcmaFormat
                 return false;
             return true;
         }
+
+        public IEnumerable<CustomAttributeData> TrueCustomAttributes => RuntimeCustomAttributeData.GetCustomAttributes(_reader, _method.GetCustomAttributes());
 
         public override bool Equals(Object obj)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/IRuntimeMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/IRuntimeMethodCommon.cs
@@ -26,7 +26,6 @@ namespace System.Reflection.Runtime.MethodInfos
         CallingConventions CallingConvention { get; }
 
         RuntimeTypeInfo ContextTypeInfo { get; }
-        IEnumerable<CustomAttributeData> CustomAttributes { get; }
         RuntimeTypeInfo DeclaringType { get; }
         RuntimeNamedTypeInfo DefiningTypeInfo { get; }
         MethodImplAttributes MethodImplementationFlags { get; }
@@ -36,6 +35,7 @@ namespace System.Reflection.Runtime.MethodInfos
         /// Return an array of the types of the return value and parameter types.
         /// </summary>
         QSignatureTypeHandle[] QualifiedMethodSignature { get; }
+        IEnumerable<CustomAttributeData> TrueCustomAttributes { get; }
 
         /// <summary>
         /// Parse the metadata that describes parameters, and for each parameter for which there is specific metadata

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text;
-using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime;
@@ -15,7 +12,6 @@ using System.Reflection.Runtime.ParameterInfos;
 using System.Reflection.Runtime.ParameterInfos.NativeFormat;
 using System.Reflection.Runtime.CustomAttributes;
 
-using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
 using Internal.Runtime.CompilerServices;
 using Internal.Runtime.TypeLoader;
@@ -146,18 +142,6 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
             get
             {
                 return _contextTypeInfo;
-            }
-        }
-
-        public IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-                IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(_reader, _method.CustomAttributes);
-                foreach (CustomAttributeData cad in customAttributes)
-                    yield return cad;
-                foreach (CustomAttributeData cad in ReflectionCoreExecution.ExecutionEnvironment.GetPseudoCustomAttributes(_reader, _methodHandle, _definingTypeInfo.TypeDefinitionHandle))
-                    yield return cad;
             }
         }
 
@@ -316,6 +300,8 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
                 return false;
             return true;
         }
+
+        public IEnumerable<CustomAttributeData> TrueCustomAttributes => RuntimeCustomAttributeData.GetCustomAttributes(_reader, _method.CustomAttributes);
 
         public override bool Equals(Object obj)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -6,9 +6,11 @@ using System;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.TypeInfos;
 using System.Reflection.Runtime.ParameterInfos;
+using System.Reflection.Runtime.CustomAttributes;
 
 using Internal.Reflection.Core.Execution;
 
@@ -80,7 +82,14 @@ namespace System.Reflection.Runtime.MethodInfos
                     ReflectionTrace.MethodBase_CustomAttributes(this);
 #endif
 
-                return _common.CustomAttributes;
+                foreach (CustomAttributeData cad in _common.TrueCustomAttributes)
+                {
+                    yield return cad;
+                }
+
+                MethodImplAttributes implAttributes = _common.MethodImplementationFlags;
+                if (0 != (implAttributes & MethodImplAttributes.PreserveSig))
+                    yield return new RuntimePseudoCustomAttributeData(typeof(PreserveSigAttribute), null, null);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -71,7 +71,7 @@ namespace System.Reflection.Runtime.MethodInfos
                     ReflectionTrace.MethodBase_CustomAttributes(this);
 #endif
 
-                return _common.CustomAttributes;
+                return _common.TrueCustomAttributes;
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/EcmaFormat/EcmaFormatMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/EcmaFormat/EcmaFormatMethodParameterInfo.cs
@@ -49,24 +49,6 @@ namespace System.Reflection.Runtime.ParameterInfos.EcmaFormat
             }
         }
 
-        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-                IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(this.Reader, _parameter.GetCustomAttributes());
-                foreach (CustomAttributeData cad in customAttributes)
-                    yield return cad;
-
-                ParameterAttributes attributes = Attributes;
-                if (0 != (attributes & ParameterAttributes.In))
-                    yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(InAttribute), null, null);
-                if (0 != (attributes & ParameterAttributes.Out))
-                    yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(OutAttribute), null, null);
-                if (0 != (attributes & ParameterAttributes.Optional))
-                    yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(OptionalAttribute), null, null);
-            }
-        }
-
         public sealed override String Name
         {
             get
@@ -82,6 +64,8 @@ namespace System.Reflection.Runtime.ParameterInfos.EcmaFormat
                 return MetadataTokens.GetToken(_parameterHandle);
             }
         }
+
+        protected sealed override IEnumerable<CustomAttributeData> TrueCustomAttributes => RuntimeCustomAttributeData.GetCustomAttributes(this.Reader, _parameter.GetCustomAttributes());
 
         protected sealed override bool GetDefaultValueIfAvailable(bool raw, out object defaultValue)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/NativeFormat/NativeFormatMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/NativeFormat/NativeFormatMethodParameterInfo.cs
@@ -47,19 +47,6 @@ namespace System.Reflection.Runtime.ParameterInfos.NativeFormat
             }
         }
 
-        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-                IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(this.Reader, _parameter.CustomAttributes);
-                foreach (CustomAttributeData cad in customAttributes)
-                    yield return cad;
-                MethodHandle declaringMethodHandle = _methodHandle;
-                foreach (CustomAttributeData cad in ReflectionCoreExecution.ExecutionEnvironment.GetPseudoCustomAttributes(this.Reader, _parameterHandle, declaringMethodHandle))
-                    yield return cad;
-            }
-        }
-
         public sealed override String Name
         {
             get
@@ -75,6 +62,8 @@ namespace System.Reflection.Runtime.ParameterInfos.NativeFormat
                 throw new InvalidOperationException(SR.NoMetadataTokenAvailable);
             }
         }
+
+        protected sealed override IEnumerable<CustomAttributeData> TrueCustomAttributes => RuntimeCustomAttributeData.GetCustomAttributes(this.Reader, _parameter.CustomAttributes);
 
         protected sealed override bool GetDefaultValueIfAvailable(bool raw, out object defaultValue)
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeFatMethodParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeFatMethodParameterInfo.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Reflection.Runtime.General;
+using System.Reflection.Runtime.CustomAttributes;
 
 namespace System.Reflection.Runtime.ParameterInfos
 {
@@ -17,6 +20,25 @@ namespace System.Reflection.Runtime.ParameterInfos
             : base(member, position, qualifiedParameterTypeHandle, typeContext)
         {
         }
+
+        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
+        {
+            get
+            {
+                foreach (CustomAttributeData cad in TrueCustomAttributes)
+                    yield return cad;
+
+                ParameterAttributes attributes = Attributes;
+                if (0 != (attributes & ParameterAttributes.In))
+                    yield return new RuntimePseudoCustomAttributeData(typeof(InAttribute), null, null);
+                if (0 != (attributes & ParameterAttributes.Out))
+                    yield return new RuntimePseudoCustomAttributeData(typeof(OutAttribute), null, null);
+                if (0 != (attributes & ParameterAttributes.Optional))
+                    yield return new RuntimePseudoCustomAttributeData(typeof(OptionalAttribute), null, null);
+            }
+        }
+
+        protected abstract IEnumerable<CustomAttributeData> TrueCustomAttributes { get; }
 
         public sealed override bool HasDefaultValue => DefaultValueInfo.Item1;
         public sealed override object DefaultValue => DefaultValueInfo.Item2;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/EcmaFormat/EcmaFormatRuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/EcmaFormat/EcmaFormatRuntimePropertyInfo.cs
@@ -79,8 +79,7 @@ namespace System.Reflection.Runtime.PropertyInfos.EcmaFormat
                     ReflectionTrace.PropertyInfo_CustomAttributes(this);
 #endif
 
-                foreach (CustomAttributeData cad in RuntimeCustomAttributeData.GetCustomAttributes(_reader, _property.GetCustomAttributes()))
-                    yield return cad;
+                return RuntimeCustomAttributeData.GetCustomAttributes(_reader, _property.GetCustomAttributes());
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/NativeFormat/NativeFormatRuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/NativeFormat/NativeFormatRuntimePropertyInfo.cs
@@ -79,10 +79,7 @@ namespace System.Reflection.Runtime.PropertyInfos.NativeFormat
                     ReflectionTrace.PropertyInfo_CustomAttributes(this);
 #endif
 
-                foreach (CustomAttributeData cad in RuntimeCustomAttributeData.GetCustomAttributes(_reader, _property.CustomAttributes))
-                    yield return cad;
-                foreach (CustomAttributeData cad in ReflectionCoreExecution.ExecutionEnvironment.GetPseudoCustomAttributes(_reader, _propertyHandle, _definingTypeInfo.TypeDefinitionHandle))
-                    yield return cad;
+                return RuntimeCustomAttributeData.GetCustomAttributes(_reader, _property.CustomAttributes);
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeNamedTypeInfo.cs
@@ -42,24 +42,6 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
             }
         }
 
-        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-#if ENABLE_REFLECTION_TRACE
-                if (ReflectionTrace.Enabled)
-                    ReflectionTrace.TypeInfo_CustomAttributes(this);
-#endif
-
-                IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(_reader, _typeDefinition.GetCustomAttributes());
-                foreach (CustomAttributeData cad in customAttributes)
-                    yield return cad;
-
-                if (0 != (_typeDefinition.Attributes & TypeAttributes.Import))
-                    yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(ComImportAttribute), null, null);
-            }
-        }
-
         protected sealed override Guid? ComputeGuidFromCustomAttributes()
         {
             //
@@ -217,6 +199,8 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
             string name = _typeDefinition.Name.GetString(_reader);
             return name.EscapeTypeNameIdentifier();
         }
+
+        protected sealed override IEnumerable<CustomAttributeData> TrueCustomAttributes => RuntimeCustomAttributeData.GetCustomAttributes(_reader, _typeDefinition.GetCustomAttributes());
 
         internal sealed override RuntimeTypeInfo[] RuntimeGenericTypeParameters
         {

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -2,19 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Text;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
 using System.Reflection.Runtime.Assemblies;
 using System.Reflection.Runtime.General;
-using System.Reflection.Runtime.MethodInfos;
-using System.Reflection.Runtime.TypeInfos;
 using System.Reflection.Runtime.CustomAttributes;
 
-using Internal.Reflection.Core.Execution;
 using Internal.Reflection.Tracing;
 
 using Internal.Metadata.NativeFormat;
@@ -43,25 +38,6 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
                 RuntimeAssemblyName runtimeAssemblyName = scopeDefinitionHandle.ToRuntimeAssemblyName(_reader);
 
                 return RuntimeAssembly.GetRuntimeAssembly(runtimeAssemblyName);
-            }
-        }
-
-        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
-        {
-            get
-            {
-#if ENABLE_REFLECTION_TRACE
-                if (ReflectionTrace.Enabled)
-                    ReflectionTrace.TypeInfo_CustomAttributes(this);
-#endif
-
-                IEnumerable<CustomAttributeData> customAttributes = RuntimeCustomAttributeData.GetCustomAttributes(_reader, _typeDefinition.CustomAttributes);
-                foreach (CustomAttributeData cad in customAttributes)
-                    yield return cad;
-                foreach (CustomAttributeData cad in ReflectionCoreExecution.ExecutionEnvironment.GetPseudoCustomAttributes(_reader, _typeDefinitionHandle))
-                {
-                    yield return cad;
-                }
             }
         }
 
@@ -209,6 +185,8 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
 
             return name.EscapeTypeNameIdentifier();
         }
+
+        protected sealed override IEnumerable<CustomAttributeData> TrueCustomAttributes => RuntimeCustomAttributeData.GetCustomAttributes(_reader, _typeDefinition.CustomAttributes);
 
         internal sealed override RuntimeTypeInfo[] RuntimeGenericTypeParameters
         {

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.ManifestResources.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.ManifestResources.cs
@@ -7,19 +7,13 @@ extern alias System_Private_CoreLib;
 using System;
 using System.IO;
 using System.Reflection;
-using System.Diagnostics;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 using Internal.Runtime;
 using Internal.Runtime.Augments;
 using Internal.Runtime.TypeLoader;
 
-using Internal.Metadata.NativeFormat;
-
-using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
-using Internal.Reflection.Execution.MethodInvokers;
 using Internal.NativeFormat;
 
 namespace Internal.Reflection.Execution

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -10,14 +10,12 @@ using global::Internal.Runtime.Augments;
 using global::Internal.Runtime.CompilerServices;
 using global::Internal.Runtime.TypeLoader;
 
-using global::Internal.Reflection.Core;
 using global::Internal.Reflection.Core.Execution;
 using global::Internal.Reflection.Execution.MethodInvokers;
 using global::Internal.Reflection.Execution.FieldAccessors;
 
 using global::Internal.Metadata.NativeFormat;
 
-using global::System.Runtime.CompilerServices;
 using global::System.Runtime.InteropServices;
 
 using global::Internal.Runtime;

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
@@ -3,17 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Reflection;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 using Internal.Runtime.Augments;
 
 using Internal.Reflection.Core.Execution;
 using Internal.Reflection.Execution.FieldAccessors;
-using Internal.Reflection.Execution.MethodInvokers;
-
-using Internal.Metadata.NativeFormat;
 
 namespace Internal.Reflection.Execution
 {
@@ -64,60 +59,6 @@ namespace Internal.Reflection.Execution
         public sealed override string GetLastResortString(RuntimeTypeHandle typeHandle)
         {
             return RuntimeAugments.GetLastResortString(typeHandle);
-        }
-
-        //==============================================================================================
-        // Pseudo Custom Attributes
-        //==============================================================================================
-        public sealed override IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, ScopeDefinitionHandle scopeDefinitionHandle)
-        {
-            return Empty<CustomAttributeData>.Enumerable;
-        }
-
-        public sealed override IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, TypeDefinitionHandle typeDefinitionHandle)
-        {
-            TypeAttributes attributes = typeDefinitionHandle.GetTypeDefinition(reader).Flags;
-            if (0 != (attributes & TypeAttributes.Import))
-                yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(ComImportAttribute), null, null);
-        }
-
-        public sealed override IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, MethodHandle methodHandle, TypeDefinitionHandle declaringTypeHandle)
-        {
-            MethodImplAttributes implAttributes = methodHandle.GetMethod(reader).ImplFlags;
-            if (0 != (implAttributes & MethodImplAttributes.PreserveSig))
-                yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(PreserveSigAttribute), null, null);
-        }
-
-        public sealed override IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, ParameterHandle parameterHandle, MethodHandle declaringMethodHandle)
-        {
-            ParameterAttributes attributes = parameterHandle.GetParameter(reader).Flags;
-            if (0 != (attributes & ParameterAttributes.In))
-                yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(InAttribute), null, null);
-            if (0 != (attributes & ParameterAttributes.Out))
-                yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(OutAttribute), null, null);
-            if (0 != (attributes & ParameterAttributes.Optional))
-                yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(OptionalAttribute), null, null);
-        }
-
-        public sealed override IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, FieldHandle fieldHandle, TypeDefinitionHandle declaringTypeHandle)
-        {
-            TypeAttributes layoutKind = declaringTypeHandle.GetTypeDefinition(reader).Flags & TypeAttributes.LayoutMask;
-            if (layoutKind == TypeAttributes.ExplicitLayout)
-            {
-                int offset = (int)(fieldHandle.GetField(reader).Offset);
-                CustomAttributeTypedArgument offsetArgument = new CustomAttributeTypedArgument(typeof(Int32), offset);
-                yield return ReflectionCoreExecution.ExecutionDomain.GetCustomAttributeData(typeof(FieldOffsetAttribute), new CustomAttributeTypedArgument[] { offsetArgument }, null);
-            }
-        }
-
-        public sealed override IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, PropertyHandle propertyHandle, TypeDefinitionHandle declaringTypeHandle)
-        {
-            return Empty<CustomAttributeData>.Enumerable;
-        }
-
-        public sealed override IEnumerable<CustomAttributeData> GetPseudoCustomAttributes(MetadataReader reader, EventHandle eventHandle, TypeDefinitionHandle declaringTypeHandle)
-        {
-            return Empty<CustomAttributeData>.Enumerable;
         }
 
         //==============================================================================================

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.cs
@@ -2,19 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Collections.Generic;
-using global::System.Diagnostics;
-
-using global::Internal.Runtime.Augments;
-
-using global::Internal.Reflection.Core;
 using global::Internal.Reflection.Core.Execution;
-
-using global::Internal.Metadata.NativeFormat;
-
-using ReflectionMapBlob = Internal.Runtime.ReflectionMapBlob;
 
 namespace Internal.Reflection.Execution
 {

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MetadataReaderExtensions.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MetadataReaderExtensions.cs
@@ -3,13 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using global::System;
-using global::System.Reflection;
-using global::System.Collections.Generic;
 
 using global::Internal.Metadata.NativeFormat;
-
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
 
 using Debug = System.Diagnostics.Debug;
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/MethodInvokerWithMethodInvokeInfo.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/MethodInvokerWithMethodInvokeInfo.cs
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using global::System;
-using global::System.Threading;
 using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
 
 using global::Internal.Runtime.Augments;
-using global::Internal.Reflection.Execution;
 using global::Internal.Reflection.Core.Execution;
 
 using global::Internal.Metadata.NativeFormat;

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/DiagnosticMappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/DiagnosticMappingTables.cs
@@ -3,17 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
 using global::System.Text;
 using global::System.Collections.Generic;
 
 using global::Internal.Metadata.NativeFormat;
 
 using global::Internal.Runtime.Augments;
-
-using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
 
 using System.Reflection.Runtime.General;
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
@@ -8,11 +8,8 @@ using global::System.Reflection;
 using global::System.Diagnostics;
 using global::System.Collections.Generic;
 
-using global::Internal.Metadata.NativeFormat;
-
 using global::Internal.Runtime.Augments;
 
-using global::Internal.Reflection.Core;
 using global::Internal.Reflection.Core.Execution;
 
 namespace Internal.Reflection.Execution.PayForPlayExperience

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
@@ -4,12 +4,8 @@
 
 using global::System;
 using global::System.Reflection;
-using global::System.Collections.Generic;
-
-using global::Internal.Metadata.NativeFormat;
 
 using global::Internal.Reflection.Core;
-using global::Internal.Reflection.Core.Execution;
 using global::Internal.Reflection.Execution.PayForPlayExperience;
 
 namespace Internal.Reflection.Execution

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -8,10 +8,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
-using Internal.Metadata.NativeFormat;
-
 using Internal.Runtime.Augments;
-using Internal.Runtime.TypeLoader;
 
 using Internal.Reflection.Core.Execution;
 using Internal.Reflection.Execution.PayForPlayExperience;
@@ -184,44 +181,6 @@ namespace Internal.Reflection.Execution
             }
             fullMethodName.Append(')');
             return fullMethodName.ToString();
-        }
-
-        private String GetTypeFullNameFromTypeRef(TypeReferenceHandle typeReferenceHandle, MetadataReader reader)
-        {
-            String s = "";
-
-            TypeReference typeReference = typeReferenceHandle.GetTypeReference(reader);
-            s = typeReference.TypeName.GetString(reader);
-            Handle parentHandle = typeReference.ParentNamespaceOrType;
-            HandleType parentHandleType = parentHandle.HandleType;
-            if (parentHandleType == HandleType.TypeReference)
-            {
-                String containingTypeName = GetTypeFullNameFromTypeRef(parentHandle.ToTypeReferenceHandle(reader), reader);
-                s = containingTypeName + "+" + s;
-            }
-            else if (parentHandleType == HandleType.NamespaceReference)
-            {
-                NamespaceReferenceHandle namespaceReferenceHandle = parentHandle.ToNamespaceReferenceHandle(reader);
-                for (;;)
-                {
-                    NamespaceReference namespaceReference = namespaceReferenceHandle.GetNamespaceReference(reader);
-                    String namespacePart = namespaceReference.Name.GetStringOrNull(reader);
-                    if (namespacePart == null)
-                        break; // Reached the root namespace.
-                    s = namespacePart + "." + s;
-                    if (namespaceReference.ParentScopeOrNamespace.HandleType != HandleType.NamespaceReference)
-                        break; // Should have reached the root namespace first but this helper is for ToString() - better to
-                    // return partial information than crash.
-                    namespaceReferenceHandle = namespaceReference.ParentScopeOrNamespace.ToNamespaceReferenceHandle(reader);
-                }
-            }
-            else
-            {
-                // If we got here, the metadata is illegal but this helper is for ToString() - better to 
-                // return something partial than throw.
-            }
-
-            return s;
         }
 
         public sealed override IntPtr TryGetStaticClassConstructionContext(RuntimeTypeHandle runtimeTypeHandle)

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Extensions/NonPortable/DelegateMethodInfoRetriever.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Extensions/NonPortable/DelegateMethodInfoRetriever.cs
@@ -11,7 +11,6 @@ using global::Internal.Runtime.CompilerServices;
 using global::Internal.Reflection.Execution;
 using global::Internal.Reflection.Core.Execution;
 
-using global::Internal.Metadata.NativeFormat;
 using System.Reflection.Runtime.General;
 
 namespace Internal.Reflection.Extensions.NonPortable


### PR DESCRIPTION
This was following the old layering rules - resulting
in pointless duplication of logic between Native
and Ecma.

As a bonus, this also fixes an edge-case bug.
PreserveSigAttribute is not valid on constructors
and isn't synthesized by the full framework even
if you force that bit on. Project N now matches
that behavior.