### PR TITLE
Route abstract method reflectability through MetadataManager

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -18,11 +18,6 @@ namespace ILCompiler.DependencyAnalysis
     {
         public static void AddDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            // TODO: https://github.com/dotnet/corert/issues/3224
-            // Reflection invoke stub handling is here because in the current reflection model we reflection-enable
-            // all methods that are compiled. Ideally the list of reflection enabled methods should be known before
-            // we even start the compilation process (with the invocation stubs being compilation roots like any other).
-            // The existing model has it's problems: e.g. the invocability of the method depends on inliner decisions.
             if (factory.MetadataManager.IsReflectionInvokable(method))
             {
                 if (dependencies == null)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -58,9 +58,8 @@ namespace ILCompiler.DependencyAnalysis
                 result.Add(factory.VirtualMethodUse(_targetMethod), "Interface method use");
             }
 
-            // TODO: https://github.com/dotnet/corert/issues/3224 
-            result.Add(factory.ReflectableMethod(_targetMethod), "Abstract reflectable method");
-
+            factory.MetadataManager.GetDependenciesDueToVirtualMethodReflectability(ref result, factory, _targetMethod);
+            
             return result;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -88,7 +88,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public IEnumerable<DependencyListEntry> InstantiateDependencies(NodeFactory factory, Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            ArrayBuilder<DependencyListEntry> result = new ArrayBuilder<DependencyListEntry>();
+            DependencyList result = new DependencyList();
 
             var lookupContext = new GenericLookupResultContext(_dictionaryOwner, typeInstantiation, methodInstantiation);
 
@@ -125,11 +125,7 @@ namespace ILCompiler.DependencyAnalysis
                                         "Dictionary dependency"));
                             }
 
-                            // TODO: https://github.com/dotnet/corert/issues/3224 
-                            if (instantiatedTargetMethod.IsAbstract)
-                            {
-                                result.Add(new DependencyListEntry(factory.ReflectableMethod(instantiatedTargetMethod), "Abstract reflectable method"));
-                            }
+                            factory.MetadataManager.GetDependenciesDueToVirtualMethodReflectability(ref result, factory, instantiatedTargetMethod);
                         }
                     }
                     break;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -146,11 +146,7 @@ namespace ILCompiler.DependencyAnalysis
                 DependencyList dependencyList = new DependencyList();
 
 #if !SUPPORT_JIT
-                // TODO: https://github.com/dotnet/corert/issues/3224 
-                if (targetMethod.IsAbstract)
-                {
-                    dependencyList.Add(factory.ReflectableMethod(targetMethod), "Abstract reflectable method");
-                }
+                factory.MetadataManager.GetDependenciesDueToVirtualMethodReflectability(ref dependencyList, factory, targetMethod);
 
                 if (!factory.VTable(targetMethod.OwningType).HasFixedSlots)
 
@@ -170,11 +166,7 @@ namespace ILCompiler.DependencyAnalysis
 
                     DependencyList dependencyList = new DependencyList();
 #if !SUPPORT_JIT
-                    // TODO: https://github.com/dotnet/corert/issues/3224 
-                    if (targetMethod.IsAbstract)
-                    {
-                        dependencyList.Add(factory.ReflectableMethod(targetMethod), "Abstract reflectable method");
-                    }
+                    factory.MetadataManager.GetDependenciesDueToVirtualMethodReflectability(ref dependencyList, factory, targetMethod);
 
                     if (!factory.VTable(info.TargetMethod.OwningType).HasFixedSlots)
                     {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -68,11 +68,7 @@ namespace ILCompiler.DependencyAnalysis
 
             dependencies.Add(new DependencyListEntry(factory.VTable(_decl.OwningType), "VTable of a VirtualMethodUse"));
 
-            // TODO: https://github.com/dotnet/corert/issues/3224
-            if (_decl.IsAbstract)
-            {
-                dependencies.Add(factory.ReflectableMethod(_decl), "Abstract reflectable method");
-            }
+            factory.MetadataManager.GetDependenciesDueToVirtualMethodReflectability(ref dependencies, factory, _decl);
 
             return dependencies;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -350,6 +350,21 @@ namespace ILCompiler
             }
         }
 
+        /// <summary>
+        /// This method is an extension point that can provide additional metadata-based dependencies on a virtual method.
+        /// </summary>
+        public void GetDependenciesDueToVirtualMethodReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            // If we have a use of an abstract method, GetDependenciesDueToReflectability is not going to see the method
+            // as being used since there's no body. We inject a dependency on a new node that serves as a logical method body
+            // for the metadata manager. Metadata manager treats that node the same as a body.
+            if (method.IsAbstract && GetMetadataCategory(method) != 0)
+            {
+                dependencies = dependencies ?? new DependencyList();
+                dependencies.Add(factory.ReflectableMethod(method), "Abstract reflectable method");
+            }
+        }
+
         protected virtual void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             // MetadataManagers can override this to provide additional dependencies caused by the emission of metadata


### PR DESCRIPTION
Progress towards #3224: route code that handles tracking reflectable abstract methods through `MetadataManager`. This is so that if we're using a `MetadataManager` that doesn't need this kind of accounting, we could avoid allocating the `ReflectableMethodNode` nodes.

This change is also making the `ReflectableMethodNode` practically a private implementation detail of `MetadataManager`.