### PR TITLE
[ILVerify] Implement backward branch verification

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -141,6 +141,7 @@ namespace Internal.IL
                     case ILOpcode.stloc_s:
                     case ILOpcode.ldc_i4_s:
                     case ILOpcode.unaligned:
+                    case ILOpcode.no:
                         SkipIL(1);
                         break;
                     case ILOpcode.ldarg:

--- a/src/ILVerify/src/Resources/Strings.resx
+++ b/src/ILVerify/src/Resources/Strings.resx
@@ -120,6 +120,9 @@
   <data name="ArrayByRef" xml:space="preserve">
     <value>Array of ELEMENT_TYPE_BYREF or ELEMENT_TYPE_TYPEDBYREF.</value>
   </data>
+  <data name="BackwardBranch" xml:space="preserve">
+    <value>Stack height at all points must be determinable in a single forward scan of IL.</value>
+  </data>
   <data name="BadBranch" xml:space="preserve">
     <value>Branch out of the method.</value>
   </data>
@@ -164,6 +167,9 @@
   </data>
   <data name="CallVirtOnValueType" xml:space="preserve">
     <value>Callvirt on a value type method.</value>
+  </data>
+  <data name="CatchByRef" xml:space="preserve">
+    <value>ByRef not allowed as catch type.</value>
   </data>
   <data name="Constrained" xml:space="preserve">
     <value>Missing callvirt following constrained prefix.</value>
@@ -236,6 +242,12 @@
   </data>
   <data name="FieldAccess" xml:space="preserve">
     <value>Field is not visible.</value>
+  </data>
+  <data name="FilterOrCatchUnexpectedStack" xml:space="preserve">
+    <value>Attempt to enter a filter or catch block with unexpected stack state.</value>
+  </data>
+  <data name="FinOrFaultNonEmptyStack" xml:space="preserve">
+    <value>Attempt to enter a finally or fault block with nonempty stack.</value>
   </data>
   <data name="InitLocals" xml:space="preserve">
     <value>initlocals must be set for verifiable methods with one or more local variables.</value>

--- a/src/ILVerify/src/VerifierError.cs
+++ b/src/ILVerify/src/VerifierError.cs
@@ -137,6 +137,8 @@ namespace ILVerify
         //E_INNERMOST_FIRST             "Innermost exception blocks should be declared first."
         CallAbstract,                   // Call not allowed on abstract methods.
         TryNonEmptyStack,               // Attempt to enter a try block with nonempty stack.
+        FilterOrCatchUnexpectedStack,   // Attempt to enter a filter or catch block with unexpected stack state.
+        FinOrFaultNonEmptyStack,        // Attempt to enter a finally or fault block with nonempty stack.
         DelegateCtor,                   // Unrecognized arguments for delegate .ctor.
         DelegatePattern,                // Dup, ldvirtftn, newobj delegate::.ctor() pattern expected (in the same basic block).
         //E_SIG_C_VC                    "ELEMENT_TYPE_CLASS ValueClass in signature."
@@ -148,7 +150,7 @@ namespace ILVerify
         DelegateCtorSigI,               // Unrecognized delegate .ctor signature; expected Native Int.
         DelegateCtorSigO,               // Unrecognized delegate .ctor signature; expected Object.
         //E_RA_PTR_TO_STACK             "Mkrefany on TypedReference, ArgHandle, or ArgIterator."
-        //E_CATCH_BYREF                 "ByRef not allowed as catch type."
+        CatchByRef,                     // ByRef not allowed as catch type.
         LdvirtftnOnStatic,              // ldvirtftn on static.
         CallVirtOnStatic,               // callvirt on static.
         InitLocals,                     // initlocals must be set for verifiable methods with one or more local variables.
@@ -173,7 +175,7 @@ namespace ILVerify
         //E_READONLY_IN_MKREFANY              "A readonly ByRef cannot be used with mkrefany."
         //E_UNALIGNED_ALIGNMENT               "Alignment specified for 'unaligned' prefix must be 1, 2, or 4."
         TailCallInsideER,                     // The tail.call (or calli or callvirt) instruction cannot be used to transfer control out of a try, filter, catch, or finally block.
-        //E_BACKWARD_BRANCH                   "Stack height at all points must be determinable in a single forward scan of IL."
+        BackwardBranch,                       // Stack height at all points must be determinable in a single forward scan of IL.
         //E_CALL_TO_VTYPE_BASE                "Call to base type of valuetype."
         NewobjAbstractClass,                  // Cannot construct an instance of abstract class.
         UnmanagedPointer,                     // Unmanaged pointers are not a verifiable type.

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -979,4 +979,27 @@
 
         ret
     }
+
+    .method static public hidebysig void Branch.BackwardWithComplexPredecessor_Valid() cil managed 
+    {
+        ldnull
+        br          MethodEnd
+
+    Predecessor:
+        ldnull
+
+    BackwardBranch:
+        pop
+
+        ldnull
+        ldc.i4.1
+        brtrue      BackwardBranch
+
+    MethodEnd:
+        pop
+        ldc.i4.1
+        brtrue          Predecessor
+
+        ret
+    }
 }

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -931,4 +931,52 @@
         call    void BranchingTestsType::StaticMethod()
         ret
     }
+
+    .method static public hidebysig void Branch.BackwardWithPredecessor_Valid() cil managed 
+    {
+        ldnull
+        ldc.i4.0
+        brfalse     MethodEnd
+
+    BackwardBranch:
+        pop
+
+        ldnull
+        ldc.i4.1
+        brtrue      BackwardBranch
+
+    MethodEnd:
+        pop
+        ret
+    }
+
+    .method static public hidebysig void Branch.BackwardWithoutPredecessor_Invalid_BackwardBranch() cil managed 
+    {
+        br      MethodEnd
+
+    BackwardBranch:
+        pop
+
+    MethodEnd:
+        ldnull
+        ldc.i4.1
+        brtrue      BackwardBranch
+
+        pop
+        ret
+    }
+
+    .method static public hidebysig void Branch.BackwardEmptyStack_Valid() cil managed 
+    {
+        br      MethodEnd
+
+    BackwardBranch:
+        nop
+
+    MethodEnd:
+        ldc.i4.1
+        brtrue      BackwardBranch
+
+        ret
+    }
 }


### PR DESCRIPTION
This implements the verification of backward branches. According to ECMA backward branches require their target blocks to have an empty entry stack or a predecessor block with a lower IL-offset.

In the course of implementing this verification I also implemented the checks for CatchByRef and correct entry stack depth of exception regions.

I also noticed the PEVerify implementation of `THIS_UNINIT_EXCEP`, but do not fully understand it:
A comment above the relevant code says `// cannot enter a try with an uninitialized 'this'`, however the code then actually only performs a check for an initialized 'this' if the region is _not_ of type `RGN_TRY` or `RGN_FAULT`. I also couldn't find the definition of this rule in ECMA.
(see: https://github.com/lewischeng-ms/sscli/blob/master/clr/src/jit64/newverify.cpp#L1580)