### PR TITLE
Add placeholder build option for WebAssembly

### DIFF
--- a/buildscripts/build-native.cmd
+++ b/buildscripts/build-native.cmd
@@ -30,13 +30,6 @@ exit /b %ERRORLEVEL%
 echo Commencing build of native components for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
 
-if "%__BuildArch%"=="wasm" (
-    set __VSVersion=none
-    goto RegenerateBuildFiles
-) else (
-    goto PrepareVs
-)
-
 :PrepareVs
 :: Set the environment for the native build
 set __VCBuildArch=x86_amd64
@@ -68,9 +61,9 @@ exit /b 1
 
 :BuildNativeEmscripten
 pushd "%__IntermediatesDir%"
-emmake make install
+nmake install
 popd
-echo Wasm build is not currently implemented
+IF NOT ERRORLEVEL 1 goto AfterNativeBuild
 exit /b 1
 
 :AfterNativeBuild

--- a/buildscripts/build-native.sh
+++ b/buildscripts/build-native.sh
@@ -16,6 +16,11 @@ check_native_prereqs()
 
     # Check for clang
     hash clang-$__ClangMajorVersion.$__ClangMinorVersion 2>/dev/null ||  hash clang$__ClangMajorVersion$__ClangMinorVersion 2>/dev/null ||  hash clang 2>/dev/null || { echo >&2 "Please install clang before running this script"; exit 1; }
+
+    # Check for additional prereqs for wasm build
+    if [ $__BuildArch == "wasm" ]; then
+        hash emcmake 2>/dev/null || { echo >&2 "Please install Emscripten before running this script"; exit 1; }
+    fi
 }
 
 prepare_native_build()
@@ -40,7 +45,14 @@ build_native_corert()
 
     # Regenerate the CMake solution
     echo "Invoking cmake with arguments: \"$__ProjectRoot\" $__BuildType"
-    "$__ProjectRoot/src/Native/gen-buildsys-clang.sh" "$__ProjectRoot" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__BuildType
+    if [ $__BuildArch == "wasm" ]; then
+        # TODO: Add a real wasm build
+        echo "Wasm build is not currently implemented"
+        popd > /dev/null
+        exit 1
+    else
+        "$__ProjectRoot/src/Native/gen-buildsys-clang.sh" "$__ProjectRoot" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__BuildType
+    fi
 
     # Check that the makefiles were created.
 

--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -26,6 +26,7 @@ if /i "%1" == "-help" goto Usage
 if /i "%1" == "x64"    (set __BuildArch=x64&&shift&goto Arg_Loop)
 if /i "%1" == "x86"    (set __BuildArch=x86&&shift&goto Arg_Loop)
 if /i "%1" == "arm"    (set __BuildArch=arm&&shift&goto Arg_Loop)
+if /i "%1" == "wasm"    (set __BuildOS=WebAssembly&&set __BuildArch=wasm&&shift&goto Arg_Loop)
 
 if /i "%1" == "debug"    (set __BuildType=Debug&shift&goto Arg_Loop)
 if /i "%1" == "release"   (set __BuildType=Release&shift&goto Arg_Loop)
@@ -71,11 +72,23 @@ if not exist "%__ObjDir%" md "%__ObjDir%"
 if not exist "%__IntermediatesDir%" md "%__IntermediatesDir%"
 if not exist "%__LogsDir%" md "%__LogsDir%"
 
-:CheckPrereqs
 :: Check prerequisites
 echo Checking pre-requisites...
 echo.
 
+if "%__BuildArch%"=="wasm" (
+    goto :CheckPrereqsEmscripten
+) else (
+    goto :CheckPrereqsVs
+)
+
+:CheckPrereqsEmscripten
+if defined EMSCRIPTEN goto Done
+echo Emscripten is a prerequisite to build for WebAssembly.
+echo See: https://github.com/dotnet/corert/blob/master/Documentation/how-to-build-WebAssembly.md
+exit /b 1
+
+:CheckPrereqsVs
 :: Validate that PowerShell is accessibile.
 for %%X in (powershell.exe) do (set __PSDir=%%~$PATH:X)
 if defined __PSDir goto EvaluatePS
@@ -168,6 +181,7 @@ if /i "%__BuildArch%" == "x86" (set __VCBuildArch=x86)
 set __NugetRuntimeId=win7-x64
 if /i "%__BuildArch%" == "x86" (set __NugetRuntimeId=win7-x86)
 
+:Done
 set BUILDVARS_DONE=1
 exit /b 0
 
@@ -181,7 +195,7 @@ echo.
 echo All arguments are optional. The options are:
 echo.
 echo./? -? /h -h /help -help: view this message.
-echo Build architecture: one of x64, x86, arm ^(default: x64^).
+echo Build architecture: one of x64, x86, arm, wasm ^(default: x64^).
 echo Build type: one of Debug, Checked, Release ^(default: Debug^).
 echo Visual Studio version: vs2015, vs2017 ^(defaults to highest detected^).
 echo clean: force a clean build ^(default is to perform an incremental build^).

