### PR TITLE
Fix for non-Windows package publishing

### DIFF
--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -28,20 +28,20 @@
       <TargetPath>framework</TargetPath>
     </File>
 
-    <!-- Workaround to avoid linker warnings - include all pdb files for static native libraries -->    
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapper.pdb">
+    <!-- Workaround to avoid linker warnings on Windows - include all pdb files for static native libraries -->    
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapper.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapper.pdb">
       <TargetPath>sdk</TargetPath>
     </File>
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrappercpp.pdb">
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrappercpp.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrappercpp.pdb">
       <TargetPath>sdk</TargetPath>
     </File>
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapperdll.pdb">
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapperdll.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapperdll.pdb">
       <TargetPath>sdk</TargetPath>
     </File>
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.pdb">
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.pdb">
       <TargetPath>sdk</TargetPath>
     </File>
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb">
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb">
       <TargetPath>sdk</TargetPath>
     </File>
   </ItemGroup>


### PR DESCRIPTION
Fixes an issue which is causing Linux and Mac package builds to break.

As we're not creating the same .pdbs on all platforms, building packages on Linux and Mac would break with a "File Not Found". The workaround isn't necessary outside of Windows. 
@jkotas @MichalStrehovsky 