### PR TITLE
Make generic method definitions not runtime determined

### DIFF
--- a/src/Common/src/TypeSystem/RuntimeDetermined/DefType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/DefType.RuntimeDetermined.cs
@@ -10,6 +10,10 @@ namespace Internal.TypeSystem
         {
             get
             {
+                // Handles situation when shared code refers to uninstantiated generic
+                // type definitions (think: LDTOKEN).
+                // Walking the instantiation would make us assert. This is simply
+                // not a runtime determined type.
                 if (IsGenericDefinition)
                     return false;
 

--- a/src/Common/src/TypeSystem/RuntimeDetermined/MethodDesc.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/MethodDesc.RuntimeDetermined.cs
@@ -84,6 +84,13 @@ namespace Internal.TypeSystem
                 if (containingType.IsRuntimeDeterminedSubtype)
                     return true;
 
+                // Handles situation when shared code refers to uninstantiated generic
+                // method definitions (think: LDTOKEN).
+                // Walking the instantiation would make us assert. This is simply
+                // not a runtime determined method.
+                if (IsGenericMethodDefinition)
+                    return false;
+
                 foreach (TypeDesc typeArg in Instantiation)
                 {
                     if (typeArg.IsRuntimeDeterminedSubtype)


### PR DESCRIPTION
This should be handled the same way we handle generic type definitions.

The test I added in dotnet/coreclr#10592 is asserting the compiler without this.