### PR TITLE
Implemented Array instructions for WebAssembly

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -942,6 +942,7 @@ namespace Internal.IL
             MetadataType metadataType = (MetadataType)type;
             var eeTypeDesc = _compilation.TypeSystemContext.SystemModule.GetKnownType("System", "EETypePtr");
             var arguments = new StackEntry[] { new LoadExpressionEntry(StackValueKind.ByRef, "eeType", GetEETypePointerForTypeDesc(metadataType, true), eeTypeDesc) };
+            //TODO: call GetNewObjectHelperForType from JitHelper.cs (needs refactoring)
             return CallRuntime(_compilation.TypeSystemContext, RuntimeExport, "RhNewObject", arguments, type);
         }
 
@@ -2160,8 +2161,8 @@ namespace Internal.IL
             var sizeOfArray = _stack.Pop();
             var eeTypeDesc = _compilation.TypeSystemContext.SystemModule.GetKnownType("System", "EETypePtr");
             var arguments = new StackEntry[] { new LoadExpressionEntry(StackValueKind.ValueType, "eeType", GetEETypePointerForTypeDesc(arrayType, true), eeTypeDesc.MakePointerType()), sizeOfArray };
+            //TODO: call GetNewArrayHelperForType from JitHelper.cs (needs refactoring)
             PushNonNull(CallRuntime(_compilation.TypeSystemContext, RuntimeExport, "RhNewArray", arguments, arrayType));
-
         }
 
         private LLVMValueRef ArrayBaseSize()
@@ -2178,8 +2179,8 @@ namespace Internal.IL
         {
             StackEntry index = _stack.Pop();
             StackEntry arrayReference = _stack.Pop();
-            var nullsafeElementType = elementType ?? GetWellKnownType(WellKnownType.Object);
-            PushLoadExpression(GetStackValueKind(nullsafeElementType), "ldelem", GetElementAddress(index.ValueAsInt32(_builder, true), arrayReference.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder), nullsafeElementType), nullsafeElementType);
+            var nullSafeElementType = elementType ?? GetWellKnownType(WellKnownType.Object);
+            PushLoadExpression(GetStackValueKind(nullSafeElementType), "ldelem", GetElementAddress(index.ValueAsInt32(_builder, true), arrayReference.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder), nullSafeElementType), nullSafeElementType);
         }
 
         private void ImportStoreElement(int token)
@@ -2192,9 +2193,9 @@ namespace Internal.IL
             StackEntry value = _stack.Pop();
             StackEntry index = _stack.Pop();
             StackEntry arrayReference = _stack.Pop();
-            var nullsafeElementType = elementType ?? GetWellKnownType(WellKnownType.Object);
-            LLVMValueRef elementAddress = GetElementAddress(index.ValueAsInt32(_builder, true), arrayReference.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder), nullsafeElementType);
-            CastingStore(elementAddress, value, nullsafeElementType);
+            var nullSafeElementType = elementType ?? GetWellKnownType(WellKnownType.Object);
+            LLVMValueRef elementAddress = GetElementAddress(index.ValueAsInt32(_builder, true), arrayReference.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder), nullSafeElementType);
+            CastingStore(elementAddress, value, nullSafeElementType);
         }
 
         private void ImportLoadLength()

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -99,7 +99,7 @@ namespace Internal.IL
             // Ensure dependencies show up regardless of exceptions to avoid breaking LLVM
             methodCodeNodeNeedingCode.SetDependencies(ilImporter.GetDependencies());
         }
-
+        
         static LLVMValueRef TrapFunction = default(LLVMValueRef);
         static LLVMValueRef DoNothingFunction = default(LLVMValueRef);
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -99,7 +99,7 @@ namespace Internal.IL
             // Ensure dependencies show up regardless of exceptions to avoid breaking LLVM
             methodCodeNodeNeedingCode.SetDependencies(ilImporter.GetDependencies());
         }
-        
+
         static LLVMValueRef TrapFunction = default(LLVMValueRef);
         static LLVMValueRef DoNothingFunction = default(LLVMValueRef);
 

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -776,6 +776,7 @@ COOP_PINVOKE_HELPER(void, RhpBox, (Object * pObj, void * pData))
     
     UInt8 * pbFields = (UInt8*)pObj + sizeof(EEType*);
 
+#if !defined(_WASM_)
     // Copy the unboxed value type data into the new object.
     // Perform any write barriers necessary for embedded reference fields.
     if (pEEType->HasReferenceFields())
@@ -786,6 +787,10 @@ COOP_PINVOKE_HELPER(void, RhpBox, (Object * pObj, void * pData))
     {
         memcpy(pbFields, pData, cbFields);
     }
+#else
+    //TODO: write barriers currently crash in wasm and we dont really have GC anyway
+    memcpy(pbFields, pData, cbFields);
+#endif
 }
 
 bool EETypesEquivalentEnoughForUnboxing(EEType *pObjectEEType, EEType *pUnboxToEEType)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -134,6 +134,14 @@ internal static class Program
         Action virtualDelegate = tempObj.VirtualDelegateTarget;
         virtualDelegate();
 
+        var arrayTest = new BoxStubTest[] { new BoxStubTest { Value = "Hello" }, new BoxStubTest { Value = "Array" }, new BoxStubTest { Value = "Test" } };
+        foreach(var element in arrayTest)
+            PrintLine(element.Value);
+
+        arrayTest[1].Value = "Array load/store test: Ok.";
+        
+        PrintLine(arrayTest[1].Value);
+
         PrintLine("Done");
     }
 
@@ -239,6 +247,7 @@ public class TestClass
 {
     public string TestString { get; set; }
     public int TestInt { get; set; }
+
 
     public TestClass(int number)
     {

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -139,14 +139,32 @@ internal static class Program
             PrintLine(element.Value);
 
         arrayTest[1].Value = "Array load/store test: Ok.";
-        
         PrintLine(arrayTest[1].Value);
+
+        var largeArrayTest = new long[] { Int64.MaxValue, 0, Int64.MinValue, 0 };
+        if(largeArrayTest[0] == Int64.MaxValue &&
+            largeArrayTest[1] == 0 &&
+            largeArrayTest[2] == Int64.MinValue &&
+            largeArrayTest[3] == 0)
+        {
+            PrintLine("Large array load/store test: Ok.");
+        }
+
+        var smallArrayTest = new long[] { Int16.MaxValue, 0, Int16.MinValue, 0 };
+        if(smallArrayTest[0] == Int16.MaxValue &&
+            smallArrayTest[1] == 0 &&
+            smallArrayTest[2] == Int16.MinValue &&
+            smallArrayTest[3] == 0)
+        {
+            PrintLine("Small array load/store test: Ok.");
+        }
 
         PrintLine("Done");
     }
 
     private static int StaticDelegateTarget()
     {
+         
         return 7;
     }
 
@@ -247,7 +265,6 @@ public class TestClass
 {
     public string TestString { get; set; }
     public int TestInt { get; set; }
-
 
     public TestClass(int number)
     {


### PR DESCRIPTION
Fix #4547, #4546, #4545, #4544, #4540 
This depends on #5143 + some modifications on top of that to unify the native callable method name/MethodDesc. I was hoping to get the review started.

This is a little bit bigger than I was hoping for, I wanted to make 3 pull requests (Array instructions, managed runtime allocation (not pinvoke), managed runtime boxing) but they all ended up depending on each other.  

I'm not entirely certain that I'm doing the internal calling convention stuff right, and I ended up having to ensure only one MethodDesc is ever used for pinvoked methods.
