### PR TITLE
Update CoreCLR.issues.targets

### DIFF
--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -374,6 +374,10 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\throw2dimarray_d\throw2dimarray_d.*" />
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\throw2dimarray_r\throw2dimarray_r.*" />
 
+    <!-- Rethrown exceptions don't clear stack trace -->
+    <!-- https://github.com/dotnet/corert/issues/5183 -->
+    <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\529206\vsw529206StaticCctor\vsw529206StaticCctor.*" />    
+
     <!-- PInvoke Ansi/Widechar entrypoint probing -->
     <!-- https://github.com/dotnet/corert/issues/730 -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\tail\tail.*" />


### PR DESCRIPTION
I "broke" this test in my reflection changes.

The changes in reflectability made it possible to detect that we're not doing the right thing [here](https://github.com/dotnet/coreclr/blob/0bb37fde2befd38d4a082d5c0eb269ae3e35b546/tests/src/Loader/classloader/regressions/529206/vsw529206StaticCctor.cs#L55).

The test was passing for the wrong reason.