### PR TITLE
Do not track RuntimeDeterminedMethod dependencies from canonical methods

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -911,16 +911,14 @@ namespace Internal.IL.Stubs
 
         public override MethodIL EmitIL()
         {
-            const DelegateThunkKind maxThunkKind = DelegateThunkKind.ObjectArrayThunk + 1;
-
             ILEmitter emitter = new ILEmitter();
 
             var codeStream = emitter.NewCodeStream();
 
             ILCodeLabel returnNullLabel = emitter.NewCodeLabel();
 
-            ILCodeLabel[] labels = new ILCodeLabel[(int)maxThunkKind];
-            for (DelegateThunkKind i = 0; i < maxThunkKind; i++)
+            ILCodeLabel[] labels = new ILCodeLabel[(int)DelegateThunkCollection.MaxThunkKind];
+            for (DelegateThunkKind i = 0; i < DelegateThunkCollection.MaxThunkKind; i++)
             {
                 MethodDesc thunk = _delegateInfo.Thunks[i];
                 if (thunk != null)
@@ -934,7 +932,7 @@ namespace Internal.IL.Stubs
 
             codeStream.Emit(ILOpcode.br, returnNullLabel);
 
-            for (DelegateThunkKind i = 0; i < maxThunkKind; i++)
+            for (DelegateThunkKind i = 0; i < DelegateThunkCollection.MaxThunkKind; i++)
             {
                 MethodDesc thunk = _delegateInfo.Thunks[i];
                 if (thunk != null)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -351,17 +351,19 @@ namespace ILCompiler
 
         protected virtual IEnumerable<MethodDesc> GetAllMethodsForDelegate(TypeDesc type)
         {
-            // Inject the synthetic GetThunk virtual override
+            // Inject the synthetic methods that support the implementation of the delegate.
             InstantiatedType instantiatedType = type as InstantiatedType;
             if (instantiatedType != null)
             {
                 DelegateInfo info = GetDelegateInfo(type.GetTypeDefinition());
-                yield return GetMethodForInstantiatedType(info.GetThunkMethod, instantiatedType);
+                foreach (MethodDesc syntheticMethod in info.Methods)
+                    yield return GetMethodForInstantiatedType(syntheticMethod, instantiatedType);
             }
             else
             {
                 DelegateInfo info = GetDelegateInfo(type);
-                yield return info.GetThunkMethod;
+                foreach (MethodDesc syntheticMethod in info.Methods)
+                    yield return syntheticMethod;
             }
 
             // Append all the methods defined in metadata

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -265,6 +265,9 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
+            // Make sure the dictionary can also be populated
+            dependencies.Add(factory.ShadowConcreteMethod(_owningMethod), "Dictionary contents");
+
             return dependencies;
         }
 

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -563,7 +563,7 @@ namespace Internal.IL
                             _dependencies.Add(instParam, reason);
                         }
 
-                        _dependencies.Add(_factory.RuntimeDeterminedMethod(runtimeDeterminedMethod), reason);
+                        _dependencies.Add(_factory.CanonicalEntrypoint(targetMethod), reason);
                     }
                     else
                     {

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -3122,29 +3122,9 @@ namespace Internal.JitInterface
                     // (Note: The generic lookup in R2R is performed by a call to a helper at runtime, not by
                     // codegen emitted at crossgen time)
 
-                    MethodDesc contextMethod = methodFromContext(pResolvedToken.tokenContext);
-
-                    // Do not bother capturing the runtime determined context if we're inlining. The JIT is going
-                    // to abort the inlining attempt if the inlinee does any generic lookups.
-                    bool inlining = contextMethod != MethodBeingCompiled;
-
-                    // If we resolved a constrained call, calling GetRuntimeDeterminedObjectForToken below would
-                    // result in getting back the unresolved target. Don't capture runtime determined dependencies
-                    // in that case and rely on the dependency analysis computing them based on seeing a call to the
-                    // canonical method body.
-                    // Same applies to array address method (the method doesn't actually do any generic lookups).
-                    if (targetMethod.IsSharedByGenericInstantiations && !inlining && !resolvedConstraint && !referencingArrayAddressMethod)
-                    {
-                        MethodDesc runtimeDeterminedMethod = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
-                        pResult.codePointerOrStubLookup.constLookup = 
-                            CreateConstLookupToSymbol(_compilation.NodeFactory.RuntimeDeterminedMethod(runtimeDeterminedMethod));
-                    }
-                    else
-                    {
-                        Debug.Assert(!forceUseRuntimeLookup);
-                        pResult.codePointerOrStubLookup.constLookup = 
-                            CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
-                    }
+                    Debug.Assert(!forceUseRuntimeLookup);
+                    pResult.codePointerOrStubLookup.constLookup = 
+                        CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
                 }
                 else
                 {


### PR DESCRIPTION
The concept of RuntimeDeterminedMethodNode was added when I was trying to support a mode where generic dictionaries could have "holes" (null entries for things that are not used for the particular instantiation). This turned out to be not feasible and we now have dependency analysis infra to patch those holes up anyway. We don't need to track dependencies of canonical code on such granularity.

The only exception to that were generic methods, but I'm fixing that by having the method generic dictionary (which is tracked as a runtime determined dependency of the canonical body) to also depend on the ShadowConcreteMethod (to make sure we can actually fill it).

I'm doing this because the devirtualization in RyuJIT causes `getCallInfo` to be called with bogus `pResolvedToken` and we can no longer use that to get a `RuntimeDeterminedMethod` anyway.