### PR TITLE
[ILVerify] Instantiate constraints of generic parameters used as instantiation

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemConstraintsHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemConstraintsHelpers.cs
@@ -103,9 +103,9 @@ namespace Internal.TypeSystem
             return false;
         }
 
-        private static List<TypeDesc> GetInstantiatedConstraints(TypeDesc type, Instantiation typeInstantiation, Instantiation methodInstantiation)
+        private static ArrayBuilder<TypeDesc> GetInstantiatedConstraints(TypeDesc type, Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            var instantiatedConstraints = new List<TypeDesc>();
+            var instantiatedConstraints = new ArrayBuilder<TypeDesc>();
 
             if (type.IsGenericParameter)
             {
@@ -118,11 +118,11 @@ namespace Internal.TypeSystem
             return instantiatedConstraints;
         }
 
-        private static bool CanCastConstraint(List<TypeDesc> instantiatedConstraints, TypeDesc instantiatedType)
+        private static bool CanCastConstraint(ArrayBuilder<TypeDesc> instantiatedConstraints, TypeDesc instantiatedType)
         {
-            foreach (var instantiatedConstraint in instantiatedConstraints)
+            for (int i = 0; i < instantiatedConstraints.Count; ++i)
             {
-                if (instantiatedConstraint.CanCastTo(instantiatedType))
+                if (instantiatedConstraints[i].CanCastTo(instantiatedType))
                     return true;
             }
 

--- a/src/Common/src/TypeSystem/Common/TypeSystemConstraintsHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemConstraintsHelpers.cs
@@ -129,7 +129,6 @@ namespace Internal.TypeSystem
             return false;
         }
 
-
         public static bool CheckValidInstantiationArguments(this Instantiation instantiation)
         {
             foreach(var arg in instantiation)

--- a/src/ILCompiler.TypeSystem/tests/ConstraintsValidationTest.cs
+++ b/src/ILCompiler.TypeSystem/tests/ConstraintsValidationTest.cs
@@ -33,7 +33,12 @@ namespace TypeSystemTests
         private MetadataType _complexGenericConstraint1Type;
         private MetadataType _complexGenericConstraint2Type;
         private MetadataType _complexGenericConstraint3Type;
+        private MetadataType _complexGenericConstraint4Type;
         private MetadataType _multipleConstraintsType;
+
+        private MetadataType _genericMethodsType;
+        private MethodDesc _simpleGenericConstraintMethod;
+        private MethodDesc _complexGenericConstraintMethod;
 
         public ConstraintsValidationTest()
         {
@@ -64,13 +69,19 @@ namespace TypeSystemTests
             _complexGenericConstraint1Type = _testModule.GetType("GenericConstraints", "ComplexGenericConstraint1`2");
             _complexGenericConstraint2Type = _testModule.GetType("GenericConstraints", "ComplexGenericConstraint2`2");
             _complexGenericConstraint3Type = _testModule.GetType("GenericConstraints", "ComplexGenericConstraint3`2");
+            _complexGenericConstraint4Type = _testModule.GetType("GenericConstraints", "ComplexGenericConstraint4`2");
             _multipleConstraintsType = _testModule.GetType("GenericConstraints", "MultipleConstraints`2");
+
+            _genericMethodsType = _testModule.GetType("GenericConstraints", "GenericMethods");
+            _simpleGenericConstraintMethod = _genericMethodsType.GetMethod("SimpleGenericConstraintMethod", null);
+            _complexGenericConstraintMethod = _genericMethodsType.GetMethod("ComplexGenericConstraintMethod", null);
         }
 
         [Fact]
         public void TestTypeConstraints()
         {
-            MetadataType instantiatedType;
+            TypeDesc instantiatedType;
+            MethodDesc instantiatedMethod;
 
             MetadataType arg2OfInt = _arg2Type.MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Int32));
             MetadataType arg2OfBool = _arg2Type.MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Boolean));
@@ -272,10 +283,36 @@ namespace TypeSystemTests
                 // Type that implements a variant compatible interface
                 instantiatedType = _complexGenericConstraint3Type.MakeInstantiatedType(arg3OfObject, _context.GetWellKnownType(WellKnownType.String));
                 Assert.True(instantiatedType.CheckConstraints());
+            }
 
