### PR TITLE
[ILVerify] Implement tail-ret and invalid method end verification

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -47,11 +47,17 @@ namespace Internal.IL
 
         private byte ReadILByte()
         {
+            if (_currentOffset >= _ilBytes.Length)
+                ReportMethodEndInsideInstruction();
+
             return _ilBytes[_currentOffset++];
         }
 
         private UInt16 ReadILUInt16()
         {
+            if (_currentOffset + 1 >= _ilBytes.Length)
+                ReportMethodEndInsideInstruction();
+
             UInt16 val = (UInt16)(_ilBytes[_currentOffset] + (_ilBytes[_currentOffset + 1] << 8));
             _currentOffset += 2;
             return val;
@@ -59,6 +65,9 @@ namespace Internal.IL
 
         private UInt32 ReadILUInt32()
         {
+            if (_currentOffset + 3 >= _ilBytes.Length)
+                ReportMethodEndInsideInstruction();
+
             UInt32 val = (UInt32)(_ilBytes[_currentOffset] + (_ilBytes[_currentOffset + 1] << 8) + (_ilBytes[_currentOffset + 2] << 16) + (_ilBytes[_currentOffset + 3] << 24));
             _currentOffset += 4;
             return val;
@@ -90,6 +99,9 @@ namespace Internal.IL
 
         private void SkipIL(int bytes)
         {
+            if (_currentOffset + (bytes - 1) >= _ilBytes.Length)
+                ReportMethodEndInsideInstruction();
+
             _currentOffset += bytes;
         }
 
@@ -195,12 +207,6 @@ namespace Internal.IL
                         SkipIL(4);
                         break;
                     case ILOpcode.prefix1:
-                        if (_currentOffset >= _ilBytes.Length)
-                        {
-                            ReportMethodEndInsideInstruction();
-                            return;
-                        }
-
                         opCode = (ILOpcode)(0x100 + ReadILByte());
                         goto again;
                     case ILOpcode.br_s:
@@ -271,12 +277,6 @@ namespace Internal.IL
                         break;
                     case ILOpcode.switch_:
                         {
-                            if (_currentOffset + 3 >= _ilBytes.Length)
-                            {
-                                ReportMethodEndInsideInstruction();
-                                return;
-                            }
-
                             uint count = ReadILUInt32();
                             int jmpBase = _currentOffset + (int)(4 * count);
                             for (uint i = 0; i < count; i++)

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -195,6 +195,12 @@ namespace Internal.IL
                         SkipIL(4);
                         break;
                     case ILOpcode.prefix1:
+                        if (_currentOffset >= _ilBytes.Length)
+                        {
+                            ReportMethodEndInsideInstruction();
+                            return;
+                        }
+
                         opCode = (ILOpcode)(0x100 + ReadILByte());
                         goto again;
                     case ILOpcode.br_s:
@@ -265,6 +271,12 @@ namespace Internal.IL
                         break;
                     case ILOpcode.switch_:
                         {
+                            if (_currentOffset + 3 >= _ilBytes.Length)
+                            {
+                                ReportMethodEndInsideInstruction();
+                                return;
+                            }
+
                             uint count = ReadILUInt32();
                             int jmpBase = _currentOffset + (int)(4 * count);
                             for (uint i = 0; i < count; i++)
@@ -478,12 +490,6 @@ namespace Internal.IL
                         return;
                     case ILOpcode.switch_:
                         {
-                            if (_currentOffset + 3 >= _ilBytes.Length)
-                            {
-                                ReportMethodEndInsideInstruction();
-                                return;
-                            }
-
                             uint count = ReadILUInt32();
                             int jmpBase = _currentOffset + (int)(4 * count);
                             int[] jmpDelta = new int[count];
@@ -835,12 +841,6 @@ namespace Internal.IL
                         ImportConvert(WellKnownType.UIntPtr, false, false);
                         break;
                     case ILOpcode.prefix1:
-                        if (_currentOffset >= _ilBytes.Length)
-                        {
-                            ReportMethodEndInsideInstruction();
-                            return;
-                        }
-
                         opCode = (ILOpcode)(0x100 + ReadILByte());
                         goto again;
                     case ILOpcode.arglist:

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -424,6 +424,7 @@ namespace Internal.IL
                         break;
                     case ILOpcode.jmp:
                         ImportJmp(ReadILToken());
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.call:
                         ImportCall(opCode, ReadILToken());
@@ -433,6 +434,7 @@ namespace Internal.IL
                         break;
                     case ILOpcode.ret:
                         ImportReturn();
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.br_s:
                     case ILOpcode.brfalse_s:
@@ -452,6 +454,7 @@ namespace Internal.IL
                             ImportBranch(opCode + (ILOpcode.br - ILOpcode.br_s),
                                 _basicBlocks[_currentOffset + delta], (opCode != ILOpcode.br_s) ? _basicBlocks[_currentOffset] : null);
                         }
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.br:
                     case ILOpcode.brfalse:
@@ -471,6 +474,7 @@ namespace Internal.IL
                             ImportBranch(opCode,
                                 _basicBlocks[_currentOffset + delta], (opCode != ILOpcode.br) ? _basicBlocks[_currentOffset] : null);
                         }
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.switch_:
                         {
@@ -482,6 +486,7 @@ namespace Internal.IL
 
                             ImportSwitchJump(jmpBase, jmpDelta, _basicBlocks[_currentOffset]);
                         }
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.ldind_i1:
                         ImportLoadIndirect(WellKnownType.SByte);
@@ -609,6 +614,7 @@ namespace Internal.IL
                         break;
                     case ILOpcode.throw_:
                         ImportThrow();
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.ldfld:
                         ImportLoadField(ReadILToken(), false);
@@ -800,18 +806,21 @@ namespace Internal.IL
                         break;
                     case ILOpcode.endfinally: //both endfinally and endfault
                         ImportEndFinally();
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.leave:
                         {
                             int delta = (int)ReadILUInt32();
                             ImportLeave(_basicBlocks[_currentOffset + delta]);
                         }
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.leave_s:
                         {
                             int delta = (sbyte)ReadILByte();
                             ImportLeave(_basicBlocks[_currentOffset + delta]);
                         }
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.stind_i:
                         ImportStoreIndirect(WellKnownType.IntPtr);
@@ -859,6 +868,7 @@ namespace Internal.IL
                         break;
                     case ILOpcode.endfilter:
                         ImportEndFilter();
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.unaligned:
                         ImportUnalignedPrefix(ReadILByte());
@@ -886,6 +896,7 @@ namespace Internal.IL
                         continue;
                     case ILOpcode.rethrow:
                         ImportRethrow();
+                        EndImportingInstruction();
                         return;
                     case ILOpcode.sizeof_:
                         ImportSizeOf(ReadILToken());

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -934,12 +934,6 @@ namespace Internal.IL
                     return;
                 }
 
-                if (_currentOffset > _ilBytes.Length)
-                {
-                    ReportMethodEndInsideInstruction();
-                    return;
-                }
-
                 BasicBlock nextBasicBlock = _basicBlocks[_currentOffset];
                 if (nextBasicBlock != null)
                 {

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -1051,6 +1051,11 @@ namespace Internal.IL
             ThrowHelper.ThrowInvalidProgramException();
         }
 
+        private void ReportMethodEndInsideInstruction()
+        {
+            ThrowHelper.ThrowInvalidProgramException();
+        }
+
         private void ReportInvalidInstruction(ILOpcode opcode)
         {
             ThrowHelper.ThrowInvalidProgramException();

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2753,6 +2753,11 @@ namespace Internal.IL
             ThrowHelper.ThrowInvalidProgramException();
         }
 
+        private void ReportMethodEndInsideInstruction()
+        {
+            ThrowHelper.ThrowInvalidProgramException();
+        }
+
         private void ReportInvalidInstruction(ILOpcode opcode)
         {
             ThrowHelper.ThrowInvalidProgramException();

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1930,6 +1930,11 @@ namespace Internal.IL
             ThrowHelper.ThrowInvalidProgramException();
         }
 
+        private void ReportMethodEndInsideInstruction()
+        {
+            ThrowHelper.ThrowInvalidProgramException();
+        }
+
         private void ReportInvalidInstruction(ILOpcode opcode)
         {
             ThrowHelper.ThrowInvalidProgramException();

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -2660,13 +2660,13 @@ again:
             VerificationError(VerifierError.MethodFallthrough);
         }
 
-        private void ReportMethodEndInsideInstruction()
+        void ReportMethodEndInsideInstruction()
         {
             VerificationError(VerifierError.MethodEnd);
             AbortMethodVerification();
         }
 
-        private void ReportInvalidInstruction(ILOpcode opcode)
+        void ReportInvalidInstruction(ILOpcode opcode)
         {
             VerificationError(VerifierError.UnknownOpcode);
         }

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -2674,6 +2674,7 @@ again:
         private void ReportMethodEndInsideInstruction()
         {
             VerificationError(VerifierError.MethodEnd);
+            AbortMethodVerification();
         }
 
         private void ReportInvalidInstruction(ILOpcode opcode)

--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -461,9 +461,12 @@ again:
                         break;
                 }
 
-                var fallthrough = _basicBlocks[_currentOffset];
-                if (fallthrough != null)
-                    MarkPredecessorWithLowerOffset(0);
+                if (_currentOffset < _basicBlocks.Length)
+                {
+                    var fallthrough = _basicBlocks[_currentOffset];
+                    if (fallthrough != null)
+                        MarkPredecessorWithLowerOffset(0);
+                }
             }
         }
 
