### PR TITLE
Overhaul ToString in the type system

### DIFF
--- a/src/Common/src/TypeSystem/Canon/CanonTypes.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.cs
@@ -189,11 +189,6 @@ namespace Internal.TypeSystem
 
             return _hashcode;
         }
-
-        public override string ToString()
-        {
-            return FullName;
-        }
     }
 
     /// <summary>
@@ -280,11 +275,6 @@ namespace Internal.TypeSystem
             }
 
             return _hashcode;
-        }
-
-        public override string ToString()
-        {
-            return FullName;
         }
     }
 }

--- a/src/Common/src/TypeSystem/Common/ArrayType.cs
+++ b/src/Common/src/TypeSystem/Common/ArrayType.cs
@@ -149,11 +149,6 @@ namespace Internal.TypeSystem
 
             return flags;
         }
-
-        public override string ToString()
-        {
-            return this.ElementType.ToString() + "[" + new String(',', Rank - 1) + "]";
-        }
     }
 
     public enum ArrayMethodKind
@@ -325,11 +320,6 @@ namespace Internal.TypeSystem
                 return ((ArrayType)instantiatedOwningType).GetArrayMethod(_kind);
             else
                 return this;
-        }
-
-        public override string ToString()
-        {
-            return _owningType.ToString() + "." + Name;
         }
     }
 }

--- a/src/Common/src/TypeSystem/Common/ByRefType.cs
+++ b/src/Common/src/TypeSystem/Common/ByRefType.cs
@@ -41,10 +41,5 @@ namespace Internal.TypeSystem
 
             return flags;
         }
-
-        public override string ToString()
-        {
-            return this.ParameterType.ToString() + "&";
-        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/FieldDesc.ToString.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.ToString.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class FieldDesc
+    {
+        public override string ToString()
+        {
+            return $"{OwningType}.{Name}";
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
+++ b/src/Common/src/TypeSystem/Common/FunctionPointerType.cs
@@ -71,22 +71,5 @@ namespace Internal.TypeSystem
 
             return flags;
         }
-
-        public override string ToString()
-        {
-            StringBuilder sb = new StringBuilder();
-            sb.Append(_signature.ReturnType);
-
-            sb.Append(" *(");
-            for (int i = 0; i < _signature.Length; i++)
-            {
-                if (i > 0)
-                    sb.Append(", ");
-                sb.Append(_signature[i]);
-            }
-            sb.Append(')');
-
-            return sb.ToString();
-        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedMethod.cs
@@ -150,14 +150,5 @@ namespace Internal.TypeSystem
                 return _methodDef.Name;
             }
         }
-
-        public override string ToString()
-        {
-            var sb = new StringBuilder(_methodDef.ToString());
-            sb.Append('<');
-            sb.Append(_instantiation.ToString());
-            sb.Append('>');
-            return sb.ToString();
-        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -269,15 +269,6 @@ namespace Internal.TypeSystem
             return _typeDef;
         }
 
-        public override string ToString()
-        {
-            var sb = new StringBuilder(_typeDef.ToString());
-            sb.Append('<');
-            sb.Append(_instantiation.ToString());
-            sb.Append('>');
-            return sb.ToString();
-        }
-
         // Properties that are passed through from the type definition
         public override ClassLayoutMetadata GetClassLayout()
         {

--- a/src/Common/src/TypeSystem/Common/MethodDesc.ToString.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.ToString.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Internal.TypeSystem
+{
+    partial class MethodSignature
+    {
+        public override string ToString()
+        {
+            return ToString(includeReturnType: true);
+        }
+
+        public string ToString(bool includeReturnType)
+        {
+            var sb = new StringBuilder();
+
+            if (includeReturnType)
+            {
+                DebugNameFormatter.Instance.AppendName(sb, ReturnType, DebugNameFormatter.FormatOptions.None);
+                sb.Append('(');
+            }
+
+            bool first = true;
+            foreach (TypeDesc param in _parameters)
+            {
+                if (first)
+                    first = false;
+                else
+                    sb.Append(',');
+                DebugNameFormatter.Instance.AppendName(sb, param, DebugNameFormatter.FormatOptions.None);
+            }
+
+            if (includeReturnType)
+                sb.Append(')');
+
+            return sb.ToString();
+        }
+    }
+
+    partial class MethodDesc
+    {
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            // (Skipping return type to keep things short)
+            sb.Append(OwningType);
+            sb.Append('.');
+            sb.Append(Name);
+
+            bool first = true;
+            for (int i = 0; i < Instantiation.Length; i++)
+            {
+                if (first)
+                {
+                    sb.Append('<');
+                    first = false;
+                }
+                else
+                {
+                    sb.Append(',');
+                }
+                DebugNameFormatter.Instance.AppendName(sb, Instantiation[i], DebugNameFormatter.FormatOptions.None);
+            }
+            if (!first)
+                sb.Append('>');
+
+            sb.Append('(');
+            sb.Append(Signature.ToString(includeReturnType: false));
+            sb.Append(')');
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -134,10 +134,5 @@ namespace Internal.TypeSystem
                 return _typicalMethodDef.Name;
             }
         }
-
-        public override string ToString()
-        {
-            return OwningType.ToString() + "." + Name;
-        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/PointerType.cs
+++ b/src/Common/src/TypeSystem/Common/PointerType.cs
@@ -39,10 +39,5 @@ namespace Internal.TypeSystem
 
             return flags;
         }
-
-        public override string ToString()
-        {
-            return this.ParameterType.ToString() + "*";
-        }
     }
 }

