### PR TITLE
UserDefinedTypeDescriptor: fix type for enum vars.

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UserDefinedTypeDescriptor.cs
@@ -180,6 +180,10 @@ namespace ILCompiler
                     variableTypeIndex = GetEnumTypeIndex(type);
 
                     GetTypeIndex(type, false); // Ensure regular structure record created
+
+                    _enumTypes[type] = variableTypeIndex;
+
+                    return variableTypeIndex;
                 }
 
                 variableTypeIndex = GetTypeIndex(type, needsCompleteIndex);


### PR DESCRIPTION
We didn't use enum type index for enum vars. This patch fixes it.