@@ -2668,7 +2671,12 @@ again:
             VerificationError(VerifierError.MethodFallthrough);
         }
 
-        void ReportInvalidInstruction(ILOpcode opcode)
+        private void ReportMethodEndInsideInstruction()
+        {
+            VerificationError(VerifierError.MethodEnd);
+        }
+
+        private void ReportInvalidInstruction(ILOpcode opcode)
         {
             VerificationError(VerifierError.UnknownOpcode);
         }

--- a/src/ILVerify/src/Resources/Strings.resx
+++ b/src/ILVerify/src/Resources/Strings.resx
@@ -288,6 +288,9 @@
   <data name="MethodAccess" xml:space="preserve">
     <value>Method is not visible.</value>
   </data>
+  <data name="MethodEnd" xml:space="preserve">
+    <value>Method ends in the middle of an instruction.</value>
+  </data>
   <data name="MethodFallthrough" xml:space="preserve">
     <value>Fall through end of the method without returning.</value>
   </data>

--- a/src/ILVerify/src/Resources/Strings.resx
+++ b/src/ILVerify/src/Resources/Strings.resx
@@ -171,6 +171,9 @@
   <data name="CatchByRef" xml:space="preserve">
     <value>ByRef not allowed as catch type.</value>
   </data>
+  <data name="CodeSizeZero" xml:space="preserve">
+    <value>Code size is zero.</value>
+  </data>
   <data name="Constrained" xml:space="preserve">
     <value>Missing callvirt following constrained prefix.</value>
   </data>
