### PR TITLE
Fix a typo in type forward parser

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.GetTypeCore.CaseSensitive.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.GetTypeCore.CaseSensitive.cs
@@ -59,7 +59,7 @@ namespace System.Reflection.Runtime.Assemblies.NativeFormat
                     {
                         RuntimeAssemblyName redirectedAssemblyName = typeForwarder.Scope.ToRuntimeAssemblyName(reader);
                         RuntimeAssembly redirectedAssembly = RuntimeAssembly.GetRuntimeAssemblyIfExists(redirectedAssemblyName);
-                        if (redirectedAssemblyName == null)
+                        if (redirectedAssembly == null)
                             return null;
                         return redirectedAssembly.GetTypeCoreCaseSensitive(fullName);
                     }


### PR DESCRIPTION
Noticed this by accident when working with some incomplete metadata.

`redirectedAssembly` ended up being null and the code AV'd. I think the intent here was to check `redirectedAssembly`, not the `redirectedAssemblyName`.