### PR TITLE
Pass /LIBPATH to linker

### DIFF
--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -120,7 +120,7 @@ public class ValuesController
 
 ## Restore and Publish your app
 
-Once the package has been successfully added it's time to compile and publish your app! If you're using Windows, make sure you're using `x64 Native Tools Command Prompt for VS 2017` instead of the standard Windows command prompt. In the shell/command prompt window, run the following command:
+Once the package has been successfully added it's time to compile and publish your app! In the shell/command prompt window, run the following command:
 
 ```bash
 > dotnet publish -r <RID> -c <Configuration>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -80,12 +80,17 @@ See the LICENSE file in the project root for more information.
       <Output TaskParameter="ExitCode" PropertyName="_WhereCppTools"/>
     </Exec>
 
-    <Exec Condition="'$(_WhereCppTools)' != '0'" Command="&quot;$(MSBuildThisFileDirectory)findvcvarsall.bat&quot; x86_amd64" LogStandardErrorAsError="true" ContinueOnError="false" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="_CppToolsDirectory"/>
+    <Exec Condition="'$(_WhereCppTools)' != '0'" Command="&quot;$(MSBuildThisFileDirectory)findvcvarsall.bat&quot; amd64" LogStandardErrorAsError="true" ContinueOnError="false" ConsoleToMSBuild="true" StandardOutputImportance="Low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_FindVCVarsallOutput"/>
       <Output TaskParameter="ExitCode" PropertyName="_VCVarsAllFound"/>
     </Exec>
 
+    <ItemGroup Condition="'$(_VCVarsAllFound)' == '0'">
+      <AdditionalNativeLibraryDirectories Include="$(_FindVCVarsallOutput.Split(`#`)[1].Split(';'))" />
+    </ItemGroup>
+
     <PropertyGroup Condition="'$(_VCVarsAllFound)' == '0'">
+      <_CppToolsDirectory>$(_FindVCVarsallOutput.Split(`#`)[0])</_CppToolsDirectory>
       <CppCompiler>"$(_CppToolsDirectory)cl.exe"</CppCompiler>
       <CppLinker>"$(_CppToolsDirectory)link.exe"</CppLinker>
       <CppLibCreator>"$(_CppToolsDirectory)lib.exe"</CppLibCreator>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -202,6 +202,7 @@ See the LICENSE file in the project root for more information.
       <CustomLinkerArg Include="-o $(NativeBinary)" Condition="'$(OS)' != 'Windows_NT'" />
       <CustomLinkerArg Include="/OUT:$(NativeBinary)" Condition="'$(OS)' == 'Windows_NT'" />
       <CustomLinkerArg Include="/DEF:$(ExportsFile)" Condition="'$(OS)' == 'Windows_NT' and $(ExportsFile) != ''" />
+      <CustomLinkerArg Include="/LIBPATH:&quot;%(AdditionalNativeLibraryDirectories.Identity)&quot;" Condition="'$(OS)' == 'Windows_NT' and '@(AdditionalNativeLibraryDirectories->Count())' &gt; 0" />
       <CustomLinkerArg Include="-exported_symbols_list $(ExportsFile)" Condition="'$(OS)' != 'Windows_NT' and $(ExportsFile) != ''" />
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>

--- a/src/BuildIntegration/findvcvarsall.bat
+++ b/src/BuildIntegration/findvcvarsall.bat
@@ -15,9 +15,14 @@ IF "%vsBase%"=="" GOTO :ERROR
 CALL "%vsBase%\vc\Auxiliary\Build\vcvarsall.bat" %1% > NUL
 
 FOR /F "delims=" %%W IN ('where link') DO (
-    FOR %%A IN ("%%W") DO ECHO %%~dpA
-    EXIT /B 0
+    FOR %%A IN ("%%W") DO ECHO %%~dpA#
+    GOTO :CAPTURE_LIB_PATHS
 )
+
+:CAPTURE_LIB_PATHS
+ECHO %LIB%
+
+EXIT /B 0
 
 ENDLOCAL
 


### PR DESCRIPTION
Package [Microsoft.DotNet.ILCompiler v1.0.0-alpha-26207-01](https://dotnet.myget.org/feed/dotnet-core/package/nuget/Microsoft.DotNet.ILCompiler/1.0.0-alpha-26207-01)
was failing to compile WebAPI app when using non-developer command
prompt on Windows, because Kernel32.lib and friends weren't get located.

Capturing those from vsvarsall environment in `findvsvarsall.bat` script
and passing it to link.exe fixes the error and compiles WebAPI app
successfully.