--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -83,10 +83,20 @@ if "%__BuildArch%"=="wasm" (
 )
 
 :CheckPrereqsEmscripten
-if defined EMSCRIPTEN goto Done
-echo Emscripten is a prerequisite to build for WebAssembly.
-echo See: https://github.com/dotnet/corert/blob/master/Documentation/how-to-build-WebAssembly.md
-exit /b 1
+if not defined EMSCRIPTEN (
+    echo Emscripten is a prerequisite to build for WebAssembly.
+    echo See: https://github.com/dotnet/corert/blob/master/Documentation/how-to-build-WebAssembly.md
+    exit /b 1
+)
+where make >nul 2>nul
+if %errorlevel%==1 (
+    echo GNU Make is a prerequisite to build for WebAssembly.
+    echo Please ensure GNU Make is installed and is added to your path, for example using:
+    echo   set PATH=%%PATH%%^;C:\Program Files ^(x86^)\GnuWin32\bin\
+    echo The installer for GNU Make is available from http://gnuwin32.sourceforge.net/packages/make.htm
+    exit /b 1
+)
+goto Done
 
 :CheckPrereqsVs
 :: Validate that PowerShell is accessibile.

--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -88,15 +88,7 @@ if not defined EMSCRIPTEN (
     echo See: https://github.com/dotnet/corert/blob/master/Documentation/how-to-build-WebAssembly.md
     exit /b 1
 )
-where make >nul 2>nul
-if %errorlevel%==1 (
-    echo GNU Make is a prerequisite to build for WebAssembly.
-    echo Please ensure GNU Make is installed and is added to your path, for example using:
-    echo   set PATH=%%PATH%%^;C:\Program Files ^(x86^)\GnuWin32\bin\
-    echo The installer for GNU Make is available from http://gnuwin32.sourceforge.net/packages/make.htm
-    exit /b 1
-)
-goto Done
+goto CheckPrereqsVs
 
 :CheckPrereqsVs
 :: Validate that PowerShell is accessibile.

--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -6,7 +6,7 @@ usage()
     echo "managed - optional argument to build the managed code"
     echo "native - optional argument to build the native code"
     echo "The following arguments affect native builds only:"
-    echo "BuildArch can be: x64, x86, arm, arm64, armel"
+    echo "BuildArch can be: x64, x86, arm, arm64, armel, wasm"
     echo "BuildType can be: Debug, Release"
     echo "clean - optional argument to force a clean build."
     echo "verbose - optional argument to enable verbose build output."
@@ -123,38 +123,6 @@ case $CPUName in
 esac
 export __HostArch=$__BuildArch
 
-# Use uname to determine what the OS is.
-export OSName=$(uname -s)
-case $OSName in
-    Darwin)
-        export __BuildOS=OSX
-        export __NugetRuntimeId=osx.10.10-x64
-        ulimit -n 2048
-        ;;
-
-    FreeBSD)
-        export __BuildOS=FreeBSD
-        # TODO: Add proper FreeBSD target
-        export __NugetRuntimeId=ubuntu.14.04-x64
-        ;;
-
-    Linux)
-        export __BuildOS=Linux
-        export __NugetRuntimeId=$(get_current_linux_rid)-$__HostArch
-        ;;
-
-    NetBSD)
-        export __BuildOS=NetBSD
-        # TODO: Add proper NetBSD target
-        export __NugetRuntimeId=ubuntu.14.04-x64
-        ;;
-
-    *)
-        echo "Unsupported OS $OSName detected, configuring as if for Linux"
-        export __BuildOS=Linux
-        export __NugetRuntimeId=ubuntu.14.04-x64
-        ;;
-esac
 export __BuildType=Debug
 
 export BUILDERRORLEVEL=0
@@ -195,6 +163,9 @@ while [ "$1" != "" ]; do
             ;;
         armel)
             export __BuildArch=armel
+            ;;
+        wasm)
+            export __BuildArch=wasm
             ;;
         debug)
             export __BuildType=Debug
@@ -244,6 +215,42 @@ while [ "$1" != "" ]; do
     shift
 done
 
+if [ $__BuildArch == "wasm" ]; then
+    export __BuildOS=WebAssembly
+else
+    # Use uname to determine what the OS is.
+    export OSName=$(uname -s)
+    case $OSName in
+        Darwin)
+            export __BuildOS=OSX
+            export __NugetRuntimeId=osx.10.10-x64
+            ulimit -n 2048
+            ;;
+
+        FreeBSD)
+            export __BuildOS=FreeBSD
+            # TODO: Add proper FreeBSD target
+            export __NugetRuntimeId=ubuntu.14.04-x64
+            ;;
+
+        Linux)
+            export __BuildOS=Linux
+            export __NugetRuntimeId=$(get_current_linux_rid)-$__HostArch
+            ;;
+
+        NetBSD)
+            export __BuildOS=NetBSD
+            # TODO: Add proper NetBSD target
+            export __NugetRuntimeId=ubuntu.14.04-x64
+            ;;
+
+        *)
+            echo "Unsupported OS $OSName detected, configuring as if for Linux"
+            export __BuildOS=Linux
+            export __NugetRuntimeId=ubuntu.14.04-x64
+            ;;
+    esac
+fi
 
 # If neither managed nor native are passed as arguments, default to building both
 

