### PR TITLE
Automatic WebAssembly test execution

### DIFF
--- a/Documentation/how-to-build-WebAssembly.md
+++ b/Documentation/how-to-build-WebAssembly.md
@@ -4,6 +4,7 @@
 
 1. Install Emscripten by following the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html). 
 2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to the latest version.
+3. Install [Firefox](https://www.getfirefox.com) (for testing).
 3. Get CoreRT set up by following the [Visual Studio instructions](how-to-build-and-run-ilcompiler-in-visual-studio.md).
 4. Build the WebAssembly runtime by running ```build.cmd wasm``` from the repo root.
 5. Run the WebAssembly "Hello World" test by running ```C:\corert\tests\runtest.cmd wasm```.

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -224,7 +224,7 @@ See the LICENSE file in the project root for more information.
     <Exec Command="$(CppLibCreator)  @&quot;$(NativeIntermediateOutputPath)lib.rsp&quot;" Condition="'$(OS)' == 'Windows_NT' and '$(NativeLib)' == 'Static' and '$(NativeCodeGen)' != 'wasm'" />
     
     <PropertyGroup>
-      <EmccArgs>&quot;$(NativeObject)&quot; -o &quot;$(NativeBinary)&quot; -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 </EmccArgs>
+      <EmccArgs>&quot;$(NativeObject)&quot; -o &quot;$(NativeBinary)&quot; -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 --emrun </EmccArgs>
       <EmccArgs Condition="'$(Platform)'=='wasm'">$(EmccArgs) &quot;$(IlcPath)/sdk/libPortableRuntime.bc&quot; &quot;$(IlcPath)/sdk/libbootstrappercpp.bc&quot; </EmccArgs>
       <EmccArgs Condition="'$(Configuration)'=='Release'">$(EmccArgs) -O2 --llvm-lto 2</EmccArgs>
       <EmccArgs Condition="'$(Configuration)'=='Debug'">$(EmccArgs) -g3</EmccArgs>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -301,12 +301,19 @@ goto :eof
 
         set __SavedErrorLevel=!ErrorLevel!
         if "%CoreRT_TestRun%"=="false" (goto :SkipTestRun)
-        if "%__Mode%" == "wasm" (goto :SkipTestRun)
+        
+        set __Extension=exe
 
-        if "%__SavedErrorLevel%"=="0" (
+        if "%__Mode%"=="wasm" (
+            REM Skip running if this is WASM build-only testing running in a different architecture's build
+            if /i not "%CoreRT_BuildArch%"=="wasm" (goto :SkipTestRun)
+            set __Extension=html
+         )
+
+        if "!__SavedErrorLevel!"=="0" (
             echo.
             echo Running test !__SourceFileName!
-            call !__SourceFile!.cmd !__SourceFolder!\bin\%CoreRT_BuildType%\%CoreRT_BuildArch%\native !__SourceFileName!.exe
+            call !__SourceFile!.cmd !__SourceFolder!\bin\%CoreRT_BuildType%\%CoreRT_BuildArch%\native !__SourceFileName!.!__Extension!
             set __SavedErrorLevel=!ErrorLevel!
         )
     )

--- a/tests/src/Simple/HelloWasm/HelloWasm.cmd
+++ b/tests/src/Simple/HelloWasm/HelloWasm.cmd
@@ -1,14 +1,13 @@
 @echo off
 setlocal
-set ErrorCode=100
-for /f "usebackq delims=;" %%F in (`"%1\%2" world`) do (
-    if "%%F"=="Hello world" set ErrorCode=0
-)
-IF "%ErrorCode%"=="0" (
-    echo %~n0: pass
+
+call emrun --browser=firefox --browser_args=-headless --safe_firefox_profile --silence_timeout 10 "%1\%2" 
+
+IF "%errorlevel%"=="42" (
+    echo %~n0: Pass
     EXIT /b 0
 ) ELSE (
-    echo %~n0: fail - %ErrorCode%
+    echo %~n0: fail - %ErrorLevel%
     EXIT /b 1
 )
 endlocal


### PR DESCRIPTION
Automatically execute WebAssembly tests on Windows by using emrun to launch a headless instance of Firefox (which doesn't interfere with any other Firefox usage). This should cut down on manual testing and help us move toward CI integration. Fixes #4509.