--- a/src/Common/src/TypeSystem/Common/SignatureVariable.cs
+++ b/src/Common/src/TypeSystem/Common/SignatureVariable.cs
@@ -78,11 +78,6 @@ namespace Internal.TypeSystem
         {
             return typeInstantiation.IsNull ? this : typeInstantiation[Index];
         }
-
-        public override string ToString()
-        {
-            return "!" + Index.ToStringInvariant();
-        }
     }
 
     public sealed partial class SignatureMethodVariable : SignatureVariable
@@ -119,11 +114,6 @@ namespace Internal.TypeSystem
         public override TypeDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
             return methodInstantiation.IsNull ? this : methodInstantiation[Index];
-        }
-
-        public override string ToString()
-        {
-            return "!!" + Index.ToStringInvariant();
         }
     }
 }

--- a/src/Common/src/TypeSystem/Common/TypeDesc.ToString.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.ToString.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class TypeDesc
+    {
+        public override string ToString()
+        {
+            return DebugNameFormatter.Instance.FormatName(this, DebugNameFormatter.FormatOptions.Default);
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/Utilities/DebugNameFormatter.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/DebugNameFormatter.cs
@@ -1,0 +1,234 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    public class DebugNameFormatter : TypeNameFormatter<DebugNameFormatter.Void, DebugNameFormatter.FormatOptions>
+    {
+        public static readonly DebugNameFormatter Instance = new DebugNameFormatter();
+
+        public override Void AppendName(StringBuilder sb, ArrayType type, FormatOptions options)
+        {
+            AppendName(sb, type.ElementType, options);
+
+            if (!type.IsSzArray && type.Rank == 1)
+            {
+                sb.Append("[*]");
+            }
+            else
+            {
+                sb.Append('[');
+                sb.Append(',', type.Rank - 1);
+                sb.Append(']');
+            }
+
+            return Void.Value;
+        }
+
+        public override Void AppendName(StringBuilder sb, ByRefType type, FormatOptions options)
+        {
+            AppendName(sb, type.ParameterType, options);
+            sb.Append('&');
+
+            return Void.Value;
+        }
+
+        public override Void AppendName(StringBuilder sb, PointerType type, FormatOptions options)
+        {
+            AppendName(sb, type.ParameterType, options);
+            sb.Append('*');
+
+            return Void.Value;
+        }
+
+        public override Void AppendName(StringBuilder sb, FunctionPointerType type, FormatOptions options)
+        {
+            MethodSignature signature = type.Signature;
+
+            sb.Append("(*");
+            AppendName(sb, signature.ReturnType, options);
+            sb.Append(")(");
+            for (int i = 0; i < signature.Length; i++)
+            {
+                if (i > 0)
+                    sb.Append(',');
+                AppendName(sb, signature[i], options);
+            }
+            sb.Append(')');
+
+            return Void.Value;
+        }
+
+        public override Void AppendName(StringBuilder sb, GenericParameterDesc type, FormatOptions options)
+        {
+            sb.Append(type.Name);
+
+            return Void.Value;
+        }
+
+        public override Void AppendName(StringBuilder sb, SignatureMethodVariable type, FormatOptions options)
+        {
+            sb.Append("!!");
+            sb.Append(type.Index);
+
+            return Void.Value;
+        }
+
+        public override Void AppendName(StringBuilder sb, SignatureTypeVariable type, FormatOptions options)
+        {
+            sb.Append("!");
+            sb.Append(type.Index);
+
+            return Void.Value;
+        }
+
+        protected override Void AppendNameForNestedType(StringBuilder sb, DefType nestedType, DefType containingType, FormatOptions options)
+        {
+            if ((options & FormatOptions.NamespaceQualify) != 0)
+            {
+                AppendName(sb, containingType, options);
+                sb.Append('+');
+            }
+
+            sb.Append(nestedType.Name);
+
+            return Void.Value;
+        }
+
+        protected override Void AppendNameForNamespaceType(StringBuilder sb, DefType type, FormatOptions options)
+        {
+            // Shortcut some of the well known types
+            switch (type.Category)
+            {
+                case TypeFlags.Void:
+                    sb.Append("void");
+                    return Void.Value;
+                case TypeFlags.Boolean:
+                    sb.Append("bool");
+                    return Void.Value;
+                case TypeFlags.Char:
+                    sb.Append("char");
+                    return Void.Value;
+                case TypeFlags.SByte:
+                    sb.Append("int8");
+                    return Void.Value;
+                case TypeFlags.Byte:
+                    sb.Append("uint8");
+                    return Void.Value;
+                case TypeFlags.Int16:
+                    sb.Append("int16");
+                    return Void.Value;
+                case TypeFlags.UInt16:
+                    sb.Append("uint16");
+                    return Void.Value;
+                case TypeFlags.Int32:
+                    sb.Append("int32");
+                    return Void.Value;
+                case TypeFlags.UInt32:
+                    sb.Append("uint32");
+                    return Void.Value;
+                case TypeFlags.Int64:
+                    sb.Append("int64");
+                    return Void.Value;
+                case TypeFlags.UInt64:
+                    sb.Append("uint64");
+                    return Void.Value;
+                case TypeFlags.IntPtr:
+                    sb.Append("native int");
+                    return Void.Value;
+                case TypeFlags.UIntPtr:
+                    sb.Append("native uint");
+                    return Void.Value;
+                case TypeFlags.Single:
+                    sb.Append("float32");
+                    return Void.Value;
+                case TypeFlags.Double:
+                    sb.Append("float64");
+                    return Void.Value;
+            }
+
+            if (type.IsString)
+            {
+                sb.Append("string");
+                return Void.Value;
+            }
+
+            if (type.IsObject)
+            {
+                sb.Append("object");
+                return Void.Value;
+            }
+
+            if (((options & FormatOptions.AssemblyQualify) != 0)
+                && type is MetadataType mdType
+                && mdType.Module is IAssemblyDesc)
+            {
+                sb.Append('[');
+
+                // Trim the "System.Private." prefix
+                string assemblyName = ((IAssemblyDesc)mdType.Module).GetName().Name;
+                if (assemblyName.StartsWith("System.Private"))
+                    assemblyName = "S.P" + assemblyName.Substring(14);
+
+                sb.Append(assemblyName);
+                sb.Append(']');
+            }
+
+            if ((options & FormatOptions.NamespaceQualify) != 0)
+            {
+                string ns = type.Namespace;
+                if (ns.Length > 0)
+                {
+                    sb.Append(ns);
+                    sb.Append('.');
+                }
+            }
+
+            sb.Append(type.Name);
+
+            return Void.Value;
+        }
+
+        protected override Void AppendNameForInstantiatedType(StringBuilder sb, DefType type, FormatOptions options)
+        {
+            AppendName(sb, type.GetTypeDefinition(), options);
+
+            FormatOptions parameterOptions = options & ~FormatOptions.AssemblyQualify;
+
+            sb.Append('<');
+
+            for (int i = 0; i < type.Instantiation.Length; i++)
+            {
+                if (i != 0)
+                    sb.Append(',');
+
+                AppendName(sb, type.Instantiation[i], parameterOptions);
+            }
+
+            sb.Append('>');
+
+            return Void.Value;
+        }
+
+        public struct Void
+        {
+            public static Void Value => default(Void);
+        }
+
+        [Flags]
+        public enum FormatOptions
+        {
+            None = 0,
+            AssemblyQualify = 0x1,
+            NamespaceQualify = 0x2,
+
+            Default = AssemblyQualify | NamespaceQualify,
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaField.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.cs
@@ -41,7 +41,7 @@ namespace Internal.TypeSystem.Ecma
 
 #if DEBUG
             // Initialize name eagerly in debug builds for convenience
-            this.ToString();
+            InitializeName();
 #endif
         }
 
@@ -250,11 +250,6 @@ namespace Internal.TypeSystem.Ecma
         {
             return !MetadataReader.GetCustomAttributeHandle(MetadataReader.GetFieldDefinition(_handle).GetCustomAttributes(),
                 attributeNamespace, attributeName).IsNil;
-        }
-
-        public override string ToString()
-        {
-            return _type.ToString() + "." + Name;
         }
     }
 

--- a/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaGenericParameter.cs
@@ -133,11 +133,5 @@ namespace Internal.TypeSystem.Ecma
                 return constraintTypes;
             }
         }
