### PR TITLE
Emit metadata for type forwarders

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -390,6 +390,11 @@ namespace ILCompiler
                     _graph.AddRoot(_factory.ReflectableMethod(method), reason);
                 }
             }
+
+            public void RootModuleMetadata(ModuleDesc module, string reason)
+            {
+                _graph.AddRoot(_factory.ModuleMetadata(module), reason);
+            }
         }
     }
 

--- a/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
@@ -17,5 +17,6 @@ namespace ILCompiler
         void RootGCStaticBaseForType(TypeDesc type, string reason);
         void RootNonGCStaticBaseForType(TypeDesc type, string reason);
         void RootVirtualMethodForReflection(MethodDesc method, string reason);
+        void RootModuleMetadata(ModuleDesc module, string reason);
     }
 }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
@@ -32,6 +32,7 @@
     <Compile Include="ILCompiler\Metadata\Transform.Scope.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.String.cs" />
     <Compile Include="ILCompiler\Metadata\Transform.Type.cs" />
+    <Compile Include="ILCompiler\Metadata\Transform.TypeForwarders.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="'$(IsProjectNLibrary)' != 'true'"/>
 </Project>

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -158,8 +158,7 @@ namespace ILCompiler.Metadata
 
             public int GetHashCode(AssemblyName obj)
             {
-                string simpleName = obj.Name;
-                return simpleName != null ? simpleName.GetHashCode() : 0;
+                return obj.Name?.GetHashCode() ?? 0;
             }
         }
     }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -97,6 +97,8 @@ namespace ILCompiler.Metadata
                     {
                         scopeDefinition.ModuleCustomAttributes = HandleCustomAttributes(ecmaAssembly, moduleAttributes);
                     }
+
+                    HandleTypeForwarders(ecmaAssembly);
                 }
             }
             else

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Scope.cs
@@ -13,6 +13,7 @@ using Debug = System.Diagnostics.Debug;
 using AssemblyFlags = Internal.Metadata.NativeFormat.AssemblyFlags;
 using AssemblyNameFlags = System.Reflection.AssemblyNameFlags;
 using AssemblyContentType = System.Reflection.AssemblyContentType;
+using AssemblyName = System.Reflection.AssemblyName;
 
 namespace ILCompiler.Metadata
 {
@@ -107,45 +108,58 @@ namespace ILCompiler.Metadata
             }
         }
 
-        private EntityMap<Cts.ModuleDesc, ScopeReference> _scopeRefs
-            = new EntityMap<Cts.ModuleDesc, ScopeReference>(EqualityComparer<Cts.ModuleDesc>.Default);
-        private Action<Cts.ModuleDesc, ScopeReference> _initScopeRef;
+        private EntityMap<AssemblyName, ScopeReference> _scopeRefs
+            = new EntityMap<AssemblyName, ScopeReference>(new SimpleAssemblyNameComparer());
+        private Action<AssemblyName, ScopeReference> _initScopeRef;
 
         private ScopeReference HandleScopeReference(Cts.ModuleDesc module)
         {
-            return _scopeRefs.GetOrCreate(module, _initScopeRef ?? (_initScopeRef = InitializeScopeReference));
+            var assembly = module as Cts.IAssemblyDesc;
+            if (assembly != null)
+                return HandleScopeReference(assembly.GetName());
+            else
+                throw new NotSupportedException("Multi-module assemblies");
         }
 
