### PR TITLE
[ILVerify] Implement verification of return instruction

### DIFF
--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -16,7 +16,8 @@ namespace Internal.IL
         public enum StackValueFlags
         {
             None = 0,
-            ReadOnly = 1 << 1
+            ReadOnly = 1 << 1,
+            PermanentHome = 1 << 2
         }
         private StackValueFlags Flags;
 
@@ -37,9 +38,19 @@ namespace Internal.IL
             Flags |= StackValueFlags.ReadOnly;
         }
 
+        public void SetIsPermanentHome()
+        {
+            Flags |= StackValueFlags.PermanentHome;
+        }
+
         public bool IsReadOnly
         {
             get { return (Flags & StackValueFlags.ReadOnly) == StackValueFlags.ReadOnly; }
+        }
+
+        public bool IsPermanentHome
+        {
+            get { return (Flags & StackValueFlags.PermanentHome) == StackValueFlags.PermanentHome; }
         }
 
         public bool IsNullReference
@@ -83,9 +94,11 @@ namespace Internal.IL
             return new StackValue(StackValueKind.ValueType, type);
         }
 
-        static public StackValue CreateByRef(TypeDesc type, bool readOnly = false)
+        static public StackValue CreateByRef(TypeDesc type, bool readOnly = false, bool permanentHome = false)
         {
-            return new StackValue(StackValueKind.ByRef, type, null, readOnly ? StackValueFlags.ReadOnly : StackValueFlags.None);
+            return new StackValue(StackValueKind.ByRef, type, null,
+                (readOnly ? StackValueFlags.ReadOnly : StackValueFlags.None) | 
+                (permanentHome ? StackValueFlags.PermanentHome : StackValueFlags.None));
         }
 
         static public StackValue CreateMethod(MethodDesc method)

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -687,6 +687,7 @@ namespace Internal.IL
         void EndImportingInstruction()
         {
             CheckPendingPrefix(_pendingPrefix);
+            ClearPendingPrefix(_pendingPrefix); // Make sure prefix is cleared
         }
 
         void StartImportingBasicBlock(BasicBlock basicBlock)