@@ -365,6 +368,9 @@
   </data>
   <data name="TailCallInsideER" xml:space="preserve">
     <value>The tail.call (or calli or callvirt) instruction cannot be used to transfer control out of a try, filter, catch, or finally block.</value>
+  </data>
+  <data name="TailRet" xml:space="preserve">
+    <value>tail.call may only be followed by ret.</value>
   </data>
   <data name="TailRetType" xml:space="preserve">
     <value>Tail call return type not compatible.</value>

--- a/src/ILVerify/src/VerifierError.cs
+++ b/src/ILVerify/src/VerifierError.cs
@@ -122,10 +122,10 @@ namespace ILVerify
         //E_SIG_ARRAY                   "Cannot resolve Array type."
         ArrayByRef,                     // Array of ELEMENT_TYPE_BYREF or ELEMENT_TYPE_TYPEDBYREF.
         ByrefOfByref,                   // ByRef of ByRef.
-        //E_CODE_SIZE_ZERO              "Code size is zero."
+        CodeSizeZero,                   // Code size is zero.
         TailCall,                       // Missing call/callvirt/calli.
         TailByRef,                      // Cannot pass ByRef to a tail call.
-        //E_TAIL_RET                    "Missing ret."
+        TailRet,                        // tail.call may only be followed by ret.
         TailRetVoid,                    // Void ret type expected for tail call.
         TailRetType,                    // Tail call return type not compatible.
         TailStackEmpty,                 // Stack not empty after tail call.

