### PR TITLE
Implement break opcode as llvm.debugtrap

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -324,6 +324,11 @@ namespace Internal.IL
 
         private void ImportBreak()
         {
+            if (DebugtrapFunction.Pointer == IntPtr.Zero)
+            {
+                DebugtrapFunction = LLVM.AddFunction(Module, "llvm.debugtrap", LLVM.FunctionType(LLVM.VoidType(), Array.Empty<LLVMTypeRef>(), false));
+            }
+            LLVM.BuildCall(_builder, DebugtrapFunction, Array.Empty<LLVMValueRef>(), string.Empty);
         }
 
         private void ImportLoadVar(int index, bool argument)

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -100,6 +100,7 @@ namespace Internal.IL
             methodCodeNodeNeedingCode.SetDependencies(ilImporter.GetDependencies());
         }
 
+        static LLVMValueRef DebugtrapFunction = default(LLVMValueRef);
         static LLVMValueRef TrapFunction = default(LLVMValueRef);
         static LLVMValueRef DoNothingFunction = default(LLVMValueRef);
 

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -1044,8 +1044,13 @@ extern "C" void LeaveCriticalSection(CRITICAL_SECTION * lpCriticalSection)
 
 extern "C" UInt32_BOOL IsDebuggerPresent()
 {
+#ifdef _WASM_
+    // For now always true since the browser will handle it in case of WASM.
+    return UInt32_TRUE;
+#else
     // UNIXTODO: Implement this function
     return UInt32_FALSE;
+#endif
 }
 
 extern "C" void TerminateProcess(HANDLE arg1, UInt32 arg2)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -205,8 +205,10 @@ internal static class Program
         {   
             PrintLine("Type casting with isinst & castclass to array test: Ok.");
         }
-      
+
         ldindTest();
+
+        System.Diagnostics.Debugger.Break();
 
         PrintLine("Done");
     }


### PR DESCRIPTION
Implemented break opcode as llvm.debugtrap. Not adding any test cases since it seems that no C# codes generates break opcode directly.