### PR TITLE
[ILVerify] Implement tracking of 'this' pointer state

### DIFF
--- a/src/ILVerify/README.md
+++ b/src/ILVerify/README.md
@@ -61,7 +61,23 @@ The method name must contain 2 '`_`' characters.
  3. part: the expected [VerifierErrors](https://github.com/dotnet/corert/blob/master/src/ILVerify/src/VerifierError.cs) as string separated by '.'. We assert on these errors; the test fails if ILVerify does not report these errors.     
  
  E.g.: ```SimpleAdd_Invalid_ExpectedNumericType```
+ 
+### Methods with special names:
 
+In order to test methods with special names (e.g. '.ctor'), the specialname method is defined as usual and a separate empty method is added to the type:
+```
+special.[FriendlyName].[SpecialName]_[Valid | Invalid]_[ExpectedVerifierError1].[ExpectedVerifierError2]....[ExpectedVerifierErrorN]
+```
+
+The format of the special test method is equal to normal valid or invalid tests, except that the first part must contain 3 sub-parts separated by '`.`':
+ 1. part: the '`special`' prefix
+ 2. part: a friendly name
+ 3. part: the name of the specialname method to actually test
+
+Additionally the method signature of the special test method must be equal to the signature of the method that shall be tested.
+
+ E.g.: In order to test a specific invalid constructor method the specialname `.ctor` method is defined as usual, while an additional method ```'special.SimpleAdd..ctor_Invalid_StackUnexpected'``` is defined.
+<br/><br/>
 The methods are automatically fed into appropriate XUnit theories based on the naming convention. Methods not following this naming conventions are ignored by the test scaffolding system.
 
 You can run the tests either in Visual Studio (in Test Explorer) or with the ```dotnet test ``` command from the command line.

--- a/src/ILVerify/README.md
+++ b/src/ILVerify/README.md
@@ -77,7 +77,8 @@ The format of the special test method is equal to normal valid or invalid tests,
 Additionally the method signature of the special test method must be equal to the signature of the method that shall be tested.
 
  E.g.: In order to test a specific invalid constructor method the specialname `.ctor` method is defined as usual, while an additional method ```'special.SimpleAdd..ctor_Invalid_StackUnexpected'``` is defined.
-<br/><br/>
+
+
 The methods are automatically fed into appropriate XUnit theories based on the naming convention. Methods not following this naming conventions are ignored by the test scaffolding system.
 
 You can run the tests either in Visual Studio (in Test Explorer) or with the ```dotnet test ``` command from the command line.

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -17,7 +17,8 @@ namespace Internal.IL
         {
             None = 0,
             ReadOnly = 1 << 1,
-            PermanentHome = 1 << 2
+            PermanentHome = 1 << 2,
+            ThisPtr = 1 << 3,
         }
         private StackValueFlags Flags;
 
@@ -35,12 +36,19 @@ namespace Internal.IL
 
         public void SetIsReadOnly()
         {
+            Debug.Assert(Kind == StackValueKind.ByRef);
             Flags |= StackValueFlags.ReadOnly;
         }
 
         public void SetIsPermanentHome()
         {
+            Debug.Assert(Kind == StackValueKind.ByRef);
             Flags |= StackValueFlags.PermanentHome;
+        }
+
+        public void SetIsThisPtr()
+        {
+            Flags |= StackValueFlags.ThisPtr;
         }
 
         public bool IsReadOnly
@@ -51,6 +59,11 @@ namespace Internal.IL
         public bool IsPermanentHome
         {
             get { return (Flags & StackValueFlags.PermanentHome) == StackValueFlags.PermanentHome; }
+        }
+
+        public bool IsThisPtr
+        {
+            get { return (Flags & StackValueFlags.ThisPtr) == StackValueFlags.ThisPtr; }
         }
 
         public bool IsNullReference

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -858,7 +858,7 @@ namespace Internal.IL
 
         void ImportDup()
         {
-            var value = Pop();
+            var value = Pop(true);
 
             Push(value);
             Push(value);
@@ -988,7 +988,7 @@ namespace Internal.IL
             else
             if (methodType != null)
             {
-                var actualThis = Pop();
+                var actualThis = Pop(true);
                 var declaredThis = methodType.IsValueType ?
                     StackValue.CreateByRef(methodType) : StackValue.CreateObjRef(methodType);
 
@@ -1609,9 +1609,6 @@ namespace Internal.IL
 
             CheckIsObjRef(value);
 
-            if (_trackObjCtorState && !_currentBasicBlock.IsThisInitialized)
-                Check(!value.IsThisPtr, VerifierError.UninitStack);
-
             EmptyTheStack();
         }
 
@@ -1905,7 +1902,7 @@ namespace Internal.IL
             Check(_currentBasicBlock.FilterIndex.HasValue, VerifierError.Endfilter);
             Check(_currentOffset == _exceptionRegions[_currentBasicBlock.FilterIndex.Value].ILRegion.HandlerOffset, VerifierError.Endfilter);
 
-            var result = Pop();
+            var result = Pop(true);
             Check(result.Kind == StackValueKind.Int32, VerifierError.StackUnexpected);
             Check(_stackTop == 0, VerifierError.EndfilterStack);
         }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -616,7 +616,7 @@ namespace Internal.IL
                 VerificationError(VerifierError.StackObjRef, value);
         }
 
