### PR TITLE
Add PinvokeMarshal implementation for xplat mcg

### DIFF
--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Unix.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Unix.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Security;
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// This PInvokeMarshal class should provide full public Marshal 
+    /// implementation for all things related to P/Invoke marshalling
+    /// </summary>
+    public partial class PInvokeMarshal
+    {
+        public static void SaveLastWin32Error()
+        {
+            s_lastWin32Error = Interop.Sys.GetErrNo();
+        }
+
+        public static void ClearLastWin32Error()
+        {
+            Interop.Sys.ClearErrNo();
+        }
+
+        private static bool IsWin32Atom(IntPtr ptr)
+        {
+            return false;
+        }
+
+        public static unsafe String PtrToStringAnsi(IntPtr ptr)
+        {
+            if (IntPtr.Zero == ptr)
+            {
+                return null;
+            }
+
+            int len = Internal.Runtime.CompilerHelpers.InteropHelpers.strlen((byte*)ptr);
+            if (len == 0)
+            {
+                return string.Empty;
+            }
+
+            return System.Text.Encoding.UTF8.GetString((byte*)ptr, len);
+        }
+
+        public static unsafe String PtrToStringAnsi(IntPtr ptr, int len)
+        {
+            if (ptr == IntPtr.Zero)
+                throw new ArgumentNullException(nameof(ptr));
+            if (len < 0)
+                throw new ArgumentException(nameof(len));
+
+            return System.Text.Encoding.UTF8.GetString((byte*)ptr, len);
+        }
+
+        public static unsafe IntPtr MemAlloc(IntPtr cb)
+        {
+            return Interop.MemAlloc((UIntPtr)(void*)cb);
+        }
+
+        public static void MemFree(IntPtr hglobal)
+        {
+            Interop.MemFree(hglobal);
+        }
+
+        public static unsafe IntPtr MemReAlloc(IntPtr pv, IntPtr cb)
+        {
+            return Interop.MemReAlloc(pv, new UIntPtr((void*)cb));
+        }
+
+        public static IntPtr CoTaskMemAlloc(UIntPtr bytes)
+        {
+            return Interop.MemAlloc(bytes);
+        }
+
+        public static void CoTaskMemFree(IntPtr allocatedMemory)
+        {
+            Interop.MemFree(allocatedMemory);
+        }
+
+        public static unsafe IntPtr CoTaskMemReAlloc(IntPtr pv, IntPtr cb)
+        {
+            return Interop.MemReAlloc(pv, new UIntPtr((void*)cb));
+        }
+
+        public static IntPtr SecureStringToBSTR(SecureString s)
+        {
+            if (s == null)
+            {
+                throw new ArgumentNullException(nameof(s));
+            }
+            throw new PlatformNotSupportedException();
+        }
+
+        // In CoreRT on Unix, there is not yet a BSTR implementation. On Windows, we would use SysAllocStringLen from OleAut32.dll.
+        internal static IntPtr AllocBSTR(int length)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        internal static void FreeBSTR(IntPtr ptr)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        #region String marshalling
+
+        public static unsafe int ConvertMultiByteToWideChar(byte* multiByteStr,
+                                                            int multiByteLen,
+                                                            char* wideCharStr,
+                                                            int wideCharLen)
+        {
+            return System.Text.Encoding.UTF8.GetChars(multiByteStr, multiByteLen, wideCharStr, wideCharLen);
+        }
+
+        public static unsafe int ConvertWideCharToMultiByte(char* wideCharStr,
+                                                            int wideCharLen,
+                                                            byte* multiByteStr,
+                                                            int multiByteLen,
+                                                            bool bestFit,
+                                                            bool throwOnUnmappableChar)
+        {
+            return System.Text.Encoding.UTF8.GetBytes(wideCharStr, wideCharLen, multiByteStr, multiByteLen);
+        }
+
+        public static unsafe int ConvertWideCharToMultiByte(char* wideCharStr,
+                                                            int wideCharLen,
+                                                            byte* multiByteStr,
+                                                            int multiByteLen)
+        {
+            return System.Text.Encoding.UTF8.GetBytes(wideCharStr, wideCharLen, multiByteStr, multiByteLen);
+        }
+
+        public static unsafe int GetByteCount(char* wideCharStr, int wideCharLen)
+        {
+            return System.Text.Encoding.UTF8.GetByteCount(wideCharStr, wideCharLen);
+        }
+
+        public static unsafe int GetCharCount(byte* multiByteStr, int multiByteLen)
+        {
+            return System.Text.Encoding.UTF8.GetCharCount(multiByteStr, multiByteLen);
+        }
+
+        public static unsafe int GetSystemMaxDBCSCharSize()
+        {
+            return 3;
+        }
+        #endregion
+    }
+}

