### PR TITLE
[ILVerify] Fix backward branching rule using signed byte for short-branch deltas

### DIFF
--- a/src/ILVerify/src/ILImporter.Verify.cs
+++ b/src/ILVerify/src/ILImporter.Verify.cs
@@ -364,7 +364,7 @@ again:
                         break;
                     case ILOpcode.br_s:
                     case ILOpcode.leave_s:
-                        MarkPredecessorWithLowerOffset(ReadILByte());
+                        MarkPredecessorWithLowerOffset((sbyte)ReadILByte());
                         continue;
                     case ILOpcode.brfalse_s:
                     case ILOpcode.brtrue_s:
@@ -378,7 +378,7 @@ again:
                     case ILOpcode.bgt_un_s:
                     case ILOpcode.ble_un_s:
                     case ILOpcode.blt_un_s:
-                        MarkPredecessorWithLowerOffset(ReadILByte());
+                        MarkPredecessorWithLowerOffset((sbyte)ReadILByte());
                         break;
                     case ILOpcode.switch_:
                         {

--- a/src/ILVerify/tests/ILTests/BranchingTests.il
+++ b/src/ILVerify/tests/ILTests/BranchingTests.il
@@ -966,6 +966,18 @@
         ret
     }
 
+    .method static public hidebysig void BrFalseS.Backward_Valid() cil managed 
+    {
+    BackwardBranch:
+        // Note: additional nops to increase branch delta
+        nop
+        nop
+        ldc.i4.0
+        brfalse.s   BackwardBranch
+
+        ret
+    }
+
     .method static public hidebysig void Branch.BackwardEmptyStack_Valid() cil managed 
     {
         br      MethodEnd


### PR DESCRIPTION
This fixes the MarkPredecessorWithLowerOffset missing a cast to signed byte for short versions of branching instruction.

I also added a valid test case for this scenario.