### PR TITLE
Make ContractException public in impl assembly to support binary serialization with type forwarding

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/ContractsBCL.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/ContractsBCL.cs
@@ -199,8 +199,8 @@ namespace System.Diagnostics.Contracts
 
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    [SuppressMessage("Microsoft.Design", "CA1064:ExceptionsShouldBePublic")]
-    internal sealed class ContractException : Exception
+    // Needs to be public for type forwarding serialization support.
+    public sealed class ContractException : Exception
     {
         private readonly ContractFailureKind _kind;
         private readonly string _userMessage;


### PR DESCRIPTION
Related: https://github.com/dotnet/corefx/issues/24424

I missed that one...