### PR TITLE
Fix WebAssembly interface issues

### DIFF
--- a/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyVTableSlotNode.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyVTableSlotNode.cs
@@ -61,7 +61,16 @@ namespace ILCompiler.DependencyAnalysis
 
             if (!relocsOnly)
             {
-                var tableOffset = EETypeNode.GetVTableOffset(factory.Target.PointerSize) / factory.Target.PointerSize;
+                int tableOffset;
+                if (_targetMethod.OwningType.IsInterface)
+                {
+                    tableOffset = 0;
+                }
+                else
+                {
+                    tableOffset = EETypeNode.GetVTableOffset(factory.Target.PointerSize) / factory.Target.PointerSize;
+                }
+
                 objData.EmitInt(tableOffset + VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, _targetMethod, _targetMethod.OwningType));
             }
             return objData.ToObjectData();


### PR DESCRIPTION
Fix issues related to WebAssembly interface dispatch:
1. Don't add a vtable offset to interface slot numbers
2. Ensure values are loaded before applying conv to them to avoid loading too wide of a value (found when interface dispatch loads a uint16 and then converts to IntPtr)