--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Unix.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Unix.cs
@@ -23,32 +23,6 @@ namespace System.Runtime.InteropServices
             return false;
         }
 
-        public static unsafe String PtrToStringAnsi(IntPtr ptr)
-        {
-            if (IntPtr.Zero == ptr)
-            {
-                return null;
-            }
-
-            int len = Internal.Runtime.CompilerHelpers.InteropHelpers.strlen((byte*)ptr);
-            if (len == 0)
-            {
-                return string.Empty;
-            }
-
-            return System.Text.Encoding.UTF8.GetString((byte*)ptr, len);
-        }
-
-        public static unsafe String PtrToStringAnsi(IntPtr ptr, int len)
-        {
-            if (ptr == IntPtr.Zero)
-                throw new ArgumentNullException(nameof(ptr));
-            if (len < 0)
-                throw new ArgumentException(nameof(len));
-
-            return System.Text.Encoding.UTF8.GetString((byte*)ptr, len);
-        }
-
         // In CoreRT on Unix, there is not yet a BSTR implementation. On Windows, we would use SysAllocStringLen from OleAut32.dll.
         internal static IntPtr AllocBSTR(int length)
         {

--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Unix.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Unix.cs
@@ -13,14 +13,9 @@ namespace System.Runtime.InteropServices
     /// </summary>
     public partial class PInvokeMarshal
     {
-        public static void SaveLastWin32Error()
-        {
-            s_lastWin32Error = Interop.Sys.GetErrNo();
-        }
-
         public static void ClearLastWin32Error()
         {
-            Interop.Sys.ClearErrNo();
+            // no-op
         }
 
         private static bool IsWin32Atom(IntPtr ptr)
@@ -52,45 +47,6 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentException(nameof(len));
 
             return System.Text.Encoding.UTF8.GetString((byte*)ptr, len);
-        }
-
-        public static unsafe IntPtr MemAlloc(IntPtr cb)
-        {
-            return Interop.MemAlloc((UIntPtr)(void*)cb);
-        }
-
-        public static void MemFree(IntPtr hglobal)
-        {
-            Interop.MemFree(hglobal);
-        }
-
-        public static unsafe IntPtr MemReAlloc(IntPtr pv, IntPtr cb)
-        {
-            return Interop.MemReAlloc(pv, new UIntPtr((void*)cb));
-        }
-
-        public static IntPtr CoTaskMemAlloc(UIntPtr bytes)
-        {
-            return Interop.MemAlloc(bytes);
-        }
-
-        public static void CoTaskMemFree(IntPtr allocatedMemory)
-        {
-            Interop.MemFree(allocatedMemory);
-        }
-
-        public static unsafe IntPtr CoTaskMemReAlloc(IntPtr pv, IntPtr cb)
-        {
-            return Interop.MemReAlloc(pv, new UIntPtr((void*)cb));
-        }
-
-        public static IntPtr SecureStringToBSTR(SecureString s)
-        {
-            if (s == null)
-            {
-                throw new ArgumentNullException(nameof(s));
-            }
-            throw new PlatformNotSupportedException();
         }
 
         // In CoreRT on Unix, there is not yet a BSTR implementation. On Windows, we would use SysAllocStringLen from OleAut32.dll.

--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Windows.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Windows.cs
@@ -34,12 +34,6 @@ namespace System.Runtime.InteropServices
             long lPtr = (long)ptr;
             return 0 != (lPtr & HIWORDMASK);
         }
