### PR TITLE
[ILVerify] Fix assigning interface with variance to object generating error

### DIFF
--- a/src/Common/src/TypeSystem/Common/CastingHelper.cs
+++ b/src/Common/src/TypeSystem/Common/CastingHelper.cs
@@ -317,6 +317,11 @@ namespace Internal.TypeSystem
         {
             TypeDesc curType = thisType;
 
+            if (curType.IsInterface && otherType.IsObject)
+            {
+                return true;
+            }
+
             // If the target type has variant type parameters, we take a slower path
             if (curType.HasVariance)
             {
@@ -354,7 +359,7 @@ namespace Internal.TypeSystem
 
                 if (curType.IsInterface)
                 {
-                    return otherType.IsObject;
+                    return false;
                 }
 
                 do

--- a/src/Common/src/TypeSystem/Common/CastingHelper.cs
+++ b/src/Common/src/TypeSystem/Common/CastingHelper.cs
@@ -357,11 +357,6 @@ namespace Internal.TypeSystem
                     return thisType.CanCastTo(otherType.Instantiation[0]);
                 }
 
-                if (curType.IsInterface)
-                {
-                    return false;
-                }
-
                 do
                 {
                     if (curType == otherType)

--- a/src/ILCompiler.TypeSystem/tests/CastingTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/CastingTests.cs
@@ -184,6 +184,13 @@ namespace TypeSystemTests
 
             Assert.True(stringSzArrayType.CanCastTo(iEnumerableOfObjectType));
             Assert.False(stringSzArrayType.CanCastTo(iEnumerableOfExceptionType));
+
+            MetadataType iContravariantOfTType = _testModule.GetType("Casting", "IContravariant`1");
+            InstantiatedType iContravariantOfObjectType = iContravariantOfTType.MakeInstantiatedType(objectType);
+            InstantiatedType iEnumerableOfStringType = iEnumerableOfTType.MakeInstantiatedType(stringType);
+
+            Assert.True(iContravariantOfObjectType.CanCastTo(objectType));
+            Assert.True(iEnumerableOfStringType.CanCastTo(objectType));
         }
 
         [Fact]

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -200,6 +200,17 @@
         ret
     }
 
+    .method public hidebysig instance void Casting.AssignVariantInterfaceToObject_Valid(class [System.Runtime]System.Collections.Generic.IEnumerable`1<string> e) cil managed
+    {
+        .locals init (
+            object o
+        )
+
+        ldarg.1
+        stloc.0
+        ret
+    }
+
     .method public hidebysig instance void Casting.AssignThisToSameTypeWithOtherGenericArgs_Invalid_StackUnexpected() cil managed
     {
         .locals init (


### PR DESCRIPTION
Currently the casting helper returns false for assigning an interface which has variance to `System.Object`, even though this should be considered is valid.

I changed the `CanCastToClass` method to always return true when trying to cast an interface to object (independent of variance). I also added a test case for assigning an `IEnumerable<string>` to `object`.

This fixes #4535.