### PR TITLE
Add a couple more metadata rules

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
@@ -178,14 +178,15 @@ namespace ILCompiler.DependencyAnalysis
             if (factory.MetadataManager.IsReflectionBlocked(type))
                 return false;
 
+            // Reflection will need to be able to allocate this type at runtime
+            // (e.g. this could be an array that needs to be allocated, or an enum that needs to be boxed).
+            dependencies.Add(factory.ConstructedTypeSymbol(type), "Custom attribute blob");
+
             if (type.UnderlyingType.IsPrimitive || type.IsString || value == null)
                 return true;
 
             if (type.IsSzArray)
             {
-                // Reflection will need to be able to allocate this array at runtime.
-                dependencies.Add(factory.ConstructedTypeSymbol(type), "Custom attribute blob");
-
                 TypeDesc elementType = ((ArrayType)type).ElementType;
                 if (elementType.UnderlyingType.IsPrimitive || elementType.IsString)
                     return true;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -44,6 +44,13 @@ namespace ILCompiler.DependencyAnalysis
             else
                 dependencies.Add(factory.ModuleMetadata(_type.Module), "Containing module of a reflectable type");
 
+            if (_type.IsDelegate)
+            {
+                // A delegate type metadata is rather useless without the Invoke method.
+                // If someone reflects on a delegate, chances are they're going to look at the signature.
+                dependencies.Add(factory.MethodMetadata(_type.GetMethod("Invoke", null)), "Delegate invoke method metadata");
+            }
+
             return dependencies;
         }
 


### PR DESCRIPTION
Found these when looking at getting Benchmark.net to run with CoreRT.

The delegate Invoke method rule is something I hit multiple times already - LINQ Expressions are guaranteed to reflect on Invoke.