### PR TITLE
Fix init-tools when launched from a different directory

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
+__scriptpath=$(cd "$(dirname "$0")"; pwd -P)
+
 if [ "$BUILDVARS_DONE" != 1 ]; then
-    . ./buildscripts/hostvars-setup.sh
+    . $__scriptpath/buildscripts/hostvars-setup.sh
 fi
 
-__scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __init_tools_log=$__scriptpath/init-tools.log
 __PACKAGES_DIR=$__scriptpath/packages
 __TOOLRUNTIME_DIR=$__scriptpath/Tools


### PR DESCRIPTION
Official builds don't set the current directory before launching the script...