### PR TITLE
DwarfSimpleArrayTypeInfo: change type of Size to uint64_t

### DIFF
--- a/src/Native/ObjWriter/debugInfo/dwarf/dwarfTypeBuilder.h
+++ b/src/Native/ObjWriter/debugInfo/dwarf/dwarfTypeBuilder.h
@@ -193,7 +193,7 @@ private:
 class DwarfSimpleArrayTypeInfo : public DwarfInfo
 {
 public:
-  DwarfSimpleArrayTypeInfo(uint32_t ArrayElementType, uint32_t Size) :
+  DwarfSimpleArrayTypeInfo(uint32_t ArrayElementType, uint64_t Size) :
                            ElementType(ArrayElementType),
                            Size(Size) {}
 
@@ -206,7 +206,7 @@ protected:
 
 private:
   uint32_t ElementType;
-  uint32_t Size;
+  uint64_t Size;
 };
 
 class DwarfPointerTypeInfo : public DwarfInfo


### PR DESCRIPTION
It fixes lldb error in case of zero-length arrays:
DW_TAG_member 'm_Data' refers to type 0x00000c70 which extends beyond the bounds of 0x00000c7c