### PR TITLE
Introduce NetCore 1.0 compat hack for GetTypeInfo()

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/IntrospectionExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/IntrospectionExtensions.cs
@@ -13,7 +13,10 @@ namespace System.Reflection
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
 
-            return ((IReflectableType)type).GetTypeInfo();  // Unguarded cast is unbecoming but kept for compatibility.
+            if (type is IReflectableType reflectableType)
+                return reflectableType.GetTypeInfo();
+
+            return new TypeDelegator(type);
         }
     }
 }


### PR DESCRIPTION
We encountered a scenario with F# where a user-extended
Type object was passed to another component that used
GetTypeInfo() on the object.

The user-extended Type object seemingly had no way
to implement IReflectableType.GetTypeInfo() because
there's no protected constructor on TypeInfo. But luckily,
TypeDelegator already extends TypeInfo so returning an instance
of that was enough to make the other component happy.

This is a cheap insurance to avoid getting other
reports of this.