@@ -1208,7 +1209,10 @@ namespace Internal.IL
 
             if (declaredReturnType.IsVoid)
             {
-                Check(_stackTop == 0, VerifierError.ReturnVoid, _stack[_stackTop - 1]);
+                Debug.Assert(_stackTop >= 0);
+
+                if (_stackTop > 0)
+                    VerificationError(VerifierError.ReturnVoid, _stack[_stackTop - 1]);
             }
             else
             {

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1444,7 +1444,6 @@ namespace Internal.IL
         void ImportAddressOfField(int token, bool isStatic)
         {
             var field = ResolveFieldToken(token);
-            var actualThis = Pop();
 
             if (isStatic)
             {
@@ -1457,6 +1456,7 @@ namespace Internal.IL
                 // Note that even if the field is static, we require that the this pointer
                 // satisfy the same constraints as a non-static field  This happens to
                 // be simpler and seems reasonable
+                var actualThis = Pop();
                 if (actualThis.Kind == StackValueKind.ValueType)
                     actualThis = StackValue.CreateByRef(actualThis.Type);
 
@@ -1466,8 +1466,8 @@ namespace Internal.IL
                 CheckIsAssignable(actualThis, declaredThis);
             }
 
-            var isPermanentHome = isStatic || actualThis.Kind == StackValueKind.ObjRef || actualThis.IsPermanentHome;
-            Push(StackValue.CreateByRef(field.FieldType, false, isPermanentHome));
+            var fieldStackValue = StackValue.CreateFromType(field.FieldType);
+            Push(StackValue.CreateByRef(field.FieldType, false, isStatic || fieldStackValue.Kind == StackValueKind.ObjRef));
         }
 
         void ImportStoreField(int token, bool isStatic)

--- a/src/ILVerify/src/Resources/Strings.resx
+++ b/src/ILVerify/src/Resources/Strings.resx
@@ -222,6 +222,27 @@
   <data name="Rethrow" xml:space="preserve">
     <value>Rethrow from outside a catch handler.</value>
   </data>
+  <data name="ReturnEmpty" xml:space="preserve">
+    <value>Stack must contain only the return value.</value>
+  </data>
+  <data name="ReturnFromFilter" xml:space="preserve">
+    <value>Return out of exception filter block.</value>
+  </data>
+  <data name="ReturnFromHandler" xml:space="preserve">
+    <value>Return out of exception handler block.</value>
+  </data>
+  <data name="ReturnFromTry" xml:space="preserve">
+    <value>Return out of try block.</value>
+  </data>
+  <data name="ReturnMissing" xml:space="preserve">
+    <value>Return value missing on the stack.</value>
+  </data>
+  <data name="ReturnPtrToStack" xml:space="preserve">
+    <value>Return type is ByRef, TypedReference, ArgHandle, or ArgIterator.</value>
+  </data>
+  <data name="ReturnVoid" xml:space="preserve">
+    <value>Stack must be empty on return from a void function.</value>
+  </data>
   <data name="StackByRef" xml:space="preserve">
     <value>Expected ByRef on the stack.</value>
   </data>

--- a/src/ILVerify/src/VerifierError.cs
+++ b/src/ILVerify/src/VerifierError.cs
@@ -70,9 +70,9 @@ namespace ILVerify
         BranchOutOfHandler,     //"Branch out of exception handler block."
         BranchOutOfFilter,      //"Branch out of exception filter block."
         //E_BR_OUTOF_FIN       "Branch out of finally block."
-        //E_RET_FROM_TRY       "Return out of try block."
-        //E_RET_FROM_HND       "Return out of exception handler block."
-        //E_RET_FROM_FIL       "Return out of exception filter block."
+        ReturnFromTry,          //"Return out of try block."
+        ReturnFromHandler,      //"Return out of exception handler block."
+        ReturnFromFilter,       //"Return out of exception filter block."
         //E_BAD_JMP_TARGET     "jmp / exception into the middle of an instruction."
         //E_PATH_LOC           "Non-compatible types depending on path."
         //E_PATH_THIS          "Init state for this differs depending on path."
@@ -118,10 +118,10 @@ namespace ILVerify
         //  E_TOKEN_TYPE_SIG     "Expected signature token."
         Unverifiable,                   // Instruction can not be verified.
         StringOperand,                  // Operand does not point to a valid string ref.
-        //E_RET_PTR_TO_STACK   "Return type is ByRef, TypedReference, ArgHandle, or ArgIterator."
-        //E_RET_VOID           "Stack must be empty on return from a void function."
-        //E_RET_MISSING        "Return value missing on the stack."
-        //E_RET_EMPTY          "Stack must contain only the return value."
+        ReturnPtrToStack,               // Return type is ByRef, TypedReference, ArgHandle, or ArgIterator.
+        ReturnVoid,                     // Stack must be empty on return from a void function.
+        ReturnMissing,                  // Return value missing on the stack.
+        ReturnEmpty,                    // Stack must contain only the return value.
         //E_RET_UNINIT         "Return uninitialized data."
         //E_ARRAY_ACCESS       "Illegal array access."
         //E_ARRAY_V_STORE      "Store non Object type into Object array."

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -193,10 +193,10 @@
         .locals init (
             class [System.Runtime]System.Func`1<!T> V_0
         )
-        
-        ldarg.0
+
         ldloc.0
         callvirt  instance !0 class [System.Runtime]System.Func`1<!T>::Invoke()
+        pop
         ret
     }
 

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTest.il
@@ -17,6 +17,7 @@
     {
         ldarg.0
         ldind.ref
+        pop
         ret
     }
 
@@ -24,6 +25,7 @@
     {
         ldarg.0
         ldind.i4
+        pop
         ret
     }
 
@@ -31,6 +33,7 @@
     {
         ldarg.0
         ldind.i4
+        pop
         ret
     }
 
@@ -38,6 +41,7 @@
     {
         ldarg.0
         ldind.ref
+        pop
         ret
     }
 

--- a/src/ILVerify/tests/ILTests/PrefixTests.il
+++ b/src/ILVerify/tests/ILTests/PrefixTests.il
@@ -27,6 +27,7 @@
         readonly. 
         ldelema    [System.Runtime]System.Int32
         call       instance string [System.Runtime]System.Int32::ToString()
+        pop
         ret
     }
 
@@ -43,6 +44,7 @@
         
         readonly. 
         ldelem    [System.Runtime]System.Int32
+        pop
         ret
     }
 

