### PR TITLE
Normalize interface implementation method before asking for the slot

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -80,7 +80,7 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         builder.EmitShort(checked((short)interfaceIndex));
                         builder.EmitShort(checked((short)(interfaceMethodSlot + (interfaceType.HasGenericDictionarySlot() ? 1 : 0))));
-                        builder.EmitShort(checked((short)VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, implMethod)));
+                        builder.EmitShort(checked((short)VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, implMethod.Normalize())));
                         entryCount++;
                     }
                 }


### PR DESCRIPTION
This is hitting the new assert I added in #5169 with Project X.

I kind of expected I didn't fix all the places that were doing the wrong thing, but with the new asserts this is just a matter of compiling enough code until we weed them all out.