### PR TITLE
Package Build Fix: Add Project reference to meta package

### DIFF
--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -14,6 +14,11 @@
     <PackageTargetRuntime></PackageTargetRuntime>
   </PropertyGroup>
   
+  <!-- The package references are used to generate a runtimes.json for the meta-package-->
+  <ItemGroup>
+    <ProjectReference Include="TargetSpecific\Microsoft.DotNet.ILCompiler.pkgproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <File Include="$(PackageSourceDirectory)\BuildIntegration\*">
       <TargetPath>build</TargetPath>


### PR DESCRIPTION
Fixes package build crashes due to "runtime.json" not being found.

@jkotas  - turns out the ProjectReferences are what makes NuGet automatically generate a runtime.json file