### PR TITLE
[Linux] Fix build for non-Ubuntu distros

### DIFF
--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -60,7 +60,8 @@ check_native_prereqs()
 get_current_linux_rid() {
     # Construct RID for current distro
 
-    rid=linux
+    # Set default Ubuntu RID
+    rid=ubuntu.14.04
 
     if [ -e /etc/os-release ]; then
         source /etc/os-release


### PR DESCRIPTION
If we compile CoreRT on other Linux distributions(non-Ubuntu), it fails with:
```
CoreRT/Tools/depProj.targets(83,5): error : Error no assets were resolved from NuGet packages. [CoreRT/src/ILCompiler/ObjectWriter/ObjectWriter.depproj]
...
CoreRT/dir.traversal.targets(24,5): error : (No message specified) [CoreRT/src/dirs.proj]
CoreRT/dir.traversal.targets(24,5): error : (No message specified) [CoreRT/build.proj]
```
It's because ObjWriter msbuild file has:
```
<RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>                                                                                                                                      
<RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('ubuntu.'))">ubuntu.14.04-x64</RuntimeIdentifiers>
```
It seems with "linux" RID it doesn't work properly. I think it will be correct to set the default ubuntu ID, as for other non OS X distros.