### PR TITLE
Add ability to build CoreRT with VS BuildTools 2017

### DIFF
--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -118,7 +118,7 @@ if defined VisualStudioVersion goto :RunVCVars
 
 set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 if exist %_VSWHERE% (
-  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -prerelease -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
+  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -prerelease -property installationPath -products *`) do set _VSCOMNTOOLS=%%i\Common7\Tools
 )
 if not exist "%_VSCOMNTOOLS%" goto :MissingVersion
 


### PR DESCRIPTION
Dockerfile that builds CoreRT win-x64 packages: https://gist.github.com/am11/826911cbf6c26ea1de4747176ca2b57c

* Line 17 is required by `dotnet/buildtools`
* Line 18 and 19 are required by MSBuild
