### PR TITLE
Don't place instance methods on byref-like types in the mapping table

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -277,6 +277,11 @@ namespace ILCompiler
             if (method.IsFinalizer)
                 return false;
 
+            // Instance methods on byref-like types cannot be reflection invoked
+            // because one can't box them.
+            if (!method.Signature.IsStatic && owningType.IsByRefLike)
+                return false;
+
             // Static constructors are not reflection invokable
             if (method.IsStaticConstructor)
                 return false;


### PR DESCRIPTION
WASM codegen backend will fail making unboxing stubs for these (and other codegens would likely fail too, if this was an unboxing stub to shared generic code; something that we actually compile).