### PR TITLE
ObjWriter integration

### DIFF
--- a/Documentation/how-to-build-ObjectWriter.md
+++ b/Documentation/how-to-build-ObjectWriter.md
@@ -1,0 +1,40 @@
+# Build ObjectWriter library #
+
+ObjWriter is based on LLVM, so it requires recent CMake and GCC/Clang to build LLVM.
+See http://llvm.org/docs/GettingStarted.html#requirements for more details.
+
+1. Clone LLVM from official LLVM mirror github git repository:
+
+    ```
+    $ git clone -b release_50 https://github.com/llvm-mirror/llvm.git
+    ```
+
+2. Copy ObjWriter directory from CoreRT into LLVM tree
+
+    ```
+    $ cp -r CoreRT/src/Native/ObjWriter llvm/tools/
+    ```
+
+3. Apply the patch to LLVM:
+
+    ```
+    $ cd llvm
+    $ git apply tools/ObjWriter/llvm.patch
+    ```
+
+4. Configure and build LLVM with ObjWriter:
+
+    ```
+    $ mkdir build
+    $ cd build
+    $ cmake ../ -DCMAKE_BUILD_TYPE=Release -DLLVM_OPTIMIZED_TABLEGEN=1 -DHAVE_POSIX_SPAWN=0 -DLLVM_ENABLE_PIC=1 -DLLVM_BUILD_TESTS=0 -DLLVM_ENABLE_DOXYGEN=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_TESTS=0
+    $ make -j10 objwriter
+    $ cd ..
+    ```
+
+* You can change the building type(CMAKE_BUILD_TYPE) to the debugging type(Debug), if necessary to debug ObjWriter.
+* Also, you can do this under chroot to building ObjWriter for other platforms.
+
+5. Get ObjWriter:
+
+   If all goes well, the build will complete in the previous step and you will get ObjWriter library as llvm/build/lib/libobjwriter.so

--- a/src/Native/ObjWriter/CMakeLists.txt
+++ b/src/Native/ObjWriter/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(objwriter)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti")
 include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${CORECLR_INCLUDE})
 include_directories(.)
 add_definitions(${LLVM_DEFINITIONS})
 