-
-        public override string ToString()
-        {
-            MetadataReader reader = _module.MetadataReader;
-            return reader.GetString(reader.GetGenericParameter(_handle).Name);
-        }
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -51,7 +51,7 @@ namespace Internal.TypeSystem.Ecma
 
 #if DEBUG
             // Initialize name eagerly in debug builds for convenience
-            this.ToString();
+            InitializeName();
 #endif
         }
 
@@ -395,11 +395,6 @@ namespace Internal.TypeSystem.Ecma
         {
             return !MetadataReader.GetCustomAttributeHandle(MetadataReader.GetMethodDefinition(_handle).GetCustomAttributes(),
                 attributeNamespace, attributeName).IsNil;
-        }
-
-        public override string ToString()
-        {
-            return _type.ToString() + "." + Name;
         }
 
         public override bool IsPInvoke

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -42,7 +42,8 @@ namespace Internal.TypeSystem.Ecma
 
 #if DEBUG
             // Initialize name eagerly in debug builds for convenience
-            this.ToString();
+            InitializeName();
+            InitializeNamespace();
 #endif
         }
 
@@ -474,11 +475,6 @@ namespace Internal.TypeSystem.Ecma
         {
             return !MetadataReader.GetCustomAttributeHandle(_typeDefinition.GetCustomAttributes(),
                 attributeNamespace, attributeName).IsNil;
-        }
-
-        public override string ToString()
-        {
-            return "[" + _module.ToString() + "]" + this.GetFullName();
         }
 
         public override ClassLayoutMetadata GetClassLayout()

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeTargetNativeMethod.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeTargetNativeMethod.cs
@@ -76,10 +76,5 @@ namespace Internal.IL.Stubs
         {
             return _declMethod.GetPInvokeMethodMetadata();
         }