--- a/src/ILVerify/src/VerifierError.cs
+++ b/src/ILVerify/src/VerifierError.cs
@@ -129,7 +129,7 @@ namespace ILVerify
         TailRetVoid,                    // Void ret type expected for tail call.
         TailRetType,                    // Tail call return type not compatible.
         TailStackEmpty,                 // Stack not empty after tail call.
-        //E_METHOD_END                  "Method ends in the middle of an instruction."
+        MethodEnd,                      // Method ends in the middle of an instruction.
         BadBranch,                      // Branch out of the method.
         //E_LEXICAL_NESTING             "Lexical nesting."
         Volatile,                       // Missing ldsfld, stsfld, ldind, stind, ldfld, stfld, ldobj, stobj, initblk, or cpblk.

--- a/src/ILVerify/tests/ILTests/PrefixTests.il
+++ b/src/ILVerify/tests/ILTests/PrefixTests.il
@@ -95,7 +95,7 @@
         ret
     }
 
-    .method static public hidebysig void Tail.FromTry_Invalid_TailCallInsideER() cil managed 
+    .method static public hidebysig void Tail.FromTry_Invalid_TailCallInsideER.TailRet() cil managed 
     {
         .try
         {
@@ -110,6 +110,52 @@
         }
 
     MethodEnd:
+        ret
+    }
+
+    .method static public hidebysig void Tail.FollowedByRet_Valid() cil managed 
+    {
+        tail.
+        call        void PrefixTestsType::StaticMethod()
+        ret
+    }
+
+    .method static public hidebysig void Tail.DoubleCall_Invalid_TailRet() cil managed 
+    {
+        tail.
+        call        void PrefixTestsType::StaticMethod()
+        call        void PrefixTestsType::StaticMethod()
+        ret
+    }
+
+    .method static public hidebysig void Tail.BranchToRet_Valid() cil managed 
+    {
+        ldc.i4.0
+        brfalse     MethodEnd
+
+        tail.
+        call        void PrefixTestsType::StaticMethod()
+
+    MethodEnd:
+        ret
+    }
+
+    .method static public hidebysig void Tail.BranchToNopRet_Invalid_TailRet() cil managed 
+    {
+        ldc.i4.0
+        brfalse     MethodEnd
+
+        tail.
+        call        void PrefixTestsType::StaticMethod()
+
+    MethodEnd:
+        nop
+        ret
+    }
+
+    .method static public hidebysig void Tail.Ret_Invalid_TailCall() cil managed 
+    {
+        tail.
         ret
     }
 }

--- a/src/ILVerify/tests/ILTests/PrefixTests.il
+++ b/src/ILVerify/tests/ILTests/PrefixTests.il
@@ -120,6 +120,12 @@
         ret
     }
 
