### PR TITLE
Enable Alpine build

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -36,6 +36,22 @@ if [ -z "$__DOTNET_PKG" ]; then
         Linux)
             __DOTNET_PKG=dotnet-dev-linux-x64
             OS=Linux
+
+            if [ -e /etc/os-release ]; then
+                source /etc/os-release
+                if [[ $ID == "alpine" ]]; then
+                    # remove the last version digit
+                    VERSION_ID=${VERSION_ID%.*}
+                    __DOTNET_PKG=dotnet-dev-alpine.$VERSION_ID-x64
+                fi
+
+            elif [ -e /etc/redhat-release ]; then
+                redhatRelease=$(</etc/redhat-release)
+                if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
+                    __DOTNET_PKG=dotnet-dev-rhel.6-x64
+                fi
+            fi
+
             ;;
 
         *)


### PR DESCRIPTION
Using Linux distro detection part of CoreCLR's init-tools.sh here.

The following DockerFile is used to build on Alpine Linue:

```dockerfile
FROM alpine:3.6
RUN cat /etc/*-release

RUN apk update
RUN apk add --no-cache \
        autoconf bash build-base clang clang-dev \
        cmake curl-dev gcc gettext-dev git icu-dev libtool \
        linux-headers libunwind-dev llvm make openssl zlib-dev \
        util-linux-dev

# note that the testing URL will be changed once lldb-dev is moved to
# aports' (more prominent) "main" repo.
# See https://github.com/alpinelinux/aports/pull/2342#issuecomment-330894890
RUN apk add --no-cache \
       -X https://dl-cdn.alpinelinux.org/alpine/edge/testing \
        lldb-dev

RUN git clone https://github.com/dotnet/corert -b master --single-branch \
    && cd corert && ./build.sh
```

Contributes to #4552.