-                // Instantiate type with own generic parameters
+            // Constraints requiring InstantiationContext
+            {
+                // Instantiate type / method with own generic parameters
                 instantiatedType = _complexGenericConstraint3Type.MakeInstantiatedType(_complexGenericConstraint3Type.Instantiation[0], _complexGenericConstraint3Type.Instantiation[1]);
                 Assert.True(instantiatedType.CheckConstraints(new InstantiationContext(instantiatedType.Instantiation, default(Instantiation))));
+
+                instantiatedType = _complexGenericConstraint4Type.MakeInstantiatedType(_complexGenericConstraint4Type.Instantiation[0], _complexGenericConstraint4Type.Instantiation[1]);
+                Assert.True(instantiatedType.CheckConstraints(new InstantiationContext(instantiatedType.Instantiation, default(Instantiation))));
+
+                instantiatedMethod = _simpleGenericConstraintMethod.MakeInstantiatedMethod(_simpleGenericConstraintMethod.Instantiation);
+                Assert.True(instantiatedMethod.CheckConstraints(new InstantiationContext(default(Instantiation), instantiatedMethod.Instantiation)));
+
+                instantiatedMethod = _complexGenericConstraintMethod.MakeInstantiatedMethod(_complexGenericConstraintMethod.Instantiation);
+                Assert.True(instantiatedMethod.CheckConstraints(new InstantiationContext(default(Instantiation), instantiatedMethod.Instantiation)));
+
+                // Instantiate type with generic parameters of method
+                instantiatedType = _simpleGenericConstraintType.MakeInstantiatedType(_simpleGenericConstraintMethod.Instantiation);
+                Assert.True(instantiatedType.CheckConstraints(new InstantiationContext(default(Instantiation), _simpleGenericConstraintMethod.Instantiation)));
+
+                instantiatedType = _complexGenericConstraint4Type.MakeInstantiatedType(_complexGenericConstraintMethod.Instantiation);
+                Assert.True(instantiatedType.CheckConstraints(new InstantiationContext(default(Instantiation), _complexGenericConstraintMethod.Instantiation)));
+
+                // Instantiate method with generic parameters of type
+                instantiatedMethod = _simpleGenericConstraintMethod.MakeInstantiatedMethod(_simpleGenericConstraintType.Instantiation);
+                Assert.True(instantiatedMethod.CheckConstraints(new InstantiationContext(_simpleGenericConstraintType.Instantiation, default(Instantiation))));
+
+                instantiatedMethod = _complexGenericConstraintMethod.MakeInstantiatedMethod(_complexGenericConstraint4Type.Instantiation);
+                Assert.True(instantiatedMethod.CheckConstraints(new InstantiationContext(_complexGenericConstraint4Type.Instantiation, default(Instantiation))));
             }
 
             // MultipleConstraints

--- a/src/ILCompiler.TypeSystem/tests/ConstraintsValidationTest.cs
+++ b/src/ILCompiler.TypeSystem/tests/ConstraintsValidationTest.cs
@@ -272,6 +272,10 @@ namespace TypeSystemTests
                 // Type that implements a variant compatible interface
                 instantiatedType = _complexGenericConstraint3Type.MakeInstantiatedType(arg3OfObject, _context.GetWellKnownType(WellKnownType.String));
                 Assert.True(instantiatedType.CheckConstraints());
+
+                // Instantiate type with own generic parameters
+                instantiatedType = _complexGenericConstraint3Type.MakeInstantiatedType(_complexGenericConstraint3Type.Instantiation[0], _complexGenericConstraint3Type.Instantiation[1]);
+                Assert.True(instantiatedType.CheckConstraints());
             }
 
             // MultipleConstraints

--- a/src/ILCompiler.TypeSystem/tests/ConstraintsValidationTest.cs
+++ b/src/ILCompiler.TypeSystem/tests/ConstraintsValidationTest.cs
@@ -275,7 +275,7 @@ namespace TypeSystemTests
 
                 // Instantiate type with own generic parameters
                 instantiatedType = _complexGenericConstraint3Type.MakeInstantiatedType(_complexGenericConstraint3Type.Instantiation[0], _complexGenericConstraint3Type.Instantiation[1]);
-                Assert.True(instantiatedType.CheckConstraints());
+                Assert.True(instantiatedType.CheckConstraints(new InstantiationContext(instantiatedType.Instantiation, default(Instantiation))));
             }
 
             // MultipleConstraints

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/GenericConstraints.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/GenericConstraints.cs
@@ -59,5 +59,14 @@ namespace GenericConstraints
 
     public class ComplexGenericConstraint3<T, U> where T : IGen<U> { }
 
+    public class ComplexGenericConstraint4<T, U> where T : U where U : IGen<T> { }
+
     public class MultipleConstraints<T, U> where T : class, IGen<U>, new() { }
+
+    public class GenericMethods
+    {
+        public static void SimpleGenericConstraintMethod<T, U>() where T : U { }
+
+        public static void ComplexGenericConstraintMethod<T, U>() where T : U where U : IGen<T> { }
+    }
 }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -140,17 +140,19 @@ namespace Internal.IL
 
             // Instantiate method and its owning type
             var instantiatedType = method.OwningType;
