### PR TITLE
Fix docker image used for official builds from Debian to Ubuntu

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Linux.json
+++ b/buildpipeline/DotNet-CoreRT-Linux.json
@@ -741,7 +741,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs"
     },
     "DockerTag": {
-      "value": "ubuntu-14.04-coredeps-67592e6-20170319080304"
+      "value": "ubuntu-14.04-198573d-20170319080304"
     },
     "DockerCopyDest": {
       "value": "$(Build.BinariesDirectory)/docker_$(SourceFolder)"

--- a/buildpipeline/DotNet-CoreRT-Linux.json
+++ b/buildpipeline/DotNet-CoreRT-Linux.json
@@ -741,7 +741,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs"
     },
     "DockerTag": {
-      "value": "debian-8.2-corert-395a49e-20170403100424"
+      "value": "ubuntu-14.04-coredeps-67592e6-20170319080304"
     },
     "DockerCopyDest": {
       "value": "$(Build.BinariesDirectory)/docker_$(SourceFolder)"


### PR DESCRIPTION
We never supported Debian and whatever was making this work stopped working.

I confirmed this is the last thing we need to fix official builds and publishing for the repo. 🍾 