### PR TITLE
Fix Marshal.GetDelegateForFunctionPointer to throw exception when it cannot create the stub

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -1831,7 +1831,7 @@ namespace Internal.TypeSystem.Interop
             LoadManagedValue(codeStream);
 
             codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(
-                Context.GetHelperEntryPoint("InteropHelpers", "GetStubForPInvokeDelegate")));
+                Context.GetHelperEntryPoint("InteropHelpers", "GetFunctionPointerForDelegate")));
 
             StoreNativeValue(codeStream);
         }
@@ -1842,7 +1842,7 @@ namespace Internal.TypeSystem.Interop
 
             codeStream.Emit(ILOpcode.ldtoken, _ilCodeStreams.Emitter.NewToken(ManagedType));
             codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(
-                Context.GetHelperEntryPoint("InteropHelpers", "GetPInvokeDelegateForStub")));
+                Context.GetHelperEntryPoint("InteropHelpers", "GetDelegateForFunctionPointer")));
 
             StoreManagedValue(codeStream);
         }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/InteropCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/InteropCallbacks.cs
@@ -12,7 +12,9 @@ namespace Internal.Runtime.Augments
     [System.Runtime.CompilerServices.ReflectionBlocked]
     public abstract class InteropCallbacks
     {
-        public abstract bool TryGetMarshallerDataForDelegate(RuntimeTypeHandle delegateTypeHandle, out McgPInvokeDelegateData  delegateData);
+        public abstract IntPtr GetForwardDelegateCreationStub(RuntimeTypeHandle delegateTypeHandle);
+
+        public abstract IntPtr GetDelegateMarshallingStub(RuntimeTypeHandle delegateTypeHandle, bool openStaticDelegate);
 
         public abstract bool TryGetStructUnmarshalStub(RuntimeTypeHandle structureTypeHandle, out IntPtr unmarshalStub);
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -339,20 +339,15 @@ namespace Internal.Runtime.CompilerHelpers
         {
             PInvokeMarshal.CoTaskMemFree((IntPtr)p);
         }
-        /// <summary>
-        /// Returns the stub to the pinvoke marshalling stub
-        /// </summary>
-        public static IntPtr GetStubForPInvokeDelegate(Delegate del)
+
+        public static IntPtr GetFunctionPointerForDelegate(Delegate del)
         {
-            return PInvokeMarshal.GetStubForPInvokeDelegate(del);
+            return PInvokeMarshal.GetFunctionPointerForDelegate(del);
         }
 
-        /// <summary>
-        /// Retrieve the corresponding P/invoke instance from the stub
-        /// </summary>
-        public static Delegate GetPInvokeDelegateForStub(IntPtr pStub, RuntimeTypeHandle delegateType)
+        public static Delegate GetDelegateForFunctionPointer(IntPtr ptr, RuntimeTypeHandle delegateType)
         {
-            return PInvokeMarshal.GetPInvokeDelegateForStub(pStub, delegateType);
+            return PInvokeMarshal.GetDelegateForFunctionPointer(ptr, delegateType);
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -263,6 +263,7 @@
     <Compile Include="System\Runtime\InteropServices\GCHandleType.cs" />
     <Compile Include="System\Runtime\InteropServices\InteropExtensions.cs" />
     <Compile Include="System\Runtime\InteropServices\NativeCallableAttribute.cs" />
+    <Compile Include="System\Runtime\InteropServices\NativeFunctionPointerWrapper.cs" />
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal.cs" />
     <Compile Include="System\Runtime\InteropServices\SafeHandle.cs" />
@@ -675,9 +676,6 @@
     </Compile>
     <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgGeneratedNativeCallCodeAttribute.cs">
       <Link>System\Runtime\InteropServices\McgGeneratedNativeCallCodeAttribute.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgPInvokeData.cs">
-      <Link>System\Runtime\InteropServices\McgPInvokeData.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\System\NotImplemented.cs">
       <Link>System\NotImplemented.cs</Link>

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeFunctionPointerWrapper.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeFunctionPointerWrapper.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// Base class for all 'wrapper' classes that wraps a native function pointer
+    /// The forward delegates (that wraps native function pointers) points to derived Invoke method of this
+    /// class, and the Invoke method would implement the marshalling and making the call
+    /// </summary>
+    public abstract class NativeFunctionPointerWrapper
+    {
+        public NativeFunctionPointerWrapper(IntPtr nativeFunctionPointer)
+        {
+            m_nativeFunctionPointer = nativeFunctionPointer;
+        }
+
+        IntPtr m_nativeFunctionPointer;
+
+        public IntPtr NativeFunctionPointer
+        {
+            get { return m_nativeFunctionPointer; }
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/PInvokeMarshal.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/PInvokeMarshal.cs
@@ -186,7 +186,7 @@ namespace System.Runtime.InteropServices
         /// Return the stub to the pinvoke marshalling stub
         /// </summary>
         /// <param name="del">The delegate</param>
-        public static IntPtr GetStubForPInvokeDelegate(Delegate del)
+        public static IntPtr GetFunctionPointerForDelegate(Delegate del)
         {
             if (del == null)
                 return IntPtr.Zero;
@@ -314,16 +314,13 @@ namespace System.Runtime.InteropServices
 
             var delegateThunk = new PInvokeDelegateThunk(del);
 
-            McgPInvokeDelegateData pinvokeDelegateData;
-            if (!RuntimeAugments.InteropCallbacks.TryGetMarshallerDataForDelegate(del.GetTypeHandle(), out pinvokeDelegateData))
-            {
-                Environment.FailFast("Couldn't find marshalling stubs for delegate.");
-            }
-
             //
             //  For open static delegates set target to ReverseOpenStaticDelegateStub which calls the static function pointer directly
             //
-            IntPtr pTarget = del.GetRawFunctionPointerForOpenStaticDelegate() == IntPtr.Zero ? pinvokeDelegateData.ReverseStub : pinvokeDelegateData.ReverseOpenStaticDelegateStub;
+            bool openStaticDelegate = del.GetRawFunctionPointerForOpenStaticDelegate() != IntPtr.Zero;
+
+            IntPtr pTarget = RuntimeAugments.InteropCallbacks.GetDelegateMarshallingStub(del.GetTypeHandle(), openStaticDelegate);
+            Debug.Assert(pTarget != IntPtr.Zero);
 
             RuntimeAugments.SetThunkData(s_thunkPoolHeap, delegateThunk.Thunk, delegateThunk.ContextData, pTarget);
 
@@ -333,9 +330,9 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Retrieve the corresponding P/invoke instance from the stub
         /// </summary>
-        public static Delegate GetPInvokeDelegateForStub(IntPtr pStub, RuntimeTypeHandle delegateType)
+        public static Delegate GetDelegateForFunctionPointer(IntPtr ptr, RuntimeTypeHandle delegateType)
         {
-            if (pStub == IntPtr.Zero)
+            if (ptr == IntPtr.Zero)
                 return null;
             //
             // First try to see if this is one of the thunks we've allocated when we marshal a managed
@@ -344,7 +341,7 @@ namespace System.Runtime.InteropServices
             //
             IntPtr pContext;
             IntPtr pTarget;
-            if (s_thunkPoolHeap != null && RuntimeAugments.TryGetThunkData(s_thunkPoolHeap, pStub, out pContext, out pTarget))
+            if (s_thunkPoolHeap != null && RuntimeAugments.TryGetThunkData(s_thunkPoolHeap, ptr, out pContext, out pTarget))
             {
                 GCHandle handle;
                 unsafe
@@ -372,15 +369,10 @@ namespace System.Runtime.InteropServices
             // We need to create the delegate that points to the invoke method of a
             // NativeFunctionPointerWrapper derived class
             //
-            McgPInvokeDelegateData pInvokeDelegateData;
-            if (!RuntimeAugments.InteropCallbacks.TryGetMarshallerDataForDelegate(delegateType, out pInvokeDelegateData))
-            {
-                return null;
-            }
-            return CalliIntrinsics.Call<Delegate>(
-                pInvokeDelegateData.ForwardDelegateCreationStub,
-                pStub
-            );
+            IntPtr pDelegateCreationStub = RuntimeAugments.InteropCallbacks.GetForwardDelegateCreationStub(delegateType);
+            Debug.Assert(pDelegateCreationStub != IntPtr.Zero);
+
+            return CalliIntrinsics.Call<Delegate>(pDelegateCreationStub, ptr);
         }
 
         /// <summary>

--- a/src/System.Private.Interop/src/Internal/Runtime/CompilerHelpers/RuntimeInteropData.ProjectN.cs
+++ b/src/System.Private.Interop/src/Internal/Runtime/CompilerHelpers/RuntimeInteropData.ProjectN.cs
@@ -14,9 +14,22 @@ namespace Internal.Runtime.CompilerHelpers
 {
     internal partial class RuntimeInteropData : InteropCallbacks
     {
-        public override bool TryGetMarshallerDataForDelegate(RuntimeTypeHandle delegateTypeHandle, out McgPInvokeDelegateData data)
+        public override IntPtr GetForwardDelegateCreationStub(RuntimeTypeHandle delegateTypeHandle)
         {
-            return McgModuleManager.GetPInvokeDelegateData(delegateTypeHandle, out data);
+            McgModuleManager.GetPInvokeDelegateData(delegateTypeHandle, out McgPInvokeDelegateData data);
+            IntPtr pStub = data.ForwardDelegateCreationStub;
+            if (pStup == IntPtr.Zero)
+                throw new MissingInteropDataException(SR.DelegateMarshalling_MissingInteropData, Type.GetTypeFromHandle(delegateTypeHandle));
+            return pStub;
+        }
+
+        public override IntPtr GetDelegateMarshallingStub(RuntimeTypeHandle delegateTypeHandle, bool openStaticDelegate)
+        {
+            McgModuleManager.GetPInvokeDelegateData(delegateTypeHandle, out McgPInvokeDelegateData pinvokeDelegateData);
+            IntPtr pStub = openStaticDelegate ? pinvokeDelegateData.ReverseOpenStaticDelegateStub : pinvokeDelegateData.ReverseStub;
+            if (pStup == IntPtr.Zero)
+                throw new MissingInteropDataException(SR.DelegateMarshalling_MissingInteropData, Type.GetTypeFromHandle(delegateTypeHandle));
+            return pStub;
         }
 
         #region "Struct Data"

--- a/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/PInvokeMarshal.cs
@@ -32,12 +32,12 @@ namespace System.Runtime.InteropServices
             s_lastWin32Error = Marshal.GetLastWin32Error();
         }
 
-        public static IntPtr GetStubForPInvokeDelegate(Delegate del)
+        public static IntPtr GetFunctionPointerForDelegate(Delegate del)
         {
             return IntPtr.Zero;
         }
 
-        public static Delegate GetPInvokeDelegateForStub(IntPtr pStub, RuntimeTypeHandle delegateType)
+        public static Delegate GetDelegateForFunctionPointer(IntPtr pStub, RuntimeTypeHandle delegateType)
         {
             return default(Delegate);
         }

--- a/src/System.Private.Interop/src/Shared/McgMarshal.cs
+++ b/src/System.Private.Interop/src/Shared/McgMarshal.cs
@@ -1118,7 +1118,7 @@ namespace System.Runtime.InteropServices
 #if CORECLR
              throw new NotSupportedException();
 #else
-            return PInvokeMarshal.GetStubForPInvokeDelegate(dele);
+            return PInvokeMarshal.GetFunctionPointerForDelegate(dele);
 #endif
         }
 
@@ -1142,7 +1142,7 @@ namespace System.Runtime.InteropServices
                 pStub
             );
 #else
-            return PInvokeMarshal.GetPInvokeDelegateForStub(pStub, delegateType);
+            return PInvokeMarshal.GetDelegateForFunctionPointer(pStub, delegateType);
 #endif
         }
 

--- a/src/System.Private.Interop/src/Shared/McgModuleManager.cs
+++ b/src/System.Private.Interop/src/Shared/McgModuleManager.cs
@@ -724,11 +724,7 @@ namespace System.Runtime.InteropServices
                     return true;
                 }
             }
-#if ENABLE_WINRT
-           throw new MissingInteropDataException(SR.DelegateMarshalling_MissingInteropData, Type.GetTypeFromHandle(delegateType));
-#else
             return false;
-#endif
         }
 #endregion
 

--- a/src/System.Private.Interop/src/Shared/McgPInvokeData.cs
+++ b/src/System.Private.Interop/src/Shared/McgPInvokeData.cs
@@ -102,25 +102,4 @@ namespace System.Runtime.InteropServices
         /// </summary>
         public IntPtr ForwardDelegateCreationStub;
     }
