### PR TITLE
[WIP] Avoid reflection in Enum.ToString

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -35,6 +35,7 @@ namespace Internal.Reflection.Augments
         // One time start up initialization - called by Reflection.Core.dll to provide System.Reflection with a way to call back
         // into Reflection.Core.dll.
         //
+        [CLSCompliant(false)]
         public static void Initialize(ReflectionCoreCallbacks reflectionCoreCallbacks)
         {
             s_reflectionCoreCallbacks = reflectionCoreCallbacks;
@@ -125,6 +126,7 @@ namespace Internal.Reflection.Augments
     // of Type.GetTypeInfo() and (on Project N) (Assembly.Load()).
     //
     [System.Runtime.CompilerServices.ReflectionBlocked]
+    [CLSCompliant(false)]
     public abstract class ReflectionCoreCallbacks
     {
         public abstract Assembly Load(AssemblyName refName, bool throwOnFileNotFound);
@@ -165,5 +167,7 @@ namespace Internal.Reflection.Augments
         public abstract Assembly[] GetLoadedAssemblies();
 
         public abstract EnumInfo GetEnumInfo(Type type);
+
+        public abstract EnumInfo GetLowLevelEnumInfo(Type type);
     }
 }

--- a/src/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.cs
@@ -821,7 +821,7 @@ namespace System
             if (format == null || format.Length == 0)
                 format = "G";
 
-            EnumInfo enumInfo = GetEnumInfo(this.GetType());
+            EnumInfo enumInfo = GetAllocatedEnumInfo(this.GetType());
 
             // Project N port note: If Reflection info isn't available, fallback to ToString() which will substitute a numeric value for the "correct" output.
             // This scenario has been hit frequently when throwing exceptions formatted with error strings containing enum substitations.
@@ -852,6 +852,15 @@ namespace System
             Debug.Assert(enumType.IsEnum);
 
             return ReflectionAugments.ReflectionCoreCallbacks.GetEnumInfo(enumType);
+        }
+
+        private static EnumInfo GetAllocatedEnumInfo(Type enumType)
+        {
+            Debug.Assert(enumType != null);
+            Debug.Assert(enumType.IsRuntimeImplemented());
+            Debug.Assert(enumType.IsEnum);
+
+            return ReflectionAugments.ReflectionCoreCallbacks.GetLowLevelEnumInfo(enumType);
         }
 
         //

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -308,49 +308,61 @@ namespace System.Reflection.Runtime.General
             return value;
         }
 
+        public static Object ParseConstantNumericValue(this Handle handle, MetadataReader reader)
+        {
+            HandleType handleType = handle.HandleType;
+            switch (handleType)
+            {
+                case HandleType.ConstantBooleanValue:
+                    return handle.ToConstantBooleanValueHandle(reader).GetConstantBooleanValue(reader).Value;
+                case HandleType.ConstantCharValue:
+                    return handle.ToConstantCharValueHandle(reader).GetConstantCharValue(reader).Value;
+                case HandleType.ConstantByteValue:
+                    return handle.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value;
+                case HandleType.ConstantSByteValue:
+                    return handle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value;
+                case HandleType.ConstantInt16Value:
+                    return handle.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value;
+                case HandleType.ConstantUInt16Value:
+                    return handle.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value;
+                case HandleType.ConstantInt32Value:
+                    return handle.ToConstantInt32ValueHandle(reader).GetConstantInt32Value(reader).Value;
+                case HandleType.ConstantUInt32Value:
+                    return handle.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value;
+                case HandleType.ConstantInt64Value:
+                    return handle.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value;
+                case HandleType.ConstantUInt64Value:
+                    return handle.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value;
+                case HandleType.ConstantSingleValue:
+                    return handle.ToConstantSingleValueHandle(reader).GetConstantSingleValue(reader).Value;
+                case HandleType.ConstantDoubleValue:
+                    return handle.ToConstantDoubleValueHandle(reader).GetConstantDoubleValue(reader).Value;
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
         public static Exception TryParseConstantValue(this Handle handle, MetadataReader reader, out Object value)
         {
             HandleType handleType = handle.HandleType;
             switch (handleType)
             {
                 case HandleType.ConstantBooleanValue:
-                    value = handle.ToConstantBooleanValueHandle(reader).GetConstantBooleanValue(reader).Value;
+                case HandleType.ConstantCharValue:
+                case HandleType.ConstantByteValue:
+                case HandleType.ConstantSByteValue:
+                case HandleType.ConstantInt16Value:
+                case HandleType.ConstantUInt16Value:
+                case HandleType.ConstantInt32Value:
+                case HandleType.ConstantUInt32Value:
+                case HandleType.ConstantInt64Value:
+                case HandleType.ConstantUInt64Value:
+                case HandleType.ConstantSingleValue:
+                case HandleType.ConstantDoubleValue:
+                    value = handle.ParseConstantNumericValue(reader);
                     return null;
                 case HandleType.ConstantStringValue:
                     value = handle.ToConstantStringValueHandle(reader).GetConstantStringValue(reader).Value;
-                    return null;
-                case HandleType.ConstantCharValue:
-                    value = handle.ToConstantCharValueHandle(reader).GetConstantCharValue(reader).Value;
-                    return null;
-                case HandleType.ConstantByteValue:
-                    value = handle.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value;
-                    return null;
-                case HandleType.ConstantSByteValue:
-                    value = handle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value;
-                    return null;
-                case HandleType.ConstantInt16Value:
-                    value = handle.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt16Value:
-                    value = handle.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value;
-                    return null;
-                case HandleType.ConstantInt32Value:
-                    value = handle.ToConstantInt32ValueHandle(reader).GetConstantInt32Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt32Value:
-                    value = handle.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value;
-                    return null;
-                case HandleType.ConstantInt64Value:
-                    value = handle.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt64Value:
-                    value = handle.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value;
-                    return null;
-                case HandleType.ConstantSingleValue:
-                    value = handle.ToConstantSingleValueHandle(reader).GetConstantSingleValue(reader).Value;
-                    return null;
-                case HandleType.ConstantDoubleValue:
-                    value = handle.ToConstantDoubleValueHandle(reader).GetConstantDoubleValue(reader).Value;
                     return null;
                 case HandleType.TypeDefinition:
                 case HandleType.TypeReference:

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -389,5 +389,7 @@ namespace System.Reflection.Runtime.General
         public sealed override Assembly[] GetLoadedAssemblies() => RuntimeAssembly.GetLoadedAssemblies();
 
         public sealed override EnumInfo GetEnumInfo(Type type) => type.CastToRuntimeTypeInfo().EnumInfo;
+
+        public sealed override EnumInfo GetLowLevelEnumInfo(Type type) => type.CastToRuntimeTypeInfo().LowLevelEnumInfo;
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -617,6 +617,8 @@ namespace System.Reflection.Runtime.TypeInfos
 
         internal EnumInfo EnumInfo => Cache.EnumInfo;
 
+        internal EnumInfo LowLevelEnumInfo => Cache.LowLevelEnumInfo;
+
         internal abstract Type InternalDeclaringType { get; }
 
         //


### PR DESCRIPTION
Contributes to #5013.

Having reflection field access and custom attribute parsing support in a code path reachable from `Enum.ToString` means that any "hello world"-style app needs to have pretty much the full reflection stack embedded in it. The reflection stack is huge.

I'm creating a shortcut EnumInfo that takes advantage of the fact that the TypeInfo is native metadata based and has a full type handle. It uses metadata APIs directly to read the metadata, bypassing the reflection stack.