### PR TITLE
Remove .NET limit on env var name and value length

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Interop.Errors.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Interop.Errors.cs
@@ -39,6 +39,7 @@ internal partial class Interop
         internal const int ERROR_NO_UNICODE_TRANSLATION = 0x459;
         internal const int ERROR_NOT_FOUND = 0x490;
         internal const int ERROR_BAD_IMPERSONATION_LEVEL = 0x542;
+        internal const int ERROR_NO_SYSTEM_RESOURCES = 0x5AA;        
         internal const int E_FILENOTFOUND = unchecked((int)0x80070002);
         internal const int ERROR_TIMEOUT = 0x000005B4;
     }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Windows.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Windows.cs
@@ -60,6 +60,9 @@ namespace Internal.Runtime.Augments
                         // The error message from Win32 is "The filename or extension is too long",
                         // which is not accurate.
                         throw new ArgumentException(SR.Argument_LongEnvVarValue);
+                    case Interop.Errors.ERROR_NOT_ENOUGH_MEMORY:
+                    case Interop.Errors.ERROR_NO_SYSTEM_RESOURCES:
+                        throw new OutOfMemoryException(Interop.Kernel32.GetMessage(errorCode));
                     default:
                         throw new ArgumentException(Interop.Kernel32.GetMessage(errorCode));
                 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
@@ -55,8 +55,6 @@ namespace Internal.Runtime.Augments
 
         private static void ValidateVariableAndValue(string variable, ref string value)
         {
-            const int MaxEnvVariableValueLength = 32767;
-
             if (variable == null)
                 throw new ArgumentNullException(nameof(variable));
 
@@ -66,9 +64,6 @@ namespace Internal.Runtime.Augments
             if (variable[0] == '\0')
                 throw new ArgumentException(SR.Argument_StringFirstCharIsZero, nameof(variable));
 
-            if (variable.Length >= MaxEnvVariableValueLength)
-                throw new ArgumentException(SR.Argument_LongEnvVarValue, nameof(variable));
-
             if (variable.IndexOf('=') != -1)
                 throw new ArgumentException(SR.Argument_IllegalEnvVarName, nameof(variable));
 
@@ -76,10 +71,6 @@ namespace Internal.Runtime.Augments
             {
                 // Explicitly null out value if it's empty
                 value = null;
-            }
-            else if (value.Length >= MaxEnvVariableValueLength)
-            {
-                throw new ArgumentException(SR.Argument_LongEnvVarValue, nameof(value));
             }
         }
 


### PR DESCRIPTION
Port https://github.com/dotnet/coreclr/pull/14872 to make the associated tests pass eg https://mc.dot.net/#/product/netcore/master/source/official~2Fcorefx~2Fmaster~2F/type/test~2Ffunctional~2Filc~2F/build/20180119.06/workItem/System.Runtime.Extensions.Tests/analysis/xunit/System.Tests.SetEnvironmentVariable~2FAllowAnyVariableLengths