### PR TITLE
WebAssembly instance method support

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -125,7 +125,11 @@ namespace Internal.IL
         /// <returns>Element at the top of the stack</returns>
         public T Peek()
         {
-            Debug.Assert(_top > 0, "Stack is not empty");
+#if DEBUG // This should eventually be an assert, but while many opcodes are unimplemented, we can just throw to avoid
+            // killing the process
+            if(_top <= 0)
+                throw new Exception("Stack is not empty");
+#endif //DEBUG
             return _stack[_top - 1];
         }
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -125,11 +125,11 @@ namespace Internal.IL
         /// <returns>Element at the top of the stack</returns>
         public T Peek()
         {
-#if DEBUG // This should eventually be an assert, but while many opcodes are unimplemented, we can just throw to avoid
-            // killing the process
-            if(_top <= 0)
-                throw new Exception("Stack is not empty");
-#endif //DEBUG
+            if (_top <= 0)
+            {
+                ThrowHelper.ThrowInvalidProgramException();
+            }
+
             return _stack[_top - 1];
         }
 
@@ -139,11 +139,11 @@ namespace Internal.IL
         /// <returns>Element formerly at the top of the stack</returns>
         public T Pop()
         {
-#if DEBUG // This should eventually be an assert, but while many opcodes are unimplemented, we can just throw to avoid
-            // killing the process
-            if(_top <= 0)
-                throw new Exception("Stack is not empty");
-#endif //DEBUG
+            if (_top <= 0)
+            {
+                ThrowHelper.ThrowInvalidProgramException();
+            }
+
             return _stack[--_top];
         }
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -731,7 +731,7 @@ namespace Internal.IL
                 }
                 else
                 {
-                    argType = callee.Signature[index];
+                    argType = callee.Signature[index - instanceAdjustment];
                 }
 
                 LLVMTypeRef valueType = GetLLVMTypeForTypeDesc(argType);

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -313,7 +313,7 @@ namespace Internal.IL
             {
                 varCountBase = 0;
                 varBase = 0;
-                if(!_signature.IsStatic)
+                if (!_signature.IsStatic)
                 {
                     varCountBase = 1;
                 }
@@ -515,7 +515,7 @@ namespace Internal.IL
             {
                 offset += _signature[i].GetElementSize().AsInt;
             }
-            if(!_signature.IsStatic)
+            if (!_signature.IsStatic)
             {
                 // If this is a struct, then it's a pointer on the stack
                 if (_thisType.IsValueType)
@@ -614,7 +614,7 @@ namespace Internal.IL
 
         private void ImportReturn()
         {
-            if(_signature.ReturnType != GetWellKnownType(WellKnownType.Void))
+            if (_signature.ReturnType != GetWellKnownType(WellKnownType.Void))
             {
                 StackEntry retVal = _stack.Pop();
                 LLVMTypeRef valueType = GetLLVMTypeForTypeDesc(_signature.ReturnType);
@@ -648,7 +648,7 @@ namespace Internal.IL
             {
                 throw new NotImplementedException();
             }
-            if(opcode == ILOpcode.callvirt && callee.IsAbstract)
+            if (opcode == ILOpcode.callvirt && callee.IsAbstract)
             {
                 throw new NotImplementedException();
             }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -517,7 +517,15 @@ namespace Internal.IL
             }
             if(!_signature.IsStatic)
             {
-                offset += _thisType.GetElementSize().AsInt;
+                // If this is a struct, then it's a pointer on the stack
+                if (_thisType.IsValueType)
+                {
+                    offset += _thisType.Context.Target.PointerSize;
+                }
+                else
+                {
+                    offset += _thisType.GetElementSize().AsInt;
+                }
             }
 
             return offset;
@@ -528,7 +536,7 @@ namespace Internal.IL
             int thisSize = 0;
             if (!_signature.IsStatic)
             {
-                thisSize = _thisType.GetElementSize().AsInt;
+                thisSize = _thisType.IsValueType ? _thisType.Context.Target.PointerSize : _thisType.GetElementSize().AsInt;
                 if (index == 0)
                 {
                     size = thisSize;

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -31,7 +31,8 @@ namespace Internal.IL
 
             if (method.HasCustomAttribute("System.Runtime", "RuntimeImportAttribute"))
             {
-                throw new NotImplementedException();
+                methodCodeNodeNeedingCode.CompilationCompleted = true;
+                //throw new NotImplementedException();
                 //CompileExternMethod(methodCodeNodeNeedingCode, ((EcmaMethod)method).GetRuntimeImportName());
                 //return;
             }
@@ -49,7 +50,18 @@ namespace Internal.IL
             ILImporter ilImporter = null;
             try
             {
-                ilImporter = new ILImporter(compilation, method, methodIL, methodCodeNodeNeedingCode.GetMangledName(compilation.NameMangler));
+                string mangledName;
+                // TODO: We should have better detection for main or a way for native main to find out what managed main's name is
+                if(methodCodeNodeNeedingCode.Method.Signature.IsStatic && methodCodeNodeNeedingCode.Method.Name == "Main")
+                {
+                    mangledName = "Main";
+                }
+                else
+                {
+                    mangledName = compilation.NameMangler.GetMangledMethodName(methodCodeNodeNeedingCode.Method).ToString();
+                }
+
+                ilImporter = new ILImporter(compilation, method, methodIL, mangledName);
 
                 CompilerTypeSystemContext typeSystemContext = compilation.TypeSystemContext;
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -52,7 +52,7 @@ namespace Internal.IL
             {
                 string mangledName;
                 // TODO: We should use the startup node to generate StartupCodeMain and avoid special casing here
-                if(methodCodeNodeNeedingCode.Method.Signature.IsStatic && methodCodeNodeNeedingCode.Method.Name == "Main")
+                if (methodCodeNodeNeedingCode.Method.Signature.IsStatic && methodCodeNodeNeedingCode.Method.Name == "Main")
                 {
                     mangledName = "Main";
                 }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -51,7 +51,7 @@ namespace Internal.IL
             try
             {
                 string mangledName;
-                // TODO: We should have better detection for main or a way for native main to find out what managed main's name is
+                // TODO: We should use the startup node to generate StartupCodeMain and avoid special casing here
                 if(methodCodeNodeNeedingCode.Method.Signature.IsStatic && methodCodeNodeNeedingCode.Method.Name == "Main")
                 {
                     mangledName = "Main";

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
@@ -19,7 +19,7 @@ namespace ILCompiler
         WebAssemblyCodegenConfigProvider _config = new WebAssemblyCodegenConfigProvider(Array.Empty<string>());
 
         public WebAssemblyCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group)
-            : base(context, group, new CoreRTNameMangler(new WebAssemblyNodeMangler(), true))
+            : base(context, group, new CoreRTNameMangler(new WebAssemblyNodeMangler(), false))
         {
         }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -22,7 +22,7 @@ internal static class Program
 		if(tempInt == 9)
 		{
 			string s = "Hello from C#!";
-			PrintString(s, s.Length);
+			PrintString(s);
 		}
 		
 		var not = Not(0xFFFFFFFF) == 0x00000000;
@@ -60,8 +60,9 @@ internal static class Program
         }
     }
 
-    private static unsafe void PrintString(string s, int length)
+    private static unsafe void PrintString(string s)
     {
+        int length = s.Length;
         fixed (char* curChar = s)
         {
             for (int i = 0; i < length; i++)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -28,35 +28,35 @@ internal static class Program
 		var not = Not(0xFFFFFFFF) == 0x00000000;
 		if(not)
 		{
-			PrintString("\n", 1);
-			PrintString("not test: Ok.", 13);
+			PrintString("\n");
+			PrintString("not test: Ok.");
 		}
 		
 		var negInt = Neg(42) == -42;
 		if(negInt)
 		{
-			PrintString("\n", 1);
-			PrintString("negInt test: Ok.", 16);
+			PrintString("\n");
+			PrintString("negInt test: Ok.");
 		}
 
         var shiftLeft = ShiftLeft(1, 2) == 4;
         if(shiftLeft)
         {
-            PrintString("\n", 1);
-            PrintString("shiftLeft test: Ok.", 19);
+            PrintString("\n");
+            PrintString("shiftLeft test: Ok.");
         }
 
         var shiftRight = ShiftRight(4, 2) == 1;
         if(shiftRight)
         {
-            PrintString("\n", 1);
-            PrintString("shiftRight test: Ok.", 20);
+            PrintString("\n");
+            PrintString("shiftRight test: Ok.");
         }
         var unsignedShift = UnsignedShift(0xFFFFFFFFu, 4) == 0x0FFFFFFFu;
         if(unsignedShift)
         {
-            PrintString("\n", 1);
-            PrintString("unsignedShift test: Ok.", 23);
+            PrintString("\n");
+            PrintString("unsignedShift test: Ok.");
         }
     }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -22,7 +22,7 @@ internal static class Program
 		if(tempInt == 9)
 		{
 			string s = "Hello from C#!";
-			PrintString(s, 14);
+			PrintString(s, s.Length);
 		}
 		
 		var not = Not(0xFFFFFFFF) == 0x00000000;


### PR DESCRIPTION
Implements instance method support for WebAssembly. String.Length now works (there aren't many testable instance methods since we don't have newobj yet). By doing this, many more methods start compiling, so I had to fix bugs related to those.

Includes:
* Fixing instance method 'this' parameter handling
* Correcting method names to include their types since LLVM was treating all methods with the same short name as the same method
* Implementing ldfld for instance fields. Fixes #4530 
* Implementing leave opcode to fix bad codegen that made LLVM fail compilation
* Creating trap stubs for RuntimeImport methods since we can't build the runtime yet, but ignoring them would fail compilation
