### PR TITLE
Remove reference to WASM workaround

### DIFF
--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -52,8 +52,6 @@
 
   <ItemGroup>
     <IlcArg Include="--targetarch=$(Platform)" />
-    
-    <!-- Broken on wasm: https://github.com/dotnet/corert/issues/5005 -->
     <IlcArg Include="--stacktracedata" />
   </ItemGroup>
 


### PR DESCRIPTION
Sigh, should have spotted this in the code review.

@dotnet-bot skip ci please
