### PR TITLE
Enable generation of stack trace data for simple tests

### DIFF
--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -52,7 +52,9 @@
 
   <ItemGroup>
     <IlcArg Include="--targetarch=$(Platform)" />
-    <IlcArg Include="--stacktracedata" />
+    
+    <!-- Broken on wasm: https://github.com/dotnet/corert/issues/5005 -->
+    <IlcArg Condition="$(NativeCodeGen) != 'wasm'" Include="--stacktracedata" />
   </ItemGroup>
 
 </Project>

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -52,6 +52,7 @@
 
   <ItemGroup>
     <IlcArg Include="--targetarch=$(Platform)" />
+    <IlcArg Include="--stacktracedata" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
BasicThreading is hitting an intermittent failure on Unix and this would
likely help root causing it.