### PR TITLE
Use results of whole program analysis to drive devirtualization

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -25,6 +25,7 @@ namespace ILCompiler
         protected readonly NodeFactory _nodeFactory;
         protected readonly Logger _logger;
         private readonly DebugInformationProvider _debugInformationProvider;
+        private readonly DevirtualizationManager _devirtualizationManager;
 
         public NameMangler NameMangler => _nodeFactory.NameMangler;
         public NodeFactory NodeFactory => _nodeFactory;
@@ -41,12 +42,14 @@ namespace ILCompiler
             NodeFactory nodeFactory,
             IEnumerable<ICompilationRootProvider> compilationRoots,
             DebugInformationProvider debugInformationProvider,
+            DevirtualizationManager devirtualizationManager,
             Logger logger)
         {
             _dependencyGraph = dependencyGraph;
             _nodeFactory = nodeFactory;
             _logger = logger;
             _debugInformationProvider = debugInformationProvider;
+            _devirtualizationManager = devirtualizationManager;
 
             _dependencyGraph.ComputeDependencyRoutine += ComputeDependencyNodeDependencies;
             NodeFactory.AttachToDependencyGraph(_dependencyGraph);
@@ -176,6 +179,21 @@ namespace ILCompiler
         public bool HasFixedSlotVTable(TypeDesc type)
         {
             return NodeFactory.VTable(type).HasFixedSlots;
+        }
+
+        public bool IsEffectivelySealed(TypeDesc type)
+        {
+            return _devirtualizationManager.IsEffectivelySealed(type);
+        }
+
+        public bool IsEffectivelySealed(MethodDesc method)
+        {
+            return _devirtualizationManager.IsEffectivelySealed(method);
+        }
+
+        public MethodDesc ResolveVirtualMethod(MethodDesc declMethod, TypeDesc implType)
+        {
+            return _devirtualizationManager.ResolveVirtualMethod(declMethod, implType);
         }
 
         public bool NeedsRuntimeLookup(ReadyToRunHelperId lookupKind, object targetOfLookup)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -26,6 +26,7 @@ namespace ILCompiler
         protected VTableSliceProvider _vtableSliceProvider = new LazyVTableSliceProvider();
         protected DictionaryLayoutProvider _dictionaryLayoutProvider = new LazyDictionaryLayoutProvider();
         protected DebugInformationProvider _debugInformationProvider = new DebugInformationProvider();
+        protected DevirtualizationManager _devirtualizationManager = new DevirtualizationManager();
 
         public CompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup compilationGroup, NameMangler nameMangler)
         {
@@ -74,6 +75,12 @@ namespace ILCompiler
         public CompilationBuilder UseGenericDictionaryLayoutProvider(DictionaryLayoutProvider provider)
         {
             _dictionaryLayoutProvider = provider;
+            return this;
+        }
+
+        public CompilationBuilder UseDevirtualizationManager(DevirtualizationManager manager)
+        {
+            _devirtualizationManager = manager;
             return this;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DevirtualizationManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DevirtualizationManager.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Manages devirtualization behaviors. Devirtualization is the process of converting
+    /// virtual calls to direct calls in cases where we can compute the result of a virtual
+    /// lookup at compile time.
+    /// </summary>
+    public class DevirtualizationManager
+    {
+        /// <summary>
+        /// Returns true if <paramref name="type"/> cannot be the base class of any other
+        /// type.
+        /// </summary>
+        public virtual bool IsEffectivelySealed(TypeDesc type)
+        {
+            switch (type.Category)
+            {
+                case TypeFlags.Array:
+                case TypeFlags.SzArray:
+                case TypeFlags.ByRef:
+                case TypeFlags.Pointer:
+                case TypeFlags.FunctionPointer:
+                    return true;
+
+                default:
+                    Debug.Assert(type.IsDefType);
+                    var metadataType = (MetadataType)type;
+                    return metadataType.IsSealed || metadataType.IsModuleType;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="method"/> cannot be overriden by any other method.
+        /// </summary>
+        public virtual bool IsEffectivelySealed(MethodDesc method)
+        {
+            return method.IsFinal || IsEffectivelySealed(method.OwningType);
+        }
+
+        /// <summary>
+        /// Attempts to resolve the <paramref name="declMethod"/> virtual method into
+        /// a method on <paramref name="implType"/> that implements the declaring method.
+        /// Returns null if this is not possible.
+        /// </summary>
+        /// <remarks>
+        /// Note that if <paramref name="implType"/> is a value type, the result of the resolution
+        /// might have to be treated as an unboxing thunk by the caller.
+        /// </remarks>
+        public MethodDesc ResolveVirtualMethod(MethodDesc declMethod, TypeDesc implType)
+        {
+            Debug.Assert(declMethod.IsVirtual);
+
+            // Quick check: if decl matches impl, we're done.
+            if (declMethod.OwningType == implType)
+                return declMethod;
+
+            // We're operating on virtual methods. This means that if implType is an array, we need
+            // to get the type that has all the virtual methods provided by the class library.
+            return ResolveVirtualMethod(declMethod, implType.GetClosestDefType());
+        }
+
+        protected virtual MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType)
+        {
+            MethodDesc impl;
+
+            if (declMethod.OwningType.IsInterface)
+            {
+                impl = implType.ResolveInterfaceMethodTarget(declMethod);
+                if (impl != null)
+                {
+                    impl = implType.FindVirtualFunctionTargetMethodOnObjectType(impl);
+                }
+            }
+            else
+            {
+                impl = implType.FindVirtualFunctionTargetMethodOnObjectType(declMethod);
+            }
+
+            return impl;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
@@ -30,7 +30,7 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             DebugInformationProvider debugInformationProvider,
             Logger logger)
-            : base(dependencyGraph, nodeFactory, roots, debugInformationProvider, logger)
+            : base(dependencyGraph, nodeFactory, roots, debugInformationProvider, null, logger)
         {
         }
 
@@ -106,6 +106,11 @@ namespace ILCompiler
             return new ScannedDictionaryLayoutProvider(MarkedNodes);
         }
 
+        public DevirtualizationManager GetDevirtualizationManager()
+        {
+            return new ScannedDevirtualizationManager(MarkedNodes);
+        }
+
         private class ScannedVTableProvider : VTableSliceProvider
         {
             private Dictionary<TypeDesc, IReadOnlyList<MethodDesc>> _vtableSlices = new Dictionary<TypeDesc, IReadOnlyList<MethodDesc>>();
@@ -173,6 +178,95 @@ namespace ILCompiler
                     else
                         return new LazilyBuiltDictionaryLayoutNode(method);
                 }
+            }
+        }
+
+        private class ScannedDevirtualizationManager : DevirtualizationManager
+        {
+            private HashSet<TypeDesc> _constructedTypes = new HashSet<TypeDesc>();
+            private HashSet<TypeDesc> _unsealedTypes = new HashSet<TypeDesc>();
+
+            public ScannedDevirtualizationManager(ImmutableArray<DependencyNodeCore<NodeFactory>> markedNodes)
+            {
+                foreach (var node in markedNodes)
+                {
+                    if (node is ConstructedEETypeNode eetypeNode)
+                    {
+                        TypeDesc type = eetypeNode.Type;
+
+                        if (!type.IsInterface)
+                        {
+                            //
+                            // We collect this information:
+                            //
+                            // 1. What types got allocated
+                            //    This is needed for optimizing codegens that might attempt to devirtualize
+                            //    calls to sealed types. The devirtualization is not allowed to succeed
+                            //    for types that never got allocated because the scanner likely didn't scan
+                            //    the target of the virtual call.
+                            // 2. What types are the base types of other types
+                            //    This is needed for optimizations. We use this information to effectively
+                            //    seal types that are not base types for any other type.
+                            //
+
+                            TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
+
+                            _constructedTypes.Add(canonType);
+
+                            // Since this is used for the purposes of devirtualization, it's really convenient
+                            // to also have Array<T> for each T[].
+                            if (canonType.IsArray)
+                                _constructedTypes.Add(canonType.GetClosestDefType());
+
+                            TypeDesc baseType = canonType.BaseType;
+                            bool added = true;
+                            while (baseType != null && added)
+                            {
+                                baseType = baseType.ConvertToCanonForm(CanonicalFormKind.Specific);
+                                added = _unsealedTypes.Add(baseType);
+                                baseType = baseType.BaseType;
+                            }
+                        }
+
+                    }
+                }
+            }
+
+            public override bool IsEffectivelySealed(TypeDesc type)
+            {
+                // If we know we scanned a type that derives from this one, this for sure can't be reported as sealed.
+                TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
+                if (_unsealedTypes.Contains(canonType))
+                    return false;
+
+                // We don't want to report types that never got allocated as sealed because that would allow
+                // the codegen to do direct calls to the type's methods. That can potentially lead to codegen
+                // generating calls to methods we never scanned (consider a sealed type that never got allocated
+                // with a virtual method that can be devirtualized because the type is sealed).
+                // Codegen looking at code we didn't scan is never okay.
+                if (!_constructedTypes.Contains(canonType))
+                    return false;
+
+                if (type is MetadataType metadataType)
+                {
+                    // Due to how the compiler is structured, we might see "constructed" EETypes for things
+                    // that never got allocated (doing a typeof() on a class that is otherwise never used is
+                    // a good example of when that happens). This can put us into a position where we could
+                    // report `sealed` on an `abstract` class, but that doesn't lead to anything good.
+                    return !metadataType.IsAbstract;
+                }
+
+                // Everything else can be considered sealed.
+                return true;
+            }
+
+            public override bool IsEffectivelySealed(MethodDesc method)
+            {
+                // For the same reason as above, don't report methods on unallocated types as sealed.
+                if (!_constructedTypes.Contains(method.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific)))
+                    return false;
+
+                return base.IsEffectivelySealed(method);
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilation.cs
@@ -25,8 +25,9 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             DebugInformationProvider debugInformationProvider,
             Logger logger,
+            DevirtualizationManager devirtualizationManager,
             JitConfigProvider configProvider)
-            : base(dependencyGraph, nodeFactory, roots, debugInformationProvider, logger)
+            : base(dependencyGraph, nodeFactory, roots, debugInformationProvider, devirtualizationManager, logger)
         {
             _jitConfigProvider = configProvider;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
@@ -91,7 +91,7 @@ namespace ILCompiler
 
             var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-            return new RyuJitCompilation(graph, factory, _compilationRoots, _debugInformationProvider, _logger, jitConfig);
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _debugInformationProvider, _logger, _devirtualizationManager, jitConfig);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Compiler\DependencyAnalysis\IMethodBodyNodeWithFuncletSymbols.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ISymbolNodeWithFuncletId.cs" />
     <Compile Include="Compiler\DependencyAnalysis\LoopHijackFlagNode.cs" />
+    <Compile Include="Compiler\DevirtualizationManager.cs" />
     <Compile Include="Compiler\DictionaryLayoutProvider.cs" />
     <Compile Include="Compiler\EmptyInteropStubManager.cs" />
     <Compile Include="Compiler\DependencyAnalysis\SortableDependencyNode.cs" />

--- a/src/ILCompiler.Compiler/tests/DevirtualizationTests.cs
+++ b/src/ILCompiler.Compiler/tests/DevirtualizationTests.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+
+using Xunit;
+
+namespace ILCompiler.Compiler.Tests
+{
+    public class DevirtualizationTests
+    {
+        private readonly CompilerTypeSystemContext _context;
+        private readonly ModuleDesc _testModule;
+
+        public DevirtualizationTests()
+        {
+            var target = new TargetDetails(TargetArchitecture.X64, TargetOS.Windows, TargetAbi.CoreRT);
+            _context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes);
+
+            _context.InputFilePaths = new Dictionary<string, string> {
+                { "Test.CoreLib", @"Test.CoreLib.dll" },
+                { "ILCompiler.Compiler.Tests.Assets", @"ILCompiler.Compiler.Tests.Assets.dll" },
+                };
+            _context.ReferenceFilePaths = new Dictionary<string, string>();
+
+            _context.SetSystemModule(_context.GetModuleForSimpleName("Test.CoreLib"));
+            _testModule = _context.GetModuleForSimpleName("ILCompiler.Compiler.Tests.Assets");
+        }
+
+        private DevirtualizationManager GetDevirtualizationManagerFromScan(MethodDesc method)
+        {
+            CompilationModuleGroup compilationGroup = new SingleFileCompilationModuleGroup(_context);
+
+            CompilationBuilder builder = new RyuJitCompilationBuilder(_context, compilationGroup);
+            IILScanner scanner = builder.GetILScannerBuilder()
+                .UseCompilationRoots(new ICompilationRootProvider[] { new SingleMethodRootProvider(method) })
+                .ToILScanner();
+
+            return scanner.Scan().GetDevirtualizationManager();
+        }
+
+        [Fact]
+        public void TestDevirtualizeWithUnallocatedType()
+        {
+            MetadataType testType = _testModule.GetType("Devirtualization", "DevirtualizeWithUnallocatedType");
+            DevirtualizationManager scanDevirt = GetDevirtualizationManagerFromScan(testType.GetMethod("Run", null));
+
+            MethodDesc decl = testType.GetNestedType("Base").GetMethod("Unreachable", null);
+            MetadataType impl = testType.GetNestedType("Derived");
+
+            // Base::Unreachable should resolve into Derived::Unreachable on Derived.
+            MethodDesc resolvedMethod = scanDevirt.ResolveVirtualMethod(decl, impl);
+            Assert.Same(impl.GetMethod("Unreachable", null), resolvedMethod);
+
+            // The resolved method should not be treated as sealed
+            Assert.False(scanDevirt.IsEffectivelySealed(resolvedMethod));
+
+            // Even though the metadata based algorithm would say it's sealed
+            var devirt = new DevirtualizationManager();
+            Assert.True(devirt.IsEffectivelySealed(resolvedMethod));
+        }
+
+        [Fact]
+        public void TestDevirtualizeWithOtherUnallocatedType()
+        {
+            MetadataType testType = _testModule.GetType("Devirtualization", "DevirtualizeWithOtherUnallocatedType");
+            DevirtualizationManager scanDevirt = GetDevirtualizationManagerFromScan(testType.GetMethod("Run", null));
+
+            MetadataType impl = testType.GetNestedType("Derived");
+
+            // The resolved method should not be treated as sealed
+            Assert.False(scanDevirt.IsEffectivelySealed(impl.GetMethod("Unreachable", null)));
+        }
+
+        [Fact]
+        public void TestDevirtualizeSimple()
+        {
+            MetadataType testType = _testModule.GetType("Devirtualization", "DevirtualizeSimple");
+            DevirtualizationManager scanDevirt = GetDevirtualizationManagerFromScan(testType.GetMethod("Run", null));
+
+            MethodDesc implMethod = testType.GetNestedType("Derived").GetMethod("Virtual", null);
+
+            // The impl method should be treated as sealed
+            Assert.True(scanDevirt.IsEffectivelySealed(implMethod));
+
+            // Even though the metadata based algorithm would say it isn't
+            var devirt = new DevirtualizationManager();
+            Assert.False(devirt.IsEffectivelySealed(implMethod));
+        }
+
+        [Fact]
+        public void TestDevirtualizeAbstract()
+        {
+            MetadataType testType = _testModule.GetType("Devirtualization", "DevirtualizeAbstract");
+            DevirtualizationManager scanDevirt = GetDevirtualizationManagerFromScan(testType.GetMethod("Run", null));
+
+            Assert.False(scanDevirt.IsEffectivelySealed(testType.GetNestedType("Abstract")));
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/tests/ILCompiler.Compiler.Tests.Assets/Devirtualization.cs
+++ b/src/ILCompiler.Compiler/tests/ILCompiler.Compiler.Tests.Assets/Devirtualization.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Devirtualization
+{
+    class DevirtualizeWithUnallocatedType
+    {
+        abstract class Base
+        {
+            public abstract void Unreachable();
+        }
+
+        sealed class Derived : Base
+        {
+            public override void Unreachable()
+            {
+                new Derived();
+            }
+        }
+
+        static void Run()
+        {
+            Derived p = null;
+            if (new object() == null)
+                p.Unreachable();
+        }
+    }
+
+    class DevirtualizeWithOtherUnallocatedType
+    {
+        abstract class Base
+        {
+            public abstract void Unreachable();
+        }
+
+        class Derived : Base
+        {
+            public sealed override void Unreachable()
+            {
+                new Derived();
+            }
+        }
+
+        static void Run()
+        {
+            Derived p = null;
+            if (new object() == null)
+                p.Unreachable();
+        }
+    }
+
+    class DevirtualizeSimple
+    {
+        abstract class Base
+        {
+            public abstract void Virtual();
+        }
+
+        class Derived : Base
+        {
+            public override void Virtual()
+            {
+                new Derived();
+            }
+        }
+
+        static void Run()
+        {
+            Base p = new Derived();
+            p.Virtual();
+        }
+    }
+
+    class DevirtualizeAbstract
+    {
+        abstract class Abstract { }
+
+        static void Run()
+        {
+            typeof(Abstract).GetHashCode();
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/tests/ILCompiler.Compiler.Tests.Assets/ILCompiler.Compiler.Tests.Assets.csproj
+++ b/src/ILCompiler.Compiler/tests/ILCompiler.Compiler.Tests.Assets/ILCompiler.Compiler.Tests.Assets.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="DependencyGraph.cs" />
+    <Compile Include="Devirtualization.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/ILCompiler.Compiler/tests/ILCompiler.Compiler.Tests.csproj
+++ b/src/ILCompiler.Compiler/tests/ILCompiler.Compiler.Tests.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <Compile Include="DependencyGraphTests.cs" />
+    <Compile Include="DevirtualizationTests.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilation.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilation.cs
@@ -25,7 +25,7 @@ namespace ILCompiler
             DebugInformationProvider debugInformationProvider,
             Logger logger,
             CppCodegenConfigProvider options)
-            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), debugInformationProvider, logger)
+            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), debugInformationProvider, null, logger)
         {
             Options = options;
         }

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
@@ -23,7 +23,7 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             Logger logger,
             WebAssemblyCodegenConfigProvider options)
