### PR TITLE
revert "Work around MCG bug around `ref char` marshalling #5481"

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
@@ -13,18 +13,6 @@ internal partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use GetFullPathName or PathHelper.
         /// </summary>
         [DllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
-#if PROJECTN
-        internal static extern unsafe uint GetFullPathNameW(char* lpFileName, uint nBufferLength, char* lpBuffer, IntPtr lpFilePart);
-
-        // Works around https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=575202
-        internal static unsafe uint GetFullPathNameW(ref char lpFileName, uint nBufferLength, ref char lpBuffer, IntPtr lpFilePart)
-        {
-            fixed (char* pBuffer = &lpBuffer)
-            fixed (char* pFileName = &lpFileName)
-                return GetFullPathNameW(pFileName, nBufferLength, pBuffer, lpFilePart);
-        }
-#else
         internal static extern uint GetFullPathNameW(ref char lpFileName, uint nBufferLength, ref char lpBuffer, IntPtr lpFilePart);
-#endif
     }
 }

--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetLongPathNameW.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetLongPathNameW.cs
@@ -13,18 +13,6 @@ internal partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use GetFullPath/PathHelper.
         /// </summary>
         [DllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
-#if PROJECTN
-        internal static extern unsafe uint GetLongPathNameW(char* lpszShortPath, char* lpszLongPath, uint cchBuffer);
-
-        // Works around https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=575202
-        internal static unsafe uint GetLongPathNameW(ref char lpszShortPath, ref char lpszLongPath, uint cchBuffer)
-        {
-            fixed (char* plpszLongPath = &lpszLongPath)
-            fixed (char* plpszShortPath = &lpszShortPath)
-                return GetLongPathNameW(plpszShortPath, plpszLongPath, cchBuffer);
-        }
-#else
         internal static extern uint GetLongPathNameW(ref char lpszShortPath, ref char lpszLongPath, uint cchBuffer);
-#endif
     }
 }

--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetTempFileNameW.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetTempFileNameW.cs
@@ -9,18 +9,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-#if PROJECTN
-        internal static extern unsafe uint GetTempFileNameW(char* lpPathName, string lpPrefixString, uint uUnique, char* lpTempFileName);
-
-        // Works around https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=575202
-        internal static unsafe uint GetTempFileNameW(ref char lpPathName, string lpPrefixString, uint uUnique, ref char lpTempFileName)
-        {
-            fixed (char* plpPathName = &lpPathName)
-            fixed (char* plpTempFileName = &lpTempFileName)
-                return GetTempFileNameW(plpPathName, lpPrefixString, uUnique, plpTempFileName);
-        }
-#else
         internal static extern uint GetTempFileNameW(ref char lpPathName, string lpPrefixString, uint uUnique, ref char lpTempFileName);
-#endif
     }
 }

--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetTempPathW.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetTempPathW.cs
@@ -9,17 +9,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, BestFitMapping = false)]
-#if PROJECTN
-        internal static extern unsafe uint GetTempPathW(int bufferLen, char* buffer);
-
-        // Works around https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=575202
-        internal static unsafe uint GetTempPathW(int bufferLen, ref char buffer)
-        {
-            fixed (char* pbuffer = &buffer)
-                return GetTempPathW(bufferLen, pbuffer);
-        }
-#else
         internal static extern uint GetTempPathW(int bufferLen, ref char buffer);
-#endif
     }
 }


### PR DESCRIPTION
This reverts commit https://github.com/dotnet/corert/pull/5481/commits/b2901d08b67d4ab051cc39b38deaa96933e2f714 and https://github.com/dotnet/corert/pull/5576/commits/be184ac590a76bad08640f6d32a8da03f767220e.