### PR TITLE
 Fix marshalling code to meet the CIL backwards branch constraint

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -549,25 +549,6 @@ namespace Internal.IL.Stubs
         }
     }
 
-    // Workaround for places that emit IL that doesn't conform to the ECMA-335 CIL stack requirements.
-    // https://github.com/dotnet/corert/issues/5152
-    // This class and all references to it should be deleted when the issue is fixed.
-    // Do not add new references to this.
-    public class ILStubMethodILWithNonConformingStack : ILStubMethodIL
-    {
-        public ILStubMethodILWithNonConformingStack(MethodDesc owningMethod, byte[] ilBytes, LocalVariableDefinition[] locals, Object[] tokens, MethodDebugInformation debugInfo)
-            : base(owningMethod, ilBytes, locals, tokens, debugInfo)
-        {
-        }
-
-        public ILStubMethodILWithNonConformingStack(ILStubMethodIL methodIL)
-            : base(methodIL)
-        {
-        }
-
-        public override int MaxStack => GetILBytes().Length;
-    }
-
     public class ILCodeLabel
     {
         private ILCodeStream _codeStream;
@@ -665,7 +646,7 @@ namespace Internal.IL.Stubs
             return newLabel;
         }
 
-        public MethodIL Link(MethodDesc owningMethod, bool nonConformingStackWorkaround = false)
+        public MethodIL Link(MethodDesc owningMethod)
         {
             int totalLength = 0;
             int numSequencePoints = 0;
@@ -711,17 +692,8 @@ namespace Internal.IL.Stubs
                 debugInfo = new EmittedMethodDebugInformation(sequencePoints);
             }
 
-            ILStubMethodIL result;
-            if (nonConformingStackWorkaround)
-            {
-                // nonConformingStackWorkaround is a workaround for https://github.com/dotnet/corert/issues/5152
-                result = new ILStubMethodILWithNonConformingStack(owningMethod, ilInstructions, _locals.ToArray(), _tokens.ToArray(), debugInfo);
-            }
-            else
-            {
-                result = new ILStubMethodIL(owningMethod, ilInstructions, _locals.ToArray(), _tokens.ToArray(), debugInfo);
-                result.CheckStackBalance();
-            }
+            var result = new ILStubMethodIL(owningMethod, ilInstructions, _locals.ToArray(), _tokens.ToArray(), debugInfo);
+            result.CheckStackBalance();
             return result;
         }
 

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -306,7 +306,7 @@ namespace Internal.IL.Stubs
 
             unmarshallingCodestream.Emit(ILOpcode.ret);
 
-            return new  PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(_targetMethod, nonConformingStackWorkaround: true), 
+            return new  PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(_targetMethod), 
                 IsStubRequired());
         }
 
@@ -395,7 +395,7 @@ namespace Internal.IL.Stubs
         }
     }
 
-    public sealed class PInvokeILStubMethodIL : ILStubMethodILWithNonConformingStack
+    public sealed class PInvokeILStubMethodIL : ILStubMethodIL
     {
         public bool IsStubRequired { get; }
         public PInvokeILStubMethodIL(ILStubMethodIL methodIL, bool isStubRequired) : base(methodIL)

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -107,6 +107,7 @@ namespace Internal.IL.Stubs
         {
             ILEmitter emitter = ilCodeStreams.Emitter;
             ILCodeStream fnptrLoadStream = ilCodeStreams.FunctionPointerLoadStream;
+            ILCodeStream marshallingCodeStream = ilCodeStreams.MarshallingCodeStream;
             ILCodeStream callsiteSetupCodeStream = ilCodeStreams.CallsiteSetupCodeStream;
             TypeSystemContext context = _targetMethod.Context;
 
@@ -155,7 +156,7 @@ namespace Internal.IL.Stubs
 
                 ILLocalVariable vDelegateStub = emitter.NewLocal(delegateMethod.DelegateType);
                 fnptrLoadStream.EmitStLoc(vDelegateStub);
-                fnptrLoadStream.EmitLdLoc(vDelegateStub);
+                marshallingCodeStream.EmitLdLoc(vDelegateStub);
                 MethodDesc invokeMethod = delegateMethod.DelegateType.GetKnownMethod("Invoke", null);
                 callsiteSetupCodeStream.Emit(ILOpcode.callvirt, emitter.NewToken(invokeMethod));
             }

--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -304,10 +304,10 @@ namespace Internal.IL.Stubs
                 EmitPInvokeCall(pInvokeILCodeStreams);
             }
 
