### PR TITLE
[WIP] Remove reflection in ValueType.Equals/GetHashCode

### DIFF
--- a/src/Common/src/Internal/NativeFormat/NativeFormat.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormat.cs
@@ -59,6 +59,7 @@ namespace Internal.NativeFormat
         GenericVarianceInfo         = 0x50,
         DelegateInvokeSignature     = 0x51,
         GcStaticEEType              = 0x52,
+        InstanceFieldLayout         = 0x53,
 
         // Add new custom bag elements that don't match to something you'd find in the ECMA metadata here.
     }

--- a/src/Common/src/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormatWriter.cs
@@ -680,6 +680,14 @@ namespace Internal.NativeFormat
     {
         private List<Vertex> _elements;
 
+        public int Count
+        {
+            get
+            {
+                return _elements.Count;
+            }
+        }
+
         public VertexSequence()
         {
             _elements = new List<Vertex>();

--- a/src/Common/src/Internal/Runtime/MetadataBlob.cs
+++ b/src/Common/src/Internal/Runtime/MetadataBlob.cs
@@ -43,5 +43,6 @@ namespace Internal.Runtime
         StaticsInfoHashtable                        = 34,
         GenericMethodsHashtable                     = 35,
         ExactMethodInstantiationsHashtable          = 36,
+        InstanceFieldLayoutHashtable                = 37,
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -130,6 +130,10 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(new DependencyListEntry(factory.TypeNonGCStaticsSymbol((MetadataType)_type), "Class constructor"));
             }
 
+            // TODO: this should really be conditional in some way - this depends on whether the class library
+            // is able to use this (and whether we have a classlib with Equals/GetHashCode on System.Object in the first place)
+            InstanceFieldLayoutNode.AddDependenciesDueToEETypePresence(ref dependencyList, factory, _type);
+
             // Ask the metadata manager if we have any dependencies due to reflectability.
             factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencyList, factory, _type);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InstanceFieldLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InstanceFieldLayoutNode.cs
