### PR TITLE
Compat: Disallow boxing return type conversion by CreateDelegate()

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -377,8 +377,16 @@ namespace System.Reflection.Runtime.MethodInfos
             MethodInfo invokeMethod = runtimeDelegateType.GetInvokeMethod();
 
             // Make sure the return type is assignment-compatible.
-            if (!IsAssignableFrom(executionEnvironment, invokeMethod.ReturnParameter.ParameterType, this.ReturnParameter.ParameterType))
+            Type expectedReturnType = ReturnParameter.ParameterType;
+            Type actualReturnType = invokeMethod.ReturnParameter.ParameterType;
+            if (!IsAssignableFrom(executionEnvironment, actualReturnType, expectedReturnType))
                 return null;
+            if (expectedReturnType.IsValueType && !actualReturnType.IsValueType)
+            {
+                // For value type returning methods, conversions between enums and primitives are allowed (and screened by the above call to IsAssignableFrom)
+                // but conversions to Object or interfaces implemented by the value type are not.
+                return null;
+            }
 
             IList<ParameterInfo> delegateParameters = invokeMethod.GetParametersNoCopy();
             IList<ParameterInfo> targetParameters = this.GetParametersNoCopy();


### PR DESCRIPTION
On CoreCLR,

   MethodInfo m = ..."Moo"..;
   m.CreateDelegate(typeof(Func<Object>))

   static int Moo() => 7;

throws an ArgumentException regarding a mismatching signature.

On Project N, the CreateDelegate() succeeds. But the celebration
turns into tears as soon as you invoke the delegate
as the hoped for boxing never occurs. Instead you get an unboxed
integer stored into a variable that expects an object reference.