### PR TITLE
Use common formatter to format stack trace metadata

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
+++ b/src/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
@@ -41,29 +41,9 @@ namespace Internal.DeveloperExperience
                 }
             }
 
-            ReflectionExecutionDomainCallbacks reflectionCallbacks = RuntimeAugments.CallbacksIfAvailable;
-            String moduleFullFileName = null;
-
-            if (reflectionCallbacks != null)
-            {
-                IntPtr methodStart = RuntimeImports.RhFindMethodStartAddress(ip);
-                if (methodStart != IntPtr.Zero)
-                {
-                    string methodName = string.Empty;
-                    try
-                    {
-                        methodName = reflectionCallbacks.GetMethodNameFromStartAddressIfAvailable(methodStart);
-                    }
-                    catch { }
-
-                    if (!string.IsNullOrEmpty(methodName))
-                        return methodName;
-                }
-
-                // If we don't have precise information, try to map it at least back to the right module.
-                IntPtr moduleBase = RuntimeImports.RhGetOSModuleFromPointer(ip);
-                moduleFullFileName = RuntimeAugments.TryGetFullPathToApplicationModule(moduleBase);
-            }
+            // If we don't have precise information, try to map it at least back to the right module.
+            IntPtr moduleBase = RuntimeImports.RhGetOSModuleFromPointer(ip);
+            string moduleFullFileName = RuntimeAugments.TryGetFullPathToApplicationModule(moduleBase);
 
             // Without any callbacks or the ability to map ip correctly we better admit that we don't know
             if (string.IsNullOrEmpty(moduleFullFileName))

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
@@ -48,7 +48,6 @@ namespace Internal.Runtime.Augments
 
         public abstract String GetBetterDiagnosticInfoIfAvailable(RuntimeTypeHandle runtimeTypeHandle);
         public abstract MethodBase GetMethodBaseFromStartAddressIfAvailable(IntPtr methodStartAddress);
-        public abstract String GetMethodNameFromStartAddressIfAvailable(IntPtr methodStartAddress);
         public abstract int ValueTypeGetHashCodeUsingReflection(object valueType);
         public abstract bool ValueTypeEqualsUsingReflection(object left, object right);
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -120,69 +120,6 @@ namespace Internal.Reflection.Execution
             return ReflectionCoreExecution.ExecutionDomain.GetMethod(declaringTypeHandle, methodHandle, genericMethodTypeArgumentHandles: null);
         }
 
-        public sealed override String GetMethodNameFromStartAddressIfAvailable(IntPtr methodStartAddress)
-        {
-            RuntimeTypeHandle declaringTypeHandle = default(RuntimeTypeHandle);
-            QMethodDefinition methodHandle;
-            RuntimeTypeHandle[] genericMethodTypeArgumentHandles;
-            if (!ReflectionExecution.ExecutionEnvironment.TryGetMethodForOriginalLdFtnResult(methodStartAddress,
-                ref declaringTypeHandle, out methodHandle, out genericMethodTypeArgumentHandles))
-            {
-                return null;
-            }
-
-            MethodBase methodBase = ReflectionCoreExecution.ExecutionDomain.GetMethod(
-                                        declaringTypeHandle, methodHandle, genericMethodTypeArgumentHandles);
-            if (methodBase == null || string.IsNullOrEmpty(methodBase.Name))
-                return null;
-
-            // get type name
-            string typeName = string.Empty;
-            Type declaringType = Type.GetTypeFromHandle(declaringTypeHandle);
-            if (declaringType != null)
-                typeName = declaringType.ToDisplayStringIfAvailable(null);
-            if (string.IsNullOrEmpty(typeName))
-                typeName = "<unknown>";
-
-            StringBuilder fullMethodName = new StringBuilder();
-            fullMethodName.Append(typeName);
-            fullMethodName.Append('.');
-            fullMethodName.Append(methodBase.Name);
-            fullMethodName.Append('(');
-
-            // get parameter list
-            ParameterInfo[] paramArr = methodBase.GetParametersNoCopy();
-            for (int i = 0; i < paramArr.Length; ++i)
-            {
-                if (i != 0)
-                    fullMethodName.Append(", ");
-
-                ParameterInfo param = paramArr[i];
-                string paramTypeName = string.Empty;
-                if (param.ParameterType != null)
-                    paramTypeName = param.ParameterType.ToDisplayStringIfAvailable(null);
-                if (string.IsNullOrEmpty(paramTypeName))
-                    paramTypeName = "<unknown>";
-                else
-                {
-                    // remove namespace from param type-name
-                    int idxSeparator = paramTypeName.IndexOf(".");
-                    if (idxSeparator >= 0)
-                        paramTypeName = paramTypeName.Remove(0, idxSeparator + 1);
-                }
-
-                string paramName = param.Name;
-                if (string.IsNullOrEmpty(paramName))
-                    paramName = "<unknown>";
-
-                fullMethodName.Append(paramTypeName);
-                fullMethodName.Append(' ');
-                fullMethodName.Append(paramName);
-            }
-            fullMethodName.Append(')');
-            return fullMethodName.ToString();
-        }
-
         public sealed override IntPtr TryGetStaticClassConstructionContext(RuntimeTypeHandle runtimeTypeHandle)
         {
             return _executionEnvironment.TryGetStaticClassConstructionContext(runtimeTypeHandle);

--- a/src/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/MethodNameFormatter.cs
+++ b/src/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/MethodNameFormatter.cs
@@ -39,6 +39,13 @@ namespace Internal.StackTraceMetadata
             return formatter._outputBuilder.ToString();
         }
 
