### PR TITLE
Add StdCall intrinsic support

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -246,7 +246,7 @@ namespace Internal.IL
                 if (((MetadataType)method.OwningType).HasCustomAttribute("System.Runtime.InteropServices", "McgIntrinsicsAttribute"))
                 {
                     var name = method.Name;
-                    if (name == "Call")
+                    if (name == "Call" || name == "StdCall")
                     {
                         return CalliIntrinsic.EmitIL(method);
                     }

--- a/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
@@ -18,7 +18,7 @@ namespace Internal.IL.Stubs
     {
         public static MethodIL EmitIL(MethodDesc target)
         {
-            Debug.Assert(target.Name == "Call");
+            Debug.Assert(target.Name == "Call" || target.Name == "StdCall");
             Debug.Assert(target.Signature.Length > 0
                 && target.Signature[0] == target.Context.GetWellKnownType(WellKnownType.IntPtr));
 
@@ -44,7 +44,11 @@ namespace Internal.IL.Stubs
                 parameters[i - 1] = template[i];
             }
 
-            var signature = new MethodSignature(template.Flags, 0, returnType, parameters);
+            MethodSignatureFlags flags = template.Flags;
+            if (target.Name == "StdCall")
+                flags |= MethodSignatureFlags.UnmanagedCallingConventionStdCall;
+
+            var signature = new MethodSignature(flags, 0, returnType, parameters);
             codeStream.Emit(ILOpcode.calli, emitter.NewToken(signature));
             codeStream.Emit(ILOpcode.ret);
 


### PR DESCRIPTION
This is a building block to be able to write a repro case for #5587 in C#. With this, it's possible to use `AddrOf` intrinsic in connection with `StdCall` and a `NativeCallable` method to hit the unimplemented functionality with pure C#.