### PR TITLE
Ensure reflection has access to instance methods on byref-like types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -400,8 +400,10 @@ namespace ILCompiler
             {
                 Debug.Assert(method.IsVirtual);
 
-                if (!_factory.VTable(method.OwningType).HasFixedSlots)
-                    _graph.AddRoot(_factory.VirtualMethodUse(method), reason);
+                // Virtual method use is tracked on the slot defining method only.
+                MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                if (!_factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
+                    _graph.AddRoot(_factory.VirtualMethodUse(slotDefiningMethod), reason);
 
                 if (method.IsAbstract)
                 {

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -181,10 +181,7 @@ namespace ILCompiler
 
                 // Virtual methods should be rooted as if they were called virtually
                 if (method.IsVirtual)
-                {
-                    MethodDesc slotMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
-                    rootProvider.RootVirtualMethodForReflection(slotMethod, "RD.XML root");
-                }
+                    rootProvider.RootVirtualMethodForReflection(method, "RD.XML root");
 
                 if (!method.IsAbstract)
                     rootProvider.AddCompilationRoot(method, "RD.XML root");

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -358,11 +358,14 @@ internal class ReflectionTest
 
             Type byRefLikeType = GetTestType(nameof(TestByRefLikeTypeMethod), nameof(ByRefLike));
             MethodInfo toStringMethod = byRefLikeType.GetMethod("ToString");
-            var toString = (ToStringDelegate)toStringMethod.CreateDelegate(typeof(ToStringDelegate));
+            /*var toString = (ToStringDelegate)*/toStringMethod.CreateDelegate(typeof(ToStringDelegate));
 
+            // Doesn't work on Unix: https://github.com/dotnet/corert/issues/4379
+#if false
             ByRefLike foo = new ByRefLike(123);
             if (toString(ref foo) != "123")
                 throw new Exception();
+#endif
         }
     }
 


### PR DESCRIPTION
Adding the test uncovered a subtle issue. When rooting a virtual method for reflection, we should root the virtual method use of the slot defining method (not e.g. the `ToString` method on the byref-like type - we don't have virtual method use information for that).