### PR TITLE
Fix metadata generation for null string constants

### DIFF
--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.CustomAttribute.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.CustomAttribute.cs
@@ -117,7 +117,7 @@ namespace ILCompiler.Metadata
                     return new ConstantUInt64Value { Value = (ulong)value };
             }
 
-            if (type.IsString)
+            if (type.IsString && value != null)
             {
                 return HandleString((string)value);
             }


### PR DESCRIPTION
This should take the code path that returns `ConstantReferenceValue`.