### PR TITLE
Add Delegate cast to Task constructors

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -128,7 +128,6 @@ namespace System.Threading.Tasks
             : this(function, null, default(CancellationToken),
                 TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
 
@@ -150,7 +149,6 @@ namespace System.Threading.Tasks
             : this(function, null, cancellationToken,
                 TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -174,7 +172,6 @@ namespace System.Threading.Tasks
         public Task(Func<TResult> function, TaskCreationOptions creationOptions)
             : this(function, Task.InternalCurrentIfAttached(creationOptions), default(CancellationToken), creationOptions, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -202,7 +199,6 @@ namespace System.Threading.Tasks
         public Task(Func<TResult> function, CancellationToken cancellationToken, TaskCreationOptions creationOptions)
             : this(function, Task.InternalCurrentIfAttached(creationOptions), cancellationToken, creationOptions, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -220,7 +216,6 @@ namespace System.Threading.Tasks
             : this(function, state, null, default(CancellationToken),
                 TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -242,7 +237,6 @@ namespace System.Threading.Tasks
             : this(function, state, null, cancellationToken,
                     TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -268,7 +262,6 @@ namespace System.Threading.Tasks
             : this(function, state, Task.InternalCurrentIfAttached(creationOptions), default(CancellationToken),
                     creationOptions, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
 
@@ -299,7 +292,6 @@ namespace System.Threading.Tasks
             : this(function, state, Task.InternalCurrentIfAttached(creationOptions), cancellationToken,
                     creationOptions, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -315,7 +307,6 @@ namespace System.Threading.Tasks
             TaskCreationOptions creationOptions, InternalTaskOptions internalOptions, TaskScheduler scheduler) :
             base(valueSelector, null, parent, cancellationToken, creationOptions, internalOptions, scheduler)
         {
-            PossiblyCaptureContext();
         }
 
 
@@ -333,7 +324,6 @@ namespace System.Threading.Tasks
             TaskCreationOptions creationOptions, InternalTaskOptions internalOptions, TaskScheduler scheduler) :
             base(valueSelector, state, parent, cancellationToken, creationOptions, internalOptions, scheduler)
         {
-            PossiblyCaptureContext();
         }
 
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/FutureFactory.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/FutureFactory.cs
@@ -679,10 +679,10 @@ namespace System.Threading.Tasks
             // Just specify this task as detached. No matter what happens, we want endMethod 
             // to be called -- even if the parent is canceled.  So we don't want to flow 
             // RespectParentCancellation.
-            Task t = new Task(delegate
+            Task t = new Task(new Action<object>(delegate
                 {
                     FromAsyncCoreLogic(asyncResult, endFunction, endAction, promise, requiresSynchronization: true);
-                },
+                }),
                 (object)null, null,
                 default(CancellationToken), TaskCreationOptions.None, InternalTaskOptions.None, null);
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -408,7 +408,7 @@ namespace System.Threading.Tasks
         /// The <paramref name="action"/> argument is null.
         /// </exception>
         public Task(Action<object> action, object state)
-            : this(action, state, null, default(CancellationToken), TaskCreationOptions.None, InternalTaskOptions.None, null)
+            : this((Delegate)action, state, null, default(CancellationToken), TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
             PossiblyCaptureContext();
         }
@@ -426,7 +426,7 @@ namespace System.Threading.Tasks
         /// has already been disposed.
         /// </exception>
         public Task(Action<object> action, object state, CancellationToken cancellationToken)
-            : this(action, state, null, cancellationToken, TaskCreationOptions.None, InternalTaskOptions.None, null)
+            : this((Delegate)action, state, null, cancellationToken, TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
             PossiblyCaptureContext();
         }
@@ -448,7 +448,7 @@ namespace System.Threading.Tasks
         /// cref="T:System.Threading.Tasks.TaskCreationOptions"/>.
         /// </exception>
         public Task(Action<object> action, object state, TaskCreationOptions creationOptions)
-            : this(action, state, Task.InternalCurrentIfAttached(creationOptions), default(CancellationToken), creationOptions, InternalTaskOptions.None, null)
+            : this((Delegate)action, state, Task.InternalCurrentIfAttached(creationOptions), default(CancellationToken), creationOptions, InternalTaskOptions.None, null)
         {
             PossiblyCaptureContext();
         }
@@ -474,7 +474,7 @@ namespace System.Threading.Tasks
         /// has already been disposed.
         /// </exception>
         public Task(Action<object> action, object state, CancellationToken cancellationToken, TaskCreationOptions creationOptions)
-            : this(action, state, Task.InternalCurrentIfAttached(creationOptions), cancellationToken, creationOptions, InternalTaskOptions.None, null)
+            : this((Delegate)action, state, Task.InternalCurrentIfAttached(creationOptions), cancellationToken, creationOptions, InternalTaskOptions.None, null)
         {
             PossiblyCaptureContext();
         }

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -479,7 +479,6 @@ namespace System.Threading.Tasks
 
         /// <summary>
         /// An internal constructor used by the factory methods on task and its descendent(s).
-        /// This variant does not capture the ExecutionContext; it is up to the caller to do that.
         /// </summary>
         /// <param name="action">An action to execute.</param>
         /// <param name="state">Optional state to pass to the action.</param>

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -333,7 +333,6 @@ namespace System.Threading.Tasks
         public Task(Action action)
             : this(action, null, null, default(CancellationToken), TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -349,7 +348,6 @@ namespace System.Threading.Tasks
         public Task(Action action, CancellationToken cancellationToken)
             : this(action, null, null, cancellationToken, TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -370,7 +368,6 @@ namespace System.Threading.Tasks
         public Task(Action action, TaskCreationOptions creationOptions)
             : this(action, null, Task.InternalCurrentIfAttached(creationOptions), default(CancellationToken), creationOptions, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -395,7 +392,6 @@ namespace System.Threading.Tasks
         public Task(Action action, CancellationToken cancellationToken, TaskCreationOptions creationOptions)
             : this(action, null, Task.InternalCurrentIfAttached(creationOptions), cancellationToken, creationOptions, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
 
@@ -408,9 +404,8 @@ namespace System.Threading.Tasks
         /// The <paramref name="action"/> argument is null.
         /// </exception>
         public Task(Action<object> action, object state)
-            : this((Delegate)action, state, null, default(CancellationToken), TaskCreationOptions.None, InternalTaskOptions.None, null)
+            : this(action, state, null, default(CancellationToken), TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -426,9 +421,8 @@ namespace System.Threading.Tasks
         /// has already been disposed.
         /// </exception>
         public Task(Action<object> action, object state, CancellationToken cancellationToken)
-            : this((Delegate)action, state, null, cancellationToken, TaskCreationOptions.None, InternalTaskOptions.None, null)
+            : this(action, state, null, cancellationToken, TaskCreationOptions.None, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -448,9 +442,8 @@ namespace System.Threading.Tasks
         /// cref="T:System.Threading.Tasks.TaskCreationOptions"/>.
         /// </exception>
         public Task(Action<object> action, object state, TaskCreationOptions creationOptions)
-            : this((Delegate)action, state, Task.InternalCurrentIfAttached(creationOptions), default(CancellationToken), creationOptions, InternalTaskOptions.None, null)
+            : this(action, state, Task.InternalCurrentIfAttached(creationOptions), default(CancellationToken), creationOptions, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -474,16 +467,14 @@ namespace System.Threading.Tasks
         /// has already been disposed.
         /// </exception>
         public Task(Action<object> action, object state, CancellationToken cancellationToken, TaskCreationOptions creationOptions)
-            : this((Delegate)action, state, Task.InternalCurrentIfAttached(creationOptions), cancellationToken, creationOptions, InternalTaskOptions.None, null)
+            : this(action, state, Task.InternalCurrentIfAttached(creationOptions), cancellationToken, creationOptions, InternalTaskOptions.None, null)
         {
-            PossiblyCaptureContext();
         }
 
         internal Task(Action<object> action, object state, Task parent, CancellationToken cancellationToken,
             TaskCreationOptions creationOptions, InternalTaskOptions internalOptions, TaskScheduler scheduler)
             : this((Delegate)action, state, parent, cancellationToken, creationOptions, internalOptions, scheduler)
         {
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -590,6 +581,8 @@ namespace System.Threading.Tasks
 
                 AssignCancellationToken(cancellationToken, null, null);
             }
+
+            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -1273,7 +1266,6 @@ namespace System.Threading.Tasks
             // Create and schedule the task. This throws an InvalidOperationException if already shut down.
             // Here we add the InternalTaskOptions.QueuedByRuntime to the internalOptions, so that TaskConstructorCore can skip the cancellation token registration
             Task t = new Task(action, state, creatingTask, cancellationToken, options, internalOptions | InternalTaskOptions.QueuedByRuntime, scheduler);
-            t.PossiblyCaptureContext();
 
             t.ScheduleAndStart(false);
             return t;

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -471,11 +471,6 @@ namespace System.Threading.Tasks
         {
         }
 
-        internal Task(Action<object> action, object state, Task parent, CancellationToken cancellationToken,
-            TaskCreationOptions creationOptions, InternalTaskOptions internalOptions, TaskScheduler scheduler)
-            : this((Delegate)action, state, parent, cancellationToken, creationOptions, internalOptions, scheduler)
-        {
-        }
 
         /// <summary>
         /// An internal constructor used by the factory methods on task and its descendent(s).

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -576,7 +576,10 @@ namespace System.Threading.Tasks
                 AssignCancellationToken(cancellationToken, null, null);
             }
 
-            PossiblyCaptureContext();
+            Debug.Assert(m_contingentProperties == null || m_contingentProperties.m_capturedContext == null,
+                "Captured an ExecutionContext when one was already captured.");
+
+            CapturedContext = ExecutionContext.Capture();
         }
 
         /// <summary>
@@ -767,19 +770,6 @@ namespace System.Threading.Tasks
                 return "0x" + fptr.ToString("x");
                 //return d != null ? d.Method.ToString() : "{null}";
             }
-        }
-
-        /// <summary>
-        /// Captures the ExecutionContext so long as flow isn't suppressed.
-        /// </summary>
-        /// <param name="stackMark">A stack crawl mark pointing to the frame of the caller.</param>
-
-        internal void PossiblyCaptureContext()
-        {
-            Debug.Assert(m_contingentProperties == null || m_contingentProperties.m_capturedContext == null,
-                "Captured an ExecutionContext when one was already captured.");
-
-            CapturedContext = ExecutionContext.Capture();
         }
 
         // Internal property to process TaskCreationOptions access and mutation.

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -36,7 +36,6 @@ namespace System.Threading.Tasks
             Debug.Assert(action is Action<Task> || action is Action<Task, object>,
                 "Invalid delegate type in ContinuationTaskFromTask");
             m_antecedent = antecedent;
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -84,7 +83,6 @@ namespace System.Threading.Tasks
             Debug.Assert(function is Func<Task, TResult> || function is Func<Task, object, TResult>,
                 "Invalid delegate type in ContinuationResultTaskFromTask");
             m_antecedent = antecedent;
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -132,7 +130,6 @@ namespace System.Threading.Tasks
             Debug.Assert(action is Action<Task<TAntecedentResult>> || action is Action<Task<TAntecedentResult>, object>,
                 "Invalid delegate type in ContinuationTaskFromResultTask");
             m_antecedent = antecedent;
-            PossiblyCaptureContext();
         }
 
         /// <summary>
@@ -180,7 +177,6 @@ namespace System.Threading.Tasks
             Debug.Assert(function is Func<Task<TAntecedentResult>, TResult> || function is Func<Task<TAntecedentResult>, object, TResult>,
                 "Invalid delegate type in ContinuationResultTaskFromResultTask");
             m_antecedent = antecedent;
-            PossiblyCaptureContext();
         }
 
         /// <summary>


### PR DESCRIPTION
Running runtest.cmd /corefx on Windows with the `System.Threading.Tests` in the CoreFX test list hits the following assertion 

https://github.com/dotnet/corert/blob/becb08ebde12bf06c8223b9b2a6232fb8f20ee51/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L792

The assertion is caused by a Task constructors calling an overloaded constructor, both of which call PossiblyCaptureContext in their body. Is this intentional? 

Adding the cast resolves the constructor to this one
https://github.com/dotnet/corert/blob/becb08ebde12bf06c8223b9b2a6232fb8f20ee51/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L500

This seems to fix the problem without glaring regressions, including allowing `System.Threading.Tests` to run under Windows.