### PR TITLE
[ILVerify] Fix leave from catch into enclosing try and assignability of readonly ByRefs

### DIFF
--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -168,7 +168,7 @@ namespace Internal.IL
                 return false;
 
             var value = (StackValue)obj;
-            return this.Kind == value.Kind && this.IsReadOnly == value.IsReadOnly && this.Type == value.Type;
+            return this.Kind == value.Kind && this.Flags == value.Flags && this.Type == value.Type;
         }
 
         public static bool operator ==(StackValue left, StackValue right)
@@ -488,7 +488,7 @@ namespace Internal.IL
 
         bool IsAssignable(StackValue src, StackValue dst)
         {
-            if (src == dst)
+            if (src.Kind == dst.Kind && src.Type == dst.Type && src.IsReadOnly == dst.IsReadOnly)
                 return true;
 
             if (dst.Type == null)

--- a/src/ILVerify/src/ILImporter.StackValue.cs
+++ b/src/ILVerify/src/ILImporter.StackValue.cs
@@ -168,7 +168,7 @@ namespace Internal.IL
                 return false;
 
             var value = (StackValue)obj;
-            return this.Kind == value.Kind && this.Flags == value.Flags && this.Type == value.Type;
+            return this.Kind == value.Kind && this.IsReadOnly == value.IsReadOnly && this.Type == value.Type;
         }
 
         public static bool operator ==(StackValue left, StackValue right)
@@ -228,7 +228,7 @@ namespace Internal.IL
                 case StackValueKind.Float:
                     return "Double";
                 case StackValueKind.ByRef:
-                    return "address of " + TypeToStringForByRef(Type);
+                    return (IsReadOnly ? "readonly " : "") + "address of " + TypeToStringForByRef(Type);
                 case StackValueKind.ObjRef:
                     return (Type != null) ? "ref '" + Type.ToString() + "'" : "Nullobjref 'NullReference'";
                 case StackValueKind.ValueType:
@@ -488,7 +488,7 @@ namespace Internal.IL
 
         bool IsAssignable(StackValue src, StackValue dst)
         {
-            if (src.Kind == dst.Kind && src.Type == dst.Type)
+            if (src == dst)
                 return true;
 
             if (dst.Type == null)
@@ -513,6 +513,8 @@ namespace Internal.IL
                 return false;
 
             case StackValueKind.ByRef:
+                if (dst.Kind == StackValueKind.ByRef && dst.IsReadOnly)
+                    return src.Type == dst.Type;
 
                 // TODO: Other cases - variance, etc.
 

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -614,7 +614,7 @@ again:
             {
                 if (target.TryIndex.HasValue)
                 {
-                    ref var srcRegion = ref _exceptionRegions[target.TryIndex.Value].ILRegion;
+                    ref var srcRegion = ref _exceptionRegions[src.HandlerIndex.Value].ILRegion;
                     ref var targetRegion = ref _exceptionRegions[target.TryIndex.Value].ILRegion;
 
                     // If target is not associated try block, and not enclosing srcRegion

--- a/src/ILVerify/tests/ILTests/CallTests.il
+++ b/src/ILVerify/tests/ILTests/CallTests.il
@@ -24,6 +24,11 @@
     {
         ret
     }
+
+    .method public hidebysig static void InObjectMethod([in] object&) cil managed 
+    {
+        ret
+    }
 }
 
 .class public auto ansi beforefieldinit DerivedClass
@@ -128,6 +133,18 @@
     {
         ldarg.1
         call    instance void SimpleClass::VirtualMethod()
+        ret
+    }
+
+    .method public hidebysig instance void Call.ReadonlyByRefForInArg_Invalid_StackUnexpected(object[] objectArray) cil managed
+    {
+        // SimpleClass.InObjectMethod(objectArray[0]);
+
+        ldarg.1
+        ldc.i4.0
+        readonly.
+        ldelema     [System.Runtime]System.Object
+        call        void SimpleClass::InObjectMethod(object&)
         ret
     }
 }

--- a/src/ILVerify/tests/ILTests/ExceptionRegionTests.il
+++ b/src/ILVerify/tests/ILTests/ExceptionRegionTests.il
@@ -548,7 +548,7 @@
         ret
     }
 
-    .method public instance void Leave.CatchToEnclosingCatch_Valid() cil managed
+    .method public instance void Leave.TryToEnclosingCatch_Valid() cil managed
     {
         .try
         {

--- a/src/ILVerify/tests/ILTests/ExceptionRegionTests.il
+++ b/src/ILVerify/tests/ILTests/ExceptionRegionTests.il
@@ -453,30 +453,6 @@
         ret
     }
 
-    .method public instance void Leave.IntoEnclosingTry_Valid() cil managed
-    {
-        .try
-        {
-            .try
-            {
-                leave   EnclosingTry
-            }
-            catch [System.Runtime]System.Object
-            {
-                leave   EnclosingTry
-            }
-            EnclosingTry:
-                leave   MethodEnd
-        }
-        finally
-        {
-            endfinally
-        }
-        
-    MethodEnd:
-        ret
-    }
-
     .method public instance void Leave.OutOfCatch_Valid() cil managed
     {
         .try
@@ -572,7 +548,7 @@
         ret
     }
 
-    .method public instance void Leave.CatchToEnclosingTry_Valid() cil managed
+    .method public instance void Leave.CatchToEnclosingCatch_Valid() cil managed
     {
         .try
         {
@@ -582,14 +558,44 @@
         {
             .try
             {
-                leave   EnclosingTry
+                leave   EnclosingCatch
             }
             finally
             {
                 endfinally
             }
 
+        EnclosingCatch:
+            leave   MethodEnd
+        }
+
+    MethodEnd:
+        ret
+    }
+
+    .method public instance void Leave.CatchToEnclosingTry_Valid() cil managed
+    {
+        .try
+        {
+            .try
+            {
+                leave   MethodEnd
+            }
+            catch [System.Runtime]System.Object
+            {
+                leave   EnclosingTry
+            }
+
         EnclosingTry:
+            leave   MethodEnd
+        }
+        filter
+        {
+            pop
+            ldc.i4.0
+            endfilter
+        }
+        {
             leave   MethodEnd
         }
 


### PR DESCRIPTION
This fixes two bugs discovered in course of the [prototyped](https://github.com/dotnet/roslyn/pull/23210/files#diff-21f74235fa50cbcb57190284b2578455) Roslyn test integration:
- When checking a leave from a catch into an enclosing try, the validation of leave targets used the wrong index to get the source region information.
- IsAssignable was not checking for the readonlyness of ByRefs.

@jcouv FYI: this should fix the `LeaveIntoTry` and `UnexpectedTypeOnStack` flags of [your prototype](https://github.com/dotnet/roslyn/pull/23210/files#diff-21f74235fa50cbcb57190284b2578455). I have also had a quick look over all other flags; many are related to ILVerify not supporting TypedReferences / ArgIterators, and there are also a lot of special cases which are not implemented by ILVerify yet. I will have to look up how PEVerify implements those first.
For some of the other flags I have to actually debug the Roslyn tests, but I am still working on getting that to run.