### PR TITLE
Implement efficient/correct Comparer.get_Default and EqualityComparer.get_Default

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ComparerIntrinsics.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ComparerIntrinsics.cs
@@ -1,0 +1,216 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Intrinsic support arround EqualityComparer&lt;T&gt; and Comparer&lt;T&gt;.
+    /// </summary>
+    public static class ComparerIntrinsics
+    {
+        /// <summary>
+        /// Generates a specialized method body for Comparer`1.Create or returns null if no specialized body can be generated.
+        /// </summary>
+        public static MethodIL EmitComparerCreate(MethodDesc target)
+        {
+            return EmitComparerAndEqualityComparerCreateCommon(target, "Comparer", "IComparable`1");
+        }
+
+        /// <summary>
+        /// Generates a specialized method body for EqualityComparer`1.Create or returns null if no specialized body can be generated.
+        /// </summary>
+        public static MethodIL EmitEqualityComparerCreate(MethodDesc target)
+        {
+            return EmitComparerAndEqualityComparerCreateCommon(target, "EqualityComparer", "IEquatable`1");
+        }
+
+        /// <summary>
+        /// Gets the concrete type EqualityComparer`1.Create returns or null if it's not known at compile time.
+        /// </summary>
+        public static TypeDesc GetEqualityComparerForType(TypeDesc comparand)
+        {
+            return GetComparerForType(comparand, "EqualityComparer", "IEquatable`1");
+        }
+
+        private static MethodIL EmitComparerAndEqualityComparerCreateCommon(MethodDesc methodBeingGenerated, string flavor, string interfaceName)
+        {
+            // We expect the method to be fully instantiated
+            Debug.Assert(!methodBeingGenerated.IsTypicalMethodDefinition);
+
+            TypeDesc owningType = methodBeingGenerated.OwningType;
+            TypeDesc comparedType = owningType.Instantiation[0];
+
+            // If the type is canonical, we use the default implementation provided by the class library.
+            // This will rely on the type loader to load the proper type at runtime.
+            if (comparedType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                return null;
+
+            TypeDesc comparerType = GetComparerForType(comparedType, flavor, interfaceName);
+            Debug.Assert(comparerType != null);
+
+            ILEmitter emitter = new ILEmitter();
+            var codeStream = emitter.NewCodeStream();
+
+            codeStream.Emit(ILOpcode.newobj, emitter.NewToken(comparerType.GetParameterlessConstructor()));
+            codeStream.Emit(ILOpcode.dup);
+            codeStream.Emit(ILOpcode.stsfld, emitter.NewToken(owningType.GetKnownField("_default")));
+            codeStream.Emit(ILOpcode.ret);
+
+            return emitter.Link(methodBeingGenerated);
+        }
+
+        /// <summary>
+        /// Gets the comparer type that is suitable to compare instances of <paramref name="type"/>
+        /// or null if such comparer cannot be determined at compile time.
+        /// </summary>
+        private static TypeDesc GetComparerForType(TypeDesc type, string flavor, string interfaceName)
+        {
+            TypeSystemContext context = type.Context;
+
+            if (context.IsCanonicalDefinitionType(type, CanonicalFormKind.Any) ||
+                (type.IsRuntimeDeterminedSubtype && !type.HasInstantiation))
+            {
+                // The comparer will be determined at runtime. We can't tell the exact type at compile time.
+                return null;
+            }
+            else if (type.IsNullable)
+            {
+                TypeDesc nullableType = type.Instantiation[0];
+
+                if (context.IsCanonicalDefinitionType(nullableType, CanonicalFormKind.Universal))
+                {
+                    // We can't tell at compile time either.
+                    return null;
+                }
+                else if (ImplementsInterfaceOfSelf(nullableType, interfaceName))
+                {
+                    return context.SystemModule.GetKnownType("System.Collections.Generic", $"Nullable{flavor}`1")
+                        .MakeInstantiatedType(nullableType);
+                }
+            }
+            else if (flavor == "EqualityComparer" && type.IsEnum)
+            {
+                // Enums have a specialized comparer that avoids boxing
+                return context.SystemModule.GetKnownType("System.Collections.Generic", $"Enum{flavor}`1")
+                    .MakeInstantiatedType(type);
+            }
+            else if (ImplementsInterfaceOfSelf(type, interfaceName))
+            {
+                return context.SystemModule.GetKnownType("System.Collections.Generic", $"Generic{flavor}`1")
+                    .MakeInstantiatedType(type);
+            }
+
+            return context.SystemModule.GetKnownType("System.Collections.Generic", $"Object{flavor}`1")
+                    .MakeInstantiatedType(type);
+        }
+
+        public static TypeDesc[] GetPotentialComparersForType(TypeDesc type)
+        {
+            return GetPotentialComparersForTypeCommon(type, "Comparer", "IComparable`1");
+        }
+
+        public static TypeDesc[] GetPotentialEqualityComparersForType(TypeDesc type)
+        {
+            return GetPotentialComparersForTypeCommon(type, "EqualityComparer", "IEquatable`1");
+        }
+
+        /// <summary>
+        /// Gets the set of template types needed to support loading comparers for the give canonical type at runtime.
+        /// </summary>
+        private static TypeDesc[] GetPotentialComparersForTypeCommon(TypeDesc type, string flavor, string interfaceName)
+        {
+            Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
+
+            TypeDesc exactComparer = GetComparerForType(type, flavor, interfaceName);
+
+            if (exactComparer != null)
+            {
+                // If we have a comparer that is exactly known at runtime, we're done.
+                // This will typically be if type is a generic struct, generic enum, or a nullable.
+                return new TypeDesc[] { exactComparer };
+            }
+
+            TypeSystemContext context = type.Context;
+
+            if (context.IsCanonicalDefinitionType(type, CanonicalFormKind.Universal))
+            {
+                // This can be any of the comparers we have.
+
+                ArrayBuilder<TypeDesc> universalComparers = new ArrayBuilder<TypeDesc>();
+
+                universalComparers.Add(context.SystemModule.GetKnownType("System.Collections.Generic", $"Nullable{flavor}`1")
+                        .MakeInstantiatedType(type));
+
+                if (flavor == "EqualityComparer")
+                    universalComparers.Add(context.SystemModule.GetKnownType("System.Collections.Generic", $"Enum{flavor}`1")
+                        .MakeInstantiatedType(type));
+
+                universalComparers.Add(context.SystemModule.GetKnownType("System.Collections.Generic", $"Generic{flavor}`1")
+                    .MakeInstantiatedType(type));
+
+                universalComparers.Add(context.SystemModule.GetKnownType("System.Collections.Generic", $"Object{flavor}`1")
+                    .MakeInstantiatedType(type));
+
+                return universalComparers.ToArray();
+            }
+            
+            // This mirrors exactly what GetUnknownEquatableComparer and GetUnknownComparer (in the class library)
+            // will need at runtime. This is the general purpose code path that can be used to compare
+            // anything.
+
+            if (type.IsNullable)
+            {
+                TypeDesc nullableType = type.Instantiation[0];
+
+                // This should only be reachabe for universal canon code.
+                // For specific canon, this should have been an exact match above.
+                Debug.Assert(context.IsCanonicalDefinitionType(nullableType, CanonicalFormKind.Universal));
+
+                return new TypeDesc[]
+                {
+                    context.SystemModule.GetKnownType("System.Collections.Generic", $"Nullable{flavor}`1")
+                        .MakeInstantiatedType(nullableType),
+                    context.SystemModule.GetKnownType("System.Collections.Generic", $"Object{flavor}`1")
+                        .MakeInstantiatedType(type),
+                };
+            }
+            
+            return new TypeDesc[]
+            {
+                context.SystemModule.GetKnownType("System.Collections.Generic", $"Generic{flavor}`1")
+                    .MakeInstantiatedType(type),
+                context.SystemModule.GetKnownType("System.Collections.Generic", $"Object{flavor}`1")
+                    .MakeInstantiatedType(type),
+            };
+        }
+
+        private static bool ImplementsInterfaceOfSelf(TypeDesc type, string interfaceName)
+        {
+            MetadataType interfaceType = null;
+
+            foreach (TypeDesc implementedInterface in type.RuntimeInterfaces)
+            {
+                Instantiation interfaceInstantiation = implementedInterface.Instantiation;
+                if (interfaceInstantiation.Length == 1 &&
+                    interfaceInstantiation[0] == type)
+                {
+                    if (interfaceType == null)
+                        interfaceType = type.Context.SystemModule.GetKnownType("System", interfaceName);
+
+                    if (implementedInterface.GetTypeDefinition() == interfaceType)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -55,6 +55,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\AssemblyGetExecutingAssemblyMethodThunk.Sorting.cs">
       <Link>IL\Stubs\AssemblyGetExecutingAssemblyMethodThunk.Sorting.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\ComparerIntrinsics.cs">
+      <Link>IL\Stubs\ComparerIntrinsics.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DynamicInvokeMethodThunk.Sorting.cs">
       <Link>IL\Stubs\DynamicInvokeMethodThunk.Sorting.cs</Link>
     </Compile>

--- a/src/System.Private.CoreLib/src/Internal/IntrinsicSupport/ComparerHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/IntrinsicSupport/ComparerHelpers.cs
@@ -94,7 +94,7 @@ namespace Internal.IntrinsicSupport
             return RuntimeAugments.NewObject(comparerType);
         }
 
-        private static Comparer<T> GetUnknownComparer<T>()
+        internal static Comparer<T> GetUnknownComparer<T>()
         {
             return (Comparer<T>)GetComparer(typeof(T).TypeHandle);
         }

--- a/src/System.Private.CoreLib/src/Internal/IntrinsicSupport/EqualityComparerHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/IntrinsicSupport/EqualityComparerHelpers.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Internal.IntrinsicSupport;
 using Internal.Runtime.Augments;
@@ -106,7 +107,7 @@ namespace Internal.IntrinsicSupport
         //----------------------------------------------------------------------
         // target functions of intrinsic replacement in EqualityComparer.get_Default
         //----------------------------------------------------------------------
-        private static EqualityComparer<T> GetUnknownEquatableComparer<T>()
+        internal static EqualityComparer<T> GetUnknownEquatableComparer<T>()
         {
             return (EqualityComparer<T>)GetComparer(typeof(T).TypeHandle);
         }
@@ -136,6 +137,7 @@ namespace Internal.IntrinsicSupport
         //-----------------------------------------------------------------------
 
         // This one is an intrinsic that is used to make enum comparisions more efficient.
+        [Intrinsic]
         internal static bool EnumOnlyEquals<T>(T x, T y) where T : struct
         {
             return x.Equals(y);

--- a/src/System.Private.CoreLib/src/System/Collections/Generic/Comparer.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/Comparer.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Runtime.CompilerServices;
+
+using Internal.IntrinsicSupport;
 
 namespace System.Collections.Generic
 {
@@ -26,8 +26,10 @@ namespace System.Collections.Generic
             // instantiation-specific implementation.
             throw new NotSupportedException();
 #else
-            // CORERT: TODO: https://github.com/dotnet/corert/issues/763
-            return (_default = new DefaultComparer<T>());
+            // The compiler will overwrite the Create method with optimized
+            // instantiation-specific implementation.
+            // This body serves as a fallback when instantiation-specific implementation is unavailable.
+            return (_default = ComparerHelpers.GetUnknownComparer<T>());
 #endif
         }
 

--- a/src/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.cs
@@ -73,6 +73,7 @@ namespace System.Collections.Generic
         }
     }
 
+#if false
     internal sealed class DefaultEqualityComparer<T> : EqualityComparer<T>
     {
         public DefaultEqualityComparer()
@@ -112,4 +113,5 @@ namespace System.Collections.Generic
         // This needs to use GetType instead of typeof to avoid infinite recursion in the type loader
         public sealed override int GetHashCode() => GetType().GetHashCode();
     }
+#endif
 }

--- a/src/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-using System;
-using System.Collections;
 using System.Runtime.CompilerServices;
+
+using Internal.IntrinsicSupport;
 
 namespace System.Collections.Generic
 {
@@ -27,8 +27,10 @@ namespace System.Collections.Generic
             // instantiation-specific implementation.
             throw new NotSupportedException();
 #else
-            // CORERT: TODO: https://github.com/dotnet/corert/issues/763
-            return (_default = new DefaultEqualityComparer<T>());
+            // The compiler will overwrite the Create method with optimized
+            // instantiation-specific implementation.
+            // This body serves as a fallback when instantiation-specific implementation is unavailable.
+            return (_default = EqualityComparerHelpers.GetUnknownEquatableComparer<T>());
 #endif
         }
 
@@ -38,6 +40,7 @@ namespace System.Collections.Generic
 
         public static EqualityComparer<T> Default
         {
+            [Intrinsic]
             get
             {
                 // Lazy initialization produces smaller code for CoreRT than initialization in constructor

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -66,6 +66,7 @@
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\AddrOfIntrinsic.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\ArrayMethodILEmitter.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\CalliIntrinsic.cs" />
+    <Compile Include="$(TypeSystemBasePath)\IL\Stubs\ComparerIntrinsics.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\DelegateMarshallingMethodThunk.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\ForwardDelegateCreationThunk.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\EETypePtrOfIntrinsic.cs" />


### PR DESCRIPTION
This work has several parts that largely hook up into the existing infrastructure in the class library we built for Project N.

1. Generate specialized method bodies for Comparer.Create and EqualityComparer.Create that create the right comparer specialized for the given T (if T implement the interface, doesn't implement the interface, is nullable, or is an enum)
2. If specialization is not possible at compile time, fall back to using template type loader to load the right type.
3. Add code that ensures appropriate templates get generated. This is a bit of a divergence from what Project N does because there we don't track precisely what we need and rely on universal shared code to fill in the blanks.
4. Enable RyuJIT optimization around EqualityComparer.get_Default that lets us devirtualize subsequent calls on the result of the intrinsic.