-
-        public static void SaveLastWin32Error()
-        {
-            s_lastWin32Error = Marshal.GetLastWin32Error();
-        }
-
         public static void ClearLastWin32Error()
         {
             Interop.mincore.SetLastError(0);

--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Windows.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.Windows.cs
@@ -1,0 +1,162 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// This PInvokeMarshal class should provide full public Marshal 
+    /// implementation for all things related to P/Invoke marshalling
+    /// </summary>
+    public partial class PInvokeMarshal
+    {
+        private const long HIWORDMASK = unchecked((long)0xffffffffffff0000L);
+
+        // Win32 has the concept of Atoms, where a pointer can either be a pointer
+        // or an int.  If it's less than 64K, this is guaranteed to NOT be a
+        // pointer since the bottom 64K bytes are reserved in a process' page table.
+        // We should be careful about deallocating this stuff.  Extracted to
+        // a function to avoid C# problems with lack of support for IntPtr.
+        // We have 2 of these methods for slightly different semantics for NULL.
+        private static bool IsWin32Atom(IntPtr ptr)
+        {
+            long lPtr = (long)ptr;
+            return 0 == (lPtr & HIWORDMASK);
+        }
+
+        private static bool IsNotWin32Atom(IntPtr ptr)
+        {
+            long lPtr = (long)ptr;
+            return 0 != (lPtr & HIWORDMASK);
+        }
+
+        public static void SaveLastWin32Error()
+        {
+            s_lastWin32Error = Marshal.GetLastWin32Error();
+        }
+
+        public static void ClearLastWin32Error()
+        {
+            Interop.mincore.SetLastError(0);
+        }
+        
+        #region String marshalling
+
+        public static unsafe int ConvertMultiByteToWideChar(byte* buffer, int ansiLength, char* pWChar, int uniLength)
+        {
+            return Interop.Kernel32.MultiByteToWideChar(Interop.Kernel32.CP_ACP, 0, buffer, ansiLength, pWChar, uniLength);
+        }
+
+        // Convert a UTF16 string to ANSI byte array
+        public static unsafe int ConvertWideCharToMultiByte(char* wideCharStr, int wideCharLen, byte* multiByteStr, int multiByteLen)
+        {
+            return Interop.Kernel32.WideCharToMultiByte(Interop.Kernel32.CP_ACP,
+                                                        0,
+                                                        wideCharStr,
+                                                        wideCharLen,
+                                                        multiByteStr,
+                                                        multiByteLen,
+                                                        default(IntPtr),
+                                                        default(IntPtr)
+                                                        );
+        }
+
+        // Convert a UTF16 string to ANSI byte array using flags
+        public static unsafe int ConvertWideCharToMultiByte(char* wideCharStr,
+                                                            int wideCharLen,
+                                                            byte* multiByteStr,
+                                                            int multiByteLen,
+                                                            bool bestFit,
+                                                            bool throwOnUnmappableChar)
+        {
+            uint flags = (bestFit ? 0 : Interop.Kernel32.WC_NO_BEST_FIT_CHARS);
+            int defaultCharUsed = 0;
+            int ret = Interop.Kernel32.WideCharToMultiByte(Interop.Kernel32.CP_ACP,
+                                                        flags,
+                                                        wideCharStr,
+                                                        wideCharLen,
+                                                        multiByteStr,
+                                                        multiByteLen,
+                                                        default(IntPtr),
+                                                        throwOnUnmappableChar ? new System.IntPtr(&defaultCharUsed) : default(IntPtr)
+                                                        );
+            if (defaultCharUsed != 0)
+            {
+                throw new ArgumentException(SR.Arg_InteropMarshalUnmappableChar);
+            }
+
+            return ret;
+        }
+
+        // Return size in bytes required to convert a UTF16 string to byte array.
+        public static unsafe int GetByteCount(char* wStr, int wideStrLen)
+        {
+            return Interop.Kernel32.WideCharToMultiByte(Interop.Kernel32.CP_ACP,
+                                                        0,
+                                                        wStr,
+                                                        wideStrLen,
+                                                        default(byte*),
+                                                        0,
+                                                        default(IntPtr),
+                                                        default(IntPtr)
+                                                        );
+        }
+
+        // Return number of charaters encoded in native byte array lpMultiByteStr
+        unsafe public static int GetCharCount(byte* multiByteStr, int multiByteLen)
+        {
+            return Interop.Kernel32.MultiByteToWideChar(Interop.Kernel32.CP_ACP, 0, multiByteStr, multiByteLen, default(char*), 0);
+        }
+
+        public static unsafe int GetSystemMaxDBCSCharSize()
+        {
+            Interop.Kernel32.CPINFO cpInfo;
+            if (Interop.Kernel32.GetCPInfo(Interop.Kernel32.CP_ACP, &cpInfo) != 0)
+            {
+                return cpInfo.MaxCharSize;
+            }
+            else
+            {
+                return 2;
+            }
+        }
+        #endregion
+    }
+}
+
+internal static partial class Interop
+{
+    internal static partial class Libraries
+    {
+        internal const string Kernel32 = "kernel32.dll";
+    }
+
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32)]
+        internal static extern unsafe int WideCharToMultiByte(
+            uint CodePage, uint dwFlags,
+            char* lpWideCharStr, int cchWideChar,
+            byte* lpMultiByteStr, int cbMultiByte,
+            IntPtr lpDefaultChar, IntPtr lpUsedDefaultChar);
+
+        internal const uint CP_ACP = 0;
+        internal const uint WC_NO_BEST_FIT_CHARS = 0x00000400;
+
+        internal unsafe struct CPINFO
+        {
+            internal int MaxCharSize;
+
+            internal fixed byte DefaultChar[2 /* MAX_DEFAULTCHAR */];
+            internal fixed byte LeadByte[12 /* MAX_LEADBYTES */];
+        }
+
+        [DllImport(Libraries.Kernel32)]
+        internal static extern unsafe int GetCPInfo(uint codePage, CPINFO* lpCpInfo);
+    }
+}

