### PR TITLE
Manual mirror of changes from dotnet/coreclr - PR 15410

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/MemoryHandle.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/MemoryHandle.cs
@@ -21,18 +21,6 @@ namespace System.Buffers
             _handle = handle;
         }
 
-        internal void AddOffset(int offset)
-        {
-            if (_pointer == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pointer);
-            }
-            else
-            {
-                _pointer = (void*)((byte*)_pointer + offset);
-            }
-        }
-
         [CLSCompliant(false)]
         public void* Pointer => _pointer;
 

--- a/src/System.Private.CoreLib/shared/System/Buffers/OwnedMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/OwnedMemory.cs
@@ -25,7 +25,7 @@ namespace System.Buffers
             }
         }
 
-        public abstract MemoryHandle Pin();
+        public abstract MemoryHandle Pin(int offset = 0);
 
         protected internal abstract bool TryGetArray(out ArraySegment<T> arraySegment);
 

--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -233,8 +233,7 @@ namespace System
             {
                 if (_index < 0)
                 {
-                    memoryHandle = ((OwnedMemory<T>)_object).Pin();
-                    memoryHandle.AddOffset((_index & RemoveOwnedFlagBitMask) * Unsafe.SizeOf<T>());
+                    memoryHandle = ((OwnedMemory<T>)_object).Pin((_index & RemoveOwnedFlagBitMask) * Unsafe.SizeOf<T>());
                 }
                 else if (typeof(T) == typeof(char) && _object is string s)
                 {

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -215,8 +215,7 @@ namespace System
             {
                 if (_index < 0)
                 {
-                    memoryHandle = ((OwnedMemory<T>)_object).Pin();
-                    memoryHandle.AddOffset((_index & RemoveOwnedFlagBitMask) * Unsafe.SizeOf<T>());
+                    memoryHandle = ((OwnedMemory<T>)_object).Pin((_index & RemoveOwnedFlagBitMask) * Unsafe.SizeOf<T>());
                 }
                 else if (typeof(T) == typeof(char) && _object is string s)
                 {


### PR DESCRIPTION
Add optional integer offset to OwnedMemory Pin [mirror]

Is the mirror to CoreRT broken?
I don't see [this](https://github.com/dotnet/coreclr/pull/15410) PR from coreclr mirrored in corert, resulting in the CI failure (in here - https://github.com/dotnet/corefx/pull/25787).

https://ci3.dot.net/job/dotnet_corefx/job/master/job/windows-TGroup_uapaot+CGroup_Release+AGroup_x86+TestOuter_false_prtest/6041/console

cc @jkotas, @safern, @stephentoub 