### PR TITLE
Port dotnet/coreclr#15902 and dotnet/coreclr#15938 - Cache Invariant CompareInfo

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Unix.cs
@@ -30,5 +30,10 @@ namespace System.Globalization
 
             return cultureInfo;
         }
+
+        private static CultureInfo GetUserDefaultUICulture()
+        {
+            return s_userDefaultCulture ?? InitializeUserDefaultCulture();
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Windows.cs
@@ -56,5 +56,36 @@ namespace System.Globalization
 
             return temp;
         }
+
+        private static CultureInfo GetUserDefaultUICulture()
+        {
+#if !ENABLE_WINRT
+            if (GlobalizationMode.Invariant)
+                return CultureInfo.InvariantCulture;
+
+            const uint MUI_LANGUAGE_NAME = 0x8;    // Use ISO language (culture) name convention
+            uint langCount = 0;
+            uint bufLen = 0;
+
+            if (Interop.Kernel32.GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, out langCount, null, ref bufLen))
+            {
+                char[] languages = new char[bufLen];
+                if (Interop.Kernel32.GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, out langCount, languages, ref bufLen))
+                {
+                    int index = 0;
+                    while (languages[index] != (char)0 && index < languages.Length)
+                    {
+                        index++;
+                    }
+
+                    CultureInfo temp = GetCultureByName(new String(languages, 0, index), true);
+                    temp._isReadOnly = true;
+                    return temp;
+                }
+            }
+#endif
+
+            return s_userDefaultCulture ?? InitializeUserDefaultCulture();
+        }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -100,12 +100,8 @@ namespace System.Globalization
         //
         //--------------------------------------------------------------------//
 
-        //Get the current user default culture.  This one is almost always used, so we create it by default.
         private static volatile CultureInfo s_userDefaultCulture;
-
-        //
-        // All of the following will be created on demand.
-        //
+        private static volatile CultureInfo s_userDefaultUICulture;
 
         // WARNING: We allow diagnostic tools to directly inspect these three members (s_InvariantCultureInfo, s_DefaultThreadCurrentUICulture and s_DefaultThreadCurrentCulture)
         // See https://github.com/dotnet/corert/blob/master/Documentation/design-docs/diagnostics/diagnostics-tools-contract.md for more details. 
@@ -113,7 +109,7 @@ namespace System.Globalization
         // Get in touch with the diagnostics team if you have questions.
 
         //The Invariant culture;
-        private static volatile CultureInfo s_InvariantCultureInfo;
+        private static readonly CultureInfo s_InvariantCultureInfo = new CultureInfo(CultureData.Invariant, isReadOnly: true);
 
         //These are defaults that we use if a thread has not opted into having an explicit culture
         private static volatile CultureInfo s_DefaultThreadCurrentUICulture;
@@ -140,23 +136,16 @@ namespace System.Globalization
         internal const int LOCALE_CUSTOM_DEFAULT = 0x0c00;
         internal const int LOCALE_INVARIANT = 0x007F;
 
-        //
-        // The CultureData  instance that reads the data provided by our CultureData class.
-        //
-        // Using a field initializer rather than a static constructor so that the whole class can be lazy
-        // init.
-        private static readonly bool s_init = Init();
-        private static bool Init()
+        private static CultureInfo InitializeUserDefaultCulture()
         {
-            if (s_InvariantCultureInfo == null)
-            {
-                CultureInfo temp = new CultureInfo("", false);
-                temp._isReadOnly = true;
-                s_InvariantCultureInfo = temp;
-            }
+            Interlocked.CompareExchange(ref s_userDefaultCulture, GetUserDefaultCulture(), null);
+            return s_userDefaultCulture;
+        }
 
-            s_userDefaultCulture = GetUserDefaultCulture();
-            return true;
+        private static CultureInfo InitializeUserDefaultUICulture()
+        {
+            Interlocked.CompareExchange(ref s_userDefaultUICulture, GetUserDefaultUICulture(), null);
+            return s_userDefaultUICulture;
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -180,22 +169,23 @@ namespace System.Globalization
             }
 
             // Get our data providing record
-            this._cultureData = CultureData.GetCultureData(name, useUserOverride);
+            _cultureData = CultureData.GetCultureData(name, useUserOverride);
 
-            if (this._cultureData == null)
+            if (_cultureData == null)
                 throw new CultureNotFoundException(
                     nameof(name), name, SR.Argument_CultureNotSupported);
 
