### PR TITLE
Add sample app and guide

### DIFF
--- a/samples/WebApi/Controllers/ValuesController.cs
+++ b/samples/WebApi/Controllers/ValuesController.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/samples/WebApi/Controllers/ValuesController.cs
+++ b/samples/WebApi/Controllers/ValuesController.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace SampleWebApi.Controllers
+{
+    public class ValuesController
+    {
+        [HttpGet("/")]
+        public string Hello() => "Hello World!";
+
+        // GET api/values
+        [HttpGet("/api/values")]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+
+        // GET api/values/5
+        [HttpGet("/api/values/{id}")]
+        public string Get(int id)
+        {
+            return "value is " + id;
+        }
+    }
+}

--- a/samples/WebApi/Program.cs
+++ b/samples/WebApi/Program.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/samples/WebApi/Program.cs
+++ b/samples/WebApi/Program.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace SampleWebApi
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -1,7 +1,5 @@
 # Description
-This is a sample application, which uses CoreRT to compile a .NET Core Web API sample.
-TODO WIP - Might not work on Linix
-
+This is a sample application, which uses CoreRT to compile a .NET Core Web API sample. 
 # Building a WebAPI app with CoreRT
 
 ## Install the .NET Core SDK
@@ -17,10 +15,10 @@ Open a **new** shell/command prompt window and run the following commands.
 ```
 
 ## Add CoreRT to your project
+Using CoreRT to compile your application is done via the ILCompiler NuGet package, which is [published to MyGet with the CoreRT daily builds](https://dotnet.myget.org/feed/dotnet-core/package/nuget/Microsoft.DotNet.ILCompiler).
+For the compiler to work, it first needs to be added to your project.
 
-Using CoreRT to compile your application is done via the ILCompiler NuGet package.
-
-In your shell/command prompt navigate to the root directory of your project run the command 
+In your shell/command prompt navigate to the root directory of your project and run the command:
 
 `> dotnet new nuget `
 
@@ -74,10 +72,19 @@ Once you've created a rd.xml file, navigate to the root directory of your projec
 
 ```xml
 <RdXmlFile>path_to_rdxml_file\rd.xml</RdXmlFile>
+```
+
+where path_to_rdxml_file is the location of the file on your disk.
+
+Directly below, add:
+
+```xml
 <RuntimeIdentifiers>runtime_identifier</RuntimeIdentifiers>
 ```
 
-where path_to_rdxml_file is the location of the file on your disk and runtime_identifier is one of win-x64, linux-x64 or osx-x64, depending on the OS for which you would like to publish. Under the second `<ItemGroup>` remove the line containing a reference to `Microsoft.AspNetCore.All` and substitute it with:
+where runtime_identifier is one of win-x64, linux-x64 or osx-x64, depending on the OS for which you would like to publish. 
+
+Under the second `<ItemGroup>` remove the line containing a reference to `Microsoft.AspNetCore.All` and substitute it with:
 
 ```xml
 <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -5,7 +5,7 @@ TODO WIP - Might not work on Linix
 # Building a WebAPI app with CoreRT
 
 ## Install the .NET Core SDK
