### PR TITLE
Implement WebAssembly delegates

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -484,6 +484,25 @@ namespace Internal.IL
     }
 
     /// <summary>
+    /// Represents a managed function pointer
+    /// </summary>
+    internal class FunctionPointerEntry : ExpressionEntry
+    {
+        /// <summary>
+        /// True if the function pointer was loaded as a virtual function pointer
+        /// </summary>
+        public bool IsVirtual { get; }
+
+        public MethodDesc Method { get; }
+
+        public FunctionPointerEntry(string name, MethodDesc method, LLVMValueRef llvmValue, TypeDesc type, bool isVirtual) : base(StackValueKind.NativeInt, name, llvmValue, type)
+        {
+            Method = method;
+            IsVirtual = isVirtual;
+        }
+    }
+
+    /// <summary>
     /// Entry representing some token (either of TypeDesc, MethodDesc or FieldDesc) along with its string representation
     /// </summary>
     internal class LdTokenEntry<T> : ExpressionEntry

--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -490,14 +490,14 @@ namespace Internal.IL
     {
         public T LdToken { get; }
 
-        public LdTokenEntry(StackValueKind kind, string name, T token, TypeDesc type = null) : base(kind, name, default(LLVMValueRef), type)
+        public LdTokenEntry(StackValueKind kind, string name, T token, LLVMValueRef llvmValue, TypeDesc type = null) : base(kind, name, llvmValue, type)
         {
             LdToken = token;
         }
 
         public override StackEntry Duplicate()
         {
-            return new LdTokenEntry<T>(Kind, Name, LdToken, Type);
+            return new LdTokenEntry<T>(Kind, Name, LdToken, RawLLVMValue, Type);
         }
 
         protected override LLVMValueRef ValueAsTypeInternal(LLVMTypeRef type, LLVMBuilderRef builder, bool signExtend)

--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -484,7 +484,7 @@ namespace Internal.IL
     }
 
     /// <summary>
-    /// Represents a managed function pointer
+    /// Represents the result of a ldftn or ldvirtftn
     /// </summary>
     internal class FunctionPointerEntry : ExpressionEntry
     {
@@ -499,6 +499,11 @@ namespace Internal.IL
         {
             Method = method;
             IsVirtual = isVirtual;
+        }
+
+        public override StackEntry Duplicate()
+        {
+            return new FunctionPointerEntry(Name, Method, RawLLVMValue, Type, IsVirtual);
         }
     }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -131,6 +131,9 @@ internal static class Program
             PrintLine("Instance delegate test: Ok.");
         }
 
+        Action virtualDelegate = tempObj.VirtualDelegateTarget;
+        virtualDelegate();
+
         PrintLine("Done");
     }
 
@@ -223,6 +226,13 @@ public struct BoxStubTest
     {
         return Value;
     }
+
+    public string GetValue()
+    {
+        Program.PrintLine("BoxStubTest.GetValue called");
+        Program.PrintLine(Value);
+        return Value;
+    }
 }
 
 public class TestClass
@@ -256,6 +266,11 @@ public class TestClass
     {
         return TestInt;
     }
+
+    public virtual void VirtualDelegateTarget()
+    {
+        Program.PrintLine("Virtual delegate incorrectly dispatched to base.");
+    }
 }
 
 public class TestDerivedClass : TestClass
@@ -273,6 +288,11 @@ public class TestDerivedClass : TestClass
     public override string ToString()
     {
         throw new Exception();
+    }
+
+    public override void VirtualDelegateTarget()
+    {
+        Program.PrintLine("Virtual Delegate Test: Ok");
     }
 }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -117,6 +117,26 @@ internal static class Program
         {
             PrintLine("CpObj test: Ok.");
         }
+
+        Func<int> staticDelegate = StaticDelegateTarget;
+        if(staticDelegate() == 7)
+        {
+            PrintLine("Static delegate test: Ok.");
+        }
+
+        tempObj.TestInt = 8;
+        Func<int> instanceDelegate = tempObj.InstanceDelegateTarget;
+        if(instanceDelegate() == 8)
+        {
+            PrintLine("Instance delegate test: Ok.");
+        }
+
+        PrintLine("Done");
+    }
+
+    private static int StaticDelegateTarget()
+    {
+        return 7;
     }
 
     private static unsafe void PrintString(string s)
@@ -207,7 +227,8 @@ public struct BoxStubTest
 
 public class TestClass
 {
-    public string TestString {get; set;}
+    public string TestString { get; set; }
+    public int TestInt { get; set; }
 
     public TestClass(int number)
     {
@@ -229,6 +250,11 @@ public class TestClass
 	public virtual void TestVirtualMethod2(string str)
     {
         Program.PrintLine("Virtual Slot Test 2: Ok");
+    }
+
+    public int InstanceDelegateTarget()
+    {
+        return TestInt;
     }
 }
 


### PR DESCRIPTION
Implements WebAssembly delegates and fix other minor codegen issues. Includes implementing ldftn, calli, sizeof, and ldind.ref.

Depends on a separate codegen fix in #5141, so CI will fail until that's merged, but this is otherwise ready to review. 

Fixes #4518, #4517. Progress toward #4520.