### PR TITLE
Make some edge-case GetCustomAttribute() behavior match NETFx behavior.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeExtensions.cs
@@ -345,7 +345,18 @@ namespace System.Reflection
             }
             int count = attributes.Count;
             Attribute[] result;
-            result = (Attribute[])Array.CreateInstance(actualElementType, count);
+            try
+            {
+                result = (Attribute[])Array.CreateInstance(actualElementType, count);
+            }
+            catch (NotSupportedException) when (actualElementType.ContainsGenericParameters)
+            {
+                // This is here for desktop compatibility (using try-catch as control flow to avoid slowing down the mainline case.)
+                // CustomAttributeExtensions.GetCustomAttributes() normally returns an array of the exact attribute type requested except when
+                // the reqested type is an open type. Its ICustomAttributeProvider counterpart would return an Object[] array but that's
+                // not possible with this api's return type so it returns null instead.
+                return null;
+            }
             attributes.CopyTo(result, 0);
             return result;
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -189,8 +189,14 @@ namespace System.Reflection.Runtime.General
                 object instantiatedAttribute = cad.Instantiate();
                 attributes.Add(instantiatedAttribute);
             }
+
+            // This is here for desktop compatibility. ICustomAttribute.GetCustomAttributes() normally returns an array of the 
+            // exact attribute type requested except in two cases: when the passed in type is an open type and when 
+            // it is a value type. In these two cases, it returns an array of type Object[].
+            bool useObjectArray = actualElementType.ContainsGenericParameters || actualElementType.IsValueType;
             int count = attributes.Count;
-            object[] result = (object[])Array.CreateInstance(actualElementType, count);
+            object[] result = useObjectArray ? new object[count] : (object[])Array.CreateInstance(actualElementType, count);
+
             attributes.CopyTo(result, 0);
             return result;
         }


### PR DESCRIPTION
This was discovered while reviewing incoming CoreCLR changes
that enable the use of generic custom attributes. With these
changes (plus a separate change that comments out an assert in NUTC)
the tests introduced for that feature pass in Project N.


Object[] ICustomAttributeProvider.GetCustomAttributes()

 If the passed in attribute type is an open type or a value type,
 the return array is of type Object[] rather than the exact
 array type (which would be impossible in the case of an open type.)
 Chances are the array length would be zero though I don't
 hardcode that assumption.


IEnumerable<Attribute> CustomAttributeExtensions.GetCustomAttributes()

 If the passed in attribute type is an open type, the code internally
 generates a Object[] array which then decays to null due to a
 "as Attribute[]" conversion.

 If the passed in attribute type is a value type, it gets thrown
 out by the "must derive from System.Attribute" check so that
 case doesn't apply to this api.


Attribute.GetCustomAttributes()

 Everything that applies to CustomAttributeExtensions applies
 to this.