### PR TITLE
Update CoreFX Test Binaries URL

### DIFF
--- a/tests/CoreFXTestListURL.txt
+++ b/tests/CoreFXTestListURL.txt
@@ -1,1 +1,1 @@
-https://dotnetbuilddrops.blob.core.windows.net/build-987f9e019ca4405c9127f02516782d07/TestList.json?sv=2015-04-05&sr=c&sig=ETMKT2IFbiyndcPMJtEMeBwySuZURBxQ2eqlJ4xVXi4%3D&st=2018-03-13T21%3A14%3A10.2227157Z&se=2118-02-17T21%3A14%3A10.2242145Z&sp=r
+https://cloudcijobs.blob.core.windows.net/corertci/CoreFXArchives/TestList.json


### PR DESCRIPTION
Update the URL to point to our own test binary storage account. 
