### PR TITLE
[WIP] ILCompiler Package Multi-Runtime Package Support

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Publish.json
+++ b/buildpipeline/DotNet-CoreRT-Publish.json
@@ -94,7 +94,7 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "",
-        "inlineScript": "if ($env:Configuration -ne \"Release\") { exit }\n\n& $env:Build_SourcesDirectory\\scripts\\DotNet-Trusted-Publish\\Embed-Index.ps1 `\n  $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\$env:AzureContainerSymbolPackageGlob `\n  $env:Build_StagingDirectory\\IndexedSymbolPackages",
+        "inlineScript": "if ($env:Configuration -ne \"Release\") { exit }\n\n& $env:Build_SourcesDirectory\\scripts\\DotNet-Trusted-Publish\\Embed-Index.ps1 `\n  $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\$env:Configuration\\$env:AzureContainerSymbolPackageGlob `\n  $env:Build_StagingDirectory\\IndexedSymbolPackages",
         "workingFolder": "",
         "failOnStandardError": "true"
       }
@@ -152,7 +152,7 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "$(MyGetApiKey)",
-        "inlineScript": "param($ApiKey)\nif ($env:Configuration -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\$env:AzureContainerPackageGlob $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
+        "inlineScript": "param($ApiKey)\nif ($env:Configuration -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\$env:Configuration\\$env:AzureContainerPackageGlob $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
         "workingFolder": "",
         "failOnStandardError": "true"
       }
@@ -192,7 +192,7 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "-gitHubAuthToken $(UpdatePublishedVersions.AuthToken) -root $(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($gitHubAuthToken, $root)\nif ($env:Configuration -ne \"Release\") { exit }\ncd $root\n. $root\\buildscripts\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo $env:VersionsRepo `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\Windows_NT.x64.$env:Configuration\\$env:AzureContainerPackageGlob",
+        "inlineScript": "param($gitHubAuthToken, $root)\nif ($env:Configuration -ne \"Release\") { exit }\ncd $root\n. $root\\buildscripts\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo $env:VersionsRepo `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\$env:Configuration\\$env:AzureContainerPackageGlob",
         "workingFolder": "",
         "failOnStandardError": "true"
       }

--- a/dir.props
+++ b/dir.props
@@ -135,7 +135,7 @@
     <!-- Use the shared tools host and runtime for testing -->
     <TestHostRootPath Condition="'$(TestHostRootPath)' == ''">$(DotnetCliPath)</TestHostRootPath>
 
-    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(OSPlatformConfig)/</PackageOutputPath>
+    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackageOutputRoot)$(BinDirConfiguration)/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
 
     <!-- Folder where we will drop the Nuget package for the toolchain -->

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.Common.props
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.Common.props
@@ -22,7 +22,7 @@
     <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\*" Exclude="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\*.pdb">
       <TargetPath>sdk</TargetPath>
     </File>
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\framework\*.dll">
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\framework\*">
       <TargetPath>framework</TargetPath>
     </File>
     <!-- Workaround to avoid linker warnings on Windows - include all pdb files for static native libraries -->

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.Common.props
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.Common.props
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <!-- This target defines files and properties that need to be included in the package regardless of platform -->
+    <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <BaseLinePackageDependencies>false</BaseLinePackageDependencies>
+    <PackagePlatforms>x64;</PackagePlatforms>
+    <PreventImplementationReference>true</PreventImplementationReference>
+    <SkipValidatePackage>true</SkipValidatePackage>
+    <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(PackageSourceDirectory)\BuildIntegration\*">
+      <TargetPath>targets</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\tools\*" Exclude="$(BaseOutputPath)\$(OSPlatformConfig)\tools\*.pdb">
+      <TargetPath>tools</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\*" Exclude="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\*.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\framework\*.dll">
+      <TargetPath>framework</TargetPath>
+    </File>
+    <!-- Workaround to avoid linker warnings on Windows - include all pdb files for static native libraries -->
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapper.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapper.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrappercpp.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrappercpp.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapperdll.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapperdll.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+  </ItemGroup>
+  <Target Name="GetPackageDependencies"/>
+
+</Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.builds
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.builds
@@ -1,12 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <TargetOS Condition="'$(TargetOS)' == '' and '$(OS)' == 'Unix' and Exists('/Applications')">OSX</TargetOS>
+    <!-- The correct OS detection code. Uncomment once CI machines are upgraded to the latest version of MSBuild -->
+    <!-- <TargetOS Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">OSX</TargetOS>  -->    
+    <TargetOS Condition="'$(TargetOS)' == ''">$(OS)</TargetOS>
+    <TargetRuntimePackageLocation Condition="'$(TargetOS)' == 'Windows_NT'">win</TargetRuntimePackageLocation>
+    <TargetRuntimePackageLocation Condition="'$(TargetOS)' == 'Unix'">linux</TargetRuntimePackageLocation>
+    <TargetRuntimePackageLocation Condition="'$(TargetOS)' == 'OSX'">osx</TargetRuntimePackageLocation>
+  </PropertyGroup>
+  
+  
+
   <ItemGroup>
     <Project Include="Microsoft.DotNet.ILCompiler.pkgproj" >
-      <OSGroup>Windows_NT</OSGroup>
-      <OSGroup>Linux</OSGroup>
-      <OSGroup>Mac</OSGroup>
+      <OSGroup>AnyOS</OSGroup>
     </Project>
