### PR TITLE
 Convert uses of the Dangerous APIs to use MemoryMarshal.GetReference

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
@@ -152,7 +152,7 @@ namespace System.Globalization
             Debug.Assert(string2 != null);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
-            fixed (char* pString1 = &string1.DangerousGetPinnableReference())
+            fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &string2.GetRawStringData())
             {
                 return Interop.GlobalizationInterop.CompareString(_sortHandle, pString1, string1.Length, pString2, string2.Length, options);
@@ -164,8 +164,8 @@ namespace System.Globalization
             Debug.Assert(!_invariantMode);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
-            fixed (char* pString1 = &string1.DangerousGetPinnableReference())
-            fixed (char* pString2 = &string2.DangerousGetPinnableReference())
+            fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
+            fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
             {
                 return Interop.GlobalizationInterop.CompareString(_sortHandle, pString1, string1.Length, pString2, string2.Length, options);
             }

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -120,7 +120,7 @@ namespace System.Globalization
             string localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
 
             fixed (char* pLocaleName = localeName)
-            fixed (char* pString1 = &string1.DangerousGetPinnableReference())
+            fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &string2.GetRawStringData())
             {
                 int result = Interop.Kernel32.CompareStringEx(
@@ -152,8 +152,8 @@ namespace System.Globalization
             string localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
 
             fixed (char* pLocaleName = localeName)
-            fixed (char* pString1 = &string1.DangerousGetPinnableReference())
-            fixed (char* pString2 = &string2.DangerousGetPinnableReference())
+            fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
+            fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
             {
                 int result = Interop.Kernel32.CompareStringEx(
                                     pLocaleName,

--- a/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace System.Globalization
 {

--- a/src/System.Private.CoreLib/src/System/IO/BinaryReader.cs
+++ b/src/System.Private.CoreLib/src/System/IO/BinaryReader.cs
@@ -6,6 +6,7 @@ using Internal.Runtime.CompilerServices;
 using System;
 using System.Text;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace System.IO
 {

--- a/src/System.Private.CoreLib/src/System/IO/BinaryReader.cs
+++ b/src/System.Private.CoreLib/src/System/IO/BinaryReader.cs
@@ -445,7 +445,7 @@ namespace System.IO
                     unsafe
                     {
                         fixed (byte* pBytes = byteBuffer)
-                        fixed (char* pChars = &buffer.DangerousGetPinnableReference())
+                        fixed (char* pChars = &MemoryMarshal.GetReference(buffer))
                         {
                             charsRead = _decoder.GetChars(pBytes + position, numBytes, pChars + index, charsRemaining, flush: false);
                         }

--- a/src/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -317,7 +318,7 @@ namespace System.IO
 
         public virtual Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (source.DangerousTryGetArray(out ArraySegment<byte> array))
+            if (MemoryMarshal.TryGetArray(source, out ArraySegment<byte> array))
             {
                 return WriteAsync(array.Array, array.Offset, array.Count, cancellationToken);
             }

--- a/src/System.Private.CoreLib/src/System/String.cs
+++ b/src/System.Private.CoreLib/src/System/String.cs
@@ -408,7 +408,7 @@ namespace System
             }
 
             string result = FastAllocateString(value.Length);
-            fixed (char* dest = &result._firstChar, src = &value.DangerousGetPinnableReference())
+            fixed (char* dest = &result._firstChar, src = &MemoryMarshal.GetReference(value))
             {
                 wstrcpy(dest, src, value.Length);
             }


### PR DESCRIPTION
Part of:
https://github.com/dotnet/corefx/issues/25412
https://github.com/dotnet/corefx/issues/25615

Related to: https://github.com/dotnet/coreclr/pull/15532

I am not making the changes to the shared section since they will get mirrored from the PR above.

Following the staging plan from here: https://github.com/dotnet/corefx/issues/23881#issuecomment-343767740

- [x] Add MemoryExtensions.GetReference/TryGetArray
- [ ] Convert all uses of DangerousGetPinnableReference/DangerousTryGetArray in coreclr, corefx, corert, corefxlab, aspnet, ... to MemoryExtensions.GetReference
- [ ] Change DangerousGetPinnableReference to whatever we like to make it fit the pinning pattern and remove DangerousTryGetArray.

Doing it this way will avoid the need for complex staging or things being on the floor for extensive periods of time.

cc @jkotas, @KrzysztofCwalina, @stephentoub 
