### PR TITLE
Speed up locating method info on Unix

### DIFF
--- a/src/Native/Runtime/unix/UnixContext.cpp
+++ b/src/Native/Runtime/unix/UnixContext.cpp
@@ -272,6 +272,9 @@ bool GetUnwindProcInfo(PCODE ip, unw_proc_info_t *procInfo)
     }
 
 #ifdef _AMD64_
+    // We manually index into the unw_context_t's internals for now because there's
+    // no better way to modify it. This will go away in the future when we locate the
+    // LSDA and other information without initializing an unwind cursor.
     unwContext.data[16] = ip;
 #elif _ARM_
     unwContext.data[15] = ip;


### PR DESCRIPTION
`InitializeUnwindContextAndCursor` was being used from `FindProcInfo`, which gets called on some perf-critical paths (such as when scanning for GC roots). However, it does some extra work which we don't need when just trying to find the info for an IP which was causing it to be much slower than it needs to be.

This change adds a new routine to get the `unw_proc_info_t`. This is used in the case where we are just trying to find the MethodInfo for a PC. Before, we were unnecessarily allocating stack space for a full-on REGDISPLAY which was all zeroes except for the IP portion, and then (after cursor initialization) copying the zeroed registers to the unwind cursor which didn't serve any purpose since all we wanted was the proc info.

I've been measuring the performance using a simple allocation benchmark to which I added 100 threads that are just waiting (but will still get scanned during GCs). The total duration to run the benchmark goes down about 16% with just this one change. The gains are obviously smaller with fewer threads, but still very significant. Profiling data revealed that the extra work removed by this change accounted for roughly a quarter of what was being done by the `GcScanRootsWorker`, so we get a sizeable perf gain there.

This is only the first change I'm making in this area. I have a few more changes and perf improvements to all of this unwind-related code that I'll be sending out.

@janvorli @jkotas @sergiy-k PTAL