### PR TITLE
ILCompiler nuget package support

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Publish.json
+++ b/buildpipeline/DotNet-CoreRT-Publish.json
@@ -94,7 +94,7 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "",
-        "inlineScript": "if ($env:Configuration -ne \"Release\") { exit }\n\n& $env:Build_SourcesDirectory\\scripts\\DotNet-Trusted-Publish\\Embed-Index.ps1 `\n  $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\Microsoft.TargetingPack.Private.CoreRT\\$env:AzureContainerSymbolPackageGlob `\n  $env:Build_StagingDirectory\\IndexedSymbolPackages",
+        "inlineScript": "if ($env:Configuration -ne \"Release\") { exit }\n\n& $env:Build_SourcesDirectory\\scripts\\DotNet-Trusted-Publish\\Embed-Index.ps1 `\n  $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\$env:AzureContainerSymbolPackageGlob `\n  $env:Build_StagingDirectory\\IndexedSymbolPackages",
         "workingFolder": "",
         "failOnStandardError": "true"
       }
@@ -152,7 +152,7 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "$(MyGetApiKey)",
-        "inlineScript": "param($ApiKey)\nif ($env:Configuration -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\Microsoft.TargetingPack.Private.CoreRT\\$env:AzureContainerPackageGlob $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
+        "inlineScript": "param($ApiKey)\nif ($env:Configuration -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\$env:AzureContainerPackageGlob $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
         "workingFolder": "",
         "failOnStandardError": "true"
       }
@@ -192,7 +192,7 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "-gitHubAuthToken $(UpdatePublishedVersions.AuthToken) -root $(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($gitHubAuthToken, $root)\nif ($env:Configuration -ne \"Release\") { exit }\ncd $root\n. $root\\buildscripts\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo $env:VersionsRepo `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\Microsoft.TargetingPack.Private.CoreRT\\$env:AzureContainerPackageGlob",
+        "inlineScript": "param($gitHubAuthToken, $root)\nif ($env:Configuration -ne \"Release\") { exit }\ncd $root\n. $root\\buildscripts\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo $env:VersionsRepo `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\$env:AzureContainerPackageGlob",
         "workingFolder": "",
         "failOnStandardError": "true"
       }

--- a/dir.props
+++ b/dir.props
@@ -135,7 +135,7 @@
     <!-- Use the shared tools host and runtime for testing -->
     <TestHostRootPath Condition="'$(TestHostRootPath)' == ''">$(DotnetCliPath)</TestHostRootPath>
 
-    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(OSPlatformConfig)/$(MSBuildProjectName)/</PackageOutputPath>
+    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(OSPlatformConfig)/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
 
     <!-- Folder where we will drop the Nuget package for the toolchain -->

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.builds
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.builds
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="Microsoft.DotNet.ILCompiler.pkgproj" >
+      <OSGroup>Windows_NT</OSGroup>
+      <OSGroup>Linux</OSGroup>
+      <OSGroup>Mac</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -1,37 +1,31 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageTargetRuntime/>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <BaseLinePackageDependencies>false</BaseLinePackageDependencies>
     <PackagePlatforms>x64;</PackagePlatforms>
     <PreventImplementationReference>true</PreventImplementationReference>
     <SkipValidatePackage>true</SkipValidatePackage>
 
+    <!-- Override this property so that the package name won't look like runtime.[RID].[TFM].[ID] -->
+    <PackageTargetRuntime></PackageTargetRuntime>
   </PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(PackageSourceDirectory)ILCompiler\src\ILCompiler.csproj"/>