-        private void CheckIsNotUnmanaged(TypeDesc type)
+        private void CheckIsNotPointer(TypeDesc type)
         {
             if (type.IsPointer)
                 VerificationError(VerifierError.UnmanagedPointer);
@@ -821,7 +821,7 @@ namespace Internal.IL
             if (!argument)
                 Check(_initLocals, VerifierError.InitLocals);
 
-            CheckIsNotUnmanaged(varType);
+            CheckIsNotPointer(varType);
 
             var stackValue = StackValue.CreateFromType(varType);
             if (index == 0 && argument)
@@ -864,7 +864,7 @@ namespace Internal.IL
 
         void ImportDup()
         {
-            var value = Pop(true);
+            var value = Pop(allowUninitThis: true);
 
             Push(value);
             Push(value);
@@ -872,7 +872,7 @@ namespace Internal.IL
 
         void ImportPop()
         {
-            Pop(true);
+            Pop(allowUninitThis: true);
         }
 
         void ImportJmp(int token)
@@ -976,7 +976,7 @@ namespace Internal.IL
             {
                 for (int i = sig.Length - 1; i >= 0; i--)
                 {
-                    var actual = Pop(true);
+                    var actual = Pop(allowUninitThis: true);
                     var declared = StackValue.CreateFromType(sig[i]);
 
                     CheckIsAssignable(actual, declared);
@@ -994,7 +994,7 @@ namespace Internal.IL
             else
             if (methodType != null)
             {
-                var actualThis = Pop(true);
+                var actualThis = Pop(allowUninitThis: true);
                 var declaredThis = methodType.IsValueType ?
                     StackValue.CreateByRef(methodType) : StackValue.CreateObjRef(methodType);
 
@@ -1482,7 +1482,7 @@ namespace Internal.IL
                 // Note that even if the field is static, we require that the this pointer
                 // satisfy the same constraints as a non-static field  This happens to
                 // be simpler and seems reasonable
-                var actualThis = Pop(true);
+                var actualThis = Pop(allowUninitThis: true);
                 if (actualThis.Kind == StackValueKind.ValueType)
                     actualThis = StackValue.CreateByRef(actualThis.Type);
 
@@ -1513,7 +1513,7 @@ namespace Internal.IL
                 // Note that even if the field is static, we require that the this pointer
                 // satisfy the same constraints as a non-static field  This happens to
                 // be simpler and seems reasonable
-                var actualThis = Pop(true);
+                var actualThis = Pop(allowUninitThis: true);
                 if (actualThis.Kind == StackValueKind.ValueType)
                     actualThis = StackValue.CreateByRef(actualThis.Type);
 
@@ -1548,7 +1548,7 @@ namespace Internal.IL
                 // Note that even if the field is static, we require that the this pointer
                 // satisfy the same constraints as a non-static field  This happens to
                 // be simpler and seems reasonable
-                var actualThis = Pop(true);
+                var actualThis = Pop(allowUninitThis: true);
                 if (actualThis.Kind == StackValueKind.ValueType)
                     actualThis = StackValue.CreateByRef(actualThis.Type);
 
@@ -1914,7 +1914,7 @@ namespace Internal.IL
             Check(_currentBasicBlock.FilterIndex.HasValue, VerifierError.Endfilter);
             Check(_currentOffset == _exceptionRegions[_currentBasicBlock.FilterIndex.Value].ILRegion.HandlerOffset, VerifierError.Endfilter);
 
-            var result = Pop(true);
+            var result = Pop(allowUninitThis: true);
             Check(result.Kind == StackValueKind.Int32, VerifierError.StackUnexpected);
             Check(_stackTop == 0, VerifierError.EndfilterStack);
         }

--- a/src/ILVerify/src/Resources/Strings.resx
+++ b/src/ILVerify/src/Resources/Strings.resx
@@ -138,8 +138,14 @@
   <data name="BranchOutOfTry" xml:space="preserve">
     <value>Branch out of try block.</value>
   </data>
+  <data name="ByrefOfByref" xml:space="preserve">
+    <value>ByRef of ByRef.</value>
+  </data>
   <data name="CallAbstract" xml:space="preserve">
     <value>Call not allowed on abstract methods.</value>
+  </data>
+  <data name="CallCtor" xml:space="preserve">
+    <value>call to .ctor only allowed to initialize this pointer from within a .ctor. Try newobj.</value>
   </data>
   <data name="CallVirtOnStatic" xml:space="preserve">
     <value>callvirt on static.</value>
@@ -279,6 +285,12 @@
   <data name="TailRetVoid" xml:space="preserve">
     <value>Void ret type expected for tail call.</value>
   </data>
+  <data name="ThisUninitReturn" xml:space="preserve">
+    <value>Return from .ctor when this is uninitialized.</value>
+  </data>
+  <data name="ThisUninitStore" xml:space="preserve">
+    <value>Store into this when it is uninitialized.</value>
+  </data>
   <data name="TokenResolve" xml:space="preserve">
     <value>Unable to resolve token.</value>
   </data>
@@ -287,6 +299,12 @@
   </data>
   <data name="Unaligned" xml:space="preserve">
     <value>Missing ldind, stind, ldfld, stfld, ldobj, stobj, initblk, cpblk.</value>
+  </data>
+  <data name="UninitStack" xml:space="preserve">
+    <value>Uninitialized item on stack.</value>
+  </data>
+  <data name="UnmanagedPointer" xml:space="preserve">
+    <value>Unmanaged pointers are not a verifiable type.</value>
   </data>
   <data name="UnrecognizedArgumentNumber" xml:space="preserve">
     <value>Unrecognized argument number.</value>

--- a/src/ILVerify/src/VerifierError.cs
+++ b/src/ILVerify/src/VerifierError.cs
@@ -80,8 +80,8 @@ namespace ILVerify
         PathStackDepth,         //"Stack depth differs depending on path."
         //E_THIS               "Instance variable (this) missing."
         //E_THIS_UNINIT_EXCEP  "Uninitialized this on entering a try block."
-        //E_THIS_UNINIT_STORE  "Store into this when it is uninitialized."
-        //E_THIS_UNINIT_RET    "Return from .ctor when this is uninitialized."
+        ThisUninitStore,        // Store into this when it is uninitialized.
+        ThisUninitReturn,       // Return from .ctor when this is uninitialized.
         //E_THIS_UNINIT_V_RET  "Return from .ctor before all fields are initialized."
         //E_THIS_UNINIT_BR     "Branch back when this is uninitialized."
         LdftnCtor,       //"ldftn/ldvirtftn not allowed on .ctor."
@@ -92,7 +92,7 @@ namespace ILVerify
         StackOverflow,                  // Stack overflow.
         StackUnderflow,                 // Stack underflow.
         //E_STACK_EMPTY        "Stack empty."
-        //E_STACK_UNINIT       "Uninitialized item on stack."
+        UninitStack,                    // Uninitialized item on stack.
         ExpectedIntegerType,            // Expected I, I4, or I8 on the stack.
         ExpectedFloatType,              // Expected R, R4, or R8 on the stack.
         //E_STACK_NO_R_I8      "unexpected R, R4, R8, or I8 on the stack."
@@ -156,7 +156,7 @@ namespace ILVerify
         //E_SIG_ELEM_PTR       "ELEMENT_TYPE_PTR cannot be verified."
         //E_SIG_VARARG         "Unexpected vararg."
         //E_SIG_VOID           "Unexpected Void."
-        //E_SIG_BYREF_BYREF    "ByRef of ByRef"
+        ByrefOfByref,                   // ByRef of ByRef.
         //E_CODE_SIZE_ZERO     "Code size is zero."
         //E_BAD_VARARG         "Unrecognized use of vararg."
         TailCall,                       // Missing call/callvirt/calli.
@@ -197,7 +197,7 @@ namespace ILVerify
         CallVirtOnStatic,       // callvirt on static.
         InitLocals,             // initlocals must be set for verifiable methods with one or more local variables.
         //E_BR_TO_EXCEPTION    "branch/leave to the beginning of a catch/filter handler"
-        //E_CALL_CTOR          "call to .ctor only allowed to initialize this pointer from within a .ctor. Try newobj." 
+        CallCtor,               // call to .ctor only allowed to initialize this pointer from within a .ctor. Try newobj.
         
         ////@GENERICSVER: new generics related error messages
         ExpectedValClassObjRefVariable, // Value type, ObjRef type or variable type expected.
@@ -232,7 +232,7 @@ namespace ILVerify
         //E_BACKWARD_BRANCH          "Stack height at all points must be determinable in a single forward scan of IL."
         //E_CALL_TO_VTYPE_BASE       "Call to base type of valuetype."
         //E_NEWOBJ_OF_ABSTRACT_CLASS "Cannot construct an instance of abstract class."
-        //E_UNMANAGED_POINTER        "Unmanaged pointers are not a verifiable type."
+        UnmanagedPointer,                     // Unmanaged pointers are not a verifiable type.
         //E_LDFTN_NON_FINAL_VIRTUAL  "Cannot LDFTN a non-final virtual method for delegate creation if target object is potentially not the same type as the method class."
         //E_FIELD_OVERLAP      "Accessing type with overlapping fields."
         //E_THIS_MISMATCH      "The 'this' parameter to the call must be the calling method's 'this' parameter."

--- a/src/ILVerify/tests/ILMethodTester.cs
+++ b/src/ILVerify/tests/ILMethodTester.cs
@@ -62,7 +62,7 @@ namespace ILVerify.Tests
                 {
                     Assert.True(verifierErrors.Contains(item));
                 }
-            }        
+            }
         }
 
         private ILImporter ConstructILImporter(TestCase testCase)

--- a/src/ILVerify/tests/ILTests/ReturnTests.il
+++ b/src/ILVerify/tests/ILTests/ReturnTests.il
@@ -148,4 +148,18 @@
         ldflda      int32 Struct::instanceField
         ret
     }
