### PR TITLE
[ILVerify] Add net46 as additional target framework

### DIFF
--- a/src/ILVerify/src/AccessVerificationHelpers.cs
+++ b/src/ILVerify/src/AccessVerificationHelpers.cs
@@ -262,7 +262,7 @@ namespace ILVerify
 
             foreach (var attribute in assembly.GetDecodedCustomAttributes("System.Runtime.CompilerServices", "InternalsVisibleToAttribute"))
             {
-                var friendValues = ((string)attribute.FixedArguments[0].Value).Split(", ");
+                var friendValues = ((string)attribute.FixedArguments[0].Value).Split(new string[] { ", " }, StringSplitOptions.None);
                 if (friendValues.Length >= 1 && friendValues.Length <= 2)
                 {
                     if (friendValues[0] != friendName.Name)

--- a/src/ILVerify/src/ILVerify.csproj
+++ b/src/ILVerify/src/ILVerify.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <CLSCompliant>false</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
@@ -294,7 +294,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.MemoryMappedFiles" Version="4.0.0" />
+    <PackageReference Include="System.IO.MemoryMappedFiles" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.1" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e160909-1" />
   </ItemGroup>


### PR DESCRIPTION
This adds `net46` as an additional target framework to ILVerify, as suggested in https://github.com/dotnet/roslyn/issues/22872.