### PR TITLE
Fix debugger stepping into R2R helpers and unboxing thunks

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/AssemblyStubNode.cs
@@ -33,14 +33,14 @@ namespace ILCompiler.DependencyAnalysis
                     EmitCode(factory, ref x64Emitter, relocsOnly);
                     x64Emitter.Builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);
                     x64Emitter.Builder.AddSymbol(this);
-                    return x64Emitter.Builder.ToObjectData();
+                    return x64Emitter.Builder.ToMethodCode(x64Emitter.GetDebugLocInfos(), null);
 
                 case TargetArchitecture.X86:
                     X86.X86Emitter x86Emitter = new X86.X86Emitter(factory, relocsOnly);
                     EmitCode(factory, ref x86Emitter, relocsOnly);
                     x86Emitter.Builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);
                     x86Emitter.Builder.AddSymbol(this);
-                    return x86Emitter.Builder.ToObjectData();
+                    return x86Emitter.Builder.ToMethodCode(x86Emitter.GetDebugLocInfos(), null);
 
                 case TargetArchitecture.ARM:
                 case TargetArchitecture.ARMEL:
@@ -48,14 +48,14 @@ namespace ILCompiler.DependencyAnalysis
                     EmitCode(factory, ref armEmitter, relocsOnly);
                     armEmitter.Builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);
                     armEmitter.Builder.AddSymbol(this);
-                    return armEmitter.Builder.ToObjectData();
+                    return armEmitter.Builder.ToMethodCode(armEmitter.GetDebugLocInfos(), null);
 
                 case TargetArchitecture.ARM64:
                     ARM64.ARM64Emitter arm64Emitter = new ARM64.ARM64Emitter(factory, relocsOnly);
                     EmitCode(factory, ref arm64Emitter, relocsOnly);
                     arm64Emitter.Builder.RequireInitialAlignment(factory.Target.MinimumFunctionAlignment);
                     arm64Emitter.Builder.AddSymbol(this);
-                    return arm64Emitter.Builder.ToObjectData();
+                    return arm64Emitter.Builder.ToMethodCode(arm64Emitter.GetDebugLocInfos(), null);
 
                 default:
                     throw new NotImplementedException();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodCodeNode.cs
