### PR TITLE
Report IsIntrinsic on InstantiatedType

### DIFF
--- a/src/Common/src/TypeSystem/CodeGen/TypeDesc.CodeGen.cs
+++ b/src/Common/src/TypeSystem/CodeGen/TypeDesc.CodeGen.cs
@@ -18,4 +18,13 @@ namespace Internal.TypeSystem
             }
         }
     }
+
+    partial class InstantiatedType
+    {
+        partial void AddComputedIntrinsicFlag(ref TypeFlags flags)
+        {
+            if (_typeDef.IsIntrinsic)
+                flags |= TypeFlags.IsIntrinsic;
+        }
+    }
 }

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -79,6 +79,10 @@ namespace Internal.TypeSystem
             }
         }
 
+        // Type system implementations that support the notion of intrinsic types
+        // will provide an implementation that adds the flag if necessary.
+        partial void AddComputedIntrinsicFlag(ref TypeFlags flags);
+
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
         {
             TypeFlags flags = 0;
@@ -110,6 +114,8 @@ namespace Internal.TypeSystem
 
                 if (_typeDef.IsByRefLike)
                     flags |= TypeFlags.IsByRefLike;
+
+                AddComputedIntrinsicFlag(ref flags);
             }
 
             return flags;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1006,7 +1006,7 @@ namespace Internal.JitInterface
         {
             TypeDesc type = HandleToObject(classHnd);
             
-            if (_simdHelper.IsSimdType(type.GetTypeDefinition()))
+            if (_simdHelper.IsSimdType(type))
             {
 #if DEBUG
                 // If this is Vector<T>, make sure the codegen and the type system agree on what instructions/registers


### PR DESCRIPTION
Commit 5d96263c66e50ab88f51ec5aae01bd1d57d4ef37 made me aware that `IsIntrinsic` doesn't work on instantiated types. This fixes the problem in a bit of a roundabout way - we only want certain type system implementations to have the IsIntrinsic bit but the flags computation is in the core ECMA type system; a partial method to the rescue...