-    <ProjectReference Include="$(PackageSourceDirectory)ILCompiler.Compiler\src\ILCompiler.Compiler.csproj"/>
-    <ProjectReference Include="$(PackageSourceDirectory)ILCompiler.DependencyAnalysisFramework\src\ILCompiler.DependencyAnalysisFramework.csproj"/>
-    <ProjectReference Include="$(PackageSourceDirectory)ILCompiler.MetadataTransform\src\ILCompiler.MetadataTransform.csproj"/>
-    <ProjectReference Include="$(PackageSourceDirectory)ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj"/>
-    <ProjectReference Include="$(PackageSourceDirectory)ILCompiler.TypeSystem\src\ILCompiler.TypeSystem.csproj"/>
-
-    <Dependency Include="Microsoft.DotNet.ObjectWriter">
-      <Version>1.0.13-prerelease-00001</Version>
-    </Dependency>
-    <Dependency Include="Microsoft.NetCore.Jit">
-      <Version>1.2.0-beta-24815-03</Version>
-    </Dependency>
-    <Dependency Include="System.Collections.Immutable">
-      <Version>1.2.0</Version>
-    </Dependency>
-
-
+    <File Include="$(MSBuildThisFileDirectory)\Microsoft.DotNet.ILCompiler.targets" >
+      <TargetPath>build</TargetPath>
+    </File>
+    <File Include="$(PackageSourceDirectory)\BuildIntegration\*">
+      <TargetPath>targets</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\tools\*" Exclude="$(BaseOutputPath)\$(OSPlatformConfig)\tools\*.pdb">
+      <TargetPath>tools</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\*" Exclude="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\*.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\framework\*.dll">
+      <TargetPath>framework</TargetPath>
+    </File>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\src\dir.targets" />

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -6,6 +6,7 @@
     <PackagePlatforms>x64;</PackagePlatforms>
     <PreventImplementationReference>true</PreventImplementationReference>
     <SkipValidatePackage>true</SkipValidatePackage>
+    <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
 
     <!-- Override this property so that the package name won't look like runtime.[RID].[TFM].[ID] -->
     <PackageTargetRuntime></PackageTargetRuntime>
@@ -25,6 +26,23 @@
     </File>
     <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\framework\*.dll">
       <TargetPath>framework</TargetPath>
+    </File>
+
+    <!-- Workaround to avoid linker warnings - include all pdb files for static native libraries -->    
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapper.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrappercpp.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapperdll.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb">
+      <TargetPath>sdk</TargetPath>
     </File>
   </ItemGroup>
 

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-      <_ILCompilerRootDir>$(MSBuildThisFileDirectory)../</_ILCompilerRootDir>
-      <IlCompilerTargetsDir>$(_ILCompilerRootDir)targets/</IlCompilerTargetsDir>
+    <_ILCompilerRootDir>$(MSBuildThisFileDirectory)../</_ILCompilerRootDir>
+    <IlCompilerTargetsDir>$(_ILCompilerRootDir)targets/</IlCompilerTargetsDir>
   </PropertyGroup>
   <Import Project="$(IlCompilerTargetsDir)/Microsoft.NETCore.Native.targets"/>
 </Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+      <_ILCompilerRootDir>$(MSBuildThisFileDirectory)../</_ILCompilerRootDir>
+      <IlCompilerTargetsDir>$(_ILCompilerRootDir)targets/</IlCompilerTargetsDir>
+  </PropertyGroup>
+  <Import Project="$(IlCompilerTargetsDir)/Microsoft.NETCore.Native.targets"/>
+</Project>

--- a/pkg/packageIndex.json
+++ b/pkg/packageIndex.json
@@ -4,6 +4,10 @@
       "StableVersions": [],
       "BaselineVersion": "1.0.0",
     },
