### PR TITLE
[ILVerify] Fix test assembly names

### DIFF
--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -6,7 +6,7 @@
 {
 }
 
-.assembly Branching
+.assembly BranchingTests
 {
 }
 

--- a/src/ILVerify/tests/ILTests/CastingTests.il
+++ b/src/ILVerify/tests/ILTests/CastingTests.il
@@ -6,7 +6,7 @@
 {
 }
 
-.assembly Casting
+.assembly CastingTests
 {
 }
 

--- a/src/ILVerify/tests/ILTests/ComparisonTests.il
+++ b/src/ILVerify/tests/ILTests/ComparisonTests.il
@@ -6,7 +6,7 @@
 {
 }
 
-.assembly Comparison
+.assembly ComparisonTests
 {
 }
 

--- a/src/ILVerify/tests/ILTests/ExceptionRegionTests.il
+++ b/src/ILVerify/tests/ILTests/ExceptionRegionTests.il
@@ -6,7 +6,7 @@
 {
 }
 
-.assembly ExceptionRegion
+.assembly ExceptionRegionTests
 {
 }
 

--- a/src/ILVerify/tests/ILTests/LoadStoreIndirectTests.il
+++ b/src/ILVerify/tests/ILTests/LoadStoreIndirectTests.il
@@ -6,7 +6,7 @@
 {
 }
 
-.assembly LoadStoreIndirect
+.assembly LoadStoreIndirectTests
 {
 }
 

--- a/src/ILVerify/tests/ILTests/PrefixTests.il
+++ b/src/ILVerify/tests/ILTests/PrefixTests.il
@@ -6,7 +6,7 @@
 {
 }
 
-.assembly Prefix 
+.assembly PrefixTests
 {
 }
 

--- a/src/ILVerify/tests/ILTests/ValueTypeTests.il
+++ b/src/ILVerify/tests/ILTests/ValueTypeTests.il
@@ -6,7 +6,7 @@
 {
 }
 
-.assembly ValueType
+.assembly ValueTypeTests
 {
 }
 


### PR DESCRIPTION
This fixes some older test assemblies not defining assembly name = file name to be more consistent with the way ILVerify handles input assemblies.