### PR TITLE
Enable generation of stack trace data

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StackTraceMethodMappingNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StackTraceMethodMappingNode.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.Text;
-using Internal.TypeSystem.Ecma;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
+
+using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -60,10 +56,13 @@ namespace ILCompiler.DependencyAnalysis
             objData.AddSymbol(this);
             objData.AddSymbol(_endSymbol);
 
+            RelocType reloc = factory.Target.Abi == TargetAbi.CoreRT ?
+                RelocType.IMAGE_REL_BASED_RELPTR32 : RelocType.IMAGE_REL_BASED_ADDR32NB;
+
             foreach (var mappingEntry in factory.MetadataManager.GetStackTraceMapping(factory))
             {
-                objData.EmitReloc(factory.MethodEntrypoint(mappingEntry.Entity), RelocType.IMAGE_REL_BASED_ADDR32NB);
-                objData.EmitInt(mappingEntry.MetadataHandle);                
+                objData.EmitReloc(factory.MethodEntrypoint(mappingEntry.Entity), reloc);
+                objData.EmitInt(mappingEntry.MetadataHandle);
             }
 
             _endSymbol.SetSymbolOffset(objData.CountBytes);

--- a/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
@@ -17,7 +17,7 @@ namespace ILCompiler
         public override bool SupportsReflection => false;
 
         public EmptyMetadataManager(CompilationModuleGroup group, CompilerTypeSystemContext typeSystemContext)
-            : base(group, typeSystemContext, new FullyBlockedMetadataPolicy(), new NoStackTraceEmissionPolicy())
+            : base(group, typeSystemContext, new FullyBlockedMetadataPolicy())
         {
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/ILScannerBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScannerBuilder.cs
@@ -46,7 +46,7 @@ namespace ILCompiler
         public IILScanner ToILScanner()
         {
             // TODO: we will want different metadata managers depending on whether we're doing reflection analysis
-            var metadataManager = new CompilerGeneratedMetadataManager(_compilationGroup, _context, null);
+            var metadataManager = new CompilerGeneratedMetadataManager(_compilationGroup, _context, null, new NoStackTraceEmissionPolicy());
             var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_compilationGroup.GeneratedAssembly));
             var nodeFactory = new ILScanNodeFactory(_context, _compilationGroup, metadataManager, interopStubManager, _nameMangler);
             DependencyAnalyzerBase<NodeFactory> graph = _dependencyTrackingLevel.CreateDependencyGraph(nodeFactory);

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
@@ -29,6 +29,7 @@ namespace ILCompiler
                 new LibraryInitializerInfo("System.Private.Reflection.Execution"),
                 new LibraryInitializerInfo("System.Private.DeveloperExperience.Console"),
                 new LibraryInitializerInfo("System.Private.Interop"),
+                new LibraryInitializerInfo("System.Private.StackTraceMetadata"),
             };
 
         private List<MethodDesc> _libraryInitializerMethods;

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -37,7 +37,6 @@ namespace ILCompiler
         protected readonly CompilationModuleGroup _compilationModuleGroup;
         protected readonly CompilerTypeSystemContext _typeSystemContext;
         protected readonly MetadataBlockingPolicy _blockingPolicy;
-        protected readonly StackTraceEmissionPolicy _stackTraceEmissionPolicy;
 
         private List<NonGCStaticsNode> _cctorContextsGenerated = new List<NonGCStaticsNode>();
         private HashSet<TypeDesc> _typesWithEETypesGenerated = new HashSet<TypeDesc>();
@@ -53,12 +52,11 @@ namespace ILCompiler
         internal DynamicInvokeTemplateDataNode DynamicInvokeTemplateData { get; private set; }
         public virtual bool SupportsReflection => true;
 
-        public MetadataManager(CompilationModuleGroup compilationModuleGroup, CompilerTypeSystemContext typeSystemContext, MetadataBlockingPolicy blockingPolicy, StackTraceEmissionPolicy stackTraceEmissionPolicy)
+        public MetadataManager(CompilationModuleGroup compilationModuleGroup, CompilerTypeSystemContext typeSystemContext, MetadataBlockingPolicy blockingPolicy)
         {
             _compilationModuleGroup = compilationModuleGroup;
             _typeSystemContext = typeSystemContext;
             _blockingPolicy = blockingPolicy;
-            _stackTraceEmissionPolicy = stackTraceEmissionPolicy;
         }
 
         public void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
@@ -145,10 +143,10 @@ namespace ILCompiler
 #if !CORERT
             var stackTraceEmbeddedMetadataNode = new StackTraceEmbeddedMetadataNode();
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.BlobIdStackTraceEmbeddedMetadata), stackTraceEmbeddedMetadataNode, stackTraceEmbeddedMetadataNode, stackTraceEmbeddedMetadataNode.EndSymbol);
+#endif
 
             var stackTraceMethodMappingNode = new StackTraceMethodMappingNode();
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.BlobIdStackTraceMethodRvaToTokenMapping), stackTraceMethodMappingNode, stackTraceMethodMappingNode, stackTraceMethodMappingNode.EndSymbol);
-#endif
             
             // The external references tables should go last
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.CommonFixupsTable), commonFixupsTableNode, commonFixupsTableNode, commonFixupsTableNode.EndSymbol);

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -50,6 +50,7 @@ namespace ILCompiler
         private readonly Lazy<MetadataLoadedInfo> _loadedMetadata;
         private Lazy<Dictionary<MethodDesc, MethodDesc>> _dynamicInvokeStubs;
         private readonly byte[] _metadataBlob;
