### PR TITLE
Reflection-block some types in CoreLib

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/BlockedInternalsBlockingPolicy.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/BlockedInternalsBlockingPolicy.cs
@@ -94,6 +94,10 @@ namespace ILCompiler
 
             private bool ComputeIsBlocked(EcmaType type, ModuleBlockingMode blockingMode)
             {
+                // If the type is explicitly blocked, it's always blocked.
+                if (type.HasCustomAttribute("System.Runtime.CompilerServices", "ReflectionBlockedAttribute"))
+                    return true;
+
                 // If no blocking is applied to the module, the type is not blocked
                 if (blockingMode == ModuleBlockingMode.None)
                     return false;

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureTypeExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureTypeExtensions.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 namespace System.Reflection
 {
 #if CORERT
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public // Needs to be public so that Reflection.Core can see it.
 #else
     internal

--- a/src/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
+++ b/src/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
@@ -13,6 +13,7 @@ using Internal.Runtime.Augments;
 
 namespace Internal.DeveloperExperience
 {
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public class DeveloperExperience
     {
         public virtual void WriteLine(String s)

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -28,6 +28,7 @@ using EnumInfo = Internal.Runtime.Augments.EnumInfo;
 
 namespace Internal.Reflection.Augments
 {
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public static class ReflectionAugments
     {
         //
@@ -123,6 +124,7 @@ namespace Internal.Reflection.Augments
     // This class is implemented by Internal.Reflection.Core.dll and provides the actual implementation
     // of Type.GetTypeInfo() and (on Project N) (Assembly.Load()).
     //
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public abstract class ReflectionCoreCallbacks
     {
         public abstract Assembly Load(AssemblyName refName, bool throwOnFileNotFound);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnumInfo.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnumInfo.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 
 namespace Internal.Runtime.Augments
 {
+    [ReflectionBlocked]
     public sealed class EnumInfo
     {
         public EnumInfo(Type enumType)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/InteropCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/InteropCallbacks.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 namespace Internal.Runtime.Augments
 {
     [CLSCompliant(false)]
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public abstract class InteropCallbacks
     {
         public abstract bool TryGetMarshallerDataForDelegate(RuntimeTypeHandle delegateTypeHandle, out McgPInvokeDelegateData  delegateData);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 namespace Internal.Runtime.Augments
 {
     [CLSCompliant(false)]
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public abstract class ReflectionExecutionDomainCallbacks
     {
         // Api's that are exposed in System.Runtime but are really reflection apis.

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -35,6 +35,7 @@ using Volatile = System.Threading.Volatile;
 
 namespace Internal.Runtime.Augments
 {
+    [ReflectionBlocked]
     public static class RuntimeAugments
     {
         /// <summary>

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/StackTraceMetadataCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/StackTraceMetadataCallbacks.cs
@@ -15,6 +15,7 @@ namespace Internal.Runtime.Augments
     /// Internal.Runtime.Augments.RuntimeAugments.InitializeStackTraceMetadataSupport(StackTraceMetadataCallbacks callbacks);
     ///
     /// </summary>
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     [CLSCompliant(false)]
     public abstract class StackTraceMetadataCallbacks
     {

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
@@ -11,6 +11,7 @@ using Internal.Runtime.CompilerServices;
 namespace Internal.Runtime.Augments
 {
     [CLSCompliant(false)]
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public abstract class TypeLoaderCallbacks
     {
         public abstract bool TryGetConstructedGenericTypeForComponents(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/FunctionPointerOps.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/FunctionPointerOps.cs
@@ -9,6 +9,7 @@ using Internal.Runtime.Augments;
 
 namespace Internal.Runtime.CompilerServices
 {
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public static class FunctionPointerOps
     {
         private struct GenericMethodDescriptorInfo : IEquatable<GenericMethodDescriptorInfo>

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/GenericMethodDescriptor.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/GenericMethodDescriptor.cs
@@ -6,6 +6,7 @@ using System;
 
 namespace Internal.Runtime.CompilerServices
 {
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public unsafe struct GenericMethodDescriptor
     {
         internal IntPtr _MethodFunctionPointer;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
@@ -20,6 +20,7 @@ namespace Internal.Runtime.CompilerServices
     //    so that repeated allocation of the same resolver will not leak.
     // 3) Use the ResolveMethod function to do the virtual lookup. This function takes advantage of 
     //    a lockless cache so the resolution is very fast for repeated lookups.
+    [ReflectionBlocked]
     public struct OpenMethodResolver : IEquatable<OpenMethodResolver>
     {
         public const short DispatchResolve = 0;

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebugAnnotations.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebugAnnotations.cs
@@ -7,6 +7,7 @@ namespace System.Diagnostics
     /// <summary>
     /// Annotations used by debugger
     /// </summary>
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public static class DebugAnnotations
     {
         /// <summary>

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebuggerGuidedStepThroughAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebuggerGuidedStepThroughAttribute.cs
@@ -4,6 +4,7 @@
 
 namespace System.Diagnostics
 {
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor, Inherited = false)]
     public sealed class DebuggerGuidedStepThroughAttribute : Attribute
     {

--- a/src/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -14,6 +14,7 @@ using Internal.Runtime.CompilerServices;
 
 namespace System
 {
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     [System.Runtime.CompilerServices.DependencyReductionRoot]
     public static class InvokeUtils
     {

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyNameHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyNameHelpers.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 
 namespace System.Reflection
 {
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public static partial class AssemblyNameHelpers
     {
         //

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyNameParser.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyNameParser.cs
@@ -15,6 +15,7 @@ namespace System.Reflection
     //
     // Parses an assembly name.
     //
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public static class AssemblyNameParser
     {
         public static void Parse(AssemblyName blank, String s)

--- a/src/System.Private.CoreLib/src/System/Reflection/BinderBundle.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/BinderBundle.cs
@@ -12,6 +12,7 @@ namespace System.Reflection
     // to manage.)
     //
     // This is not an api type but needs to be public as both Reflection.Core and System.Private.Corelib accesses it.
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public sealed class BinderBundle
     {
         public BinderBundle(Binder binder, CultureInfo culture)

--- a/src/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeImplementedCustomAttributeData.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeImplementedCustomAttributeData.cs
@@ -12,6 +12,7 @@ namespace System.Reflection.Runtime.CustomAttributes
     // If a CustomAttributeData implementation derives from this, it is a hint that it has a AttributeType implementation
     // that's more efficient than building a ConstructorInfo and gettings its DeclaredType.
     //
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public abstract class RuntimeImplementedCustomAttributeData : CustomAttributeData
     {
         public new abstract Type AttributeType { get; }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -19,6 +19,7 @@ namespace System.Runtime.InteropServices
     ///     in order to be accessible from System.Private.Interop.dll.
     /// </summary>
     [CLSCompliant(false)]
+    [ReflectionBlocked]
     public static class InteropExtensions
     {
         // Converts a managed DateTime to native OLE datetime

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -26,7 +26,7 @@ namespace System.Runtime
     //      E.g., the class and methods are marked internal assuming that only the base class library needs them
     //            but if a class library wants to factor differently (such as putting the GCHandle methods in an
     //            optional library, those methods can be moved to a different file/namespace/dll
-
+    [ReflectionBlocked]
     public static class RuntimeImports
     {
         private const string RuntimeLibrary = "[MRT]";

--- a/src/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Runtime
 {
+    [ReflectionBlocked]
     public static class TypeLoaderExports
     {
 #if PROJECTN
@@ -419,6 +420,7 @@ namespace System.Runtime
         }
     }
 
+    [ReflectionBlocked]
     public delegate IntPtr RuntimeObjectFactory(IntPtr context, IntPtr signature, object contextObject, ref IntPtr auxResult);
 
     [System.Runtime.InteropServices.McgIntrinsicsAttribute]

--- a/src/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -24,6 +24,7 @@ namespace System
         }
     }
 
+    [ReflectionBlocked]
     public class RuntimeExceptionHelpers
     {
         //------------------------------------------------------------------------------------------------------------

--- a/src/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 
 namespace System.Threading
 {
+    [System.Runtime.CompilerServices.ReflectionBlocked]
     public sealed class Condition
     {
         internal class Waiter

--- a/src/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -9,6 +9,7 @@ using Internal.Runtime.Augments;
 
 namespace System.Threading
 {
+    [ReflectionBlocked]
     public sealed class Lock
     {
         // The following constants define characteristics of spinning logic in the Lock class

--- a/src/System.Private.CoreLib/src/System/Threading/LockHolder.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LockHolder.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Threading
 {
+    [ReflectionBlocked]
     public struct LockHolder : IDisposable
     {
         private Lock _lock;


### PR DESCRIPTION
This saves 50 kB on a hello world app (~20 kB in metadata and blobs, the rest is in code).

This is using the existing ReflectionBlocked attribute to manually block public types that get otherwise blocked by the IL2IL toolchain in Project N. These types are public within the repo, but should be considered private implementation details everywhere else.

Wrote a small tool that would let me identify these: https://gist.github.com/MichalStrehovsky/e2ddec899d3e0db6eba95bf68694b40e. There is more.