### PR TITLE
Enable Server GC

### DIFF
--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -46,6 +46,8 @@ set(COMMON_RUNTIME_SOURCES
     ../gc/gccommon.cpp
     ../gc/gceewks.cpp
     ../gc/gcwks.cpp
+    ../gc/gceesvr.cpp
+    ../gc/gcsvr.cpp
     ../gc/gcscan.cpp
     ../gc/handletable.cpp
     ../gc/handletablecache.cpp
@@ -154,6 +156,7 @@ convert_to_absolute_path(ARCH_SOURCES_DIR ${ARCH_SOURCES_DIR})
 include_directories(${ARCH_SOURCES_DIR})
 
 add_definitions(-DFEATURE_BACKGROUND_GC)
+add_definitions(-DFEATURE_SVR_GC)
 add_definitions(-DFEATURE_BASICFREEZE)
 add_definitions(-DFEATURE_CONSERVATIVE_GC)
 add_definitions(-DFEATURE_CUSTOM_IMPORTS)

--- a/tests/src/Simple/BasicThreading/BasicThreading.cmd
+++ b/tests/src/Simple/BasicThreading/BasicThreading.cmd
@@ -1,5 +1,8 @@
 @echo off
 setlocal
+
+rem Enable Server GC for this test
+set RH_UseServerGC=1
 "%1\%2"
 set ErrorCode=%ERRORLEVEL%
 IF "%ErrorCode%"=="100" (

--- a/tests/src/Simple/BasicThreading/BasicThreading.sh
+++ b/tests/src/Simple/BasicThreading/BasicThreading.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Enable Server GC for this test
+export RH_UseServerGC=1
 $1/$2
 if [ $? == 100 ]; then
     echo pass


### PR DESCRIPTION
This change adds support for Server GC.
To enable the Server GC for an application, the RH_UseServerGC environment variable (which is already supported by the runtime) should be set to 1.
