### PR TITLE
Linux and OSX Package Publish Regression Fix

### DIFF
--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.builds
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.builds
@@ -3,12 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
-    <Project Include="Microsoft.DotNet.ILCompiler.pkgproj" >
-      <OSGroup>AnyOS</OSGroup>
-    </Project>
 
-    <!-- Include this to force a build of platform-specific packages-->
-    <Project Include="$(MSBuildThisFileDirectory)\TargetSpecific\Microsoft.DotNet.ILCompiler.pkgproj" />
+    <!-- Only build the metapackage in Windows - in CoreCLR this logic is included in a dir.props file. This is a workaround until CoreRT supports multiple packages -->
+    <Project Include="Microsoft.DotNet.ILCompiler.pkgproj" Condition="'$(BuildIdentityPackage)' != 'false'"/>
+
+    <!-- Include this to force a build of platform-specific packages -->
+    <Project Include="$(MSBuildThisFileDirectory)\TargetSpecific\Microsoft.DotNet.ILCompiler.pkgproj"/>
 
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -16,7 +16,15 @@
   
   <!-- The package references are used to generate a runtimes.json for the meta-package-->
   <ItemGroup>
-    <ProjectReference Include="TargetSpecific\Microsoft.DotNet.ILCompiler.pkgproj" />
+    <ProjectReference Include="TargetSpecific\Microsoft.DotNet.ILCompiler.pkgproj">
+      <AdditionalProperties>%(ProjectReference.AdditionalProperties);PackageTargetRuntime=win-x64</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="TargetSpecific\Microsoft.DotNet.ILCompiler.pkgproj">
+      <AdditionalProperties>%(ProjectReference.AdditionalProperties);PackageTargetRuntime=linux-x64</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="TargetSpecific\Microsoft.DotNet.ILCompiler.pkgproj">
+      <AdditionalProperties>%(ProjectReference.AdditionalProperties);PackageTargetRuntime=osx-x64</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/packages.proj
+++ b/pkg/packages.proj
@@ -6,12 +6,23 @@
     <BuildAllOSGroups Condition="'$(FilterToOSGroup)' != ''">false</BuildAllOSGroups>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(SkipManagedPackageBuild)' != 'true'">
+  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+    <!-- During an official build, only build identity and targeting packages in the Windows build -->  
+    <BuildIdentityPackage Condition="'$(BuildIdentityPackage)' == '' AND '$(OS)' != 'Windows_NT'">false</BuildIdentityPackage>
+    <BuildIdentityPackage Condition="'$(BuildIdentityPackage)' == '' AND '$(OS)' == 'Windows_NT' AND '$(BuildArch)' == 'x64'">true</BuildIdentityPackage>
+  </PropertyGroup>
+
+  <!-- Targeting pack to be consumed by CoreFX - intentionally produce only a Windows x64 version -->
+  <ItemGroup Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildIdentityPackage)' != 'false'">
     <Project Include="$(MSBuildThisFileDirectory)Microsoft.TargetingPack.Private.CoreRT\Microsoft.TargetingPack.Private.CoreRT.builds">
-      <OSGroup>AnyOS</OSGroup>
+      <OSGroup>Windows_NT</OSGroup>
     </Project>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipManagedPackageBuild)' != 'true'">
     <Project Include="$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler\Microsoft.DotNet.ILCompiler.builds">
       <OSGroup>AnyOS</OSGroup>
+      <AdditionalProperties>$(AdditionalProperties);BuildIdentityPackage=$(BuildIdentityPackage)</AdditionalProperties>
     </Project>
   </ItemGroup>
   


### PR DESCRIPTION
Third time that packaging issues have popped up, clashes in naming cause the build pipeline to attempt to publish the same package multiple times and OverwriteOnPublish needs to be explicitly set to allow this. Instead of leaving it to chance (which machine finishes the build first), we define a "canonical" meta-package build. 

This adds details to the ILCompiler runtimes.json files and only builds the necessary packages during official builds - i.e. runtime packages and the TargetingPack, which was being built multiple times, even though CoreCLR only consumes the win-x64 build. 

I really don't like adding logic to the .builds files. This works as a temporary workaround to get the ILCompiler package off the ground, but ideally we would copy CoreCLR's framework in making the package build and publishing selection logic generic for any additional packages.

@MichalStrehovsky - could you take a look when you get the chance?
cc @jkotas 