--- a/src/Native/gen-buildsys-clang.sh
+++ b/src/Native/gen-buildsys-clang.sh
@@ -113,12 +113,20 @@ if [[ -n "$CROSSCOMPILE" ]]; then
     cmake_extra_defines="$cmake_extra_defines -DCMAKE_TOOLCHAIN_FILE=$1/cross/$build_arch/toolchain.cmake"
 fi
 
-cmake \
-  "-DCMAKE_AR=$llvm_ar" \
-  "-DCMAKE_LINKER=$llvm_link" \
-  "-DCMAKE_NM=$llvm_nm" \
-  "-DCMAKE_OBJDUMP=$llvm_objdump" \
-  "-DCMAKE_RANLIB=$llvm_ranlib" \
-  "-DCMAKE_BUILD_TYPE=$build_type" \
-  $cmake_extra_defines \
-  "$1/src/Native"
+if [ $build_arch == "wasm" ]; then
+    emcmake cmake \
+        "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" \
+        "-DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake" \
+        "-DCMAKE_BUILD_TYPE=$build_type" \
+        "$1/src/Native"
+else
+    cmake \
+        "-DCMAKE_AR=$llvm_ar" \
+        "-DCMAKE_LINKER=$llvm_link" \
+        "-DCMAKE_NM=$llvm_nm" \
+        "-DCMAKE_OBJDUMP=$llvm_objdump" \
+        "-DCMAKE_RANLIB=$llvm_ranlib" \
+        "-DCMAKE_BUILD_TYPE=$build_type" \
+        $cmake_extra_defines \
+        "$1/src/Native"
+fi

--- a/src/Native/gen-buildsys-win.bat
+++ b/src/Native/gen-buildsys-win.bat
@@ -5,7 +5,7 @@ rem This file invokes cmake and generates the build system for windows.
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-if NOT %argC%==3 GOTO :USAGE
+if NOT %argC%==4 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal
@@ -26,7 +26,11 @@ if defined CMakePath goto DoGen
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& %~dp0\probe-win.ps1"') do %%a
 
 :DoGen
-"%CMakePath%" "-DCLR_CMAKE_TARGET_ARCH=%3" -G "Visual Studio %__VSString%" %1
+if "%3" == "wasm" (
+  emcmake "%CMakePath%" "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" "-DCMAKE_MAKE_PROGRAM=make" "-DCMAKE_TOOLCHAIN_FILE=%EMSCRIPTEN%/cmake/Modules/Platform/Emscripten.cmake" "-DCMAKE_BUILD_TYPE=%4" -G "MinGW Makefiles" %1
+) else (
+  "%CMakePath%" "-DCLR_CMAKE_TARGET_ARCH=%3" -G "Visual Studio %__VSString%" %1
+)
 endlocal
 GOTO :DONE
 
@@ -35,6 +39,7 @@ GOTO :DONE
   echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion>"
   echo "Specify the path to the top level CMake file - <corert>/src/Native"
   echo "Specify the VSVersion to be used - VS2013 or VS2015"
+  echo "Specify the build type (Debug, Release)"
   EXIT /B 1
 
 :DONE

--- a/src/Native/gen-buildsys-win.bat
+++ b/src/Native/gen-buildsys-win.bat
@@ -27,7 +27,7 @@ for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& %~dp0
 
 :DoGen
 if "%3" == "wasm" (
-  emcmake "%CMakePath%" "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" "-DCMAKE_MAKE_PROGRAM=make" "-DCMAKE_TOOLCHAIN_FILE=%EMSCRIPTEN%/cmake/Modules/Platform/Emscripten.cmake" "-DCMAKE_BUILD_TYPE=%4" -G "MinGW Makefiles" %1
+  emcmake "%CMakePath%" "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" "-DCMAKE_TOOLCHAIN_FILE=%EMSCRIPTEN%/cmake/Modules/Platform/Emscripten.cmake" "-DCMAKE_BUILD_TYPE=%4" -G "NMake Makefiles" %1
 ) else (
   "%CMakePath%" "-DCLR_CMAKE_TARGET_ARCH=%3" -G "Visual Studio %__VSString%" %1
 )


### PR DESCRIPTION
This commit adds a placeholder build target for WebAssembly to the bash and batch build scripts (#4504).

At present, an error is displayed advising that the wasm build is not yet implemented before exiting.

I was hoping to try and take a look at the cmake scripts for #4505, and this seemed like a sensible first step. 