### PR TITLE
 Normalize reflectable methods to slot defining methods 

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -401,7 +401,7 @@ namespace ILCompiler
                 Debug.Assert(method.IsVirtual);
 
                 // Virtual method use is tracked on the slot defining method only.
-                MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method).Normalize();
                 if (!_factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
                     _graph.AddRoot(_factory.VirtualMethodUse(slotDefiningMethod), reason);
 

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -669,7 +669,7 @@ namespace Internal.IL
             else
             {
                 MethodDesc slotDefiningMethod = targetMethod.IsNewSlot ?
-                        targetMethod : MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(targetMethod);
+                        targetMethod : MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(targetMethod).Normalize();
                 _dependencies.Add(_factory.VirtualMethodUse(slotDefiningMethod), reason);
             }
         }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -3340,7 +3340,7 @@ namespace Internal.JitInterface
                     // Get the slot defining method to make sure our virtual method use tracking gets this right.
                     // For normal C# code the targetMethod will always be newslot.
                     MethodDesc slotDefiningMethod = targetMethod.IsNewSlot ?
-                        targetMethod : MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(targetMethod);
+                        targetMethod : MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(targetMethod).Normalize();
 
                     pResult.codePointerOrStubLookup.constLookup = 
                         CreateConstLookupToSymbol(


### PR DESCRIPTION
Fixes the MonoGame NeonShooter sample.

The other commit fixes it in two more spots for good measure.