### PR TITLE
Revert "Make g_rgWellKnownMethodNames specific to binder (#5390)"

### DIFF
--- a/src/Native/Runtime/inc/WellKnownMethods.h
+++ b/src/Native/Runtime/inc/WellKnownMethods.h
@@ -22,8 +22,6 @@ enum WellKnownMethodIds
 };
 #undef DEFINE_WELL_KNOWN_METHOD
 
-#ifdef BINDER
-
 // Define an array of well known method names which are indexed by the enums defined above.
 #define DEFINE_WELL_KNOWN_METHOD(_name) #_name,
 extern __declspec(selectany) const char * const g_rgWellKnownMethodNames[] = 
@@ -31,7 +29,5 @@ extern __declspec(selectany) const char * const g_rgWellKnownMethodNames[] =
 #include "WellKnownMethodList.h"
 };
 #undef DEFINE_WELL_KNOWN_METHOD
-
-#endif // BINDER
 
 #endif // !__WELLKNOWNMETHODS_INCLUDED


### PR DESCRIPTION
This reverts commit b02c2edaa6b4390615de5bb1daefdf1ec39d5e7b.

This commit didn't actually fully fix #5390 (it's an external issue), but it triggered a linker warning on Windows (`AsmOffsetsVerify.obj : warning LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library`). It doesn't seem worth it to try to fix the warning and the useless `extern` nicely works around the problem...