### PR TITLE
Objwriter: fix warnings

### DIFF
--- a/src/Native/ObjWriter/debugInfo/dwarf/dwarfAbbrev.cpp
+++ b/src/Native/ObjWriter/debugInfo/dwarf/dwarfAbbrev.cpp
@@ -34,7 +34,7 @@ void Dump(MCObjectStreamer *Streamer, uint16_t DwarfVersion, unsigned TargetPoin
       return;
   }
 
-  const char AbbrevTable[] = {
+  const uint16_t AbbrevTable[] = {
     CompileUnit,
         dwarf::DW_TAG_compile_unit, dwarf::DW_CHILDREN_yes,
         dwarf::DW_AT_producer, dwarf::DW_FORM_string,
@@ -275,7 +275,9 @@ void Dump(MCObjectStreamer *Streamer, uint16_t DwarfVersion, unsigned TargetPoin
   MCContext &context = Streamer->getContext();
   Streamer->SwitchSection(context.getObjectFileInfo()->getDwarfAbbrevSection());
 
-  Streamer->EmitBytes(StringRef(AbbrevTable, sizeof(AbbrevTable)));
+  for (uint16_t e : AbbrevTable) {
+      Streamer->EmitULEB128IntValue(e);
+  }
 }
 
 }

--- a/src/Native/ObjWriter/debugInfo/dwarf/dwarfGen.cpp
+++ b/src/Native/ObjWriter/debugInfo/dwarf/dwarfGen.cpp
@@ -760,7 +760,6 @@ static void DumpEHClause(MCObjectStreamer *Streamer, MCSection *TypeSection, int
 
 void SubprogramInfo::DumpEHClauses(MCObjectStreamer *Streamer, MCSection *TypeSection) {
   MCContext &context = Streamer->getContext();
-  unsigned TargetPointerSize = context.getAsmInfo()->getCodePointerSize();
 
   MCSymbol *Sym = context.getOrCreateSymbol(Twine(Name));
   const MCExpr *SymExpr = MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_None, context);


### PR DESCRIPTION
- Delete unused variable in SubprogramInfo::DumpEHClauses
- Fix narrowing conversions in DwarfAbbrev::Dump

It fixes https://github.com/dotnet/corert/issues/5567