### PR TITLE
Fix delegate marshalling thunk determinism

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.Sorting.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.Sorting.cs
@@ -14,7 +14,7 @@ namespace Internal.IL.Stubs
         protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (DelegateMarshallingMethodThunk)other;
-            int result = Kind - otherMethod.Kind;
+            int result = (int)Kind - (int)otherMethod.Kind;
             if (result != 0)
                 return result;
 


### PR DESCRIPTION
Marshalling thunks were emitted in non-deterministic order. This was caused by `DelegateMarshallingMethodThunkKind` having unsigned (byte) representation and the CompareToImpl method using subtraction to compare two `DelegateMarshallingMethodThunkKind` values. The result could not be negative, breaking the Sort algorithm for this type.