-
-        public override string ToString()
-        {
-            return "[EXTERNAL]" + Name;
-        }
     }
 }

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatField.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatField.cs
@@ -42,7 +42,7 @@ namespace Internal.TypeSystem.NativeFormat
 
 #if DEBUG
             // Initialize name eagerly in debug builds for convenience
-            this.ToString();
+            InitializeName();
 #endif
         }
 
@@ -266,11 +266,6 @@ namespace Internal.TypeSystem.NativeFormat
         {
             return MetadataReader.HasCustomAttribute(MetadataReader.GetField(_handle).CustomAttributes,
                 attributeNamespace, attributeName);
-        }
-
-        public override string ToString()
-        {
-            return _type.ToString() + "." + Name;
         }
     }
 }

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatGenericParameter.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatGenericParameter.cs
@@ -121,12 +121,5 @@ namespace Internal.TypeSystem.NativeFormat
                 return constraintTypes;
             }
         }
-
-        public override string ToString()
-        {
-            MetadataReader reader = MetadataReader;
-            GenericParameter parameter = reader.GetGenericParameter(_handle);
-            return parameter.Name.GetConstantStringValue(reader).Value;
-        }
     }
 }

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatMethod.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatMethod.cs
@@ -53,7 +53,7 @@ namespace Internal.TypeSystem.NativeFormat
 
 #if DEBUG
             // Initialize name eagerly in debug builds for convenience
-            this.ToString();
+            InitializeName();
 #endif
         }
 
@@ -414,11 +414,6 @@ namespace Internal.TypeSystem.NativeFormat
         {
             return MetadataReader.HasCustomAttribute(MetadataReader.GetMethod(_handle).CustomAttributes,
                 attributeNamespace, attributeName);
-        }
-
-        public override string ToString()
-        {
-            return _type.ToString() + "." + Name;
         }
 
         public override MethodNameAndSignature NameAndSignature

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
@@ -68,7 +68,7 @@ namespace Internal.TypeSystem.NativeFormat
 
 #if DEBUG
             // Initialize name eagerly in debug builds for convenience
-            this.ToString();
+            InitializeName();
 #endif
         }
 
@@ -540,11 +540,6 @@ namespace Internal.TypeSystem.NativeFormat
         {
             return MetadataReader.HasCustomAttribute(_typeDefinition.CustomAttributes,
                 attributeNamespace, attributeName);
-        }
-
-        public override string ToString()
-        {
-            return "[" + NativeFormatModule.GetName().Name + "]" + this.GetFullName();
         }
 
         public override ClassLayoutMetadata GetClassLayout()