+
+    <!-- Include platform-specific package definitions-->
+    <Project Include="$(TargetRuntimePackageLocation)\Microsoft.DotNet.ILCompiler.pkgproj" />
+
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -5,44 +5,35 @@
     <BaseLinePackageDependencies>false</BaseLinePackageDependencies>
     <PackagePlatforms>x64;</PackagePlatforms>
     <PreventImplementationReference>true</PreventImplementationReference>
+    <RestorePackages>true</RestorePackages>
     <SkipValidatePackage>true</SkipValidatePackage>
     <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
-
+    <!-- Mark this package as a lineup (meta-) package -->
+    <IsLineupPackage Condition="'$(IsLineupPackage)' == ''">true</IsLineupPackage>
     <!-- Override this property so that the package name won't look like runtime.[RID].[TFM].[ID] -->
     <PackageTargetRuntime></PackageTargetRuntime>
   </PropertyGroup>
+
   <ItemGroup>
-    <File Include="$(MSBuildThisFileDirectory)\Microsoft.DotNet.ILCompiler.targets" >
+    <ProjectReference Include="win\Microsoft.DotNet.ILCompiler.pkgproj" />
+    <ProjectReference Include="linux\Microsoft.DotNet.ILCompiler.pkgproj" />
+    <ProjectReference Include="osx\Microsoft.DotNet.ILCompiler.pkgproj" />
+  </ItemGroup>
+
+  <!-- Add the ILCompiler package to the Lineup package, because otherwise NuGet will ignore it -->
+  <ItemGroup>
+
+    <File Include="$(MSBuildThisFileDirectory)\Microsoft.DotNet.ILCompiler.targets">
       <TargetPath>build</TargetPath>
     </File>
-    <File Include="$(PackageSourceDirectory)\BuildIntegration\*">
-      <TargetPath>targets</TargetPath>
-    </File>
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\tools\*" Exclude="$(BaseOutputPath)\$(OSPlatformConfig)\tools\*.pdb">
+
+    <!-- Add this to the metapackage so the tasks can be resolved and run from the metapackage -->
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\tools\\ILCompiler.Build.Tasks.dll" Exclude="$(BaseOutputPath)\$(OSPlatformConfig)\tools\*.pdb">
       <TargetPath>tools</TargetPath>
     </File>
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\*" Exclude="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\*.pdb">
-      <TargetPath>sdk</TargetPath>
-    </File>
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\framework\*.dll">
-      <TargetPath>framework</TargetPath>
-    </File>
 
-    <!-- Workaround to avoid linker warnings on Windows - include all pdb files for static native libraries -->    
-    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapper.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapper.pdb">
-      <TargetPath>sdk</TargetPath>
-    </File>
-    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrappercpp.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrappercpp.pdb">
-      <TargetPath>sdk</TargetPath>
-    </File>
-    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapperdll.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\bootstrapperdll.pdb">
-      <TargetPath>sdk</TargetPath>
-    </File>
-    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.pdb">
-      <TargetPath>sdk</TargetPath>
-    </File>
-    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb">
-      <TargetPath>sdk</TargetPath>
+    <File Include="$(MSBuildThisFileDirectory)\targets\*">
+      <TargetPath>targets</TargetPath>
     </File>
   </ItemGroup>
 

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
@@ -11,10 +11,11 @@
     <!-- <TargetOS Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">OSX</TargetOS>  -->
     <TargetOS Condition="'$(TargetOS)' == ''">$(OS)</TargetOS>
     
-    <TargetRuntime Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</TargetRuntime>
-    <TargetRuntime Condition="'$(TargetOS)' == 'Linux'">linux-x64</TargetRuntime>
-    <TargetRuntime Condition="'$(TargetOS)' == 'OSX'">osx-x64</TargetRuntime>
-    <_RuntimeILCompilerPackageName Condition="'$(TargetRuntime)' != ''">runtime.$(TargetRuntime).Microsoft.DotNet.ILCompiler</_RuntimeILCompilerPackageName>
+    <TargetRuntimeIdentifier Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</TargetRuntimeIdentifier>
+    <TargetRuntimeIdentifier Condition="'$(TargetOS)' == 'Unix'">linux-x64</TargetRuntimeIdentifier>
+    <TargetRuntimeIdentifier Condition="'$(TargetOS)' == 'OSX'">osx-x64</TargetRuntimeIdentifier>
+
+    <_RuntimeILCompilerPackageName Condition="'$(TargetRuntimeIdentifier)' != ''">runtime.$(TargetRuntimeIdentifier).Microsoft.DotNet.ILCompiler</_RuntimeILCompilerPackageName>
     <RuntimeILCompilerBuildTargetPath>$(IlCompilerTargetsDir)$(_RuntimeILCompilerPackageName).targets</RuntimeILCompilerBuildTargetPath>
   </PropertyGroup>
 

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
@@ -111,7 +111,7 @@
     BuildFrameworkLib is invoked before IlcCompile in multi-module builds to 
     produce the shared framework library on demand
   -->