+        private readonly StackTraceEmissionPolicy _stackTraceEmissionPolicy;
         private byte[] _stackTraceBlob;
 
         public PrecomputedMetadataManager(
@@ -60,7 +61,7 @@ namespace ILCompiler
             IEnumerable<ModuleDesc> inputMetadataOnlyAssemblies,
             byte[] metadataBlob,
             StackTraceEmissionPolicy stackTraceEmissionPolicy)
-            : base(group, typeSystemContext, new AttributeSpecifiedBlockingPolicy(), stackTraceEmissionPolicy)
+            : base(group, typeSystemContext, new AttributeSpecifiedBlockingPolicy())
         {
             _metadataDescribingModule = metadataDescribingModule;
             _compilationModules = new HashSet<ModuleDesc>(compilationModules);
@@ -68,6 +69,7 @@ namespace ILCompiler
             _loadedMetadata = new Lazy<MetadataLoadedInfo>(LoadMetadata);
             _dynamicInvokeStubs = new Lazy<Dictionary<MethodDesc, MethodDesc>>(LoadDynamicInvokeStubs);
             _metadataBlob = metadataBlob;
+            _stackTraceEmissionPolicy = stackTraceEmissionPolicy;
         }
 
         /// <summary>
@@ -866,7 +868,7 @@ namespace ILCompiler
                         Method = record,
                     };
                     methodInst.GenericTypeArguments.Capacity = methodToGenerateMetadataFor.Instantiation.Length;
-                    foreach (Internal.TypeSystem.Ecma.EcmaGenericParameter typeArgument in methodToGenerateMetadataFor.Instantiation)
+                    foreach (EcmaGenericParameter typeArgument in methodToGenerateMetadataFor.Instantiation)
                     {
                         var genericParam = new TypeReference
                         {

--- a/src/ILCompiler.Compiler/src/Compiler/StackTraceEmissionPolicy.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/StackTraceEmissionPolicy.cs
@@ -21,4 +21,16 @@ namespace ILCompiler
             return false;
         }
     }
+
+    /// <summary>
+    /// Stack trace emission policy that ensures presence of stack trace metadata for all
+    /// <see cref="Internal.TypeSystem.Ecma.EcmaMethod"/>-based methods.
+    /// </summary>
+    public class EcmaMethodStackTraceEmissionPolicy : StackTraceEmissionPolicy
+    {
+        public override bool ShouldIncludeMethod(MethodDesc method)
+        {
+            return method.GetTypicalMethodDefinition() is Internal.TypeSystem.Ecma.EcmaMethod;
+        }
+    }
 }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Type.cs
