### PR TITLE
Make Server GC component optional

### DIFF
--- a/pkg/Microsoft.DotNet.ILCompiler/TargetSpecific/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/TargetSpecific/Microsoft.DotNet.ILCompiler.pkgproj
@@ -46,6 +46,12 @@
     <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.pdb">
       <TargetPath>sdk</TargetPath>
     </File>
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.ServerGC.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.ServerGC.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
+    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.ServerGC.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.ServerGC.pdb">
+      <TargetPath>sdk</TargetPath>
+    </File>
   </ItemGroup>
   <Target Name="GetPackageDependencies"/>
 

--- a/pkg/Microsoft.DotNet.ILCompiler/TargetSpecific/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/TargetSpecific/Microsoft.DotNet.ILCompiler.pkgproj
@@ -49,9 +49,6 @@
     <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.ServerGC.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\Runtime.ServerGC.pdb">
       <TargetPath>sdk</TargetPath>
     </File>
-    <File Condition="Exists('$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.ServerGC.pdb')" Include="$(BaseOutputPath)\$(OSPlatformConfig)\sdk\PortableRuntime.ServerGC.pdb">
-      <TargetPath>sdk</TargetPath>
-    </File>
   </ItemGroup>
   <Target Name="GetPackageDependencies"/>
 

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -36,6 +36,7 @@ See the LICENSE file in the project root for more information.
     <PropertyGroup>
       <NativeLibraryExtension Condition="'$(NativeCodeGen)' != 'wasm'">.a</NativeLibraryExtension>
       <NativeLibraryExtension Condition="'$(NativeCodeGen)' == 'wasm'">.bc</NativeLibraryExtension>
+      <ServerGCExtension Condition="'$(ServerGarbageCollection)' != ''">.ServerGC</ServerGCExtension>
     </PropertyGroup>
 
     <ItemGroup>
@@ -50,9 +51,9 @@ See the LICENSE file in the project root for more information.
       <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(SharedLibrary)" />
       <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) == ''" Include="$(IlcPath)/sdk/libbootstrapper.a" />
       <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) != ''" Include="$(IlcPath)/sdk/libbootstrapperdll.a" />
-      <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libRuntime.a" />
+      <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libRuntime$(ServerGCExtension).a" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libbootstrappercpp.a" />
-      <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libPortableRuntime.a" />
+      <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libPortableRuntime$(ServerGCExtension).a" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)/sdk/libbootstrappercpp.bc" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)/sdk/libPortableRuntime.bc" />
     </ItemGroup>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -36,7 +36,8 @@ See the LICENSE file in the project root for more information.
     <PropertyGroup>
       <NativeLibraryExtension Condition="'$(NativeCodeGen)' != 'wasm'">.a</NativeLibraryExtension>
       <NativeLibraryExtension Condition="'$(NativeCodeGen)' == 'wasm'">.bc</NativeLibraryExtension>
-      <ServerGCExtension Condition="'$(ServerGarbageCollection)' != ''">.ServerGC</ServerGCExtension>
+      <FullRuntimeName>libRuntime</FullRuntimeName>
+      <FullRuntimeName Condition="'$(ServerGarbageCollection)' != ''">libRuntime.ServerGC</FullRuntimeName>
     </PropertyGroup>
 
     <ItemGroup>
@@ -51,9 +52,9 @@ See the LICENSE file in the project root for more information.
       <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(SharedLibrary)" />
       <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) == ''" Include="$(IlcPath)/sdk/libbootstrapper.a" />
       <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) != ''" Include="$(IlcPath)/sdk/libbootstrapperdll.a" />
-      <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libRuntime$(ServerGCExtension).a" />
+      <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/$(FullRuntimeName).a" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libbootstrappercpp.a" />
-      <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libPortableRuntime$(ServerGCExtension).a" />
+      <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)/sdk/libPortableRuntime.a" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)/sdk/libbootstrappercpp.bc" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)/sdk/libPortableRuntime.bc" />
     </ItemGroup>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -18,6 +18,7 @@ See the LICENSE file in the project root for more information.
     <CppCompiler>cl</CppCompiler>
     <CppLinker>link</CppLinker>
     <CppLibCreator>lib</CppLibCreator>
