### PR TITLE
Use canonical method IL in scanner's ImportCall

### DIFF
--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -19,6 +19,7 @@ namespace Internal.IL
     partial class ILImporter
     {
         private readonly MethodIL _methodIL;
+        private readonly MethodIL _canonMethodIL;
         private readonly ILScanner _compilation;
         private readonly ILScanNodeFactory _factory;
 
@@ -83,6 +84,8 @@ namespace Internal.IL
             _factory = (ILScanNodeFactory)compilation.NodeFactory;
             
             _ilBytes = methodIL.GetILBytes();
+
+            _canonMethodIL = methodIL;
 
             // Get the runtime determined method IL so that this works right in shared code
             // and tokens in shared code resolve to runtime determined types.
@@ -266,11 +269,10 @@ namespace Internal.IL
         
         private void ImportCall(ILOpcode opcode, int token)
         {
-            // Strip runtime determined characteristics off of the method (because that's how RyuJIT operates)
+            // We get both the canonical and runtime determined form - JitInterface mostly operates
+            // on the canonical form.
             var runtimeDeterminedMethod = (MethodDesc)_methodIL.GetObject(token);
-            MethodDesc method = runtimeDeterminedMethod;
-            if (runtimeDeterminedMethod.IsRuntimeDeterminedExactMethod)
-                method = runtimeDeterminedMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            var method = (MethodDesc)_canonMethodIL.GetObject(token);
 
             if (method.IsRawPInvoke())
             {

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -32,6 +32,7 @@ class Program
         TestFieldAccess.Run();
         TestNativeLayoutGeneration.Run();
         TestInterfaceVTableTracking.Run();
+        TestClassVTableTracking.Run();
 
         return 100;
     }
@@ -2119,6 +2120,30 @@ class Program
             s_foo = new Derived<string>();
             Array arr = s_foo.Frob();
             arr.SetValue(new Gen<Gen<string>>(), new int[] { 0, 0 });
+        }
+    }
+
+    class TestClassVTableTracking
+    {
+        class Unit { }
+
+        class Gen<T, U>
+        {
+            public virtual int Test()
+            {
+                return 42;
+            }
+        }
+
+        static int Call<T>()
+        {
+            return new Gen<T, Unit>().Test();
+        }
+
+        public static void Run()
+        {
+            // This only really tests whether we can compile this.
+            Call<object>();
         }
     }
 }


### PR DESCRIPTION
This is necessary so that the scanner can accurately predict what weird things we're going to need later. We're emulating what `getCallInfo` will do.

Fixes #5648. Note that the F# hello app is still blocked, this time on complex tail calls (#1683).