### PR TITLE
Enable LibraryInitializer for CoreCLR

### DIFF
--- a/src/System.Private.Interop/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/System.Private.Interop/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -20,7 +20,7 @@ namespace Internal.Runtime.CompilerHelpers
     {
         public static void InitializeLibrary()
         {
-#if PROJECTN
+#if PROJECTN || CORECLR
             __vtable_IUnknown.Initialize();
             McgModuleManager.Initialize();
 #endif

--- a/src/System.Private.Interop/src/Shared/ComCallableObject.cs
+++ b/src/System.Private.Interop/src/Shared/ComCallableObject.cs
@@ -1109,7 +1109,7 @@ namespace System.Runtime.InteropServices
         internal static void InitRefCountedHandleCallback()
         {
             // TODO: <https://github.com/dotnet/corert/issues/1596>
-#if PROJECTN
+#if PROJECTN || CORECLR
             //
             // Register the callback to ref-counted handles
             // Inside this callback we'll determine whether the ref count handle to the target object


### PR DESCRIPTION
Jan's previous change(Define CORERT for ProjectN builds ) replaced !CoreRT with ProjectN for the following files, which accidently break CoreCLR behavior.