+    <ServerGCExtension Condition="'$(ServerGarbageCollection)' != ''">.ServerGC</ServerGCExtension>
   </PropertyGroup>
     
   <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
@@ -36,9 +37,9 @@ See the LICENSE file in the project root for more information.
     <ItemGroup>
       <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) == ''" Include="$(IlcPath)\sdk\bootstrapper.lib" />
       <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) != ''" Include="$(IlcPath)\sdk\bootstrapperdll.lib" />
-      <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)\sdk\Runtime.lib" />
+      <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)\sdk\Runtime$(ServerGCExtension).lib" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\bootstrappercpp.lib" />
-      <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\PortableRuntime.lib" />
+      <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\PortableRuntime$(ServerGCExtension).lib" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)\sdk\bootstrappercpp.lib" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)\sdk\PortableRuntime.lib" />
       <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(SharedLibrary)" />

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -19,7 +19,7 @@ See the LICENSE file in the project root for more information.
     <CppLinker>link</CppLinker>
     <CppLibCreator>lib</CppLibCreator>
     <FullRuntimeName>Runtime.lib</FullRuntimeName>
-    <FullRuntimeName Condition="'$(ServerGarbageCollection)' != ''">Runtime.ServerGC.lib</FullRuntimeName>
+    <FullRuntimeName Condition="'$(ServerGarbageCollection)' != ''">Runtime.ServerGC</FullRuntimeName>
   </PropertyGroup>
     
   <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -18,7 +18,7 @@ See the LICENSE file in the project root for more information.
     <CppCompiler>cl</CppCompiler>
     <CppLinker>link</CppLinker>
     <CppLibCreator>lib</CppLibCreator>
-    <FullRuntimeName>Runtime.lib</FullRuntimeName>
+    <FullRuntimeName>Runtime</FullRuntimeName>
     <FullRuntimeName Condition="'$(ServerGarbageCollection)' != ''">Runtime.ServerGC</FullRuntimeName>
   </PropertyGroup>
     

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -18,7 +18,8 @@ See the LICENSE file in the project root for more information.
     <CppCompiler>cl</CppCompiler>
     <CppLinker>link</CppLinker>
     <CppLibCreator>lib</CppLibCreator>
-    <ServerGCExtension Condition="'$(ServerGarbageCollection)' != ''">.ServerGC</ServerGCExtension>
+    <FullRuntimeName>Runtime.lib</FullRuntimeName>
+    <FullRuntimeName Condition="'$(ServerGarbageCollection)' != ''">Runtime.ServerGC.lib</FullRuntimeName>
   </PropertyGroup>
     
   <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
@@ -37,9 +38,9 @@ See the LICENSE file in the project root for more information.
     <ItemGroup>
       <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) == ''" Include="$(IlcPath)\sdk\bootstrapper.lib" />
       <NativeLibrary Condition="$(NativeCodeGen) == '' and $(NativeLib) != ''" Include="$(IlcPath)\sdk\bootstrapperdll.lib" />
-      <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)\sdk\Runtime$(ServerGCExtension).lib" />
+      <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)\sdk\$(FullRuntimeName).lib" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\bootstrappercpp.lib" />
-      <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\PortableRuntime$(ServerGCExtension).lib" />
+      <NativeLibrary Condition="$(NativeCodeGen) == 'cpp'" Include="$(IlcPath)\sdk\PortableRuntime.lib" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)\sdk\bootstrappercpp.lib" />
       <NativeLibrary Condition="$(NativeCodeGen) == 'wasm'" Include="$(IlcPath)\sdk\PortableRuntime.lib" />
       <NativeLibrary Condition="'$(IlcMultiModule)' == 'true' and $(NativeCodeGen) == ''" Include="$(SharedLibrary)" />