-            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), null, logger)
+            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), null, null, logger)
         {
             NodeFactory = nodeFactory;
             LLVM.LoadLibrary_libLLVM("./libLLVM-x64.dll");

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -437,6 +437,12 @@ namespace ILCompiler
                 // If we have a scanner, feed the generic dictionary results to the compilation.
                 // This could be a command line switch if we really wanted to.
                 builder.UseGenericDictionaryLayoutProvider(scanResults.GetDictionaryLayoutInfo());
+
+                // If we feed any outputs of the scanner into the compilation, it's essential
+                // we use scanner's devirtualization manager. It prevents optimizing codegens
+                // from accidentally devirtualizing cases that can never happen at runtime
+                // (e.g. devirtualizing a method on a type that never gets allocated).
+                builder.UseDevirtualizationManager(scanResults.GetDevirtualizationManager());
             }
 
             ICompilation compilation = builder.ToCompilation();

--- a/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitCompilation.cs
+++ b/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitCompilation.cs
@@ -23,6 +23,7 @@ namespace ILCompiler
             _typeGetTypeMethodThunks = new TypeGetTypeMethodThunkCache(context.GetWellKnownType(WellKnownType.Object));
             _methodILCache = new ILProvider(new PInvokeILProvider(new PInvokeILEmitterConfiguration(forceLazyResolution: true), null));
             _nodeFactory = new NodeFactory(context);
