### PR TITLE
Add correct AssemblyMetadataAttribute for Framework Assembly

### DIFF
--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -11,6 +11,7 @@
     <CLSCompliant>true</CLSCompliant>
     <!-- Use MSFT assembly key for compatibility with uapaot targeting pack -->
     <AssemblyKey>MSFT</AssemblyKey>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" />

--- a/src/System.Private.DeveloperExperience.Console/src/System.Private.DeveloperExperience.Console.csproj
+++ b/src/System.Private.DeveloperExperience.Console/src/System.Private.DeveloperExperience.Console.csproj
@@ -5,6 +5,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">

--- a/src/System.Private.Interop/src/System.Private.Interop.CoreCLR.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.CoreCLR.csproj
@@ -17,6 +17,7 @@
     <TargetNetCoreForCoreCLRFramework>true</TargetNetCoreForCoreCLRFramework>
     <OutputPath>$(OutputPath)\coreclr</OutputPath>
     <TargetFramework>netstandard1.3</TargetFramework>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup> 
 
   <ItemGroup>

--- a/src/System.Private.Interop/src/System.Private.Interop.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.csproj
@@ -9,6 +9,7 @@
     <NoWarn>$(NoWarn);3021</NoWarn>
     <!-- Use MSFT assembly key for compatibility with uapaot targeting pack -->
     <AssemblyKey>MSFT</AssemblyKey>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ReferencePath Include="$(AotPackageReferencePath)\System.Runtime.dll" />

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -9,6 +9,7 @@
     <METADATA_TYPE_LOADER>true</METADATA_TYPE_LOADER>
     <EcmaMetadataSupport>true</EcmaMetadataSupport>
     <JitSupport>true</JitSupport>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(JitSupport)' == 'true'">
     <DefineConstants>SUPPORT_JIT;$(DefineConstants)</DefineConstants>

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -7,6 +7,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsProjectNLibrary)' == 'true'">
     <DefineConstants>ENABLE_REFLECTION_TRACE;$(DefineConstants)</DefineConstants>

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -7,6 +7,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EcmaMetadataSupport)' == 'true'">

--- a/src/System.Private.Reflection.Metadata/src/System.Private.Reflection.Metadata.csproj
+++ b/src/System.Private.Reflection.Metadata/src/System.Private.Reflection.Metadata.csproj
@@ -5,6 +5,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">

--- a/src/System.Private.StackTraceGenerator/src/System.Private.StackTraceGenerator.csproj
+++ b/src/System.Private.StackTraceGenerator/src/System.Private.StackTraceGenerator.csproj
@@ -4,7 +4,8 @@
     <AssemblyName>System.Private.StackTraceGenerator</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks> 
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">

--- a/src/System.Private.StackTraceMetadata/src/System.Private.StackTraceMetadata.csproj
+++ b/src/System.Private.StackTraceMetadata/src/System.Private.StackTraceMetadata.csproj
@@ -5,6 +5,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">

--- a/src/System.Private.Threading/src/System.Private.Threading.csproj
+++ b/src/System.Private.Threading/src/System.Private.Threading.csproj
@@ -5,6 +5,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -17,6 +17,7 @@
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>TYPE_LOADER_IMPLEMENTATION;$(DefineConstants)</DefineConstants>
+    <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(EcmaMetadataSupport)' == 'true'">
     <DefineConstants>ECMA_METADATA_SUPPORT;$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
With Project file cotains Property <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>, the final assembly will contain the following assembly attribute and will consider as Framework Assembly.
[assembly: AssemblyMetadata(".NETFrameworkAssembly", "")]