### PR TITLE
[x86] Set CORJIT_FLAG_USE_SSE2

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -3636,6 +3636,12 @@ namespace Internal.JitInterface
             flags.Set(CorJitFlag.CORJIT_FLAG_RELOC);
             flags.Set(CorJitFlag.CORJIT_FLAG_PREJIT);
             flags.Set(CorJitFlag.CORJIT_FLAG_USE_PINVOKE_HELPERS);
+#if X86
+            // RyuJIT/x86 requires SSE2 to be available.
+            // On .NET Core, the VM always tells us that SSE2 is available.
+            // On CoreRT not, so we have to set it manually.
+            flags.Set(CorJitFlag.CORJIT_FLAG_USE_SSE2);
+#endif
 
             if (this.MethodBeingCompiled.IsNativeCallable)
                 flags.Set(CorJitFlag.CORJIT_FLAG_REVERSE_PINVOKE);

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -1459,7 +1459,7 @@ namespace Internal.JitInterface
         CORJIT_FLAG_UNUSED2 = 9,
         CORJIT_FLAG_UNUSED3 = 10,
         CORJIT_FLAG_UNUSED4 = 11,
-        CORJIT_FLAG_UNUSED5 = 12,
+        CORJIT_FLAG_USE_SSE2 = 12,
         CORJIT_FLAG_USE_SSE3_4 = 13,
         CORJIT_FLAG_USE_AVX = 14,
         CORJIT_FLAG_USE_AVX2 = 15,


### PR DESCRIPTION
RyuJIT/x86 requires SSE2 and we set it.

@MichalStrehovsky @jkotas PTAL

cc @Dmitri-Botcharnikov, @sergign60, @BredPet 