-  <Target Name="BuildFrameworkLib" Condition="'$(DisableFrameworkLibGeneration)' != 'true'" DependsOnTargets="SetupProperties" BeforeTargets="Publish">
+  <Target Name="BuildFrameworkLib" Condition="'$(DisableFrameworkLibGeneration)' != 'true'" DependsOnTargets="SetupProperties" BeforeTargets="IlcCompile">
     <ItemGroup>
     <!-- This builds the project with the ILC implementation in the identified runtime package to avoid resolving it again  -->
       <ProjectToBuild Include="$(IlCompilerTargetsDir)BuildFrameworkNativeObjects.proj">
@@ -119,7 +119,7 @@
         </AdditionalProperties>
       </ProjectToBuild>
     </ItemGroup>
-    <MSBuild Projects="@(ProjectToBuild)" BuildInParallel="false" />
+    <MSBuild Projects="@(ProjectToBuild)" BuildInParallel="true" />
   </Target>
   
   <Target Name="IlcCompile" Inputs="@(IlcCompileInput)" Outputs="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)" DependsOnTargets="$(IlcCompileDependsOn)" BeforeTargets="Publish">

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.targets
@@ -1,7 +1,203 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_ILCompilerRootDir>$(MSBuildThisFileDirectory)../</_ILCompilerRootDir>
-    <IlCompilerTargetsDir>$(_ILCompilerRootDir)targets/</IlCompilerTargetsDir>
+    <DeployAppHost>false</DeployAppHost>
+    <_ILCompilerPackageRootDir>$(MSBuildThisFileDirectory)../</_ILCompilerPackageRootDir>
+    <IlCompilerTargetsDir>$(_ILCompilerPackageRootDir)targets/</IlCompilerTargetsDir>
+   
+    <!-- Workaround for lack of current host OS detection - https://github.com/Microsoft/msbuild/issues/539 -->
+    <TargetOS Condition="'$(TargetOS)' == '' and '$(OS)' == 'Unix' and Exists('/Applications')">OSX</TargetOS>
+    <!-- The correct OS detection code. Uncomment once CI machines are upgraded to the latest version of MSBuild -->
+    <!-- <TargetOS Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">OSX</TargetOS>  -->
+    <TargetOS Condition="'$(TargetOS)' == ''">$(OS)</TargetOS>
+    
+    <TargetRuntime Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</TargetRuntime>
+    <TargetRuntime Condition="'$(TargetOS)' == 'Linux'">linux-x64</TargetRuntime>
+    <TargetRuntime Condition="'$(TargetOS)' == 'OSX'">osx-x64</TargetRuntime>
+    <_RuntimeILCompilerPackageName Condition="'$(TargetRuntime)' != ''">runtime.$(TargetRuntime).Microsoft.DotNet.ILCompiler</_RuntimeILCompilerPackageName>
+    <RuntimeILCompilerBuildTargetPath>$(IlCompilerTargetsDir)$(_RuntimeILCompilerPackageName).targets</RuntimeILCompilerBuildTargetPath>
   </PropertyGroup>