--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.cs
@@ -2,7 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Debug = System.Diagnostics.Debug;
 using System.Runtime.CompilerServices;
+
+#if BIT64
+using nuint = System.UInt64;
+#else
+using nuint = System.UInt32;
+#endif
 
 namespace System.Runtime.InteropServices
 {
@@ -11,26 +18,19 @@ namespace System.Runtime.InteropServices
     /// implementation for all things related to P/Invoke marshalling
     /// </summary>
     [CLSCompliant(false)]
-    public sealed class PInvokeMarshal
-    {
-        public static void SaveLastWin32Error()
-        {
-            // nop
-        }
-
-        public static void ClearLastWin32Error()
-        {
-            // nop
-        }
+    public partial class PInvokeMarshal
+    {        
+        [ThreadStatic]
+        internal static int s_lastWin32Error;
 
         public static int GetLastWin32Error()
         {
-            return 0;
+            return s_lastWin32Error;
         }
 
         public static void SetLastWin32Error(int errorCode)
         {
-            // nop
+            s_lastWin32Error = errorCode;
         }
 
         public static IntPtr GetStubForPInvokeDelegate(Delegate del)
@@ -85,124 +85,400 @@ namespace System.Runtime.InteropServices
 
         public static unsafe void StringBuilderToUnicodeString(System.Text.StringBuilder stringBuilder, ushort* destination)
         {
-            // nop
+            stringBuilder.UnsafeCopyTo((char*)destination);
         }
 
         public static unsafe void UnicodeStringToStringBuilder(ushort* newBuffer, System.Text.StringBuilder stringBuilder)
         {
-            // nop
+            stringBuilder.ReplaceBuffer((char*)newBuffer);
         }
 
         public static unsafe void StringBuilderToAnsiString(System.Text.StringBuilder stringBuilder, byte* pNative,
             bool bestFit, bool throwOnUnmappableChar)
         {
-            // nop
+            int len;
+
+            // Convert StringBuilder to UNICODE string
+            // Optimize for the most common case. If there is only a single char[] in the StringBuilder,
+            // get it and convert it to ANSI
+            char[] buffer = stringBuilder.GetBuffer(out len);
+            if (buffer != null)
+            {
+                fixed (char* pManaged = buffer)
+                {
+                    StringToAnsiString(pManaged, len, pNative, /*terminateWithNull=*/true, bestFit, throwOnUnmappableChar);
+                }
+            }
+            else // Otherwise, convert StringBuilder to string and then convert to ANSI
+            {
+                string str = stringBuilder.ToString();
+                
+                // Convert UNICODE string to ANSI string
+                fixed (char* pManaged = str)
+                {
+                    StringToAnsiString(pManaged, str.Length, pNative, /*terminateWithNull=*/true, bestFit, throwOnUnmappableChar);
+                }
+            }
         }
 
         public static unsafe void AnsiStringToStringBuilder(byte* newBuffer, System.Text.StringBuilder stringBuilder)
         {
-            // nop
-        }
+            if (newBuffer == null)
+                throw new ArgumentNullException(nameof(newBuffer));
 
+            int lenAnsi;
+            int lenUnicode;
+            CalculateStringLength(newBuffer, out lenAnsi, out lenUnicode);
+
+            if (lenUnicode > 0)
+            {
+                char[] buffer = new char[lenUnicode];
+                fixed (char* pTemp = &buffer[0])
+                {
+                    ConvertMultiByteToWideChar(newBuffer,
+                                               lenAnsi,
+                                               pTemp,
+                                               lenUnicode);
+                }
+                stringBuilder.ReplaceBuffer(buffer);
+            }
+            else
+            {
+                stringBuilder.Clear();
+            }
+        }
+        
         public static unsafe string AnsiStringToString(byte* pchBuffer)
         {
-            return default(string);
+            if (pchBuffer == null)
+            {
+                return null;
+            }
+
+            int lenAnsi;
+            int lenUnicode;
+            CalculateStringLength(pchBuffer, out lenAnsi, out lenUnicode);
+
+            string result = String.Empty;
+
+            if (lenUnicode > 0)
+            {
+                result = new string(' ',lenUnicode);
+
+                fixed (char* pTemp = result)
+                {
+                    ConvertMultiByteToWideChar(pchBuffer,
+                                               lenAnsi,
+                                               pTemp,
+                                               lenUnicode);
+                }
+            }
+
+            return result;
         }
 
         public static unsafe byte* StringToAnsiString(string str, bool bestFit, bool throwOnUnmappableChar)
         {
-            return default(byte*);
+            if (str != null)
+            {
+                int lenUnicode = str.Length;
+
+                fixed (char* pManaged = str)
+                {
+                    return StringToAnsiString(pManaged, lenUnicode, null, /*terminateWithNull=*/true, bestFit, throwOnUnmappableChar);
+                }
+            }
+
+            return null;
         }
 
         public static unsafe void ByValWideCharArrayToAnsiCharArray(char[] managedArray, byte* pNative, int expectedCharCount,
             bool bestFit, bool throwOnUnmappableChar)
         {
-            // nop
+            // Zero-init pNative if it is NULL
+            if (managedArray == null)
+            {
+                // @TODO - Create a more efficient version of zero initialization
+                for (int i = 0; i < expectedCharCount; i++)
+                {
+                    pNative[i] = 0;
+                }
+            }
+
+
+            int lenUnicode = managedArray.Length;
+            if (lenUnicode < expectedCharCount)
+
+                throw new ArgumentException(SR.WrongSizeArrayInNStruct);
+
+            fixed (char* pManaged = managedArray)
+            {
+                StringToAnsiString(pManaged, lenUnicode, pNative, /*terminateWithNull=*/false, bestFit, throwOnUnmappableChar);
+            }
         }
 
         public static unsafe void ByValAnsiCharArrayToWideCharArray(byte* pNative, char[] managedArray)
         {
-            // nop
+            // This should never happen because it is a embedded array
+            Debug.Assert(pNative != null);
+
+            // This should never happen because the array is always allocated by the marshaller
+            Debug.Assert(managedArray != null);
+
+            // COMPAT: Use the managed array length as the maximum length of native buffer
+            // This obviously doesn't make sense but desktop CLR does that
+            int lenInBytes = managedArray.Length;
+            fixed (char* pManaged = managedArray)
+            {
+                ConvertMultiByteToWideChar(pNative,
+                                           lenInBytes,
+                                           pManaged,
+                                           lenInBytes);
+            }
         }
 
         public static unsafe void WideCharArrayToAnsiCharArray(char[] managedArray, byte* pNative, bool bestFit, bool throwOnUnmappableChar)
         {
-            // nop
+            // Do nothing if array is NULL. This matches desktop CLR behavior
+            if (managedArray == null)
+                return;
+
+            // Desktop CLR crash (AV at runtime) - we can do better in .NET Native
+            if (pNative == null)
+                throw new ArgumentNullException(nameof(pNative));
+
+            int lenUnicode = managedArray.Length;
+            fixed (char* pManaged = managedArray)
+            {
+                StringToAnsiString(pManaged, lenUnicode, pNative, /*terminateWithNull=*/false, bestFit, throwOnUnmappableChar);
+            }
         }
 
         public static unsafe void AnsiCharArrayToWideCharArray(byte* pNative, char[] managedArray)
         {
-            // nop
+            // Do nothing if native is NULL. This matches desktop CLR behavior
+            if (pNative == null)
+                return;
+
+            // Desktop CLR crash (AV at runtime) - we can do better in .NET Native
+            if (managedArray == null)
+                throw new ArgumentNullException(nameof(managedArray));
+
+            // COMPAT: Use the managed array length as the maximum length of native buffer
+            // This obviously doesn't make sense but desktop CLR does that
+            int lenInBytes = managedArray.Length;
+            fixed (char* pManaged = managedArray)
+            {
+                ConvertMultiByteToWideChar(pNative,
+                                           lenInBytes,
+                                           pManaged,
+                                           lenInBytes);
+            }
         }
 
         public static unsafe byte WideCharToAnsiChar(char managedValue, bool bestFit, bool throwOnUnmappableChar)
         {
-            return default(byte);
+            // @TODO - we really shouldn't allocate one-byte arrays and then destroy it
+            byte* nativeArray = StringToAnsiString(&managedValue, 1, null, /*terminateWithNull=*/false, bestFit, throwOnUnmappableChar);
+            byte native = (*nativeArray);
+            CoTaskMemFree(new IntPtr(nativeArray));
+            return native;
         }
 
         public static unsafe char AnsiCharToWideChar(byte nativeValue)
         {
-            return default(char);
+            char ch;
+            ConvertMultiByteToWideChar(&nativeValue, 1, &ch, 1);
+            return ch;
         }
 
         public static unsafe void StringToByValAnsiString(string str, byte* pNative, int charCount, bool bestFit, bool throwOnUnmappableChar, bool truncate = true)
         {
-            // nop
+            if (pNative == null)
+                throw new ArgumentNullException(nameof(pNative));
+
+            if (str != null)
+            {
+                // Truncate the string if it is larger than specified by SizeConst
+                int lenUnicode;
+
+                if (truncate)
+                {
+                    lenUnicode = str.Length;
+                    if (lenUnicode >= charCount)
+                        lenUnicode = charCount - 1;
+                }
+                else
+                {
+                    lenUnicode = charCount;
+                }
+
+                fixed (char* pManaged = str)
+                {
+                    StringToAnsiString(pManaged, lenUnicode, pNative, /*terminateWithNull=*/true, bestFit, throwOnUnmappableChar);
+                }
+            }
+            else
+            {
+                (*pNative) = (byte)'\0';
+            }
         }
 
         public static unsafe string ByValAnsiStringToString(byte* pchBuffer, int charCount)
         {
-            return default(string);
+            // Match desktop CLR behavior
+            if (charCount == 0)
+                throw new MarshalDirectiveException();
+
+            int lenAnsi = GetAnsiStringLen(pchBuffer);
+            int lenUnicode = charCount;
+
+            string result = String.Empty;
+
+            if (lenUnicode > 0)
+            {
+                char* unicodeBuf = stackalloc char[lenUnicode];
+                int unicodeCharWritten = ConvertMultiByteToWideChar(pchBuffer,
+                                                                    lenAnsi,
+                                                                    unicodeBuf,
+                                                                    lenUnicode);
+
+                // If conversion failure, return empty string to match desktop CLR behavior
+                if (unicodeCharWritten > 0)
+                    result = new string(unicodeBuf, 0, unicodeCharWritten);
+            }
+
+            return result;
+        }
+        
+        
+        private static unsafe int GetAnsiStringLen(byte* pchBuffer)
+        {
+            byte* pchBufferOriginal = pchBuffer;
+            while (*pchBuffer != 0)
+            {
+                pchBuffer++;
+            }
+            
+            return (int)(pchBuffer - pchBufferOriginal);
         }
 
-        public static unsafe int ConvertMultiByteToWideChar(byte* buffer, int ansiLength, char* pWChar, int uniLength)
+        // c# string (UTF-16) to UTF-8 encoded byte array
+        private static unsafe byte* StringToAnsiString(char* pManaged, int lenUnicode, byte* pNative, bool terminateWithNull,
+            bool bestFit, bool throwOnUnmappableChar)
         {
-            return default(int);
-        }
+            bool allAscii = true;
 
-        public static unsafe int ConvertWideCharToMultiByte(char* wideCharStr, int wideCharLen, byte* multiByteStr, int multiByteLen)
-        {
-            return default(int);
-        }
+            for (int i = 0; i < lenUnicode; i++)
+            {
+                if (pManaged[i] >= 128)
+                {
+                    allAscii = false;
+                    break;
+                }
+            }
 
-        public static unsafe int ConvertWideCharToMultiByte(char* wideCharStr,
-                                                            int wideCharLen,
-                                                            byte* multiByteStr,
-                                                            int multiByteLen,
-                                                            uint flags,
-                                                            IntPtr usedDefaultChar)
-        {
-            return default(int);
-        }
+            int length;
 
-        public static unsafe int GetByteCount(char* wStr, int wideStrLen)
-        {
-            return default(int);
-        }
+            if (allAscii) // If all ASCII, map one UNICODE character to one ANSI char
+            {
+                length = lenUnicode;
+            }
+            else // otherwise, let OS count number of ANSI chars
+            {
+                length = GetByteCount(pManaged, lenUnicode);
+            }
 
-        unsafe public static int GetCharCount(byte* multiByteStr, int multiByteLen)
-        {
-            return default(int);
-        }
+            if (pNative == null)
+            {
+                pNative = (byte*)CoTaskMemAlloc((System.UIntPtr)(length + 1));
+            }
+            if (allAscii) // ASCII conversion
+            {
+                byte* pDst = pNative;
+                char* pSrc = pManaged;
 
-        public static unsafe int GetSystemMaxDBCSCharSize()
-        {
-            return default(int);
+                while (lenUnicode > 0)
+                {
+                    unchecked
+                    {
+                        *pDst++ = (byte)(*pSrc++);
+                        lenUnicode--;
+                    }
+                }
+            }
+            else // Let OS convert
+            {
+                ConvertWideCharToMultiByte(pManaged,
+                                           lenUnicode,
+                                           pNative,
+                                           length,
+                                           bestFit,
+                                           throwOnUnmappableChar);
+            }
+
+            // Zero terminate
+            if (terminateWithNull)
+                *(pNative + length) = 0;
+
+            return pNative;
         }
 
         public static unsafe String PtrToStringUni(IntPtr ptr, int len)
         {
-            return default(String);
+            return Marshal.PtrToStringUni(ptr, len);
         }
 
         public static unsafe String PtrToStringUni(IntPtr ptr)
         {
-            return default(String);
+            return Marshal.PtrToStringUni(ptr);
         }
-
+        
+        //====================================================================
+        // Copy blocks from CLR arrays to native memory.
+        //====================================================================
         public static unsafe void CopyToNative(Array source, int startIndex, IntPtr destination, int length)
         {  
-            // nop
-        }  
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>
+        /// This is a auxiliary function that counts the length of the ansi buffer and
+        ///  estimate the length of the buffer in Unicode. It returns true if all bytes
+        ///  in the buffer are ANSII.
+        /// </summary>
+        private static unsafe bool CalculateStringLength(byte* pchBuffer, out int ansiBufferLen, out int unicodeBufferLen)
+        {
+            ansiBufferLen = 0;
+
+            bool allAscii = true;
+
+            {
+                byte* p = pchBuffer;
+                byte b = *p++;
+
+                while (b != 0)
+                {
+                    if (b >= 128)
+                    {
+                        allAscii = false;
+                    }
+
+                    ansiBufferLen++;
+
+                    b = *p++;
+                }
+            }
+
+            if (allAscii)
+            {
+                unicodeBufferLen = ansiBufferLen;
+            }
+            else // If non ASCII, let OS calculate number of characters
+            {
+                unicodeBufferLen = GetCharCount(pchBuffer, ansiBufferLen);
+            }
+            return allAscii;
+        }        
     }
 }

