### PR TITLE
Clashing assemblies names fix

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -49,6 +49,10 @@
   <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(BuildTasksPath)" />
   <Target Name="_ComputeAssembliesToCompileToNative">
 
+    <!-- CoreRT SDK and Framework Assemblies need to be defined to avoid CoreCLR implementations being set as compiler inputs -->  
+    <Error Condition="'@(PrivateSdkAssemblies)' == ''" Text="The PrivateSdkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
+    <Error Condition="'@(FrameworkAssemblies)' == ''" Text="The FrameworkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
+
     <ComputeManagedAssemblies Assemblies="@(ResolvedAssembliesToPublish)" 
     DotNetAppHostExecutableName="$(_DotNetAppHostExecutableName)" DotNetHostFxrLibraryName="$(_DotNetHostFxrLibraryName)" DotNetHostPolicyLibraryName="$(_DotNetHostPolicyLibraryName)"
     SdkAssemblies="@(PrivateSdkAssemblies)" FrameworkAssemblies="@(FrameworkAssemblies)">

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -67,8 +67,15 @@ See the LICENSE file in the project root for more information.
   </PropertyGroup>
 
   <ItemGroup>
-    <DefaultFrameworkAssemblies Include="$(IlcPath)\sdk\*.dll" />
-    <DefaultFrameworkAssemblies Include="$(IlcPath)\framework\*.dll" />
+    <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <FrameworkAssemblies Include="$(IlcPath)\framework\*.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
+    <DefaultFrameworkAssemblies Include="@(PrivateSdkAssemblies)" />
   </ItemGroup>
 
   <Target Name="ComputeIlcCompileInputs">


### PR DESCRIPTION
Fixes an issue, introduced by #4870, which occurs when trying to load CoreRT-specific assemblies. 

If clashing with a CoreCLR assembly, the one passed first would be taken as input to the ILCompiler, causing type loading errors, e.g. looking for an ILGenerator in System.Reflection.Emit if the incorrect version of  System.Linq.Expressions.LambaCompiler.dll is loaded.