### PR TITLE
Fix RegistryKey access modifier when REGISTRY_ASSEMBLY is defined

### DIFF
--- a/src/System.Private.CoreLib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/System.Private.CoreLib/src/Microsoft/Win32/RegistryKey.cs
@@ -13,7 +13,11 @@ using System.Text;
 namespace Microsoft.Win32
 {
     /// <summary>Registry encapsulation. To get an instance of a RegistryKey use the Registry class's static members then call OpenSubKey.</summary>
+#if REGISTRY_ASSEMBLY
+    public
+#else
     internal
+#endif
     sealed partial class RegistryKey : IDisposable
     {
         public static readonly IntPtr HKEY_CLASSES_ROOT = new IntPtr(unchecked((int)0x80000000));


### PR DESCRIPTION
RegistryKey is partial but has only 'internal' access modifier while [RegistryKey.Windows.cs](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/Microsoft/Win32/RegistryKey.Windows.cs#L58-L62) has both. 