### PR TITLE
ILVerification NuGet package

### DIFF
--- a/pkg/Microsoft.DotNet.ILVerification/Microsoft.DotNet.ILVerification.builds
+++ b/pkg/Microsoft.DotNet.ILVerification/Microsoft.DotNet.ILVerification.builds
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="$(MSBuildProjectName).pkgproj" >
+      <OSGroup>AnyOS</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/Microsoft.DotNet.ILVerification/Microsoft.DotNet.ILVerification.pkgproj
+++ b/pkg/Microsoft.DotNet.ILVerification/Microsoft.DotNet.ILVerification.pkgproj
@@ -1,0 +1,27 @@
+<Project DefaultTargets="Build" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipValidatePackage>true</SkipValidatePackage>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <BaseLinePackageDependencies>false</BaseLinePackageDependencies>
+    <PackagePlatforms>x64;</PackagePlatforms>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(PackageSourceDirectory)\BuildIntegration\StrongNameKeys\ILVerify.snk</AssemblyOriginatorKeyFile>
+    <PackageTargetFramework>netcoreapp2.0</PackageTargetFramework>
+    <!-- Override this property so that the package name won't look like runtime.[RID].[TFM].[ID] -->
+    <PackageTargetRuntime></PackageTargetRuntime>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(PackageSourceDirectory)ILVerification\src\ILVerification.csproj">
+      <AdditionalProperties>$(AdditionalProperties);PackageTargetRuntime=</AdditionalProperties>
+    </ProjectReference>    
+
+    <Dependency Include="System.IO.MemoryMappedFiles" Version="4.3.0" />
+    <Dependency Include="System.Reflection.Metadata" Version="1.4.1" />
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\src\dir.targets" />
+  <Target Name="GetPackageDependencies"/>
+</Project>
+

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -24,4 +24,9 @@
     "Description":"Provides the toolchain to compile managed code to native",
     "CommonTypes": [],
   },
+  {
+    "Name": "Microsoft.DotNet.ILVerification",
+    "Description":"Provides a library, containing a cross platform, open-source tool that is capable of verifying MSIL code based on ECMA-335",
+    "CommonTypes": [],
+  },
 ]

--- a/pkg/packages.proj
+++ b/pkg/packages.proj
@@ -17,6 +17,9 @@
     <Project Include="$(MSBuildThisFileDirectory)Microsoft.TargetingPack.Private.CoreRT\Microsoft.TargetingPack.Private.CoreRT.builds">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.DotNet.ILVerification\Microsoft.DotNet.ILVerification.builds">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipManagedPackageBuild)' != 'true'">


### PR DESCRIPTION
To be consumed by Roslyn. In Helix builds we only build this along with the TargetingPack under Windows.
@jcouv , could you take a look at this?
cc @sergiy-k 