### PR TITLE
Improved System.Decimal performance

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -96,7 +96,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static decimal Abs(decimal value)
         {
-            return decimal.Abs(value);
+            return decimal.Abs(ref value);
         }
 
         [StackTraceHidden]
@@ -453,7 +453,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static decimal Max(decimal val1, decimal val2)
         {
-            return decimal.Max(val1, val2);
+            return decimal.Max(ref val1, ref val2);
         }
 
         public static double Max(double val1, double val2)
@@ -541,7 +541,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static decimal Min(decimal val1, decimal val2)
         {
-            return decimal.Min(val1, val2);
+            return decimal.Min(ref val1, ref val2);
         }
 
         public static double Min(double val1, double val2)

--- a/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -757,8 +757,13 @@ ThrowOverflow:
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static int LeadingZeroCount(uint value)
+            private static int LeadingZeroCount(uint value)
             {
+#if CORECLR
+                if (System.Runtime.Intrinsics.X86.Lzcnt.IsSupported)
+                    return (int)System.Runtime.Intrinsics.X86.Lzcnt.LeadingZeroCount(value);
+#endif
+
                 int c = 1;
                 if ((value & 0xFFFF0000) == 0)
                 {
@@ -1244,7 +1249,7 @@ ReturnResult:
                 return;
             }
 
-            #endregion
+#endregion
 
             //**********************************************************************
             // VarCyFromDec - Convert Currency to Decimal (similar to OleAut32 api.)
@@ -2423,7 +2428,7 @@ done:
                 return;
             }
 
-            #region Number Formatting helpers
+#region Number Formatting helpers
 
             private static uint D32DivMod1E9(uint hi32, ref uint lo32)
             {
@@ -2489,7 +2494,7 @@ done:
                 D32AddCarry(ref value.uhi, d.High);
             }
 
-            #endregion
+#endregion
 
             struct PowerOvfl
             {

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -666,46 +666,21 @@ namespace System
         // By default a mid-point value is rounded to the nearest even number. If the mode is
         // passed in, it can also round away from zero.
 
-        public static Decimal Round(Decimal d)
-        {
-            return Round(d, 0);
-        }
+        public static Decimal Round(Decimal d) => Round(ref d, 0, MidpointRounding.ToEven);
+        public static Decimal Round(Decimal d, int decimals) => Round(ref d, decimals, MidpointRounding.ToEven);
+        public static Decimal Round(Decimal d, MidpointRounding mode) => Round(ref d, 0, mode);
+        public static Decimal Round(Decimal d, int decimals, MidpointRounding mode) => Round(ref d, decimals, mode);
 
-        public static Decimal Round(Decimal d, int decimals)
+        static Decimal Round(ref Decimal d, int decimals, MidpointRounding mode)
         {
-            Decimal result = new Decimal();
-
-            if (decimals < 0 || decimals > 28)
+            if ((uint)decimals > 28)
                 throw new ArgumentOutOfRangeException(nameof(decimals), SR.ArgumentOutOfRange_DecimalRound);
+            if ((uint)mode > (uint)MidpointRounding.AwayFromZero)
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
 
-            DecCalc.VarDecRound(ref d, decimals, ref result);
-
-            d = result;
-            return d;
-        }
-
-        public static Decimal Round(Decimal d, MidpointRounding mode)
-        {
-            return Round(d, 0, mode);
-        }
-
-        public static Decimal Round(Decimal d, int decimals, MidpointRounding mode)
-        {
-            if (decimals < 0 || decimals > 28)
-                throw new ArgumentOutOfRangeException(nameof(decimals), SR.ArgumentOutOfRange_DecimalRound);
-            if (mode < MidpointRounding.ToEven || mode > MidpointRounding.AwayFromZero)
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, "MidpointRounding"), nameof(mode));
-
-            if (mode == MidpointRounding.ToEven)
-            {
-                Decimal result = new Decimal();
-                DecCalc.VarDecRound(ref d, decimals, ref result);
-                d = result;
-            }
-            else
-            {
-                DecCalc.InternalRoundFromZero(ref d, decimals);
-            }
+            int scale = d.Scale - decimals;
+            if (scale > 0)
+                DecCalc.InternalRound(ref d, (uint)scale, (DecCalc.RoundingMode)mode);
             return d;
         }
 

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -248,9 +248,7 @@ namespace System
 
         public static long ToOACurrency(Decimal value)
         {
-            long cy;
-            DecCalc.VarCyFromDec(ref value, out cy);
-            return cy;
+            return DecCalc.VarCyFromDec(ref value);
         }
 
         private static bool IsValid(uint flags) => (flags & ~(SignMask | ScaleMask)) == 0 && ((flags & ScaleMask) <= (28 << 16));

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -658,7 +658,7 @@ namespace System
         public static Decimal Round(Decimal d, MidpointRounding mode) => Round(ref d, 0, mode);
         public static Decimal Round(Decimal d, int decimals, MidpointRounding mode) => Round(ref d, decimals, mode);
 