-CoreRT is and AOT-optimized .NET Core runtime. If you're new to .NET Core make sure to visit the [official starting page](http://dotnet.github.io). It will guide you through installing pre-requisites and building your first app.
+CoreRT is an AOT-optimized .NET Core runtime. If you're new to .NET Core make sure to visit the [official starting page](http://dotnet.github.io). It will guide you through installing pre-requisites and building your first app.
 If you're already familiar with .NET Core make sure you've [downloaded and installed the .NET Core 2 SDK](https://www.microsoft.com/net/download/core).
 
 ## Create your app 
@@ -30,9 +30,7 @@ This will add a nuget.config file to your application. Open the file and in the 
 
 Once you've added the package source, add a reference to the compiler by running the following command:
 
-`` dotnet add package Microsoft.DotNet.ILCompiler -v <Version> `` 
-
-where ``<Version>`` is the [latest version of the ILCompiler package](https://dotnet.myget.org/feed/dotnet-core/package/nuget/Microsoft.DotNet.ILCompiler) (e.g. 1.0.0-alpha-26006-02).
+`` dotnet add package Microsoft.DotNet.ILCompiler -v 1.0.0-alpha-* `` 
 
 After the package has been succesfully added to your project, open the file called ``Startup.cs`` and in the ``ConfigureServices()`` method modify the line:    
     

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -76,14 +76,6 @@ Once you've created a rd.xml file, navigate to the root directory of your projec
 
 where path_to_rdxml_file is the location of the file on your disk.
 
-Directly below, add:
-
-```xml
-<RuntimeIdentifiers>runtime_identifier</RuntimeIdentifiers>
-```
-
-where runtime_identifier is one of win-x64, linux-x64 or osx-x64, depending on the OS for which you would like to publish. 
-
 Under the second `<ItemGroup>` remove the line containing a reference to `Microsoft.AspNetCore.All` and substitute it with:
 
 ```xml
@@ -120,11 +112,6 @@ public class ValuesController
 
 
 ## Restore and Publish your app
-In your console run the command:
-
-`> dotnet restore `
-
-This will restore your application's packages and download and import the correct version of the ILCompiler for your runtime.
 
 Once the package has been successfully added it's time to compile and publish your app! If you're using Windows, make sure you're using `x64 Native Tools Command Prompt for VS 2017` instead of the standard Windows command prompt. In the shell/command prompt window, run the following command:
 

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -11,9 +11,10 @@ If you're already familiar with .NET Core make sure you've [downloaded and insta
 ## Create your app 
 
 Open a **new** shell/command prompt window and run the following commands.
-``> dotnet new webapi -o myApp`` 
-
-``> cd myApp``
+``` 
+> dotnet new webapi -o myApp 
+> cd myApp
+```
 
 ## Add CoreRT to your project
 
@@ -21,70 +22,83 @@ Using CoreRT to compile your application is done via the ILCompiler NuGet packag
 
 In your shell/command prompt navigate to the root directory of your project run the command 
 
-`` dotnet new nuget ``
+`> dotnet new nuget `
 
 This will add a nuget.config file to your application. Open the file and in the ``<packageSources> `` element under ``<clear/>`` add the following:
 
-``<add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> ``
-``<add key="aspnet-core" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" /> ``
+```xml
+<add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> 
+<add key="aspnet-core" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" /> 
+```
 
 Once you've added the package source, add a reference to the compiler by running the following command:
 
-`` dotnet add package Microsoft.DotNet.ILCompiler -v 1.0.0-alpha-* `` 
+`> dotnet add package Microsoft.DotNet.ILCompiler -v 1.0.0-alpha-* `
 
-After the package has been succesfully added to your project, open the file called ``Startup.cs`` and in the ``ConfigureServices()`` method modify the line:    
+After the package has been succesfully added to your project, open the file called `Startup.cs` and in the `ConfigureServices()` method modify the line:    
     
-    services.AddMvc();
+```csharp
+services.AddMvc(); 
+```
 
 to
 
-    services.AddMvcCore().AddJsonFormatters();
+```csharp 
+services.AddMvcCore().AddJsonFormatters(); 
+```
 
 ## Using reflection 
 Runtime directives are XML configuration files, which specify which elements of your program are available for reflection. They are used at compile-time to enable AOT compilation in applications at runtime. 
 
 In this sample a basic rd.xml file has been added for a simple Web API application under the root project folder. Copy its contents to your application directory and modify the
-``<Assembly Name="SampleWebApi" Dynamic="Required All" /> `` element to use your app's name.
+```xml <Assembly Name="SampleWebApi" Dynamic="Required All" /> ``` element to use your app's name.
 
-If your application makes use of reflection, you will need to create a rd.xml file specifying explicitly which assemblies and types should be made available. For example, in  your .NET Core Web API application, reflection is required to determine the correct namespace, from which to load the ``Startup`` type. Both are defined respectively via the ``<Assembly> `` and ``<Type>`` attributes. For example, in the case of our specific application;
+If your application makes use of reflection, you will need to create a rd.xml file specifying explicitly which assemblies and types should be made available. For example, in  your .NET Core Web API application, reflection is required to determine the correct namespace, from which to load the ``Startup`` type. Both are defined respectively via the `<Assembly>` and `<Type>` attributes. For example, in the case of our specific application;
 
-    <Assembly Name="SampleWebApi">
-      <Type Name="SampleWebApi.Startup" Dynamic="Required All" />
-    </Assembly>
+```xml 
+<Assembly Name="SampleWebApi">
+  <Type Name="SampleWebApi.Startup" Dynamic="Required All" />
+</Assembly> 
+```
 
 At runtime, if a method or type is not found or cannot be loaded, an exception will be thrown. The exception message will contain information on the missing type reference, which you can then add to the rd.xml of your program.
 
-Once you've created a rd.xml file, navigate to the root directory of your project and open its ``.csproj `` file and in the first ``<PropertyGroup>`` element add the following:
+Once you've created a rd.xml file, navigate to the root directory of your project and open its `.csproj` file and in the first `<PropertyGroup>` element add the following:
 
-    <RdXmlFile>path_to_rdxml_file\rd.xml</RdXmlFile>
-    <RuntimeIdentifiers>runtime_identifier</RuntimeIdentifiers>
+```xml
+<RdXmlFile>path_to_rdxml_file\rd.xml</RdXmlFile>
+<RuntimeIdentifiers>runtime_identifier</RuntimeIdentifiers>
+```
 
-where path_to_rdxml_file is the location of the file on your disk and runtime_identifier is one of win-x64, linux-x64 or osx-x64, depending on the OS for which you would like to publish. Under the second ``<ItemGroup>`` remove the line containing a reference to ``Microsoft.AspNetCore.All`` and substitute it with:
+where path_to_rdxml_file is the location of the file on your disk and runtime_identifier is one of win-x64, linux-x64 or osx-x64, depending on the OS for which you would like to publish. Under the second `<ItemGroup>` remove the line containing a reference to `Microsoft.AspNetCore.All` and substitute it with:
 
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" /> 
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" /> 
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.0.1" />
+```xml
+<PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" /> 
+<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" /> 
+<PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.0.1" />
+```
 
-After you've created your rd.xml file and specified its location, open your application's controller file (in the default template this should be called ``ValuesController.cs``) and substitute the ValuesController class with the following: 
+After you've created your rd.xml file and specified its location, open your application's controller file (in the default template this should be called `ValuesController.cs`) and substitute the ValuesController class with the following: 
 
-    public class ValuesController 
-    { 
-        [HttpGet("/")]
-        public string Hello() => "Hello World!";
-
-        // GET api/values
-        [HttpGet("/api/values")]
-        public IEnumerable<string> Get()
-        {
-            return new string[] { "value1", "value2" };
-        }
-        // GET api/values/5
-        [HttpGet("/api/values/{id}")]
-        public string Get(int id)
-        {
-            return "Your value is " + id;
-        }
+```csharp 
+public class ValuesController 
+{ 
+    [HttpGet("/")]
+    public string Hello() => "Hello World!";
+    // GET api/values
+    [HttpGet("/api/values")]
+    public IEnumerable<string> Get()
+    {
+        return new string[] { "value1", "value2" };
     }
+    // GET api/values/5
+    [HttpGet("/api/values/{id}")]
+    public string Get(int id)
+    {
+        return "Your value is " + id;
+    }
+} 
+```
 
 (note the removed inheritance and [Route] directive). Also note that URL request paths are explicitly defined on each method. 
 
@@ -92,22 +106,22 @@ After you've created your rd.xml file and specified its location, open your appl
 ## Restore and Publish your app
 In your console run the command:
 
-`` dotnet restore ``
+`> dotnet restore `
 
 This will restore your application's packages and download and import the correct version of the ILCompiler for your runtime.
 
-Once the package has been successfully added it's time to compile and publish your app! If you're using Windows, make sure you're using ``x64 Native Tools Command Prompt for VS 2017`` instead of the standard Windows command prompt. In the shell/command prompt window, run the following command:
+Once the package has been successfully added it's time to compile and publish your app! If you're using Windows, make sure you're using `x64 Native Tools Command Prompt for VS 2017` instead of the standard Windows command prompt. In the shell/command prompt window, run the following command:
 
-``dotnet publish -r <RID> -c <Configuration>``
+`> dotnet publish -r <RID> -c <Configuration>`
 
-where ``<Configuration>`` is your project configuration (such as Debug or Release) and ``<RID>`` is theis the runtime identifier, which you specified in the csproj file (one of win-x64, linux-x64, osx-x64). For example, if you want to publish a release configuration of your app for a 64-bit version of Windows the command would look like:
+where `<Configuration>` is your project configuration (such as Debug or Release) and `<RID>` is the runtime identifier, which you specified in the csproj file (one of win-x64, linux-x64, osx-x64). For example, if you want to publish a release configuration of your app for a 64-bit version of Windows the command would look like:
 
-``dotnet publish -r win-x64 -c release`
+`> dotnet publish -r win-x64 -c release`
 
-Once completed, you can find the native executable in the root folder of your project under ``/bin/x64/<Configuration>/netcoreapp2.0/publish/`` 
+Once completed, you can find the native executable in the root folder of your project under `/bin/x64/<Configuration>/netcoreapp2.0/publish/`
 
 ## Try it out!
 
-Navigate to ``/bin/x64/<Configuration>/netcoreapp2.0/publish/`` in your project folder and run the produced executable. It should display "Now listening on: http://localhost:XXXX" with XXXX being a port on your machine. Open your browser and navigate to that URL. You should see "Hello World!" displayed in your browser.
+Navigate to `/bin/x64/<Configuration>/netcoreapp2.0/publish/` in your project folder and run the produced executable. It should display "Now listening on: http://localhost:XXXX" with XXXX being a port on your machine. Open your browser and navigate to that URL. You should see "Hello World!" displayed in your browser.
 
 Feel free to modify the sample application and experiment. However, keep in mind some functionality might not yet be supported in CoreRT. Let us know on the [Issues page](https://github.com/dotnet/corert/issues/).

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -9,7 +9,7 @@ If you're already familiar with .NET Core make sure you've [downloaded and insta
 ## Create your app 
 
 Open a new shell/command prompt window and run the following commands.
-``` 
+```bash
 > dotnet new webapi -o myApp
 > cd myApp
 ```
@@ -20,7 +20,9 @@ For the compiler to work, it first needs to be added to your project.
 
 In your shell/command prompt navigate to the root directory of your project and run the command:
 
-`> dotnet new nuget `
+```bash
+> dotnet new nuget 
+```
 
 This will add a nuget.config file to your application. Open the file and in the ``<packageSources> `` element under ``<clear/>`` add the following:
 
@@ -31,7 +33,9 @@ This will add a nuget.config file to your application. Open the file and in the 
 
 Once you've added the package source, add a reference to the compiler by running the following command:
 
-`> dotnet add package Microsoft.DotNet.ILCompiler -v 1.0.0-alpha-* `
+```bash
+> dotnet add package Microsoft.DotNet.ILCompiler -v 1.0.0-alpha-* 
+```
 
 ## Add Core MVC services
 With the package successfully added to your project, your project's default registered MVC services must be modified.
@@ -55,10 +59,13 @@ Replacing `AddMvc()` with `AddMvcCore()` adds only the basic MVC functionality. 
 ## Using reflection 
 Runtime directives are XML configuration files, which specify which elements of your program are available for reflection. They are used at compile-time to enable AOT compilation in applications at runtime. 
 
-In this sample a basic rd.xml file has been added for a simple Web API application under the root project folder. Copy its contents to your application directory and modify the
-```xml <Assembly Name="SampleWebApi" Dynamic="Required All" /> ``` element to use your app's name.
+In this sample a basic rd.xml file has been added for a simple Web API application under the root project folder. Copy its contents to your application directory and modify the element
+```xml
+ <Assembly Name="SampleWebApi" Dynamic="Required All" /> 
+ ``` 
+ to use your app's name.
 
-If your application makes use of reflection, you will need to create a rd.xml file specifying explicitly which assemblies and types should be made available. For example, in  your .NET Core Web API application, reflection is required to determine the correct namespace, from which to load the ``Startup`` type. Both are defined respectively via the `<Assembly>` and `<Type>` attributes. For example, in the case of our specific application;
+If your application makes use of reflection, you will need to create a rd.xml file specifying explicitly which assemblies and types should be made available. For example, in  your .NET Core Web API application, reflection is required to determine the correct namespace, from which to load the ``Startup`` type. Both are defined respectively via the `<Assembly>` and `<Type>` attributes. For example, in the case of our specific application:
 
 ```xml 
 <Assembly Name="SampleWebApi">
@@ -115,11 +122,15 @@ public class ValuesController
 
 Once the package has been successfully added it's time to compile and publish your app! If you're using Windows, make sure you're using `x64 Native Tools Command Prompt for VS 2017` instead of the standard Windows command prompt. In the shell/command prompt window, run the following command:
 
-`> dotnet publish -r <RID> -c <Configuration>`
+```bash
+> dotnet publish -r <RID> -c <Configuration>
+```
 
 where `<Configuration>` is your project configuration (such as Debug or Release) and `<RID>` is the runtime identifier, which you specified in the csproj file (one of win-x64, linux-x64, osx-x64). For example, if you want to publish a release configuration of your app for a 64-bit version of Windows the command would look like:
 
-`> dotnet publish -r win-x64 -c release`
+```bash 
+> dotnet publish -r win-x64 -c release
+```
 
 Once completed, you can find the native executable in the root folder of your project under `/bin/x64/<Configuration>/netcoreapp2.0/publish/`
 

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -1,6 +1,6 @@
-# Description
-This is a sample application, which uses CoreRT to compile a .NET Core Web API sample. 
 # Building a WebAPI app with CoreRT
+
+This document will guide you through compiling a .NET Core Web API application with CoreRT. 
 
 ## Install the .NET Core SDK
 CoreRT is an AOT-optimized .NET Core runtime. If you're new to .NET Core make sure to visit the [official starting page](http://dotnet.github.io). It will guide you through installing pre-requisites and building your first app.
@@ -8,7 +8,7 @@ If you're already familiar with .NET Core make sure you've [downloaded and insta
 
 ## Create your app 
 
-Open a **new** shell/command prompt window and run the following commands.
+Open a new shell/command prompt window and run the following commands.
 ``` 
 > dotnet new webapi -o myApp
 > cd myApp

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -12,7 +12,7 @@ If you're already familiar with .NET Core make sure you've [downloaded and insta
 
 Open a **new** shell/command prompt window and run the following commands.
 ``` 
-> dotnet new webapi -o myApp 
+> dotnet new webapi -o myApp
 > cd myApp
 ```
 
@@ -27,8 +27,8 @@ In your shell/command prompt navigate to the root directory of your project run 
 This will add a nuget.config file to your application. Open the file and in the ``<packageSources> `` element under ``<clear/>`` add the following:
 
 ```xml
-<add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> 
-<add key="aspnet-core" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" /> 
+<add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
 ```
 
 Once you've added the package source, add a reference to the compiler by running the following command:
@@ -80,17 +80,17 @@ Once you've created a rd.xml file, navigate to the root directory of your projec
 where path_to_rdxml_file is the location of the file on your disk and runtime_identifier is one of win-x64, linux-x64 or osx-x64, depending on the OS for which you would like to publish. Under the second `<ItemGroup>` remove the line containing a reference to `Microsoft.AspNetCore.All` and substitute it with:
 
 ```xml
-<PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" /> 
-<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" /> 
+<PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
+<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />
 <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.0.1" />
 ```
 
-This substitution removes unnecessary package references added by AspNetCore.All, which will reduce the size of your application's published binary files and avoid encountering unsupported features, as described in [the section above](#add-core-mvc-services)
+This substitution removes unnecessary package references added by AspNetCore.All, which will remove them from your application's published files and avoid encountering unsupported features, as described in [the section above](#add-core-mvc-services)
 
 After you've modified your project's `.csproj` file, open your application's controller file (in the default template this should be called `ValuesController.cs`) and substitute the ValuesController class with the following: 
 
 ```csharp 
-public class ValuesController 
+public class ValuesController
 { 
     [HttpGet("/")]
     public string Hello() => "Hello World!";
@@ -106,7 +106,7 @@ public class ValuesController
     {
         return "Your value is " + id;
     }
-} 
+}
 ```
 
 (note the removed inheritance and [Route] directive). Also note that URL request paths are explicitly defined on each method. 

--- a/samples/WebApi/SampleWebApi.csproj
+++ b/samples/WebApi/SampleWebApi.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+        <RdXmlFile>rd.xml</RdXmlFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" /> 
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" /> 
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.0.1" />     
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-25929-0" />
+  </ItemGroup>
+
+</Project>

--- a/samples/WebApi/SampleWebApi.csproj
+++ b/samples/WebApi/SampleWebApi.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RdXmlFile>rd.xml</RdXmlFile>
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers> 
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/WebApi/SampleWebApi.csproj
+++ b/samples/WebApi/SampleWebApi.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" /> 
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" /> 
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.0.1" />     
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-25929-0" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
   </ItemGroup>
 
 </Project>

--- a/samples/WebApi/SampleWebApi.csproj
+++ b/samples/WebApi/SampleWebApi.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-        <RdXmlFile>rd.xml</RdXmlFile>
+    <RdXmlFile>rd.xml</RdXmlFile>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers> 
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/WebApi/Startup.cs
+++ b/samples/WebApi/Startup.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/samples/WebApi/Startup.cs
+++ b/samples/WebApi/Startup.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace SampleWebApi
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvcCore().AddJsonFormatters();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMvc();
+        }
+    }
+}

--- a/samples/WebApi/appsettings.Development.json
+++ b/samples/WebApi/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/samples/WebApi/appsettings.json
+++ b/samples/WebApi/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}

--- a/samples/WebApi/nuget.config
+++ b/samples/WebApi/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+ </packageSources>
+</configuration>

--- a/samples/WebApi/nuget.config
+++ b/samples/WebApi/nuget.config
@@ -4,5 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="aspnet-core" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
  </packageSources>
 </configuration>

--- a/samples/WebApi/nuget.config
+++ b/samples/WebApi/nuget.config
@@ -4,6 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="aspnet-core" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
  </packageSources>
 </configuration>

--- a/samples/WebApi/rd.xml
+++ b/samples/WebApi/rd.xml
@@ -2,26 +2,9 @@
     <Application>
         <Assembly Name="SampleWebApi" Dynamic="Required All" />
         <Assembly Name="System.Private.CoreLib">
-            <Type Name="System.Runtime.CompilerServices.CompilationRelaxationsAttribute" Dynamic="Required All" />
-            <Type Name="System.Runtime.CompilerServices.RuntimeCompatibilityAttribute" Dynamic="Required All" />
-            <Type Name="System.Runtime.CompilerServices.ExtensionAttribute" Dynamic="Required All" />
-            <Type Name="System.Runtime.CompilerServices.IntrinsicAttribute" Dynamic="Required All" />
-            <Type Name="System.Diagnostics.DebuggableAttribute" Dynamic="Required All" />
             <Type Name="System.Diagnostics.StackTrace" Dynamic="Required All" />            
-            <Type Name="System.Reflection.AssemblyInformationalVersionAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.AssemblyTitleAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.AssemblyFileVersionAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.AssemblyDescriptionAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.AssemblyCompanyAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.AssemblyCopyrightAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.AssemblyProductAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.AssemblyDefaultAliasAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.AssemblyMetadataAttribute" Dynamic="Required All" />
             <Type Name="System.AttributeUsageAttribute" Dynamic="Required All" />
             <Type Name="System.AttributeUsageAttribute[]" Dynamic="Required All" />
-            <Type Name="System.Runtime.InteropServices.ComVisibleAttribute" Dynamic="Required All" />
-            <Type Name="System.CLSCompliantAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.Assembly" Dynamic="Required All" />
             <Type Name="System.RuntimeExceptionHelpers+ExceptionData" Dynamic="Required All" />
             <Type Name="System.Func`2[System.Object,System.Object]" Dynamic="Required All" />
             <Type Name="System.Func`2[System.Reflection.MethodInfo,System.Boolean]" Dynamic="Required All" />
@@ -33,24 +16,10 @@
             <Type Name="System.Action`2[System.Object,System.Boolean]" Dynamic="Required All" />
             <Type Name="System.Action`1[System.Object]" Dynamic="Required All" />
             <Type Name="System.Tuple`3[System.Object,System.Object,System.Boolean]" Dynamic="Required All" />
-            <Type Name="System.Runtime.CompilerServices.CompilerGeneratedAttribute" Dynamic="Required All" />
-            <Type Name="System.ComponentModel.DefaultValueAttribute" Dynamic="Required All" />
-            <Type Name="System.ComponentModel.DefaultValueAttribute[]" Dynamic="Required All" />
-            <Type Name="System.Reflection.DefaultMemberAttribute" Dynamic="Required All" />
-            <Type Name="System.Reflection.DefaultMemberAttribute[]" Dynamic="Required All" />
-            <Type Name="System.Reflection.MethodInfo" Dynamic="Required All" />
-            <Type Name="System.Reflection.MethodInfo[]" Dynamic="Required All" />
             <Type Name="System.Collections.Generic.KeyValuePair`2[System.Object,System.Object]" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="System.Collections">
             <Type Name="System.Collections.Generic.Dictionary`2[[System.Object,System.Private.CoreLib],[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
-        </Assembly>
-        <Assembly Name="System.Diagnostics.Tracing">
-            <Type Name="System.Diagnostics.Tracing.EventSourceAttribute" Dynamic="Required All" />
-            <Type Name="System.Diagnostics.Tracing.EventSourceAttribute[]" Dynamic="Required All" />
-        </Assembly>
-        <Assembly Name="System.Reflection">
-            <Type Name="System.Reflection.Assembly" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="Microsoft.AspNetCore.Server.Kestrel.Core">
             <Type Name="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer" Dynamic="Required All" />
@@ -133,11 +102,6 @@
             <Type Name="Microsoft.Extensions.Logging.Debug.DebugLoggerProvider" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="System.Runtime">
-            <Type Name="System.Collections.Generic.IEnumerable`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
-            <Type Name="System.Collections.Generic.IList`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
-            <Type Name="System.Collections.Generic.IReadOnlyCollection`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
-            <Type Name="System.Collections.Generic.IReadOnlyList`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
-            <Type Name="System.Collections.Generic.IEnumerator`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
             <Type Name="System.Collections.Generic.IEnumerable`1[[Microsoft.Extensions.Options.IConfigureOptions`1[[Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions,Microsoft.AspNetCore.Server.Kestrel.Core]],Microsoft.Extensions.Options]]" Dynamic="Required All" />
             <Type Name="System.Collections.Generic.IEnumerable`1[[Microsoft.Extensions.Options.IConfigureOptions`1[[Microsoft.AspNetCore.Http.Features.FormOptions,Microsoft.AspNetCore.Http]],Microsoft.Extensions.Options]]" Dynamic="Required All" />
         </Assembly>
@@ -154,7 +118,6 @@
         <Assembly Name="System.ComponentModel.TypeConverter">
             <Type Name="System.ComponentModel.TypeConverter" Dynamic="Required All" />
             <Type Name="System.ComponentModel.StringConverter" Dynamic="Required All" />
-            <Type Name="System.ComponentModel.BooleanConverter" Dynamic="Required All" />
             <Type Name="System.ComponentModel.Int32Converter" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="Microsoft.Extensions.Configuration.Json">

--- a/samples/WebApi/rd.xml
+++ b/samples/WebApi/rd.xml
@@ -1,0 +1,164 @@
+<Directives>
+    <Application>
+        <Assembly Name="SampleWebApi" Dynamic="Required All" />
+        <Assembly Name="System.Private.CoreLib">
+            <Type Name="System.Runtime.CompilerServices.CompilationRelaxationsAttribute" Dynamic="Required All" />
+            <Type Name="System.Runtime.CompilerServices.RuntimeCompatibilityAttribute" Dynamic="Required All" />
+            <Type Name="System.Runtime.CompilerServices.ExtensionAttribute" Dynamic="Required All" />
+            <Type Name="System.Runtime.CompilerServices.IntrinsicAttribute" Dynamic="Required All" />
+            <Type Name="System.Diagnostics.DebuggableAttribute" Dynamic="Required All" />
+            <Type Name="System.Diagnostics.StackTrace" Dynamic="Required All" />            
+            <Type Name="System.Reflection.AssemblyInformationalVersionAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.AssemblyTitleAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.AssemblyFileVersionAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.AssemblyDescriptionAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.AssemblyCompanyAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.AssemblyCopyrightAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.AssemblyProductAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.AssemblyDefaultAliasAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.AssemblyMetadataAttribute" Dynamic="Required All" />
+            <Type Name="System.AttributeUsageAttribute" Dynamic="Required All" />
+            <Type Name="System.AttributeUsageAttribute[]" Dynamic="Required All" />
+            <Type Name="System.Runtime.InteropServices.ComVisibleAttribute" Dynamic="Required All" />
+            <Type Name="System.CLSCompliantAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.Assembly" Dynamic="Required All" />
+            <Type Name="System.RuntimeExceptionHelpers+ExceptionData" Dynamic="Required All" />
+            <Type Name="System.Func`2[System.Object,System.Object]" Dynamic="Required All" />
+            <Type Name="System.Func`2[System.Reflection.MethodInfo,System.Boolean]" Dynamic="Required All" />
+            <Type Name="System.Func`3[System.Object,System.Object,System.Object]" Dynamic="Required All" />
+            <Type Name="System.Func`4[[System.Collections.Generic.IDictionary`2[System.Object,System.Object]],System.Object,System.Object,System.Boolean]" Dynamic="Required All" />
+            <Type Name="System.Func`5[[System.Linq.Expressions.Expression,System.Linq.Expressions],System.String,System.Boolean,System.Collections.ObjectModel.ReadOnlyCollection`1[[System.Linq.Expressions.ParameterExpression,System.Linq.Expressions]],[System.Linq.Expressions.LambdaExpression,System.Linq.Expressions]]" Dynamic="Required All" />
+            <Type Name="System.Action`3[[System.Collections.Generic.IDictionary`2[System.Object,System.Object]],System.Object,System.Object]" Dynamic="Required All" />
+            <Type Name="System.Action`3[[System.Collections.Generic.IDictionary`2[System.Object,System.Object]],System.Object,System.Object]" Dynamic="Required All" />
+            <Type Name="System.Action`2[System.Object,System.Boolean]" Dynamic="Required All" />
+            <Type Name="System.Action`1[System.Object]" Dynamic="Required All" />
+            <Type Name="System.Tuple`3[System.Object,System.Object,System.Boolean]" Dynamic="Required All" />
+            <Type Name="System.Runtime.CompilerServices.CompilerGeneratedAttribute" Dynamic="Required All" />
+            <Type Name="System.ComponentModel.DefaultValueAttribute" Dynamic="Required All" />
+            <Type Name="System.ComponentModel.DefaultValueAttribute[]" Dynamic="Required All" />
+            <Type Name="System.Reflection.DefaultMemberAttribute" Dynamic="Required All" />
+            <Type Name="System.Reflection.DefaultMemberAttribute[]" Dynamic="Required All" />
+            <Type Name="System.Reflection.MethodInfo" Dynamic="Required All" />
+            <Type Name="System.Reflection.MethodInfo[]" Dynamic="Required All" />
+            <Type Name="System.Collections.Generic.KeyValuePair`2[System.Object,System.Object]" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="System.Collections">
+            <Type Name="System.Collections.Generic.Dictionary`2[[System.Object,System.Private.CoreLib],[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="System.Diagnostics.Tracing">
+            <Type Name="System.Diagnostics.Tracing.EventSourceAttribute" Dynamic="Required All" />
+            <Type Name="System.Diagnostics.Tracing.EventSourceAttribute[]" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="System.Reflection">
+            <Type Name="System.Reflection.Assembly" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.Server.Kestrel.Core">
+            <Type Name="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Server.Kestrel.Core.Internal.KestrelServerOptionsSetup" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.Server.Kestrel" Dynamic="Required All"/>
+        <Assembly Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv">
+            <Type Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.LibuvTransportFactory" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.LibuvTransportOptions" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.Extensions.DependencyInjection" Dynamic="Required All">
+            <Type Name="Microsoft.Extensions.DependencyInjection.DefaultServiceProviderFactory" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteExpressionBuilder" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.Extensions.Options">
+            <Type Name="Microsoft.Extensions.Options.OptionsManager`1[[Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions,Microsoft.AspNetCore.Server.Kestrel.Core]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsFactory`1[[Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions,Microsoft.AspNetCore.Server.Kestrel.Core]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.IConfigureOptions`1[[Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions,Microsoft.AspNetCore.Server.Kestrel.Core]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.IConfigureOptions`1[[Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions,Microsoft.AspNetCore.Server.Kestrel.Core]][]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.IConfigureOptions`1[[Microsoft.AspNetCore.Http.Features.FormOptions,Microsoft.AspNetCore.Http]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.IConfigureOptions`1[[Microsoft.AspNetCore.Http.Features.FormOptions,Microsoft.AspNetCore.Http]][]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsManager`1[[Microsoft.AspNetCore.Http.Features.FormOptions,Microsoft.AspNetCore.Http]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsManager`1[[Microsoft.AspNetCore.Http.Features.FormOptions,Microsoft.AspNetCore.Http]][]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsFactory`1[[Microsoft.AspNetCore.Http.Features.FormOptions,Microsoft.AspNetCore.Http]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsMonitor`1[[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.IOptionsSnapshot`1[[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsFactory`1[[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsCache`1[[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsManager`1[[Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.LibuvTransportOptions,Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsFactory`1[[Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.LibuvTransportOptions,Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsManager`1[[Microsoft.AspNetCore.Mvc.MvcOptions,Microsoft.AspNetCore.Mvc.Core]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsManager`1[[Microsoft.AspNetCore.Mvc.MvcJsonOptions,Microsoft.AspNetCore.Mvc.Formatters.Json]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsManager`1[[Microsoft.AspNetCore.Authorization.AuthorizationOptions,Microsoft.AspNetCore.Authorization]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsManager`1[[Microsoft.AspNetCore.Routing.RouteOptions,Microsoft.AspNetCore.Routing]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsFactory`1[[Microsoft.AspNetCore.Routing.RouteOptions,Microsoft.AspNetCore.Routing]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsMonitor`1[[Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions,Microsoft.Extensions.Logging.Console]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsFactory`1[[Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions,Microsoft.Extensions.Logging.Console]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsMonitor`1[[Microsoft.Extensions.Logging.LoggerFilterOptions,Microsoft.Extensions.Logging]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Options.OptionsFactory`1[[Microsoft.Extensions.Logging.LoggerFilterOptions,Microsoft.Extensions.Logging]]" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.Http.Abstractions">
+            <Type Name="Microsoft.AspNetCore.Http.RequestDelegate" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.Mvc.Core" Dynamic="Required All" />
+        <Assembly Name="Microsoft.AspNetCore.Routing">
+            <Type Name="Microsoft.AspNetCore.Routing.Internal.RoutingMarkerService" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Builder.RouterMiddleware" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Routing.Tree.TreeRouteBuilder" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Routing.DefaultInlineConstraintResolver" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Routing.RouteOptions" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.Mvc.Formatters.Json">
+            <Type Name="Microsoft.AspNetCore.Mvc.Formatters.Json.Internal.MvcJsonMvcOptionsSetup" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Mvc.MvcJsonOptions" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.Authorization">
+            <Type Name="Microsoft.AspNetCore.Authorization.DefaultAuthorizationPolicyProvider" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Authorization.AuthorizationOptions" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.Http">
+            <Type Name="Microsoft.AspNetCore.Http.HttpContextFactory" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.Hosting" Dynamic="Required All">
+            <Type Name="Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.Extensions.Logging.Abstractions">
+            <Type Name="Microsoft.Extensions.Logging.ILogger`1[[Microsoft.AspNetCore.Hosting.Internal.WebHost,Microsoft.AspNetCore.Hosting]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Logging.Logger`1[[Microsoft.AspNetCore.Hosting.Internal.WebHost,Microsoft.AspNetCore.Hosting]]" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.Extensions.Logging">
+            <Type Name="Microsoft.Extensions.Logging.LoggerFactory" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.Extensions.Logging.Console">
+            <Type Name="Microsoft.Extensions.Logging.Console.ConsoleLoggerProvider" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.Extensions.Logging.Debug">
+            <Type Name="Microsoft.Extensions.Logging.Debug.DebugLogger" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Logging.Debug.DebugLoggerProvider" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="System.Runtime">
+            <Type Name="System.Collections.Generic.IEnumerable`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
+            <Type Name="System.Collections.Generic.IList`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
+            <Type Name="System.Collections.Generic.IReadOnlyCollection`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
+            <Type Name="System.Collections.Generic.IReadOnlyList`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
+            <Type Name="System.Collections.Generic.IEnumerator`1[[System.Diagnostics.Tracing.EventSourceAttribute,System.Diagnostics.Tracing]]" Dynamic="Required All" />
+            <Type Name="System.Collections.Generic.IEnumerable`1[[Microsoft.Extensions.Options.IConfigureOptions`1[[Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions,Microsoft.AspNetCore.Server.Kestrel.Core]],Microsoft.Extensions.Options]]" Dynamic="Required All" />
+            <Type Name="System.Collections.Generic.IEnumerable`1[[Microsoft.Extensions.Options.IConfigureOptions`1[[Microsoft.AspNetCore.Http.Features.FormOptions,Microsoft.AspNetCore.Http]],Microsoft.Extensions.Options]]" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="System.Linq.Expressions">
+            <Type Name="System.Linq.Expressions.ExpressionCreator`1[[Newtonsoft.Json.Serialization.ObjectConstructor`1[[System.Object,System.Private.CoreLib]],Newtonsoft.Json]]" Dynamic="Required All" />
+            <Type Name="System.Linq.Expressions.ExpressionCreator`1[[System.Func`2[[System.Object,System.Private.CoreLib],[System.Object,System.Private.CoreLib]],System.Private.CoreLib]]" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.Extensions.ObjectPool">
+            <Type Name="Microsoft.Extensions.ObjectPool.DefaultObjectPoolProvider" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Newtonsoft.Json">
+            <Type Name="Newtonsoft.Json.Serialization.ObjectConstructor`1[[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="System.ComponentModel.TypeConverter">
+            <Type Name="System.ComponentModel.TypeConverter" Dynamic="Required All" />
+            <Type Name="System.ComponentModel.StringConverter" Dynamic="Required All" />
+            <Type Name="System.ComponentModel.BooleanConverter" Dynamic="Required All" />
+            <Type Name="System.ComponentModel.Int32Converter" Dynamic="Required All" />
+        </Assembly>
+        <Assembly Name="Microsoft.Extensions.Configuration.Json">
+            <Type Name="Microsoft.Extensions.Configuration.Json.JsonConfigurationSource" Dynamic="Required All" />
+        </Assembly>
+    </Application>
+</Directives>


### PR DESCRIPTION
Add a sample app to demonstrate use of the ILCompiler NuGet package now that we publish it for all target runtimes. 
This doesn't work under non-Windows platforms - we don't yet statically link to CoreFX libraries (with the exception of System.Native). When we do, this can be merged.
