### PR TITLE
Implement P/Invoke 'A' and 'W' Probing

### DIFF
--- a/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
@@ -292,7 +292,7 @@ namespace Internal.TypeSystem
 
         public override bool Equals(object obj)
         {
-            return obj is PInvokeAttributes other && Equals(other);
+            return obj is PInvokeFlags other && Equals(other);
         }
 
         public override int GetHashCode()

--- a/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/MethodDesc.Interop.cs
@@ -101,7 +101,7 @@ namespace Internal.TypeSystem
         ThrowOnUnmappableCharMask = 12288
     }
 
-    public struct PInvokeFlags
+    public struct PInvokeFlags : IEquatable<PInvokeFlags>, IComparable<PInvokeFlags>
     {
         private PInvokeAttributes _attributes;
         public PInvokeAttributes Attributes
@@ -279,7 +279,26 @@ namespace Internal.TypeSystem
                 }
             }
         }
-        
+
+        public int CompareTo(PInvokeFlags other)
+        {
+            return Attributes.CompareTo(other.Attributes);
+        }
+
+        public bool Equals(PInvokeFlags other)
+        {
+            return Attributes == other.Attributes;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PInvokeAttributes other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Attributes.GetHashCode();
+        }
     }
 
     /// <summary>

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -102,7 +102,7 @@ namespace ILCompiler
             {
                 var pInvokeFixup = (PInvokeLazyFixupField)field;
                 PInvokeMetadata metadata = pInvokeFixup.PInvokeMetadata;
-                return NodeFactory.PInvokeMethodFixup(metadata.Module, metadata.Name);
+                return NodeFactory.PInvokeMethodFixup(metadata.Module, metadata.Name, metadata.Flags.ExactSpelling, metadata.Flags.CharSet);
             }
             else
             {

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -102,7 +102,7 @@ namespace ILCompiler
             {
                 var pInvokeFixup = (PInvokeLazyFixupField)field;
                 PInvokeMetadata metadata = pInvokeFixup.PInvokeMetadata;
-                return NodeFactory.PInvokeMethodFixup(metadata.Module, metadata.Name, metadata.Flags.ExactSpelling, metadata.Flags.CharSet);
+                return NodeFactory.PInvokeMethodFixup(metadata.Module, metadata.Name, metadata.Flags);
             }
             else
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -283,9 +283,9 @@ namespace ILCompiler.DependencyAnalysis
                 return new PInvokeModuleFixupNode(name);
             });
 
-            _pInvokeMethodFixups = new NodeCache<Tuple<string, string, bool, CharSet>, PInvokeMethodFixupNode>((Tuple<string, string, bool, CharSet> key) =>
+            _pInvokeMethodFixups = new NodeCache<Tuple<string, string, PInvokeFlags>, PInvokeMethodFixupNode>((Tuple<string, string, PInvokeFlags> key) =>
             {
-                return new PInvokeMethodFixupNode(key.Item1, key.Item2, key.Item3, key.Item4);
+                return new PInvokeMethodFixupNode(key.Item1, key.Item2, key.Item3);
             });
 
             _methodEntrypoints = new NodeCache<MethodDesc, IMethodNode>(CreateMethodEntrypointNode);
@@ -689,11 +689,11 @@ namespace ILCompiler.DependencyAnalysis
             return _pInvokeModuleFixups.GetOrAdd(moduleName);
         }
 
-        private NodeCache<Tuple<string, string, bool, CharSet>, PInvokeMethodFixupNode> _pInvokeMethodFixups;
+        private NodeCache<Tuple<string, string, PInvokeFlags>, PInvokeMethodFixupNode> _pInvokeMethodFixups;
 
-        public PInvokeMethodFixupNode PInvokeMethodFixup(string moduleName, string entryPointName, bool exactSpelling, CharSet charSet)
+        public PInvokeMethodFixupNode PInvokeMethodFixup(string moduleName, string entryPointName, PInvokeFlags flags)
         {
-            return _pInvokeMethodFixups.GetOrAdd(Tuple.Create(moduleName, entryPointName, exactSpelling, charSet));
+            return _pInvokeMethodFixups.GetOrAdd(Tuple.Create(moduleName, entryPointName, flags));
         }
 
         private NodeCache<TypeDesc, VTableSliceNode> _vTableNodes;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 using ILCompiler.DependencyAnalysisFramework;
