### PR TITLE
Implement intrinsic call to RuntimeHelpers.InitializeArray for WASM

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1093,7 +1093,7 @@ namespace Internal.IL
                             LLVM.Int32Type(),
                             LLVM.Int1Type()
                         };
-                        MemcpyI8I8I32Function = GetOrCreateLLVMFunction("llvm.memcpy.p0i8.p0i8.i32", LLVM.FunctionType(LLVM.VoidType(), argsType, false));
+                        var memcpyFunction = GetOrCreateLLVMFunction("llvm.memcpy.p0i8.p0i8.i32", LLVM.FunctionType(LLVM.VoidType(), argsType, false));
 
                         var args = new LLVMValueRef[]
                         {
@@ -1105,7 +1105,7 @@ namespace Internal.IL
                             BuildConstInt32(16),
                             BuildConstInt1(0)
                         };
-                        LLVM.BuildCall(_builder, MemcpyI8I8I32Function, args, string.Empty);
+                        LLVM.BuildCall(_builder, memcpyFunction, args, string.Empty);
 
                         return true;
                     }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1074,6 +1074,8 @@ namespace Internal.IL
                         _dependencies.Add(node);
                         int srcLength = node.GetData(_compilation.NodeFactory, false).Data.Length;
 
+                        LLVMValueRef arrayObjPtr = arraySlot.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder);
+
                         var argsType = new LLVMTypeRef[]
                         {
                             LLVM.PointerType(LLVM.Int8Type(), 0),
@@ -1086,9 +1088,7 @@ namespace Internal.IL
 
                         var args = new LLVMValueRef[]
                         {
-                            // TODO: Where to get the base size of this array? We don't have the EEType of the array here.
-                            // Currently the base size is assumed to be 8 (while it seems always be).
-                            LLVM.BuildGEP(_builder, arraySlot.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder), new LLVMValueRef[] { BuildConstInt32(8) }, String.Empty),
+                            LLVM.BuildGEP(_builder, arrayObjPtr, new LLVMValueRef[] { ArrayBaseSize() }, String.Empty),
                             LLVM.BuildBitCast(_builder, src, LLVM.PointerType(LLVM.Int8Type(), 0), String.Empty),
                             BuildConstInt32(srcLength),
                             BuildConstInt32(16),

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1091,7 +1091,7 @@ namespace Internal.IL
                             LLVM.BuildGEP(_builder, arrayObjPtr, new LLVMValueRef[] { ArrayBaseSize() }, String.Empty),
                             LLVM.BuildBitCast(_builder, src, LLVM.PointerType(LLVM.Int8Type(), 0), String.Empty),
                             BuildConstInt32(srcLength),
-                            BuildConstInt32(16),
+                            BuildConstInt32(0), // Assume no alignment
                             BuildConstInt1(0)
                         };
                         LLVM.BuildCall(_builder, memcpyFunction, args, string.Empty);

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -210,6 +210,14 @@ internal static class Program
 
         System.Diagnostics.Debugger.Break();
 
+        var testRuntimeHelpersInitArray = new long[] {1, 2, 3};
+        if(testRuntimeHelpersInitArray[0] == 1 &&
+            testRuntimeHelpersInitArray[1] == 2 &&
+            testRuntimeHelpersInitArray[2] == 3)
+        {
+            PrintLine("Runtime.Helpers array initialization test: Ok.");
+        }
+
         PrintLine("Done");
     }
 


### PR DESCRIPTION
`RuntimeHelpers.InitializeArray` is now implemented as a call to LLVM intrinsic `llvm.memcpy.p0i8.p0i8.i32`, which copies from generated global constant to provided target array.

Currently the base size of the array object is hard-coded to 8, since no EEType is provided in the intrinsic call. Is there anyway to get the EEType of the object on stack? I don't think the current working around is doing any good, except it's working.