### PR TITLE
enabled thread static fields in WebAssembly

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -847,7 +847,7 @@ namespace Internal.IL
 
         private LLVMValueRef GetOrCreateMethodSlot(MethodDesc method)
         {
-            var vtableSlotSymbol = ((WebAssemblyCodegenNodeFactory)_compilation.NodeFactory).VTableSlot(method);
+            var vtableSlotSymbol = _compilation.NodeFactory.VTableSlot(method);
             _dependencies.Add(vtableSlotSymbol);
             LLVMValueRef slot = LoadAddressOfSymbolNode(vtableSlotSymbol);
             return LLVM.BuildLoad(_builder, slot, string.Empty);

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -837,6 +837,11 @@ namespace Internal.IL
                 if (callee.OwningType.IsInterface)
                     throw new NotImplementedException();
 
+                //This appears to be needed at least for virtual method calls off System.Type its not clear why
+                var node = _compilation.NodeFactory.NecessaryTypeSymbol(callee.OwningType);
+                if (!_dependencies.Contains(node))
+                    _dependencies.Add(node);
+
                 return GetCallableVirtualMethod(thisPointer.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder), callee);
             }
             else

--- a/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
@@ -699,27 +699,6 @@ namespace ILCompiler.DependencyAnalysis
                     if (node.ShouldSkipEmittingObjectNode(factory))
                         continue;
 
-                    if (node is EETypeNode)
-                    {
-                        DefType t = ((EETypeNode)node).Type.GetClosestDefType();
-                        int iSlot = GetVTableSlotsCount(factory, t.BaseType);
-                        var pointerSize = factory.Target.PointerSize;
-                        foreach (MethodDesc m in factory.VTable(t).Slots)
-                        {
-                            // set _getslot variable to sizeof(EEType) + iSlot * pointer size
-                            string realSymbolName = factory.NameMangler.GetMangledMethodName(m).ToString();
-                            var globalRefName = "__getslot__" + realSymbolName;
-                            LLVMValueRef slot = LLVM.GetNamedGlobal(compilation.Module, globalRefName);
-                            if (slot.Pointer == IntPtr.Zero)
-                            {
-                                slot = LLVM.AddGlobal(compilation.Module, LLVM.Int32Type(), globalRefName);
-                            }
-                            LLVM.SetInitializer(slot, LLVM.ConstInt(LLVM.Int32Type(), (ulong)((EETypeNode.GetVTableOffset(pointerSize) / pointerSize) + iSlot), LLVMMisc.False));
-                            LLVM.SetGlobalConstant(slot, LLVMMisc.True);
-                            iSlot++;
-                        }
-                    }
-
                     objectWriter.StartObjectNode(node);
                     ObjectData nodeContents = node.GetData(factory);
 

--- a/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
@@ -10,15 +10,15 @@ namespace ILCompiler.DependencyAnalysis
 {
     public sealed class WebAssemblyCodegenNodeFactory : NodeFactory
     {
-        private NodeCache<MethodKey, WebAssemblyVTableSlotNode> _vTableSlotNodes;
+        private NodeCache<MethodDesc, WebAssemblyVTableSlotNode> _vTableSlotNodes;
 
         public WebAssemblyCodegenNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager,
             InteropStubManager interopStubManager, NameMangler nameMangler, VTableSliceProvider vtableSliceProvider, DictionaryLayoutProvider dictionaryLayoutProvider)
             : base(context, compilationModuleGroup, metadataManager, interopStubManager, nameMangler, new LazyGenericsDisabledPolicy(), vtableSliceProvider, dictionaryLayoutProvider)
         {
-            _vTableSlotNodes = new NodeCache<MethodKey, WebAssemblyVTableSlotNode>(methodKey =>
+            _vTableSlotNodes = new NodeCache<MethodDesc, WebAssemblyVTableSlotNode>(methodKey =>
             {
-                return new WebAssemblyVTableSlotNode(methodKey.Method);
+                return new WebAssemblyVTableSlotNode(methodKey);
             });
         }
 
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public WebAssemblyVTableSlotNode VTableSlot(MethodDesc method)
         {
-            return _vTableSlotNodes.GetOrAdd(new MethodKey(method, false));
+            return _vTableSlotNodes.GetOrAdd(method);
         }
 
         protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)

--- a/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyVTableSlotNode.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyVTableSlotNode.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+using Internal.Runtime;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public class WebAssemblyVTableSlotNode : ObjectNode, ISymbolDefinitionNode
+    {
+        private readonly MethodDesc _targetMethod;
+
+        public WebAssemblyVTableSlotNode(MethodDesc targetMethod)
+        {
+            Debug.Assert(targetMethod.IsVirtual);
+            Debug.Assert(!targetMethod.IsSharedByGenericInstantiations);
+            _targetMethod = targetMethod;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(GetMangledName(nameMangler, _targetMethod));
+        }
+        public int Offset => 0;
+
+        public override bool IsShareable => false;
+
+        public static string GetMangledName(NameMangler nameMangler, MethodDesc method)
+        {
+            return "__getslot__" + nameMangler.GetMangledMethodName(method);
+        }
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            DependencyList result = new DependencyList();
+
+            if (!factory.VTable(_targetMethod.OwningType).HasFixedSlots)
+            {
+                result.Add(factory.VirtualMethodUse(_targetMethod), "VTable method use");
+            }
+
+            return result;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+
+            ObjectDataBuilder objData = new ObjectDataBuilder(factory, relocsOnly);
+
+            objData.AddSymbol(this);
+
+            if (!relocsOnly)
+            {
+                var tableOffset = EETypeNode.GetVTableOffset(factory.Target.PointerSize) / factory.Target.PointerSize;
+                objData.EmitInt(tableOffset + VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, _targetMethod));
+            }
+            return objData.ToObjectData();
+        }
+
+        protected override int ClassCode => 0;
+
+        protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
+        {
+            return comparer.Compare(_targetMethod, ((WebAssemblyVTableSlotNode)other)._targetMethod);
+        }
+    }
+}