@@ -1,0 +1,212 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.NativeFormat;
+using Internal.Text;
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+using TypeFlags = Internal.TypeSystem.TypeFlags;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a hashtable that describes instance field layout of select types.
+    /// Instance field layout information includes information about offsets and types of instance fields.
+    /// </summary>
+    internal sealed class InstanceFieldLayoutNode : ObjectNode, ISymbolDefinitionNode
+    {
+        private readonly ObjectAndOffsetSymbolNode _endSymbol;
+        private readonly ExternalReferencesTableNode _externalReferences;
+
+        public InstanceFieldLayoutNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__instanceFieldLayout_End", true);
+            _externalReferences = externalReferences;
+        }
+
+        public ISymbolNode EndSymbol => _endSymbol;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__instanceFieldLayout");
+        }
+        public int Offset => 0;
+        public override bool IsShareable => false;
+
+        public override ObjectNodeSection Section => _externalReferences.Section;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        public static void AddDependenciesDueToEETypePresence(ref DependencyList dependencyList, NodeFactory factory, TypeDesc type)
+        {
+            if (factory.Target.Abi == TargetAbi.ProjectN)
+                return;
+
+            // The hash table will reference the types of all instance field if this type qualifies
+            if (NeedsFieldLayoutInformation(type))
+            {
+                dependencyList = dependencyList ?? new DependencyList();
+
+                foreach (FieldDesc field in type.GetFields())
+                {
+                    if (field.IsStatic)
+                        continue;
+
+                    TypeDesc fieldType = NormalizeFieldType(field.FieldType);                    
+                    dependencyList.Add(factory.ConstructedTypeSymbol(fieldType), "Instance field layout");
+                }
+            }
+        }
+
+        public static bool NeedsFieldLayoutInformation(TypeDesc type)
+        {
+            // We need field layout information for boxable valuetypes that cannot be compared
+            // bit-by-bit.
+            //
+            // One might think that the presence of Equals/GetHashCode overrides on the type
+            // would mean we no longer need this information, but we have seen customer code
+            // that does:
+            //
+            // public override bool Equals(object obj) => base.Equals(obj);
+            //
+            // to shut up analyzer warnings (demonstrating their lack of understanding why the
+            // warning shows up in the first place). We need this information in case the customer
+            // code does that.
+            return type.IsValueType &&
+                !type.IsByRefLike &&
+                !CanCompareBits((MetadataType)type);
+        }
+        
+        public static TypeDesc NormalizeFieldType(TypeDesc fieldType)
+        {
+            TypeSystemContext context = fieldType.Context;
+
+            // We don't care about the exact type for reference types. This lets us save some size on disk.
+            if (fieldType.IsGCPointer)
+                fieldType = context.GetWellKnownType(WellKnownType.Object);
+
+            // We need something boxable
+            if (fieldType.IsPointer || fieldType.IsFunctionPointer)
+                fieldType = context.GetWellKnownType(WellKnownType.IntPtr);
+
+            return fieldType;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
+
+            var writer = new NativeWriter();
+            var typeMapHashTable = new VertexHashtable();
+
+            Section hashTableSection = writer.NewSection();
+            hashTableSection.Place(typeMapHashTable);
+
+            foreach (var type in factory.MetadataManager.GetTypesWithConstructedEETypes())
+            {
+                if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
+                    continue;
+
+                if (!NeedsFieldLayoutInformation(type))
+                    continue;
+
+                VertexSequence fieldsSequence = new VertexSequence();
+                foreach (FieldDesc field in type.GetFields())
+                {
+                    if (field.IsStatic)
+                        continue;
+
+                    TypeDesc fieldType = NormalizeFieldType(field.FieldType);
+                    IEETypeNode fieldTypeSymbol = factory.ConstructedTypeSymbol(fieldType);
+
+                    fieldsSequence.Append(writer.GetTuple(
+                        writer.GetUnsignedConstant(_externalReferences.GetIndex(fieldTypeSymbol)),
+                        writer.GetUnsignedConstant((uint)field.Offset.AsInt)));
+                }
+
+                IEETypeNode typeSymbol = factory.ConstructedTypeSymbol(type);
+
+                Vertex vertex = writer.GetTuple(
+                    writer.GetUnsignedConstant(_externalReferences.GetIndex(typeSymbol)),
+                    fieldsSequence
+                    );
+
+                int hashCode = type.GetHashCode();
+                typeMapHashTable.Append((uint)hashCode, hashTableSection.Place(vertex));
+            }
+
+            byte[] hashTableBytes = writer.Save();
+
+            _endSymbol.SetSymbolOffset(hashTableBytes.Length);
+
+            return new ObjectData(hashTableBytes, Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this, _endSymbol });
+        }
+
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        protected internal override int ClassCode => (int)ObjectNodeOrder.InstanceFieldLayoutNode;
+
+        private static bool CanCompareBits(MetadataType type)
+        {
+            Debug.Assert(type.IsValueType);
+
+            if (type.ContainsGCPointers)
+                return false;
+
+            // TODO: what we're shooting for is overlapping fields
+            // or gaps between fields
+            if (type.IsExplicitLayout || type.GetClassLayout().Size != 0)
+                return false;
+
+            bool result = true;
+            foreach (var field in type.GetFields())
+            {
+                if (field.IsStatic)
+                    continue;
+
+                TypeDesc fieldType = field.FieldType;
+                if (fieldType.IsPrimitive || fieldType.IsEnum || fieldType.IsPointer || fieldType.IsFunctionPointer)
+                {
+                    TypeFlags category = fieldType.Category;
+                    if (category == TypeFlags.Single || category == TypeFlags.Double)
+                    {
+                        // Double/Single have weird behaviors around NaN
+                        result = false;
+                        break;
+                    }
+                }
+                else
+                {
+                    // Would be a suprise if this wasn't a valuetype. We checked ContainsGCPointers above.
+                    Debug.Assert(fieldType.IsValueType);
+
+                    // TODO: might want to cache the Equals/GetHashCode MethodDesc in a central location.
+                    MethodDesc equalsMethod = type.Context.GetWellKnownType(WellKnownType.Object).GetMethod("Equals", null);
+                    MethodDesc hashCodeMethod = type.Context.GetWellKnownType(WellKnownType.Object).GetMethod("GetHashCode", null);
+                    if (fieldType.FindVirtualFunctionTargetMethodOnObjectType(equalsMethod) != null ||
+                        fieldType.FindVirtualFunctionTargetMethodOnObjectType(hashCodeMethod) != null)
+                    {
+                        result = false;
+                        break;
+                    }
+
+                    if (!CanCompareBits((MetadataType)fieldType))
+                    {
+                        result = false;
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SortableDependencyNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SortableDependencyNode.cs
@@ -57,6 +57,7 @@ namespace ILCompiler.DependencyAnalysis
             ResourceDataNode,
             ResourceIndexNode,
             TypeMetadataMapNode,
+            InstanceFieldLayoutNode,
             ClassConstructorContextMap,
             DynamicInvokeTemplateDataNode,
             ReflectionInvokeMapNode,

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -138,6 +138,9 @@ namespace ILCompiler
 #if !CORERT
             var stackTraceEmbeddedMetadataNode = new StackTraceEmbeddedMetadataNode();
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.BlobIdStackTraceEmbeddedMetadata), stackTraceEmbeddedMetadataNode, stackTraceEmbeddedMetadataNode, stackTraceEmbeddedMetadataNode.EndSymbol);
+#else
+            var instanceFieldLayoutNode = new InstanceFieldLayoutNode(nativeReferencesTableNode);
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.InstanceFieldLayoutHashtable), instanceFieldLayoutNode, instanceFieldLayoutNode, instanceFieldLayoutNode.EndSymbol);
 #endif
 
             var stackTraceMethodMappingNode = new StackTraceMethodMappingNode();

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Compiler\DependencyAnalysis\DefaultConstructorMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsWithIndirectionImportedNodeProvider.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\InstanceFieldLayoutNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MrtImportImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MrtImports.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MrtProcessedExportAddressTableNode.cs" />

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -1120,6 +1120,11 @@ namespace Internal.Runtime.Augments
             return RuntimeImports.RhBoxAny((void*)pData, new EETypePtr(pEEType));
         }
 
