### PR TITLE
Fixed ldind failure and properly zext unsigned types in WebAssembly

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -392,6 +392,10 @@ namespace Internal.IL
             {
                 return LLVM.BuildSExtOrBitCast(builder, value, type, "SExtOrBitCast");
             }
+            else if (type.GetIntTypeWidth() > LLVM.TypeOf(value).GetIntTypeWidth())
+            {
+                return LLVM.BuildZExtOrBitCast(builder, value, type, "ZExtOrBitCast");
+            }
             else
             {
                 Debug.Assert(typeKind == LLVMTypeKind.LLVMIntegerTypeKind);
@@ -1547,7 +1551,7 @@ namespace Internal.IL
 
             LLVMValueRef pointerElementType = pointer.ValueAsType(type.MakePointerType(), _builder);
             _stack.Push(new LoadExpressionEntry(type != null ? GetStackValueKind(type) : StackValueKind.ByRef, "ldind",
-                pointerElementType, type.MakePointerType()));
+                pointerElementType, type));
         }
 
         private void ImportStoreIndirect(int token)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -181,6 +181,8 @@ internal static class Program
 
         IntToStringTest();
 
+        ldindTest();
+
         PrintLine("Done");
     }
 
@@ -278,6 +280,35 @@ internal static class Program
         PrintLine("Int to String Test: Ok if next line says 42.");
         string intString = 42.ToString();
         PrintLine(intString);
+    }
+
+    private unsafe static void ldindTest()
+    {
+        var ldindTarget = new TwoByteStr { first = byte.MaxValue, second = byte.MinValue };
+        var ldindField = &ldindTarget.first;
+        if((*ldindField) == byte.MaxValue)
+        {
+            ldindTarget.second = byte.MaxValue;
+            *ldindField = byte.MinValue;
+            //ensure there isnt any overwrite of nearby fields
+            if(ldindTarget.first == byte.MinValue && ldindTarget.second == byte.MaxValue)
+            {
+                PrintLine("ldind test: Ok.");
+            }
+            else if(ldindTarget.first != byte.MinValue)
+            {
+                PrintLine("ldind test: Failed didnt update target.");
+            }
+            else
+            {
+                PrintLine("ldind test: Failed overwrote data");
+            }
+        }
+        else
+        {
+            uint ldindFieldValue = *ldindField;
+            PrintLine("ldind test: Failed." + ldindFieldValue.ToString());
+        }
     }
 
     [DllImport("*")]


### PR DESCRIPTION
@morganbr 
This is to fix the ldind issue I noticed in testing for #5172, In making the test for this I noticed that we weren't getting the right results for comparisons between unsigned types (smaller than 32bit) when they had the high bit set.