### PR TITLE
Fix handling of default runtime handles

### DIFF
--- a/src/System.Private.CoreLib/src/System/RuntimeFieldHandle.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeFieldHandle.cs
@@ -31,6 +31,9 @@ namespace System
             if (_value == handle._value)
                 return true;
 
+            if (_value == IntPtr.Zero || handle._value == IntPtr.Zero)
+                return false;
+
             string fieldName1, fieldName2;
             RuntimeTypeHandle declaringType1, declaringType2;
 
@@ -48,6 +51,9 @@ namespace System
 
         public override int GetHashCode()
         {
+            if (_value == IntPtr.Zero)
+                return 0;
+
             string fieldName;
             RuntimeTypeHandle declaringType;
             RuntimeAugments.TypeLoaderCallbacks.GetRuntimeFieldHandleComponents(this, out declaringType, out fieldName);

--- a/src/System.Private.CoreLib/src/System/RuntimeMethodHandle.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeMethodHandle.cs
@@ -33,6 +33,9 @@ namespace System
             if (_value == handle._value)
                 return true;
 
+            if (_value == IntPtr.Zero || handle._value == IntPtr.Zero)
+                return false;
+
             RuntimeTypeHandle declaringType1, declaringType2;
             MethodNameAndSignature nameAndSignature1, nameAndSignature2;
             RuntimeTypeHandle[] genericArgs1, genericArgs2;
@@ -68,6 +71,9 @@ namespace System
 
         public override int GetHashCode()
         {
+            if (_value == IntPtr.Zero)
+                return 0;
+
             RuntimeTypeHandle declaringType;
             MethodNameAndSignature nameAndSignature;
             RuntimeTypeHandle[] genericArgs;


### PR DESCRIPTION
Found by running CoreCLR tests. We would AV since the pointer is null.
