### PR TITLE
[ILVerify] Fix block re-verification possibly causing endless loop

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -317,13 +317,13 @@ namespace Internal.IL
 
         private void MarkBasicBlock(BasicBlock basicBlock)
         {
-            if (basicBlock.EndOffset == 0)
+            if (basicBlock.State == BasicBlock.ImportState.Unmarked)
             {
                 // Link
                 basicBlock.Next = _pendingBasicBlocks;
                 _pendingBasicBlocks = basicBlock;
 
-                basicBlock.EndOffset = -1;
+                basicBlock.State = BasicBlock.ImportState.IsPending;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -34,10 +34,15 @@ namespace Internal.IL
         private class BasicBlock
         {
             // Common fields
+            public enum ImportState : int
+            {
+                Unmarked = 0, IsPending = -1
+            }
+
             public BasicBlock Next;
 
             public int StartOffset;
-            public int EndOffset;
+            public ImportState State = ImportState.Unmarked;
 
             public bool TryStart;
             public bool FilterStart;

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -34,9 +34,10 @@ namespace Internal.IL
         private class BasicBlock
         {
             // Common fields
-            public enum ImportState : int
+            public enum ImportState : byte
             {
-                Unmarked = 0, IsPending = -1
+                Unmarked,
+                IsPending
             }
 
             public BasicBlock Next;

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -81,12 +81,13 @@ namespace Internal.IL
 
         private class BasicBlock
         {
-            public enum ImportState : int
+            // Common fields
+            public enum ImportState : byte
             {
-                Unmarked = 0, IsPending = -1,
+                Unmarked,
+                IsPending
             }
 
-            // Common fields
             public BasicBlock Next;
 
             public int StartOffset;

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -81,11 +81,16 @@ namespace Internal.IL
 
         private class BasicBlock
         {
+            public enum BlockState : int
+            {
+                Unmarked = 0, IsPending = -1,
+            }
+
             // Common fields
             public BasicBlock Next;
 
             public int StartOffset;
-            public int EndOffset;
+            public BlockState State = BlockState.Unmarked;
 
             public EvaluationStack<StackEntry> EntryStack;
 

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -81,7 +81,7 @@ namespace Internal.IL
 
         private class BasicBlock
         {
-            public enum BlockState : int
+            public enum ImportState : int
             {
                 Unmarked = 0, IsPending = -1,
             }
@@ -90,7 +90,7 @@ namespace Internal.IL
             public BasicBlock Next;
 
             public int StartOffset;
-            public BlockState State = BlockState.Unmarked;
+            public ImportState State = ImportState.Unmarked;
 
             public EvaluationStack<StackEntry> EntryStack;
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -44,10 +44,15 @@ namespace Internal.IL
         private class BasicBlock
         {
             // Common fields
+            public enum ImportState : int
+            {
+                Unmarked = 0, IsPending = -1
+            }
+
             public BasicBlock Next;
 
             public int StartOffset;
-            public int EndOffset;
+            public ImportState State = ImportState.Unmarked;
 
             public EvaluationStack<StackEntry> EntryStack;
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -44,9 +44,10 @@ namespace Internal.IL
         private class BasicBlock
         {
             // Common fields
-            public enum ImportState : int
+            public enum ImportState : byte
             {
-                Unmarked = 0, IsPending = -1
+                Unmarked,
+                IsPending
             }
 
             public BasicBlock Next;

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -81,9 +81,11 @@ namespace Internal.IL
         class BasicBlock
         {
             // Common fields
-            public enum ImportState : int
+            public enum ImportState : byte
             {
-                Unmarked = 0, IsPending = -1, WasVerified = -2
+                Unmarked,
+                IsPending,
+                WasVerified
             }
 
             public BasicBlock Next;

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -84,7 +84,7 @@ namespace Internal.IL
             public BasicBlock Next;
 
             public int StartOffset;
-            public int EndOffset;
+            public int EndOffset = UNMARKED;
 
             public StackValue[] EntryStack;
 
@@ -107,14 +107,18 @@ namespace Internal.IL
                 ErrorCount++;
             }
 
+            public const int WAS_VERIFIED = -2;
+            public const int IS_PENDING = -1;
+            public const int UNMARKED = 0;
+
             public bool WasVerified()
             {
-                return EndOffset == -2;
+                return EndOffset == WAS_VERIFIED;
             }
 
             public bool IsPending()
             {
-                return EndOffset == -1;
+                return EndOffset == IS_PENDING;
             }
         };
 
@@ -702,7 +706,7 @@ namespace Internal.IL
 
         void EndImportingBasicBlock(BasicBlock basicBlock)
         {
-            basicBlock.EndOffset = -2; // Mark as already verified
+            basicBlock.EndOffset = BasicBlock.WAS_VERIFIED;
         }
 
         void ImportNop()
@@ -1158,7 +1162,7 @@ namespace Internal.IL
                                 entryStack[i] = mergedValue;
 
                                 if (next.ErrorCount == 0 && !next.IsPending())
-                                    next.EndOffset = 0; // Make sure block is reverified
+                                    next.EndOffset = BasicBlock.UNMARKED; // Make sure block is reverified
                             }
                         }
                     }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -112,7 +112,7 @@ namespace Internal.IL
                 return EndOffset == -2;
             }
 
-            public bool IsEnqueued()
+            public bool IsPending()
             {
                 return EndOffset == -1;
             }
@@ -1157,7 +1157,7 @@ namespace Internal.IL
                             {
                                 entryStack[i] = mergedValue;
 
-                                if (next.ErrorCount == 0 && !next.WasVerified())
+                                if (next.ErrorCount == 0 && !next.IsPending())
                                     next.EndOffset = 0; // Make sure block is reverified
                             }
                         }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -106,6 +106,16 @@ namespace Internal.IL
             {
                 ErrorCount++;
             }
+
+            public bool WasVerified()
+            {
+                return EndOffset == -2;
+            }
+
+            public bool IsEnqueued()
+            {
+                return EndOffset == -1;
+            }
         };
 
         void EmptyTheStack() => _stackTop = 0;
@@ -692,6 +702,7 @@ namespace Internal.IL
 
         void EndImportingBasicBlock(BasicBlock basicBlock)
         {
+            basicBlock.EndOffset = -2; // Mark as already verified
         }
 
         void ImportNop()
@@ -1146,7 +1157,7 @@ namespace Internal.IL
                             {
                                 entryStack[i] = mergedValue;
 
-                                if (next.ErrorCount == 0)
+                                if (next.ErrorCount == 0 && !next.WasVerified())
                                     next.EndOffset = 0; // Make sure block is reverified
                             }
                         }


### PR DESCRIPTION
Currently basic-blocks are marked to be re-verified after a stack merge, if they do not contain any identified errors. As described in #4534 this causes an endless loop if this basic block happens to be the next in the pending basic blocks chain.

To prevent this, I changed the stack merge to only re-verify blocks, which are not currently in the pending blocks chain. In order to distinguish between blocks which currently are in the chain and blocks which have already been verified, I set the `EndOffset` of BasicBlocks to `-2` in the `EndImportingBasicBlock` method.

This fixes #4534.