+        public static unsafe object RhBoxAny(ref byte data, RuntimeTypeHandle typeHandle)
+        {
+            return RuntimeImports.RhBoxAny(ref data, typeHandle.ToEETypePtr());
+        }
+
         public static IntPtr RhHandleAlloc(Object value, GCHandleType type)
         {
             return RuntimeImports.RhHandleAlloc(value, type);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
@@ -25,6 +25,8 @@ namespace Internal.Runtime.Augments
         public abstract bool TryGetPointerTypeForTargetType(RuntimeTypeHandle pointeeTypeHandle, out RuntimeTypeHandle pointerTypeHandle);
         public abstract bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, bool isMdArray, int rank, out RuntimeTypeHandle arrayTypeHandle);
         public abstract IntPtr UpdateFloatingDictionary(IntPtr context, IntPtr dictionaryPtr);
+        public abstract bool ValueTypeEquals(ValueType thisObj, object thatObj);
+        public abstract int ValueTypeGetHashCode(ValueType thisObj);
         
         /// <summary>
         /// Register a new runtime-allocated code thunk in the diagnostic stream.

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -340,6 +340,10 @@ namespace System.Runtime
         internal static extern unsafe object RhBoxAny(void* pData, EETypePtr pEEType);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhBoxAny")]
+        internal static extern unsafe object RhBoxAny(ref byte pData, EETypePtr pEEType);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhNewObject")]
         internal static extern object RhNewObject(EETypePtr pEEType);
 

--- a/src/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/System.Private.CoreLib/src/System/ValueType.cs
@@ -28,12 +28,26 @@ namespace System
 
         public override bool Equals(object obj)
         {
+#if PROJECTN
             return RuntimeAugments.Callbacks.ValueTypeEqualsUsingReflection(this, obj);
+#else
+            if (obj == null)
+                return false;
+
+            if (EETypePtr != obj.EETypePtr)
+                return false;
+
+            return RuntimeAugments.TypeLoaderCallbacks.ValueTypeEquals(this, obj);
+#endif
         }
 
         public override int GetHashCode()
         {
+#if PROJECTN
             return RuntimeAugments.Callbacks.ValueTypeGetHashCodeUsingReflection(this);
+#else
+            return RuntimeAugments.TypeLoaderCallbacks.ValueTypeGetHashCode(this);
+#endif
         }
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -629,6 +629,11 @@ namespace Internal.Runtime.TypeLoader
                         typeInfoParser.SkipInteger(); // Handled in type layout algorithm
                         break;
 
