### PR TITLE
Force link time symbol resolution for "__Internal" module for compatibility with Mono

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -101,6 +101,10 @@ namespace Internal.TypeSystem.Interop
             if (importModule == "[MRT]" || importModule == "*")
                 return false;
 
+            // Force link time symbol resolution for "__Internal" module for compatibility with Mono
+            if (importModule == "__Internal")
+                return false;
+
             if (method.Context.Target.IsWindows)
             {
                 return !importModule.StartsWith("api-ms-win-");


### PR DESCRIPTION
Addressing @kekekeks feedback on gitter:

    AFAIK, Mono uses __Internal for statically linked libraries

    Using * means additional work for library maintainers (another #if in P/Invoke declaration code)