@@ -32,7 +32,6 @@ add_library(objwriter
 
 # Find the libraries that correspond to the LLVM components
 # that we wish to use
-
 llvm_map_components_to_libnames(llvm_libs
   ${LLVM_TARGETS_TO_BUILD}
 )

--- a/src/Native/ObjWriter/cfi.h
+++ b/src/Native/ObjWriter/cfi.h
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// Keep in sync with https://github.com/dotnet/coreclr/blob/master/src/inc/cfi.h
+//
+
+#ifndef CFI_H_
+#define CFI_H_
+
+#define DWARF_REG_ILLEGAL -1
+enum CFI_OPCODE
+{
+   CFI_ADJUST_CFA_OFFSET,    // Offset is adjusted relative to the current one.
+   CFI_DEF_CFA_REGISTER,     // New register is used to compute CFA
+   CFI_REL_OFFSET            // Register is saved at offset from the current CFA
+};
+
+struct CFI_CODE
+{
+    unsigned char CodeOffset;// Offset from the start of code the frame covers.
+    unsigned char CfiOpCode;
+    short DwarfReg;          // Dwarf register number. 0~32 for x64.
+    int Offset;
+    CFI_CODE(unsigned char codeOffset, unsigned char cfiOpcode,
+        short dwarfReg, int offset)
+        : CodeOffset(codeOffset)
+        , CfiOpCode(cfiOpcode)
+        , DwarfReg(dwarfReg)
+        , Offset(offset)
+    {}
+};
+typedef CFI_CODE* PCFI_CODE;
+
+#endif // CFI_H
+

--- a/src/Native/ObjWriter/cordebuginfo.h
+++ b/src/Native/ObjWriter/cordebuginfo.h
@@ -1,0 +1,327 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// Keep in sync with https://github.com/dotnet/coreclr/blob/master/src/inc/cordebuginfo.h
+//
+
+/**********************************************************************************/
+// DebugInfo types shared by JIT-EE interface and EE-Debugger interface
+
+class ICorDebugInfo
+{
+public:
+    /*----------------------------- Boundary-info ---------------------------*/
+
+    enum MappingTypes
+    {
+        NO_MAPPING  = -1,
+        PROLOG      = -2,
+        EPILOG      = -3,
+        MAX_MAPPING_VALUE = -3 // Sentinal value. This should be set to the largest magnitude value in the enum
+                               // so that the compression routines know the enum's range.
+    };
+
+    enum BoundaryTypes
+    {
+        NO_BOUNDARIES           = 0x00,     // No implicit boundaries
+        STACK_EMPTY_BOUNDARIES  = 0x01,     // Boundary whenever the IL evaluation stack is empty
+        NOP_BOUNDARIES          = 0x02,     // Before every CEE_NOP instruction
+        CALL_SITE_BOUNDARIES    = 0x04,     // Before every CEE_CALL, CEE_CALLVIRT, etc instruction
+
+        // Set of boundaries that debugger should always reasonably ask the JIT for.
+        DEFAULT_BOUNDARIES      = STACK_EMPTY_BOUNDARIES | NOP_BOUNDARIES | CALL_SITE_BOUNDARIES
+    };
+
+    // Note that SourceTypes can be OR'd together - it's possible that
+    // a sequence point will also be a stack_empty point, and/or a call site.
+    // The debugger will check to see if a boundary offset's source field &
+    // SEQUENCE_POINT is true to determine if the boundary is a sequence point.
+
+    enum SourceTypes
+    {
+        SOURCE_TYPE_INVALID        = 0x00, // To indicate that nothing else applies
+        SEQUENCE_POINT             = 0x01, // The debugger asked for it.
+        STACK_EMPTY                = 0x02, // The stack is empty here
+        CALL_SITE                  = 0x04, // This is a call site.
+        NATIVE_END_OFFSET_UNKNOWN  = 0x08, // Indicates a epilog endpoint
+        CALL_INSTRUCTION           = 0x10  // The actual instruction of a call.
+
+    };
+
+    struct OffsetMapping
+    {
+        DWORD           nativeOffset;
+        DWORD           ilOffset;
+        SourceTypes     source; // The debugger needs this so that
+                                // we don't put Edit and Continue breakpoints where
+                                // the stack isn't empty.  We can put regular breakpoints
+                                // there, though, so we need a way to discriminate
+                                // between offsets.
+    };
+
+    /*------------------------------ Var-info -------------------------------*/
+
+    // Note: The debugger needs to target register numbers on platforms other than which the debugger itself
+    // is running. To this end it maintains its own values for REGNUM_SP and REGNUM_AMBIENT_SP across multiple
+    // platforms. So any change here that may effect these values should be reflected in the definitions
+    // contained in debug/inc/DbgIPCEvents.h.
+    enum RegNum
+    {
+#ifdef _TARGET_X86_
+        REGNUM_EAX,
+        REGNUM_ECX,
+        REGNUM_EDX,
+        REGNUM_EBX,
+        REGNUM_ESP,
+        REGNUM_EBP,
+        REGNUM_ESI,
+        REGNUM_EDI,
+#elif _TARGET_ARM_
+        REGNUM_R0,
+        REGNUM_R1,
+        REGNUM_R2,
+        REGNUM_R3,
+        REGNUM_R4,
+        REGNUM_R5,
+        REGNUM_R6,
+        REGNUM_R7,
+        REGNUM_R8,
+        REGNUM_R9,
+        REGNUM_R10,
+        REGNUM_R11,
+        REGNUM_R12,
+        REGNUM_SP,
+        REGNUM_LR,
+        REGNUM_PC,
+#elif _TARGET_ARM64_
+        REGNUM_X0,
+        REGNUM_X1,
+        REGNUM_X2,
+        REGNUM_X3,
+        REGNUM_X4,
+        REGNUM_X5,
+        REGNUM_X6,
+        REGNUM_X7,
+        REGNUM_X8,
+        REGNUM_X9,
+        REGNUM_X10,
+        REGNUM_X11,
+        REGNUM_X12,
+        REGNUM_X13,
+        REGNUM_X14,
+        REGNUM_X15,
+        REGNUM_X16,
+        REGNUM_X17,
+        REGNUM_X18,
+        REGNUM_X19,
+        REGNUM_X20,
+        REGNUM_X21,
+        REGNUM_X22,
+        REGNUM_X23,
+        REGNUM_X24,
+        REGNUM_X25,
+        REGNUM_X26,
+        REGNUM_X27,
+        REGNUM_X28,
+        REGNUM_FP,
+        REGNUM_LR,
+        REGNUM_SP,
+        REGNUM_PC,
+#elif _TARGET_AMD64_
+        REGNUM_RAX,
+        REGNUM_RCX,
+        REGNUM_RDX,
+        REGNUM_RBX,
+        REGNUM_RSP,
+        REGNUM_RBP,
+        REGNUM_RSI,
+        REGNUM_RDI,
+        REGNUM_R8,
+        REGNUM_R9,
+        REGNUM_R10,
+        REGNUM_R11,
+        REGNUM_R12,
+        REGNUM_R13,
+        REGNUM_R14,
+        REGNUM_R15,
+#else
+        PORTABILITY_WARNING("Register numbers not defined on this platform")
+#endif
+        REGNUM_COUNT,
+        REGNUM_AMBIENT_SP, // ambient SP support. Ambient SP is the original SP in the non-BP based frame.
+                           // Ambient SP should not change even if there are push/pop operations in the method.
+
+#ifdef _TARGET_X86_
+        REGNUM_FP = REGNUM_EBP,
+        REGNUM_SP = REGNUM_ESP,
+#elif _TARGET_AMD64_
+        REGNUM_SP = REGNUM_RSP,
+#elif _TARGET_ARM_
+#ifdef REDHAWK
+        REGNUM_FP = REGNUM_R7,
+#else
+        REGNUM_FP = REGNUM_R11,
+#endif //REDHAWK
+#elif _TARGET_ARM64_
+        //Nothing to do here. FP is already alloted.
+#else
+        // RegNum values should be properly defined for this platform
+        REGNUM_FP = 0,
+        REGNUM_SP = 1,
+#endif
+
+    };
+
+    // VarLoc describes the location of a native variable.  Note that currently, VLT_REG_BYREF and VLT_STK_BYREF 
+    // are only used for value types on X64.
+
+    enum VarLocType
+    {
+        VLT_REG,        // variable is in a register
+        VLT_REG_BYREF,  // address of the variable is in a register
+        VLT_REG_FP,     // variable is in an fp register
+        VLT_STK,        // variable is on the stack (memory addressed relative to the frame-pointer)
+        VLT_STK_BYREF,  // address of the variable is on the stack (memory addressed relative to the frame-pointer)
+        VLT_REG_REG,    // variable lives in two registers
+        VLT_REG_STK,    // variable lives partly in a register and partly on the stack
+        VLT_STK_REG,    // reverse of VLT_REG_STK
+        VLT_STK2,       // variable lives in two slots on the stack
+        VLT_FPSTK,      // variable lives on the floating-point stack
+        VLT_FIXED_VA,   // variable is a fixed argument in a varargs function (relative to VARARGS_HANDLE)
+
+        VLT_COUNT,
+        VLT_INVALID,
+    };
+
+    struct VarLoc
+    {
+        VarLocType      vlType;
+
+        union
+        {
+            // VLT_REG/VLT_REG_FP -- Any pointer-sized enregistered value (TYP_INT, TYP_REF, etc)
+            // eg. EAX
+            // VLT_REG_BYREF -- the specified register contains the address of the variable
+            // eg. [EAX]
+
+            struct
+            {
+                RegNum      vlrReg;
+            } vlReg;
+
+            // VLT_STK -- Any 32 bit value which is on the stack
+            // eg. [ESP+0x20], or [EBP-0x28]
+            // VLT_STK_BYREF -- the specified stack location contains the address of the variable
+            // eg. mov EAX, [ESP+0x20]; [EAX]
+
+            struct
+            {
+                RegNum      vlsBaseReg;
+                signed      vlsOffset;
+            } vlStk;
+
+            // VLT_REG_REG -- TYP_LONG with both DWords enregistred
+            // eg. RBM_EAXEDX
+
+            struct
+            {
+                RegNum      vlrrReg1;
+                RegNum      vlrrReg2;
+            } vlRegReg;
+
+            // VLT_REG_STK -- Partly enregistered TYP_LONG
+            // eg { LowerDWord=EAX UpperDWord=[ESP+0x8] }
+
+            struct
+            {
+                RegNum      vlrsReg;
+                struct
+                {
+                    RegNum      vlrssBaseReg;
+                    signed      vlrssOffset;
+                }           vlrsStk;
+            } vlRegStk;
+
+            // VLT_STK_REG -- Partly enregistered TYP_LONG
+            // eg { LowerDWord=[ESP+0x8] UpperDWord=EAX }
+
+            struct
+            {
+                struct
+                {
+                    RegNum      vlsrsBaseReg;
+                    signed      vlsrsOffset;
+                }           vlsrStk;
+                RegNum      vlsrReg;
+            } vlStkReg;
+
+            // VLT_STK2 -- Any 64 bit value which is on the stack,
+            // in 2 successsive DWords.
+            // eg 2 DWords at [ESP+0x10]
+
+            struct
+            {
+                RegNum      vls2BaseReg;
+                signed      vls2Offset;
+            } vlStk2;
+
+            // VLT_FPSTK -- enregisterd TYP_DOUBLE (on the FP stack)
+            // eg. ST(3). Actually it is ST("FPstkHeigth - vpFpStk")
+
+            struct
+            {
+                unsigned        vlfReg;
+            } vlFPstk;
+
+            // VLT_FIXED_VA -- fixed argument of a varargs function.
+            // The argument location depends on the size of the variable
+            // arguments (...). Inspecting the VARARGS_HANDLE indicates the
+            // location of the first arg. This argument can then be accessed
+            // relative to the position of the first arg
+
+            struct
+            {
+                unsigned        vlfvOffset;
+            } vlFixedVarArg;
+
+            // VLT_MEMORY
+
+            struct
+            {
+                void        *rpValue; // pointer to the in-process
+                // location of the value.
+            } vlMemory;
+        };
+    };
+
+    // This is used to report implicit/hidden arguments
+
+    enum
+    {
+        VARARGS_HND_ILNUM   = -1, // Value for the CORINFO_VARARGS_HANDLE varNumber
+        RETBUF_ILNUM        = -2, // Pointer to the return-buffer
+        TYPECTXT_ILNUM      = -3, // ParamTypeArg for CORINFO_GENERICS_CTXT_FROM_PARAMTYPEARG
+
+        UNKNOWN_ILNUM       = -4, // Unknown variable
+
+        MAX_ILNUM           = -4  // Sentinal value. This should be set to the largest magnitude value in th enum
+                                  // so that the compression routines know the enum's range.
+    };
+
+    struct ILVarInfo
+    {
+        DWORD           startOffset;
+        DWORD           endOffset;
+        DWORD           varNumber;
+    };
+
+    struct NativeVarInfo
+    {
+        DWORD           startOffset;
+        DWORD           endOffset;
+        DWORD           varNumber;
+        VarLoc          loc;
+    };
+};

--- a/src/Native/ObjWriter/llvm.patch
+++ b/src/Native/ObjWriter/llvm.patch
@@ -1,0 +1,123 @@
+diff --git a/include/llvm/MC/MCObjectStreamer.h b/include/llvm/MC/MCObjectStreamer.h
+index 7c1189e46ab..d1d77c97311 100644
+--- a/include/llvm/MC/MCObjectStreamer.h
++++ b/include/llvm/MC/MCObjectStreamer.h
+@@ -101,6 +101,11 @@ public:
+   void EmitInstruction(const MCInst &Inst, const MCSubtargetInfo &STI,
+                        bool = false) override;
+ 
++  /// \brief EmitValueImpl with additional param, that allows to emit PCRelative
++  /// MCFixup.
++  void EmitValueImpl(const MCExpr *Value, unsigned Size, SMLoc Loc,
++                     bool isPCRelative);
++
+   /// \brief Emit an instruction to a special fragment, because this instruction
+   /// can change its size during relaxation.
+   virtual void EmitInstToFragment(const MCInst &Inst, const MCSubtargetInfo &);
+diff --git a/lib/MC/MCObjectStreamer.cpp b/lib/MC/MCObjectStreamer.cpp
+index 174397e2739..ef7161fb56c 100644
+--- a/lib/MC/MCObjectStreamer.cpp
++++ b/lib/MC/MCObjectStreamer.cpp
+@@ -122,7 +122,7 @@ void MCObjectStreamer::EmitCFISections(bool EH, bool Debug) {
+ }
+ 
+ void MCObjectStreamer::EmitValueImpl(const MCExpr *Value, unsigned Size,
+-                                     SMLoc Loc) {
++                                     SMLoc Loc, bool isPCRelative) {
+   MCStreamer::EmitValueImpl(Value, Size, Loc);
+   MCDataFragment *DF = getOrCreateDataFragment();
+   flushPendingLabels(DF, DF->getContents().size());
+@@ -143,10 +143,16 @@ void MCObjectStreamer::EmitValueImpl(const MCExpr *Value, unsigned Size,
+   }
+   DF->getFixups().push_back(
+       MCFixup::create(DF->getContents().size(), Value,
+-                      MCFixup::getKindForSize(Size, false), Loc));
++                      MCFixup::getKindForSize(Size, isPCRelative), Loc));
+   DF->getContents().resize(DF->getContents().size() + Size, 0);
+ }
+ 
++
++void MCObjectStreamer::EmitValueImpl(const MCExpr *Value, unsigned Size,
++                                     SMLoc Loc) {
++  EmitValueImpl(Value, Size, Loc, false);
++}
++
+ void MCObjectStreamer::EmitCFIStartProcImpl(MCDwarfFrameInfo &Frame) {
+   // We need to create a local symbol to avoid relocations.
+   Frame.Begin = getContext().createTempSymbol();
+diff --git a/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp b/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+index a77df7a2598..e1aa7526f9b 100644
+--- a/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
++++ b/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+@@ -48,6 +48,14 @@ public:
+ };
+ } // end anonymous namespace
+ 
++Optional<MCFixupKind> ARMAsmBackend::getFixupKind(StringRef Name) const {
++  return StringSwitch<Optional<MCFixupKind>>(Name)
++      .Case("R_ARM_THM_MOVW_ABS_NC", (MCFixupKind)ARM::fixup_t2_movw_lo16)
++      .Case("R_ARM_THM_MOVT_ABS", (MCFixupKind)ARM::fixup_t2_movt_hi16)
++      .Case("R_ARM_THM_JUMP24", (MCFixupKind)ARM::fixup_arm_thumb_blx)
++      .Default(MCAsmBackend::getFixupKind(Name));
++}
++
+ const MCFixupKindInfo &ARMAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
+   const static MCFixupKindInfo InfosLE[ARM::NumTargetFixupKinds] = {
+       // This table *must* be in the order that the fixup_* kinds are defined in
+@@ -386,6 +394,8 @@ unsigned ARMAsmBackend::adjustFixupValue(const MCAssembler &Asm,
+   case FK_Data_2:
+   case FK_Data_4:
+     return Value;
++  case FK_PCRel_4:
++    return Value;
+   case FK_SecRel_2:
+     return Value;
+   case FK_SecRel_4:
+@@ -825,6 +835,9 @@ static unsigned getFixupKindNumBytes(unsigned Kind) {
+   case ARM::fixup_t2_so_imm:
+     return 4;
+ 
++  case FK_PCRel_4:
++    return 4;
++
+   case FK_SecRel_2:
+     return 2;
+   case FK_SecRel_4:
+diff --git a/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h b/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
+index 02374966daf..01676a01683 100644
+--- a/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
++++ b/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
+@@ -36,6 +36,7 @@ public:
+ 
+   bool hasNOP() const { return STI->getFeatureBits()[ARM::HasV6T2Ops]; }
+ 
++  Optional<MCFixupKind> getFixupKind(StringRef Name) const override;
+   const MCFixupKindInfo &getFixupKindInfo(MCFixupKind Kind) const override;
+ 
+   bool shouldForceRelocation(const MCAssembler &Asm, const MCFixup &Fixup,
+diff --git a/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp b/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
+index 59f31be69d5..9b95598f99f 100644
+--- a/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
++++ b/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
+@@ -103,6 +103,9 @@ unsigned ARMELFObjectWriter::GetRelocTypeInner(const MCValue &Target,
+         break;
+       }
+       break;
++    case FK_PCRel_4:
++      Type = ELF::R_ARM_REL32;
++      break;
+     case ARM::fixup_arm_blx:
+     case ARM::fixup_arm_uncondbl:
+       switch (Modifier) {
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index b654b8c5cb8..58d25159af8 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -46,6 +46,7 @@ add_llvm_external_project(clang)
+ add_llvm_external_project(llgo)
+ add_llvm_external_project(lld)
+ add_llvm_external_project(lldb)
++add_llvm_external_project(ObjWriter)
+ 
+ # Automatically add remaining sub-directories containing a 'CMakeLists.txt'
+ # file as external projects.


### PR DESCRIPTION
ObjWriter integration patch:
	- remove CoreCLR dependence
	- fix build with the latest LLVM 5 version
	- add documentation

@dotnet/arm32-corert-contrib please review