### PR TITLE
Fix PInvokeTransitionFrame build break

### DIFF
--- a/src/Native/Runtime/inc/rhbinder.h
+++ b/src/Native/Runtime/inc/rhbinder.h
@@ -631,7 +631,7 @@ enum PInvokeTransitionFrameFlags
 #pragma warning(push)
 #pragma warning(disable:4200) // nonstandard extension used: zero-sized array in struct/union
 class Thread;
-#ifdef USE_PORTABLE_HELPERS
+#if defined(USE_PORTABLE_HELPERS) && defined(CORERT)
 //the members of this structure are currently unused except m_pThread and exist only to allow compilation 
 //of StackFrameIterator their values are not currently being filled in and will require significant rework  
 //in order to satisfy the runtime requirements of StackFrameIterator
@@ -644,7 +644,7 @@ struct PInvokeTransitionFrame
     uint32_t    m_dwFlags;  // PInvokeTransitionFrameFlags
     uint64_t    m_PreservedRegs[];
 };
-#else
+#else // USE_PORTABLE_HELPERS && CORERT
 struct PInvokeTransitionFrame
 {
 #ifdef _TARGET_ARM_
@@ -660,7 +660,7 @@ struct PInvokeTransitionFrame
 #endif
     UIntTarget      m_PreservedRegs[];
 };
-#endif //USE_PORTABLE_HELPERS
+#endif // USE_PORTABLE_HELPERS && CORERT
 #pragma warning(pop)
 
 #ifdef _TARGET_AMD64_


### PR DESCRIPTION
In ProjectN, the latest change of PInvokeTransitionFrame specific for
USE_PORTABLE_HELPERS breaks the build. So I am fixing it by changing it
so that the change is for CoreRT only.