--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -48,14 +48,17 @@ set(COMMON_RUNTIME_SOURCES
     ../gc/gccommon.cpp
     ../gc/gceewks.cpp
     ../gc/gcwks.cpp
-    ../gc/gceesvr.cpp
-    ../gc/gcsvr.cpp
     ../gc/gcscan.cpp
     ../gc/handletable.cpp
     ../gc/handletablecache.cpp
     ../gc/handletablecore.cpp
     ../gc/handletablescan.cpp
     ../gc/objecthandle.cpp
+)
+
+set(SERVER_GC_SOURCES
+    ../gc/gceesvr.cpp
+    ../gc/gcsvr.cpp
 )
 
 set(FULL_RUNTIME_SOURCES
@@ -221,6 +224,7 @@ convert_to_absolute_path(COMMON_RUNTIME_SOURCES ${COMMON_RUNTIME_SOURCES})
 
 convert_to_absolute_path(FULL_RUNTIME_SOURCES ${FULL_RUNTIME_SOURCES})
 convert_to_absolute_path(PORTABLE_RUNTIME_SOURCES ${PORTABLE_RUNTIME_SOURCES})
+convert_to_absolute_path(SERVER_GC_SOURCES ${SERVER_GC_SOURCES})
 
 convert_to_absolute_path(RUNTIME_SOURCES_ARCH_ASM ${RUNTIME_SOURCES_ARCH_ASM})
 

--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -174,7 +174,6 @@ convert_to_absolute_path(ARCH_SOURCES_DIR ${ARCH_SOURCES_DIR})
 include_directories(${ARCH_SOURCES_DIR})
 
 add_definitions(-DFEATURE_BACKGROUND_GC)
-add_definitions(-DFEATURE_SVR_GC)
 add_definitions(-DFEATURE_BASICFREEZE)
 add_definitions(-DFEATURE_CONSERVATIVE_GC)
 add_definitions(-DFEATURE_CUSTOM_IMPORTS)

--- a/src/Native/Runtime/Full/CMakeLists.txt
+++ b/src/Native/Runtime/Full/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(../../gc/env)
 
 add_definitions(-DFEATURE_RX_THUNKS)
 
-add_library(Runtime STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM})
+add_library(Runtime STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM} ${SERVER_GC_SOURCES})
 
 # Get the current list of definitions
 get_compile_definitions(DEFINITIONS)

--- a/src/Native/Runtime/Full/CMakeLists.txt
+++ b/src/Native/Runtime/Full/CMakeLists.txt
@@ -9,7 +9,12 @@ include_directories(../../gc/env)
 
 add_definitions(-DFEATURE_RX_THUNKS)
 
-add_library(Runtime STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM} ${SERVER_GC_SOURCES})
+add_library(Runtime STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM})
+
+add_library(Runtime.ServerGC STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM} ${SERVER_GC_SOURCES})
+
+target_compile_definitions(Runtime.ServerGC PRIVATE -DFEATURE_SVR_GC)
+
 
 # Get the current list of definitions
 get_compile_definitions(DEFINITIONS)
@@ -72,7 +77,8 @@ foreach(CONFIG IN LISTS CMAKE_CONFIGURATION_TYPES)
 endforeach()
 
 # Install the static Runtime library
-install (TARGETS Runtime DESTINATION sdk)
+install (TARGETS Runtime Runtime.ServerGC DESTINATION sdk)
 if(WIN32)
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/Runtime.dir/$<CONFIG>/Runtime.pdb DESTINATION sdk)
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/Runtime.ServerGC.dir/$<CONFIG>/Runtime.ServerGC.pdb DESTINATION sdk)
 endif()

--- a/src/Native/Runtime/Portable/CMakeLists.txt
+++ b/src/Native/Runtime/Portable/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(PortableRuntime)
 
-# Portable version of the runtime is designed to be used with CppCodeGen only.
+# Portable version of the runtime is designed to be used with CppCodeGen or WASM.
 # It should be written in pure C/C++, with no assembly code.
 
 include_directories(..)
@@ -9,7 +9,13 @@ include_directories(../../gc/env)
 
 add_definitions(-DUSE_PORTABLE_HELPERS)
 
-add_library(PortableRuntime STATIC ${COMMON_RUNTIME_SOURCES} ${PORTABLE_RUNTIME_SOURCES} ${SERVER_GC_SOURCES})
+add_library(PortableRuntime STATIC ${COMMON_RUNTIME_SOURCES} ${PORTABLE_RUNTIME_SOURCES})
+
+if(NOT CLR_CMAKE_PLATFORM_ARCH_WASM)
+    add_library(PortableRuntime.ServerGC STATIC ${COMMON_RUNTIME_SOURCES} ${PORTABLE_RUNTIME_SOURCES} ${SERVER_GC_SOURCES})
+
+    target_compile_definitions(PortableRuntime.ServerGC PRIVATE -DFEATURE_SVR_GC)
+endif()
 
 # Get the current list of definitions
 get_compile_definitions(DEFINITIONS)
