### PR TITLE
Improve CMake detection on Windows when not in PATH

### DIFF
--- a/src/Native/probe-win.ps1
+++ b/src/Native/probe-win.ps1
@@ -6,7 +6,7 @@ function GetCMakeVersions
   $items = @()
   $items += @(Get-ChildItem hklm:\SOFTWARE\Wow6432Node\Kitware -ErrorAction SilentlyContinue)
   $items += @(Get-ChildItem hklm:\SOFTWARE\Kitware -ErrorAction SilentlyContinue)
-  return $items | where { $_.PSChildName.StartsWith("CMake ") }
+  return $items | where { $_.PSChildName.StartsWith("CMake") }
 }
 
 function GetCMakeInfo($regKey)
@@ -17,7 +17,13 @@ function GetCMakeInfo($regKey)
   catch {
     return $null
   }
-  $cmakeDir = (Get-ItemProperty $regKey.PSPath).'(default)'
+  $itemProperty = Get-ItemProperty $regKey.PSPath;
+  if (Get-Member -inputobject $itemProperty -name "InstallDir" -Membertype Properties) {
+    $cmakeDir = $itemProperty.InstallDir
+  }
+  else {
+    $cmakeDir = $itemProperty.'(default)'
+  }
   $cmakePath = [System.IO.Path]::Combine($cmakeDir, "bin\cmake.exe")
   if (![System.IO.File]::Exists($cmakePath)) {
     return $null


### PR DESCRIPTION
In CMake v10.2, the key `hklm:\SOFTWARE\Kitware` returns:

```powershell
    Hive: HKEY_LOCAL_MACHINE\SOFTWARE\Kitware

Name                           Property
----                           --------
CMake                          InstallDir : C:\Program Files\CMake\
```

with no space after `CMake` and property name `InstallDir`,
instead of `'(default)'`.