### PR TITLE
[Linux/ARM] Fix mapping symbols for compiled managed code

### DIFF
--- a/src/Native/ObjWriter/llvm.patch
+++ b/src/Native/ObjWriter/llvm.patch
@@ -15,7 +15,7 @@ index 7c1189e..d1d77c9 100644
    /// can change its size during relaxation.
    virtual void EmitInstToFragment(const MCInst &Inst, const MCSubtargetInfo &);
 diff --git a/include/llvm/MC/MCStreamer.h b/include/llvm/MC/MCStreamer.h
-index 5390e79..e28a3cc 100644
+index 5390e79..5b258e7 100644
 --- a/include/llvm/MC/MCStreamer.h
 +++ b/include/llvm/MC/MCStreamer.h
 @@ -115,6 +115,7 @@ public:
@@ -26,6 +26,16 @@ index 5390e79..e28a3cc 100644
    virtual void emitUnwindRaw(int64_t StackOffset,
                               const SmallVectorImpl<uint8_t> &Opcodes);
  
+@@ -548,6 +549,9 @@ public:
+   /// etc.
+   virtual void EmitBytes(StringRef Data);
+ 
++  /// \brief Emit the given \p Instruction data into the current section.
++  virtual void EmitInstructionBytes(StringRef Data);
++
+   /// Functionally identical to EmitBytes. When emitting textual assembly, this
+   /// method uses .byte directives instead of .ascii or .asciz for readability.
+   virtual void EmitBinaryData(StringRef Data);
 diff --git a/lib/MC/MCObjectStreamer.cpp b/lib/MC/MCObjectStreamer.cpp
 index 174397e..ef7161f 100644
 --- a/lib/MC/MCObjectStreamer.cpp