+            _devirtualizationManager = new DevirtualizationManager();
         }
 
         private readonly NodeFactory _nodeFactory;
@@ -30,6 +31,7 @@ namespace ILCompiler
         protected readonly Logger _logger = Logger.Null;
         private readonly TypeGetTypeMethodThunkCache _typeGetTypeMethodThunks;
         private ILProvider _methodILCache;
+        private readonly DevirtualizationManager _devirtualizationManager;
 
         internal Logger Logger => _logger;
 
@@ -100,6 +102,21 @@ namespace ILCompiler
         public bool HasFixedSlotVTable(TypeDesc type)
         {
             return true;
+        }
+
+        public bool IsEffectivelySealed(TypeDesc type)
+        {
+            return _devirtualizationManager.IsEffectivelySealed(type);
+        }
+
+        public bool IsEffectivelySealed(MethodDesc method)
+        {
+            return _devirtualizationManager.IsEffectivelySealed(method);
+        }
+
+        public MethodDesc ResolveVirtualMethod(MethodDesc declMethod, TypeDesc implType)
+        {
+            return _devirtualizationManager.ResolveVirtualMethod(declMethod, implType);
         }
 
         public bool NeedsRuntimeLookup(ReadyToRunHelperId lookupKind, object targetOfLookup)

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -134,6 +134,7 @@
     <Compile Include="$(ILCompilerBasePath)\Compiler\TypeExtensions.cs" />
     <Compile Include="$(ILCompilerBasePath)\Compiler\NameMangler.cs" />
     <Compile Include="$(ILCompilerBasePath)\Compiler\NodeMangler.cs" />
