### PR TITLE
Allow type info request to fall through to RuntimeNoMetadataNamedType…

### DIFF
--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -125,9 +125,14 @@ namespace Internal.Reflection.Execution
         {
             // For generic types, use the generic type definition
             runtimeTypeHandle = GetTypeDefinition(runtimeTypeHandle);
-
             var moduleHandle = RuntimeAugments.GetModuleFromTypeHandle(runtimeTypeHandle);
-            NativeFormatModuleInfo module = ModuleList.Instance.GetModuleInfoByHandle(moduleHandle);
+
+            //make sure the module is actually NativeFormatModuleInfo, if the module
+            //doesnt have reflection enabled it wont be a NativeFormatModuleInfo
+            if (!(ModuleList.Instance.TryGetModuleInfoByHandle(moduleHandle, out ModuleInfo untypedModuleInfo) && (untypedModuleInfo is NativeFormatModuleInfo module)))
+            {
+                return true;
+            }
 
             NativeReader blockedReflectionReader = GetNativeReaderForBlob(module, ReflectionMapBlob.BlockReflectionTypeMap);
             NativeParser blockedReflectionParser = new NativeParser(blockedReflectionReader, 0);


### PR DESCRIPTION
…Info when encountering a module that isnt an instance of NativeFormatModuleInfo
This is to address one of the failure paths in #4558