+        public static string FormatMethodName(MetadataReader metadataReader, TypeDefinitionHandle enclosingTypeHandle, MethodHandle methodHandle)
+        {
+            MethodNameFormatter formatter = new MethodNameFormatter(metadataReader);
+            formatter.EmitMethodDefinitionName(enclosingTypeHandle, methodHandle);
+            return formatter._outputBuilder.ToString();
+        }
+
         /// <summary>
         /// Emit a given method signature to a specified string builder.
         /// </summary>
@@ -96,11 +103,16 @@ namespace Internal.StackTraceMetadata
         private void EmitMethodDefinitionName(QualifiedMethodHandle qualifiedMethodHandle)
         {
             QualifiedMethod qualifiedMethod = _metadataReader.GetQualifiedMethod(qualifiedMethodHandle);
-            Method method = _metadataReader.GetMethod(qualifiedMethod.Method);
+            EmitMethodDefinitionName(qualifiedMethod.EnclosingType, qualifiedMethod.Method);
+        }
+
+        private void EmitMethodDefinitionName(TypeDefinitionHandle enclosingTypeHandle, MethodHandle methodHandle)
+        {
+            Method method = _metadataReader.GetMethod(methodHandle);
             MethodSignature methodSignature = _metadataReader.GetMethodSignature(method.Signature);
             EmitTypeName(methodSignature.ReturnType, namespaceQualified: false);
             _outputBuilder.Append(' ');
-            EmitTypeName(qualifiedMethod.EnclosingType, namespaceQualified: true);
+            EmitTypeName(enclosingTypeHandle, namespaceQualified: true);
             _outputBuilder.Append('.');
             EmitString(method.Name);
             EmitMethodParameters(methodSignature);

--- a/src/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
+++ b/src/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime;
-using System.Text;
 
 using Internal.Metadata.NativeFormat;
 using Internal.Runtime;
@@ -13,7 +12,7 @@ using Internal.Runtime.Augments;
 using Internal.Runtime.TypeLoader;
 using Internal.TypeSystem;
 
-using MethodSignature = Internal.Metadata.NativeFormat.MethodSignature;
+using ReflectionExecution = Internal.Reflection.Execution.ReflectionExecution;
 
 #if BIT64
 using nint = System.Int64;
@@ -63,6 +62,15 @@ namespace Internal.StackTraceMetadata
                     if (name != null)
                         return name;
                 }
+            }
+
+            // We haven't found information in the stack trace metadata tables, but maybe reflection will have this
+            if (ReflectionExecution.TryGetMethodMetadataFromStartAddress(methodStartAddress,
+                out MetadataReader reader,
+                out TypeDefinitionHandle typeHandle,
+                out MethodHandle methodHandle))
+            {
+                return MethodNameFormatter.FormatMethodName(reader, typeHandle, methodHandle);
             }
 
             return null;

--- a/src/System.Private.StackTraceMetadata/src/System.Private.StackTraceMetadata.csproj
+++ b/src/System.Private.StackTraceMetadata/src/System.Private.StackTraceMetadata.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\System.Private.CoreLib\src\System.Private.CoreLib.csproj" />
     <ProjectReference Include="..\..\System.Private.Reflection.Metadata\src\System.Private.Reflection.Metadata.csproj" />
     <ProjectReference Include="..\..\System.Private.TypeLoader\src\System.Private.TypeLoader.csproj" />
+    <ProjectReference Include="..\..\System.Private.Reflection.Execution\src\System.Private.Reflection.Execution.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The reflection path was using MethodBase/ParameterInfos which is both really heavy (it drags method reflection into every CoreRT app), and leads to different behaviors and bugs (e.g. the reflection path wasn't including the offset from the method start in the stack frame string).