### PR TITLE
Implement ISpanFormattable on Decimal

### DIFF
--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -54,7 +54,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Explicit)]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public partial struct Decimal : IFormattable, IComparable, IConvertible, IComparable<Decimal>, IEquatable<Decimal>, IDeserializationCallback
+    public partial struct Decimal : IFormattable, IComparable, IConvertible, IComparable<Decimal>, IEquatable<Decimal>, IDeserializationCallback, ISpanFormattable
     {
         // Sign mask for the flags field. A value of zero in this bit indicates a
         // positive Decimal value, and a value of one in this bit indicates a


### PR DESCRIPTION
Opts `Decimal` in to the optimization in `StringBuilder.AppendFormat`.

Related: https://github.com/dotnet/coreclr/pull/15170