### PR TITLE
Fix MethodDesc.ToString in runtime type loader

### DIFF
--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/InstantiatedMethod.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/InstantiatedMethod.Runtime.cs
@@ -63,5 +63,16 @@ namespace Internal.TypeSystem
                 return _methodDef.UnboxingStub;
             }
         }
+
+#if DEBUG
+        public override string ToString()
+        {
+            var sb = new System.Text.StringBuilder(_methodDef.ToString());
+            sb.Append('<');
+            sb.Append(_instantiation.ToString());
+            sb.Append('>');
+            return sb.ToString();
+        }
+#endif
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/MethodForInstantiatedType.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/MethodForInstantiatedType.Runtime.cs
@@ -17,5 +17,12 @@ namespace Internal.TypeSystem
                 return _typicalMethodDef.NameAndSignature;
             }
         }
+
+#if DEBUG
+        public override string ToString()
+        {
+            return OwningType.ToString() + "." + Name; 
+        }
+#endif
     }
 }

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -17,6 +17,10 @@
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>TYPE_LOADER_IMPLEMENTATION;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition="'$(TYPE_LOADER_TRACE)' != ''">TYPE_LOADER_TRACE;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition="'$(GVM_RESOLUTION_TRACE)' != ''">GVM_RESOLUTION_TRACE;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition="'$(CCCONVERTER_TRACE)' != ''">CCCONVERTER_TRACE;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition="'$(GENERICS_FORCE_USG)' != ''">GENERICS_FORCE_USG;$(DefineConstants)</DefineConstants>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(EcmaMetadataSupport)' == 'true'">
@@ -33,13 +37,7 @@
     <DefineConstants>SUPPORT_JIT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsProjectNLibrary)' == 'true'">
-    <DefineConstants>TYPE_LOADER_IMPLEMENTATION;$(DefineConstants)</DefineConstants>
     <DefineConstants>FEATURE_INTERPRETER;$(DefineConstants)</DefineConstants>
-    <DefineConstants Condition="'$(CCCONVERTER_TRACE)' != ''">CCCONVERTER_TRACE;$(DefineConstants)</DefineConstants>
-    <DefineConstants Condition="'$(TYPE_LOADER_TRACE)' != ''">TYPE_LOADER_TRACE;$(DefineConstants)</DefineConstants>
-    <DefineConstants Condition="'$(GENERICS_FORCE_USG)' != ''">GENERICS_FORCE_USG;$(DefineConstants)</DefineConstants>
-    <DefineConstants Condition="'$(GVM_RESOLUTION_TRACE)' != ''">GVM_RESOLUTION_TRACE;$(DefineConstants)</DefineConstants>
-    <DefineConstants>TYPE_SYSTEM_SINGLE_THREADED;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <!-- Setup the right references -->
   <ItemGroup>
@@ -533,9 +531,6 @@
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
     <Compile Include="..\..\Common\src\TypeSystem\Common\TypeDesc.ToString.cs">
       <Link>Internal\TypeSystem\TypeDesc.ToString.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.ToString.cs">
-      <Link>Internal\TypeSystem\MethodDesc.ToString.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\FieldDesc.ToString.cs">
       <Link>Internal\TypeSystem\FieldDesc.ToString.cs</Link>


### PR DESCRIPTION
The full `ToString` implementation includes the signature to help diagnosability, but the runtime type loader might not be able to provide that information.

Stop including MethodDesc.ToString.cs in the runtime type loader and restore old overrides on `MethodForInstantiatiatedType` and `InstantiatedMethod` that got deleted in #5065 (but only for the runtime type loader).

Also fixing up the the project file:
* The tracing options should also be available in CoreRT
* Deleting `TYPE_SYSTEM_SINGLE_THREADED` that got introduced in TFS changeset 1553623 and got never used for anything