### PR TITLE
Added real support for Unbox stubs to WebAssembly

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -526,7 +526,7 @@ namespace ILCompiler
                 }
 
                 // Call an instance method on the target valuetype
-                codeStream.Emit(ILOpcode.call, emit.NewToken(_targetMethod));
+                codeStream.Emit(ILOpcode.call, emit.NewToken(_targetMethod.InstantiateAsOpen()));
                 codeStream.Emit(ILOpcode.ret);
 
                 return emit.Link(this);

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -111,11 +111,16 @@ namespace ILCompiler
             {
                 InstantiatedType boxedType = boxedTypeDefinition.MakeInstantiatedType(owningType.Instantiation);
                 MethodDesc thunk = GetMethodForInstantiatedType(thunkDefinition, boxedType);
+                //TODO: this might be triggered by a struct that implements an interface with a generic method
                 Debug.Assert(!thunk.HasInstantiation);
                 return thunk;
             }
             else
+            {
+                //TODO: this might be triggered by a struct that implements an interface with a generic method
+                Debug.Assert(!thunkDefinition.HasInstantiation);
                 return thunkDefinition;
+            }
         }
 
         /// <summary>

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Sorting.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Sorting.cs
@@ -40,6 +40,17 @@ namespace ILCompiler
             }
         }
 
+        partial class UnboxingThunk
+        {
+            protected override int ClassCode => 446545583;
+
+            protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+            {
+                var otherMethod = (UnboxingThunk)other;
+                return comparer.Compare(_targetMethod, otherMethod._targetMethod);
+            }
+        }
+
         partial class ValueTypeInstanceMethodWithHiddenParameter
         {
             protected override int ClassCode => 2131875345;

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1656,9 +1656,6 @@ namespace Internal.IL
 
         private LLVMValueRef GetInstanceFieldAddress(StackEntry objectEntry, FieldDesc field)
         {
-            if (!field.IsTypicalFieldDefinition)
-                throw new InvalidProgramException();
-
             var objectType = objectEntry.Type ?? field.OwningType;
             LLVMValueRef untypedObjectValue;
             LLVMTypeRef llvmObjectType = GetLLVMTypeForTypeDesc(objectType);

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -451,8 +451,6 @@ namespace Internal.IL
                 case TypeFlags.Interface:
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
-                case TypeFlags.SignatureTypeVariable:
-                case TypeFlags.SignatureMethodVariable:
                     return StackValueKind.ObjRef;
                 case TypeFlags.ByRef:
                     return StackValueKind.ByRef;
@@ -1658,6 +1656,9 @@ namespace Internal.IL
 
         private LLVMValueRef GetInstanceFieldAddress(StackEntry objectEntry, FieldDesc field)
         {
+            if (!field.IsTypicalFieldDefinition)
+                throw new InvalidProgramException();
+
             var objectType = objectEntry.Type ?? field.OwningType;
             LLVMValueRef untypedObjectValue;
             LLVMTypeRef llvmObjectType = GetLLVMTypeForTypeDesc(objectType);
@@ -1708,7 +1709,7 @@ namespace Internal.IL
 
         private void ImportLoadField(int token, bool isStatic)
         {
-            FieldDesc field = ((FieldDesc)_methodIL.GetObject(token)).GetTypicalFieldDefinition();
+            FieldDesc field = (FieldDesc)_methodIL.GetObject(token);
             LLVMValueRef fieldAddress = GetFieldAddress(field, isStatic);
             PushLoadExpression(GetStackValueKind(field.FieldType), "ldfld_" + field.Name, fieldAddress, field.FieldType);
         }

--- a/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
@@ -51,8 +51,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
         {
-            // TODO: this is wrong: this returns an unstubbed node
-            return new WebAssemblyMethodCodeNode(method);
+            return new WebAssemblyMethodCodeNode(TypeSystemContext.GetUnspecialUnboxingThunk(method, CompilationModuleGroup.GeneratedAssembly));
         }
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)

--- a/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
         {
-            return new WebAssemblyMethodCodeNode(TypeSystemContext.GetUnspecialUnboxingThunk(method, CompilationModuleGroup.GeneratedAssembly));
+            return new WebAssemblyMethodCodeNode(TypeSystemContext.GetUnboxingThunk(method, CompilationModuleGroup.GeneratedAssembly));
         }
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -58,6 +58,9 @@ internal static class Program
             PrintLine("box test: Ok.");
         }
 
+        var boxedStruct = (object)new BoxStubTest { Value = "Boxed Stub Test: Ok." };
+        PrintLine(boxedStruct.ToString());
+
         var not = Not(0xFFFFFFFF) == 0x00000000;
         if (not)
         {
@@ -182,6 +185,15 @@ public struct TwoByteStr
 {
     public byte first;
     public byte second;
+}
+
+public struct BoxStubTest
+{
+    public string Value;
+    public override string ToString()
+    {
+        return Value;
+    }
 }
 
 public class TestClass

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -54,7 +54,7 @@
     <IlcArg Include="--targetarch=$(Platform)" />
     
     <!-- Broken on wasm: https://github.com/dotnet/corert/issues/5005 -->
-    <IlcArg Condition="$(NativeCodeGen) != 'wasm'" Include="--stacktracedata" />
+    <IlcArg Include="--stacktracedata" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes #5005 
@MichalStrehovsky I think this is in line with your first suggested path, but I'm a little hazy on the real meaning of things like the ClassCode when adding a new node. I'm also not totally sure that I really needed to use BoxedValueType at all, I think maybe I could have just used the original value type.