### PR TITLE
Remove eager assert

### DIFF
--- a/src/Common/src/TypeSystem/IL/TypeSystemContext.ValueTypeMethods.cs
+++ b/src/Common/src/TypeSystem/IL/TypeSystemContext.ValueTypeMethods.cs
@@ -37,9 +37,6 @@ namespace Internal.TypeSystem
             {
                 MethodDesc getFieldHelperMethod = _valueTypeMethodHashtable.GetOrCreateValue((DefType)valueTypeDefinition);
 
-                // Check that System.ValueType has the method we're overriding.
-                Debug.Assert(valueTypeDefinition.BaseType.GetMethod(getFieldHelperMethod.Name, null) != null);
-
                 if (valueType != valueTypeDefinition)
                 {
                     yield return GetMethodForInstantiatedType(getFieldHelperMethod, (InstantiatedType)valueType);


### PR DESCRIPTION
This assert can kick in while building against Test.CoreLib. Adding the extra virtual method is pretty harmless since we'll never see it as used and it won't be compiled anyway.

@dotnet-bot skip ci please