### PR TITLE
[ObjWriter] Add IMAGE_REL_BASED_RELPTR32 relocs support

### DIFF
--- a/src/Native/ObjWriter/objwriter.cpp
+++ b/src/Native/ObjWriter/objwriter.cpp
@@ -374,6 +374,11 @@ int ObjectWriter::EmitSymbolRef(const char *SymbolName,
     Size = 4;
     IsPCRel = true;
     break;
+  case RelocType::IMAGE_REL_BASED_RELPTR32:
+    Size = 4;
+    IsPCRel = true;
+    Delta += 4; // size of C# (int) type is always 4 bytes
+    break;
   case RelocType::IMAGE_REL_BASED_THUMB_MOV32: {
     const unsigned Offset = GetDFSize();
     const MCExpr *TargetExpr = GenTargetExpr(SymbolName, Kind, Delta);

--- a/src/Native/ObjWriter/objwriter.h
+++ b/src/Native/ObjWriter/objwriter.h
@@ -44,6 +44,7 @@ enum class RelocType {
   IMAGE_REL_BASED_DIR64 = 0x0A,
   IMAGE_REL_BASED_REL32 = 0x10,
   IMAGE_REL_BASED_THUMB_BRANCH24 = 0x13,
+  IMAGE_REL_BASED_RELPTR32 = 0x7C,
 };
 
 class ObjectWriter {


### PR DESCRIPTION
	- https://github.com/dotnet/corert/issues/3278
	- Enabled only for ARM32. When ObjWriter is remotely updated,
	it will be possible to completely remove this workaround for other archs.

@jkotas Need to rebuild and update ObjWriter remotely in repos, so that we can enable it for all architectures, including x64.
@dotnet/arm32-corert-contrib please review