### PR TITLE
Fix "dotnet publish" on Unix

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -66,7 +66,7 @@
     
   </Target>
 
-  <Target Name="CopyNativePdb" Condition="'$(DebugType)'!='None'" AfterTargets="Publish">
+  <Target Name="CopyNativePdb" Condition="'$(DebugType)' != 'None' and '$(TargetOS)' == 'Windows_NT'" AfterTargets="Publish">
     <!-- dotnet CLI produces managed debug symbols - substitute with those we generated during native compilation -->
     <Delete Files="$(PublishDir)\$(TargetName).pdb"/>    
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName).pdb" DestinationFolder="$(PublishDir)" />  


### PR DESCRIPTION
dotnet publish fails with:

```
HelloWorld -> /home/jkotas/xxx/bin/Debug/netcoreapp2.0/linux-x64/publish/
/home/jkotas/.nuget/packages/microsoft.dotnet.ilcompiler/1.0.0-alpha-2632301/build/Microsoft.NETCore.Native.Publish.targets(72,5): error MSB3030: Could not copy the file "bin/Debug/netcoreapp2.0/linux-x64/native/HelloWorld.pdb" because it was not found. [/home/jkotas/xxx/HelloWorld.csproj]
```