### PR TITLE
Enable local strongname signing

### DIFF
--- a/src/ILVerification/src/ILVerification.csproj
+++ b/src/ILVerification/src/ILVerification.csproj
@@ -7,8 +7,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>netstandard1.3</TargetFramework>
-    <AssemblyKey></AssemblyKey>
-    <AssemblyOriginatorKeyFile>..\StrongNameKeys\ILVerify.snk</AssemblyOriginatorKeyFile>
+    <KeyOriginatorFile>..\StrongNameKeys\ILVerify.snk</KeyOriginatorFile>
+    <!-- Suppress signing done by buildtools sign.targets -->
+    <SkipSigning>true</SkipSigning>
+    <!-- Delete once we pick up fix for https://github.com/dotnet/roslyn/issues/8210 -->
+    <DelaySign Condition="'$(RunningOnUnix)' == 'true'">true</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ILVerification/src/ILVerification.csproj
+++ b/src/ILVerification/src/ILVerification.csproj
@@ -11,7 +11,7 @@
     <!-- Suppress signing done by buildtools sign.targets -->
     <SkipSigning>true</SkipSigning>
     <!-- Delete once we pick up fix for https://github.com/dotnet/roslyn/issues/8210 -->
-    <DelaySign Condition="'$(RunningOnUnix)' == 'true'">true</DelaySign>
+    <DelaySign Condition="'$(OS)' != 'Windows_NT'">true</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ILVerification/src/ILVerification.csproj
+++ b/src/ILVerification/src/ILVerification.csproj
@@ -7,7 +7,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>netstandard1.3</TargetFramework>
-    <KeyOriginatorFile>..\StrongNameKeys\ILVerify.snk</KeyOriginatorFile>
+    <AssemblyOriginatorKeyFile>..\StrongNameKeys\ILVerify.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
     <!-- Suppress signing done by buildtools sign.targets -->
     <SkipSigning>true</SkipSigning>
     <!-- Delete once we pick up fix for https://github.com/dotnet/roslyn/issues/8210 -->

--- a/src/ILVerification/tests/ILVerification.Tests.csproj
+++ b/src/ILVerification/tests/ILVerification.Tests.csproj
@@ -32,8 +32,5 @@
     <Folder Include="ILTests\" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\ILVerification\StrongNameKeys\ILVerify.snk" Link="ILVerify.snk" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/ILVerify/src/ILVerify.csproj
+++ b/src/ILVerify/src/ILVerify.csproj
@@ -4,8 +4,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ILVerify</RootNamespace>
     <AssemblyName>ILVerify</AssemblyName>
-    <AssemblyKey></AssemblyKey>
-    <AssemblyOriginatorKeyFile>..\..\ILVerification\StrongNameKeys\ILVerify.snk</AssemblyOriginatorKeyFile>
+    <KeyOriginatorFile>..\..\ILVerification\StrongNameKeys\ILVerify.snk</KeyOriginatorFile>
+    <!-- Suppress signing done by buildtools sign.targets -->
+    <SkipSigning>true</SkipSigning>
+    <!-- Delete once we pick up fix for https://github.com/dotnet/roslyn/issues/8210 -->
+    <DelaySign Condition="'$(RunningOnUnix)' == 'true'">true</DelaySign>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <CopyNugetImplementations>false</CopyNugetImplementations>
     <!-- Force .dll extension even if output type is exe. -->

--- a/src/ILVerify/src/ILVerify.csproj
+++ b/src/ILVerify/src/ILVerify.csproj
@@ -8,7 +8,7 @@
     <!-- Suppress signing done by buildtools sign.targets -->
     <SkipSigning>true</SkipSigning>
     <!-- Delete once we pick up fix for https://github.com/dotnet/roslyn/issues/8210 -->
-    <DelaySign Condition="'$(RunningOnUnix)' == 'true'">true</DelaySign>
+    <DelaySign Condition="'$(OS)' != 'Windows_NT'">true</DelaySign>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <CopyNugetImplementations>false</CopyNugetImplementations>
     <!-- Force .dll extension even if output type is exe. -->

--- a/src/ILVerify/src/ILVerify.csproj
+++ b/src/ILVerify/src/ILVerify.csproj
@@ -4,7 +4,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ILVerify</RootNamespace>
     <AssemblyName>ILVerify</AssemblyName>
-    <KeyOriginatorFile>..\..\ILVerification\StrongNameKeys\ILVerify.snk</KeyOriginatorFile>
+    <AssemblyOriginatorKeyFile>..\..\ILVerification\StrongNameKeys\ILVerify.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
     <!-- Suppress signing done by buildtools sign.targets -->
     <SkipSigning>true</SkipSigning>
     <!-- Delete once we pick up fix for https://github.com/dotnet/roslyn/issues/8210 -->


### PR DESCRIPTION
sign.targets defaults assume that the strongname signing will be done by the official strongname keys. We do not want that for ILVerification.dll since we have our own local checked in key.