### PR TITLE
Remove overly aggressive assert

### DIFF
--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeNoMetadataType.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeNoMetadataType.cs
@@ -94,7 +94,6 @@ namespace Internal.TypeSystem.NoMetadata
                 }
                 else
                 {
-                    Debug.Assert(this.HasNativeLayout);
                     // Parsing of the base type has not yet happened. Perform that part of native layout parsing
                     // just-in-time
                     TypeBuilderState state = GetOrCreateTypeBuilderState();


### PR DESCRIPTION
It's possible to reach this code path with no native layout information available with this stack:

```
reproNative.exe!S_P_TypeLoader_Internal_TypeSystem_NoMetadata_NoMetadataType__get_BaseType() Line 97	Unknown	Symbols loaded.
reproNative.exe!S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilder__PrepareBaseTypeAndDictionaries() Line 366	Unknown	Symbols loaded.
reproNative.exe!S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilder__PrepareType() Line 331	Unknown	Symbols loaded.
reproNative.exe!S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilder__BuildType() Line 1622	Unknown	Symbols loaded.
reproNative.exe!S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilder__TryBuildGenericType() Line 1987	Unknown	Symbols loaded.
reproNative.exe!S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetConstructedGenericTypeForComponents() Line 387	Unknown	Symbols loaded.
```

The assert seems overly aggressive - we're going to throw a `MissingTemplateException` a couple lines below and do the right thing for that code path.