### PR TITLE
Port EventSource nuget package change

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventProvider.cs
@@ -149,7 +149,7 @@ namespace System.Diagnostics.Tracing
             status = EventRegister(eventSource, m_etwCallback);
             if (status != 0)
             {
-#if PLATFORM_WINDOWS
+#if PLATFORM_WINDOWS && !ES_BUILD_STANDALONE
                 throw new ArgumentException(Interop.Kernel32.GetMessage(unchecked((int)status)));
 #else
                 throw new ArgumentException(Convert.ToString(unchecked((int)status)));


### PR DESCRIPTION
This change was merged into CoreFx and then automatically sunk to CoreCLR.  Because of limitations in the mirror, this won't make it to CoreRT.

@safern is looking into fix this, but until then, we just need to manually submit it here (and then close the PR that gets created in CoreCLR for this change since it will be a no-op).