+    <Compile Include="$(ILCompilerBasePath)\Compiler\DevirtualizationManager.cs" />
     <Compile Include="$(ILCompilerBasePath)\IL\Stubs\PInvokeILProvider.cs" />
     <Compile Include="$(DependencyAnalysisFrameworkBasePath)\IDependencyNode.cs" />
     <Compile Include="$(DependencyAnalysisFrameworkBasePath)\DependencyNode.cs" />

--- a/src/Test.CoreLib/src/System/RuntimeTypeHandle.cs
+++ b/src/Test.CoreLib/src/System/RuntimeTypeHandle.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RuntimeTypeHandle
+    {
+        private EETypePtr _pEEType;
+
+        internal RuntimeTypeHandle(EETypePtr pEEType)
+        {
+            _pEEType = pEEType;
+        }
+
+        [Intrinsic]
+        internal static unsafe IntPtr GetValueInternal(RuntimeTypeHandle handle)
+        {
+            return (IntPtr)handle._pEEType.ToPointer();
+        }
+    }
+}
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    // Needed by the compiler to lower LDTOKEN
+    internal static class LdTokenHelpers
+    {
+        private static RuntimeTypeHandle GetRuntimeTypeHandle(IntPtr pEEType)
+        {
+            return new RuntimeTypeHandle(new EETypePtr(pEEType));
+        }
+    }
+}