-  <Import Project="$(IlCompilerTargetsDir)/Microsoft.NETCore.Native.targets"/>
+
+  <!-- Everything below is a temporary hack to enable runtime package resolution. Should be deleted once MSBuild in .NET Core allows importing of build artifacts 
+  from metapackage dependencies. -->
+  <PropertyGroup>
+    <NativeIntermediateOutputPath Condition="'$(NativeIntermediateOutputPath)' == ''">$(IntermediateOutputPath)native\</NativeIntermediateOutputPath>
+    <NativeOutputPath Condition="'$(NativeOutputPath)' == ''">$(OutputPath)native\</NativeOutputPath>
+    <NativeCompilationDuringPublish Condition="'$(NativeCompilationDuringPublish)' == ''">true</NativeCompilationDuringPublish>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NativeObjectExt Condition="'$(TargetOS)' == 'Windows_NT'">.obj</NativeObjectExt>
+    <NativeObjectExt Condition="'$(TargetOS)' != 'Windows_NT'">.o</NativeObjectExt>
+    <NativeObjectExt Condition="'$(NativeCodeGen)' == 'wasm'">.bc</NativeObjectExt>
+    <LibFileExt Condition="'$(TargetOS)' == 'Windows_NT'">.lib</LibFileExt>
+    <LibFileExt Condition="'$(TargetOS)' != 'Windows_NT'">.a</LibFileExt>
+    <IlcOutputFileExt>$(NativeObjectExt)</IlcOutputFileExt>
+    <IlcOutputFileExt Condition="$(NativeCodeGen) == 'cpp'">.cpp</IlcOutputFileExt>
+    <IlcOutputFileExt Condition="'$(NativeCodeGen)' == 'wasm'">.bc</IlcOutputFileExt>
+    <NativeBinaryExt Condition="'$(OutputType)' ==  'Exe' and '$(TargetOS)' == 'Windows_NT'">.exe</NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(OutputType)' ==  'Exe' and '$(TargetOS)' != 'Windows_NT'"></NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' == 'Windows_NT' and $(NativeLib) == 'Shared'">.dll</NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' == 'OSX' and $(NativeLib) == 'Shared'">.dylib</NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' != 'Windows_NT' and '$(TargetOS)' != 'OSX' and $(NativeLib) == 'Shared'">.so</NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' == 'Windows_NT' and $(NativeLib) == 'Static'">.lib</NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' != 'Windows_NT' and $(NativeLib) == 'Static'">.a</NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'wasm'">.html</NativeBinaryExt>
+    <NativeObject>$(NativeIntermediateOutputPath)$(TargetName)$(NativeObjectExt)</NativeObject>
+    <NativeBinary>$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)</NativeBinary>
+    <IlcCompileOutput Condition="$(NativeCodeGen) == ''">$(NativeObject)</IlcCompileOutput>
+    <IlcCompileOutput Condition="$(NativeCodeGen) == 'cpp'">$(NativeIntermediateOutputPath)$(TargetName).cpp</IlcCompileOutput>
+    <LinkNativeDependsOn Condition="$(NativeCodeGen) == ''">IlcCompile</LinkNativeDependsOn>
+    <LinkNativeDependsOn Condition="$(NativeCodeGen) == 'cpp'">CppCompile</LinkNativeDependsOn>
+    <LinkNativeDependsOn Condition="$(NativeCodeGen) == 'wasm'">IlcCompile</LinkNativeDependsOn>
+    <FrameworkLibPath Condition="'$(FrameworkLibPath)' == ''">$(NativeOutputPath)</FrameworkLibPath>
+    <FrameworkObjPath Condition="'$(FrameworkObjPath)' == ''">$(NativeIntermediateOutputPath)</FrameworkObjPath>
+    <SharedLibrary Condition="'$(OS)' == 'Windows_NT'">$(FrameworkLibPath)\Framework$(LibFileExt)</SharedLibrary>
+    <SharedLibrary Condition="'$(OS)' != 'Windows_NT'">$(FrameworkLibPath)\libframework$(LibFileExt)</SharedLibrary>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IlcCompileDependsOn)'=='' and '$(NativeCompilationDuringPublish)' != 'false'">
+    <IlcCompileDependsOn Condition="'$(BuildingFrameworkLibrary)' != 'true'">Compile;ComputeIlcCompileInputs</IlcCompileDependsOn>
+    <IlcCompileDependsOn Condition="'$(IlcMultiModule)' == 'true' and '$(BuildingFrameworkLibrary)' != 'true'">$(IlcCompileDependsOn);BuildFrameworkLib</IlcCompileDependsOn>
+  </PropertyGroup>
+
+  <!-- Locate the runtime package according to the current target runtime -->
+  <Target Name="ImportRuntimeILCompilerPackageTarget" DependsOnTargets="RunResolvePackageDependencies" BeforeTargets="Publish">
+
+    <!-- CoreRT SDK and Framework Assemblies need to be defined to avoid CoreCLR implementations being set as compiler inputs -->
+    <Error Condition="'@(PackageDefinitions)' == ''" Text="The PackageDefinitions ItemGroup is required for target ImportRuntimeILCompilerPackageTarget" />
+    <ItemGroup>
+      <RuntimePackage Include="@(PackageDefinitions)" Condition="'%(PackageDefinitions.Name)' == '$(_RuntimeILCompilerPackageName)'" />
+    </ItemGroup>
+    <CreateProperty Value="%(RuntimePackage.ResolvedPath)">
+      <Output TaskParameter="Value" PropertyName="RuntimePackagePath"/>
+    </CreateProperty>
+    
+  </Target>
+
+  <!-- The properties below need to be defined only after we've found the correct runtime package reference -->
+  <Target Name="SetupProperties" DependsOnTargets="ImportRuntimeILCompilerPackageTarget" BeforeTargets="Publish">
+    <PropertyGroup>
+      <!-- Define paths used in build targets to point to the runtime-specific ILCompiler implementation -->
+      <IlcPath Condition="'$(IlcPath)' == ''">$(RuntimePackagePath)</IlcPath>
+      <BuildTasksPath>$(RuntimePackagePath)\tools\ILCompiler.Build.Tasks.dll</BuildTasksPath>
+      <!-- Set defaults for unspecified properties -->
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <FrameworkAssemblies Include="$(IlcPath)\framework\*.dll" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
+      <DefaultFrameworkAssemblies Include="@(PrivateSdkAssemblies)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ComputeIlcCompileInputs" DependsOnTargets="SetupProperties" BeforeTargets="Publish">
+    <ItemGroup>
+      <ManagedBinary Condition="$(BuildingFrameworkLibrary) != 'true'" Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
+      <IlcCompileInput Include="@(ManagedBinary)" />
+      <IlcReference Include="@(DefaultFrameworkAssemblies)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    BuildFrameworkLib is invoked before IlcCompile in multi-module builds to 
+    produce the shared framework library on demand
+  -->
+  <Target Name="BuildFrameworkLib" Condition="'$(DisableFrameworkLibGeneration)' != 'true'" DependsOnTargets="SetupProperties" BeforeTargets="Publish">
+    <ItemGroup>
+    <!-- This builds the project with the ILC implementation in the identified runtime package to avoid resolving it again  -->
+      <ProjectToBuild Include="$(IlCompilerTargetsDir)BuildFrameworkNativeObjects.proj">
+        <AdditionalProperties> IntermediateOutputPath=$(IntermediateOutputPath); FrameworkLibPath=$(FrameworkLibPath); FrameworkObjPath=$(FrameworkObjPath); RuntimePackagePath=$(RuntimePackagePath)
+        </AdditionalProperties>
+      </ProjectToBuild>
+    </ItemGroup>
+    <MSBuild Projects="@(ProjectToBuild)" BuildInParallel="false" />
+  </Target>
+  
+  <Target Name="IlcCompile" Inputs="@(IlcCompileInput)" Outputs="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)" DependsOnTargets="$(IlcCompileDependsOn)" BeforeTargets="Publish">
+    <ItemGroup>
+      <IlcArg Include="@(IlcCompileInput)" />
+      <IlcArg Include="-o:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)" />
+      <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
+      <IlcArg Condition="$(IlcGenerateMetadataLog) == 'true'" Include="--metadatalog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).metadata.csv" />
+      <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />
+      <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
+      <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
+      <IlcArg Condition="$(DebugSymbols) == 'true'" Include="-g" />
+      <IlcArg Condition="$(IlcGenerateMapFile) == 'true'" Include="--map:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).map.xml" />
+      <IlcArg Condition="$(RdXmlFile) != ''" Include="--rdxml:$(RdXmlFile)" />
+      <IlcArg Condition="$(OutputType) ==  'Library' and $(NativeLib) != ''" Include="--nativelib" />
+      <ILcArg Condition="'$(Platform)' == 'wasm'" Include="--wasm" />
+    </ItemGroup>
+    
+    <MakeDir Directories="$(NativeIntermediateOutputPath)" />
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp" Lines="@(IlcArg)" Overwrite="true" />
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeObject)))" />
+    <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;" />
+  </Target>
+  
+  <Import Project="$(IlCompilerTargetsDir)Microsoft.NETCore.Native.Windows.props" Condition="'$(TargetOS)' == 'Windows_NT'" />
+  <Import Project="$(IlCompilerTargetsDir)Microsoft.NETCore.Native.Unix.props" Condition="'$(TargetOS)' != 'Windows_NT'" />
+  
+  <Target Name="CppCompile" Inputs="$(IlcCompileOutput)" Outputs="$(NativeObject)" DependsOnTargets="IlcCompile" BeforeTargets="Publish">
+    <ItemGroup>
+      <CompilerArg Include="$(IlcCompileOutput)" />
+      <CompilerArg Include="/Fo$(NativeObject)" Condition="'$(OS)' == 'Windows_NT'" />
+      <CompilerArg Include="-o $(NativeObject)" Condition="'$(OS)' != 'Windows_NT'" />
+      <CompilerArg Include="@(CppCompilerAndLinkerArg)" />
+    </ItemGroup>
+    
+    <MakeDir Directories="$(NativeIntermediateOutputPath)" />
+    <Exec Command="$(CppCompiler) @(CompilerArg, ' ')" Condition="'$(OS)' != 'Windows_NT'" />
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)cl.rsp" Lines="@(CompilerArg)" Overwrite="true" Condition="'$(OS)' == 'Windows_NT'"/>
+    <Exec Command="$(CppCompiler) @&quot;$(NativeIntermediateOutputPath)cl.rsp&quot;" Condition="'$(OS)' == 'Windows_NT'" />
+  </Target>
+  
+  <Target Name="LinkNative" Inputs="$(NativeObject);@(NativeLibrary)" Outputs="$(NativeBinary)" DependsOnTargets="$(LinkNativeDependsOn)" BeforeTargets="ComputeLinkedFilesToPublish">
+    <ItemGroup>
+      <CustomLinkerArg Include="$(NativeObject)" />
+      <CustomLinkerArg Include="-o $(NativeBinary)" Condition="'$(OS)' != 'Windows_NT'" />
+      <CustomLinkerArg Include="/OUT:$(NativeBinary)" Condition="'$(OS)' == 'Windows_NT'" />
+      <CustomLinkerArg Include="@(LinkerArg)" />
+    </ItemGroup>
+    <ItemGroup>
+      <CustomLibArg Include="-crs $(NativeBinary)" Condition="'$(OS)' != 'Windows_NT'" />
+      <CustomLibArg Include="/OUT:$(NativeBinary)" Condition="'$(OS)' == 'Windows_NT'" />
+      <CustomLibArg Include="$(NativeObject)" />
+    </ItemGroup>
+  
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeBinary)))" />
+    
+    <Exec Command="$(CppLinker) @(CustomLinkerArg, ' ')" Condition="'$(OS)' != 'Windows_NT' and '$(NativeLib)' != 'Static'" />
+    <Exec Command="$(CppLibCreator) @(CustomLibArg, ' ')" Condition="'$(OS)' != 'Windows_NT' and '$(NativeLib)' == 'Static'" />
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)link.rsp" Lines="@(CustomLinkerArg)" Overwrite="true" Condition="'$(OS)' == 'Windows_NT' and '$(NativeLib)' != 'Static'" />
+    <Exec Command="$(CppLinker)  @&quot;$(NativeIntermediateOutputPath)link.rsp&quot;" Condition="'$(OS)' == 'Windows_NT' and '$(NativeLib)' != 'Static' and '$(NativeCodeGen)' != 'wasm'" />
+  
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)lib.rsp" Lines="@(CustomLibArg)" Overwrite="true" Condition="'$(OS)' == 'Windows_NT' and '$(NativeLib)' == 'Static'" />
+    <Exec Command="$(CppLibCreator)  @&quot;$(NativeIntermediateOutputPath)lib.rsp&quot;" Condition="'$(OS)' == 'Windows_NT' and '$(NativeLib)' == 'Static' and '$(NativeCodeGen)' != 'wasm'" />
+    
+    <Exec Command="&quot;$(EMSCRIPTEN)\emcc.bat&quot;  &quot;$(NativeObject)&quot; -o &quot;$(NativeBinary)&quot; -s WASM=1" Condition="'$(NativeCodeGen)' == 'wasm' and '$(EMSCRIPTEN)' != ''" />    <Message Text="Emscripten not found, not linking WebAssembly. To enable WebAssembly linking, install Emscripten and ensure the EMSCRIPTEN environment variable points to the directory containing emcc.bat" Condition="'$(NativeCodeGen)' == 'wasm' and '$(EMSCRIPTEN)' == ''" />
+
+  </Target>
+  
+  <Target Name="CreateLib" Inputs="@(LibInputs)" Outputs="$(SharedLibrary)" DependsOnTargets="$(CreateLibDependsOn);SetupProperties" BeforeTargets="Publish">
+    <ItemGroup>
+      <CustomLibArg Include="/out:$(SharedLibrary)" Condition="'$(OS)' == 'Windows_NT'" />
+      <CustomLibArg Include="-crs $(SharedLibrary)" Condition="'$(OS)' != 'Windows_NT'" />
+      <CustomLibArg Include="@(LibInputs->'%(Identity)')" />
+    </ItemGroup>
+    <MakeDir Directories="$(NativeIntermediateOutputPath)" />
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)lib.rsp" Lines="@(CustomLibArg)" Overwrite="true" Condition="'$(OS)' == 'Windows_NT'" />
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(SharedLibrary)))" />
+    <Exec Command="$(CppLibCreator) @&quot;$(NativeIntermediateOutputPath)lib.rsp&quot;" Condition="'$(OS)' == 'Windows_NT'" />
+    <Exec Command="$(CppLibCreator) @(CustomLibArg, ' ')" Condition="'$(OS)' != 'Windows_NT'" />
+  </Target>
+  <Import Project="$(IlCompilerTargetsDir)Microsoft.NETCore.Native.Publish.targets" Condition="'$(NativeCompilationDuringPublish)' != 'false'" />
 </Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/linux/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/linux/Microsoft.DotNet.ILCompiler.pkgproj