-
-
-    /// <summary>
-    /// Base class for all 'wrapper' classes that wraps a native function pointer
-    /// The forward delegates (that wraps native function pointers) points to derived Invoke method of this
-    /// class, and the Invoke method would implement the marshalling and making the call
-    /// </summary>
-    public abstract class NativeFunctionPointerWrapper
-    {
-        public NativeFunctionPointerWrapper(IntPtr nativeFunctionPointer)
-        {
-            m_nativeFunctionPointer = nativeFunctionPointer;
-        }
-
-        IntPtr m_nativeFunctionPointer;
-
-        public IntPtr NativeFunctionPointer
-        {
-            get { return m_nativeFunctionPointer; }
-        }
-    }
 }

--- a/src/System.Private.Interop/src/System.Private.Interop.CoreCLR.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.CoreCLR.csproj
@@ -50,9 +50,6 @@
     <Compile Include="InteropExtensions\PreInitializedAttribute.cs" />
     <Compile Include="InteropExtensions\PInvokeMarshal.cs" />
     <Compile Include="Interop\Interop.PlatformNotSupported.cs" />            
-    <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgPInvokeData.cs">
-      <Link>System\Runtime\InteropServices\McgPInvokeData.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgGeneratedNativeCallCodeAttribute.cs">
       <Link>System\Runtime\InteropServices\McgGeneratedNativeCallCodeAttribute.cs</Link>
     </Compile>

