### PR TITLE
Implement neg (float/integer) and not IL instructions. Fixes #4524 and #4525

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1087,6 +1087,29 @@ namespace Internal.IL
 
         private void ImportUnaryOperation(ILOpcode opCode)
         {
+            var argument = _stack.Pop();
+             
+            LLVMValueRef result;
+            switch (opCode)
+            {
+                case ILOpcode.neg:
+                    if (argument.Kind == StackValueKind.Float)
+                    {
+                        result = LLVM.BuildFNeg(_builder, argument.LLVMValue, string.Empty);
+                    }   
+                    else
+                    {
+                        result = LLVM.BuildNeg(_builder, argument.LLVMValue, string.Empty);
+                    }
+                    break;
+                case ILOpcode.not:
+                    result = LLVM.BuildNot(_builder, argument.LLVMValue, string.Empty);
+                    break;
+                default:
+                    throw new NotSupportedException(); // unreachable
+            }
+
+            _stack.Push(new ExpressionEntry(argument.Kind, string.Empty, result, argument.Type));
         }
 
         private void ImportCpOpj(int token)

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1095,21 +1095,21 @@ namespace Internal.IL
                 case ILOpcode.neg:
                     if (argument.Kind == StackValueKind.Float)
                     {
-                        result = LLVM.BuildFNeg(_builder, argument.LLVMValue, string.Empty);
+                        result = LLVM.BuildFNeg(_builder, argument.LLVMValue, "neg");
                     }   
                     else
                     {
-                        result = LLVM.BuildNeg(_builder, argument.LLVMValue, string.Empty);
+                        result = LLVM.BuildNeg(_builder, argument.LLVMValue, "neg");
                     }
                     break;
                 case ILOpcode.not:
-                    result = LLVM.BuildNot(_builder, argument.LLVMValue, string.Empty);
+                    result = LLVM.BuildNot(_builder, argument.LLVMValue, "not");
                     break;
                 default:
                     throw new NotSupportedException(); // unreachable
             }
 
-            _stack.Push(new ExpressionEntry(argument.Kind, string.Empty, result, argument.Type));
+            PushExpression(argument.Kind, "", result, argument.Type);
         }
 
         private void ImportCpOpj(int token)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -23,6 +23,20 @@ internal static class Program
 			string s = "Hello from C#!";
 			PrintString(s, 14);
 		}
+		
+		var not = Not(0xFFFFFFFF) == 0x00000000;
+		if(not)
+		{
+			PrintString("\n", 1);
+			PrintString("not test: Ok.", 13);
+		}
+		
+		var negInt = Neg(42) == -42;
+		if(negInt)
+		{
+			PrintString("\n", 1);
+			PrintString("negInt test: Ok.", 16);
+		}
     }
 
     private static unsafe void PrintString(string s, int length)
@@ -41,6 +55,16 @@ internal static class Program
     private static int Add(int a, int b)
     {
         return a + b;
+    }
+	
+	private static uint Not(uint a)
+    {
+        return ~a;
+    }
+	
+	private static int Neg(int a)
+    {
+        return -a;
     }
 
     [DllImport("*")]


### PR DESCRIPTION
I took some time to implement the neg and not opcode. I also added support to float for neg op because I noticed a BuildFNeg method was available. I don't really know if this it's correct.
Just let me know if this can help you guys ;)