### PR TITLE
Fix IL of open instance thunk

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -187,11 +187,20 @@ namespace Internal.IL.Stubs
 
             // Call a helper to get the actual method target
             codeStream.EmitLdArg(0);
-            codeStream.EmitLdArg(1);
-            if (boxThisType != null)
+
+            if (Signature[0].IsByRef)
             {
-                codeStream.Emit(ILOpcode.box, emitter.NewToken(boxThisType));
+                codeStream.Emit(ILOpcode.ldnull);
             }
+            else
+            {
+                codeStream.EmitLdArg(1);
+                if (boxThisType != null)
+                {
+                    codeStream.Emit(ILOpcode.box, emitter.NewToken(boxThisType));
+                }
+            }
+            
             codeStream.Emit(ILOpcode.call, emitter.NewToken(SystemDelegateType.GetKnownMethod("GetActualTargetFunctionPointer", null)));
 
             MethodSignature targetSignature = new MethodSignature(0, 0, Signature.ReturnType, parameters);


### PR DESCRIPTION
When we have an open instance thunk for a method on a valuetype (i.e. a delegate whose signature has a `ref` (valuetype) first parameter), we shouldn't push the first argument to `GetActualTargetFunctionPointer` because that method expects a reference type.

Project N delegate transform already has this fix.