+
+    .method public hidebysig instance void 'special.ReturnAfterBaseCtor..ctor_Valid'() cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed 
+    {
+        ldarg.0
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+
+    .method public hidebysig instance void 'special.ReturnBeforeBaseCtor..ctor_Invalid_ThisUninitReturn'(int32) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(int32) cil managed 
+    {
+        ret
+    }
 }

--- a/src/ILVerify/tests/ILTests/ThisStateTests.il
+++ b/src/ILVerify/tests/ILTests/ThisStateTests.il
@@ -27,7 +27,7 @@
         ret
     }
 
-    .method public hidebysig instance void 'special.LoadFieldThisUninit..ctor_Invalid_UninitStack'(int32) cil managed { ret }
+    .method public hidebysig instance void 'special.LoadFieldThisUninit..ctor_Valid'(int32) cil managed { ret }
     .method public hidebysig specialname rtspecialname instance void .ctor(int32) cil managed 
     {
         ldarg.0
@@ -59,7 +59,7 @@
         ret
     }
 
-    .method public hidebysig instance void 'special.StoreFieldThisUninit..ctor_Invalid_UninitStack'(int32, int32) cil managed { ret }
+    .method public hidebysig instance void 'special.StoreFieldThisUninit..ctor_Valid'(int32, int32) cil managed { ret }
     .method public hidebysig specialname rtspecialname instance void .ctor(int32, int32) cil managed 
     {
         ldarg.0

--- a/src/ILVerify/tests/ILTests/ThisStateTests.il
+++ b/src/ILVerify/tests/ILTests/ThisStateTests.il
@@ -1,0 +1,140 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly ThisStateTests
+{
+}
+
+.class public auto ansi beforefieldinit FieldTestsType
+        extends [System.Runtime]System.Object
+{
+    .field private int32 instanceField
+    .field private static int32 staticField
+
+    .method public hidebysig instance void 'special.LoadFieldThisInit..ctor_Valid'() cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed 
+    {
+        ldarg.0
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ldarg.0
+        ldfld   int32 FieldTestsType::instanceField
+        pop
+        ret
+    }
+
+    .method public hidebysig instance void 'special.LoadFieldThisUninit..ctor_Invalid_UninitStack'(int32) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(int32) cil managed 
+    {
+        ldarg.0
+        dup
+        ldfld   int32 FieldTestsType::instanceField
+        pop
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+
+    .method public hidebysig instance void 'special.LoadSFieldThisUninit..ctor_Valid'(float64) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(float64) cil managed 
+    {
+        ldarg.0
+        ldsfld   int32 FieldTestsType::staticField
+        pop
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+
+    .method public hidebysig instance void 'special.StoreFieldThisInit..ctor_Valid'(int64) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(int64) cil managed 
+    {
+        ldarg.0
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ldarg.0
+        ldc.i4.0
+        stfld   int32 FieldTestsType::instanceField
+        ret
+    }
+
+    .method public hidebysig instance void 'special.StoreFieldThisUninit..ctor_Invalid_UninitStack'(int32, int32) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(int32, int32) cil managed 
+    {
+        ldarg.0
+        dup
+        ldc.i4.0
+        stfld   int32 FieldTestsType::instanceField
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+
+    .method public hidebysig instance void 'special.StoreSFieldThisUninit..ctor_Valid'(native int) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(native int) cil managed 
+    {
+        ldc.i4.0
+        stsfld   int32 FieldTestsType::staticField
+        ldarg.0
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit ThisStateTestsType
+        extends [System.Runtime]System.Object
+{
+    .method public hidebysig instance void 'special.ThrowThisUninit..ctor_Invalid_UninitStack'() cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed 
+    {
+        ldarg.0
+        throw
+        ret
+    }
+
+    .method public hidebysig instance void 'special.CallCtorOverload..ctor_Valid'(int32) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(int32) cil managed 
+    {
+        ldarg.0
+        call    instance void ThisStateTestsType::.ctor()
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit LoadStoreVarTestsType
+        extends [System.Runtime]System.Object
+{
+    .method public hidebysig instance void 'special.StoreLocUninit..ctor_Invalid_StackUninit'() cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed 
+    {
+        .locals init (
+            [0] int32
+        )
+
+        ldc.i4.0
+        stloc.0
+        ldarg.0
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+
+    .method public hidebysig instance void 'special.StoreThisUninit..ctor_Invalid_ThisUninitStore'(int32) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(int32) cil managed 
+    {
+        newobj  instance void LoadStoreVarTestsType::.ctor()
+        starg 0
+        ldarg.0
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+
+    .method public hidebysig instance void 'special.LoadAddrOfThisUninit..ctor_Invalid_ThisUninitStore'(int64) cil managed { ret }
+    .method public hidebysig specialname rtspecialname instance void .ctor(int64) cil managed 
+    {
+        ldarga 0
+        pop
+        ldarg.0
+        call    instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+}


### PR DESCRIPTION
The ECMA standard defines that:

> the verification algorithm shall treat the `this` pointer as uninitialized unless the base class constructor has been called. No operations can be performed on an uninitialized `this` except for storing into and loading from the object's fields.

I implemented the tracking of the `this` pointer state in order to be able to verify these rules.

In order to test this new implementation, I had to adapt our current test-framework to be able to also test methods with a special name, e.g. `.ctor`. Since the framework relies on the test method's name, it was not previously possible to test a type's constructor.
I have implemented special test case handling in the test data loader and added documentation on how to add test cases for specialname methods in the Readme.md.
Basically the specialname method is defined as usual and a separate method (which may stay empty) has to be added, which defines the test case in the accustomed manner and also defines the name of the special method that should actually be tested. The method tester then takes the test parameters of the dummy method, but tests the specialname method.

I have added several test cases for tracking the `this` state this way.