+                    case BagElementKind.InstanceFieldLayout:
+                        TypeLoaderLogger.WriteLine("Found BagElementKind.InstanceFieldLayout");
+                        typeInfoParser.SkipInteger(); // Handled in ValueType.GetHashCode/Equals support code
+                        break;
+
                     case BagElementKind.VTableMethodSignatures:
                         TypeLoaderLogger.WriteLine("Found BagElementKind.VTableMethodSignatures");
                         ParseVTableMethodSignatures(state, context, typeInfoParser.GetParserFromRelativeOffset());

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ValueTypeSupport.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ValueTypeSupport.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Runtime.InteropServices;
+
+using Internal.Runtime.Augments;
+using Internal.Runtime.CompilerServices;
+using Internal.NativeFormat;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.Runtime.TypeLoader
+{
+    //
+    // Implements functionality to support ValueType.Equals and ValueType.GetHashCode
+    //
+    partial class TypeLoaderEnvironment
+    {
+        public bool ValueTypeEquals(ValueType thisObj, object thatObj)
+        {
+            RuntimeTypeHandle typeHandle = RuntimeAugments.GetRuntimeTypeHandleFromObjectReference(thisObj);
+
+            Debug.Assert(typeHandle.Equals(RuntimeAugments.GetRuntimeTypeHandleFromObjectReference(thatObj)));
+            Debug.Assert(thatObj != null);
+
+            if (!RuntimeAugments.IsDynamicType(typeHandle))
+            {
+                return StaticValueTypeEquals(typeHandle, thisObj, thatObj);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool StaticValueTypeEquals(RuntimeTypeHandle typeHandle, ValueType thisObj, object thatObj)
+        {
+            NativeFormatModuleInfo module = ModuleList.GetModuleInfoByHandle(RuntimeAugments.GetModuleFromTypeHandle(typeHandle));
+            
+            NativeHashtable layoutHashTable;
+            ExternalReferencesTable externalReferencesLookup;
+
+            if (!GetHashtableFromBlob(module, ReflectionMapBlob.InstanceFieldLayoutHashtable, out layoutHashTable, out externalReferencesLookup))
+                Environment.FailFast("Instance field layout not generated");
+
+            ref byte thisRawData = ref RuntimeAugments.GetRawData(thisObj);
+            ref byte thatRawData = ref RuntimeAugments.GetRawData(thatObj);
+
+            var enumerator = layoutHashTable.Lookup(typeHandle.GetHashCode());
+
+            //
+            // First try to find instance field layout information in the hashtable.
+            //
+            NativeParser entryParser;
+            while (!(entryParser = enumerator.GetNext()).IsNull)
+            {
+                RuntimeTypeHandle tentativeType = externalReferencesLookup.GetRuntimeTypeHandleFromIndex(entryParser.GetUnsigned());
+                if (!typeHandle.Equals(tentativeType))
+                    continue;
+
+                // Found the entry - for each field, compare the fields for equality
+                int fieldCount = (int)entryParser.GetUnsigned();
+                for (int i = 0; i < fieldCount; i++)
+                {
+                    RuntimeTypeHandle fieldType = externalReferencesLookup.GetRuntimeTypeHandleFromIndex(entryParser.GetUnsigned());
+                    int fieldOffset = (int)entryParser.GetUnsigned();
+
+                    // Fetch the value of the field on both types
+                    object thisField = RuntimeAugments.RhBoxAny(ref Unsafe.Add(ref thisRawData, fieldOffset), fieldType);
+                    object thatField = RuntimeAugments.RhBoxAny(ref Unsafe.Add(ref thatRawData, fieldOffset), fieldType);
+
+                    if (thisField == null)
+                    {
+                        if (thatField != null)
+                            return false;
+                    }
+                    else if (!thisField.Equals(thatField))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            //
+            // If the field layout information isn't present, we can memcompare
+            //
+
+            // Sanity check
+            Debug.Assert(RuntimeAugments.GetGCDescSize(typeHandle) == 0);
+
+            int valueTypeSize = typeHandle.GetValueTypeSize();
+            for (int i = 0; i < valueTypeSize; i++)
+                if (Unsafe.Add(ref thisRawData, i) != Unsafe.Add(ref thatRawData, i))
+                    return false;
+
+            return true;
+        }
+
+        public int ValueTypeGetHashCode(ValueType thisObj)
+        {
+            RuntimeTypeHandle typeHandle = RuntimeAugments.GetRuntimeTypeHandleFromObjectReference(thisObj);
+
+            if (!RuntimeAugments.IsDynamicType(typeHandle))
+            {
+                return StaticValueTypeGetHashCode(typeHandle, thisObj);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private int StaticValueTypeGetHashCode(RuntimeTypeHandle typeHandle, ValueType thisObj)
+        {
+            // TODO: we should also use hashcode of the type
+
+            NativeFormatModuleInfo module = ModuleList.GetModuleInfoByHandle(RuntimeAugments.GetModuleFromTypeHandle(typeHandle));
+
+            NativeHashtable layoutHashTable;
+            ExternalReferencesTable externalReferencesLookup;
+
+            if (!GetHashtableFromBlob(module, ReflectionMapBlob.InstanceFieldLayoutHashtable, out layoutHashTable, out externalReferencesLookup))
+                Environment.FailFast("Instance field layout not generated");
+
+            ref byte thisRawData = ref RuntimeAugments.GetRawData(thisObj);
+
+            var enumerator = layoutHashTable.Lookup(typeHandle.GetHashCode());
+
+            //
+            // First try to find instance field layout information in the hashtable.
+            //
+            NativeParser entryParser;
+            while (!(entryParser = enumerator.GetNext()).IsNull)
+            {
+                RuntimeTypeHandle tentativeType = externalReferencesLookup.GetRuntimeTypeHandleFromIndex(entryParser.GetUnsigned());
+                if (!typeHandle.Equals(tentativeType))
+                    continue;
+
+                // Found the entry - find the first non-null field
+                int fieldCount = (int)entryParser.GetUnsigned();
+                for (int i = 0; i < fieldCount; i++)
+                {
+                    RuntimeTypeHandle fieldType = externalReferencesLookup.GetRuntimeTypeHandleFromIndex(entryParser.GetUnsigned());
+                    int fieldOffset = (int)entryParser.GetUnsigned();
+                    
+                    // TODO: the CLR doesn't seem to be boxing and calling GetHashCode on valuetype fields, even if they
+                    //       override GetHashCode? We might be able to get rid of the box here.
+                    object fieldValue = RuntimeAugments.RhBoxAny(ref Unsafe.Add(ref thisRawData, fieldOffset), fieldType);
+                    if (fieldValue != null)
+                        return fieldValue.GetHashCode();
+                }
+
+                // Found no non-null fields
+                return 0;
+            }
+
+            //
+            // If the field layout information isn't present, we can hash the memory
+            //
+            return FastValueTypeGetHashCode(ref thisRawData, typeHandle);
+        }
+
+        private static int FastValueTypeGetHashCode(ref byte location, RuntimeTypeHandle type)
+        {
+            int size = RuntimeAugments.GetValueTypeSize(type);
+            int hashCode = 0;
+
+            for (int i = 0; i < size / 4; i++)
+            {
+                hashCode ^= Unsafe.As<byte, int>(ref Unsafe.Add(ref location, i * 4));
+            }
+
+            return hashCode;
+        }
+    }
+}

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -91,6 +91,16 @@ namespace Internal.Runtime.TypeLoader
             return TypeLoaderEnvironment.Instance.UpdateFloatingDictionary(context, dictionaryPtr);
         }
 
+        public override bool ValueTypeEquals(ValueType thisObj, object thatObj)
+        {
+            return TypeLoaderEnvironment.Instance.ValueTypeEquals(thisObj, thatObj);
+        }
+
+        public override int ValueTypeGetHashCode(ValueType thisObj)
+        {
+            return TypeLoaderEnvironment.Instance.ValueTypeGetHashCode(thisObj);
+        }
+
         /// <summary>
         /// Register a new runtime-allocated code thunk in the diagnostic stream.
         /// </summary>

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -473,6 +473,7 @@
     <Compile Include="Internal\Runtime\TypeLoader\TypeLoaderEnvironment.NamedTypeLookup.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\TypeLoaderEnvironment.SignatureParsing.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\TypeLoaderEnvironment.StaticsLookup.cs" />
+    <Compile Include="Internal\Runtime\TypeLoader\TypeLoaderEnvironment.ValueTypeSupport.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\TypeLoaderLogger.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\TypeLoaderTypeSystemContext.cs" />
     <Compile Include="Internal\Runtime\TypeLoader\TypeSystemContextFactory.cs" />


### PR DESCRIPTION
My weekend project. Contributes to #5013.

This adds support for emitting new data structures that describe instance field layout of valuetypes that can't be memcompared. The data structure enables us to iterate over fields at runtime and compare them individually.

Adds 7 kB to hello world. The cost of the new blob is about 2 kB and the rest of the diff is a mixed bag of regressions and improvements.

On the improvements side:
* The part of the reflection stack that reads fields using reflection is gone from the image
* We now generate some new code and EETypes for valuetypes we didn't previously generate. E.g. we now generate an EEType for `System.EETypePtr` since `OpenMethodResolver` has a field of that type.

We can get some decent size back if we do some extra work around reflection blocking (to make sure various internal (but "public" in the assembly) valuetypes are not considered reflectable, and therefore boxed, and therefore needing this extra data).
  