### PR TITLE
[WIP] Package build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -49,9 +49,9 @@ call %~dp0buildscripts\build-packages.cmd %*
 IF NOT ERRORLEVEL 1 goto AfterNuGetPackageBuild
 echo Package build failed.
 exit /b %ERRORLEVEL%
-call %~dp0buildscripts\build-tests.cmd %*
 
 :AfterNuGetPackageBuild
+call %~dp0buildscripts\build-tests.cmd %*
 IF NOT ERRORLEVEL 1 goto AfterTests
 echo Tests failed.
 exit /b %ERRORLEVEL%

--- a/build.cmd
+++ b/build.cmd
@@ -44,8 +44,14 @@ exit /b %ERRORLEVEL%
 
 :AfterManagedBuild
 
+call %~dp0buildscripts\build-packages.cmd %*
+
+IF NOT ERRORLEVEL 1 goto AfterNuGetPackageBuild
+echo Package build failed.
+exit /b %ERRORLEVEL%
 call %~dp0buildscripts\build-tests.cmd %*
 
+:AfterNuGetPackageBuild
 IF NOT ERRORLEVEL 1 goto AfterTests
 echo Tests failed.
 exit /b %ERRORLEVEL%

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,13 @@ if [ $BUILDERRORLEVEL != 0 ]; then
     exit $BUILDERRORLEVEL
 fi
 
+. ./buildscripts/build-packages.sh $*
+
+# If NuGet package build failed, exit with the status code of the package build
+if [ $BUILDERRORLEVEL != 0 ]; then
+    exit $BUILDERRORLEVEL
+fi
+
 . ./buildscripts/build-tests.sh $*
 
 if [ $TESTERRORLEVEL != 0 ]; then

--- a/buildscripts/build-packages.cmd
+++ b/buildscripts/build-packages.cmd
@@ -27,5 +27,7 @@ exit /b %ERRORLEVEL%
 
 :AfterVarSetup
 
+if defined __SkipBuildPackages exit /b 0
+
 %_msbuildexe% "%__ProjectDir%\pkg\packages.proj" /m /nologo /flp:v=diag;LogFile=build-packages.log /p:NuPkgRid=%__NugetRuntimeId% /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
 exit /b %ERRORLEVEL%

--- a/buildscripts/build-packages.sh
+++ b/buildscripts/build-packages.sh
@@ -2,6 +2,10 @@
 
 scriptRoot="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+if [ "$__SkipBuildPackages" == "true" ]; then
+    exit 0
+fi
+
 if [ "$BUILDVARS_DONE" != 1 ]; then
     . $scriptRoot/buildvars-setup.sh $*
 fi

--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -35,6 +35,8 @@ if /i "%1" == "clean"   (set __CleanBuild=1&shift&goto Arg_Loop)
 
 if /i "%1" == "skiptests" (set __SkipTests=1&shift&goto Arg_Loop)
 if /i "%1" == "skipvsdev" (set __SkipVsDev=1&shift&goto Arg_Loop)
+if /i "%1" == "skipbuildpackages" (set __SkipBuildPackages=1&shift&goto Arg_Loop)
+
 if /i "%1" == "/dotnetclipath" (set __DotNetCliPath=%2&shift&shift&goto Arg_Loop)
 
 if /i "%1" == "/officialbuildid" (set "__ExtraMsBuildParams=/p:OfficialBuildId=%2"&shift&shift&goto Arg_Loop)
@@ -49,6 +51,7 @@ set "__ObjDir=%__RootBinDir%\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__IntermediatesDir=%__RootBinDir%\obj\Native\%__BuildOS%.%__BuildArch%.%__BuildType%\"
 set "__NativeBuildLog=%__LogsDir%\Native_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
 set "__BuildLog=%__LogsDir%\msbuild_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
+set "__PackagesDir=%__RootBinDir%\packages"
 
 :: Generate path to be set for CMAKE_INSTALL_PREFIX to contain forward slash
 set "__CMakeBinDir=%__BinDir%"
