### PR TITLE
Cleanup NuGet rids

### DIFF
--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -163,8 +163,8 @@ set Platform=
 set __VCBuildArch=x86_amd64
 if /i "%__BuildArch%" == "x86" (set __VCBuildArch=x86)
 
-set __NugetRuntimeId=win7-x64
-if /i "%__BuildArch%" == "x86" (set __NugetRuntimeId=win7-x86)
+set __NugetRuntimeId=win-x64
+if /i "%__BuildArch%" == "x86" (set __NugetRuntimeId=win-x86)
 
 :Done
 set BUILDVARS_DONE=1

--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -68,8 +68,6 @@ get_current_linux_rid() {
             # remove the last version digit
             VERSION_ID=${VERSION_ID%.*}
             rid=alpine.$VERSION_ID
-        elif [[ $ID == "ubuntu" ]]; then
-            rid=$ID.$VERSION_ID
         fi
 
     elif [ -e /etc/redhat-release ]; then
@@ -198,14 +196,14 @@ export OSName=$(uname -s)
 case $OSName in
     Darwin)
         export __HostOS=OSX
-        export __NugetRuntimeId=osx.10.10-x64
+        export __NugetRuntimeId=osx-x64
         ulimit -n 2048
         ;;
 
     FreeBSD)
         export __HostOS=FreeBSD
         # TODO: Add proper FreeBSD target
-        export __NugetRuntimeId=ubuntu.14.04-x64
+        export __NugetRuntimeId=linux-x64
         ;;
 
     Linux)
@@ -216,13 +214,13 @@ case $OSName in
     NetBSD)
         export __HostOS=NetBSD
         # TODO: Add proper NetBSD target
-        export __NugetRuntimeId=ubuntu.14.04-x64
+        export __NugetRuntimeId=linux-x64
         ;;
 
     *)
         echo "Unsupported OS $OSName detected, configuring as if for Linux"
         export __HostOS=Linux
-        export __NugetRuntimeId=ubuntu.14.04-x64
+        export __NugetRuntimeId=linux-x64
         ;;
 esac
 

--- a/src/Common/test-runtime/XUnit.Runtime.depproj
+++ b/src/Common/test-runtime/XUnit.Runtime.depproj
@@ -4,7 +4,7 @@
     <!-- Given that xunit packages bring with them part of the framework, we need to specify a runtime in order to get the assets
          This RID value doesn't really matter, since the assets we are copying are not RID specific, so defaulting to Windows here
     -->
-    <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RidSpecificAssets>true</RidSpecificAssets>
     <OutputPath>$(RuntimePath)</OutputPath>

--- a/src/Framework/Framework-native.depproj
+++ b/src/Framework/Framework-native.depproj
@@ -9,8 +9,6 @@
     <NuGetTargetMoniker>.NETCoreApp,Version=v2.0</NuGetTargetMoniker>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('osx.'))">osx-x64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('ubuntu.'))">linux-x64</RuntimeIdentifiers>
     <RidSpecificAssets>true</RidSpecificAssets>
   </PropertyGroup>
 

--- a/src/Framework/Framework.depproj
+++ b/src/Framework/Framework.depproj
@@ -8,8 +8,6 @@
     <NuGetTargetMoniker>.NETCoreApp,Version=v2.1</NuGetTargetMoniker>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('osx.'))">osx-x64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('ubuntu.'))">linux-x64</RuntimeIdentifiers>
     <RidSpecificAssets>true</RidSpecificAssets>
   </PropertyGroup>
 

--- a/src/ILCompiler.WebAssembly/src/libLLVMdep.depproj
+++ b/src/ILCompiler.WebAssembly/src/libLLVMdep.depproj
@@ -8,7 +8,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('ubuntu.'))">ubuntu.14.04-x64</RuntimeIdentifiers>
     <RidSpecificAssets>true</RidSpecificAssets>
   </PropertyGroup>
 

--- a/src/ILCompiler/ObjectWriter/ObjectWriter.depproj
+++ b/src/ILCompiler/ObjectWriter/ObjectWriter.depproj
@@ -8,7 +8,8 @@
     <NuGetTargetMoniker>.NETCoreApp,Version=v2.0</NuGetTargetMoniker>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('ubuntu.'))">ubuntu.14.04-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(NuPkgRid)'=='win-x64'">win7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(NuPkgRid)'=='linux-x64'">ubuntu.14.04-x64</RuntimeIdentifiers>
     <RidSpecificAssets>true</RidSpecificAssets>
   </PropertyGroup>
 

--- a/src/ILCompiler/ObjectWriter/ObjectWriter.depproj
+++ b/src/ILCompiler/ObjectWriter/ObjectWriter.depproj
@@ -9,6 +9,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(NuPkgRid)'=='win-x64'">win7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(NuPkgRid)'=='osx-x64'">osx.10.10-x64</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(NuPkgRid)'=='linux-x64'">ubuntu.14.04-x64</RuntimeIdentifiers>
     <RidSpecificAssets>true</RidSpecificAssets>
   </PropertyGroup>

--- a/src/ILCompiler/RyuJIT/RyuJIT.depproj
+++ b/src/ILCompiler/RyuJIT/RyuJIT.depproj
@@ -8,9 +8,6 @@
     <NuGetTargetMoniker>.NETCoreApp,Version=v2.0</NuGetTargetMoniker>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('win7'))">win-x64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('osx.'))">osx-x64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(NuPkgRid.StartsWith('ubuntu.'))">linux-x64</RuntimeIdentifiers>
     <RidSpecificAssets>true</RidSpecificAssets>
   </PropertyGroup>
 


### PR DESCRIPTION
Switch rid to generic linux in most places and stop pretending that we are on ubuntu-14.04. ubuntu-14.04 is left just at the two places that still need it.