### PR TITLE
Move check for IsByRefLike to MakeArrayType

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -272,9 +272,6 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             Debug.Assert(multiDim || rank == 1);
 
-            if (elementType.IsByRef || elementType.IsByRefLike)
-                throw new TypeLoadException(SR.Format(SR.ArgumentException_InvalidArrayElementType, elementType));
-
             // We only permit creating parameterized types if the pay-for-play policy specifically allows them *or* if the result
             // type would be an open type.
             if (typeHandle.IsNull() && !elementType.ContainsGenericParameters && !(elementType is RuntimeCLSIDTypeInfo))

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -389,6 +389,8 @@ namespace System.Reflection.Runtime.TypeInfos
                 ReflectionTrace.TypeInfo_MakeArrayType(this);
 #endif
 
+            CheckIsValidArrayElementType();
+
             // Do not implement this as a call to MakeArrayType(1) - they are not interchangable. MakeArrayType() returns a
             // vector type ("SZArray") while MakeArrayType(1) returns a multidim array of rank 1. These are distinct types
             // in the ECMA model and in CLR Reflection.
@@ -404,6 +406,9 @@ namespace System.Reflection.Runtime.TypeInfos
 
             if (rank <= 0)
                 throw new IndexOutOfRangeException();
+
+            CheckIsValidArrayElementType();
+
             return this.GetMultiDimArrayType(rank);
         }
 
@@ -798,6 +803,12 @@ namespace System.Reflection.Runtime.TypeInfos
                 }
                 return baseType;
             }
+        }
+
+        private void CheckIsValidArrayElementType()
+        {
+            if (this.IsByRef || this.IsByRefLike)
+                throw new TypeLoadException(SR.Format(SR.ArgumentException_InvalidArrayElementType, this));
         }
 
         private string GetDefaultMemberName()


### PR DESCRIPTION
Having a call to `IsByRefLike` in the type unifier meant that an app that uses a simple `typeof()` would require the full reflection stack to be present in the image (all of the custom attribute resolution, method resolution, etc.).

This is a step towards having a more pay for play framework (a hello world EXE really should not have the full reflection stack compiled in it).