### PR TITLE
Fix F5 debugging of ILCompiler project

### DIFF
--- a/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
+++ b/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
@@ -18,10 +18,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">
-    <ProjectReference Include="libLLVMdep.depproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-    </ProjectReference>
     <ProjectReference Include="..\..\ILCompiler.DependencyAnalysisFramework\src\ILCompiler.DependencyAnalysisFramework.csproj" />
     <ProjectReference Include="..\..\ILCompiler.MetadataTransform\src\ILCompiler.MetadataTransform.csproj" />
     <ProjectReference Include="..\..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj" />

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -17,7 +17,9 @@
     <Project Include="Framework\Framework-uapaot.depproj" />
     <Project Include="Framework\Framework-native.depproj" Condition="$(TargetsUnix) and '$(Platform)' != 'wasm'" />
 
-    <Project Include="ILCompiler\**\*.depproj" />
+    <Project Include="ILCompiler\RyuJIT\RyuJIT.depproj" />
+    <Project Include="ILCompiler\ObjectWriter\ObjectWriter.depproj" />
+    <Project Include="ILCompiler.WebAssembly\src\libLLVMdep.depproj" />
 
     <Project Include="*\src\*.csproj" Exclude="@(ExcludeProjects)" />
     <Project Include="*\src\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'" Exclude="@(ExcludeProjects)" />


### PR DESCRIPTION
Trying to debug ILCompiler in Visual Studio was failing with missing assemblies. The problem was caused by recently added libLLVMdep.depproj reference that made NuGet delete certain files from the output tools directory. The fix is to move the .depproj reference to a different part of the build next to other similar .depproj reference where it won't be confusing NuGet.