### PR TITLE
Fix up handling of Delegate.Invoke in the scanner

### DIFF
--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -354,10 +354,14 @@ namespace Internal.IL
                 }
             }
 
-            if (method.OwningType.IsDelegate && method.Name == "Invoke")
+            if (method.OwningType.IsDelegate && method.Name == "Invoke" &&
+                opcode != ILOpcode.ldftn && opcode != ILOpcode.ldvirtftn)
             {
-                // TODO: might not want to do this if scanning for reflection.
-                // This is expanded as an intrinsic, not a function call.
+                // This call is expanded as an intrinsic; it's not an actual function call.
+                // Before codegen realizes this is an intrinsic, it might still ask questions about
+                // the vtable of this virtual method, so let's make sure it's marked in the scanner's
+                // dependency graph.
+                _dependencies.Add(_factory.VTable(method.OwningType), reason);
                 return;
             }
 


### PR DESCRIPTION
We special case the method to avoid unnecessarily rooting the body (it's pretty big). The codegen might ask questions about the vtable before realizing it's this special method. If the delegate type is not allocated (not a ConstructedEEType), we wouldn't have vtable information for it from the scanner. Fixing that by adding the vtable to the scanner's dependency graph.