### PR TITLE
Fix incorrect arm ifdef

### DIFF
--- a/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
@@ -149,7 +149,7 @@ static int LookupUnwindInfoForMethod(UInt32 relativePc,
                                      int low,
                                      int high)
 {
-#ifdef TARGET_ARM
+#ifdef _TARGET_ARM_
     relativePc |= THUMB_CODE;
 #endif 
 

--- a/src/Native/jitinterface/JITCodeManager.cpp
+++ b/src/Native/jitinterface/JITCodeManager.cpp
@@ -319,7 +319,7 @@ static int LookupUnwindInfoForMethod(UInt32 RelativePc,
                                      int Low,
                                      int High)
 {
-#ifdef TARGET_ARM
+#ifdef _TARGET_ARM_
     RelativePc |= THUMB_CODE;
 #endif 
 


### PR DESCRIPTION
Everywhere in the native code except for two places, we use
`_TARGET_ARM_` as a define to identify compilation for ARM32.
But at those two places, we use `TARGET_ARM`. This is incorrect since
`TARGET_ARM` is not defined anywhere for CoreRT builds.
This change replaces those two usages by the `_TARGET_ARM_`.