@@ -34,6 +40,14 @@ add_custom_command(
 
 # Install the static Runtime library
 install (TARGETS PortableRuntime DESTINATION sdk)
+
+if(NOT CLR_CMAKE_PLATFORM_ARCH_WASM)
+    install (TARGETS PortableRuntime.ServerGC DESTINATION sdk)
+endif()
+
 if(WIN32)
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/PortableRuntime.dir/$<CONFIG>/PortableRuntime.pdb DESTINATION sdk)
+    if(NOT CLR_CMAKE_PLATFORM_ARCH_WASM)
+        install (FILES ${CMAKE_CURRENT_BINARY_DIR}/PortableRuntime.ServerGC.dir/$<CONFIG>/PortableRuntime.ServerGC.pdb DESTINATION sdk)
+    endif()
 endif()

--- a/src/Native/Runtime/Portable/CMakeLists.txt
+++ b/src/Native/Runtime/Portable/CMakeLists.txt
@@ -11,12 +11,6 @@ add_definitions(-DUSE_PORTABLE_HELPERS)
 
 add_library(PortableRuntime STATIC ${COMMON_RUNTIME_SOURCES} ${PORTABLE_RUNTIME_SOURCES})
 
-if(NOT CLR_CMAKE_PLATFORM_ARCH_WASM)
-    add_library(PortableRuntime.ServerGC STATIC ${COMMON_RUNTIME_SOURCES} ${PORTABLE_RUNTIME_SOURCES} ${SERVER_GC_SOURCES})
-
-    target_compile_definitions(PortableRuntime.ServerGC PRIVATE -DFEATURE_SVR_GC)
-endif()
-
 # Get the current list of definitions
 get_compile_definitions(DEFINITIONS)
 set(ASM_OFFSETS_CSPP ${RUNTIME_DIR}/../../Runtime.Base/src/AsmOffsets.cspp)
@@ -41,13 +35,6 @@ add_custom_command(
 # Install the static Runtime library
 install (TARGETS PortableRuntime DESTINATION sdk)
 
-if(NOT CLR_CMAKE_PLATFORM_ARCH_WASM)
-    install (TARGETS PortableRuntime.ServerGC DESTINATION sdk)
-endif()
-
 if(WIN32)
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/PortableRuntime.dir/$<CONFIG>/PortableRuntime.pdb DESTINATION sdk)
-    if(NOT CLR_CMAKE_PLATFORM_ARCH_WASM)
-        install (FILES ${CMAKE_CURRENT_BINARY_DIR}/PortableRuntime.ServerGC.dir/$<CONFIG>/PortableRuntime.ServerGC.pdb DESTINATION sdk)
-    endif()
 endif()

--- a/src/Native/Runtime/Portable/CMakeLists.txt
+++ b/src/Native/Runtime/Portable/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(../../gc/env)
 
 add_definitions(-DUSE_PORTABLE_HELPERS)
 
-add_library(PortableRuntime STATIC ${COMMON_RUNTIME_SOURCES} ${PORTABLE_RUNTIME_SOURCES})
+add_library(PortableRuntime STATIC ${COMMON_RUNTIME_SOURCES} ${PORTABLE_RUNTIME_SOURCES} ${SERVER_GC_SOURCES})
 
 # Get the current list of definitions
 get_compile_definitions(DEFINITIONS)

--- a/tests/src/Simple/BasicThreading/BasicThreading.csproj
+++ b/tests/src/Simple/BasicThreading/BasicThreading.csproj
@@ -1,4 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>


### PR DESCRIPTION
Make the Server GC an optional component by building two flavors of the runtime and selecting a specific one in the build via the `ServerGarbageCollection` MSBuild property. Don't build the Server GC flavor for Web Assembly.

Fixes #5182, Fixes #5306.