### PR TITLE
Fix MdArray::Set for pointer type arrays

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -87,7 +87,7 @@ namespace Internal.IL.Stubs
             var rangeExceptionLabel = _emitter.NewCodeLabel();
             ILCodeLabel typeMismatchExceptionLabel = null;
 
-            if (!_elementType.IsValueType)
+            if (_elementType.IsGCPointer)
             {
                 // Type check
                 if (_method.Kind == ArrayMethodKind.Set)


### PR DESCRIPTION
Ran the regression test I wrote for dotnet/coreclr#16381 and found CoreRT has a different bug around this.