+            _marshallers[0].LoadReturnValue(unmarshallingCodestream);
             unmarshallingCodestream.Emit(ILOpcode.ret);
 
-            return new  PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(_targetMethod), 
-                IsStubRequired());
+            return new  PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(_targetMethod), IsStubRequired());
         }
 
         public static MethodIL EmitIL(MethodDesc method, 

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -849,7 +849,7 @@ namespace Internal.TypeSystem.Interop
             codeStream.Emit(ILOpcode.throw_);
             codeStream.Emit(ILOpcode.ret);
 
-            return new PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(method, nonConformingStackWorkaround: true), true);
+            return new PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(method), true);
         }
 
     }

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -847,9 +847,8 @@ namespace Internal.TypeSystem.Interop
             codeStream.Emit(ILOpcode.ldstr, emitter.NewToken(message));
             codeStream.Emit(ILOpcode.newobj, emitter.NewToken(exceptionCtor));
             codeStream.Emit(ILOpcode.throw_);
-            codeStream.Emit(ILOpcode.ret);
 
-            return new PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(method), true);
+            return new PInvokeILStubMethodIL((ILStubMethodIL)emitter.Link(method), isStubRequired: true);
         }
 
     }

--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -434,7 +434,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public void EmitArgumentMarshallingIL()
+        private void EmitArgumentMarshallingIL()
         {
             switch (MarshalDirection)
             {
@@ -443,7 +443,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public void EmitElementMarshallingIL()
+        private void EmitElementMarshallingIL()
         {
             switch (MarshalDirection)
             {
@@ -452,7 +452,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public void EmitFieldMarshallingIL()
+        private void EmitFieldMarshallingIL()
         {
             switch (MarshalDirection)
             {
@@ -526,14 +526,22 @@ namespace Internal.TypeSystem.Interop
             StoreNativeValue(_ilCodeStreams.ReturnValueMarshallingCodeStream);
 
             AllocAndTransformNativeToManaged(_ilCodeStreams.ReturnValueMarshallingCodeStream);
+        }
 
-            LoadManagedValue(_ilCodeStreams.ReturnValueMarshallingCodeStream);
+        public virtual void LoadReturnValue(ILCodeStream codeStream)
+        {
+            Debug.Assert(Return);
+
+            switch (MarshalDirection)
+            {
+                case MarshalDirection.Forward: LoadManagedValue(codeStream); return;
+                case MarshalDirection.Reverse: LoadNativeValue(codeStream); return;
+            }
         }
 
         protected virtual void SetupArguments()
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
-            ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
 
             if (MarshalDirection == MarshalDirection.Forward)
             {
@@ -560,7 +568,6 @@ namespace Internal.TypeSystem.Interop
         protected virtual void SetupArgumentsForElementMarshalling()
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
-            ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
 
             _managedHome = new Home(emitter.NewLocal(ManagedType), ManagedType, isByRef: false);
             _nativeHome = new Home(emitter.NewLocal(NativeType), NativeType, isByRef: false);
@@ -569,7 +576,6 @@ namespace Internal.TypeSystem.Interop
         protected virtual void SetupArgumentsForFieldMarshalling()
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
-            ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
 
             //
             // these are temporary locals for propagating value
@@ -581,7 +587,6 @@ namespace Internal.TypeSystem.Interop
         protected virtual void SetupArgumentsForReturnValueMarshalling()
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
-            ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
 
             _managedHome = new Home(emitter.NewLocal(ManagedType), ManagedType, isByRef: false);
             _nativeHome = new Home(emitter.NewLocal(NativeType), NativeType, isByRef: false);
@@ -768,8 +773,6 @@ namespace Internal.TypeSystem.Interop
             StoreManagedValue(_ilCodeStreams.ReturnValueMarshallingCodeStream);
 
             AllocAndTransformManagedToNative(_ilCodeStreams.ReturnValueMarshallingCodeStream);
-
-            LoadNativeValue(_ilCodeStreams.ReturnValueMarshallingCodeStream);
         }
 
         protected virtual void EmitMarshalArgumentNativeToManaged()
@@ -901,6 +904,10 @@ namespace Internal.TypeSystem.Interop
         }
         protected override void EmitMarshalReturnValueNativeToManaged()
         {
+        }
+        public override void LoadReturnValue(ILCodeStream codeStream)
+        {
+            Debug.Assert(Return);
         }
     }
 
@@ -1174,8 +1181,7 @@ namespace Internal.TypeSystem.Interop
 
             codeStream.EmitLdLoc(vIndex);
             codeStream.EmitLdLoc(vLength);
-            codeStream.Emit(ILOpcode.clt);
-            codeStream.Emit(ILOpcode.brtrue, lLoopHeader);
+            codeStream.Emit(ILOpcode.blt, lLoopHeader);
             codeStream.EmitLabel(lNullArray);
         }
 
@@ -1243,8 +1249,7 @@ namespace Internal.TypeSystem.Interop
             codeStream.EmitLabel(lRangeCheck);
             codeStream.EmitLdLoc(vIndex);
             codeStream.EmitLdLoc(vLength);
-            codeStream.Emit(ILOpcode.clt);
-            codeStream.Emit(ILOpcode.brtrue, lLoopHeader);
+            codeStream.Emit(ILOpcode.blt, lLoopHeader);
             codeStream.EmitLabel(lNullArray);
         }
 
@@ -1323,8 +1328,7 @@ namespace Internal.TypeSystem.Interop
 
                 codeStream.EmitLdLoc(vIndex);
                 codeStream.EmitLdLoc(vLength);
-                codeStream.Emit(ILOpcode.clt);
-                codeStream.Emit(ILOpcode.brtrue, lLoopHeader);
+                codeStream.Emit(ILOpcode.blt, lLoopHeader);
             }
 
             LoadNativeValue(codeStream);
