### PR TITLE
[ILVerify] Fix some false negatives verifying mscorlib

### DIFF
--- a/src/ILVerify/src/AccessVerificationHelpers.cs
+++ b/src/ILVerify/src/AccessVerificationHelpers.cs
@@ -72,11 +72,14 @@ namespace ILVerify
             if (targetMethod.HasInstantiation && !currentType.CanAccessInstantiation(targetMethod.Instantiation))
                 return false;
 
-            var targetMethodDef = (EcmaMethod)targetMethod.GetTypicalMethodDefinition();
+            var targetMethodDef = targetMethod.GetTypicalMethodDefinition() as EcmaMethod;
             var currentTypeDef = (MetadataType)currentType.GetTypeDefinition();
 
-            if (!currentTypeDef.CanAccessMember(targetMethod.OwningType, targetMethodDef.Attributes & MethodAttributes.MemberAccessMask, instance))
-                return false;
+            if (targetMethodDef != null) // Non metadata methods, such as ArrayMethods, may be null at this point
+            {
+                if (!currentTypeDef.CanAccessMember(targetMethod.OwningType, targetMethodDef.Attributes & MethodAttributes.MemberAccessMask, instance))
+                    return false;
+            }
 
             return currentTypeDef.CanAccessMethodSignature(targetMethod);
         }


### PR DESCRIPTION
This fixes some false negatives:

- When a non-metadata method, such as `ArrayMethods`, are verfied, the current implementation throws an exception when trying to cast such methods or their owning type to `EcmaMethod`/`MetadataType`.
- When verifying the constructor of `System.Object` the current implementation reports an `UninitReturn` verification error, because the constructor returns before calling any base class ctor.