### PR TITLE
Fix direction of variance check in delegate assignment

### DIFF
--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -1003,12 +1003,12 @@ again:
 
             for (int i = 0; i < ftnSignature.Length; i++)
             {
-                if (!IsAssignable(ftnSignature[i], delegateSignature[i]))
+                if (!IsAssignable(delegateSignature[i], ftnSignature[i]))
                     return false;
             }
 
             // Compare return type
-            return IsAssignable(delegateSignature.ReturnType, ftnSignature.ReturnType);
+            return IsAssignable(ftnSignature.ReturnType, delegateSignature.ReturnType);
         }
 
         ILOpcode GetOpcodeAt(int instructionOffset)

--- a/src/ILVerify/src/ILVerify.csproj
+++ b/src/ILVerify/src/ILVerify.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <CLSCompliant>false</CLSCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/ILVerify/tests/ILMethodTester.cs
+++ b/src/ILVerify/tests/ILMethodTester.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using Internal.IL;
 using Internal.TypeSystem.Ecma;
@@ -60,7 +61,8 @@ namespace ILVerify.Tests
 
                 foreach (var item in invalidIL.ExpectedVerifierErrors)
                 {
-                    Assert.True(verifierErrors.Contains(item));
+                    var actual = verifierErrors.Select(e => e.ToString());
+                    Assert.True(verifierErrors.Contains(item), $"Actual errors where: {string.Join(',', actual)}");
                 }
             }
         }

--- a/src/ILVerify/tests/ILTests/DelegateTests.il
+++ b/src/ILVerify/tests/ILTests/DelegateTests.il
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly DelegateTests
+{
+}
+
+.class private auto ansi beforefieldinit C
+       extends [System.Runtime]System.Object
+{
+    // assignment from Func<int, string> to Func<int, object> is valid
+    .method private hidebysig instance class [System.Runtime]System.Func`2<int32,object>
+          DelegateAssignmentReturn_Valid(class [System.Runtime]System.Func`2<int32,string> input) cil managed
+    {
+        ldarg.1
+        ret
+    }
+
+    // assignment from Func<object, int> to Func<string, int> is valid
+    .method private hidebysig instance class [System.Runtime]System.Func`2<string,int32>
+          DelegateAssignmentParameter_Valid(class [System.Runtime]System.Func`2<object,int32> input) cil managed
+    {
+        ldarg.1
+        ret
+    }
+
+    // assignment from Func<string, int> to Func<object, int> is invalid
+    .method private hidebysig instance class [System.Runtime]System.Func`2<object,int32>
+          DelegateAssignmentParameter_Invalid_StackUnexpected(class [System.Runtime]System.Func`2<string,int32> input) cil managed
+    {
+        ldarg.1
+        ret
+    }
+
+    // assignment from Func<int, object> to Func<int, string> is invalid
+    .method private hidebysig instance class [System.Runtime]System.Func`2<int32,string>
+          DelegateAssignment_Invalid_StackUnexpected(class [System.Runtime]System.Func`2<int32,object> input) cil managed
+    {
+        ldarg.1
+        ret
+    }
+
+    .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+    {
+        call       instance void [System.Runtime]System.Object::.ctor()
+        nop
+        ret
+    }
+}

--- a/src/ILVerify/tests/ILTests/DelegateTests.il
+++ b/src/ILVerify/tests/ILTests/DelegateTests.il
@@ -48,8 +48,8 @@
     .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
     {
+        ldarg.0
         call       instance void [System.Runtime]System.Object::.ctor()
-        nop
         ret
     }
 }


### PR DESCRIPTION
I found this problem while debugging the integration of ILVerify into Roslyn. I copied the involved C# code below, but essentially, the usage of delegate returned by `Bar` (which is a `Func<int, string>`) in a `Func<int, object>`.
ILVerify previously thought that is illegal because it treated the return type `string` as the destination and `object` as the source for an assignment. But, actually, `string` is the source, and `object` is the destination.
The arguments are also in the wrong order (although in the other order).

I'm happy to add a unittest, but was unable to run tests so far. 
In Test Explorer, I get `Message: System.InvalidOperationException : No data found for ILVerify.Tests.ILMethodTester.TestMethodsWithInvalidIL`.
I've compiled some IL files in `repos\corert\src\ILVerify\tests\ILTests` (for example, with `ilasm AccessTests.il /dll /ERROR`), but the test runner doesn't detect the resulting assembly somehow. Not debugged yet.

Also, I'm setting the project to target AnyCPU, which helps for integration with Roslyn.

```C#
using System;
using System.Collections.Generic;
using System.Text;
using System.Threading;
using System.Threading.Tasks;

class TestCase
{
    static int test = 0;
    static int count = 0;

    public static async Task Run()
    {
        try
        {
            test++;
            var f = new Func<int, object>(checked(await Bar()));
            var x = f(1);
            if ((string)x != ""1"")
                count--;
        }
        finally
        {
            Driver.Result = test - count;
            Driver.CompleteSignal.Set();
        }
    }
    static async Task<Converter<int, string>> Bar()
    {
        count++;
        await Task.Delay(1);

        return delegate(int p1) { return p1.ToString(); };
    }
}

class Driver
{
    static public AutoResetEvent CompleteSignal = new AutoResetEvent(false);
    public static int Result = -1;
    public static void Main()
    {
        TestCase.Run();
        CompleteSignal.WaitOne();

        Console.Write(Result);
    }
}
```

Tagging @jkotas @ArztSamuel @VSadov 