### PR TITLE
Get rid of compiler warning in StaticLibrary test

### DIFF
--- a/tests/src/Simple/StaticLibrary/StaticLibrary.csproj
+++ b/tests/src/Simple/StaticLibrary/StaticLibrary.csproj
@@ -24,7 +24,9 @@
       <NativeRunnerCompilerArg Include="/Fo$(NativeRunnerBinary)" Condition="'$(OS)' == 'Windows_NT'" />
       <NativeRunnerCompilerArg Include="/Fe$(NativeRunnerBinary)" Condition="'$(OS)' == 'Windows_NT'" />
       <NativeRunnerCompilerArg Include="$(NativeBinary)" Condition="'$(OS)' == 'Windows_NT'" />
-      <NativeRunnerCompilerArg Include="@(NativeLibrary)" Condition="'$(OS)' == 'Windows_NT'" />      
+      <NativeRunnerCompilerArg Include="@(NativeLibrary)" Condition="'$(OS)' == 'Windows_NT'" />
+      <NativeRunnerCompilerArg Include="/MTd" Condition="'$(OS)' == 'Windows_NT' and '$(Configuration)' == 'Debug'" />
+      <NativeRunnerCompilerArg Include="/MT" Condition="'$(OS)' == 'Windows_NT' and '$(Configuration)' != 'Debug'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Gets rid of `LINK : warning LNK4098: defaultlib 'LIBCMTD' conflicts with use of other libs; use /NODEFAULTLIB:library [d:\git\rt\tests\src\Simple\StaticLibrary\StaticLibrary.csproj]`.