### PR TITLE
Improve diagnosability of failed VS autodetect

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -80,7 +80,9 @@ See the LICENSE file in the project root for more information.
       <Output TaskParameter="ExitCode" PropertyName="_WhereCppTools"/>
     </Exec>
 
-    <Exec Condition="'$(_WhereCppTools)' != '0'" Command="&quot;$(MSBuildThisFileDirectory)findvcvarsall.bat&quot; amd64" LogStandardErrorAsError="true" ContinueOnError="false" ConsoleToMSBuild="true" StandardOutputImportance="Low">
+    <Message Condition="'$(_WhereCppTools)' != '0'" Text="Tools '$(CppCompiler)' and '$(CppLinker)' not found on PATH. Attempting to autodetect." />
+
+    <Exec Condition="'$(_WhereCppTools)' != '0'" Command="&quot;$(MSBuildThisFileDirectory)findvcvarsall.bat&quot; amd64" IgnoreExitCode="true" ConsoleToMSBuild="true" StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="_FindVCVarsallOutput"/>
       <Output TaskParameter="ExitCode" PropertyName="_VCVarsAllFound"/>
     </Exec>
@@ -96,6 +98,6 @@ See the LICENSE file in the project root for more information.
       <CppLibCreator>"$(_CppToolsDirectory)lib.exe"</CppLibCreator>
     </PropertyGroup>
 
-    <Error Condition="'$(_WhereCppTools)' != '0' AND '$(_VCVarsAllFound)' == '1'" Text="Platform linker not found. Make sure to publish from a x64 Native Tools Command Prompt for VS 2017 with C++ tools installed." />
+    <Error Condition="'$(_WhereCppTools)' != '0' AND '$(_VCVarsAllFound)' == '1'" Text="Platform linker not found. To fix this problem, download and install Visual Studio 2017 from http://visualstudio.com. Make sure to install the Desktop Development for C++ workload." />
   </Target>
 </Project>

--- a/src/BuildIntegration/findvcvarsall.bat
+++ b/src/BuildIntegration/findvcvarsall.bat
@@ -27,5 +27,4 @@ EXIT /B 0
 ENDLOCAL
 
 :ERROR
-    ECHO "Visual Studio not found, try to downloading it from https://www.visualstudio.com/ and select Desktop Development for C++ workload."
     EXIT /B 1


### PR DESCRIPTION
I was setting up a new machine today so I played with a "new user" experience.

Before this change, `dotnet publish` without VS installed would result in a message like

```
C:\Users\michals\.nuget\packages\microsoft.dotnet.ilcompiler\1.0.0-alpha-26216-01\build\Microsoft.NETCore.Native.Windows.props(83,5): error MSB3073: The command ""C:\Users\michals\.nuget\packages\microsoft.dotnet.ilcompiler\1.0.0-alpha-26216-01\build\findvcvarsall.bat" amd64" exited with code 1. [D:\Temp\hello\hello.csproj]
```

After this change, we get

```
C:\Users\michals\.nuget\packages\microsoft.dotnet.ilcompiler\1.0.0-alpha-26216-01\build\Microsoft.NETCore.Native.Windows.props(101,5): error : Platform linker not found. To fix this problem, download and install Visual Studio 2017 from http://visualstudio.com. Make sure to install the Desktop Development for C++ workload. [D:\Temp\hello\hello.csproj]
```