+    .method static public hidebysig void Tail.NoRet_Invalid_TailRet() cil managed 
+    {
+        tail.
+        call        void PrefixTestsType::StaticMethod()
+    }
+
     .method static public hidebysig void Tail.DoubleCall_Invalid_TailRet() cil managed 
     {
         tail.
@@ -138,6 +144,24 @@
 
     MethodEnd:
         ret
+    }
+
+    .method static public hidebysig void Tail.ComplexBranchToRet_Valid() cil managed 
+    {
+        br          AfterTail
+
+    TailCall:
+        tail.
+        call        void PrefixTestsType::StaticMethod()
+
+    MethodEnd:
+        ret
+
+    AfterTail:
+        ldc.i4.0
+        brfalse     TailCall
+
+        br          MethodEnd
     }
 
     .method static public hidebysig void Tail.BranchToNopRet_Invalid_TailRet() cil managed 

--- a/src/ILVerify/tests/ILTests/PrefixTests.il
+++ b/src/ILVerify/tests/ILTests/PrefixTests.il
@@ -120,7 +120,7 @@
         ret
     }
 
-    .method static public hidebysig void Tail.NoRet_Invalid_TailRet() cil managed 
+    .method static public hidebysig void Tail.NoRet_Invalid_TailRet.MethodFallthrough() cil managed 
     {
         tail.
         call        void PrefixTestsType::StaticMethod()

--- a/src/ILVerify/tests/ILTests/ReturnTests.il
+++ b/src/ILVerify/tests/ILTests/ReturnTests.il
@@ -149,6 +149,11 @@
         ret
     }
 
+    .method public hidebysig instance void MissingReturn_Invalid_MethodFallthrough() cil managed
+    {
+        ldarg.0
+    }
+
     .method public hidebysig instance void 'special.ReturnAfterBaseCtor..ctor_Valid'() cil managed { ret }
     .method public hidebysig specialname rtspecialname instance void .ctor() cil managed 
     {


### PR DESCRIPTION
This adds 3 new verification rules:
- `CodeSizeZero`: an error is reported when the il-bytes buffer is 0
- `TailRet`: a tail.call (or calli / callvirt) shall always be followed by a ret
- `MethodEnd`: an error is reported when the method ends in the middle of an instruction (e.g. method end after prefix1 or directly after switch byte)

While implementing `TailRet` I noticed a bug in PEVerify:
As far as I understand it, the test cases `Tail.DoubleCall` and `Tail.BranchToNopRet` should both report a `TailRet` error, but PEVerify will classify them as valid IL.

I also noticed that the current `ILImporter` implementation will not call `EndImportingInstruction` on specific instructions which immediately return from the switch (e.g. `ret`, `leave`, etc.). This also meant that the current implementation would not report an error for a method body like this:
```
{
    tail.
    ret
}
```
I added a call to `EndImportingInstruction` to all these instructions and added the described scenario as a test case. As far as I understand the other implementations of the `ILImporter`, this change should not have any impact on those.

In order to implement the `MethodEnd` error I added a new method to the `ILImporter` called `ReportMethodEndInsideInstruction`. This method is called, when a `prefix1.` is the last instruction of the method or when a `switch` instruction is not followed by enough bytes to make up the target count. It is also reported, when the `currentOffset` exceeds the il bytes length at the end of parsing an instruction.
This mimics the exact behavior of how PEVerify reports this error. However, I am not sure if it would make sense to always verify that we read inside the range of the `ilBytes` array inside the IL stream reading operations.
For example instead of checking the offset inside the `switch` / `prefix` instruction cases, we could change the ReadILByte method to:
```csharp
private byte ReadILByte()
{
    if (_currentOffset >= _ilBytes.Length)
    {
        ReportMethodEndInsideInstruction();
        return 0;
    }
    
    return _ilBytes[_currentOffset++];
}
```
I am not sure, which value should be returned in such a case, though. Do you have any thoughts on this, @jkotas ?