### PR TITLE
Route LDTOKEN dependencies through MetadataManager

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
@@ -37,18 +37,9 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            // TODO: https://github.com/dotnet/corert/issues/3224
-            // We should figure out reflectable fields when scanning for reflection
-            FieldDesc fieldDefinition = _targetField.GetTypicalFieldDefinition();
-            if (factory.MetadataManager.CanGenerateMetadata(fieldDefinition))
-            {
-                return new DependencyList
-                {
-                    new DependencyListEntry(factory.FieldMetadata(fieldDefinition), "LDTOKEN")
-                };
-            }
-
-            return null;
+            DependencyList result = null;
+            factory.MetadataManager.GetDependenciesDueToLDToken(ref result, factory, _targetField);
+            return result;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DependencyList result = null;
-            factory.MetadataManager.GetDependenciesDueToLDToken(ref result, factory, _targetField);
+            factory.MetadataManager.GetDependenciesDueToLdToken(ref result, factory, _targetField);
             return result;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -50,7 +50,7 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(factory.GVMDependencies(_targetMethod), "GVM dependencies for runtime method handle");
             }
 
-            factory.MetadataManager.GetDependenciesDueToLDToken(ref dependencies, factory, _targetMethod);
+            factory.MetadataManager.GetDependenciesDueToLdToken(ref dependencies, factory, _targetMethod);
 
             return dependencies;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -50,14 +50,7 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(factory.GVMDependencies(_targetMethod), "GVM dependencies for runtime method handle");
             }
 
-            // TODO: https://github.com/dotnet/corert/issues/3224
-            // We should figure out reflectable methods when scanning for reflection
-            MethodDesc methodDefinition = _targetMethod.GetTypicalMethodDefinition();
-            if (factory.MetadataManager.CanGenerateMetadata(methodDefinition))
-            {
-                dependencies = dependencies ?? new DependencyList();
-                dependencies.Add(factory.MethodMetadata(methodDefinition), "LDTOKEN");
-            }
+            factory.MetadataManager.GetDependenciesDueToLDToken(ref dependencies, factory, _targetMethod);
 
             return dependencies;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -410,7 +410,7 @@ namespace ILCompiler
         /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies to generated RuntimeMethodHandles.
         /// </summary>
-        public virtual void GetDependenciesDueToLDToken(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        public virtual void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             // MetadataManagers can override this to provide additional dependencies caused by the presence of a
             // RuntimeMethodHandle data structure.
@@ -419,7 +419,7 @@ namespace ILCompiler
         /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies to generated RuntimeFieldHandles.
         /// </summary>
-        public virtual void GetDependenciesDueToLDToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
+        public virtual void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
         {
             // MetadataManagers can override this to provide additional dependencies caused by the presence of a
             // RuntimeFieldHandle data structure.

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -408,6 +408,24 @@ namespace ILCompiler
         }
 
         /// <summary>
+        /// This method is an extension point that can provide additional metadata-based dependencies to generated RuntimeMethodHandles.
+        /// </summary>
+        public virtual void GetDependenciesDueToLDToken(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            // MetadataManagers can override this to provide additional dependencies caused by the presence of a
+            // RuntimeMethodHandle data structure.
+        }
+
+        /// <summary>
+        /// This method is an extension point that can provide additional metadata-based dependencies to generated RuntimeFieldHandles.
+        /// </summary>
+        public virtual void GetDependenciesDueToLDToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
+        {
+            // MetadataManagers can override this to provide additional dependencies caused by the presence of a
+            // RuntimeFieldHandle data structure.
+        }
+
+        /// <summary>
         /// Given that a method is invokable, does there exist a reflection invoke stub?
         /// </summary>
         public abstract bool HasReflectionInvokeStubForInvokableMethod(MethodDesc method);

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
@@ -194,6 +194,28 @@ namespace ILCompiler
             }
         }
 
+        public override void GetDependenciesDueToLDToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
+        {
+            // In order for the RuntimeFieldHandle data structure to be usable at runtime, ensure the field
+            // is generating metadata.
+            if ((GetMetadataCategory(field) & MetadataCategory.Description) == MetadataCategory.Description)
+            {
+                dependencies = dependencies ?? new DependencyList();
+                dependencies.Add(factory.FieldMetadata(field.GetTypicalFieldDefinition()), "LDTOKEN field");
+            }
+        }
+
+        public override void GetDependenciesDueToLDToken(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            // In order for the RuntimeMethodHandle data structure to be usable at runtime, ensure the method
+            // is generating metadata.
+            if ((GetMetadataCategory(method) & MetadataCategory.Description) == MetadataCategory.Description)
+            {
+                dependencies = dependencies ?? new DependencyList();
+                dependencies.Add(factory.MethodMetadata(method.GetTypicalMethodDefinition()), "LDTOKEN method");
+            }
+        }
+
         protected override IEnumerable<FieldDesc> GetFieldsWithRuntimeMapping()
         {
             if (_hasPreciseFieldUsageInformation)

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
@@ -194,7 +194,7 @@ namespace ILCompiler
             }
         }
 
-        public override void GetDependenciesDueToLDToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
+        public override void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
         {
             // In order for the RuntimeFieldHandle data structure to be usable at runtime, ensure the field
             // is generating metadata.
@@ -205,7 +205,7 @@ namespace ILCompiler
             }
         }
 
-        public override void GetDependenciesDueToLDToken(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        public override void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             // In order for the RuntimeMethodHandle data structure to be usable at runtime, ensure the method
             // is generating metadata.


### PR DESCRIPTION
The presence of `RuntimeMethodHandle`/`RuntimeFieldHandle` data structure should only imply the need of metadata if we're generating/collecting metadata from usage.

Closes #3224. This was the last place that needed fixes.