--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.cs
@@ -5,12 +5,6 @@
 using Debug = System.Diagnostics.Debug;
 using System.Runtime.CompilerServices;
 
-#if BIT64
-using nuint = System.UInt64;
-#else
-using nuint = System.UInt32;
-#endif
-
 namespace System.Runtime.InteropServices
 {
     /// <summary>
@@ -31,6 +25,11 @@ namespace System.Runtime.InteropServices
         public static void SetLastWin32Error(int errorCode)
         {
             s_lastWin32Error = errorCode;
+        }
+        
+        public static void SaveLastWin32Error()
+        {
+            s_lastWin32Error = Marshal.GetLastWin32Error();
         }
 
         public static IntPtr GetStubForPInvokeDelegate(Delegate del)

--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.cs
@@ -433,6 +433,16 @@ namespace System.Runtime.InteropServices
             return Marshal.PtrToStringUni(ptr);
         }
         
+        public static unsafe String PtrToStringAnsi(IntPtr ptr)
+        {
+            return Marshal.PtrToStringAnsi(ptr);
+        }
+ 
+        public static unsafe String PtrToStringAnsi(IntPtr ptr, int len)
+        {
+            return Marshal.PtrToStringAnsi(ptr, len);
+        }
+        
         //====================================================================
         // Copy blocks from CLR arrays to native memory.
         //====================================================================