@@ -2042,8 +2046,7 @@ namespace Internal.TypeSystem.Interop
             codeStream.EmitLdLoc(vIndex);
 
             codeStream.EmitLdLoc(vLength);
-            codeStream.Emit(ILOpcode.clt);
-            codeStream.Emit(ILOpcode.brtrue, lLoopHeader);
+            codeStream.Emit(ILOpcode.blt, lLoopHeader);
 
             codeStream.EmitLabel(lDone);
         }
@@ -2121,8 +2124,7 @@ namespace Internal.TypeSystem.Interop
 
             codeStream.EmitLdLoc(vIndex);
             codeStream.EmitLdLoc(vLength);
-            codeStream.Emit(ILOpcode.clt);
-            codeStream.Emit(ILOpcode.brtrue, lLoopHeader);
+            codeStream.Emit(ILOpcode.blt, lLoopHeader);
         }
     }
 

--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -1102,7 +1102,7 @@ namespace Internal.TypeSystem.Interop
             codeStream.Emit(ILOpcode.brfalse, lNullArray);
 
             // allocate memory
-            // nativeParameter = (byte**)CoTaskMemAllocAndZeroMemory((IntPtr)(checked(manageParameter.Length * sizeof(byte*))));
+            // nativeParameter = (byte**)CoTaskMemAllocAndZeroMemory((IntPtr)(checked(managedParameter.Length * sizeof(byte*))));
 
             // loads the number of elements
             EmitElementCount(codeStream, MarshalDirection.Forward);
@@ -1111,10 +1111,6 @@ namespace Internal.TypeSystem.Interop
             codeStream.Emit(ILOpcode.sizeof_, emitter.NewToken(nativeElementType));
 
             codeStream.Emit(ILOpcode.mul_ovf);
-            codeStream.Emit(ILOpcode.call, emitter.NewToken(
-                                Context.SystemModule.
-                                    GetKnownType("System", "IntPtr").
-                                        GetKnownMethod("op_Explicit", null)));
 
             codeStream.Emit(ILOpcode.call, emitter.NewToken(
                                 Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemAllocAndZeroMemory")));


### PR DESCRIPTION
The marshalling code was keeping return value pushed value on IL stack during whole
unmarshalling sequece. It made it easy for backward branches in the unmarshalling
code to break the CIL backwards branch constraint. The fix is to push the return value
onto IL stack right before returning.

Fixes #5152