--- a/src/Common/src/TypeSystem/RuntimeDetermined/MethodForRuntimeDeterminedType.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/MethodForRuntimeDeterminedType.cs
@@ -46,11 +46,6 @@ namespace Internal.TypeSystem
             return _typicalMethodDef.HasCustomAttribute(attributeNamespace, attributeName);
         }
 
-        public override string ToString()
-        {
-            return OwningType.ToString() + "." + Name;
-        }
-
         public override bool IsCanonicalMethod(CanonicalFormKind policy)
         {
             // Owning type is a RuntimeDeterminedType, so it can never be canonical.

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -173,11 +173,6 @@ namespace Internal.TypeSystem
             return false;
         }
 
-        public override string ToString()
-        {
-            return String.Concat(_runtimeDeterminedDetailsType.ToString(), "_", _rawCanonType.ToString());
-        }
-
         public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
             if (_runtimeDeterminedDetailsType.Kind == GenericParameterKind.Type)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -248,11 +248,6 @@ namespace ILCompiler
                 return hashCodeBuilder.ToHashCode();
             }
 
-            public override string ToString()
-            {
-                return "Boxed " + Module.ToString() + ValueTypeRepresented.ToString();
-            }
-
             protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
             {
                 TypeFlags flags = 0;

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -121,6 +121,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\CustomAttributeTypeNameParser.cs">
       <Link>Utilities\CustomAttributeTypeNameParser.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\DebugNameFormatter.cs">
+      <Link>Utilities\DebugNameFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\GCPointerMap.Algorithm.cs">
       <Link>Utilities\GCPointerMap.Algorithm.cs</Link>
     </Compile>
@@ -153,6 +156,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.cs">
       <Link>TypeSystem\Common\FieldDesc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.ToString.cs">
+      <Link>TypeSystem\Common\FieldDesc.ToString.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.FieldLayout.cs">
       <Link>TypeSystem\Common\FieldDesc.FieldLayout.cs</Link>
@@ -250,11 +256,17 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.cs">
       <Link>TypeSystem\Common\MethodDesc.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.ToString.cs">
+      <Link>TypeSystem\Common\MethodDesc.ToString.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\MetadataVirtualMethodAlgorithm.cs">
       <Link>TypeSystem\Common\StandardVirtualMethodAlgorithm.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.cs">
       <Link>TypeSystem\Common\TypeDesc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.ToString.cs">
+      <Link>TypeSystem\Common\TypeDesc.ToString.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.Interfaces.cs">
       <Link>TypeSystem\Common\TypeDesc.Interfaces.cs</Link>

--- a/src/ILCompiler.TypeSystem/tests/SyntheticVirtualOverrideTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/SyntheticVirtualOverrideTests.cs
@@ -226,11 +226,6 @@ namespace TypeSystemTests
             {
                 return false;
             }
-
-            public override string ToString()
-            {
-                return "[::Synthetic]" + _owningType.ToString() + "." + _name;
-            }
         }
     }
 }

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -528,5 +528,19 @@
       <Link>NativeFormat\NativeFormatType.MethodImpls.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'=='Debug'">
+    <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.ToString.cs">
+      <Link>Internal\TypeSystem\TypeDesc.ToString.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.ToString.cs">
+      <Link>Internal\TypeSystem\MethodDesc.ToString.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.ToString.cs">
+      <Link>Internal\TypeSystem\FieldDesc.ToString.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\DebugNameFormatter.cs">
+      <Link>Utilities\DebugNameFormatter.cs</Link>
+    </Compile>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Fixes #1276.

This is fixing several problems with how we did `ToString`:
* The existing scheme required every `TypeDesc`/`MethodDesc`/`FieldDesc` descendant to override `ToString`. Of course we were not consistent with this and as a result, most of our synthetic type system entities had non-existent representation in the debugger. Overriding is a lot of boilerplate.
* We were not flexible with the stringified names. E.g. instantiated types became too long because we were module- and namespace- qualifying everything.
* (Minor) The runtime type loader was shipping with ToString support in retail configuration that was largely unused.

With the new scheme, besides fixing the problems above, I'm adding a bunch of conveniences:
* `MethodDesc` now also have signatures in their `ToString`.
* Well-known primitive types have short aliases
* System.Private prefix is shortened to S.P.

I tested that the `TYPE_LOADER_TRACE` still works after this. The runtime type loader overrides the `ToString` in all the places that matter.
