### PR TITLE
ILVerification: Use correct name to fetch embedded resource

### DIFF
--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -18,7 +18,7 @@ namespace ILVerify
     public class Verifier
     {
         private Lazy<ResourceManager> _stringResourceManager =
-            new Lazy<ResourceManager>(() => new ResourceManager("ILVerify.Resources.Strings", typeof(Verifier).GetTypeInfo().Assembly));
+            new Lazy<ResourceManager>(() => new ResourceManager("FxResources.ILVerification.SR", typeof(Verifier).GetTypeInfo().Assembly));
 
         private ILVerifyTypeSystemContext _typeSystemContext;
 


### PR DESCRIPTION
While integrating the preview package that @A-And sent me (thanks!), I ran into an error loading resource strings.
Looking at the resources embedded into the dll, the proper resource name is `FxResources.ILVerification.SR`. That's the resource that exists in the dll, both from the package and from my local build. I suspect the name of the embedded resource changed as a result of recent build changes, which uses the coreRT build infrastructure to build ILVerify.

![image](https://user-images.githubusercontent.com/12466233/36771962-2a1e034c-1c08-11e8-8336-01284789494b.png)

The bad news is that I was only able to validate this change by testing from Roslyn, because it seems the test project is broken. The test project no longer lists its two source files, and the test project doesn't build if I add them. 
Tagging @ArztSamuel in case he's encountered this.

Tagging @jkotas @VSadov 