### PR TITLE
Reflection.Core MQ

### DIFF
--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Internal.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Tracing/ReflectionTrace.Internal.cs
@@ -52,8 +52,7 @@ namespace Internal.Reflection.Tracing
         {
             try
             {
-                RuntimeAssembly runtimeAssembly = assembly as RuntimeAssembly;
-                if (runtimeAssembly == null)
+                if (!(assembly is RuntimeAssembly runtimeAssembly))
                     return null;
                 return runtimeAssembly.RuntimeAssemblyName.FullName;
             }
@@ -70,8 +69,7 @@ namespace Internal.Reflection.Tracing
         {
             try
             {
-                RuntimeCustomAttributeData runtimeCustomAttributeData = customAttributeData as RuntimeCustomAttributeData;
-                if (runtimeCustomAttributeData == null)
+                if (!(customAttributeData is RuntimeCustomAttributeData runtimeCustomAttributeData))
                     return null;
                 return runtimeCustomAttributeData.AttributeType.NameString();
             }
@@ -88,8 +86,7 @@ namespace Internal.Reflection.Tracing
         {
             try
             {
-                ITraceableTypeMember traceableTypeMember = memberInfo as ITraceableTypeMember;
-                if (traceableTypeMember == null)
+                if (!(memberInfo is ITraceableTypeMember traceableTypeMember))
                     return null;
                 return traceableTypeMember.ContainingType.NameString();
             }
@@ -106,13 +103,12 @@ namespace Internal.Reflection.Tracing
         {
             try
             {
-                TypeInfo typeInfo = memberInfo as TypeInfo;
-                if (typeInfo != null)
+                if (memberInfo is TypeInfo typeInfo)
                     return typeInfo.AsType().NameString();
 
-                ITraceableTypeMember traceableTypeMember = memberInfo as ITraceableTypeMember;
-                if (traceableTypeMember == null)
+                if (!(memberInfo is ITraceableTypeMember traceableTypeMember))
                     return null;
+
                 return traceableTypeMember.MemberName;
             }
             catch
@@ -195,8 +191,7 @@ namespace Internal.Reflection.Tracing
             }
             else
             {
-                RuntimeNamedTypeInfo runtimeNamedTypeInfo = type.GetTypeInfo() as RuntimeNamedTypeInfo;
-                if (runtimeNamedTypeInfo == null)
+                if (!(type.GetTypeInfo() is RuntimeNamedTypeInfo runtimeNamedTypeInfo))
                     return null;
 
                 return runtimeNamedTypeInfo.TraceableTypeName;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -186,8 +186,7 @@ namespace System.Reflection.Runtime.CustomAttributes
             }
 
             // Handle the array case
-            IEnumerable enumerableValue = value as IEnumerable;
-            if (enumerableValue != null && !(value is String))
+            if (value is IEnumerable enumerableValue && !(value is string))
             {
                 if (!argumentType.IsArray)
                     throw new BadImageFormatException();

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/EcmaFormat/EcmaFormatRuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/EcmaFormat/EcmaFormatRuntimeEventInfo.cs
@@ -117,8 +117,7 @@ namespace System.Reflection.Runtime.EventInfos.EcmaFormat
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            EcmaFormatRuntimeEventInfo otherEvent = other as EcmaFormatRuntimeEventInfo;
-            if (otherEvent == null)
+            if (!(other is EcmaFormatRuntimeEventInfo otherEvent))
                 return false;
             if (!(_reader == otherEvent._reader))
                 return false;
@@ -129,8 +128,7 @@ namespace System.Reflection.Runtime.EventInfos.EcmaFormat
 
         public sealed override bool Equals(Object obj)
         {
-            EcmaFormatRuntimeEventInfo other = obj as EcmaFormatRuntimeEventInfo;
-            if (other == null)
+            if (!(obj is EcmaFormatRuntimeEventInfo other))
                 return false;
             if (!(_reader == other._reader))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/NativeFormat/NativeFormatRuntimeEventInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/EventInfos/NativeFormat/NativeFormatRuntimeEventInfo.cs
@@ -113,8 +113,7 @@ namespace System.Reflection.Runtime.EventInfos.NativeFormat
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            NativeFormatRuntimeEventInfo otherEvent = other as NativeFormatRuntimeEventInfo;
-            if (otherEvent == null)
+            if (!(other is NativeFormatRuntimeEventInfo otherEvent))
                 return false;
             if (!(_reader == otherEvent._reader))
                 return false;
@@ -127,8 +126,7 @@ namespace System.Reflection.Runtime.EventInfos.NativeFormat
 
         public sealed override bool Equals(Object obj)
         {
-            NativeFormatRuntimeEventInfo other = obj as NativeFormatRuntimeEventInfo;
-            if (other == null)
+            if (!(obj is NativeFormatRuntimeEventInfo other))
                 return false;
             if (!(_reader == other._reader))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/EcmaFormat/EcmaFormatRuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/EcmaFormat/EcmaFormatRuntimeFieldInfo.cs
@@ -115,8 +115,7 @@ namespace System.Reflection.Runtime.FieldInfos.EcmaFormat
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            EcmaFormatRuntimeFieldInfo otherField = other as EcmaFormatRuntimeFieldInfo;
-            if (otherField == null)
+            if (!(other is EcmaFormatRuntimeFieldInfo otherField))
                 return false;
             if (!(_reader == otherField._reader))
                 return false;
@@ -127,8 +126,7 @@ namespace System.Reflection.Runtime.FieldInfos.EcmaFormat
 
         public sealed override bool Equals(Object obj)
         {
-            EcmaFormatRuntimeFieldInfo other = obj as EcmaFormatRuntimeFieldInfo;
-            if (other == null)
+            if (!(obj is EcmaFormatRuntimeFieldInfo other))
                 return false;
             if (!(_reader == other._reader))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
@@ -101,8 +101,7 @@ namespace System.Reflection.Runtime.FieldInfos.NativeFormat
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            NativeFormatRuntimeFieldInfo otherField = other as NativeFormatRuntimeFieldInfo;
-            if (otherField == null)
+            if (!(other is NativeFormatRuntimeFieldInfo otherField))
                 return false;
             if (!(_reader == otherField._reader))
                 return false;
@@ -115,8 +114,7 @@ namespace System.Reflection.Runtime.FieldInfos.NativeFormat
 
         public sealed override bool Equals(Object obj)
         {
-            NativeFormatRuntimeFieldInfo other = obj as NativeFormatRuntimeFieldInfo;
-            if (other == null)
+            if (!(obj is NativeFormatRuntimeFieldInfo other))
                 return false;
             if (!(_reader == other._reader))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.Ecma.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.Ecma.cs
@@ -68,9 +68,9 @@ namespace System.Reflection.Runtime.Assemblies.EcmaFormat
 
             public override bool Equals(Object obj)
             {
-                if (!(obj is EcmaRuntimeAssemblyKey))
+                if (!(obj is EcmaRuntimeAssemblyKey other))
                     return false;
-                return Equals((EcmaRuntimeAssemblyKey)obj);
+                return Equals(other);
             }
 
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.NativeFormat.cs
@@ -85,9 +85,9 @@ namespace System.Reflection.Runtime.Assemblies.NativeFormat
 
             public override bool Equals(Object obj)
             {
-                if (!(obj is RuntimeAssemblyKey))
+                if (!(obj is RuntimeAssemblyKey other))
                     return false;
-                return Equals((RuntimeAssemblyKey)obj);
+                return Equals(other);
             }
 
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -97,8 +97,7 @@ namespace System.Reflection.Runtime.General
 
         public static Type GetTypeCore(this Assembly assembly, string name, bool ignoreCase)
         {
-            RuntimeAssembly runtimeAssembly = assembly as RuntimeAssembly;
-            if (runtimeAssembly != null)
+            if (assembly is RuntimeAssembly runtimeAssembly)
             {
                 // Not a recursion - this one goes to the actual instance method on RuntimeAssembly.
                 return runtimeAssembly.GetTypeCore(name, ignoreCase: ignoreCase);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
@@ -36,10 +36,9 @@ namespace System.Reflection.Runtime.General
             {
                 return _handle.TryResolve((global::Internal.Metadata.NativeFormat.MetadataReader)Reader, typeContext, ref exception);
             }
-            
+
 #if ECMA_METADATA_SUPPORT
-            global::System.Reflection.Metadata.MetadataReader ecmaReader = Reader as global::System.Reflection.Metadata.MetadataReader;
-            if (ecmaReader != null)
+            if (Reader is global::System.Reflection.Metadata.MetadataReader ecmaReader)
             {
                 return TryResolveSignature(typeContext, ref exception);
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -203,12 +203,10 @@ namespace System.Reflection.Runtime.General
             if (method == null)
                 throw new ArgumentNullException(nameof(method));
 
-            RuntimeTypeInfo runtimeDelegateType = type as RuntimeTypeInfo;
-            if (runtimeDelegateType == null)
+            if (!(type is RuntimeTypeInfo runtimeDelegateType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
 
-            RuntimeMethodInfo runtimeMethodInfo = method as RuntimeMethodInfo;
-            if (runtimeMethodInfo == null)
+            if (!(method is RuntimeMethodInfo runtimeMethodInfo))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(method));
 
             if (!runtimeDelegateType.IsDelegate)
@@ -234,8 +232,7 @@ namespace System.Reflection.Runtime.General
             if (method == null)
                 throw new ArgumentNullException(nameof(method));
 
-            RuntimeTypeInfo runtimeDelegateType = type as RuntimeTypeInfo;
-            if (runtimeDelegateType == null)
+            if (!(type is RuntimeTypeInfo runtimeDelegateType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
             if (!runtimeDelegateType.IsDelegate)
                 throw new ArgumentException(SR.Arg_MustBeDelegate);
@@ -263,12 +260,10 @@ namespace System.Reflection.Runtime.General
             if (method == null)
                 throw new ArgumentNullException(nameof(method));
 
-            RuntimeTypeInfo runtimeDelegateType = type as RuntimeTypeInfo;
-            if (runtimeDelegateType == null)
+            if (!(type is RuntimeTypeInfo runtimeDelegateType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
 
-            RuntimeTypeInfo runtimeContainingType = target as RuntimeTypeInfo;
-            if (runtimeContainingType == null)
+            if (!(target is RuntimeTypeInfo runtimeContainingType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(target));
 
             if (!runtimeDelegateType.IsDelegate)
@@ -367,8 +362,7 @@ namespace System.Reflection.Runtime.General
             Type targetType = target.GetType();
             for (int i = 0; i < flds.Length; i++)
             {
-                RuntimeFieldInfo field = flds[i] as RuntimeFieldInfo;
-                if (field == null)
+                if (!(flds[i] is RuntimeFieldInfo field))
                     throw new ArgumentException(SR.Argument_MustBeRuntimeFieldInfo);
                 if (field.IsInitOnly || field.IsStatic)
                     throw new ArgumentException(SR.Argument_TypedReferenceInvalidField);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/RuntimeTypeHandleKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/RuntimeTypeHandleKey.cs
@@ -20,9 +20,9 @@ namespace System.Reflection.Runtime.General
 
         public override bool Equals(object obj)
         {
-            if (!(obj is RuntimeTypeHandleKey))
+            if (!(obj is RuntimeTypeHandleKey other))
                 return false;
-            return Equals((RuntimeTypeHandleKey)obj);
+            return Equals(other);
         }
 
         public bool Equals(RuntimeTypeHandleKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeResolver.cs
@@ -38,10 +38,9 @@ namespace System.Reflection.Runtime.General
             {
                 return global::Internal.Metadata.NativeFormat.Handle.FromIntToken(typeDefOrRefOrSpec.Handle).TryResolve((global::Internal.Metadata.NativeFormat.MetadataReader)typeDefOrRefOrSpec.Reader, typeContext, ref exception);
             }
-            
+
 #if ECMA_METADATA_SUPPORT
-            global::System.Reflection.Metadata.MetadataReader ecmaReader = typeDefOrRefOrSpec.Reader as global::System.Reflection.Metadata.MetadataReader;
-            if (ecmaReader != null)
+            if (typeDefOrRefOrSpec.Reader is global::System.Reflection.Metadata.MetadataReader ecmaReader)
                 return global::System.Reflection.Metadata.Ecma335.MetadataTokens.Handle(typeDefOrRefOrSpec.Handle).TryResolve(ecmaReader, typeContext, ref exception);
 #endif
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/EcmaFormat/EcmaFormatMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/EcmaFormat/EcmaFormatMethodCommon.cs
@@ -308,9 +308,9 @@ namespace System.Reflection.Runtime.MethodInfos.EcmaFormat
 
         public override bool Equals(Object obj)
         {
-            if (!(obj is EcmaFormatMethodCommon))
+            if (!(obj is EcmaFormatMethodCommon other))
                 return false;
-            return Equals((EcmaFormatMethodCommon)obj);
+            return Equals(other);
         }
 
         public bool Equals(EcmaFormatMethodCommon other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
@@ -305,9 +305,9 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
 
         public override bool Equals(Object obj)
         {
-            if (!(obj is NativeFormatMethodCommon))
+            if (!(obj is NativeFormatMethodCommon other))
                 return false;
-            return Equals((NativeFormatMethodCommon)obj);
+            return Equals(other);
         }
 
         public bool Equals(NativeFormatMethodCommon other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeClsIdNullaryConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeClsIdNullaryConstructorInfo.cs
@@ -42,8 +42,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override bool Equals(object obj)
         {
-            RuntimeCLSIDNullaryConstructorInfo other = obj as RuntimeCLSIDNullaryConstructorInfo;
-            if (other == null)
+            if (!(obj is RuntimeCLSIDNullaryConstructorInfo other))
                 return false;
             if (!(_declaringType.Equals(other._declaringType)))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructedGenericMethodInfo.cs
@@ -56,8 +56,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override bool Equals(Object obj)
         {
-            RuntimeConstructedGenericMethodInfo other = obj as RuntimeConstructedGenericMethodInfo;
-            if (other == null)
+            if (!(obj is RuntimeConstructedGenericMethodInfo other))
                 return false;
             if (!_genericMethodDefinition.Equals(other._genericMethodDefinition))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -86,8 +86,7 @@ namespace System.Reflection.Runtime.MethodInfos
             if (delegateType == null)
                 throw new ArgumentNullException(nameof(delegateType));
 
-            RuntimeTypeInfo runtimeDelegateType = delegateType as RuntimeTypeInfo;
-            if (runtimeDelegateType == null)
+            if (!(delegateType is RuntimeTypeInfo runtimeDelegateType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(delegateType));
 
             if (!runtimeDelegateType.IsDelegate)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -210,12 +210,10 @@ namespace System.Reflection.Runtime.MethodInfos
                 throw new ArgumentNullException(nameof(other));
 
             // Do not rewrite as a call to IsConstructedGenericMethod - we haven't yet established that "other" is a runtime-implemented member yet!
-            RuntimeConstructedGenericMethodInfo otherConstructedGenericMethod = other as RuntimeConstructedGenericMethodInfo;
-            if (otherConstructedGenericMethod != null)
+            if (other is RuntimeConstructedGenericMethodInfo otherConstructedGenericMethod)
                 other = otherConstructedGenericMethod.GetGenericMethodDefinition();
 
-            RuntimeNamedMethodInfo<TRuntimeMethodCommon> otherMethod = other as RuntimeNamedMethodInfo<TRuntimeMethodCommon>;
-            if (otherMethod == null)
+            if (!(other is RuntimeNamedMethodInfo<TRuntimeMethodCommon> otherMethod))
                 return false;
 
             return _common.HasSameMetadataDefinitionAs(otherMethod._common);
@@ -223,8 +221,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override bool Equals(Object obj)
         {
-            RuntimeNamedMethodInfo<TRuntimeMethodCommon> other = obj as RuntimeNamedMethodInfo<TRuntimeMethodCommon>;
-            if (other == null)
+            if (!(obj is RuntimeNamedMethodInfo<TRuntimeMethodCommon> other))
                 return false;
             if (!_common.Equals(other._common))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -150,16 +150,15 @@ namespace System.Reflection.Runtime.MethodInfos
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            RuntimePlainConstructorInfo<TRuntimeMethodCommon> otherConstructor = other as RuntimePlainConstructorInfo<TRuntimeMethodCommon>;
-            if (otherConstructor == null)
+            if (!(other is RuntimePlainConstructorInfo<TRuntimeMethodCommon> otherConstructor))
                 return false;
+
             return _common.HasSameMetadataDefinitionAs(otherConstructor._common);
         }
 
         public sealed override bool Equals(Object obj)
         {
-            RuntimePlainConstructorInfo<TRuntimeMethodCommon> other = obj as RuntimePlainConstructorInfo<TRuntimeMethodCommon>;
-            if (other == null)
+            if (!(obj is RuntimePlainConstructorInfo<TRuntimeMethodCommon> other))
                 return false;
             return _common.Equals(other._common);
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticConstructorInfo.cs
@@ -115,8 +115,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override bool Equals(object obj)
         {
-            RuntimeSyntheticConstructorInfo other = obj as RuntimeSyntheticConstructorInfo;
-            if (other == null)
+            if (!(obj is RuntimeSyntheticConstructorInfo other))
                 return false;
             if (_syntheticMethodId != other._syntheticMethodId)
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeSyntheticMethodInfo.cs
@@ -65,8 +65,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public sealed override bool Equals(Object obj)
         {
-            RuntimeSyntheticMethodInfo other = obj as RuntimeSyntheticMethodInfo;
-            if (other == null)
+            if (!(obj is RuntimeSyntheticMethodInfo other))
                 return false;
             if (_syntheticMethodId != other._syntheticMethodId)
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -35,10 +35,9 @@ namespace System.Reflection.Runtime.Modules
 
         public abstract override string Name { get; }
 
-        public sealed override bool Equals(object o)
+        public sealed override bool Equals(object obj)
         {
-            RuntimeModule other = o as RuntimeModule;
-            if (other == null)
+            if (!(obj is RuntimeModule other))
                 return false;
             return Assembly.Equals(other.Assembly);
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
@@ -27,8 +27,7 @@ namespace System.Reflection.Runtime.ParameterInfos
 
         public sealed override bool Equals(Object obj)
         {
-            RuntimeParameterInfo other = obj as RuntimeParameterInfo;
-            if (other == null)
+            if (!(obj is RuntimeParameterInfo other))
                 return false;
             if (_position != other._position)
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/EcmaFormat/EcmaFormatRuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/EcmaFormat/EcmaFormatRuntimePropertyInfo.cs
@@ -88,8 +88,7 @@ namespace System.Reflection.Runtime.PropertyInfos.EcmaFormat
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            EcmaFormatRuntimePropertyInfo otherProperty = other as EcmaFormatRuntimePropertyInfo;
-            if (otherProperty == null)
+            if (!(other is EcmaFormatRuntimePropertyInfo otherProperty))
                 return false;
             if (!(_reader == otherProperty._reader))
                 return false;
@@ -100,8 +99,7 @@ namespace System.Reflection.Runtime.PropertyInfos.EcmaFormat
 
         public sealed override bool Equals(Object obj)
         {
-            EcmaFormatRuntimePropertyInfo other = obj as EcmaFormatRuntimePropertyInfo;
-            if (other == null)
+            if (!(obj is EcmaFormatRuntimePropertyInfo other))
                 return false;
             if (!(_reader == other._reader))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/NativeFormat/NativeFormatRuntimePropertyInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/PropertyInfos/NativeFormat/NativeFormatRuntimePropertyInfo.cs
@@ -88,8 +88,7 @@ namespace System.Reflection.Runtime.PropertyInfos.NativeFormat
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            NativeFormatRuntimePropertyInfo otherProperty = other as NativeFormatRuntimePropertyInfo;
-            if (otherProperty == null)
+            if (!(other is NativeFormatRuntimePropertyInfo otherProperty))
                 return false;
             if (!(_reader == otherProperty._reader))
                 return false;
@@ -102,8 +101,7 @@ namespace System.Reflection.Runtime.PropertyInfos.NativeFormat
 
         public sealed override bool Equals(Object obj)
         {
-            NativeFormatRuntimePropertyInfo other = obj as NativeFormatRuntimePropertyInfo;
-            if (other == null)
+            if (!(obj is NativeFormatRuntimePropertyInfo other))
                 return false;
             if (!(_reader == other._reader))
                 return false;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeGenericParameterTypeInfoForMethods.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeGenericParameterTypeInfoForMethods.UnificationKey.cs
@@ -37,9 +37,9 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeGenericParameterTypeInfoForTypes.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeGenericParameterTypeInfoForTypes.UnificationKey.cs
@@ -35,9 +35,9 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeNamedTypeInfo.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeNamedTypeInfo.UnificationKey.cs
@@ -42,9 +42,9 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/EcmaFormat/EcmaFormatRuntimeNamedTypeInfo.cs
@@ -75,8 +75,7 @@ namespace System.Reflection.Runtime.TypeInfos.EcmaFormat
                             if (firstArg.Value == null)
                                 continue;
 
-                            string guidString = firstArg.Value as string;
-                            if (guidString == null)
+                            if (!(firstArg.Value is string guidString))
                                 continue;
 
                             return new Guid(guidString);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfoForMethods.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfoForMethods.UnificationKey.cs
@@ -37,9 +37,9 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfoForTypes.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeGenericParameterTypeInfoForTypes.UnificationKey.cs
@@ -35,9 +35,9 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.UnificationKey.cs
@@ -42,9 +42,9 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -62,8 +62,7 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
                     if (fahEnumerator.MoveNext())
                         continue;
                     FixedArgument guidStringArgument = guidStringArgumentHandle.GetFixedArgument(_reader);
-                    String guidString = guidStringArgument.Value.ParseConstantValue(_reader) as String;
-                    if (guidString == null)
+                    if (!(guidStringArgument.Value.ParseConstantValue(_reader) is string guidString))
                         continue;
                     return new Guid(guidString);
                 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeClsIdTypeInfo.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeClsIdTypeInfo.UnificationKey.cs
@@ -22,9 +22,9 @@ namespace System.Reflection.Runtime.TypeInfos
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.UnificationKey.cs
@@ -39,9 +39,9 @@ namespace System.Reflection.Runtime.TypeInfos
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -245,8 +245,7 @@ namespace System.Reflection.Runtime.TypeInfos
             get
             {
                 RuntimeTypeInfo genericTypeDefinition = this.GenericTypeDefinitionTypeInfo;
-                RuntimeNamedTypeInfo genericTypeDefinitionNamedTypeInfo = genericTypeDefinition as RuntimeNamedTypeInfo;
-                if (genericTypeDefinitionNamedTypeInfo == null)
+                if (!(genericTypeDefinition is RuntimeNamedTypeInfo genericTypeDefinitionNamedTypeInfo))
                     throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(genericTypeDefinition);
                 return genericTypeDefinitionNamedTypeInfo;
             }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.UnificationKey.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeHasElementTypeInfo.UnificationKey.cs
@@ -37,9 +37,9 @@ namespace System.Reflection.Runtime.TypeInfos
 
             public override bool Equals(object obj)
             {
-                if (!(obj is UnificationKey))
+                if (!(obj is UnificationKey other))
                     return false;
-                return Equals((UnificationKey)obj);
+                return Equals(other);
             }
 
             public bool Equals(UnificationKey other)

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeDefinitionTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeDefinitionTypeInfo.cs
@@ -49,8 +49,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 throw new ArgumentNullException(nameof(other));
 
             // Do not rewrite as a call to IsConstructedGenericType - we haven't yet established that "other" is a runtime-implemented member yet!
-            RuntimeConstructedGenericTypeInfo otherConstructedGenericType = other as RuntimeConstructedGenericTypeInfo;
-            if (otherConstructedGenericType != null)
+            if (other is RuntimeConstructedGenericTypeInfo otherConstructedGenericType)
                 other = otherConstructedGenericType.GetGenericTypeDefinition();
 
             // Unlike most other MemberInfo objects, types never get cloned due to containing generic types being instantiated.

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
@@ -48,9 +48,8 @@ namespace Internal.Reflection.Execution
         {
             String resourceName = SR.Object_NotInvokable;
 
-            if (pertainant is MethodBase)
+            if (pertainant is MethodBase methodBase)
             {
-                MethodBase methodBase = (MethodBase)pertainant;
                 resourceName = methodBase.IsConstructedGenericMethod ? SR.MakeGenericMethod_NoMetadata : SR.Object_NotInvokable;
                 if (methodBase is ConstructorInfo)
                 {

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -299,13 +299,12 @@ namespace Internal.Reflection.Execution
         {
             defaultValue = null;
 
-            MethodBase methodInfo = defaultParametersContext as MethodBase;
-            if (methodInfo == null)
+            if (!(defaultParametersContext is MethodBase methodBase))
             {
                 return false;
             }
 
-            ParameterInfo parameterInfo = methodInfo.GetParametersNoCopy()[argIndex];
+            ParameterInfo parameterInfo = methodBase.GetParametersNoCopy()[argIndex];
             if (!parameterInfo.HasDefaultValue)
             {
                 // If the parameter is optional, with no default value and we're asked for its default value,


### PR DESCRIPTION
Having wasted way too much time fixing "No, I meant
'if (other == null)' not 'if (obj== null)'!" bugs in
an unrelated project recently, I decided to replace
all those error-prone "R t as R; if (t [!]= null)"
constructs in favor of pattern matching so as not
invite any more of those.