### PR TITLE
Produce correct pdb file during "Dotnet publish"

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -66,8 +66,8 @@
     
   </Target>
 
-  <Target Name="CopyNativePdb" Condition="'$(Configuration)'=='Debug'" AfterTargets="Publish">
-    <!-- dotnet CLI produces the incorrect debug symbols - substitute with those we generated during native compilation -->
+  <Target Name="CopyNativePdb" Condition="'$(DebugType)'!='None'" AfterTargets="Publish">
+    <!-- dotnet CLI produces managed debug symbols - substitute with those we generated during native compilation -->
     <Delete Files="$(PublishDir)\$(TargetName).pdb"/>    
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName).pdb" DestinationFolder="$(PublishDir)" />  
   </Target>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -66,4 +66,10 @@
     
   </Target>
 
+  <Target Name="CopyNativePdb" Condition="'$(Configuration)'=='Debug'" AfterTargets="Publish">
+    <!-- dotnet CLI produces the incorrect debug symbols - substitute with those we generated during native compilation -->
+    <Delete Files="$(PublishDir)\$(TargetName).pdb"/>    
+    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).pdb" DestinationFolder="$(PublishDir)" />  
+  </Target>
+
 </Project>


### PR DESCRIPTION
The .pdb file under the publish folder only contains the target app's managed symbols. This deletes the incorrect symbols and substitutes them with the correctly generated native ones. 