@@ -282,9 +283,9 @@ namespace ILCompiler.DependencyAnalysis
                 return new PInvokeModuleFixupNode(name);
             });
 
-            _pInvokeMethodFixups = new NodeCache<Tuple<string, string>, PInvokeMethodFixupNode>((Tuple<string, string> key) =>
+            _pInvokeMethodFixups = new NodeCache<Tuple<string, string, bool, CharSet>, PInvokeMethodFixupNode>((Tuple<string, string, bool, CharSet> key) =>
             {
-                return new PInvokeMethodFixupNode(key.Item1, key.Item2);
+                return new PInvokeMethodFixupNode(key.Item1, key.Item2, key.Item3, key.Item4);
             });
 
             _methodEntrypoints = new NodeCache<MethodDesc, IMethodNode>(CreateMethodEntrypointNode);
@@ -688,11 +689,11 @@ namespace ILCompiler.DependencyAnalysis
             return _pInvokeModuleFixups.GetOrAdd(moduleName);
         }
 
-        private NodeCache<Tuple<string, string>, PInvokeMethodFixupNode> _pInvokeMethodFixups;
+        private NodeCache<Tuple<string, string, bool, CharSet>, PInvokeMethodFixupNode> _pInvokeMethodFixups;
 
-        public PInvokeMethodFixupNode PInvokeMethodFixup(string moduleName, string entryPointName)
+        public PInvokeMethodFixupNode PInvokeMethodFixup(string moduleName, string entryPointName, bool exactSpelling, CharSet charSet)
         {
-            return _pInvokeMethodFixups.GetOrAdd(new Tuple<string, string>(moduleName, entryPointName));
+            return _pInvokeMethodFixups.GetOrAdd(Tuple.Create(moduleName, entryPointName, exactSpelling, charSet));
         }
 
         private NodeCache<TypeDesc, VTableSliceNode> _vTableNodes;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -93,9 +93,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             var exactMatchCompare = _exactMatchOnly.CompareTo(((PInvokeMethodFixupNode)other)._exactMatchOnly);
             if (exactMatchCompare != 0)
-            {
                 return exactMatchCompare;
-            }
 
             var charSetCompare = ((int)_charSet).CompareTo((int)((PInvokeMethodFixupNode)other)._charSet);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -17,15 +17,13 @@ namespace ILCompiler.DependencyAnalysis
     {
         private string _moduleName;
         private string _entryPointName;
-        private bool _exactMatchOnly;
-        private CharSet _charSet;
+        private PInvokeFlags _flags;
 
-        public PInvokeMethodFixupNode(string moduleName, string entryPointName, bool exactSpelling, CharSet charSet)
+        public PInvokeMethodFixupNode(string moduleName, string entryPointName, PInvokeFlags flags)
         {
             _moduleName = moduleName;
             _entryPointName = entryPointName;
-            _exactMatchOnly = exactSpelling;
-            _charSet = charSet;
+            _flags = flags;
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -34,10 +32,10 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append(_moduleName);
             sb.Append("__");
             sb.Append(_entryPointName);
-            if(!_exactMatchOnly)
+            if(!_flags.ExactSpelling)
             {
-                sb.Append("_");
-                sb.Append(_charSet.ToString());
+                sb.Append("__");
+                sb.Append(_flags.CharSet.ToString());
             }
         }
         public int Offset => 0;
@@ -82,7 +80,7 @@ namespace ILCompiler.DependencyAnalysis
             // Module fixup cell
             builder.EmitPointerReloc(factory.PInvokeModuleFixup(_moduleName));
 
-            builder.EmitInt(_exactMatchOnly ? 0 : (int)_charSet);
+            builder.EmitInt(_flags.ExactSpelling ? 0 : (int)_flags.CharSet);
 
             return builder.ToObjectData();
         }
