### PR TITLE
Fix emission of metadata for namespace references

### DIFF
--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Namespace.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.Namespace.cs
@@ -72,6 +72,10 @@ namespace ILCompiler.Metadata
 
         private NamespaceReference HandleNamespaceReference(Cts.ModuleDesc parentScope, string namespaceString)
         {
+            // The format represents root namespace as a namespace with null name, in contrast with ECMA-335
+            if (namespaceString.Length == 0)
+                namespaceString = null;
+
             NamespaceReference result;
             NamespaceKey key = new NamespaceKey(parentScope, namespaceString);
             if (_namespaceRefs.TryGetValue(key, out result))
@@ -91,6 +95,9 @@ namespace ILCompiler.Metadata
                 };
                 _namespaceRefs.Add(key, rootNamespace);
             }
+
+            if (namespaceString == null)
+                return rootNamespace;
 
             NamespaceReference currentNamespace = rootNamespace;
             string currentNamespaceName = String.Empty;


### PR DESCRIPTION
We were generating NamespaceReference hierarchy with an extra level of nesting. These are used very rarely, so we didn't notice before.