### PR TITLE
Fix empty dispatch map optimization and unnormalized vtables

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -392,6 +392,12 @@ namespace ILCompiler.DependencyAnalysis
                 }
 
                 AddVirtualMethodUseDependencies(dependencies, factory);
+
+                // Also add the un-normalized vtable slices of implemented interfaces.
+                // This is important to do in the scanning phase so that the compilation phase can find
+                // vtable information for things like IEnumerator<List<__Canon>>.
+                foreach (TypeDesc intface in _type.RuntimeInterfaces)
+                    dependencies.Add(factory.VTable(intface), "Interface vtable slice");
             }
 
             if (factory.CompilationModuleGroup.PresenceOfEETypeImpliesAllMethodsOnType(_type))

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -31,6 +31,7 @@ class Program
         TestGvmDependencies.Run();
         TestFieldAccess.Run();
         TestNativeLayoutGeneration.Run();
+        TestInterfaceVTableTracking.Run();
 
         return 100;
     }
@@ -2086,6 +2087,38 @@ class Program
             }
 
             throw new Exception();
+        }
+    }
+
+    class TestInterfaceVTableTracking
+    {
+        class Gen<T> { }
+
+        interface IFoo<T>
+        {
+            Array Frob();
+        }
+
+        class GenericBase<T> : IFoo<T>
+        {
+            public Array Frob()
+            {
+                return new Gen<T>[1,1];
+            }
+        }
+
+        class Derived<T> : GenericBase<Gen<T>>
+        {
+        }
+
+        static volatile IFoo<Gen<string>> s_foo;
+
+        public static void Run()
+        {
+            // This only really tests whether we can compile this.
+            s_foo = new Derived<string>();
+            Array arr = s_foo.Frob();
+            arr.SetValue(new Gen<Gen<string>>(), new int[] { 0, 0 });
         }
     }
 }


### PR DESCRIPTION
Since we currently allow unnormalized things in the dependency graph (see #5264), we need to ensure scanner produces a dependency graph that can be queried for unnormalized vtable slices.

This fixes a regression in a ASP.NET scenario. Also fixes #5508.