### PR TITLE
Couple usability fixes to dependency graph viewer

### DIFF
--- a/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/DependencyGraphsForm.Designer.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/DependencyGraphsForm.Designer.cs
@@ -73,6 +73,7 @@ namespace DependencyLogViewer
             this.listBox1.Name = "listBox1";
             this.listBox1.Size = new System.Drawing.Size(844, 565);
             this.listBox1.TabIndex = 2;
+            this.listBox1.DoubleClick += new System.EventHandler(this.explore_Click);
             // 
             // splitContainer1
             // 

--- a/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/ILCompiler-DependencyGraph-Viewer.csproj
+++ b/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/ILCompiler-DependencyGraph-Viewer.csproj
@@ -34,6 +34,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -86,6 +89,7 @@
     <EmbeddedResource Include="SingleDependencyGraphForm.resx">
       <DependentUpon>SingleDependencyGraphForm.cs</DependentUpon>
     </EmbeddedResource>
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/NodeForm.Designer.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/NodeForm.Designer.cs
@@ -94,6 +94,7 @@ namespace DependencyLogViewer
             this.dependeesListBox.Name = "dependeesListBox";
             this.dependeesListBox.Size = new System.Drawing.Size(1497, 424);
             this.dependeesListBox.TabIndex = 0;
+            this.dependeesListBox.DoubleClick += new System.EventHandler(this.exploreDependee_Click);
             // 
             // exploreDependent
             // 
@@ -115,6 +116,7 @@ namespace DependencyLogViewer
             this.dependentsListBox.Name = "dependentsListBox";
             this.dependentsListBox.Size = new System.Drawing.Size(1497, 425);
             this.dependentsListBox.TabIndex = 0;
+            this.dependentsListBox.DoubleClick += new System.EventHandler(this.exploreDependent_Click);
             // 
             // NodeForm
             // 

--- a/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/NodeForm.Designer.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/NodeForm.Designer.cs
@@ -68,8 +68,8 @@ namespace DependencyLogViewer
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.exploreDependee);
             this.splitContainer1.Panel2.Controls.Add(this.dependeesListBox);
+            this.splitContainer1.Panel2.Controls.Add(this.exploreDependee);
             this.splitContainer1.Size = new System.Drawing.Size(1497, 892);
             this.splitContainer1.SplitterDistance = 464;
             this.splitContainer1.TabIndex = 1;

--- a/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/SingleDependencyGraphForm.Designer.cs
+++ b/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/SingleDependencyGraphForm.Designer.cs
@@ -72,6 +72,7 @@ namespace DependencyLogViewer
             this.filteredNodes.Name = "filteredNodes";
             this.filteredNodes.Size = new System.Drawing.Size(920, 359);
             this.filteredNodes.TabIndex = 0;
+            this.filteredNodes.DoubleClick += new System.EventHandler(this.exploreNode_Click);
             // 
             // tableLayoutPanel1
             // 

--- a/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/app.manifest
+++ b/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/app.manifest
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on and is
+           is designed to work with. Uncomment the appropriate elements and Windows will 
+           automatically selected the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>


### PR DESCRIPTION
* Make double-clicking an item open subview
* Reorder button and list (makes button not cover a part of the listbox)
* Add UAC manifest