-            this._name = this._cultureData.CultureName;
-            this._isInherited = !this.EETypePtr.FastEquals(EETypePtr.EETypePtrOf<CultureInfo>());
+            _name = _cultureData.CultureName;
+            _isInherited = !this.EETypePtr.FastEquals(EETypePtr.EETypePtrOf<CultureInfo>());
         }
 
-        private CultureInfo(CultureData cultureData)
+        private CultureInfo(CultureData cultureData, bool isReadOnly = false)
         {
             Debug.Assert(cultureData != null);
             _cultureData = cultureData;
             _name = cultureData.CultureName;
             _isInherited = false;
+            _isReadOnly = isReadOnly;
         }
 
         private static CultureInfo CreateCultureInfoNoThrow(string name, bool useUserOverride)
@@ -222,11 +212,6 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(nameof(culture), SR.ArgumentOutOfRange_NeedPosNum);
             }
 
-            InitializeFromCultureId(culture, useUserOverride);
-        }
-
-        private void InitializeFromCultureId(int culture, bool useUserOverride)
-        {
             switch (culture)
             {
                 case LOCALE_CUSTOM_DEFAULT:
@@ -354,15 +339,6 @@ namespace System.Globalization
             return (new CultureInfo(culture._cultureData.SSPECIFICCULTURE));
         }
 
-        //        //
-        //        // Return a specific culture.  A tad irrelevent now since we always return valid data
-        //        // for neutral locales.
-        //        //
-        //        // Note that there's interesting behavior that tries to find a smaller name, ala RFC4647,
-        //        // if we can't find a bigger name.  That doesn't help with things like "zh" though, so
-        //        // the approach is of questionable value
-        //        //
-
         internal static bool VerifyCultureName(String cultureName, bool throwException)
         {
             // This function is used by ResourceManager.GetResourceFileName().
@@ -439,15 +415,7 @@ namespace System.Globalization
                     return ci;
                 }
 
-                // if s_userDefaultCulture == null means CultureInfo statics didn't get initialized yet. this can happen if there early static
-                // method get executed which eventually hit the cultureInfo code while CultureInfo statics didn't get chance to initialize
-                if (s_userDefaultCulture == null)
-                {
-                    Init();
-                }
-
-                Debug.Assert(s_userDefaultCulture != null);
-                return s_userDefaultCulture;
+                return s_userDefaultCulture ?? InitializeUserDefaultCulture();
             }
 
             set
@@ -491,15 +459,7 @@ namespace System.Globalization
                     return ci;
                 }
 
-                // if s_userDefaultCulture == null means CultureInfo statics didn't get initialized yet. this can happen if there early static
-                // method get executed which eventually hit the cultureInfo code while CultureInfo statics didn't get chance to initialize
-                if (s_userDefaultCulture == null)
-                {
-                    Init();
-                }
-
-                Debug.Assert(s_userDefaultCulture != null);
-                return s_userDefaultCulture;
+                return s_userDefaultUICulture ?? InitializeUserDefaultUICulture();
             }
 
             set
@@ -530,31 +490,9 @@ namespace System.Globalization
             s_currentThreadUICulture = null;
         }
 
-        internal static CultureInfo UserDefaultUICulture
-        {
-            get
-            {
-                if (s_userDefaultCulture == null)
-                {
-                    Init();
-                }
-                Debug.Assert(s_userDefaultCulture != null, "[CultureInfo.InstalledUICulture] s_userDefaultCulture != null");
-                return s_userDefaultCulture;
-            }
-        }
+        internal static CultureInfo UserDefaultUICulture => s_userDefaultUICulture ?? InitializeUserDefaultUICulture();
 