@@ -32,8 +32,6 @@ namespace ILCompiler.Metadata
 
         public override MetadataRecord HandleType(Cts.TypeDesc type)
         {
-            Debug.Assert(!IsBlocked(type));
-
             MetadataRecord rec;
             if (_types.TryGet(type, out rec))
             {
@@ -78,6 +76,7 @@ namespace ILCompiler.Metadata
                             var metadataType = (Cts.MetadataType)type;
                             if (_policy.GeneratesMetadata(metadataType))
                             {
+                                Debug.Assert(!_policy.IsBlocked(metadataType));
                                 rec = _types.Create(metadataType, _initTypeDef ?? (_initTypeDef = InitializeTypeDef));
                             }
                             else

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -42,6 +42,7 @@ namespace ILCompiler
         private bool _useSharedGenerics;
         private bool _useScanner;
         private bool _noScanner;
+        private bool _emitStackTraceData;
         private string _mapFileName;
         private string _metadataLogFileName;
 
@@ -142,6 +143,7 @@ namespace ILCompiler
                 syntax.DefineOption("scan", ref _useScanner, "Use IL scanner to generate optimized code (implied by -O)");
                 syntax.DefineOption("noscan", ref _noScanner, "Do not use IL scanner to generate optimized code");
                 syntax.DefineOption("ildump", ref _ilDump, "Dump IL assembly listing for compiler-generated IL");
+                syntax.DefineOption("stacktracedata", ref _emitStackTraceData, "Emit data to support generating stack trace strings at runtime");
 
                 syntax.DefineOption("targetarch", ref _targetArchitectureStr, "Target architecture for cross compilation");
                 syntax.DefineOption("targetos", ref _targetOSStr, "Target OS for cross compilation");
@@ -388,7 +390,14 @@ namespace ILCompiler
             DependencyTrackingLevel trackingLevel = _dgmlLogFileName == null ?
                 DependencyTrackingLevel.None : (_generateFullDgmlLog ? DependencyTrackingLevel.All : DependencyTrackingLevel.First);
 
-            CompilerGeneratedMetadataManager metadataManager = new CompilerGeneratedMetadataManager(compilationGroup, typeSystemContext, _metadataLogFileName);
+            var stackTracePolicy = _emitStackTraceData ?
+                (StackTraceEmissionPolicy)new EcmaMethodStackTraceEmissionPolicy() : new NoStackTraceEmissionPolicy();
+
+            CompilerGeneratedMetadataManager metadataManager = new CompilerGeneratedMetadataManager(
+                compilationGroup,
+                typeSystemContext,
+                _metadataLogFileName,
+                stackTracePolicy);
 
             builder
                 .UseBackendOptions(_codegenOptions)

--- a/src/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
+++ b/src/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
@@ -15,6 +15,14 @@ using Internal.TypeSystem;
 
 using MethodSignature = Internal.Metadata.NativeFormat.MethodSignature;
 
+#if BIT64
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+
 namespace Internal.StackTraceMetadata
 {
     /// <summary>
@@ -46,7 +54,7 @@ namespace Internal.StackTraceMetadata
         public static string GetMethodNameFromStartAddressIfAvailable(IntPtr methodStartAddress)
         {
             IntPtr moduleStartAddress = RuntimeAugments.GetOSModuleFromPointer(methodStartAddress);
-            int rva = (int)(methodStartAddress.ToInt64() - moduleStartAddress.ToInt64());
+            int rva = (int)((nuint)methodStartAddress - (nuint)moduleStartAddress);
             foreach (TypeManagerHandle handle in ModuleList.Enumerate())
             {
                 if (handle.OsModuleBase == moduleStartAddress)
@@ -176,7 +184,11 @@ namespace Internal.StackTraceMetadata
                 uint rvaToTokenMapBlobSize;
                 
                 if (nativeFormatModuleInfo.TryFindBlob(
+#if PROJECTN
                         (int)ReflectionMapBlob.BlobIdStackTraceEmbeddedMetadata,
+#else
+                        (int)ReflectionMapBlob.EmbeddedMetadata,
+#endif
                         out metadataBlob,
                         out metadataBlobSize) &&
                     nativeFormatModuleInfo.TryFindBlob(
@@ -189,7 +201,7 @@ namespace Internal.StackTraceMetadata
                     // RVA to token map consists of pairs of integers (method RVA - token)
                     int rvaToTokenMapEntryCount = (int)(rvaToTokenMapBlobSize / (2 * sizeof(int)));
                     _methodRvaToTokenMap = new Dictionary<int, int>(rvaToTokenMapEntryCount);
-                    PopulateRvaToTokenMap((int *)rvaToTokenMapBlob, rvaToTokenMapEntryCount);
+                    PopulateRvaToTokenMap(handle, (int *)rvaToTokenMapBlob, rvaToTokenMapEntryCount);
                 }
             }
             
@@ -199,11 +211,17 @@ namespace Internal.StackTraceMetadata
             /// </summary>
             /// <param name="rvaToTokenMap">List of RVA - token pairs</param>
             /// <param name="entryCount">Number of the RVA - token pairs in the list</param>
-            private unsafe void PopulateRvaToTokenMap(int *rvaToTokenMap, int entryCount)
+            private unsafe void PopulateRvaToTokenMap(TypeManagerHandle handle, int *rvaToTokenMap, int entryCount)
             {
                 for (int entryIndex = 0; entryIndex < entryCount; entryIndex++)
                 {
+#if PROJECTN
                     int methodRva = rvaToTokenMap[2 * entryIndex + 0];
+#else
+                    int* pRelPtr32 = &rvaToTokenMap[2 * entryIndex + 0];
+                    IntPtr pointer = (IntPtr)((byte*)pRelPtr32 + *pRelPtr32);
+                    int methodRva = (int)((nuint)pointer - (nuint)handle.OsModuleBase);
+#endif
                     int token = rvaToTokenMap[2 * entryIndex + 1];
                     _methodRvaToTokenMap[methodRva] = token;
                 }


### PR DESCRIPTION
The stack trace metadata supplements reflection metadata to provide information about method names in stack traces (ex. obtained from `Exception.StackTrace` at runtime). I made the emission optional in the compiler. Enabling emission of this data increases the size of a HelloWord-style app by about 300 kB.

In this change:
* Actual emission of the data in the compiler. This is done by checking what compiled method bodies don't have reflection information and generating metadata for those.
* Making the mapping table cross platform. The Project X/N version of this emits `ADDR32NB` relocs (RVA) that are Windows-only. I'm switching to `RELPTR32` outside of N/X.
* Enabling S.P.StackTraceMetadata library initializer to run at startup to register a callback from CoreLib.
* Weakening an assert in MetadataTransfor to prevent generation of definition metadata for blocked types. We would have probably done this anyway with the work to enable poking random holes into metadata blocking.