@@ -1,0 +1,12 @@
+<!-- The ILCompiler package is produced by including built binaries and executables from the OS-Specific builds.
+  These contents are defined in Microsoft.Dotnet.ILCompiler.Common.props - the purpose of this file is to force the build process to produce runtime-specific packages. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <PackageTargetRuntime>linux-x64</PackageTargetRuntime>
+  </PropertyGroup>
+  
+  <Import Project="..\Microsoft.DotNet.ILCompiler.Common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\src\dir.targets" />
+</Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/osx/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/osx/Microsoft.DotNet.ILCompiler.pkgproj
@@ -1,0 +1,12 @@
+<!-- The ILCompiler package is produced by including built binaries and executables from the OS-Specific builds.
+  These contents are defined in Microsoft.Dotnet.ILCompiler.Common.props - the purpose of this file is to force the build process to produce runtime-specific packages. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <PackageTargetRuntime>osx-x64</PackageTargetRuntime>
+  </PropertyGroup>
+  
+  <Import Project="..\Microsoft.DotNet.ILCompiler.Common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\src\dir.targets" />
+</Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/targets/BuildFrameworkNativeObjects.proj
+++ b/pkg/Microsoft.DotNet.ILCompiler/targets/BuildFrameworkNativeObjects.proj
@@ -8,7 +8,7 @@
     <BuildingFrameworkLibrary>true</BuildingFrameworkLibrary>
   </PropertyGroup>
   
