### PR TITLE
Make scanner failures easier to troubleshoot

### DIFF
--- a/src/Common/src/TypeSystem/Common/Utilities/ExceptionTypeNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/ExceptionTypeNameFormatter.cs
@@ -10,7 +10,7 @@ namespace Internal.TypeSystem
     /// <summary>
     /// Provides a name formatter that is compatible with SigFormat.cpp in the CLR.
     /// </summary>
-    internal partial class ExceptionTypeNameFormatter : TypeNameFormatter
+    public partial class ExceptionTypeNameFormatter : TypeNameFormatter
     {
         public static ExceptionTypeNameFormatter Instance { get; } = new ExceptionTypeNameFormatter();
 

--- a/src/ILCompiler.Compiler/src/Compiler/CodeGenerationFailedException.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CodeGenerationFailedException.cs
@@ -8,7 +8,7 @@ using Internal.TypeSystem;
 
 namespace ILCompiler
 {
-    public class CodeGenerationFailedException : Exception
+    public class CodeGenerationFailedException : InternalCompilerErrorException
     {
         private const string MessageText = "Code generation failed";
 

--- a/src/ILCompiler.Compiler/src/Compiler/InternalCompilerErrorException.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/InternalCompilerErrorException.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace ILCompiler
+{
+    public class InternalCompilerErrorException : Exception
+    {
+        public InternalCompilerErrorException(string message)
+            : this(message, innerException: null)
+        {
+        }
+
+        public InternalCompilerErrorException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Compiler\EmptyInteropStubManager.cs" />
     <Compile Include="Compiler\DependencyAnalysis\SortableDependencyNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ImportedNodeProvider.cs" />
+    <Compile Include="Compiler\InternalCompilerErrorException.cs" />
     <Compile Include="Compiler\PreInitFieldInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenArrayNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsPreInitDataNode.cs" />


### PR DESCRIPTION
Making the internal compiler error a bit more self-serviceable.

This doesn't cover the case when a slot wasn't computed, but those are typically more rare.