-        public static CultureInfo InstalledUICulture
-        {
-            get
-            {
-                if (s_userDefaultCulture == null)
-                {
-                    Init();
-                }
-                Debug.Assert(s_userDefaultCulture != null, "[CultureInfo.InstalledUICulture] s_userDefaultCulture != null");
-                return s_userDefaultCulture;
-            }
-        }
+        public static CultureInfo InstalledUICulture => s_userDefaultCulture ?? InitializeUserDefaultCulture();
 
         public static CultureInfo DefaultThreadCurrentCulture
         {
@@ -606,6 +544,7 @@ namespace System.Globalization
         {
             get
             {
+                Debug.Assert(s_InvariantCultureInfo != null);
                 return (s_InvariantCultureInfo);
             }
         }
@@ -836,7 +775,7 @@ namespace System.Globalization
                     // Since CompareInfo's don't have any overrideable properties, get the CompareInfo from
                     // the Non-Overridden CultureInfo so that we only create one CompareInfo per culture
                     CompareInfo temp = UseUserOverride
-                                        ? GetCultureInfo(this._name).CompareInfo
+                                        ? GetCultureInfo(_name).CompareInfo
                                         : new CompareInfo(this);
                     if (OkayToCacheClassWithCompatibilityBehavior)
                     {
@@ -873,7 +812,7 @@ namespace System.Globalization
                 if (_textInfo == null)
                 {
                     // Make a new textInfo
-                    TextInfo tempTextInfo = new TextInfo(this._cultureData);
+                    TextInfo tempTextInfo = new TextInfo(_cultureData);
                     tempTextInfo.SetReadOnlyState(_isReadOnly);
 
                     if (OkayToCacheClassWithCompatibilityBehavior)
@@ -963,7 +902,7 @@ namespace System.Globalization
         {
             get
             {
-                return this._cultureData.IsNeutralCulture;
+                return _cultureData.IsNeutralCulture;
             }
         }
 
@@ -998,7 +937,7 @@ namespace System.Globalization
             {
                 if (numInfo == null)
                 {
-                    NumberFormatInfo temp = new NumberFormatInfo(this._cultureData);
+                    NumberFormatInfo temp = new NumberFormatInfo(_cultureData);
                     temp.isReadOnly = _isReadOnly;
                     Interlocked.CompareExchange(ref numInfo, temp, null);
                 }
@@ -1030,7 +969,7 @@ namespace System.Globalization
                 if (dateTimeInfo == null)
                 {
                     // Change the calendar of DTFI to the specified calendar of this CultureInfo.
-                    DateTimeFormatInfo temp = new DateTimeFormatInfo(this._cultureData, this.Calendar);
+                    DateTimeFormatInfo temp = new DateTimeFormatInfo(_cultureData, this.Calendar);
                     temp._isReadOnly = _isReadOnly;
                     Interlocked.CompareExchange(ref dateTimeInfo, temp, null);
                 }
@@ -1050,7 +989,9 @@ namespace System.Globalization
 
         public void ClearCachedData()
         {
-            s_userDefaultCulture = null;
+            // reset the default culture values
+            s_userDefaultCulture = GetUserDefaultCulture();
+            s_userDefaultUICulture = GetUserDefaultUICulture();
 
             RegionInfo.s_currentRegionInfo = null;
 #pragma warning disable 0618 // disable the obsolete warning 
@@ -1128,10 +1069,10 @@ namespace System.Globalization
             {
                 if (_calendar == null)
                 {
-                    Debug.Assert(this._cultureData.CalendarIds.Length > 0, "this._cultureData.CalendarIds.Length > 0");
+                    Debug.Assert(_cultureData.CalendarIds.Length > 0, "_cultureData.CalendarIds.Length > 0");
                     // Get the default calendar for this culture.  Note that the value can be
                     // from registry if this is a user default culture.
-                    Calendar newObj = this._cultureData.DefaultCalendar;
+                    Calendar newObj = _cultureData.DefaultCalendar;
 
                     System.Threading.Interlocked.MemoryBarrier();
                     newObj.SetReadOnlyState(_isReadOnly);
@@ -1156,7 +1097,7 @@ namespace System.Globalization
                 //
                 // This property always returns a new copy of the calendar array.
                 //
-                CalendarId[] calID = this._cultureData.CalendarIds;
+                CalendarId[] calID = _cultureData.CalendarIds;
                 Calendar[] cals = new Calendar[calID.Length];
                 for (int i = 0; i < cals.Length; i++)
                 {

--- a/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -357,11 +357,10 @@ namespace System.Resources
             sb.Append(name);
 
             String givenName = sb.ToString();
-            CompareInfo comparer = CultureInfo.InvariantCulture.CompareInfo;
             String canonicalName = null;
             foreach (String existingName in satellite.GetManifestResourceNames())
             {
-                if (comparer.Compare(existingName, givenName, CompareOptions.IgnoreCase) == 0)
+                if (String.Equals(existingName, givenName, StringComparison.InvariantCultureIgnoreCase))
                 {
                     if (canonicalName == null)
                     {

--- a/src/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -470,10 +470,10 @@ namespace System
                     return CompareInfo.CompareOrdinalIgnoreCase(strA, 0, strA.Length, strB, 0, strB.Length);
 
                 case StringComparison.InvariantCulture:
-                    return CultureInfo.InvariantCulture.CompareInfo.Compare(strA, strB, CompareOptions.None);
+                    return CompareInfo.Invariant.Compare(strA, strB, CompareOptions.None);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return CultureInfo.InvariantCulture.CompareInfo.Compare(strA, strB, CompareOptions.IgnoreCase);
+                    return CompareInfo.Invariant.Compare(strA, strB, CompareOptions.IgnoreCase);
 
                 default:
                     throw new NotSupportedException(SR.NotSupported_StringComparison);
@@ -653,10 +653,10 @@ namespace System
                     return CompareInfo.CompareOrdinalIgnoreCase(strA, indexA, lengthA, strB, indexB, lengthB);
 
                 case StringComparison.InvariantCulture:
-                    return CultureInfo.InvariantCulture.CompareInfo.Compare(strA, indexA, lengthA, strB, indexB, lengthB, CompareOptions.None);
+                    return CompareInfo.Invariant.Compare(strA, indexA, lengthA, strB, indexB, lengthB, CompareOptions.None);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return CultureInfo.InvariantCulture.CompareInfo.Compare(strA, indexA, lengthA, strB, indexB, lengthB, CompareOptions.IgnoreCase);
+                    return CompareInfo.Invariant.Compare(strA, indexA, lengthA, strB, indexB, lengthB, CompareOptions.IgnoreCase);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison);
@@ -834,10 +834,10 @@ namespace System
                     return this.Length < value.Length ? false : (CompareInfo.CompareOrdinalIgnoreCase(this, this.Length - value.Length, value.Length, value, 0, value.Length) == 0);
 
                 case StringComparison.InvariantCulture:
-                    return CultureInfo.InvariantCulture.CompareInfo.IsSuffix(this, value, CompareOptions.None);
+                    return CompareInfo.Invariant.IsSuffix(this, value, CompareOptions.None);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return CultureInfo.InvariantCulture.CompareInfo.IsSuffix(this, value, CompareOptions.IgnoreCase);
+                    return CompareInfo.Invariant.IsSuffix(this, value, CompareOptions.IgnoreCase);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
@@ -947,10 +947,10 @@ namespace System
                     }
 
                 case StringComparison.InvariantCulture:
-                    return (CultureInfo.InvariantCulture.CompareInfo.Compare(this, value, CompareOptions.None) == 0);
+                    return (CompareInfo.Invariant.Compare(this, value, CompareOptions.None) == 0);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return (CultureInfo.InvariantCulture.CompareInfo.Compare(this, value, CompareOptions.IgnoreCase) == 0);
+                    return (CompareInfo.Invariant.Compare(this, value, CompareOptions.IgnoreCase) == 0);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
@@ -1011,10 +1011,10 @@ namespace System
                     }
 
                 case StringComparison.InvariantCulture:
-                    return (CultureInfo.InvariantCulture.CompareInfo.Compare(a, b, CompareOptions.None) == 0);
+                    return (CompareInfo.Invariant.Compare(a, b, CompareOptions.None) == 0);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return (CultureInfo.InvariantCulture.CompareInfo.Compare(a, b, CompareOptions.IgnoreCase) == 0);
+                    return (CompareInfo.Invariant.Compare(a, b, CompareOptions.IgnoreCase) == 0);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
@@ -1159,10 +1159,10 @@ namespace System
                     return CompareInfo.CompareOrdinalIgnoreCase(this, 0, value.Length, value, 0, value.Length) == 0;
 
                 case StringComparison.InvariantCulture:
-                    return CultureInfo.InvariantCulture.CompareInfo.IsPrefix(this, value, CompareOptions.None);
+                    return CompareInfo.Invariant.IsPrefix(this, value, CompareOptions.None);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return CultureInfo.InvariantCulture.CompareInfo.IsPrefix(this, value, CompareOptions.IgnoreCase);
+                    return CompareInfo.Invariant.IsPrefix(this, value, CompareOptions.IgnoreCase);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));


### PR DESCRIPTION
- Cache Invariant CompareInfo

The Invariant CompareInfo is used in number of places. It is fetched via virtual method on CultureInfo. Caching it avoids the virtual method calls and extra indirections.

- Break current culture initialization cycle