+    "Microsoft.DotNet.ILCompiler" : {
+      "StableVersions": [],
+      "BaselineVersion": "1.0.0",
+    },
     "Microsoft.TargetingPack.Private.CoreRT" : {
       "StableVersions": [],
       "BaselineVersion": "1.0.0",

--- a/pkg/packages.proj
+++ b/pkg/packages.proj
@@ -6,11 +6,13 @@
     <BuildAllOSGroups Condition="'$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)Microsoft.TargetingPack.Private.CoreRT\Microsoft.TargetingPack.Private.CoreRT.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
+  <ItemGroup Condition="'$(SkipManagedPackageBuild)' != 'true'">
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.TargetingPack.Private.CoreRT\Microsoft.TargetingPack.Private.CoreRT.builds" >
       <OSGroup>AnyOS</OSGroup>
     </Project>
-    <Project Include="$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler\Microsoft.DotNet.ILCompiler.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true'"/>
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler\Microsoft.DotNet.ILCompiler.builds" >
+    <OSGroup>AnyOS</OSGroup>
+    </Project>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/pkg/packages.proj
+++ b/pkg/packages.proj
@@ -1,20 +1,20 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-
+  
   <PropertyGroup>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
     <BuildAllOSGroups Condition="'$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SkipManagedPackageBuild)' != 'true'">
-    <Project Include="$(MSBuildThisFileDirectory)Microsoft.TargetingPack.Private.CoreRT\Microsoft.TargetingPack.Private.CoreRT.builds" >
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.TargetingPack.Private.CoreRT\Microsoft.TargetingPack.Private.CoreRT.builds">
       <OSGroup>AnyOS</OSGroup>
     </Project>
-    <Project Include="$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler\Microsoft.DotNet.ILCompiler.builds" >
-    <OSGroup>AnyOS</OSGroup>
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler\Microsoft.DotNet.ILCompiler.builds">
+      <OSGroup>AnyOS</OSGroup>
     </Project>
   </ItemGroup>
-
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>
 

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -22,9 +22,10 @@ See the LICENSE file in the project root for more information.
     <NativeCompilationDuringPublish Condition="'$(NativeCompilationDuringPublish)' == ''">true</NativeCompilationDuringPublish>
     <!-- Workaround for lack of current host OS detection - https://github.com/Microsoft/msbuild/issues/539 -->
     <TargetOS Condition="'$(TargetOS)' == '' and '$(OS)' == 'Unix' and Exists('/Applications')">OSX</TargetOS>
+    <!-- The correct OS detection code. Uncomment once CI machines are upgraded to the latest version of MSBuild -->
+    <!-- <TargetOS Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">OSX</TargetOS>  -->    
     <TargetOS Condition="'$(TargetOS)' == ''">$(OS)</TargetOS>
-    <!-- Detect whether we're running the ILCompiler from a package and if so override the environmental variable to point to the correct assemblies -->
-    <IlcPath Condition="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Microsoft.DotNet.ILCompiler.nuspec)) != ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Microsoft.DotNet.ILCompiler.nuspec))</IlcPath>
+    <IlcPath Condition="'$(IlcPath)' == ''"> $(MSBuildThisFileDirectory)/.. </IlcPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -130,8 +131,7 @@ See the LICENSE file in the project root for more information.
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp" Lines="@(IlcArg)" Overwrite="true" />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeObject)))" />
-        
-    <Error Condition="'$(IlcPath)' == ''" Text="The IlcPath environmental variable is required for target IlcCompile" />
+
     <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;" />
   </Target>
 

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -23,6 +23,8 @@ See the LICENSE file in the project root for more information.
     <!-- Workaround for lack of current host OS detection - https://github.com/Microsoft/msbuild/issues/539 -->
     <TargetOS Condition="'$(TargetOS)' == '' and '$(OS)' == 'Unix' and Exists('/Applications')">OSX</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == ''">$(OS)</TargetOS>
+    <!-- Detect whether we're running the ILCompiler from a package and if so override the environmental variable to point to the correct assemblies -->
+    <IlcPath Condition="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Microsoft.DotNet.ILCompiler.nuspec)) != ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Microsoft.DotNet.ILCompiler.nuspec))</IlcPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -128,7 +130,8 @@ See the LICENSE file in the project root for more information.
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp" Lines="@(IlcArg)" Overwrite="true" />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeObject)))" />
-
+        
+    <Error Condition="'$(IlcPath)' == ''" Text="The IlcPath environmental variable is required for target IlcCompile" />
     <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;" />
   </Target>
 


### PR DESCRIPTION
Below is a working implementation - CoreRT can be consumed by adding a 
```xml
 <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="X" /> 
```
where X is the version of the ILCompiler package produced by build-packages.cmd or once its published with 

```bat 
dotnet add package Microsoft.DotNet.ILCompiler
```

Ideally, I'd like to add the assemblies produced by the project references in `Microsoft.DotNet.ILCompiler.pkgproj` to have their `TargetPath` property overriden when creating this package specifically, but the paths seem to be dynamically generated somewhere in the compiler. Can anyone more familiar with the NuGet package publishing pipeline take a look?
Additionally, the implementation below doesn't include symbols for the framework, sdk and tools assemblies to the final package.