--- a/src/Test.CoreLib/src/System/Type.cs
+++ b/src/Test.CoreLib/src/System/Type.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// System.Type is only defined to support C# typeof. We shouldn't have it here since the semantic
+// is not very compatible.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    public class Type
+    {
+        private readonly RuntimeTypeHandle _typeHandle;
+
+        private Type(RuntimeTypeHandle typeHandle)
+        {
+            _typeHandle = typeHandle;
+        }
+
+        public RuntimeTypeHandle TypeHandle => _typeHandle;
+
+        public static Type GetTypeFromHandle(RuntimeTypeHandle rh)
+        {
+            return new Type(rh);
+        }
+    }
+}

--- a/src/Test.CoreLib/src/Test.CoreLib.csproj
+++ b/src/Test.CoreLib/src/Test.CoreLib.csproj
@@ -156,9 +156,6 @@
     <Compile Include="..\..\Runtime.Base\src\System\RuntimeHandles.cs">
       <Link>System\RuntimeHandles.cs</Link>
     </Compile>
-    <Compile Include="..\..\Runtime.Base\src\System\RuntimeTypeHandle.cs">
-      <Link>System\RuntimeTypeHandle.cs</Link>
-    </Compile>
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\CompilerServices\EagerStaticClassConstructionAttribute.cs">
       <Link>System\Runtime\CompilerServices\EagerStaticClassConstructionAttribute.cs</Link>
     </Compile>
@@ -238,6 +235,8 @@
     <Compile Include="System\Array.cs" />
     <Compile Include="System\RuntimeExceptionHelpers.cs" />
     <Compile Include="System\Object.cs" />
+    <Compile Include="System\Type.cs" />
+    <Compile Include="System\RuntimeTypeHandle.cs" />
     <Compile Include="..\..\Common\src\Internal\Runtime\TypeManagerHandle.cs">
       <Link>Internal\Runtime\TypeManagerHandle.cs</Link>
     </Compile>


### PR DESCRIPTION
Split into 3 commits for better reviewability.

Fixes #5019. Besides fixing that, I also made this do "sealing" of types that we see never have a derived type allocated (because it was easy). This results in more than double the number of potential successful devirtualizations (for the web app template, we see an increase from 800 to 1800 cases where `resolveVirtualMethod` returns a method that is reported as `final`).