@@ -8,11 +8,9 @@ namespace ILCompiler.DependencyAnalysis
 {
     interface IMethodCodeNode : IMethodNode, ISymbolDefinitionNode
     {
-        void SetCode(ObjectNode.ObjectData data);
+        void SetCode(byte[] data, Relocation[] relocs, DebugLocInfo[] debugLocInfos, DebugVarInfo[] debugVarInfos);
         void InitializeFrameInfos(FrameInfo[] frameInfos);
         void InitializeGCInfo(byte[] gcInfo);
         void InitializeEHInfo(ObjectNode.ObjectData ehInfo);
-        void InitializeDebugLocInfos(DebugLocInfo[] debugLocInfos);
-        void InitializeDebugVarInfos(DebugVarInfo[] debugVarInfos);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -10,7 +10,7 @@ using Internal.TypeSystem.Interop;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public class MethodCodeNode : ObjectNode, IMethodBodyNode, INodeWithCodeInfo, INodeWithDebugInfo, IMethodCodeNode, ISpecialUnboxThunkNode
+    public class MethodCodeNode : ObjectNode, IMethodBodyNode, INodeWithCodeInfo, IMethodCodeNode, ISpecialUnboxThunkNode
     {
         public static readonly ObjectNodeSection StartSection = new ObjectNodeSection(".managedcode$A", SectionType.Executable);
         public static readonly ObjectNodeSection WindowsContentSection = new ObjectNodeSection(".managedcode$I", SectionType.Executable);
@@ -22,9 +22,7 @@ namespace ILCompiler.DependencyAnalysis
         private FrameInfo[] _frameInfos;
         private byte[] _gcInfo;
         private ObjectData _ehInfo;
-        private DebugLocInfo[] _debugLocInfos;
-        private DebugVarInfo[] _debugVarInfos;
-
+        
         public MethodCodeNode(MethodDesc method)
         {
             Debug.Assert(!method.IsAbstract);
@@ -32,10 +30,12 @@ namespace ILCompiler.DependencyAnalysis
             _method = method;
         }
 
-        public void SetCode(ObjectData data)
+        public void SetCode(byte[] data, Relocation[] relocs, DebugLocInfo[] debugLocInfos, DebugVarInfo[] debugVarInfos)
         {
             Debug.Assert(_methodCode == null);
-            _methodCode = data;
+            _methodCode = new MethodCode(data, relocs,
+                _method.Context.Target.MinimumFunctionAlignment, new ISymbolDefinitionNode[] { this },
+                debugLocInfos, debugVarInfos);
         }
 
         public MethodDesc Method =>  _method;
@@ -136,21 +136,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(_ehInfo == null);
             _ehInfo = ehInfo;
-        }
-
-        public DebugLocInfo[] DebugLocInfos => _debugLocInfos;
-        public DebugVarInfo[] DebugVarInfos => _debugVarInfos;
-
-        public void InitializeDebugLocInfos(DebugLocInfo[] debugLocInfos)
-        {
-            Debug.Assert(_debugLocInfos == null);
-            _debugLocInfos = debugLocInfos;
-        }
-
-        public void InitializeDebugVarInfos(DebugVarInfo[] debugVarInfos)
-        {
-            Debug.Assert(_debugVarInfos == null);
-            _debugVarInfos = debugVarInfos;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -319,6 +319,22 @@ namespace ILCompiler.DependencyAnalysis
             return returnData;
         }
 
+        public ObjectNode.MethodCode ToMethodCode(DebugLocInfo[] debugLocInfos, DebugVarInfo[] debugVarInfos)
+        {
+#if DEBUG
+            Debug.Assert(_numReservations == 0);
+#endif
+
+            ObjectNode.MethodCode returnData = new ObjectNode.MethodCode(_data.ToArray(),
+                                                                         _relocs.ToArray(),
+                                                                         Alignment,
+                                                                         _definedSymbols.ToArray(),
+                                                                         debugLocInfos,
+                                                                         debugVarInfos);
+
+            return returnData;
+        }
+
         public enum Reservation { }
 
         public void AddSymbol(ISymbolDefinitionNode node)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNode.cs
@@ -26,6 +26,20 @@ namespace ILCompiler.DependencyAnalysis
             public readonly ISymbolDefinitionNode[] DefinedSymbols;
         }
 
+        public class MethodCode : ObjectData, INodeWithDebugInfo
+        {
+            public MethodCode(byte[] data, Relocation[] relocs, int alignment, ISymbolDefinitionNode[] definedSymbols,
+                DebugLocInfo[] debugLocInfos, DebugVarInfo[] debugVarInfos)
+                : base(data, relocs, alignment, definedSymbols)
+            {
+                DebugLocInfos = debugLocInfos;
+                DebugVarInfos = debugVarInfos;
+            }
+
+            public DebugLocInfo[] DebugLocInfos { get; }
+            public DebugVarInfo[] DebugVarInfos { get; }
+        }
+
         public virtual bool RepresentsIndirectionCell => false;
 
         public abstract ObjectData GetData(NodeFactory factory, bool relocsOnly = false);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMEmitter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMEmitter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace ILCompiler.DependencyAnalysis.ARM
@@ -13,10 +14,25 @@ namespace ILCompiler.DependencyAnalysis.ARM
         {
             Builder = new ObjectDataBuilder(factory, relocsOnly);
             TargetRegister = new TargetRegisterMap(factory.Target.OperatingSystem);
+            _debugLocInfos = new ArrayBuilder<DebugLocInfo>();
         }
 
         public ObjectDataBuilder Builder;
         public TargetRegisterMap TargetRegister;
+        private ArrayBuilder<DebugLocInfo> _debugLocInfos;
+
+        public DebugLocInfo[] GetDebugLocInfos()
+        {
+            return _debugLocInfos.ToArray();
+        }
+
+        public void MarkDebuggerStepInPoint()
+        {
+            if (_debugLocInfos.Count == 0 && Builder.CountBytes > 0)
+                _debugLocInfos.Add(new DebugLocInfo(0, "", 0xF00F00));
+
+            _debugLocInfos.Add(new DebugLocInfo(Builder.CountBytes, "", 0xFEEFEE));
+        }
 
         // check the value length
         private static bool IsBitNumOverflow(int value, byte numBits)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM64/ARM64Emitter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM64/ARM64Emitter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace ILCompiler.DependencyAnalysis.ARM64
@@ -13,10 +14,25 @@ namespace ILCompiler.DependencyAnalysis.ARM64
         {
             Builder = new ObjectDataBuilder(factory, relocsOnly);
             TargetRegister = new TargetRegisterMap(factory.Target.OperatingSystem);
+            _debugLocInfos = new ArrayBuilder<DebugLocInfo>();
         }
 
         public ObjectDataBuilder Builder;
         public TargetRegisterMap TargetRegister;
+        private ArrayBuilder<DebugLocInfo> _debugLocInfos;
+
+        public DebugLocInfo[] GetDebugLocInfos()
+        {
+            return _debugLocInfos.ToArray();
+        }
+
+        public void MarkDebuggerStepInPoint()
+        {
+            if (_debugLocInfos.Count == 0 && Builder.CountBytes > 0)
+                _debugLocInfos.Add(new DebugLocInfo(0, "", 0xF00F00));
+
+            _debugLocInfos.Add(new DebugLocInfo(Builder.CountBytes, "", 0xFEEFEE));
+        }
 
         // Assembly stub creation api. TBD, actually make this general purpose
         public void EmitMOV(Register regDst, ref AddrMode memory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace ILCompiler.DependencyAnalysis.X64
@@ -13,10 +14,25 @@ namespace ILCompiler.DependencyAnalysis.X64
         {
             Builder = new ObjectDataBuilder(factory, relocsOnly);
             TargetRegister = new TargetRegisterMap(factory.Target.OperatingSystem);
+            _debugLocInfos = new ArrayBuilder<DebugLocInfo>();
         }
 
         public ObjectDataBuilder Builder;
         public TargetRegisterMap TargetRegister;
+        private ArrayBuilder<DebugLocInfo> _debugLocInfos;
+
+        public DebugLocInfo[] GetDebugLocInfos()
+        {
+            return _debugLocInfos.ToArray();
+        }
+
+        public void MarkDebuggerStepInPoint()
+        {
+            if (_debugLocInfos.Count == 0 && Builder.CountBytes > 0)
+                _debugLocInfos.Add(new DebugLocInfo(0, "", 0xF00F00));
+
+            _debugLocInfos.Add(new DebugLocInfo(Builder.CountBytes, "", 0xFEEFEE));
+        }
 
         // Assembly stub creation api. TBD, actually make this general purpose
         public void EmitMOV(Register regDst, ref AddrMode memory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -45,6 +45,7 @@ namespace ILCompiler.DependencyAnalysis
                             Debug.Assert(slot != -1);
                         }
 
+                        encoder.MarkDebuggerStepInPoint();
                         AddrMode jmpAddrMode = new AddrMode(encoder.TargetRegister.Result, null, EETypeNode.GetVTableOffset(pointerSize) + (slot * pointerSize), 0, AddrModeSize.Int64);
                         encoder.EmitJmpToAddrMode(ref jmpAddrMode);
                     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64UnboxingStubNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64UnboxingStubNode.cs
@@ -13,6 +13,7 @@ namespace ILCompiler.DependencyAnalysis
             AddrMode thisPtr = new AddrMode(
                 Register.RegDirect | encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int64);
             encoder.EmitADD(ref thisPtr, (sbyte)factory.Target.PointerSize);
+            encoder.MarkDebuggerStepInPoint();
             encoder.EmitJMP(factory.MethodEntrypoint(Method));
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X86/X86Emitter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X86/X86Emitter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace ILCompiler.DependencyAnalysis.X86
@@ -13,10 +14,25 @@ namespace ILCompiler.DependencyAnalysis.X86
         {
             Builder = new ObjectDataBuilder(factory, relocsOnly);
             TargetRegister = new TargetRegisterMap(factory.Target.OperatingSystem);
+            _debugLocInfos = new ArrayBuilder<DebugLocInfo>();
         }
 
         public ObjectDataBuilder Builder;
         public TargetRegisterMap TargetRegister;
+        private ArrayBuilder<DebugLocInfo> _debugLocInfos;
+
+        public DebugLocInfo[] GetDebugLocInfos()
+        {
+            return _debugLocInfos.ToArray();
+        }
+
+        public void MarkDebuggerStepInPoint()
+        {
+            if (_debugLocInfos.Count == 0 && Builder.CountBytes > 0)
+                _debugLocInfos.Add(new DebugLocInfo(0, "", 0xF00F00));
+
+            _debugLocInfos.Add(new DebugLocInfo(Builder.CountBytes, "", 0xFEEFEE));
+        }
 
         public void EmitADD(ref AddrMode addrMode, sbyte immediate)
         {

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -385,20 +385,13 @@ namespace Internal.JitInterface
             var relocs = _relocs.ToArray();
             Array.Sort(relocs, (x, y) => (x.Offset - y.Offset));
 
-            var objectData = new ObjectNode.ObjectData(_code,
-                                                       relocs,
-                                                       _compilation.NodeFactory.Target.MinimumFunctionAlignment,
-                                                       new ISymbolDefinitionNode[] { _methodCodeNode });
-
-            _methodCodeNode.SetCode(objectData);
+            _methodCodeNode.SetCode(_code, relocs,
+                _debugLocInfos, _debugVarInfos);
 
             _methodCodeNode.InitializeFrameInfos(_frameInfos);
             _methodCodeNode.InitializeGCInfo(_gcInfo);
             if (_ehClauses != null)
                 _methodCodeNode.InitializeEHInfo(EncodeEHInfo());
-
-            _methodCodeNode.InitializeDebugLocInfos(_debugLocInfos);
-            _methodCodeNode.InitializeDebugVarInfos(_debugVarInfos);
         }
 
         private MethodDesc MethodBeingCompiled

--- a/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitMethodCodeNode.cs
+++ b/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitMethodCodeNode.cs
@@ -26,13 +26,12 @@ namespace Internal.Runtime.JitSupport
         private FrameInfo[] _frameInfos;
         private byte[] _gcInfo;
         private ObjectData _ehInfo;
-        private DebugLocInfo[] _debugLocInfos;
-        private DebugVarInfo[] _debugVarInfos;
 
-        public void SetCode(ObjectData data)
+        public void SetCode(byte[] data, Relocation[] relocs, DebugLocInfo[] debugLocInfos, DebugVarInfo[] debugVarInfos)
         {
             Debug.Assert(_methodCode == null);
-            _methodCode = data;
+            _methodCode = new MethodCode(data, relocs, _method.Context.Target.MinimumFunctionAlignment, new ISymbolDefinitionNode[] { this },
+                debugLocInfos, debugVarInfos);
         }
 
         public MethodDesc Method => _method;
@@ -57,20 +56,6 @@ namespace Internal.Runtime.JitSupport
         {
             Debug.Assert(_ehInfo == null);
             _ehInfo = ehInfo;
-        }
-        public DebugLocInfo[] DebugLocInfos => _debugLocInfos;
-        public DebugVarInfo[] DebugVarInfos => _debugVarInfos;
-
-        public void InitializeDebugLocInfos(DebugLocInfo[] debugLocInfos)
-        {
-            Debug.Assert(_debugLocInfos == null);
-            _debugLocInfos = debugLocInfos;
-        }
-
-        public void InitializeDebugVarInfos(DebugVarInfo[] debugVarInfos)
-        {
-            Debug.Assert(_debugVarInfos == null);
-            _debugVarInfos = debugVarInfos;
         }
 
         protected override string GetName(NodeFactory factory)


### PR DESCRIPTION
This fixes stepping into virtual methods that go through a helper call (and stepping into unboxing stubs).

It's two commits:

* Make it more convenient to generate debug information for generated assembly stubs. Debug information used to be owned by the `ObjectNode`, but I'm making it a property of the generated data packet (`ObjectData`). This is so that we can keep the single pass (generate and forget) nature of assembly stub emission.
* Add infrastructure do emit debug info in the assembly emitters and add 0xF00F00/0xFEEFEE line numbers where needed.

What we might consider for future commits:
* Implement stepping info emission for non-x64 arches. I can't really test it and I prefer not to write code blindly.
* Similar to debug info, move the ownership of unwind/EH/GC info to the `ObjectData` packet (out of `ObjectNode`).
