### PR TITLE
Remove reflection test hack

### DIFF
--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -820,8 +820,7 @@ class Program
                 new DerivedClass2<string>().GVMethod2<string>("string", "string2");
                 new DerivedClass2<string>().GVMethod3<string>("string", "string2");
                 new DerivedClass2<string>().GVMethod4<string>("string", "string2");
-                Func<IFace<string>> f = () => new BaseClass<string>(); // Hack to prevent devirtualization
-                f().IFaceMethod1("string");
+                ((IFace<string>)new BaseClass<string>()).IFaceMethod1("string");
                 ((IFace<string>)new BaseClass<string>()).IFaceGVMethod1<string>("string1", "string2");
 
                 MethodInfo m1 = typeof(BaseClass<string>).GetTypeInfo().GetDeclaredMethod("Method1");


### PR DESCRIPTION
This was added in #3773 when we started resolving interface calls into direct calls and the line stopped ensuring the interface method is callable with reflection (since there was no visible interface call happening in retail builds). Now that the scanner computes reflectable closure, the hack is no longer needed.