### PR TITLE
Implement localloc for WebAssembly

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -570,7 +570,10 @@ namespace Internal.IL
 
         protected override LLVMValueRef ValueAsTypeInternal(LLVMTypeRef type, LLVMBuilderRef builder, bool signExtend)
         {
-            return _importer.LoadTemp(LocalIndex, type);
+            LLVMTypeRef origLLVMType = ILImporter.GetLLVMTypeForTypeDesc(Type);
+            LLVMValueRef value = _importer.LoadTemp(LocalIndex, origLLVMType);
+
+            return ILImporter.CastIfNecessary(builder, value, type);
         }
 
         public override StackEntry Duplicate()

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1034,10 +1034,9 @@ namespace Internal.IL
                 case "get_Value":
                     if (metadataType.IsByReferenceOfT)
                     {
-                        InstantiatedType instantiation = (InstantiatedType)metadataType;
                         StackEntry byRefHolder = _stack.Pop();
 
-                        TypeDesc byRefType = instantiation.Instantiation[0].MakeByRefType();
+                        TypeDesc byRefType = metadataType.Instantiation[0].MakeByRefType();
                         PushLoadExpression(StackValueKind.ByRef, "byref", byRefHolder.ValueForStackKind(StackValueKind.ByRef, _builder, false), byRefType);
                         return true;
                     }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1002,7 +1002,7 @@ namespace Internal.IL
         private LLVMValueRef GetEETypePointerForTypeDesc(TypeDesc target, bool constructed)
         {
             ISymbolNode node;
-            if (constructed && !target.IsByRefLike)
+            if (constructed)
             {
                 node = _compilation.NodeFactory.MaximallyConstructableType(target);
             }
@@ -1032,17 +1032,14 @@ namespace Internal.IL
             switch (method.Name)
             {
                 case "get_Value":
-                    if (metadataType is InstantiatedType)
+                    if (metadataType.IsByReferenceOfT)
                     {
                         InstantiatedType instantiation = (InstantiatedType)metadataType;
-                        if (instantiation.GetTypeDefinition().Equals(GetWellKnownType(WellKnownType.ByReferenceOfT)))
-                        {
-                            StackEntry byRefHolder = _stack.Pop();
+                        StackEntry byRefHolder = _stack.Pop();
 
-                            TypeDesc byRefType = instantiation.Instantiation[0].MakeByRefType();
-                            PushLoadExpression(StackValueKind.ByRef, "byref", byRefHolder.ValueForStackKind(StackValueKind.ByRef, _builder, false), byRefType);
-                            return true;
-                        }
+                        TypeDesc byRefType = instantiation.Instantiation[0].MakeByRefType();
+                        PushLoadExpression(StackValueKind.ByRef, "byref", byRefHolder.ValueForStackKind(StackValueKind.ByRef, _builder, false), byRefType);
+                        return true;
                     }
                     break;
             }

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -157,9 +157,6 @@ namespace System.Runtime.CompilerServices
 
         public static int OffsetToStringData
         {
-            // Workaround to allow WebAssembly to define a size here without a special CoreLib build
-            // https://github.com/dotnet/corert/issues/4506 includes removing this.
-            [Intrinsic] 
             get
             {
                 // Number of bytes from the address pointed to by a reference to

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -62,6 +62,18 @@ internal static class Program
         var boxedStruct = (object)new BoxStubTest { Value = "Boxed Stub Test: Ok." };
         PrintLine(boxedStruct.ToString());
 
+        int subResult = tempInt - 1;
+        if (subResult == 8)
+        {
+            PrintLine("Subtraction Test: Ok.");
+        }
+
+        int divResult = tempInt / 3;
+        if (divResult == 3)
+        {
+            PrintLine("Division Test: Ok.");
+        }
+
         var not = Not(0xFFFFFFFF) == 0x00000000;
         if (not)
         {
@@ -159,12 +171,21 @@ internal static class Program
             PrintLine("Small array load/store test: Ok.");
         }
 
+        IntPtr returnedIntPtr = NewobjValueType();
+        if (returnedIntPtr.ToInt32() == 3)
+        {
+            PrintLine("Newobj value type test: Ok.");
+        }
+
+        StackallocTest();
+
+        IntToStringTest();
+
         PrintLine("Done");
     }
 
     private static int StaticDelegateTarget()
-    {
-         
+    {         
         return 7;
     }
 
@@ -233,6 +254,30 @@ internal static class Program
           default:
             return 0;
         }
+    }
+
+    private static IntPtr NewobjValueType()
+    {
+        return new IntPtr(3);
+    }
+
+    private unsafe static void StackallocTest()
+    {
+        int* intSpan = stackalloc int[2];
+        intSpan[0] = 3;
+        intSpan[1] = 7;
+
+        if (intSpan[0] == 3 && intSpan[1] == 7)
+        {
+            PrintLine("Stackalloc test: Ok.");
+        }
+    }
+
+    private static void IntToStringTest()
+    {
+        PrintLine("Int to String Test: Ok if next line says 42.");
+        string intString = 42.ToString();
+        PrintLine(intString);
     }
 
     [DllImport("*")]


### PR DESCRIPTION
Implements localloc and fixes other issues required to make Int32.ToString work (which relies on stack allocation, Spans and various value type special cases). Includes:

* Allocating localloc buffers on the C++ stack since they're guaranteed not to have GC references and LLVM might be able to optimize them a bit better
* Handling newobj for value types by allocating them in a spill slot
* Implementing the ByReference.get_Value intrinsic
* Fixing various shadow stack management bugs around calls. In particular, return values are now spilled to avoid the next call overwriting them.
* A few new tests

Fixes #5272 