### PR TITLE
Implement cpobj opcode for wasm

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1509,6 +1509,32 @@ namespace Internal.IL
 
         private void ImportCpOpj(int token)
         {
+            var type = ResolveTypeToken(token);
+
+            if (!type.IsValueType)
+            {
+                throw new InvalidOperationException();
+            }
+
+            var dest = _stack.Pop();
+
+            if (dest.Kind != StackValueKind.NativeInt && dest.Kind != StackValueKind.ByRef && dest.Kind != StackValueKind.ObjRef)
+            {
+                throw new InvalidOperationException();
+            }
+
+            var src = _stack.Pop();
+
+            if (src.Kind != StackValueKind.NativeInt && src.Kind != StackValueKind.ByRef && src.Kind != StackValueKind.ObjRef)
+            {
+                throw new InvalidOperationException();
+            }
+
+            var pointerType = GetLLVMTypeForTypeDesc(type.MakePointerType());
+
+            var value = LLVM.BuildLoad(_builder, src.ValueAsType(pointerType, _builder), "cpobj.load");
+
+            LLVM.BuildStore(_builder, value, dest.ValueAsType(pointerType, _builder));
         }
 
         private void ImportUnbox(int token, ILOpcode opCode)

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1516,16 +1516,16 @@ namespace Internal.IL
                 throw new InvalidOperationException();
             }
 
-            var dest = _stack.Pop();
+            var src = _stack.Pop();
 
-            if (dest.Kind != StackValueKind.NativeInt && dest.Kind != StackValueKind.ByRef && dest.Kind != StackValueKind.ObjRef)
+            if (src.Kind != StackValueKind.NativeInt && src.Kind != StackValueKind.ByRef && src.Kind != StackValueKind.ObjRef)
             {
                 throw new InvalidOperationException();
             }
 
-            var src = _stack.Pop();
+            var dest = _stack.Pop();
 
-            if (src.Kind != StackValueKind.NativeInt && src.Kind != StackValueKind.ByRef && src.Kind != StackValueKind.ObjRef)
+            if (dest.Kind != StackValueKind.NativeInt && dest.Kind != StackValueKind.ByRef && dest.Kind != StackValueKind.ObjRef)
             {
                 throw new InvalidOperationException();
             }

--- a/tests/src/Simple/HelloWasm/CpObj.il
+++ b/tests/src/Simple/HelloWasm/CpObj.il
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Private.CoreLib
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly CpObj { }
+
+.class public CpObj.CpObjTest
+{
+  .method public hidebysig static void CpObj(valuetype CpObj.TestValue& dest, valuetype CpObj.TestValue& src) cil managed
+  {
+    .maxstack 8
+    ldarg.0
+    ldarg.1
+    cpobj CpObj.TestValue
+    ret
+  }
+}
+
+.class public value sealed CpObj.TestValue
+{
+  .field public int32 Field;
+}

--- a/tests/src/Simple/HelloWasm/CpObj.ilproj
+++ b/tests/src/Simple/HelloWasm/CpObj.ilproj
@@ -1,0 +1,20 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <DebugType>portable</DebugType>
+    <OutputPath>$(MSBuildProjectDirectory)\bin\$(Configuration)\$(Platform)\</OutputPath>
+    <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <Compile Include="CpObj.il" />
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>$(MicrosoftNETCoreAppPackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/Simple/HelloWasm/HelloWasm.csproj
+++ b/tests/src/Simple/HelloWasm/HelloWasm.csproj
@@ -1,6 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Compile Include="*.cs" />
+
+    <ProjectReference Include="CpObj.ilproj" />
+    <IlcArg Include="-r:$(IntermediateOutputPath)\CpObj.dll" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SimpleTest.targets))\SimpleTest.targets" />

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using CpObj;
 
 internal static class Program
 {
@@ -107,6 +108,14 @@ internal static class Program
         if (switchTestDefault == 0)
         {
             PrintLine("SwitchOpDefault test: Ok.");
+        }
+
+        var cpObjTestA = new TestValue { Field = 1234 };
+        var cpObjTestB = new TestValue { Field = 5678 };
+        CpObjTest.CpObj(ref cpObjTestB, ref cpObjTestA);
+        if (cpObjTestB.Field == cpObjTestA.Field)
+        {
+            PrintLine("CpObj test: Ok.");
         }
     }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -113,7 +113,7 @@ internal static class Program
         var cpObjTestA = new TestValue { Field = 1234 };
         var cpObjTestB = new TestValue { Field = 5678 };
         CpObjTest.CpObj(ref cpObjTestB, ref cpObjTestA);
-        if (cpObjTestB.Field == cpObjTestA.Field)
+        if (cpObjTestB.Field == 1234)
         {
             PrintLine("CpObj test: Ok.");
         }


### PR DESCRIPTION
Implements the ILToWebAssembly.ImportCpObj method using an LLVM load and
store.

Fix #4548