--- a/src/ILVerify/tests/ILTests/ReturnTests.il
+++ b/src/ILVerify/tests/ILTests/ReturnTests.il
@@ -1,0 +1,151 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly ReturnTests
+{
+}
+
+.class public sequential ansi sealed beforefieldinit Struct
+        extends [System.Runtime]System.ValueType
+{
+    .field public int32 instanceField
+}
+
+.class public auto ansi beforefieldinit ReturnTestsType
+        extends [System.Runtime]System.Object
+{
+    .field private int32 instanceField
+    .field private static int32 staticField
+
+    .field private valuetype Struct instanceStruct
+
+    .method public hidebysig instance void Return.Void_Valid() cil managed
+    {
+        ldarg.0
+        pop
+        ret
+    }
+
+    .method public hidebysig instance void Return.VoidNonEmptyStack_Invalid_ReturnVoid() cil managed
+    {
+        ldarg.0
+        ret
+    }
+
+    .method public hidebysig instance int32 Return.Int32_Valid() cil managed
+    {
+        ldc.i4.0
+        ret
+    }
+
+    .method public hidebysig instance int32 Return.Int32EmptyStack_Invalid_ReturnMissing() cil managed
+    {
+        ret
+    }
+
+    .method public hidebysig instance int32 Return.Int32StackLeft_Invalid_ReturnEmpty() cil managed
+    {
+        ldc.i4.0
+        ldc.i4.0
+        ret
+    }
+
+    .method public hidebysig instance void Return.FromTry_Invalid_ReturnFromTry() cil managed
+    {
+        .try
+        {
+            ret
+        }
+        catch [System.Runtime]System.Object
+        {
+            pop
+            leave.s     lbl_ret
+        }
+
+    lbl_ret:
+        ret
+    }
+
+    .method public hidebysig instance void Return.FromCatch_Invalid_ReturnFromHandler() cil managed
+    {
+        .try
+        {
+            leave.s     lbl_ret
+        }
+        catch [System.Runtime]System.Object
+        {
+            pop
+            ret
+        }
+
+    lbl_ret:
+        ret
+    }
+
+    .method public hidebysig instance void Return.FromFilter_Invalid_ReturnFromFilter() cil managed
+    {
+        .try
+        {
+            leave.s     lbl_ret
+        }
+        filter
+        {
+            pop
+            ret
+
+            endfilter
+        }
+        {
+            pop
+            leave.s     lbl_ret
+        }
+
+    lbl_ret:
+        ret
+    }
+
+    .method public hidebysig instance int32 Return.ObjectForInt32_Invalid_StackUnexpected(object o) cil managed
+    {
+        ldarg.1
+        ret
+    }
+
+    .method public hidebysig instance int32& Return.LocalArgByRef_Invalid_ReturnPtrToStack(int32 i) cil managed
+    {
+        ldarga.s    i
+        ret
+    }
+
+    .method public hidebysig instance int32& Return.InstanceFieldByRef_Valid(int32 i) cil managed
+    {
+        ldarg.0
+        ldflda      int32 ReturnTestsType::instanceField
+        ret
+    }
+
+    .method public hidebysig instance int32& Return.StaticFieldByRef_Valid(int32 i) cil managed
+    {
+        ldsflda      int32 ReturnTestsType::staticField
+        ret
+    }
+
+    .method public hidebysig instance int32& Return.LocalStructFieldByRef_Invalid_ReturnPtrToStack(valuetype Struct s) cil managed
+    {
+        ldarg.1
+        ldflda      int32 Struct::instanceField
+        ret
+    }
+
+    .method public hidebysig instance int32& Return.FieldStructFieldByRef_Valid() cil managed
+    {
+        ldarg.0
+        ldflda      valuetype Struct ReturnTestsType::instanceStruct
+        ldflda      int32 Struct::instanceField
+        ret
+    }
+}


### PR DESCRIPTION
I implemented the verification of the return instruction and added relevant unit tests.
This also prompted the implementation of the `IsPermanentHome` flag for `ByRefs` and the according checks / state initializations in other instructions.

I also added the trackObjCtor state flag, which will be used for tracking the this-pointer state and added references to the relevant PEVerify code parts. I will be implementing the actual tracking of the this-pointer in a separate PR.

The verification of the return instruction resulted in 7 existing tests failing mostly because they did not clear the evaluation stack before returning. I fixed those tests.