### PR TITLE
Add AnalysisBasedMetadataManager

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/AnalysisBasedMetadataManager.cs
@@ -1,0 +1,254 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+
+using ILCompiler.Metadata;
+using ILCompiler.DependencyAnalysis;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// A metadata manager that knows the full set of metadata ahead of time.
+    /// </summary>
+    public sealed class AnalysisBasedMetadataManager : GeneratingMetadataManager, ICompilationRootProvider
+    {
+        private readonly List<ModuleDesc> _modulesWithMetadata;
+
+        private readonly Dictionary<TypeDesc, MetadataCategory> _reflectableTypes = new Dictionary<TypeDesc, MetadataCategory>();
+        private readonly Dictionary<MethodDesc, MetadataCategory> _reflectableMethods = new Dictionary<MethodDesc, MetadataCategory>();
+        private readonly Dictionary<FieldDesc, MetadataCategory> _reflectableFields = new Dictionary<FieldDesc, MetadataCategory>();
+
+        public AnalysisBasedMetadataManager(
+            ModuleDesc generatedAssembly,
+            CompilerTypeSystemContext typeSystemContext,
+            MetadataBlockingPolicy blockingPolicy,
+            string logFile,
+            StackTraceEmissionPolicy stackTracePolicy,
+            IEnumerable<ModuleDesc> modulesWithMetadata,
+            IEnumerable<ReflectableEntity<TypeDesc>> reflectableTypes,
+            IEnumerable<ReflectableEntity<MethodDesc>> reflectableMethods,
+            IEnumerable<ReflectableEntity<FieldDesc>> reflectableFields)
+            : base(generatedAssembly, typeSystemContext, blockingPolicy, logFile, stackTracePolicy)
+        {
+            _modulesWithMetadata = new List<ModuleDesc>(modulesWithMetadata);
+            
+            foreach (var refType in reflectableTypes)
+            {
+                _reflectableTypes.Add(refType.Entity, refType.Category);
+            }
+
+            foreach (var refMethod in reflectableMethods)
+            {
+                // Asking for description or runtime mapping for a member without asking
+                // for the owning type would mean we can't actually satisfy the request.
+                Debug.Assert((refMethod.Category & MetadataCategory.Description) == 0
+                    || (_reflectableTypes[refMethod.Entity.OwningType] & MetadataCategory.Description) != 0);
+                Debug.Assert((refMethod.Category & MetadataCategory.RuntimeMapping) == 0
+                    || (_reflectableTypes[refMethod.Entity.OwningType] & MetadataCategory.RuntimeMapping) != 0);
+                _reflectableMethods.Add(refMethod.Entity, refMethod.Category);
+
+                MethodDesc canonMethod = refMethod.Entity.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                if (refMethod.Entity != canonMethod)
+                {
+                    if (!_reflectableMethods.TryGetValue(canonMethod, out MetadataCategory category))
+                        category = 0;
+                    _reflectableMethods[canonMethod] = category | refMethod.Category;
+                }
+            }
+
+            foreach (var refField in reflectableFields)
+            {
+                // Asking for description or runtime mapping for a member without asking
+                // for the owning type would mean we can't actually satisfy the request.
+                Debug.Assert((refField.Category & MetadataCategory.Description) == 0
+                    || (_reflectableTypes[refField.Entity.OwningType] & MetadataCategory.Description) != 0);
+                Debug.Assert((refField.Category & MetadataCategory.RuntimeMapping) == 0
+                    || (_reflectableTypes[refField.Entity.OwningType] & MetadataCategory.RuntimeMapping) != 0);
+                _reflectableFields.Add(refField.Entity, refField.Category);
+            }
+
+#if DEBUG
+            HashSet<ModuleDesc> moduleHash = new HashSet<ModuleDesc>(_modulesWithMetadata);
+            foreach (var refType in reflectableTypes)
+            {
+                // The instantiated types need to agree on the Description bit with the definition.
+                // GetMetadataCategory relies on that.
+                Debug.Assert((GetMetadataCategory(refType.Entity.GetTypeDefinition()) & MetadataCategory.Description)
+                    == (GetMetadataCategory(refType.Entity) & MetadataCategory.Description));
+
+                Debug.Assert(!(refType.Entity is MetadataType) || moduleHash.Contains(((MetadataType)refType.Entity).Module));
+            }
+
+            foreach (var refMethod in reflectableMethods)
+            {
+                // The instantiated methods need to agree on the Description bit with the definition.
+                // GetMetadataCategory relies on that.
+                Debug.Assert((GetMetadataCategory(refMethod.Entity.GetTypicalMethodDefinition()) & MetadataCategory.Description)
+                    == (GetMetadataCategory(refMethod.Entity) & MetadataCategory.Description));
+            }
+
+            foreach (var refField in reflectableFields)
+            {
+                // The instantiated fields need to agree on the Description bit with the definition.
+                // GetMetadataCategory relies on that.
+                Debug.Assert((GetMetadataCategory(refField.Entity.GetTypicalFieldDefinition()) & MetadataCategory.Description)
+                    == (GetMetadataCategory(refField.Entity) & MetadataCategory.Description));
+            }
+#endif
+        }
+
+        public override IEnumerable<ModuleDesc> GetCompilationModulesWithMetadata()
+        {
+            return _modulesWithMetadata;
+        }
+
+        protected override void ComputeMetadata(NodeFactory factory,
+            out byte[] metadataBlob,
+            out List<MetadataMapping<MetadataType>> typeMappings,
+            out List<MetadataMapping<MethodDesc>> methodMappings,
+            out List<MetadataMapping<FieldDesc>> fieldMappings,
+            out List<MetadataMapping<MethodDesc>> stackTraceMapping)
+        {
+            ComputeMetadata(new Policy(_blockingPolicy, this), factory,
+                out metadataBlob,
+                out typeMappings,
+                out methodMappings,
+                out fieldMappings,
+                out stackTraceMapping);
+        }
+
+        protected sealed override MetadataCategory GetMetadataCategory(MethodDesc method)
+        {
+            if (_reflectableMethods.TryGetValue(method, out MetadataCategory value))
+                return value;
+            return 0;
+        }
+
+        protected sealed override MetadataCategory GetMetadataCategory(TypeDesc type)
+        {
+            if (_reflectableTypes.TryGetValue(type, out MetadataCategory value))
+                return value;
+            return 0;
+        }
+
+        protected sealed override MetadataCategory GetMetadataCategory(FieldDesc field)
+        {
+            if (_reflectableFields.TryGetValue(field, out MetadataCategory value))
+                return value;
+            return 0;
+        }
+
+        void ICompilationRootProvider.AddCompilationRoots(IRootingServiceProvider rootProvider)
+        {
+            // We go over all the types and members that need a runtime artiface present in the
+            // compiled executable and root it.
+
+            const string reason = "Reflection";
+
+            foreach (var pair in _reflectableTypes)
+            {
+                if ((pair.Value & MetadataCategory.RuntimeMapping) != 0)
+                    rootProvider.AddCompilationRoot(pair.Key, reason);
+            }
+
+            foreach (var pair in _reflectableMethods)
+            {
+                if ((pair.Value & MetadataCategory.RuntimeMapping) != 0)
+                {
+                    MethodDesc method = pair.Key;
+
+                    // We need to root virtual methods as if they were called virtually.
+                    // This will possibly trigger the generation of other overrides too.
+                    if (method.IsVirtual)
+                        rootProvider.RootVirtualMethodForReflection(method, reason);
+
+                    if (!method.IsAbstract)
+                        rootProvider.AddCompilationRoot(pair.Key, reason);
+                }
+            }
+
+            foreach (var pair in _reflectableFields)
+            {
+                if ((pair.Value & MetadataCategory.RuntimeMapping) != 0)
+                {
+                    FieldDesc field = pair.Key;
+
+                    // We only care about static fields at this point. Instance fields don't need
+                    // runtime artifacts generated in the image.
+                    if (field.IsStatic && !field.IsLiteral)
+                    {
+                        if (field.IsThreadStatic)
+                            rootProvider.RootThreadStaticBaseForType(field.OwningType, reason);
+                        else if (field.HasGCStaticBase)
+                            rootProvider.RootGCStaticBaseForType(field.OwningType, reason);
+                        else
+                            rootProvider.RootNonGCStaticBaseForType(field.OwningType, reason);
+                    }
+                }
+            }
+        }
+
+        private struct Policy : IMetadataPolicy
+        {
+            private readonly MetadataBlockingPolicy _blockingPolicy;
+            private readonly ExplicitScopeAssemblyPolicyMixin _explicitScopeMixin;
+            private readonly AnalysisBasedMetadataManager _parent;
+
+            public Policy(MetadataBlockingPolicy blockingPolicy, 
+                AnalysisBasedMetadataManager parent)
+            {
+                _blockingPolicy = blockingPolicy;
+                _parent = parent;
+                _explicitScopeMixin = new ExplicitScopeAssemblyPolicyMixin();
+            }
+
+            public bool GeneratesMetadata(FieldDesc fieldDef)
+            {
+                return (_parent.GetMetadataCategory(fieldDef) & MetadataCategory.Description) != 0;
+            }
+
+            public bool GeneratesMetadata(MethodDesc methodDef)
+            {
+                return (_parent.GetMetadataCategory(methodDef) & MetadataCategory.Description) != 0;
+            }
+
+            public bool GeneratesMetadata(MetadataType typeDef)
+            {
+                return (_parent.GetMetadataCategory(typeDef) & MetadataCategory.Description) != 0;
+            }
+
+            public bool IsBlocked(MetadataType typeDef)
+            {
+                return _blockingPolicy.IsBlocked(typeDef);
+            }
+
+            public bool IsBlocked(MethodDesc methodDef)
+            {
+                return _blockingPolicy.IsBlocked(methodDef);
+            }
+
+            public ModuleDesc GetModuleOfType(MetadataType typeDef)
+            {
+                return _explicitScopeMixin.GetModuleOfType(typeDef);
+            }
+        }
+    }
+
+    public struct ReflectableEntity<TEntity>
+    {
+        public readonly TEntity Entity;
+        public readonly MetadataCategory Category;
+
+        public ReflectableEntity(TEntity entity, MetadataCategory category)
+        {
+            Entity = entity;
+            Category = category;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -33,7 +33,7 @@ namespace ILCompiler
             _context = context;
             _compilationGroup = compilationGroup;
             _nameMangler = nameMangler;
-            _metadataManager = new EmptyMetadataManager(compilationGroup, context);
+            _metadataManager = new EmptyMetadataManager(context);
         }
 
         public CompilationBuilder UseLogger(Logger logger)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
@@ -63,7 +63,7 @@ namespace ILCompiler
         {
             if (metadataFile == null)
             {
-                return new EmptyMetadataManager(compilationModuleGroup, context);
+                return new EmptyMetadataManager(context);
             }
             else
             {

--- a/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
@@ -12,12 +12,12 @@ using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler
 {
-    class EmptyMetadataManager : MetadataManager
+    public class EmptyMetadataManager : MetadataManager
     {
         public override bool SupportsReflection => false;
 
-        public EmptyMetadataManager(CompilationModuleGroup group, CompilerTypeSystemContext typeSystemContext)
-            : base(group, typeSystemContext, new FullyBlockedMetadataPolicy())
+        public EmptyMetadataManager(CompilerTypeSystemContext typeSystemContext)
+            : base(typeSystemContext, new FullyBlockedMetadataPolicy())
         {
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/GeneratingMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/GeneratingMetadataManager.cs
@@ -27,12 +27,14 @@ namespace ILCompiler
         private readonly string _metadataLogFile;
         private readonly StackTraceEmissionPolicy _stackTraceEmissionPolicy;
         private readonly Dictionary<DynamicInvokeMethodSignature, MethodDesc> _dynamicInvokeThunks;
+        private readonly ModuleDesc _generatedAssembly;
 
-        public GeneratingMetadataManager(CompilationModuleGroup group, CompilerTypeSystemContext typeSystemContext, MetadataBlockingPolicy blockingPolicy, string logFile, StackTraceEmissionPolicy stackTracePolicy)
-            : base(group, typeSystemContext, blockingPolicy)
+        public GeneratingMetadataManager(ModuleDesc generatedAssembly, CompilerTypeSystemContext typeSystemContext, MetadataBlockingPolicy blockingPolicy, string logFile, StackTraceEmissionPolicy stackTracePolicy)
+            : base(typeSystemContext, blockingPolicy)
         {
             _metadataLogFile = logFile;
             _stackTraceEmissionPolicy = stackTracePolicy;
+            _generatedAssembly = generatedAssembly;
 
             if (DynamicInvokeMethodThunk.SupportsThunks(typeSystemContext))
             {
@@ -232,7 +234,7 @@ namespace ILCompiler
             var lookupSig = new DynamicInvokeMethodSignature(sig);
             if (!_dynamicInvokeThunks.TryGetValue(lookupSig, out thunk))
             {
-                thunk = new DynamicInvokeMethodThunk(_compilationModuleGroup.GeneratedAssembly.GetGlobalModuleType(), lookupSig);
+                thunk = new DynamicInvokeMethodThunk(_generatedAssembly.GetGlobalModuleType(), lookupSig);
                 _dynamicInvokeThunks.Add(lookupSig, thunk);
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/ILScannerBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScannerBuilder.cs
@@ -46,7 +46,7 @@ namespace ILCompiler
         public IILScanner ToILScanner()
         {
             // TODO: we will want different metadata managers depending on whether we're doing reflection analysis
-            var metadataManager = new CompilerGeneratedMetadataManager(_compilationGroup, _context, null, new NoStackTraceEmissionPolicy());
+            var metadataManager = new UsageBasedMetadataManager(_compilationGroup, _context, new BlockedInternalsBlockingPolicy(), null, new NoStackTraceEmissionPolicy());
             var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_compilationGroup.GeneratedAssembly));
             var nodeFactory = new ILScanNodeFactory(_context, _compilationGroup, metadataManager, interopStubManager, _nameMangler);
             DependencyAnalyzerBase<NodeFactory> graph = _dependencyTrackingLevel.CreateDependencyGraph(nodeFactory);

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -34,7 +34,6 @@ namespace ILCompiler
         private List<MetadataMapping<MethodDesc>> _methodMappings;
         private List<MetadataMapping<MethodDesc>> _stackTraceMappings;
 
-        protected readonly CompilationModuleGroup _compilationModuleGroup;
         protected readonly CompilerTypeSystemContext _typeSystemContext;
         protected readonly MetadataBlockingPolicy _blockingPolicy;
 
@@ -52,9 +51,8 @@ namespace ILCompiler
         internal DynamicInvokeTemplateDataNode DynamicInvokeTemplateData { get; private set; }
         public virtual bool SupportsReflection => true;
 
-        public MetadataManager(CompilationModuleGroup compilationModuleGroup, CompilerTypeSystemContext typeSystemContext, MetadataBlockingPolicy blockingPolicy)
+        public MetadataManager(CompilerTypeSystemContext typeSystemContext, MetadataBlockingPolicy blockingPolicy)
         {
-            _compilationModuleGroup = compilationModuleGroup;
             _typeSystemContext = typeSystemContext;
             _blockingPolicy = blockingPolicy;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -3,12 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
 using System.Collections.Generic;
 
 using Internal.TypeSystem;
 
-using ILCompiler.Metadata;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 
@@ -43,7 +41,6 @@ namespace ILCompiler
         private HashSet<MethodDesc> _methodsGenerated = new HashSet<MethodDesc>();
         private HashSet<GenericDictionaryNode> _genericDictionariesGenerated = new HashSet<GenericDictionaryNode>();
         private HashSet<IMethodBodyNode> _methodBodiesGenerated = new HashSet<IMethodBodyNode>();
-        private List<ModuleDesc> _modulesWithMetadata = new List<ModuleDesc>();
         private List<TypeGVMEntriesNode> _typeGVMEntries = new List<TypeGVMEntriesNode>();
         private HashSet<DefaultConstructorFromLazyNode> _defaultConstructorsNeeded = new HashSet<DefaultConstructorFromLazyNode>();
 
@@ -152,7 +149,7 @@ namespace ILCompiler
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.NativeStatics), nativeStaticsTableNode, nativeStaticsTableNode, nativeStaticsTableNode.EndSymbol);
         }
 
-        private void Graph_NewMarkedNode(DependencyNodeCore<NodeFactory> obj)
+        protected virtual void Graph_NewMarkedNode(DependencyNodeCore<NodeFactory> obj)
         {
             var eetypeNode = obj as EETypeNode;
             if (eetypeNode != null)
@@ -173,12 +170,9 @@ namespace ILCompiler
                 _methodBodiesGenerated.Add(methodBodyNode);
             }
 
-            IMethodNode methodNode = obj as MethodCodeNode;
+            IMethodNode methodNode = methodBodyNode;
             if (methodNode == null)
                 methodNode = obj as ShadowConcreteMethodNode;
-
-            if (methodNode == null)
-                methodNode = obj as NonExternMethodSymbolNode;
 
             if (methodNode != null)
             {
@@ -214,13 +208,6 @@ namespace ILCompiler
             if (ctorFromLazyGenericsNode != null)
             {
                 _defaultConstructorsNeeded.Add(ctorFromLazyGenericsNode);
-            }
-
-            // TODO: temporary until we have an IL scanning Metadata Manager. We shouldn't have to keep track of these.
-            var moduleMetadataNode = obj as ModuleMetadataNode;
-            if (moduleMetadataNode != null)
-            {
-                _modulesWithMetadata.Add(moduleMetadataNode.Module);
             }
         }
 
@@ -545,15 +532,7 @@ namespace ILCompiler
         /// <summary>
         /// Returns a set of modules that will get some metadata emitted into the output module
         /// </summary>
-        public virtual IEnumerable<ModuleDesc> GetCompilationModulesWithMetadata()
-        {
-            // TODO: this is temporary until we have a metadata manager for IL scanner. This method should be abstract.
-
-            // TODO: We should also return the list of satellite assemblies here (this API is used by the ResourceDataNode to
-            // generate the BlobIdResourceIndex blob, for the ResourceManager to work at runtime).
-
-            return _modulesWithMetadata;
-        }
+        public abstract IEnumerable<ModuleDesc> GetCompilationModulesWithMetadata();
 
         public byte[] GetMetadataBlob(NodeFactory factory)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -52,6 +52,7 @@ namespace ILCompiler
         private readonly byte[] _metadataBlob;
         private readonly StackTraceEmissionPolicy _stackTraceEmissionPolicy;
         private byte[] _stackTraceBlob;
+        private readonly CompilationModuleGroup _compilationModuleGroup;
 
         public PrecomputedMetadataManager(
             CompilationModuleGroup group, 
@@ -61,8 +62,9 @@ namespace ILCompiler
             IEnumerable<ModuleDesc> inputMetadataOnlyAssemblies,
             byte[] metadataBlob,
             StackTraceEmissionPolicy stackTraceEmissionPolicy)
-            : base(group, typeSystemContext, new AttributeSpecifiedBlockingPolicy())
+            : base(typeSystemContext, new AttributeSpecifiedBlockingPolicy())
         {
+            _compilationModuleGroup = group;
             _metadataDescribingModule = metadataDescribingModule;
             _compilationModules = new HashSet<ModuleDesc>(compilationModules);
             _metadataOnlyAssemblies = new HashSet<ModuleDesc>(inputMetadataOnlyAssemblies);

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+
+using ILCompiler.Metadata;
+using ILCompiler.DependencyAnalysis;
+
+using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// This class is responsible for managing native metadata to be emitted into the compiled
+    /// module. It applies a policy that every type/method that is statically used shall be reflectable.
+    /// </summary>
+    public sealed class UsageBasedMetadataManager : GeneratingMetadataManager
+    {
+        public UsageBasedMetadataManager(
+            CompilationModuleGroup group,
+            CompilerTypeSystemContext typeSystemContext,
+            MetadataBlockingPolicy blockingPolicy,
+            string logFile,
+            StackTraceEmissionPolicy stackTracePolicy)
+            : base(group, typeSystemContext, blockingPolicy, logFile, stackTracePolicy)
+        {
+        }
+
+        protected override MetadataCategory GetMetadataCategory(FieldDesc field)
+        {
+            MetadataCategory category = 0;
+
+            if (!IsReflectionBlocked(field))
+            {
+                category = MetadataCategory.RuntimeMapping;
+
+                if (_compilationModuleGroup.ContainsType(field.GetTypicalFieldDefinition().OwningType))
+                    category |= MetadataCategory.Description;
+            }
+
+            return category;
+        }
+
+        protected override MetadataCategory GetMetadataCategory(MethodDesc method)
+        {
+            MetadataCategory category = 0;
+
+            if (!IsReflectionBlocked(method))
+            {
+                category = MetadataCategory.RuntimeMapping;
+
+                if (_compilationModuleGroup.ContainsType(method.GetTypicalMethodDefinition().OwningType))
+                    category |= MetadataCategory.Description;
+            }
+
+            return category;
+        }
+
+        protected override MetadataCategory GetMetadataCategory(TypeDesc type)
+        {
+            MetadataCategory category = 0;
+
+            if (!IsReflectionBlocked(type))
+            {
+                category = MetadataCategory.RuntimeMapping;
+
+                if (_compilationModuleGroup.ContainsType(type.GetTypeDefinition()))
+                    category |= MetadataCategory.Description;
+            }
+
+            return category;
+        }
+
+        protected override void ComputeMetadata(NodeFactory factory,
+            out byte[] metadataBlob,
+            out List<MetadataMapping<MetadataType>> typeMappings,
+            out List<MetadataMapping<MethodDesc>> methodMappings,
+            out List<MetadataMapping<FieldDesc>> fieldMappings,
+            out List<MetadataMapping<MethodDesc>> stackTraceMapping)
+        {
+            ComputeMetadata(new GeneratedTypesAndCodeMetadataPolicy(_blockingPolicy, factory),
+                factory, out metadataBlob, out typeMappings, out methodMappings, out fieldMappings, out stackTraceMapping);
+        }
+
+        protected override void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            dependencies = dependencies ?? new DependencyList();
+            dependencies.Add(factory.MethodMetadata(method.GetTypicalMethodDefinition()), "Reflectable method");
+        }
+
+        protected override void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+            TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, type, "Reflectable type");
+        }
+
+        private struct GeneratedTypesAndCodeMetadataPolicy : IMetadataPolicy
+        {
+            private readonly MetadataBlockingPolicy _blockingPolicy;
+            private readonly NodeFactory _factory;
+            private readonly ExplicitScopeAssemblyPolicyMixin _explicitScopeMixin;
+
+            public GeneratedTypesAndCodeMetadataPolicy(MetadataBlockingPolicy blockingPolicy, NodeFactory factory)
+            {
+                _blockingPolicy = blockingPolicy;
+                _factory = factory;
+                _explicitScopeMixin = new ExplicitScopeAssemblyPolicyMixin();
+            }
+
+            public bool GeneratesMetadata(FieldDesc fieldDef)
+            {
+                return _factory.FieldMetadata(fieldDef).Marked;
+            }
+
+            public bool GeneratesMetadata(MethodDesc methodDef)
+            {
+                return _factory.MethodMetadata(methodDef).Marked;
+            }
+
+            public bool GeneratesMetadata(MetadataType typeDef)
+            {
+                return _factory.TypeMetadata(typeDef).Marked;
+            }
+
+            public bool IsBlocked(MetadataType typeDef)
+            {
+                return _blockingPolicy.IsBlocked(typeDef);
+            }
+
+            public bool IsBlocked(MethodDesc methodDef)
+            {
+                return _blockingPolicy.IsBlocked(methodDef);
+            }
+
+            public ModuleDesc GetModuleOfType(MetadataType typeDef)
+            {
+                return _explicitScopeMixin.GetModuleOfType(typeDef);
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
@@ -19,14 +19,17 @@ namespace ILCompiler
     /// </summary>
     public sealed class UsageBasedMetadataManager : GeneratingMetadataManager
     {
+        private readonly CompilationModuleGroup _compilationModuleGroup;
+
         public UsageBasedMetadataManager(
             CompilationModuleGroup group,
             CompilerTypeSystemContext typeSystemContext,
             MetadataBlockingPolicy blockingPolicy,
             string logFile,
             StackTraceEmissionPolicy stackTracePolicy)
-            : base(group, typeSystemContext, blockingPolicy, logFile, stackTracePolicy)
+            : base(group.GeneratedAssembly, typeSystemContext, blockingPolicy, logFile, stackTracePolicy)
         {
+            _compilationModuleGroup = group;
         }
 
         protected override MetadataCategory GetMetadataCategory(FieldDesc field)

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Compiler\EmptyInteropStubManager.cs" />
     <Compile Include="Compiler\DependencyAnalysis\SortableDependencyNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ImportedNodeProvider.cs" />
+    <Compile Include="Compiler\GeneratingMetadataManager.cs" />
     <Compile Include="Compiler\InternalCompilerErrorException.cs" />
     <Compile Include="Compiler\PreInitFieldInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenArrayNode.cs" />
@@ -321,7 +322,6 @@
     <Compile Include="Compiler\MainMethodRootProvider.cs" />
     <Compile Include="Compiler\ManagedBinaryEmitter.cs" />
     <Compile Include="Compiler\MemoryHelper.cs" />
-    <Compile Include="Compiler\CompilerGeneratedMetadataManager.cs" />
     <Compile Include="Compiler\MergedAssemblyRecords.cs" />
     <Compile Include="Compiler\MetadataManager.cs" />
     <Compile Include="Compiler\InteropStubManager.cs" />
@@ -343,6 +343,7 @@
     <Compile Include="Compiler\TypeExtensions.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.TypeInit.cs" />
     <Compile Include="Compiler\CoreRTNameMangler.cs" />
+    <Compile Include="Compiler\UsageBasedMetadataManager.cs" />
     <Compile Include="Compiler\UserDefinedTypeDescriptor.cs" />
     <Compile Include="Compiler\UniversalGenericsRootProvider.cs" />
     <Compile Include="Compiler\UnixNodeMangler.cs" />

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -97,6 +97,7 @@
     <Compile Include="..\..\JitInterface\src\TypeString.cs">
       <Link>JitInterface\TypeString.cs</Link>
     </Compile>
+    <Compile Include="Compiler\AnalysisBasedMetadataManager.cs" />
     <Compile Include="Compiler\BlockedInternalsBlockingPolicy.cs" />
     <Compile Include="Compiler\CodeGenerationFailedException.cs" />
     <Compile Include="Compiler\CompilerGeneratedType.cs" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -418,9 +418,10 @@ namespace ILCompiler
             var stackTracePolicy = _emitStackTraceData ?
                 (StackTraceEmissionPolicy)new EcmaMethodStackTraceEmissionPolicy() : new NoStackTraceEmissionPolicy();
 
-            CompilerGeneratedMetadataManager metadataManager = new CompilerGeneratedMetadataManager(
+            UsageBasedMetadataManager metadataManager = new UsageBasedMetadataManager(
                 compilationGroup,
                 typeSystemContext,
+                new BlockedInternalsBlockingPolicy(),
                 _metadataLogFileName,
                 stackTracePolicy);
 


### PR DESCRIPTION
(Split into several self-contained commits for reviewability.)

This is making progress towards a pluggable metadata generation strategy. After this change, we no longer compute reflection metadata twice in optimized builds (once during the scanning, the second time during the compilation). Instead, the scanner computes the full metadata closure, and the compilation phase uses it to drive code generation and metadata generation. We no longer suffer from the problems caused by things getting inlined and becoming no longer reflectable.

The general design goals were:

* Support a mode where the reflectable closure is computed based on what got compiled. This has two flavors:
  * The closure gets computed by the IL scanner (to provide a deterministic closure that doesn't depend on what things got optimized away)
  * The closure gets computed based on what the codegen backend compiled. This is so that we can have unoptimized builds that don't depend on the IL scanner.
* Support a mode where reflectable closure is provided by an external tool (e.g. the Project N dependency reducer).
* Support a mode where nothing is reflectable. This is to compile things like mrt100_app.dll or to do experiments.
* Support a mode where reflectable closure and the metadata blob are computed ahead of time (Project X).

The design relies on multiple metadata managers that the dependency nodes (such as `MethodCodeNode`, or `EETypeNode`) call into to get additional dependencies. Those dependencies depend on what the metadata manager is doing and can be limited to just ensuring we have invoke stubs (Project X), to ensuring we have custom attributes, metadata for owning type and module, etc.

The resulting class hierarchy is:
* `MetadataManager` - the base class for everything; handling things that are common.
  * `EmptyMetadataManager` - this one does nothing.
  * `PrecomputedMetadataManager` - for Project X.
  * `GeneratingMetadataManager` - a metadata manager that generates reflection metadata and invoke stubs
    * `UsageBasedMetadataManager` - this one collects necessary metadata based on usage. It uses some supporting node types (like `TypeMetadataNode`) to track additional dependencies of the metadata itself. This enforces invariants like usable custom attribute metadata, metadata for containing types of nested types, etc.)
    * `AnalysisBasedMetadataManager` - this one provides compilation roots based on the things that are required to be reflectable, and uses an ahead of time determined set of things that need metadata. This one can be produced from a `UsageBasedMetadataManager` (for the "IL scanner before compilation" scenario), or could be instantiated from data provided by an external tool.

There is more work left, but this seems like a reasonable checkpoint. Examples of leftover things is handling of fields (now that we have a scanner, we can have a "precise" mode for tracking reflection field usage instead of blanket policy that says all fields are reflectable; we'll still need to support the fallback logic for "no scanner" scenarios, but optimized scenarios can get some size on disk benefits).