@@ -64,6 +67,7 @@ if exist "%__BinDir%" rd /s /q "%__BinDir%"
 if exist "%__ObjDir%" rd /s /q "%__ObjDir%"
 if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"
 
+if exist "%__PackagesDir%" rd /s /q "%__PackagesDir%"
 if exist "%__LogsDir%" del /f /q "%__LogsDir%\*_%__BuildOS%__%__BuildArch%__%__BuildType%.*"
 
 :MakeDirs
@@ -71,6 +75,7 @@ if not exist "%__BinDir%" md "%__BinDir%"
 if not exist "%__ObjDir%" md "%__ObjDir%"
 if not exist "%__IntermediatesDir%" md "%__IntermediatesDir%"
 if not exist "%__LogsDir%" md "%__LogsDir%"
+if not exist "%__PackagesDir%" md "%__PackagesDir%"
 
 :: Check prerequisites
 echo Checking pre-requisites...
@@ -183,4 +188,5 @@ echo Build architecture: one of x64, x86, arm, wasm ^(default: x64^).
 echo Build type: one of Debug, Checked, Release ^(default: Debug^).
 echo clean: force a clean build ^(default is to perform an incremental build^).
 echo skiptests: skip building tests ^(default: tests are built^).
+echo skipbuildpackages: skip building packages ^(default: packages are built^).
 exit /b 1

--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -15,6 +15,7 @@ usage()
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
     echo "skiptests - optional argument to skip running tests after building."
+    echo "skipbuildpackages - optional argument to skip building packages."
     exit 1
 }
 
@@ -24,6 +25,7 @@ setup_dirs()
 
     mkdir -p "$__ProductBinDir"
     mkdir -p "$__IntermediatesDir"
+    mkdir -p "$__PackagesDir"
     if [ $__CrossBuild = 1 ]; then
         mkdir -p "$__ProductHostBinDir"
         mkdir -p "$__IntermediatesHostDir"
@@ -37,6 +39,7 @@ clean()
     echo "Cleaning previous output for the selected configuration"
     rm -rf "$__ProductBinDir"
     rm -rf "$__IntermediatesDir"
+    rm -rf "$__PackagesDir"
     if [ $__CrossBuild = 1 ]; then
         rm -rf "$__ProductHostBinDir"
         rm -rf "$__IntermediatesHostDir"
@@ -185,6 +188,9 @@ while [ "$1" != "" ]; do
         skiptests)
             export __SkipTests=true
             ;;
+        skipbuildpackages)
+            export __SkipBuildPackages=true
+            ;;
         *)
           export __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
     esac
@@ -245,6 +251,10 @@ fi
 export __ProductBinDir="$__rootbinpath/$__BuildOS.$__BuildArch.$__BuildType"
 if [ $__CrossBuild = 1 ]; then
     export __ProductHostBinDir="$__rootbinpath/$__BuildOS.$__HostArch.$__BuildType"
+fi
+export __PackagesDir="$__rootbinpath/packages"
+if [ $__CrossBuild = 1 ]; then
+    export __PackagesHostDir="$__rootbinpath/packages"
 fi
 
 # CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to set.

--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -29,6 +29,8 @@ setup_dirs()
     if [ $__CrossBuild = 1 ]; then
         mkdir -p "$__ProductHostBinDir"
         mkdir -p "$__IntermediatesHostDir"
+        mkdir -p "$__PackagesHostDir"
+
     fi
 }
 
@@ -43,6 +45,7 @@ clean()
     if [ $__CrossBuild = 1 ]; then
         rm -rf "$__ProductHostBinDir"
         rm -rf "$__IntermediatesHostDir"
+        rm -rf "$__PackagesHostDir"
     fi
 }
 


### PR DESCRIPTION
This adds `build-packages` to the standard build command. 
Until #4983 and #5123 CoreRT has only supported a single NuGet package, referencing projects directly, which wouldn't interfere with our build and publish pipeline (any build errors would show up earlier).
However, with the ILCompiler (and others soon, hopefully) being added, the process to produce them would ideally be integrated into the overall build process.
This would mimic CoreCLR and CoreFX and correctly mark any failures in building NuGet packages
as build failures. 