### PR TITLE
[ILVerify] Fix invalid branch/fallthrough into catch/finally causing assert

### DIFF
--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -607,7 +607,8 @@
             endfilter
         } 
         { 
-
+            pop
+            leave.s lbl_ret
         }
 
         lbl_ret: ret

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -571,8 +571,7 @@
         lbl_ret: ret
     }
 
-    /* These tests currently yield an assert (see issue #4537), due to a non-null entry stack to a catch/finally block; uncomment once fixed
-    .method static public hidebysig void Branching.FromTryIntoCatch_Invalid_BranchOutOfTry.BranchIntoFilter() cil managed
+    .method static public hidebysig void Branching.FromTryIntoCatch_Invalid_BranchOutOfTry.BranchIntoHandler() cil managed
     {
         .maxstack 2
 
@@ -594,8 +593,26 @@
 
         lbl_ret: ret
     }
-    */
-    /*
+
+    .method static public hidebysig void Branching.FromTryIntoFilter_Invalid_BranchOutOfTry.BranchIntoFilter() cil managed
+    {
+        .try
+        {
+            br.s  lbl_filter
+        }
+        filter
+        {
+            lbl_filter: pop
+            ldc.i4.0
+            endfilter
+        } 
+        { 
+
+        }
+
+        lbl_ret: ret
+    }
+
     .method static public hidebysig void Branching.FromTryIntoFinally_Invalid_BranchOutOfTry.BranchIntoHandler() cil managed
     {
         .maxstack 2
@@ -617,7 +634,6 @@
 
         lbl_ret: ret
     }
-    */
 
     .method static public hidebysig void Branching.FromTryIntoOtherTryStart_Invalid_BranchOutOfTry() cil managed
     {


### PR DESCRIPTION
Invalid il code that performs a branch or fallthrough into a catch/filter/finally block currently causes an assert as described in #4537.
In order to fix this issue, I moved the valid branch target check into the `ImportFallthrough` method (as we always call `ImportFallthrough` for branching anyways), and changed the check itself to return a boolean indicating whether the target is valid or not. If the target is invalid the stack is not merged and the target block is also not marked for verification. This way the state that causes the assert is never reached.

This fixes #4537.