### PR TITLE
Use fully canonical method in ready to run helpers

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -80,11 +80,17 @@ namespace ILCompiler.DependencyAnalysis
                     }
                     break;
                 case ReadyToRunHelperId.VirtualCall:
+                case ReadyToRunHelperId.ResolveVirtualFunction:
                     {
                         // Make sure we aren't trying to callvirt Object.Finalize
                         MethodDesc method = (MethodDesc)target;
                         if (method.IsFinalizer)
                             ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramCallVirtFinalize, method);
+
+                        // Method should be in fully canonical form. Otherwise we're being wasteful and generate more
+                        // helpers than needed.
+                        Debug.Assert(!method.IsCanonicalMethod(CanonicalFormKind.Any) ||
+                            method.GetCanonMethodTarget(CanonicalFormKind.Specific) == method);
                     }
                     break;
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -3355,6 +3355,7 @@ namespace Internal.JitInterface
                 else
                 {
                     pResult.exactContextNeedsRuntimeLookup = false;
+                    targetMethod = targetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
                     // Get the slot defining method to make sure our virtual method use tracking gets this right.
                     // For normal C# code the targetMethod will always be newslot.


### PR DESCRIPTION
Helper to call `Foo<string>.Virtual()` and `Foo<object>.Virtual()` is the same. Let's make fewer of them and also avoid helpers for things like `Foo<string, __Canon>.Virtual()` that put weird things in the dependency graph in the process.

Fixes #5710.