-        static Decimal Round(ref Decimal d, int decimals, MidpointRounding mode)
+        private static Decimal Round(ref Decimal d, int decimals, MidpointRounding mode)
         {
             if ((uint)decimals > 28)
                 throw new ArgumentOutOfRangeException(nameof(decimals), SR.ArgumentOutOfRange_DecimalRound);
@@ -866,7 +866,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static void Truncate(ref Decimal d)
+        private static void Truncate(ref Decimal d)
         {
             uint flags = d.uflags;
             if ((flags & ScaleMask) != 0)


### PR DESCRIPTION
This is a continuation of #4452 and covers rounding and casting. I unified all rounding functions into a single fast one (loosely based on `InternalRoundFromZero`).

@jkotas Is it possible to somehow reference `System.Runtime.Intrinsics.X86` in CoreRT? I moved `LeadingZeroCount` to a separate function and on CoreCLR successfully used `X86.Lzcnt`.

### 64-bit

|  Floor |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 34.498 ns | 0.0072 ns | 0.0026 ns |   1.00 |
|  CoreRT | 29.366 ns | 0.2997 ns | 0.1069 ns |   0.85 |
| CoreRT2 |  9.316 ns | 0.0513 ns | 0.0183 ns |   0.27 |

|  Ceiling |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 43.329 ns | 0.0614 ns | 0.0219 ns |   1.00 |
|  CoreRT | 48.774 ns | 0.2157 ns | 0.0769 ns |   1.13 |
| CoreRT2 |  9.725 ns | 0.0529 ns | 0.0189 ns |   0.22 |

|  Truncate |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 34.226 ns | 0.0914 ns | 0.0326 ns |   1.00 |
|  CoreRT | 27.686 ns | 0.2687 ns | 0.0698 ns |   0.81 |
| CoreRT2 |  7.852 ns | 0.0080 ns | 0.0021 ns |   0.23 |

|  ToDouble |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 5.044 ns | 0.0088 ns | 0.0031 ns |   1.00 |
|  CoreRT | 5.725 ns | 0.0199 ns | 0.0071 ns |   1.14 |
| CoreRT2 | 2.900 ns | 0.0049 ns | 0.0017 ns |   0.57 |

|  HashCode |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 5.103 ns | 0.0160 ns | 0.0057 ns |   1.00 |
|  CoreRT | 5.910 ns | 0.0075 ns | 0.0020 ns |   1.16 |
| CoreRT2 | 3.345 ns | 0.0027 ns | 0.0010 ns |   0.66 |

|  ToInt32 |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 33.961 ns | 0.0661 ns | 0.0236 ns |   1.00 |
|  CoreRT | 29.354 ns | 0.3211 ns | 0.1145 ns |   0.86 |
| CoreRT2 |  8.728 ns | 0.0153 ns | 0.0024 ns |   0.26 |

|  ToInt64 |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 34.992 ns | 0.0581 ns | 0.0207 ns |   1.00 |
|  CoreRT | 29.868 ns | 0.1364 ns | 0.0486 ns |   0.85 |
| CoreRT2 |  9.012 ns | 0.0516 ns | 0.0184 ns |   0.26 |

|  ToUInt32 |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 34.754 ns | 0.0869 ns | 0.0310 ns |   1.00 |
|  CoreRT | 30.132 ns | 0.2768 ns | 0.0719 ns |   0.87 |
| CoreRT2 |  8.963 ns | 0.6362 ns | 0.1653 ns |   0.26 |

|  ToUInt64 |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 36.004 ns | 0.2540 ns | 0.0906 ns |   1.00 |
|  CoreRT | 30.682 ns | 0.1914 ns | 0.0497 ns |   0.85 |
| CoreRT2 |  8.933 ns | 0.1782 ns | 0.0463 ns |   0.25 |

|  ToOACurrency |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 25.903 ns | 0.0460 ns | 0.0164 ns |   1.00 |
|  CoreRT | 24.180 ns | 0.1419 ns | 0.0506 ns |   0.93 |
| CoreRT2 |  7.064 ns | 0.0855 ns | 0.0305 ns |   0.27 |

|  Round |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 26.199 ns | 0.1273 ns | 0.0454 ns |   1.00 |
|  CoreRT | 23.982 ns | 0.1527 ns | 0.0545 ns |   0.92 |
| CoreRT2 |  7.676 ns | 0.0054 ns | 0.0014 ns |   0.29 |

|  RoundAwayFromZero |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 18.450 ns | 0.0745 ns | 0.0266 ns |   1.00 |
|  CoreRT | 19.066 ns | 0.0478 ns | 0.0171 ns |   1.03 |
| CoreRT2 |  7.528 ns | 0.0051 ns | 0.0018 ns |   0.41 |

|  FromFloat |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 22.55 ns | 0.1497 ns | 0.0534 ns |   1.00 |
|  CoreRT | 26.73 ns | 0.1119 ns | 0.0174 ns |   1.19 |
| CoreRT2 | 12.08 ns | 0.3443 ns | 0.1228 ns |   0.54 |

|  FromDouble |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 64.24 ns | 0.0779 ns | 0.0202 ns |   1.00 |
|  CoreRT | 84.70 ns | 0.2627 ns | 0.0937 ns |   1.32 |
| CoreRT2 | 14.19 ns | 0.0353 ns | 0.0092 ns |   0.22 |

|  Negate |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 1.1314 ns | 0.0013 ns | 0.0002 ns |   1.00 |
|  CoreRT | 5.5727 ns | 0.0027 ns | 0.0007 ns |   4.93 |
| CoreRT2 | 0.5278 ns | 0.0003 ns | 0.0000 ns |   0.47 |

|  Abs |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 1.5785 ns | 0.0018 ns | 0.0006 ns |   1.00 |
|  CoreRT | 5.5734 ns | 0.0027 ns | 0.0010 ns |   3.53 |
| CoreRT2 | 0.5272 ns | 0.0006 ns | 0.0002 ns |   0.33 |
