### PR TITLE
Fix debugger stepping into virtual calls

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/INodeWithDebugInfo.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/INodeWithDebugInfo.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+
 using Internal.JitInterface;
 using Internal.TypeSystem;
 
@@ -52,5 +52,18 @@ namespace ILCompiler.DependencyAnalysis
             this.Type = type;
             this.Ranges = new List<NativeVarInfo>();
         }
+    }
+
+    public static class WellKnownLineNumber
+    {
+        /// <summary>
+        /// Informs the debugger that it should step through the annotated sequence point.
+        /// </summary>
+        public const int DebuggerStepThrough = 0xF00F00;
+
+        /// <summary>
+        /// Informs the debugger that it should step into the annotated sequence point.
+        /// </summary>
+        public const int DebuggerStepIn = 0xFEEFEE;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -196,20 +196,22 @@ namespace ILCompiler.DependencyAnalysis
                 if (_id == ReadyToRunHelperId.VirtualCall)
                 {
                     // Generate debug information that lets debuggers step into the virtual calls.
+                    // We generate a step into sequence point at the point where the helper jumps to
+                    // the target of the virtual call.
                     TargetDetails target = ((MethodDesc)_target).Context.Target;
-                    int offset = -1;
+                    int debuggerStepInOffset = -1;
                     switch (target.Architecture)
                     {
                         case TargetArchitecture.X64:
-                            offset = 3;
+                            debuggerStepInOffset = 3;
                             break;
                     }
-                    if (offset != -1)
+                    if (debuggerStepInOffset != -1)
                     {
                         return new DebugLocInfo[]
                         {
                             new DebugLocInfo(0, String.Empty, WellKnownLineNumber.DebuggerStepThrough),
-                            new DebugLocInfo(offset, String.Empty, WellKnownLineNumber.DebuggerStepIn)
+                            new DebugLocInfo(debuggerStepInOffset, String.Empty, WellKnownLineNumber.DebuggerStepIn)
                         };
                     }
                 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -44,6 +44,7 @@ namespace ILCompiler.DependencyAnalysis
                             slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod);
                             Debug.Assert(slot != -1);
                         }
+                        Debug.Assert(((INodeWithDebugInfo)this).DebugLocInfos[1].NativeOffset == encoder.Builder.CountBytes);
 
                         AddrMode jmpAddrMode = new AddrMode(encoder.TargetRegister.Result, null, EETypeNode.GetVTableOffset(pointerSize) + (slot * pointerSize), 0, AddrModeSize.Int64);
                         encoder.EmitJmpToAddrMode(ref jmpAddrMode);


### PR DESCRIPTION
This is a simpler fix than #4740 and gets the job done. It only uses the existing infrastructure we already have for line number emission. It's a little bit less elegant (not "correct by construction"), but we guard correctness with an assert.