### PR TITLE
Replace ReadOnlySpan<char> in InitializeProbabilisticMap with simple …

### DIFF
--- a/src/System.Private.CoreLib/shared/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Searching.cs
@@ -252,7 +252,7 @@ namespace System
         // in each byte in the character is used to index into this map to get the
         // right block, the value of the remaining 5 msb are used as the bit position
         // inside this block. 
-        private static unsafe void InitializeProbabilisticMap(uint* charMap, ReadOnlySpan<char> anyOf)
+        private static unsafe void InitializeProbabilisticMap(uint* charMap, char[] anyOf)
         {
             bool hasAscii = false;
             uint* charMapLocal = charMap; // https://github.com/dotnet/coreclr/issues/14264


### PR DESCRIPTION
…char[] to avoid redundant conversion