### PR TITLE
Allow redefinition of a sequence point

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -442,8 +442,15 @@ namespace Internal.IL.Stubs
 
         public void DefineSequencePoint(string document, int lineNumber)
         {
-            Debug.Assert(_sequencePoints.Count == 0 || _sequencePoints[_sequencePoints.Count - 1].Offset < _length);
-            _sequencePoints.Add(new ILSequencePoint(_length, document, lineNumber));
+            // Last sequence point defined for this offset wins.
+            if (_sequencePoints.Count > 0 && _sequencePoints[_sequencePoints.Count - 1].Offset == _length)
+            {
+                _sequencePoints[_sequencePoints.Count - 1] = new ILSequencePoint(_length, document, lineNumber);
+            }
+            else
+            {
+                _sequencePoints.Add(new ILSequencePoint(_length, document, lineNumber));
+            }
         }
     }
 

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -218,9 +218,7 @@ namespace Internal.IL.Stubs.StartupCode
                 ILEmitter emit = new ILEmitter();
                 ILCodeStream codeStream = emit.NewCodeStream();
 
-                // We only need the initial step over sequence point if there's any instructions before the call.
-                if (Signature.Length > 0)
-                    codeStream.MarkDebuggerStepThroughPoint();
+                codeStream.MarkDebuggerStepThroughPoint();
 
                 for (int i = 0; i < Signature.Length; i++)
                     codeStream.EmitLdArg(i);


### PR DESCRIPTION
It's more convenient to just let the last one win.

Test.CoreLib is hitting an issue with a redefinition too because we don't know if we're going to emit anything between StepThrough and StepIn.