--- a/src/System.Private.Interop/src/System.Private.Interop.Mono.csproj
+++ b/src/System.Private.Interop/src/System.Private.Interop.Mono.csproj
@@ -54,9 +54,6 @@
     <Compile Include="InteropExtensions\PreInitializedAttribute.cs" />
     <Compile Include="InteropExtensions\PInvokeMarshal.cs" />
     <Compile Include="Interop\Interop.PlatformNotSupported.cs" />
-    <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgPInvokeData.cs">
-      <Link>System\Runtime\InteropServices\McgPInvokeData.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\src\System\Runtime\InteropServices\McgGeneratedNativeCallCodeAttribute.cs">
       <Link>System\Runtime\InteropServices\McgGeneratedNativeCallCodeAttribute.cs</Link>
     </Compile>

--- a/src/System.Private.Interop/src/System.Private.Interop.Shared.projitems
+++ b/src/System.Private.Interop/src/System.Private.Interop.Shared.projitems
@@ -38,6 +38,7 @@
     <Compile Include="Shared\McgMarshal.cs" />
     <Compile Include="Shared\McgModule.cs" />
     <Compile Include="Shared\McgModuleManager.cs" />
+    <Compile Include="Shared\McgPInvokeData.cs" />
     <Compile Include="Shared\McgPInvokeMarshalStubAttribute.cs" />
     <Compile Include="Shared\McgredirectedMethodAttribute.cs" />
     <Compile Include="Shared\McgRedirectedTypeAttribute.cs" />

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/Marshal.cs
@@ -1018,7 +1018,7 @@ namespace System.Runtime.InteropServices
             if (d == null)
                 throw new ArgumentNullException(nameof(d));
 
-            return PInvokeMarshal.GetStubForPInvokeDelegate(d);
+            return PInvokeMarshal.GetFunctionPointerForDelegate(d);
         }
 
         public static IntPtr GetFunctionPointerForDelegate<TDelegate>(TDelegate d)


### PR DESCRIPTION
- Remove WINRT ifdef from GetDelegateForFunctionPointer to consistently throw MissingInteropDataException instead of returning null. Fixes #5162.
- Move McgPInvokeData set of structure to System.Private.Interop since it is MCG specific
- Rename a few things for consistency (e.g. PInvokeMarshal.GetPInvokeDelegateForStub did not make sense since it operates on user supplied function pointers, not stubs)