### PR TITLE
Add a warning when RD.XML is used

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -357,6 +357,8 @@ namespace ILCompiler
                     compilationGroup = new SingleFileCompilationModuleGroup(typeSystemContext);
                 }
 
+                if (_rdXmlFilePaths.Count > 0)
+                    Console.WriteLine("Warning: RD.XML processing will change before release (https://github.com/dotnet/corert/issues/5001)");
                 foreach (var rdXmlFilePath in _rdXmlFilePaths)
                 {
                     compilationRoots.Add(new RdXmlRootProvider(typeSystemContext, rdXmlFilePath));


### PR DESCRIPTION
We are going to break this so if someone wants to make big investments
into the existing format, they should know.