-  <Import Project="$(RuntimePackagePath)\targets\Microsoft.NETCore.Native.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.ILCompiler.targets" />
 
   <Target Name="BuildAllFrameworkLibraries"
     Inputs="@(DefaultFrameworkAssemblies)"

--- a/pkg/Microsoft.DotNet.ILCompiler/targets/BuildFrameworkNativeObjects.proj
+++ b/pkg/Microsoft.DotNet.ILCompiler/targets/BuildFrameworkNativeObjects.proj
@@ -1,0 +1,44 @@
+<Project DefaultTargets="CreateLib" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <IlcCompileDependsOn>ComputeIlcCompileInputs;BuildOneFrameworkLibrary</IlcCompileDependsOn>
+    <CreateLibDependsOn>BuildAllFrameworkLibrariesAsSingleLib</CreateLibDependsOn>
+    <IlcMultiModule>true</IlcMultiModule>
+    <NativeIntermediateOutputPath Condition="'$(FrameworkObjPath)' != ''">$(FrameworkObjPath)\</NativeIntermediateOutputPath>
+    <BuildingFrameworkLibrary>true</BuildingFrameworkLibrary>
+  </PropertyGroup>
+  
+  <Import Project="$(RuntimePackagePath)\targets\Microsoft.NETCore.Native.targets" />
+
+  <Target Name="BuildAllFrameworkLibraries"
+    Inputs="@(DefaultFrameworkAssemblies)"
+    Outputs="@(DefaultFrameworkAssemblies->'$(NativeIntermediateOutputPath)\%(Filename)$(NativeObjectExt)')">
+    <ItemGroup>
+      <ProjectToBuild Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>
+          LibraryToCompile=%(DefaultFrameworkAssemblies.Identity)
+        </AdditionalProperties>
+      </ProjectToBuild>
+    </ItemGroup>
+    <MSBuild Projects="@(ProjectToBuild)" Targets="IlcCompile" BuildInParallel="true" />
+  </Target>
+
+  <Target Name="BuildAllFrameworkLibrariesAsSingleLib"
+    DependsOnTargets="BuildAllFrameworkLibraries">
+
+    <ItemGroup>
+      <LibInputs Include="$(NativeIntermediateOutputPath)\*$(NativeObjectExt)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="BuildOneFrameworkLibrary">
+    <PropertyGroup>
+        <IlcGenerateMetadataLog>true</IlcGenerateMetadataLog>
+    </PropertyGroup>
+    <ItemGroup>
+        <ManagedBinary Include="$(LibraryToCompile)" />
+        <IlcCompileInput Include="@(ManagedBinary)" />
+    </ItemGroup>
+  </Target>
+  
+</Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/targets/BuildIntegration.proj
+++ b/pkg/Microsoft.DotNet.ILCompiler/targets/BuildIntegration.proj
@@ -1,0 +1,18 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/build</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="*.*" Exclude="$(MSBuildProjectFile)" />
+  </ItemGroup>
+
+  <Target Name="Build">  
+      <Copy SourceFiles="@(Content)" DestinationFolder="$(OutputPath)" />  
+  </Target>
+
+  <Target Name="Restore" />  
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/targets/Microsoft.NETCore.Native.Publish.targets
+++ b/pkg/Microsoft.DotNet.ILCompiler/targets/Microsoft.NETCore.Native.Publish.targets
@@ -1,0 +1,66 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <BuildTasksPath Condition="'$(BuildTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\ILCompiler.Build.Tasks.dll</BuildTasksPath>
+    
+    <!--
+      Prevent dotnet CLI from deploying the CoreCLR shim executable since we produce
+      a native executable.
+    -->
+    <DeployAppHost>false</DeployAppHost>
+  </PropertyGroup>
+
+  <Target Name="_ComputeIlcCompileInputs"
+          BeforeTargets="ComputeIlcCompileInputs"
+          DependsOnTargets="SetupProperties">
+    <ItemGroup>
+      <IlcReference Include="@(_ManagedResolvedAssembliesToPublish)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    This target hooks into the dotnet CLI publish pipeline. That pipeline has
+    a target called ComputeFilesToPublish which produces the ItemGroup
+    ResolvedFileToPublish based on the inputs of @(IntermediateAssembly)
+    and @(ResolvedAssembliesToPublish). We modify those two item groups
+    to control what gets published after CoreRT optimizes the application.
+  -->
+  <Target Name="ComputeLinkedFilesToPublish"
+          BeforeTargets="ComputeFilesToPublish"
+          DependsOnTargets="_ComputeAssembliesToCompileToNative;LinkNative">
+    
+    <ItemGroup>
+      <ResolvedAssembliesToPublish Remove="@(_AssembliesToSkipPublish)" />
+      <ResolvedAssembliesToPublish Include="@(_LinkedResolvedAssemblies)" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <_NativeIntermediateAssembly Include="@(IntermediateAssembly->'$(NativeOutputPath)%(Filename)$(NativeBinaryExt)')" />
+      <IntermediateAssembly Remove="@(IntermediateAssembly)" />
+      <IntermediateAssembly Include="@(_NativeIntermediateAssembly)" />
+    </ItemGroup>
+  </Target>
+  
+  <!--
+    Filter the input publish file list selecting managed assemblies for compilation.
+    Also produces _AssembliesToSkipPublish which chops out things from the publish
+    pipeline we don't want to see in the output (native images, CoreCLR artifacts)
+    until we get a proper AOT NetCore app package.
+  -->
+  <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(BuildTasksPath)" />
+  <Target Name="_ComputeAssembliesToCompileToNative" DependsOnTargets="SetupProperties">
+
+    <!-- CoreRT SDK and Framework Assemblies need to be defined to avoid CoreCLR implementations being set as compiler inputs -->  
+    <Error Condition="'@(PrivateSdkAssemblies)' == ''" Text="The PrivateSdkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
+    <Error Condition="'@(FrameworkAssemblies)' == ''" Text="The FrameworkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
+
+    <ComputeManagedAssemblies Assemblies="@(ResolvedAssembliesToPublish)" 
+    DotNetAppHostExecutableName="$(_DotNetAppHostExecutableName)" DotNetHostFxrLibraryName="$(_DotNetHostFxrLibraryName)" DotNetHostPolicyLibraryName="$(_DotNetHostPolicyLibraryName)"
+    SdkAssemblies="@(PrivateSdkAssemblies)" FrameworkAssemblies="@(FrameworkAssemblies)">
+      <Output TaskParameter="ManagedAssemblies" ItemName="_ManagedResolvedAssembliesToPublish" />
+      <Output TaskParameter="AssembliesToSkipPublish" ItemName="_AssembliesToSkipPublish" />
+    </ComputeManagedAssemblies>
+    
+  </Target>
+
+</Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/targets/Microsoft.NETCore.Native.Unix.props
+++ b/pkg/Microsoft.DotNet.ILCompiler/targets/Microsoft.NETCore.Native.Unix.props
@@ -1,0 +1,68 @@
+<!--
+***********************************************************************************************
+Microsoft.NETCore.Native.Unix.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+This file defines the steps in the build process specific for native AOT compilation.
+
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MIT license.
+See the LICENSE file in the project root for more information.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!-- Ensure that runtime-specific paths have already been set -->
+<Target Name="SetupWindowsProps" DependsOnTargets="SetupProperties" BeforeTargets="LinkNative">
+  <PropertyGroup>
+    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == '' and '$(TargetOS)' == 'OSX'">clang</CppCompilerAndLinker>
+    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang-3.9</CppCompilerAndLinker>
+    <CppCompiler>$(CppCompilerAndLinker)</CppCompiler>
+    <CppLinker>$(CppCompilerAndLinker)</CppLinker>
+    <CppLibCreator>ar</CppLibCreator>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CppCompilerAndLinkerArg Include="-I $(IlcPath)/inc" />
+    <CppCompilerAndLinkerArg Condition="'$(Configuration)' == 'Debug'" Include="-g -O0" />
+    <CppCompilerAndLinkerArg Condition="'$(Configuration)' != 'Debug'" Include="-O2" />
+    <CppCompilerAndLinkerArg Include="-c -Wno-invalid-offsetof" />
+    <CppCompilerAndLinkerArg Include="$(AdditionalCppCompilerFlags)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(SharedLibrary)" />
+    <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) == ''" Include="$(IlcPath)/sdk/libbootstrapper.a" />
+    <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) != ''" Include="$(IlcPath)/sdk/libbootstrapperdll.a" />
+    <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libRuntime.a" />
+    <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libbootstrappercpp.a" />
+    <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libPortableRuntime.a" />
+    <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)/sdk/libbootstrappercpp.a" />
+    <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)/sdk/libPortableRuntime.a" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalNativeLibrary Include="$(IlcPath)/sdk/libSystem.Private.CoreLib.Native.a" />
+    <AdditionalNativeLibrary Include="$(IlcPath)/framework/System.Native.a" />
+    <AdditionalNativeLibrary Include="$(IlcPath)/framework/libSystem.Globalization.Native.a" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <LinkerArg Include="@(NativeLibrary)" />
+    <LinkerArg Include="@(AdditionalNativeLibrary)" />
+    <LinkerArg Include="-g" />
+    <LinkerArg Include="-Wl,-rpath,'$ORIGIN'" />
+    <LinkerArg Include="-pthread" />
+    <LinkerArg Include="-lstdc++" />
+    <LinkerArg Include="-ldl" />
+    <LinkerArg Include="-lm" />
+    <LinkerArg Include="-luuid" Condition="'$(TargetOS)' != 'OSX'" />
+    <LinkerArg Include="-lrt" Condition="'$(TargetOS)' != 'OSX'" />
+    <LinkerArg Include="-licucore" Condition="'$(TargetOS)' == 'OSX'" />
+    <LinkerArg Include="-shared" Condition="'$(NativeLib)' == 'Shared'" />
+  </ItemGroup>
+
+</Target>
+</Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/targets/Microsoft.NETCore.Native.Windows.props
+++ b/pkg/Microsoft.DotNet.ILCompiler/targets/Microsoft.NETCore.Native.Windows.props
@@ -14,7 +14,8 @@ See the LICENSE file in the project root for more information.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+<!-- Ensure that runtime-specific paths have already been set -->
+<Target Name="SetupWindowsProps" DependsOnTargets="SetupProperties" BeforeTargets="LinkNative">
   <PropertyGroup>
     <CppCompiler>cl</CppCompiler>
     <CppLinker>link</CppLinker>