--- a/src/System.Private.Interop/src/Resources/Strings.resx
+++ b/src/System.Private.Interop/src/Resources/Strings.resx
@@ -366,4 +366,10 @@
   <data name="TypeNotDelegate" xml:space="preserve">
     <value>'Type '{0}' is not a delegate type.  EventTokenTable may only be used with delegate types.'</value>
   </data>
+    <data name="WrongSizeArrayInNStruct" xml:space="preserve">
+    <value>Type could not be marshaled because the length of an embedded array instance does not match the declared length in the layout.</value>
+  </data>
+  <data name="Arg_InteropMarshalUnmappableChar" xml:space="preserve">
+    <value>Cannot marshal: Encountered unmappable character.</value>
+  </data>
 </root>

--- a/src/System.Private.Interop/src/System.Private.Interop.CoreCLR.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.CoreCLR.csproj
@@ -63,7 +63,24 @@
     <Compile Include="Interop\Interop.WinRT.Basic.cs" />
     <Compile Include="System\Runtime\InteropServices\Variant.cs" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="InteropExtensions\PInvokeMarshal.Windows.cs" />
+    <Compile Include="..\..\Common\src\Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs">
+      <Link>Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.SetLastError.cs">
+      <Link>Interop\Windows\mincore\Interop.SetLastError.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\Interop.Libraries.cs">
+      <Link>Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+  </ItemGroup>
   
