### PR TITLE
Fixing an incorrect cast in `System.MathF.SplitFractionSingle`.

### DIFF
--- a/src/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/System.Private.CoreLib/src/System/MathF.cs
@@ -218,7 +218,11 @@ namespace System
         private static unsafe float SplitFractionSingle(float* x)
         {
             //todo : https://github.com/dotnet/corert/issues/3167
-            return (float)RuntimeImports.modf(*x, (double*)x);
+            double d = *x;
+            double r = RuntimeImports.modf(d, &d);
+
+            *x = (float)d;
+            return (float)r;
         }
 
         private unsafe static float InternalTruncate(float x)


### PR DESCRIPTION
FYI. @danmosemsft, @AtsushiKan 

This is the workaround I mentioned for https://github.com/dotnet/corefx/issues/23433.

I am also working on resolving https://github.com/dotnet/corert/issues/3167 so we can have a proper fix.