### PR TITLE
Revert "Revert "Improved System.Decimal performance""

### DIFF
--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -177,7 +177,7 @@ namespace System
                 uflags = SignMask;
                 value_copy = -value_copy;
             }
-            Low64 = (ulong)value;
+            Low64 = (ulong)value_copy;
             uhi = 0;
         }
 

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -123,13 +123,11 @@ namespace System
         [FieldOffset(12), NonSerialized]
         private uint umid;
 
-        // Constructs a zero Decimal.
-        //public Decimal() {
-        //    lo = 0;
-        //    mid = 0;
-        //    hi = 0;
-        //    flags = 0;
-        //}
+        /// <summary>
+        /// The low and mid fields combined in little-endian order
+        /// </summary>
+        [FieldOffset(8), NonSerialized]
+        private ulong ulomidLE;
 
         // Constructs a Decimal from an integer value.
         //
@@ -179,8 +177,7 @@ namespace System
                 uflags = SignMask;
                 value_copy = -value_copy;
             }
-            ulo = (uint)value_copy;
-            umid = (uint)(value_copy >> 32);
+            Low64 = (ulong)value;
             uhi = 0;
         }
 
@@ -190,8 +187,7 @@ namespace System
         public Decimal(ulong value)
         {
             uflags = 0;
-            ulo = (uint)value;
-            umid = (uint)(value >> 32);
+            Low64 = value;
             uhi = 0;
         }
 
@@ -280,10 +276,6 @@ namespace System
         //
         public Decimal(int[] bits)
         {
-            lo = 0;
-            mid = 0;
-            hi = 0;
-            flags = 0;
             SetBits(bits);
         }
 
@@ -652,9 +644,8 @@ namespace System
         //
         public static Decimal Multiply(Decimal d1, Decimal d2)
         {
-            Decimal decRes;
-            DecCalc.VarDecMul(ref d1, ref d2, out decRes);
-            return decRes;
+            DecCalc.VarDecMul(ref d1, ref d2);
+            return d1;
         }
 
         // Returns the negated value of the given Decimal. If d is non-zero,


### PR DESCRIPTION
Reverts dotnet/corert#4651

@jkotas I fixed the `Decimal(long)` constructor bug made in https://github.com/dotnet/corert/pull/4452