### PR TITLE
Add diagnostic messages to the build targets

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -72,5 +72,10 @@ See the LICENSE file in the project root for more information.
       <LinkerArg Include="-licucore" Condition="'$(TargetOS)' == 'OSX'" />
       <LinkerArg Include="-shared" Condition="'$(NativeLib)' == 'Shared'" />
     </ItemGroup>
+    
+    <Exec Command="command -v $(CppLinker)" IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="_WhereLinker"/>
+    </Exec>
+    <Error Condition="'$(_WhereLinker)' != '0'" Text="Platform linker ('$(CppLinker)') not found. On macOS, platform linker gets installed with Xcode. On Linux, it comes with clang." />
   </Target>
 </Project>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -76,6 +76,7 @@ See the LICENSE file in the project root for more information.
     <Exec Command="command -v $(CppLinker)" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_WhereLinker"/>
     </Exec>
-    <Error Condition="'$(_WhereLinker)' != '0'" Text="Platform linker ('$(CppLinker)') not found. On macOS, platform linker gets installed with Xcode. On Linux, it comes with clang." />
+    <Error Condition="'$(_WhereLinker)' != '0' and '$(TargetOS)' == 'OSX'" Text="Platform linker ('$(CppLinker)') not found. Try installing Xcode to resolve the problem." />
+    <Error Condition="'$(_WhereLinker)' != '0' and '$(TargetOS)' != 'OSX'" Text="Platform linker ('$(CppLinker)') not found. Try installing $(CppLinker) or the appropriate package for your platform to resolve the problem." />
   </Target>
 </Project>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -81,6 +81,6 @@ See the LICENSE file in the project root for more information.
     <Exec Command="where /Q $(CppLinker)" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_WhereLinker"/>
     </Exec>
-    <Error Condition="'$(_WhereLinker)' != '0'" Text="Platform linker not found. Make sure to publish from a Visual Studio Developer Command prompt with C++ tools installed." />
+    <Error Condition="'$(_WhereLinker)' != '0'" Text="Platform linker not found. Make sure to publish from a x64 Native Tools Command Prompt for VS 2017 with C++ tools installed." />
   </Target>
 </Project>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -77,5 +77,10 @@ See the LICENSE file in the project root for more information.
       <LinkerArg Include="/OPT:REF" />
       <LinkerArg Include="/OPT:ICF" />
     </ItemGroup>
+
+    <Exec Command="where /Q $(CppLinker)" IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="_WhereLinker"/>
+    </Exec>
+    <Error Condition="'$(_WhereLinker)' != '0'" Text="Platform linker not found. Make sure to publish from a Visual Studio Developer Command prompt with C++ tools installed." />
   </Target>
 </Project>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -160,6 +160,8 @@ See the LICENSE file in the project root for more information.
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeObject)))" />
 
+    <Message Text="Generating native code" Importance="high" />
+
     <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;" />
   </Target>
 


### PR DESCRIPTION
Two things:
* Running ILC takes a while but we don't print any information about it. Print a message.
* Invoking the publish from a clean command promt is something that will happen very often I assume. Make sure the failure message is more prescriptive.

We'll want to make these messages localizable at some point...