@@ -75,5 +76,5 @@ See the LICENSE file in the project root for more information.
     <LinkerArg Include="/OPT:REF" />
     <LinkerArg Include="/OPT:ICF" />
   </ItemGroup>
-  
+</Target>
 </Project>

--- a/pkg/Microsoft.DotNet.ILCompiler/win/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/win/Microsoft.DotNet.ILCompiler.pkgproj
@@ -1,0 +1,12 @@
+<!-- The ILCompiler package is produced by including built binaries and executables from the OS-Specific builds.
+  These contents are defined in Microsoft.Dotnet.ILCompiler.Common.props - the purpose of this file is to force the build process to produce runtime-specific packages. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>win-x64</PackageTargetRuntime>
+  </PropertyGroup>
+
+  <Import Project="..\Microsoft.DotNet.ILCompiler.Common.props" />  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\src\dir.targets" />
+</Project>


### PR DESCRIPTION
As it stands we only produce a Windows ILCompiler package. This work implements building and publishing of OS-specific runtime packages and spins off ILCompiler as a meta-package, which can be referenced when adding to a project.

Working on this, a quirk in MSBuild behavior under .NET Core popped up - build artifacts (i.e. .targets and .props files) are imported for direct project package references, but not for runtime-specific packages, defined as dependencies in the meta-package. This doesn't seem to be the case in vanilla MSBuild.

The below is a serious hack to work around this - during runtime, we find the resolved runtime package reference and define the path to it on disk, from which all OS-specific components are loaded and run. The motivation behind the workaround was to keep the package as small as possible, particularly because of the large intersection of components between OS implementations. 

I don't think this is a particularly viable long-term solution, so feedback is welcomed.

@jkotas @MichalStrehovsky @nattress 