### PR TITLE
added support for box/unbox/unbox_any for WASM using malloc

### DIFF
--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -38,6 +38,12 @@ internal static class Program
             PrintLine("static int field test: Ok.");
         }
 
+        var boxedInt = (object)tempInt;
+        if(((int)boxedInt) == 9)
+        {
+            PrintLine("box test: Ok.");
+        }
+
         var not = Not(0xFFFFFFFF) == 0x00000000;
         if (not)
         {
@@ -167,7 +173,7 @@ public struct TwoByteStr
 public class TestClass
 {
     public string TestString {get; set;}
-
+	
     public TestClass(int number)
     {
         if(number != 1337)


### PR DESCRIPTION
this doesn't deal with the behavior variant where unbox.any is like cast class for a reference type