-            _method = method;
+            var instantiatedMethod = method;
             if (instantiatedType.HasInstantiation)
             {
                 instantiatedType = _typeSystemContext.GetInstantiatedType((MetadataType)instantiatedType, instantiatedType.Instantiation);
-                _method = _typeSystemContext.GetMethodForInstantiatedType(_method.GetTypicalMethodDefinition(), (InstantiatedType)instantiatedType);
+                instantiatedMethod = _typeSystemContext.GetMethodForInstantiatedType(instantiatedMethod.GetTypicalMethodDefinition(), (InstantiatedType)instantiatedType);
             }
 
-            if (_method.HasInstantiation)
-                _method = _typeSystemContext.GetInstantiatedMethod(_method, _method.Instantiation);
-            _methodIL = method == _method ? methodIL : new InstantiatedMethodIL(_method, methodIL);
-            _instantiationContext = new InstantiationContext(instantiatedType.Instantiation, _method.Instantiation);
+            if (instantiatedMethod.HasInstantiation)
+                instantiatedMethod = _typeSystemContext.GetInstantiatedMethod(instantiatedMethod, instantiatedMethod.Instantiation);
+            _method = instantiatedMethod;
+            _methodSignature = _method.Signature;
+            _methodIL = method == instantiatedMethod ? methodIL : new InstantiatedMethodIL(instantiatedMethod, methodIL);
+            _instantiationContext = new InstantiationContext(instantiatedType.Instantiation, instantiatedMethod.Instantiation);
 
             // Determine this type
             if (!_method.Signature.IsStatic)
@@ -164,7 +166,6 @@ namespace Internal.IL
                     _thisType = _thisType.MakeByRefType();
             }
 
-            _methodSignature = _method.Signature;
             _initLocals = _methodIL.IsInitLocals;
 
             _maxStack = _methodIL.MaxStack;

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1046,7 +1046,6 @@ namespace Internal.IL
             }
 
             // Check any constraints on the callee's class and type parameters
-            var ecmaType = method.OwningType as EcmaType;
             if (!method.OwningType.CheckConstraints())
                 VerificationError(VerifierError.UnsatisfiedMethodParentInst, method.OwningType);
             else if (!method.CheckConstraints())

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -41,6 +41,7 @@ namespace Internal.IL
         readonly MethodDesc _method;
         readonly MethodSignature _methodSignature;
         readonly TypeSystemContext _typeSystemContext;
+        readonly InstantiationContext _instantiationContext;
 
         readonly TypeDesc _thisType;
 
@@ -149,6 +150,7 @@ namespace Internal.IL
             if (_method.HasInstantiation)
                 _method = _typeSystemContext.GetInstantiatedMethod(_method, _method.Instantiation);
             _methodIL = method == _method ? methodIL : new InstantiatedMethodIL(_method, methodIL);
+            _instantiationContext = new InstantiationContext(instantiatedType.Instantiation, _method.Instantiation);
 
             // Determine this type
             if (!_method.Signature.IsStatic)
@@ -1046,9 +1048,9 @@ namespace Internal.IL
             }
 
             // Check any constraints on the callee's class and type parameters
-            if (!method.OwningType.CheckConstraints())
+            if (!method.OwningType.CheckConstraints(_instantiationContext))
                 VerificationError(VerifierError.UnsatisfiedMethodParentInst, method.OwningType);
-            else if (!method.CheckConstraints())
+            else if (!method.CheckConstraints(_instantiationContext))
                 VerificationError(VerifierError.UnsatisfiedMethodInst, method);
 #if false
             // Access verifications
@@ -1164,9 +1166,9 @@ namespace Internal.IL
             }
 
             // Check any constraints on the callee's class and type parameters
-            if (!method.OwningType.CheckConstraints())
+            if (!method.OwningType.CheckConstraints(_instantiationContext))
                 VerificationError(VerifierError.UnsatisfiedMethodParentInst, method.OwningType);
-            else if (!method.CheckConstraints())
+            else if (!method.CheckConstraints(_instantiationContext))
                 VerificationError(VerifierError.UnsatisfiedMethodInst, method);
 
 #if false


### PR DESCRIPTION
Currently checking the constraints using `TypeSystemConstraintsHelpers.CheckConstraints` of the field `instance` of the following sample code will return false even though it is a valid instantiation:
```
class Generic<T, S> where T : IEnumerable<S>
{
    Generic<T, S> instance;
}
```
This is caused by the `CheckConstraints` method not instantiating the constraints of instantiation parameters, but the constraints they are compared to are being instantiated. In this example, it is checked whether `IEnumerable<!!1>` can be cast to `IEnumerable<S>`, which returns false.

In order to fix this I implemented the instantiation of the generic constraints of the instantiation parameter in case it is a generic parameter itself. If one of the instantiated constraints of the instantiation parameter can be cast to the constraint to be checked, then the instantiation parameter itself also fulfills this constraint.

I also added a test case for this scenario to the `TypeSystem.Tests`.