### PR TITLE
Enable Interface dispatch for WASM

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1001,11 +1001,6 @@ namespace Internal.IL
                     {
                         targetMethod = parameterType.ResolveInterfaceMethodTarget(callee);
                     }
-                    else
-                    {
-                        //TODO: needs runtime support for DispatchByInterface
-                        throw new NotImplementedException("Interface call");
-                    }
                 }
                 else
                 {
@@ -1021,7 +1016,7 @@ namespace Internal.IL
                     return GetOrCreateLLVMFunction(_compilation.NameMangler.GetMangledMethodName(targetMethod).ToString());
                 }
 
-                return GetCallableVirtualMethod(thisPointer.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder), callee);
+                return GetCallableVirtualMethod(thisPointer, callee);
 
             }
             else

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -188,6 +188,9 @@ internal static class Program
         IntToStringTest();
 
         CastingTestClass castingTest = new DerivedCastingTestClass1();
+
+        PrintLine("interface call test: Ok " + (castingTest as ICastingTest1).GetValue().ToString());
+
         if (((DerivedCastingTestClass1)castingTest).GetValue() == 1 && !(castingTest is DerivedCastingTestClass2))
         {
             PrintLine("Type casting with isinst & castclass to class test: Ok.");


### PR DESCRIPTION
@morganbr thanks for solving the conv, vtable base and init problems. Here's my changes for interface dispatch. I think it still needs null checks before callvirt is really done. It might be a good idea to make some kind of LLVM infrastructure for injecting simple exception throwing checks inline. This would also apply nicely to the IndexOutOfRangeException that needs to be thrown in the array access code.