### PR TITLE
Generate a constructed EEType for constrained tokens

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2904,6 +2904,7 @@ namespace Internal.JitInterface
 
                 if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_NewObj
                         || pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Box
+                        || pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Constrained
                         || (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Ldtoken && ConstructedEETypeNode.CreationAllowed(td)))
                 {
                     helperId = ReadyToRunHelperId.TypeHandle;


### PR DESCRIPTION
`CorInfoTokenKind.CORINFO_TOKENKIND_Constrained` means RyuJIT is asking for a type handle for the purpose of boxing it.

This fixes:

```csharp
struct Foo { }
void Main() { Foo f = default; f.GetHashCode() }
```

We were trying to execute bogus memory because unconstructed types don't have vtables.