### PR TITLE
[ILVerify] Fix assembly friend access being sensitive to white-spaces

### DIFF
--- a/src/ILVerify/src/AccessVerificationHelpers.cs
+++ b/src/ILVerify/src/AccessVerificationHelpers.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;

--- a/src/ILVerify/src/AccessVerificationHelpers.cs
+++ b/src/ILVerify/src/AccessVerificationHelpers.cs
@@ -262,15 +262,19 @@ namespace ILVerify
 
             foreach (var attribute in assembly.GetDecodedCustomAttributes("System.Runtime.CompilerServices", "InternalsVisibleToAttribute"))
             {
-                var friendValues = ((string)attribute.FixedArguments[0].Value).Split(new string[] { ", " }, StringSplitOptions.None);
+                var friendValues = ((string)attribute.FixedArguments[0].Value).Split(',');
                 if (friendValues.Length >= 1 && friendValues.Length <= 2)
                 {
-                    if (friendValues[0] != friendName.Name)
+                    string friendToName = friendValues[0].Trim();
+                    if (friendToName != friendName.Name)
                         continue;
 
-                    if (friendValues.Length == 2 &&
-                        (!friendValues[1].StartsWith(PUBLIC_KEY) || !IsSamePublicKey(friendPublicKey, friendValues[1].Substring(PUBLIC_KEY.Length))))
-                        continue;
+                    if (friendValues.Length == 2)
+                    {
+                        string friendToPublicKey = friendValues[1].Trim();
+                        if (!friendToPublicKey.StartsWith(PUBLIC_KEY) || !IsSamePublicKey(friendPublicKey, friendToPublicKey.Substring(PUBLIC_KEY.Length)))
+                            continue;
+                    }
 
                     return true;
                 }

--- a/src/ILVerify/tests/ILTests/AccessTestsExtern.il
+++ b/src/ILVerify/tests/ILTests/AccessTestsExtern.il
@@ -10,7 +10,11 @@
 {
 }
 
-.assembly AccessTestsExternal
+.assembly extern AccessTestsFriend
+{
+}
+
+.assembly AccessTestsExtern
 {
 }
 
@@ -100,6 +104,13 @@
     .method public hidebysig instance void Call.FamAndAssemMethod_Invalid_MethodAccess() cil managed
     {
         call      void [AccessTests]SimpleClass::FamilyAndAssemblyMethod()
+        ret
+    }
+
+    .method private hidebysig instance void Load.AssemFieldOfFriendAssemblyWithSpace_Valid() cil managed
+    {
+        ldsfld       int32 [AccessTestsFriend]AccessTestsFriendType::assemblyField
+        pop
         ret
     }
 }

--- a/src/ILVerify/tests/ILTests/AccessTestsFriend.il
+++ b/src/ILVerify/tests/ILTests/AccessTestsFriend.il
@@ -16,6 +16,13 @@
     .custom instance void [System.Runtime]System.Runtime.CompilerServices.InternalsVisibleToAttribute::.ctor(string) = (
         01 00 0b 41 63 63 65 73 73 54 65 73 74 73 00 00
     )
+
+    // InternalsVisibleTo("AccessTestsExtern ")
+    //                                      ^ purposeful space at the end
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.InternalsVisibleToAttribute::.ctor(string) = (
+        01 00 12 41 63 63 65 73 73 54 65 73 74 73 45 78
+        74 65 72 6e 20 00 00
+    )
 }
 
 .class private auto ansi beforefieldinit AccessTestsFriendType


### PR DESCRIPTION
As described in #4938, ILVerify should not be sensitive to white-spaces when validating assembly friend access.

I could not find any clear definitions of allowed values for the string passed to the `InternalsVisibleToAttribute`. Are there any other rules I should consider (e.g. case insensitivity, etc.)?

This fixes #4938.

Tagging @jcouv @VSadov 