### PR TITLE
Fix standalone run of init-tools.sh

### DIFF
--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -90,37 +90,8 @@ export __buildmanaged=false
 export __buildnative=false
 export __dotnetclipath=$__ProjectRoot/Tools/dotnetcli
 
-# Use uname to determine what the CPU is.
-export CPUName=$(uname -p)
-# Some Linux platforms report unknown for platform, but the arch for machine.
-if [ $CPUName == "unknown" ]; then
-    export CPUName=$(uname -m)
-fi
-
-case $CPUName in
-    i686)
-        export __HostArch=x86
-        ;;
-
-    x86_64)
-        export __HostArch=x64
-        ;;
-
-    armv7l)
-        echo "Unsupported CPU $CPUName detected, build might not succeed!"
-        export __HostArch=arm
-        ;;
-
-    aarch64)
-        echo "Unsupported CPU $CPUName detected, build might not succeed!"
-        export __HostArch=arm64
-        ;;
-
-    *)
-        echo "Unknown CPU $CPUName detected, configuring as if for x64"
-        export __HostArch=x64
-        ;;
-esac
+# Initialize variables that depend on the compilation host
+. $__scriptpath/hostvars-setup.sh
 
 export __BuildType=Debug
 

--- a/buildscripts/hostvars-setup.sh
+++ b/buildscripts/hostvars-setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Use uname to determine what the CPU is.
+export CPUName=$(uname -p)
+# Some Linux platforms report unknown for platform, but the arch for machine.
+if [ $CPUName == "unknown" ]; then
+    export CPUName=$(uname -m)
+fi
+
+case $CPUName in
+    i686)
+        export __HostArch=x86
+        ;;
+
+    x86_64)
+        export __HostArch=x64
+        ;;
+
+    armv7l)
+        echo "Unsupported CPU $CPUName detected, build might not succeed!"
+        export __HostArch=arm
+        ;;
+
+    aarch64)
+        echo "Unsupported CPU $CPUName detected, build might not succeed!"
+        export __HostArch=arm64
+        ;;
+
+    *)
+        echo "Unknown CPU $CPUName detected, configuring as if for x64"
+        export __HostArch=x64
+        ;;
+esac

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "$BUILDVARS_DONE" != 1 ]; then
-    . ./buildscripts/buildvars-setup.sh
+    . ./buildscripts/hostvars-setup.sh
 fi
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ "$BUILDVARS_DONE" != 1 ]; then
+    . ./buildscripts/buildvars-setup.sh
+fi
+
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __init_tools_log=$__scriptpath/init-tools.log
 __PACKAGES_DIR=$__scriptpath/packages
@@ -52,12 +56,12 @@ if [ -z "$__DOTNET_PKG" ]; then
             ;;
 
         *)
-            echo "Unsupported OS '$OSName' detected. Downloading linux-$__BuildArch tools."
+            echo "Unsupported OS '$OSName' detected. Downloading linux-$__HostArch tools."
             OS=Linux
             __PKG_RID=linux
             ;;
   esac
-  __DOTNET_PKG=dotnet-sdk-${__DOTNET_TOOLS_VERSION}-$__PKG_RID-$__BuildArch
+  __DOTNET_PKG=dotnet-sdk-${__DOTNET_TOOLS_VERSION}-$__PKG_RID-$__HostArch
 fi
 
 display_error_message()


### PR DESCRIPTION
Running all of buildvars-setup.sh seems like an overkill, but it does the job of setting a `HostArch`, which is all we care about, really.