### PR TITLE
Add missing packages (curl, zlib) to Ubuntu prerequisites

### DIFF
--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -20,7 +20,7 @@ sudo apt-get update
 ```
 
 ```sh
-sudo apt-get install cmake clang-3.9 libicu52 libunwind8 uuid-dev
+sudo apt-get install cmake clang-3.9 libicu52 libunwind8 uuid-dev libcurl4-openssl-dev zlib1g-dev
 ```
 
 # macOS (10.12+)


### PR DESCRIPTION
It seemed curl and zlib were missing from the prerequisites for Ubuntu. This was on a fresh Ubuntu Desktop 14.04.5 64-bit installation.

@dotnet-bot skip ci please