+  <ItemGroup Condition="'$(TargetsUnix)'=='true'">
+    <Compile Include="InteropExtensions\PInvokeMarshal.Unix.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="System\Reflection\DispatchProxy.cs" />
     <Compile Include="System\Reflection\DispatchProxyEntry.cs" />

--- a/src/System.Private.Interop/src/System.Private.Interop.Mono.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.Mono.csproj
@@ -101,7 +101,24 @@
     <Compile Include="Windows\Foundation\Size.cs" />
     <Compile Include="Windows\Foundation\TokenizerHelper.cs" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="InteropExtensions\PInvokeMarshal.Windows.cs" />
+    <Compile Include="..\..\Common\src\Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs">
+      <Link>Interop\Windows\kernel32\Interop.MultiByteToWideChar.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\mincore\Interop.SetLastError.cs">
+      <Link>Interop\Windows\mincore\Interop.SetLastError.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\Interop.Libraries.cs">
+      <Link>Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetsUnix)'=='true'">
+    <Compile Include="InteropExtensions\PInvokeMarshal.Unix.cs" />
+  </ItemGroup>
+
   <Import Project="System.Private.Interop.Shared.projitems" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Previously we moved Pinvoke marshalling support from System.Private.Interop to System.Private.Corelib to support CoreRT x-plat PInvoke and also leave PInvokeMarshal implementation for xplat-mcg as empty(see PInvokeMarshal.cs).  This breaks xplat-mcg scenarios and this change is to bring necessary PInvokeMarshal implementation back.