### PR TITLE
Add gss as NativeFramework on OSX to support System.Net.Security.Native.a linking

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -73,6 +73,7 @@ See the LICENSE file in the project root for more information.
     <ItemGroup Condition="'$(TargetOS)' == 'OSX'">
       <NativeFramework Include="CoreFoundation" />
       <NativeFramework Include="Security" />
+      <NativeFramework Include="gss" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
When using features from CoreFX that rely on System.Net.Security.Native.a, the 'gss' Framework needs to be linked in on OSX.
I'm not sure if this should go here automatically, but I guess there shouldn't be any downsides to providing the Framework link if it isn't used.