### PR TITLE
Make updates to RD.XML invalidate the IlcCompile target

### DIFF
--- a/samples/MonoGame/NeonShooter.csproj
+++ b/samples/MonoGame/NeonShooter.csproj
@@ -5,8 +5,11 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DefineConstants>$(DefineConstants);WINDOWS;LINUX</DefineConstants>
-    <RdXmlFile>rd.xml</RdXmlFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <RdXmlFile Include="rd.xml" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="MonoGame.Samples\NeonShooter\Game.cs">

--- a/samples/MonoGame/Platformer2D.csproj
+++ b/samples/MonoGame/Platformer2D.csproj
@@ -5,8 +5,11 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DefineConstants>$(DefineConstants);WINDOWS;LINUX</DefineConstants>
-    <RdXmlFile>rd.xml</RdXmlFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <RdXmlFile Include="rd.xml" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="MonoGame.Samples\Platformer2D\Game\Accelerometer.cs">

--- a/samples/MonoGame/README.md
+++ b/samples/MonoGame/README.md
@@ -81,12 +81,12 @@ MonoGame samples include project files for number of targets, but not for .NET C
 The NeonShooter sample works on Windows-only due to https://github.com/MonoGame/MonoGame/issues/3270.
 
 ## Using reflection 
-Runtime directives are XML configuration files, which specify which otherwise unreachable elements of your program are available for reflection. They are used at compile-time to enable AOT compilation in applications at runtime. The runtime directives are reference in the project via RdXmlFile property:
+Runtime directives are XML configuration files, which specify which otherwise unreachable elements of your program are available for reflection. They are used at compile-time to enable AOT compilation in applications at runtime. The runtime directives are reference in the project via RdXmlFile item:
 
 ```xml
-<PropertyGroup>
-  <RdXmlFile>rd.xml</RdXmlFile>
-</PropertyGroup>
+<ItemGroup>
+  <RdXmlFile Include="rd.xml" />
+</ItemGroup>
 ```
 
 MonoGame serialization engine uses reflection to create types representing the game assets that needs to mentioned in the [rd.xml](rd.xml) file. If you see MissingMetadataException thrown during game startup, add the missing types to the rd.xml file.

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -75,10 +75,10 @@ If your application makes use of reflection, you will need to create a rd.xml fi
 
 At runtime, if a method or type is not found or cannot be loaded, an exception will be thrown. The exception message will contain information on the missing type reference, which you can then add to the rd.xml of your program.
 
-Once you've created a rd.xml file, navigate to the root directory of your project and open its `.csproj` file and in the first `<PropertyGroup>` element add the following:
+Once you've created a rd.xml file, navigate to the root directory of your project and open its `.csproj` file and in the first `<ItemGroup>` element add the following:
 
 ```xml
-<RdXmlFile>path_to_rdxml_file\rd.xml</RdXmlFile>
+<RdXmlFile Include="path_to_rdxml_file\rd.xml" />
 ```
 
 where path_to_rdxml_file is the location of the file on your disk.

--- a/samples/WebApi/SampleWebApi.csproj
+++ b/samples/WebApi/SampleWebApi.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RdXmlFile>rd.xml</RdXmlFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <RdXmlFile Include="rd.xml" />
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="wwwroot\" />

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -141,7 +141,7 @@ See the LICENSE file in the project root for more information.
   </Target>
 
   <Target Name="IlcCompile" 
-      Inputs="@(IlcCompileInput)"
+      Inputs="@(IlcCompileInput);@(RdXmlFile)"
       Outputs="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
@@ -155,7 +155,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
       <IlcArg Condition="$(DebugSymbols) == 'true'" Include="-g" />
       <IlcArg Condition="$(IlcGenerateMapFile) == 'true'" Include="--map:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).map.xml" />
-      <IlcArg Condition="$(RdXmlFile) != ''" Include="--rdxml:$(RdXmlFile)" />
+      <IlcArg Include="@(RdXmlFile->'--rdxml:%(Identity)')" />
       <IlcArg Condition="$(OutputType) == 'Library' and $(NativeLib) != ''" Include="--nativelib" />
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
       <ILcArg Condition="'$(Platform)' == 'wasm'" Include="--wasm" />


### PR DESCRIPTION
When iterating on RD.XML changes we shouldn't have to delete all the intermediates to trigger a recompilation.

I took this as an opportunity to make `RdXmlFile` an item. The compiler supports multiple, and so should the project.