-        private void InitializeScopeReference(Cts.ModuleDesc module, ScopeReference scopeReference)
+        private ScopeReference HandleScopeReference(AssemblyName assemblyName)
         {
-            var assemblyDesc = module as Cts.IAssemblyDesc;
-            if (assemblyDesc != null)
+            return _scopeRefs.GetOrCreate(assemblyName, _initScopeRef ?? (_initScopeRef = InitializeScopeReference));
+        }
+
+        private void InitializeScopeReference(AssemblyName assemblyName, ScopeReference scopeReference)
+        {
+            scopeReference.Name = HandleString(assemblyName.Name);
+            scopeReference.Culture = HandleString(assemblyName.CultureName);
+            scopeReference.MajorVersion = checked((ushort)assemblyName.Version.Major);
+            scopeReference.MinorVersion = checked((ushort)assemblyName.Version.Minor);
+            scopeReference.BuildNumber = checked((ushort)assemblyName.Version.Build);
+            scopeReference.RevisionNumber = checked((ushort)assemblyName.Version.Revision);
+
+            Debug.Assert((int)AssemblyFlags.PublicKey == (int)AssemblyNameFlags.PublicKey);
+            Debug.Assert((int)AssemblyFlags.Retargetable == (int)AssemblyNameFlags.Retargetable);
+
+            // References use a public key token instead of full public key.
+            scopeReference.Flags = (AssemblyFlags)(assemblyName.Flags & ~AssemblyNameFlags.PublicKey);
+
+            if (assemblyName.ContentType == AssemblyContentType.WindowsRuntime)
             {
-                var assemblyName = assemblyDesc.GetName();
-
-                scopeReference.Name = HandleString(assemblyName.Name);
-                scopeReference.Culture = HandleString(assemblyName.CultureName);
-                scopeReference.MajorVersion = checked((ushort)assemblyName.Version.Major);
-                scopeReference.MinorVersion = checked((ushort)assemblyName.Version.Minor);
-                scopeReference.BuildNumber = checked((ushort)assemblyName.Version.Build);
-                scopeReference.RevisionNumber = checked((ushort)assemblyName.Version.Revision);
-
-                Debug.Assert((int)AssemblyFlags.PublicKey == (int)AssemblyNameFlags.PublicKey);
-                Debug.Assert((int)AssemblyFlags.Retargetable == (int)AssemblyNameFlags.Retargetable);
-
-                // References use a public key token instead of full public key.
-                scopeReference.Flags = (AssemblyFlags)(assemblyName.Flags & ~AssemblyNameFlags.PublicKey);
-
-                if (assemblyName.ContentType == AssemblyContentType.WindowsRuntime)
-                {
-                    scopeReference.Flags |= (AssemblyFlags)((int)AssemblyContentType.WindowsRuntime << 9);
-                }
-
-                scopeReference.PublicKeyOrToken = assemblyName.GetPublicKeyToken();
+                scopeReference.Flags |= (AssemblyFlags)((int)AssemblyContentType.WindowsRuntime << 9);
             }
-            else
+
+            scopeReference.PublicKeyOrToken = assemblyName.GetPublicKeyToken();
+        }
+
+        private class SimpleAssemblyNameComparer : IEqualityComparer<AssemblyName>
+        {
+            public bool Equals(AssemblyName x, AssemblyName y)
             {
-                throw new NotSupportedException("Multi-module assemblies");
+                return Object.Equals(x.Name, y.Name);
+            }
+
+            public int GetHashCode(AssemblyName obj)
+            {
+                string simpleName = obj.Name;
+                return simpleName != null ? simpleName.GetHashCode() : 0;
             }
         }
     }

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.TypeForwarders.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.TypeForwarders.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.Metadata.NativeFormat.Writer;
+
+using Cts = Internal.TypeSystem;
+using Ecma = System.Reflection.Metadata;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.Metadata
+{
+    partial class Transform<TPolicy>
+    {
+        private void HandleTypeForwarders(Cts.Ecma.EcmaModule module)
+        {
+            foreach (var exportedTypeHandle in module.MetadataReader.ExportedTypes)
+            {
+                Ecma.ExportedType exportedType = module.MetadataReader.GetExportedType(exportedTypeHandle);
+                if (exportedType.IsForwarder || exportedType.Implementation.Kind == Ecma.HandleKind.ExportedType)
+                {
+                    try
+                    {
+                        HandleTypeForwarder(module, exportedType);
+                    }
+                    catch (Cts.TypeSystemException)
+                    {
+                        // TODO: We should emit unresolvable type forwards instead of skipping these
+                    }
+                }
+                else
+                {
+                    Debug.Assert(false, "Multi-module assemblies");
+                }
+            }
+        }
+
+        private TypeForwarder HandleTypeForwarder(Cts.Ecma.EcmaModule module, Ecma.ExportedType exportedType)
+        {
+            Ecma.MetadataReader reader = module.MetadataReader;
+            string name = reader.GetString(exportedType.Name);
+            TypeForwarder result;
+
+            switch (exportedType.Implementation.Kind)
+            {
+                case Ecma.HandleKind.AssemblyReference:
+                    string ns = reader.GetString(exportedType.Namespace);
+                    NamespaceDefinition namespaceDefinition = HandleNamespaceDefinition(module, ns);
+
+                    result = new TypeForwarder
+                    {
+                        Name = HandleString(name),
+                        Scope = HandleScopeReference((Cts.ModuleDesc)module.GetObject(exportedType.Implementation)),
+                    };
+                    
+                    namespaceDefinition.TypeForwarders.Add(result);
+                    break;
+
+                case Ecma.HandleKind.ExportedType:
+                    TypeForwarder scope = HandleTypeForwarder(module, reader.GetExportedType((Ecma.ExportedTypeHandle)exportedType.Implementation));
+
+                    result = new TypeForwarder
+                    {
+                        Name = HandleString(name),
+                        Scope = scope.Scope,
+                    };
+
+                    scope.NestedTypes.Add(result);
+                    break;
+
+                default:
+                    throw new BadImageFormatException();
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -62,6 +62,8 @@ namespace ILCompiler
 
             ModuleDesc assembly = _context.ResolveAssembly(new AssemblyName(assemblyNameAttribute.Value));
 
+            rootProvider.RootModuleMetadata(assembly, "RD.XML root");
+
             var dynamicDegreeAttribute = assemblyElement.Attribute("Dynamic");
             if (dynamicDegreeAttribute != null)
             {


### PR DESCRIPTION
Fixes #2279, probably also #5051. I haven't checked.

I'm marking it as WIP, because I'm not too happy with how this turned out - emitting the metadata is easy; deciding *what to emit* is hard. Seeking some feedback.

I chose to use RD.XML as the mechanism to include the (otherwise unused) assemblies into the metadata. So the user has to put `<Assembly Name="mscorlib" />` in their RD.XML to get forwarders from mscorlib. It's really not great.

~~The other problem is that mscorlib has a lot of garbage in it (like references to System.Security.Permissions). This code throws *a lot*.~~