### PR TITLE
NativeCallable methods can only be called from unmanaged code

### DIFF
--- a/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
+++ b/src/Common/src/TypeSystem/Common/ExceptionStringID.cs
@@ -31,6 +31,7 @@ namespace Internal.TypeSystem
         InvalidProgramSpecific,
         InvalidProgramVararg,
         InvalidProgramCallVirtFinalize,
+        InvalidProgramNativeCallable,
 
         // BadImageFormatException
         BadImageFormatGeneric,

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -406,8 +406,8 @@ namespace Internal.IL
 
             TypeDesc exactType = method.OwningType;
 
-            if ((method.Signature.IsStatic && reason == "callvirt")
-                || (method.IsNativeCallable && (reason != "ldftn" && reason != "ldvirtftn")))
+            if ((method.Signature.IsStatic && opcode == ILOpcode.callvirt)
+                || (method.IsNativeCallable && (opcode != ILOpcode.ldftn && opcode != ILOpcode.ldvirtftn)))
             {
                 ThrowHelper.ThrowBadImageFormatException();
             }

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -406,10 +406,9 @@ namespace Internal.IL
 
             TypeDesc exactType = method.OwningType;
 
-            if ((method.Signature.IsStatic && opcode == ILOpcode.callvirt)
-                || (method.IsNativeCallable && (opcode != ILOpcode.ldftn && opcode != ILOpcode.ldvirtftn)))
+            if (method.IsNativeCallable && (opcode != ILOpcode.ldftn && opcode != ILOpcode.ldvirtftn))
             {
-                ThrowHelper.ThrowBadImageFormatException();
+                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramNativeCallable, method);
             }
 
             bool resolvedConstraint = false;

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -406,6 +406,12 @@ namespace Internal.IL
 
             TypeDesc exactType = method.OwningType;
 
+            if ((method.Signature.IsStatic && reason == "callvirt")
+                || (method.IsNativeCallable && (reason != "ldftn" && reason != "ldvirtftn")))
+            {
+                ThrowHelper.ThrowBadImageFormatException();
+            }
+
             bool resolvedConstraint = false;
             bool forceUseRuntimeLookup = false;
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2940,7 +2940,7 @@ namespace Internal.JitInterface
             // with a stub that throws a BadImageFormatException
             if (method.IsNativeCallable && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0)
             {
-                ThrowHelper.ThrowBadImageFormatException();
+                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramNativeCallable, method);
             }
 
             TypeDesc exactType = HandleToObject(pResolvedToken.hClass);

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2935,9 +2935,9 @@ namespace Internal.JitInterface
                 throw new BadImageFormatException();
             }
 
-            // This blocks enforces the rule that methods with [NativeCallable] attribute
+            // This block enforces the rule that methods with [NativeCallable] attribute
             // can only be called from unmanaged code. The call from managed code is replaced
-            // with a stub that throws a BadImageFormatException
+            // with a stub that throws an InvalidProgramException
             if (method.IsNativeCallable && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0)
             {
                 ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramNativeCallable, method);

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2930,9 +2930,10 @@ namespace Internal.JitInterface
             // Spec says that a callvirt lookup ignores static methods. Since static methods
             // can't have the exact same signature as instance methods, a lookup that found
             // a static method would have never found an instance method.
-            if (method.Signature.IsStatic && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0)
+            if ((method.Signature.IsStatic && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0)
+                || (method.IsNativeCallable && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0))
             {
-                throw new BadImageFormatException();
+                ThrowHelper.ThrowBadImageFormatException();
             }
 
             TypeDesc exactType = HandleToObject(pResolvedToken.hClass);

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2930,8 +2930,15 @@ namespace Internal.JitInterface
             // Spec says that a callvirt lookup ignores static methods. Since static methods
             // can't have the exact same signature as instance methods, a lookup that found
             // a static method would have never found an instance method.
-            if ((method.Signature.IsStatic && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0)
-                || (method.IsNativeCallable && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0))
+            if (method.Signature.IsStatic && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0)
+            {
+                throw new BadImageFormatException();
+            }
+
+            // This blocks enforces the rule that methods with [NativeCallable] attribute
+            // can only be called from unmanaged code. The call from managed code is replaced
+            // with a stub that throws a BadImageFormatException
+            if (method.IsNativeCallable && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0)
             {
                 ThrowHelper.ThrowBadImageFormatException();
             }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
@@ -83,6 +83,8 @@ namespace Internal.Runtime
                     return SR.InvalidProgram_Vararg;
                 case ExceptionStringID.InvalidProgramCallVirtFinalize:
                     return SR.InvalidProgram_CallVirtFinalize;
+                case ExceptionStringID.InvalidProgramNativeCallable:
+                    return SR.InvalidProgram_NativeCallable;
                 case ExceptionStringID.MissingField:
                     return SR.EE_MissingField;
                 case ExceptionStringID.MissingMethod:

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1182,6 +1182,9 @@
   <data name="InvalidProgram_CallVirtFinalize" xml:space="preserve">
     <value>Object.Finalize() can not be called directly. It is only callable by the runtime.</value>
   </data>
+  <data name="InvalidProgram_NativeCallable" xml:space="preserve">
+    <value>Common Language Runtime detected an invalid program. NativeCallable method cannot be called from managed code.</value>
+  </data>
   <data name="InvalidTimeZone_InvalidRegistryData" xml:space="preserve">
     <value>The time zone ID '{0}' was found on the local computer, but the registry information was corrupt.</value>
   </data>

--- a/src/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1183,7 +1183,7 @@
     <value>Object.Finalize() can not be called directly. It is only callable by the runtime.</value>
   </data>
   <data name="InvalidProgram_NativeCallable" xml:space="preserve">
-    <value>Common Language Runtime detected an invalid program. NativeCallable method cannot be called from managed code.</value>
+    <value>NativeCallable method cannot be called from managed code.</value>
   </data>
   <data name="InvalidTimeZone_InvalidRegistryData" xml:space="preserve">
     <value>The time zone ID '{0}' was found on the local computer, but the registry information was corrupt.</value>


### PR DESCRIPTION
This PR enforces the rule that methods with `[NativeCallable]` attribute can only be called from unmanaged code. A stub that throws a `BadImageFormatException` is put in place of a call from managed (C#) code

Fixes #5012 