### PR TITLE
Devirtualize delegate creation to sealed virtuals

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -90,6 +90,12 @@ namespace ILCompiler
 
         public DelegateCreationInfo GetDelegateCtor(TypeDesc delegateType, MethodDesc target, bool followVirtualDispatch)
         {
+            // If we're creating a delegate to a virtual method that cannot be overriden, devirtualize.
+            // This is not just an optimization - it's required for correctness in the presence of sealed
+            // vtable slots.
+            if (followVirtualDispatch && (target.IsFinal || target.OwningType.IsSealed()))
+                followVirtualDispatch = false;
+
             return DelegateCreationInfo.Create(delegateType, target, NodeFactory, followVirtualDispatch);
         }
 

--- a/tests/src/Simple/Delegates/Delegates.cs
+++ b/tests/src/Simple/Delegates/Delegates.cs
@@ -107,6 +107,14 @@ public class BringUpTests
                 return false;
         }
 
+        {
+            // This will end up being a delegate to a sealed virtual method.
+            ClassWithIFoo t = new ClassWithIFoo("Class");
+            Func<int, string> d = t.DoFoo;
+            if (d(987) != "Class987")
+                return false;       
+        }
+
         Console.WriteLine("OK");
         return true;
     }


### PR DESCRIPTION
These could be in sealed vtable slots.