### PR TITLE
[armel] fixed PC passing to unwind

### DIFF
--- a/src/Native/Runtime/unix/UnixContext.cpp
+++ b/src/Native/Runtime/unix/UnixContext.cpp
@@ -254,7 +254,7 @@ bool GetUnwindProcInfo(PCODE ip, unw_proc_info_t *procInfo)
     // LSDA and other information without initializing an unwind cursor.
     unwContext.data[16] = ip;
 #elif _ARM_
-    unwContext.data[15] = ip;
+    ((uint32_t*)(unwContext.data))[15] = ip;
 #else
     #error "GetUnwindProcInfo is not supported on this arch yet."
 #endif
@@ -293,7 +293,7 @@ bool InitializeUnwindContextAndCursor(REGDISPLAY* regDisplay, unw_cursor_t* curs
 #ifdef _AMD64_
     unwContext->data[16] = regDisplay->IP;
 #elif _ARM_
-    unwContext.data[15] = regDisplay->IP;
+    ((uint32_t*)(unwContext->data))[15] = regDisplay->IP;
 #else
     #error "InitializeUnwindContextAndCursor is not supported on this arch yet."
 #endif


### PR DESCRIPTION
without this fix wrong value of pc is passed to libunwind, see gdb log below:

```
Thread 1 "Hello" hit Breakpoint 1, FindProcInfo (controlPC=1557619, startAddress=0xbeffebc0, lsda=0xbeffebbc)
    at /share/CORERT/corert/src/Native/Runtime/unix/UnixContext.cpp:549
549	    if (!GetUnwindProcInfo((PCODE)controlPC, &procInfo))
(gdb) s
GetUnwindProcInfo (ip=1557619, procInfo=0xbeffeb4c) at /share/CORERT/corert/src/Native/Runtime/unix/UnixContext.cpp:245
245	    st = unw_getcontext(&unwContext);
(gdb) s
unw_getcontext () at /share/CORERT/corert/src/Native/libunwind/src/UnwindRegistersSave.S:334
334	  stm r0, {r0-r12}
(gdb) info r
r0             0xbeffe988	3204442504
r1             0xbeffeb4c	3204442956
r2             0xbeffeb4c	3204442956
r3             0x17c473	1557619
r4             0x5f827900	1602386176
r5             0xb6ff9f38	3070205752
r6             0x5f827900	1602386176
r7             0xbeffeb20	3204442912
r8             0x0	0
r9             0x0	0
r10            0xb6ffefb4	30702263561557619
r11            0xbefff8b8	3204446392
r12            0x5f827900	1602386176
sp             0xbeffe7a0	0xbeffe7a0
lr             0x159155	1413461
pc             0x163860	0x163860 <unw_getcontext>
cpsr           0x20070010	537329680
(gdb) fin
Run till exit from #0  unw_getcontext () at /share/CORERT/corert/src/Native/libunwind/src/UnwindRegistersSave.S:334
0x00159154 in GetUnwindProcInfo (ip=1557619, procInfo=0xbeffeb4c) at /share/CORERT/corert/src/Native/Runtime/unix/UnixContext.cpp:245
245	    st = unw_getcontext(&unwContext);
(gdb) p/x unwContext
$1 = {data = {0xbeffeb4cbeffe988, 0x17c473beffeb4c, 0xb6ff9f385f827900, 0xbeffeb205f827900, 0x0, 0xbefff8b8b6ffefb4, 0xbeffe7a05f827900,
    0x15915500159155, 0x0 <repeats 13 times>, 0xbeffea88beffea88, 0xbeffea70beffea88, 0xbeffea70beffea70, 0x3a8e9beffebb0, 0x0,
    0xb6ff9f38beffea70, 0xb6ff9f38b6ff9f38, 0xb6ff9f3800000000, 0x0 <repeats 19 times>, 0x63af9c0063af9c, 0x63af9c00000000}}
(gdb) n
246	    if (st < 0)
(gdb) n
257	    unwContext.data[15] = ip;
(gdb) n
262	    st = unw_init_local(&cursor, &unwContext);
(gdb) p/x ip
$2 = 0x17c473
(gdb) p/x unwContext
$3 = {data = {0xbeffeb4cbeffe988, 0x17c473beffeb4c, 0xb6ff9f385f827900, 0xbeffeb205f827900, 0x0, 0xbefff8b8b6ffefb4, 0xbeffe7a05f827900,
    0x15915500159155, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x17c473, 0x0, 0x0, 0x0, 0x0, 0x0, 0xbeffea88beffea88, 0xbeffea70beffea88,
    0xbeffea70beffea70, 0x3a8e9beffebb0, 0x0, 0xb6ff9f38beffea70, 0xb6ff9f38b6ff9f38, 0xb6ff9f3800000000, 0x0 <repeats 19 times>,
    0x63af9c0063af9c, 0x63af9c00000000}}
(gdb) s
unw_init_local (cursor=0xbeffe7c0, context=0xbeffe988) at /share/CORERT/corert/src/Native/libunwind/src/libunwind.cpp:45
45	  _LIBUNWIND_TRACE_API("unw_init_local(cursor=%p, context=%p)",
(gdb) n
libunwind: unw_init_local(cursor=0xbeffe7c0, context=0xbeffe988)
66	  new ((void *)cursor) UnwindCursor<LocalAddressSpace, REGISTER_KIND>(
(gdb) n
67	                                 context, LocalAddressSpace::sThisAddressSpace);
(gdb) n
66	  new ((void *)cursor) UnwindCursor<LocalAddressSpace, REGISTER_KIND>(
(gdb) n
69	  AbstractUnwindCursor *co = (AbstractUnwindCursor *)cursor;
(gdb) n
70	  co->setInfoBasedOnIPRegister();
(gdb) s
libunwind::UnwindCursor<libunwind::LocalAddressSpace, libunwind::Registers_arm>::setInfoBasedOnIPRegister (this=0xbeffe7c0,
    isReturnAddress=false) at /share/CORERT/corert/src/Native/libunwind/src/UnwindCursor.hpp:1234
1234	  pint_t pc = (pint_t)this->getReg(UNW_REG_IP);
(gdb) n
1238	  pc &= (pint_t)~0x1;
(gdb) p/x pc
$4 = 0x159155  /// should be  1557618  (1557619)  == 0x17c472
```