### PR TITLE
Hardcode symbol publishing task to 1.*

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Windows.json
+++ b/buildpipeline/DotNet-CoreRT-Windows.json
@@ -170,7 +170,7 @@
       "timeoutInMinutes": 0,
       "task": {
         "id": "0675668a-7bba-4ccb-901d-5ad6554ca653",
-        "versionSpec": "*",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {


### PR DESCRIPTION
This should hopefully unblock official build publishing.

@dotnet-bot skip ci please