--- a/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyVTableSlotNode.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyVTableSlotNode.cs
@@ -54,7 +54,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-
+            Debug.Assert((EETypeNode.GetVTableOffset(factory.Target.PointerSize) % factory.Target.PointerSize) == 0, "vtable offset must be aligned");
             ObjectDataBuilder objData = new ObjectDataBuilder(factory, relocsOnly);
 
             objData.AddSymbol(this);

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
@@ -16,15 +16,16 @@ namespace ILCompiler
     {
         internal WebAssemblyCodegenConfigProvider Options { get; }
         internal LLVMModuleRef Module { get; }
-
+        public new WebAssemblyCodegenNodeFactory NodeFactory { get; private set; }
         internal WebAssemblyCodegenCompilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
-            NodeFactory nodeFactory,
+            WebAssemblyCodegenNodeFactory nodeFactory,
             IEnumerable<ICompilationRootProvider> roots,
             Logger logger,
             WebAssemblyCodegenConfigProvider options)
             : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), null, logger)
         {
+            NodeFactory = nodeFactory;
             LLVM.LoadLibrary_libLLVM("./libLLVM-x64.dll");
             Module = LLVM.ModuleCreateWithName("netscripten");
             LLVM.SetTarget(Module, "asmjs-unknown-emscripten");

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
@@ -16,7 +16,7 @@ namespace ILCompiler
     {
         internal WebAssemblyCodegenConfigProvider Options { get; }
         internal LLVMModuleRef Module { get; }
-        public new WebAssemblyCodegenNodeFactory NodeFactory { get; private set; }
+        public new WebAssemblyCodegenNodeFactory NodeFactory { get; }
         internal WebAssemblyCodegenCompilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
             WebAssemblyCodegenNodeFactory nodeFactory,

--- a/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
+++ b/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Compiler\DependencyAnalysis\RawMainMethodRootProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\WebAssemblyCodegenNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\WebAssemblyMethodCodeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\WebAssemblyVTableSlotNode.cs" />
     <Compile Include="Compiler\WebAssemblyNodeMangler.cs" />
     <Compile Include="Compiler\WebAssemblyCodegenCompilation.cs" />
     <Compile Include="Compiler\WebAssemblyCodegenCompilationBuilder.cs" />

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -41,6 +41,11 @@ internal static class Program
             PrintLine("static int field test: Ok.");
         }
 
+        if(threadStaticInt == 0)
+        {
+            PrintLine("thread static int initial value field test: Ok.");
+        }
+
         threadStaticInt = 9;
         if(threadStaticInt == 9)
         {

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -8,6 +8,8 @@ using System.Runtime.InteropServices;
 internal static class Program
 {
     private static int staticInt;
+    [ThreadStatic]
+    private static int threadStaticInt;
     private static unsafe void Main(string[] args)
     {
         Add(1, 2);
@@ -37,6 +39,12 @@ internal static class Program
         if (staticInt == 5)
         {
             PrintLine("static int field test: Ok.");
+        }
+
+        threadStaticInt = 9;
+        if(threadStaticInt == 9)
+        {
+            PrintLine("thread static int field test: Ok.");
         }
 
         var boxedInt = (object)tempInt;


### PR DESCRIPTION
@morganbr 
I've enabled thread static fields, it's generating quite a bit more code as a result and it ended up pulling in some weirdness around virtual calls to System.Type. The EEType wasnt getting output, so I've put in a dependency for the owning type when calling a virtual method. If you have any ideas for a different place to trigger the reference for the EEType that works too.