@@ -57,6 +67,18 @@ index 174397e..ef7161f 100644
  void MCObjectStreamer::EmitCFIStartProcImpl(MCDwarfFrameInfo &Frame) {
    // We need to create a local symbol to avoid relocations.
    Frame.Begin = getContext().createTempSymbol();
+diff --git a/lib/MC/MCStreamer.cpp b/lib/MC/MCStreamer.cpp
+index 2bfb9a6..a710098 100644
+--- a/lib/MC/MCStreamer.cpp
++++ b/lib/MC/MCStreamer.cpp
+@@ -830,6 +830,7 @@ void MCStreamer::EmitTBSSSymbol(MCSection *Section, MCSymbol *Symbol,
+ void MCStreamer::ChangeSection(MCSection *, const MCExpr *) {}
+ void MCStreamer::EmitWeakReference(MCSymbol *Alias, const MCSymbol *Symbol) {}
+ void MCStreamer::EmitBytes(StringRef Data) {}
++void MCStreamer::EmitInstructionBytes(StringRef Data) { EmitBytes(Data); }
+ void MCStreamer::EmitBinaryData(StringRef Data) { EmitBytes(Data); }
+ void MCStreamer::EmitValueImpl(const MCExpr *Value, unsigned Size, SMLoc Loc) {
+   visitUsedExpr(*Value);
 diff --git a/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp b/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
 index a77df7a..e1aa752 100644
 --- a/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -122,7 +144,7 @@ index 59f31be..9b95598 100644
      case ARM::fixup_arm_uncondbl:
        switch (Modifier) {
 diff --git a/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp b/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
-index 93f4006..67ae439 100644
+index 93f4006..81e4caa 100644
 --- a/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
 +++ b/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
 @@ -396,6 +396,7 @@ private:
@@ -141,7 +163,26 @@ index 93f4006..67ae439 100644
    void emitUnwindRaw(int64_t Offset, const SmallVectorImpl<uint8_t> &Opcodes);
  
    void ChangeSection(MCSection *Section, const MCExpr *Subsection) override {
-@@ -698,6 +700,7 @@ private:
+@@ -533,6 +535,18 @@ public:
+     MCELFStreamer::EmitBytes(Data);
+   }
+ 
++  /// This function is the one used to emit instruction data into the ELF
++  /// streamer. We override it to add the appropriate mapping symbol if
++  /// necessary.
++  void EmitInstructionBytes(StringRef Data) override {
++    if (IsThumb)
++      EmitThumbMappingSymbol();
++    else
++      EmitARMMappingSymbol();
++
++    MCELFStreamer::EmitBytes(Data);
++  }
++
+   void FlushPendingMappingSymbol() {
+     if (!LastEMSInfo->hasInfo())
+       return;
+@@ -698,6 +712,7 @@ private:
    bool CantUnwind;
    SmallVector<uint8_t, 64> Opcodes;
    UnwindOpcodeAssembler UnwindOpAsm;
@@ -149,7 +190,7 @@ index 93f4006..67ae439 100644
  };
  
  } // end anonymous namespace
-@@ -740,6 +743,10 @@ void ARMTargetELFStreamer::emitRegSave(const SmallVectorImpl<unsigned> &RegList,
+@@ -740,6 +755,10 @@ void ARMTargetELFStreamer::emitRegSave(const SmallVectorImpl<unsigned> &RegList,
    getStreamer().emitRegSave(RegList, isVector);
  }
  
@@ -160,7 +201,7 @@ index 93f4006..67ae439 100644
  void ARMTargetELFStreamer::emitUnwindRaw(int64_t Offset,
                                        const SmallVectorImpl<uint8_t> &Opcodes) {
    getStreamer().emitUnwindRaw(Offset, Opcodes);
-@@ -1233,6 +1240,7 @@ void ARMELFStreamer::EHReset() {
+@@ -1233,6 +1252,7 @@ void ARMELFStreamer::EHReset() {
    PendingOffset = 0;
    UsedFP = false;
    CantUnwind = false;
@@ -168,7 +209,7 @@ index 93f4006..67ae439 100644
  
    Opcodes.clear();
    UnwindOpAsm.Reset();
-@@ -1330,6 +1338,8 @@ void ARMELFStreamer::FlushUnwindOpcodes(bool NoHandlerData) {
+@@ -1330,6 +1350,8 @@ void ARMELFStreamer::FlushUnwindOpcodes(bool NoHandlerData) {
    }
  
    // Finalize the unwind opcode sequence
@@ -177,7 +218,7 @@ index 93f4006..67ae439 100644
    UnwindOpAsm.Finalize(PersonalityIndex, Opcodes);
  
    // For compact model 0, we have to emit the unwind opcodes in the .ARM.exidx
-@@ -1374,7 +1384,13 @@ void ARMELFStreamer::FlushUnwindOpcodes(bool NoHandlerData) {
+@@ -1374,7 +1396,13 @@ void ARMELFStreamer::FlushUnwindOpcodes(bool NoHandlerData) {
    //
    // In case that the .handlerdata directive is not specified by the
    // programmer, we should emit zero to terminate the handler data.
@@ -192,7 +233,7 @@ index 93f4006..67ae439 100644
      EmitIntValue(0, 4);
  }
  
-@@ -1457,6 +1473,10 @@ void ARMELFStreamer::emitRegSave(const SmallVectorImpl<unsigned> &RegList,
+@@ -1457,6 +1485,10 @@ void ARMELFStreamer::emitRegSave(const SmallVectorImpl<unsigned> &RegList,
      UnwindOpAsm.EmitRegSave(Mask);
  }
  

--- a/src/Native/ObjWriter/objwriter.cpp
+++ b/src/Native/ObjWriter/objwriter.cpp
@@ -305,7 +305,11 @@ void ObjectWriter::EmitAlignment(int ByteAlignment) {
 }
 
 void ObjectWriter::EmitBlob(int BlobSize, const char *Blob) {
-  Streamer->EmitBytes(StringRef(Blob, BlobSize));
+  if (Streamer->getCurrentSectionOnly()->getKind().isText()) {
+    Streamer->EmitInstructionBytes(StringRef(Blob, BlobSize));
+  } else {
+    Streamer->EmitBytes(StringRef(Blob, BlobSize));
+  }
 }
 
 void ObjectWriter::EmitIntValue(uint64_t Value, unsigned Size) {


### PR DESCRIPTION
ObjWriter emits compiled managed code as data (using MCStreamer::EmitBytes method). In this case on arm code is marked as data using special mapping symbol '$d' that leads to problems during debugging. For example gdb uses incorrect opcode for breakpoints that brokes program execution.

In this patch new method MCStreamer::EmitInstructionBytes is added. It uses '$a'/'$t' mapping symbols to mark data as arm/thumb code. This method is used to emit compiled managed code in ObjWriter.