### PR TITLE
Fix CppCodeGen break with latest XCode

### DIFF
--- a/src/Common/src/Internal/NativeFormat/NativeFormatReader.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormatReader.cs
@@ -390,7 +390,7 @@ namespace Internal.NativeFormat
             }
             set
             {
-                Debug.Assert(value >= 0 && value < _reader.Size);
+                Debug.Assert(value < _reader.Size);
                 _offset = value;
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -525,7 +525,7 @@ namespace System.Diagnostics.Tracing
             /// </summary>
             private static unsafe void WriteNibble(ref byte* ptr, byte* endPtr, uint value)
             {
-                Debug.Assert(0 <= value && value < 16);
+                Debug.Assert(value < 16);
                 Debug.Assert(ptr < endPtr);
 
                 if (*ptr != 0)

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -729,7 +729,7 @@ namespace System
             {
                 throw new OverflowException(SR.Overflow_Byte, e);
             }
-            if (temp < Byte.MinValue || temp > Byte.MaxValue) throw new OverflowException(SR.Overflow_Byte);
+            if (temp != (byte)temp) throw new OverflowException(SR.Overflow_Byte);
             return (byte)temp;
         }
 
@@ -749,7 +749,7 @@ namespace System
             {
                 throw new OverflowException(SR.Overflow_SByte, e);
             }
-            if (temp < SByte.MinValue || temp > SByte.MaxValue) throw new OverflowException(SR.Overflow_SByte);
+            if (temp != (sbyte)temp) throw new OverflowException(SR.Overflow_SByte);
             return (sbyte)temp;
         }
 
@@ -768,7 +768,7 @@ namespace System
             {
                 throw new OverflowException(SR.Overflow_Int16, e);
             }
-            if (temp < Int16.MinValue || temp > Int16.MaxValue) throw new OverflowException(SR.Overflow_Int16);
+            if (temp != (short)temp) throw new OverflowException(SR.Overflow_Int16);
             return (short)temp;
         }
 
@@ -842,7 +842,7 @@ namespace System
             {
                 throw new OverflowException(SR.Overflow_UInt16, e);
             }
-            if (temp < UInt16.MinValue || temp > UInt16.MaxValue) throw new OverflowException(SR.Overflow_UInt16);
+            if (temp != (ushort)temp) throw new OverflowException(SR.Overflow_UInt16);
             return (ushort)temp;
         }
 

--- a/tests/src/Simple/PInvoke/PInvokeNative.cpp
+++ b/tests/src/Simple/PInvoke/PInvokeNative.cpp
@@ -147,12 +147,13 @@ DLL_EXPORT int __stdcall VerifyAnsiString(char *val)
     return CompareAnsiString(val, "Hello World");
 }
 
-void CopyAnsiString(char *dst, char *src)
+void CopyAnsiString(char *dst, const char *src)
 {
     if (src == NULL || dst == NULL)
         return;
 
-    char *p = dst, *q = src;
+    const char *q = src;
+    char *p = dst;
     while (*q)
     {
         *p++ = *q++;
@@ -470,7 +471,7 @@ DLL_EXPORT void __stdcall StructTest_ByRef(NativeSequentialStruct *nss)
     nss->b++;
 
     char *p = nss->str;
-    while (*p != NULL)
+    while (*p != '\0')
     {
         *p = *p + 1;
         p++;


### PR DESCRIPTION
Latest XCode errors on ordered comparison of pointer with integer

Also, fixed some unnecessary always-true comparisons that the C++ compiler emitted warnings for.