### PR TITLE
Fix up some alignments

### DIFF
--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -147,10 +147,16 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return Architecture == TargetArchitecture.ARM ||
-                    Architecture == TargetArchitecture.ARMEL ||
-                    Architecture == TargetArchitecture.ARM64 ?
-                    2 : 1;
+                switch (Architecture)
+                {
+                    case TargetArchitecture.ARM:
+                    case TargetArchitecture.ARMEL:
+                        return 2;
+                    case TargetArchitecture.ARM64:
+                        return 4;
+                    default:
+                        return 1;
+                }
             }
         }
 

--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -130,14 +130,27 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Gets the minimum required method alignment.
+        /// Gets the minimum required alignment for methods whose address is visible
+        /// to managed code.
         /// </summary>
         public int MinimumFunctionAlignment
         {
             get
             {
                 // We use a minimum alignment of 4 irrespective of the platform.
+                // This is to prevent confusing the method address with a fat function pointer.
                 return 4;
+            }
+        }
+
+        public int MinimumCodeAlignment
+        {
+            get
+            {
+                return Architecture == TargetArchitecture.ARM ||
+                    Architecture == TargetArchitecture.ARMEL ||
+                    Architecture == TargetArchitecture.ARM64 ?
+                    2 : 1;
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory, relocsOnly);
-            objData.RequireInitialPointerAlignment();
+            objData.RequireInitialAlignment(1);
             objData.AddSymbol(this);
 
             if (!relocsOnly)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -63,6 +63,8 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        protected override bool IsVisibleFromManagedCode => false;
+
         protected sealed override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
         public override bool IsShareable => true;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -90,6 +90,8 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        protected override bool IsVisibleFromManagedCode => false;
+
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
         public ReadyToRunHelperId Id => _id;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -128,7 +128,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             ObjectDataBuilder objData = new ObjectDataBuilder(factory, relocsOnly);
-            objData.RequireInitialPointerAlignment();
+            objData.RequireInitialAlignment(4);
             objData.AddSymbol(this);
 
             if (BuildSealedVTableSlots(factory, relocsOnly))


### PR DESCRIPTION
* Optional fields is a bunch of bytes without relocs. We don't need a pointer alignment.
* Sealed vtables are a bunch of 32bit relative relocs. They are not pointer sized.
* R2R helpers don't have addresses that are visible from managed code. We don't need to align them at 4 byte boundaries.

Saves around 10 kB on the size of a Hello world. Won't make a huge difference, but this was an easy thing.