### PR TITLE
Normalize types and methods to fully canonical forms

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -67,7 +67,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode GetBaseTypeNode(NodeFactory factory)
         {
-            return _type.BaseType != null ? factory.NecessaryTypeSymbol(GetFullCanonicalTypeForCanonicalType(_type.BaseType)) : null;
+            return _type.BaseType != null ? factory.NecessaryTypeSymbol(_type.NormalizedBaseType()) : null;
         }
 
         protected override int GCDescSize

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -49,7 +49,7 @@ namespace ILCompiler.DependencyAnalysis
             result.Add(factory.InterfaceDispatchMapIndirection(_type), "Interface dispatch map indirection node");
 
             // VTable slots of implemented interfaces are consulted during emission
-            foreach (TypeDesc runtimeInterface in _type.RuntimeInterfaces)
+            foreach (TypeDesc runtimeInterface in _type.NormalizedRuntimeInterfaces())
             {
                 result.Add(factory.VTable(runtimeInterface), "Interface for a dispatch map");
             }
@@ -61,10 +61,10 @@ namespace ILCompiler.DependencyAnalysis
         {
             var entryCountReservation = builder.ReserveInt();
             int entryCount = 0;
+            int interfaceIndex = 0;
             
-            for (int interfaceIndex = 0; interfaceIndex < _type.RuntimeInterfaces.Length; interfaceIndex++)
+            foreach (var interfaceType in _type.NormalizedRuntimeInterfaces())
             {
-                var interfaceType = _type.RuntimeInterfaces[interfaceIndex];
                 Debug.Assert(interfaceType.IsInterface);
 
                 IReadOnlyList<MethodDesc> virtualSlots = factory.VTable(interfaceType).Slots;
@@ -84,6 +84,8 @@ namespace ILCompiler.DependencyAnalysis
                         entryCount++;
                     }
                 }
+
+                interfaceIndex++;
             }
 
             builder.EmitInt(entryCountReservation, entryCount);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode GetBaseTypeNode(NodeFactory factory)
         {
-            return _type.BaseType != null ? factory.NecessaryTypeSymbol(GetFullCanonicalTypeForCanonicalType(_type.BaseType)) : null;
+            return _type.BaseType != null ? factory.NecessaryTypeSymbol(_type.NormalizedBaseType()) : null;
         }
 
         protected internal override int ClassCode => 1505000724;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
@@ -115,7 +115,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (!method.HasInstantiation)
                 {
-                    MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                    MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method).Normalize();
                     if (!factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
                     {
                         dependencies.Add(factory.VirtualMethodUse(slotDefiningMethod), "Reflection virtual invoke method");

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -22,6 +22,8 @@ namespace ILCompiler.DependencyAnalysis
         public VTableSliceNode(TypeDesc type)
         {
             Debug.Assert(!type.IsArray, "Wanted to call GetClosestDefType?");
+            Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Any) ||
+                type.ConvertToCanonForm(CanonicalFormKind.Specific) == type);
             _type = type;
         }
 
@@ -46,9 +48,10 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            if (_type.HasBaseType)
+            DefType baseType = _type.NormalizedBaseType();
+            if (baseType != null)
             {
-                return new[] { new DependencyListEntry(factory.VTable(_type.BaseType), "Base type VTable") };
+                return new[] { new DependencyListEntry(factory.VTable(baseType), "Base type VTable") };
             }
 
             return null;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -30,6 +30,9 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(!decl.IsRuntimeDeterminedExactMethod);
             Debug.Assert(decl.IsVirtual);
 
+            Debug.Assert(!decl.IsCanonicalMethod(CanonicalFormKind.Any) ||
+                decl.GetCanonMethodTarget(CanonicalFormKind.Specific) == decl);
+
             // Virtual method use always represents the slot defining method of the virtual.
             // Places that might see virtual methods being used through an override need to normalize
             // to the slot defining method.

--- a/src/ILCompiler.Compiler/src/Compiler/MethodExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MethodExtensions.cs
@@ -113,5 +113,16 @@ namespace ILCompiler
 
             return false;
         }
+
+        /// <summary>
+        /// Gets fully canonicalized method if method is canonical.
+        /// </summary>
+        public static MethodDesc Normalize(this MethodDesc method)
+        {
+            // If method is Foo<__Canon,object>::Method, we get Foo<__Canon,__Canon>::Method.
+            if (method.IsCanonicalMethod(CanonicalFormKind.Any))
+                return method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            return method;
+        }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -855,7 +855,7 @@ namespace Internal.JitInterface
             // Normalize to the slot defining method. We don't have slot information for the overrides.
             methodDesc = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(methodDesc);
 
-            int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(_compilation.NodeFactory, methodDesc);
+            int slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(_compilation.NodeFactory, methodDesc.Normalize());
             Debug.Assert(slot != -1);
 
             offsetAfterIndirection = (uint)(EETypeNode.GetVTableOffset(pointerSize) + slot * pointerSize);
@@ -3299,7 +3299,7 @@ namespace Internal.JitInterface
                 }
             }
             else if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0
-                && _compilation.HasFixedSlotVTable(targetMethod.OwningType))
+                && _compilation.HasFixedSlotVTable(targetMethod.Normalize().OwningType))
             {
                 pResult.kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_VTABLE;
                 pResult.nullInstanceCheck = true;


### PR DESCRIPTION
There are a couple places where we might end up with things like `Foo<object, __Canon>`. We shouldn't let things like that float around in the system.

This was hit with Benchmark.net in the new code I added for reflection. We had partially canonical types and methods flying around in the system and up until the reflection work this went unnoticed. I sprinkled around some new asserts so that we'll be more likely to see a problem like this in the future.