@@ -91,14 +89,9 @@ namespace ILCompiler.DependencyAnalysis
 
         protected internal override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
         {
-            var exactMatchCompare = _exactMatchOnly.CompareTo(((PInvokeMethodFixupNode)other)._exactMatchOnly);
-            if (exactMatchCompare != 0)
-                return exactMatchCompare;
-
-            var charSetCompare = ((int)_charSet).CompareTo((int)((PInvokeMethodFixupNode)other)._charSet);
-
-            if (charSetCompare != 0)
-                return charSetCompare;
+            var flagsCompare = _flags.CompareTo(((PInvokeMethodFixupNode)other)._flags);
+            if (flagsCompare != 0)
+                return flagsCompare;
 
             var moduleCompare = string.Compare(_moduleName, ((PInvokeMethodFixupNode)other)._moduleName);
             if (moduleCompare != 0)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -37,6 +37,8 @@ namespace ILCompiler.DependencyAnalysis
                 sb.Append("__");
                 sb.Append(_flags.CharSet.ToString());
             }
+            sb.Append("__");
+            sb.Append(((int)_flags.Attributes).ToString());
         }
         public int Offset => 0;
         public override bool IsShareable => true;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -304,7 +304,7 @@ namespace Internal.Runtime.CompilerHelpers
         {
             byte* methodName = (byte*)pCell->MethodName;
 
-#if !PLATFORM_UNIX
+#if PLATFORM_WINDOWS
             pCell->Target = GetProcAddress(hModule, methodName, pCell->CharSetMangling);
 #else
             pCell->Target = Interop.Sys.GetProcAddress(hModule, methodName);
@@ -316,7 +316,7 @@ namespace Internal.Runtime.CompilerHelpers
             }
         }
 
-#if !PLATFORM_UNIX
+#if PLATFORM_WINDOWS
         private static unsafe IntPtr GetProcAddress(IntPtr hModule, byte* methodName, CharSet charSetMangling)
         {
             // First look for the unmangled name.  If it is unicode function, we are going
@@ -339,6 +339,8 @@ namespace Internal.Runtime.CompilerHelpers
             {
                 probedMethodName[i] = methodName[i];
             }
+
+            probedMethodName[nameLength + 1] = 0;
 
             probedMethodName[nameLength] = (charSetMangling == CharSet.Ansi) ? (byte)'A' : (byte)'W';
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -319,6 +319,10 @@ namespace Internal.Runtime.CompilerHelpers
 #if !PLATFORM_UNIX
         private static unsafe IntPtr GetProcAddress(IntPtr hModule, byte* methodName, CharSet charSetMangling)
         {
+            // First look for the unmangled name.  If it is unicode function, we are going
+            // to need to check for the 'W' API because it takes precedence over the
+            // unmangled one (on NT some APIs have unmangled ANSI exports).
+            
             var exactMatch = Interop.mincore.GetProcAddress(hModule, methodName);
 
             if ((charSetMangling == CharSet.Ansi && exactMatch != IntPtr.Zero) || charSetMangling == 0)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -328,16 +328,17 @@ namespace Internal.Runtime.CompilerHelpers
 
             int nameLength = strlen(methodName);
 
-            byte* probedMethodName = stackalloc byte[nameLength + 1];
+            // We need to add an extra byte for the suffix, and an extra byte for the null terminator
+            byte* probedMethodName = stackalloc byte[nameLength + 2];
 
             for (int i = 0; i < nameLength; i++)
             {
                 probedMethodName[i] = methodName[i];
             }
 
-            probedMethodName[nameLength] = (charSetMangling == CharSet.Ansi) ? (byte)'A' : (byte)'U';
+            probedMethodName[nameLength] = (charSetMangling == CharSet.Ansi) ? (byte)'A' : (byte)'W';
 
-            IntPtr probedMethod = Interop.mincore.GetProcAddress(hModule, methodName);
+            IntPtr probedMethod = Interop.mincore.GetProcAddress(hModule, probedMethodName);
             if (probedMethod != IntPtr.Zero)
             {
                 return probedMethod;


### PR DESCRIPTION
Implement probing for native function names following the A/W suffix notation used on Windows.

Fixes #730.