### PR TITLE
Add option to block all metadata in an assembly

### DIFF
--- a/src/Common/src/System/Runtime/CompilerServices/__BlockAllReflectionAttribute.cs
+++ b/src/Common/src/System/Runtime/CompilerServices/__BlockAllReflectionAttribute.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*
+  Providing a definition for __BlockAllReflectionAttribute in an assembly is a signal to the .NET Native toolchain 
+  to remove the metadata for all APIs. This both reduces size and disables all reflection on those 
+  APIs in libraries that include this.
+*/
+
+using System;
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.All)]
+    internal class __BlockAllReflectionAttribute : Attribute { }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/BlockedInternalsBlockingPolicy.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/BlockedInternalsBlockingPolicy.cs
@@ -19,14 +19,21 @@ namespace ILCompiler
     /// </summary>
     public sealed class BlockedInternalsBlockingPolicy : MetadataBlockingPolicy
     {
+        private enum ModuleBlockingMode
+        {
+            None,
+            BlockedInternals,
+            FullyBlocked,
+        }
+
         private class ModuleBlockingState
         {
             public ModuleDesc Module { get; }
-            public bool HasBlockedInternals { get; }
-            public ModuleBlockingState(ModuleDesc module, bool hasBlockedInternals)
+            public ModuleBlockingMode BlockingMode { get; }
+            public ModuleBlockingState(ModuleDesc module, ModuleBlockingMode mode)
             {
                 Module = module;
-                HasBlockedInternals = hasBlockedInternals;
+                BlockingMode = mode;
             }
         }
 
@@ -38,8 +45,18 @@ namespace ILCompiler
             protected override bool CompareValueToValue(ModuleBlockingState value1, ModuleBlockingState value2) => Object.ReferenceEquals(value1.Module, value2.Module);
             protected override ModuleBlockingState CreateValueFromKey(ModuleDesc module)
             {
-                bool moduleHasBlockingPolicy = module.GetType("System.Runtime.CompilerServices", "__BlockReflectionAttribute", false) != null;
-                return new ModuleBlockingState(module, moduleHasBlockingPolicy);
+                ModuleBlockingMode blockingMode = ModuleBlockingMode.None;
+
+                if (module.GetType("System.Runtime.CompilerServices", "__BlockAllReflectionAttribute", false) != null)
+                {
+                    blockingMode = ModuleBlockingMode.FullyBlocked;
+                }
+                else if (module.GetType("System.Runtime.CompilerServices", "__BlockReflectionAttribute", false) != null)
+                {
+                    blockingMode = ModuleBlockingMode.BlockedInternals;
+                }
+
+                return new ModuleBlockingState(module, blockingMode);
             }
         }
         private BlockedModulesHashtable _blockedModules = new BlockedModulesHashtable();
@@ -70,17 +87,17 @@ namespace ILCompiler
             protected override bool CompareValueToValue(BlockingState value1, BlockingState value2) => Object.ReferenceEquals(value1.Type, value2.Type);
             protected override BlockingState CreateValueFromKey(EcmaType type)
             {
-                bool isBlocked = false;
-                if (_blockedModules.GetOrCreateValue(type.EcmaModule).HasBlockedInternals)
-                {
-                    isBlocked = ComputeIsBlocked(type);
-                }
-
+                ModuleBlockingMode moduleBlockingMode = _blockedModules.GetOrCreateValue(type.EcmaModule).BlockingMode;
+                bool isBlocked = ComputeIsBlocked(type, moduleBlockingMode);
                 return new BlockingState(type, isBlocked);
             }
 
