### PR TITLE
Make sure CORINFO_FLG_FINAL is reported on delegate invoke methods

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -769,11 +769,9 @@ namespace Internal.JitInterface
                 // including multicast.
                 result |= CorInfoFlag.CORINFO_FLG_DELEGATE_INVOKE;
 
-                // Make sure to report the method as final if it's final in the metadata.
                 // RyuJIT special cases this method; it would assert if it's not final
                 // and we might not have set the bit in the code above.
-                if (method.IsFinal || method.OwningType.IsSealed())
-                    result |= CorInfoFlag.CORINFO_FLG_FINAL;
+                result |= CorInfoFlag.CORINFO_FLG_FINAL;
            }
 
             result |= CorInfoFlag.CORINFO_FLG_NOSECURITYWRAP;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -763,13 +763,18 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_FORCEINLINE;
             }
 
-            if (method.OwningType.IsDelegate)
+            if (method.OwningType.IsDelegate && method.Name == "Invoke")
             {
-                if (method.Name == "Invoke")
-                    // This is now used to emit efficient invoke code for any delegate invoke,
-                    // including multicast.
-                    result |= CorInfoFlag.CORINFO_FLG_DELEGATE_INVOKE;
-            }
+                // This is now used to emit efficient invoke code for any delegate invoke,
+                // including multicast.
+                result |= CorInfoFlag.CORINFO_FLG_DELEGATE_INVOKE;
+
+                // Make sure to report the method as final if it's final in the metadata.
+                // RyuJIT special cases this method; it would assert if it's not final
+                // and we might not have set the bit in the code above.
+                if (method.IsFinal || method.OwningType.IsSealed())
+                    result |= CorInfoFlag.CORINFO_FLG_FINAL;
+           }
 
             result |= CorInfoFlag.CORINFO_FLG_NOSECURITYWRAP;
 


### PR DESCRIPTION
RyuJIT special cases delegate invocation and there is an assert that the special casing is safe (the method is indeed final).

We could end up not reporting `final` if we used a devirtualization algorithm that wants to prevent devirtualization there (because the delegate type was never allocated). This is pretty safe to devirtualize though (RyuJIT is not going to actually call it anyway).