-            private bool ComputeIsBlocked(EcmaType type)
+            private bool ComputeIsBlocked(EcmaType type, ModuleBlockingMode blockingMode)
             {
+                // If no blocking is applied to the module, the type is not blocked
+                if (blockingMode == ModuleBlockingMode.None)
+                    return false;
+
                 // <Module> type always gets metadata
                 if (type.IsModuleType)
                     return false;
@@ -88,6 +105,10 @@ namespace ILCompiler
                 // The various SR types used in Resource Manager always get metadata
                 if (type.Name == "SR")
                     return false;
+
+                // We block everything else if the module is blocked
+                if (blockingMode == ModuleBlockingMode.FullyBlocked)
+                    return true;
 
                 var typeDefinition = type.MetadataReader.GetTypeDefinition(type.Handle);
                 DefType containingType = type.ContainingType;
@@ -102,7 +123,7 @@ namespace ILCompiler
                 {
                     if ((typeDefinition.Attributes & TypeAttributes.VisibilityMask) == TypeAttributes.NestedPublic)
                     {
-                        return ComputeIsBlocked((EcmaType)containingType);
+                        return ComputeIsBlocked((EcmaType)containingType, blockingMode);
                     }
                     else
                     {
@@ -154,22 +175,28 @@ namespace ILCompiler
             if (ecmaMethod == null)
                 return true;
 
+            ModuleBlockingMode moduleBlockingMode = _blockedModules.GetOrCreateValue(ecmaMethod.Module).BlockingMode;
+            if (moduleBlockingMode == ModuleBlockingMode.None)
+                return false;
+            else if (moduleBlockingMode == ModuleBlockingMode.FullyBlocked)
+                return true;
+
+            // We are blocking internal implementation details
+            Debug.Assert(moduleBlockingMode == ModuleBlockingMode.BlockedInternals);
+
             if (_blockedTypes.GetOrCreateValue((EcmaType)ecmaMethod.OwningType).IsBlocked)
                 return true;
 
-            if (_blockedModules.GetOrCreateValue(ecmaMethod.Module).HasBlockedInternals)
-            {
-                if ((ecmaMethod.Attributes & MethodAttributes.Public) != MethodAttributes.Public)
-                    return true;
+            if ((ecmaMethod.Attributes & MethodAttributes.Public) != MethodAttributes.Public)
+                return true;
 
-                // Methods on Array`1<T> are implementation details that implement the generic interfaces on
-                // arrays. They should not generate metadata or be reflection invokable.
-                // We could get rid of this special casing two ways:
-                // * Make these method stop being regular EcmaMethods with Array<T> as their owning type, or
-                // * Make these methods implement the interfaces explicitly (they would become private and naturally blocked)
-                if (ecmaMethod.OwningType == GetArrayOfTType(ecmaMethod))
-                    return true;
-            }
+            // Methods on Array`1<T> are implementation details that implement the generic interfaces on
+            // arrays. They should not generate metadata or be reflection invokable.
+            // We could get rid of this special casing two ways:
+            // * Make these method stop being regular EcmaMethods with Array<T> as their owning type, or
+            // * Make these methods implement the interfaces explicitly (they would become private and naturally blocked)
+            if (ecmaMethod.OwningType == GetArrayOfTType(ecmaMethod))
+                return true;
 
             return false;
         }
@@ -182,14 +209,20 @@ namespace ILCompiler
             if (ecmaField == null)
                 return true;
 
+            ModuleBlockingMode moduleBlockingMode = _blockedModules.GetOrCreateValue(ecmaField.Module).BlockingMode;
+            if (moduleBlockingMode == ModuleBlockingMode.None)
+                return false;
+            else if (moduleBlockingMode == ModuleBlockingMode.FullyBlocked)
+                return true;
+
+            // We are blocking internal implementation details
+            Debug.Assert(moduleBlockingMode == ModuleBlockingMode.BlockedInternals);
+
             if (_blockedTypes.GetOrCreateValue((EcmaType)ecmaField.OwningType).IsBlocked)
                 return true;
 
-            if (_blockedModules.GetOrCreateValue(ecmaField.Module).HasBlockedInternals)
-            {
-                if ((ecmaField.Attributes & FieldAttributes.Public) != FieldAttributes.Public)
-                    return true;
-            }
+            if ((ecmaField.Attributes & FieldAttributes.Public) != FieldAttributes.Public)
+                return true;
 
             return false;
         }

--- a/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
+++ b/src/System.Private.Reflection.Core/src/System.Private.Reflection.Core.csproj
@@ -258,8 +258,8 @@
     <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\DeveloperExperienceState.cs">
       <Link>System\Runtime\CompilerServices\DeveloperExperienceState.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
-      <Link>System\Runtime\CompilerServices\__BlockReflectionAttribute.cs</Link>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
+      <Link>System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -125,8 +125,8 @@
     <Compile Include="..\..\Common\src\System\Collections\Generic\Empty.cs" >
       <Link>System\Collections\Generic\Empty.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
-      <Link>System\Runtime\CompilerServices\__BlockReflectionAttribute.cs</Link>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
+      <Link>System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Private.Reflection.Metadata/src/System.Private.Reflection.Metadata.csproj
+++ b/src/System.Private.Reflection.Metadata/src/System.Private.Reflection.Metadata.csproj
@@ -30,8 +30,8 @@
     <Compile Include="$(MetadataCommonPath)\NativeFormatReaderGen.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
-      <Link>System\Runtime\CompilerServices\__BlockReflectionAttribute.cs</Link>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
+      <Link>System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Private.StackTraceGenerator/src/System.Private.StackTraceGenerator.csproj
+++ b/src/System.Private.StackTraceGenerator/src/System.Private.StackTraceGenerator.csproj
@@ -27,8 +27,8 @@
     <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgIntrinsicsAttribute.cs" >
       <Link>System\Runtime\InteropServices\McgIntrinsicsAttribute.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
-      <Link>System\Runtime\CompilerServices\__BlockReflectionAttribute.cs</Link>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
+      <Link>System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Private.StackTraceMetadata/src/System.Private.StackTraceMetadata.csproj
+++ b/src/System.Private.StackTraceMetadata/src/System.Private.StackTraceMetadata.csproj
@@ -22,8 +22,8 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\MetadataBlob.cs">
       <Link>Internal\Runtime\MetadataBlob.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
-      <Link>System\Runtime\CompilerServices\__BlockReflectionAttribute.cs</Link>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
+      <Link>System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -497,8 +497,8 @@
     <Compile Include="..\..\Common\src\TypeSystem\NativeFormat\MetadataExtensions.cs">
       <Link>NativeFormat\MetadataExtensions.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
-      <Link>System\Runtime\CompilerServices\__BlockReflectionAttribute.cs</Link>
+    <Compile Include="..\..\Common\src\System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs" Condition="'$(IsProjectNLibrary)' != 'true'">
+      <Link>System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(METADATA_TYPE_LOADER)' != ''">


### PR DESCRIPTION
Adding an attribute type whose presence makes everything in an assembly reflection blocked.

This reduces the size of a Hello world by ~300 kB (50 kB in metadata blob and the rest are various runtime artifacts we no longer need).

If we evacuate public APIs out of System.Private.Interop and mark it fully blocked, we can get some more savings (e.g. the `bool IsComObject(Type type)` method marks `__ComObject` as reflectable (and constructed!) due to the ldtoken and there's no happiness in that).