### PR TITLE
Enable resolving of .netmodule references

### DIFF
--- a/src/Common/src/CommandLine/CommandLineHelpers.cs
+++ b/src/Common/src/CommandLine/CommandLineHelpers.cs
@@ -29,11 +29,8 @@ namespace Internal.CommandLine
                 foreach (string fileName in Directory.EnumerateFiles(directoryName, searchPattern))
                 {
                     string fullFileName = Path.GetFullPath(fileName);
-                    string simpleName = Path.GetFileName(fullFileName);
-                    if (Path.GetExtension(fullFileName) != ".netmodule")
-                    {
-                        simpleName = Path.GetFileNameWithoutExtension(fileName);
-                    }
+
+                    string simpleName = Path.GetFileNameWithoutExtension(fileName);
 
                     if (dictionary.ContainsKey(simpleName))
                     {

--- a/src/Common/src/CommandLine/CommandLineHelpers.cs
+++ b/src/Common/src/CommandLine/CommandLineHelpers.cs
@@ -29,8 +29,11 @@ namespace Internal.CommandLine
                 foreach (string fileName in Directory.EnumerateFiles(directoryName, searchPattern))
                 {
                     string fullFileName = Path.GetFullPath(fileName);
-
-                    string simpleName = Path.GetFileNameWithoutExtension(fileName);
+                    string simpleName = Path.GetFileName(fullFileName);
+                    if (Path.GetExtension(fullFileName) != ".netmodule")
+                    {
+                        simpleName = Path.GetFileNameWithoutExtension(fileName);
+                    }
 
                     if (dictionary.ContainsKey(simpleName))
                     {

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -66,7 +66,7 @@ namespace Internal.TypeSystem
             return null;
         }
 
-        public virtual ModuleDesc ResolveModule(ModuleDesc referencingModule, string simpleName, bool throwIfNotFound = true)
+        internal virtual ModuleDesc ResolveModule(ModuleDesc referencingModule, string fileName, bool throwIfNotFound = true)
         {
             if (throwIfNotFound)
                 throw new NotSupportedException();

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -61,12 +61,12 @@ namespace Internal.TypeSystem
 
         public virtual ModuleDesc ResolveAssembly(AssemblyName name, bool throwIfNotFound = true)
         {
-            // Note: we use simple names instead of full names to resolve, because we can't get a full name from an assembly without reading it
-            string simpleName = name.Name;
-            return ResolveModule(simpleName, throwIfNotFound);
+            if (throwIfNotFound)
+                throw new NotSupportedException();
+            return null;
         }
 
-        public virtual ModuleDesc ResolveModule(string simpleName, bool throwIfNotFound = true)
+        public virtual ModuleDesc ResolveModule(ModuleDesc referencingModule, string simpleName, bool throwIfNotFound = true)
         {
             if (throwIfNotFound)
                 throw new NotSupportedException();

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -61,6 +61,13 @@ namespace Internal.TypeSystem
 
         public virtual ModuleDesc ResolveAssembly(AssemblyName name, bool throwIfNotFound = true)
         {
+            // Note: we use simple names instead of full names to resolve, because we can't get a full name from an assembly without reading it
+            string simpleName = name.Name;
+            return ResolveModule(simpleName, throwIfNotFound);
+        }
+
+        public virtual ModuleDesc ResolveModule(string simpleName, bool throwIfNotFound = true)
+        {
             if (throwIfNotFound)
                 throw new NotSupportedException();
             return null;

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -171,9 +170,7 @@ namespace Internal.TypeSystem.Ecma
         private object ResolveModuleReference(ModuleReferenceHandle handle)
         {
             ModuleReference moduleReference = _metadataReader.GetModuleReference(handle);
-            // Referenced modules are stored without their extension (see CommandLineHelpers.cs), so we have to drop
-            // the extension here as well to find a match.
-            string simpleName = Path.GetFileNameWithoutExtension(_metadataReader.GetString(moduleReference.Name));
+            string simpleName = _metadataReader.GetString(moduleReference.Name);
             return Context.ResolveModule(this, simpleName);
         }
 

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -170,7 +171,9 @@ namespace Internal.TypeSystem.Ecma
         private object ResolveModuleReference(ModuleReferenceHandle handle)
         {
             ModuleReference moduleReference = _metadataReader.GetModuleReference(handle);
-            string simpleName = _metadataReader.GetString(moduleReference.Name);
+            // Referenced modules are stored without their extension (see CommandLineHelpers.cs), so we have to drop
+            // the extension here as well to find a match.
+            string simpleName = Path.GetFileNameWithoutExtension(_metadataReader.GetString(moduleReference.Name));
             return Context.ResolveModule(this, simpleName);
         }
 

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -174,7 +174,7 @@ namespace Internal.TypeSystem.Ecma
         {
             ModuleReference moduleReference = _metadataReader.GetModuleReference(handle);
             string simpleName = _metadataReader.GetString(moduleReference.Name);
-            return Context.ResolveModule(simpleName);
+            return Context.ResolveModule(this, simpleName);
         }
 
         private LockFreeReaderHashtable<EntityHandle, IEntityHandleObject> _resolvedTokens;

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -147,6 +148,10 @@ namespace Internal.TypeSystem.Ecma
                         item = _module;
                         break;
 
+                    case HandleKind.ModuleReference:
+                        item = _module.ResolveModuleReference((ModuleReferenceHandle)handle);
+                        break;
+
                     default:
                         throw new BadImageFormatException("Unknown metadata token type: " + handle.Kind);
                 }
@@ -163,6 +168,13 @@ namespace Internal.TypeSystem.Ecma
                         return new EcmaObjectLookupWrapper(handle, item);
                 }
             }
+        }
+
+        private object ResolveModuleReference(ModuleReferenceHandle handle)
+        {
+            ModuleReference moduleReference = _metadataReader.GetModuleReference(handle);
+            string simpleName = _metadataReader.GetString(moduleReference.Name);
+            return Context.ResolveModule(simpleName);
         }
 
         private LockFreeReaderHashtable<EntityHandle, IEntityHandleObject> _resolvedTokens;

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -170,8 +170,8 @@ namespace Internal.TypeSystem.Ecma
         private object ResolveModuleReference(ModuleReferenceHandle handle)
         {
             ModuleReference moduleReference = _metadataReader.GetModuleReference(handle);
-            string simpleName = _metadataReader.GetString(moduleReference.Name);
-            return Context.ResolveModule(this, simpleName);
+            string fileName = _metadataReader.GetString(moduleReference.Name);
+            return Context.ResolveModule(this, fileName);
         }
 
         private LockFreeReaderHashtable<EntityHandle, IEntityHandleObject> _resolvedTokens;

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -4,13 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-
-using Internal.TypeSystem;
 
 namespace Internal.TypeSystem.Ecma
 {

--- a/src/ILVerification/src/ILVerifyTypeSystemContext.cs
+++ b/src/ILVerification/src/ILVerifyTypeSystemContext.cs
@@ -41,7 +41,7 @@ namespace ILVerify
             EcmaModule module = ResolveAssemblyOrNetmodule(name, throwIfNotFound);
             if (module.MetadataReader.IsAssembly)
             {
-                throw new VerifierException($"Assembly '{name}' is expected to be a .netmodule");
+                throw new VerifierException($"The module '{name}' is not expected to be an assembly");
             }
             return module;
         }

--- a/src/ILVerification/src/IResolver.cs
+++ b/src/ILVerification/src/IResolver.cs
@@ -13,7 +13,7 @@ namespace ILVerify
         /// <summary>
         /// This method should return the same instance when queried multiple times.
         /// </summary>
-        PEReader Resolve(AssemblyName name);
+        PEReader Resolve(string simpleName);
     }
 
     /// <summary>
@@ -23,16 +23,14 @@ namespace ILVerify
     {
         private readonly Dictionary<string, PEReader> _resolverCache = new Dictionary<string, PEReader>();
 
-        public PEReader Resolve(AssemblyName name)
+        public PEReader Resolve(string simpleName)
         {
-            // Note: we use simple names instead of full names to resolve, because we can't get a full name from an assembly without reading it
-            string simpleName = name.Name;
             if (_resolverCache.TryGetValue(simpleName, out PEReader peReader))
             {
                 return peReader;
             }
 
-            PEReader result = ResolveCore(name);
+            PEReader result = ResolveCore(simpleName);
             if (result != null)
             {
                 _resolverCache.Add(simpleName, result);
@@ -42,6 +40,6 @@ namespace ILVerify
             return null;
         }
 
-        protected abstract PEReader ResolveCore(AssemblyName name);
+        protected abstract PEReader ResolveCore(string simpleName);
     }
 }

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -34,7 +34,7 @@ namespace ILVerify
 
         public void SetSystemModuleName(AssemblyName name)
         {
-            _typeSystemContext.SetSystemModule(_typeSystemContext.GetModule(_typeSystemContext._resolver.Resolve(name)));
+            _typeSystemContext.SetSystemModule(_typeSystemContext.GetModule(_typeSystemContext._resolver.Resolve(name.Name)));
         }
 
         internal EcmaModule GetModule(PEReader peReader)

--- a/src/ILVerification/tests/TestDataLoader.cs
+++ b/src/ILVerification/tests/TestDataLoader.cs
@@ -178,9 +178,9 @@ namespace ILVerification.Tests
 
             var resolver = new TestResolver(simpleNameToPathMap);
             var typeSystemContext = new ILVerifyTypeSystemContext(resolver);
-            typeSystemContext.SetSystemModule(typeSystemContext.GetModule(resolver.Resolve(coreAssembly.GetName())));
+            typeSystemContext.SetSystemModule(typeSystemContext.GetModule(resolver.Resolve(coreAssembly.GetName().Name)));
 
-            return typeSystemContext.GetModule(resolver.Resolve(new AssemblyName(Path.GetFileNameWithoutExtension(assemblyName))));
+            return typeSystemContext.GetModule(resolver.Resolve(new AssemblyName(Path.GetFileNameWithoutExtension(assemblyName)).Name));
         }
 
         private sealed class TestResolver : ResolverBase
@@ -191,9 +191,9 @@ namespace ILVerification.Tests
                 _simpleNameToPathMap = simpleNameToPathMap;
             }
 
-            protected override PEReader ResolveCore(AssemblyName name)
+            protected override PEReader ResolveCore(string simpleName)
             {
-                if (_simpleNameToPathMap.TryGetValue(name.Name, out string path))
+                if (_simpleNameToPathMap.TryGetValue(simpleName, out string path))
                 {
                     return new PEReader(File.OpenRead(path));
                 }

--- a/src/ILVerify/src/Program.cs
+++ b/src/ILVerify/src/Program.cs
@@ -230,7 +230,7 @@ namespace ILVerify
 
         private void VerifyAssembly(AssemblyName name, string path)
         {
-            PEReader peReader = Resolve(name);
+            PEReader peReader = Resolve(name.Name);
             EcmaModule module = _verifier.GetModule(peReader);
 
             VerifyAssembly(peReader, module, path);
@@ -321,11 +321,8 @@ namespace ILVerify
             return true;
         }
 
-        protected override PEReader ResolveCore(AssemblyName name)
+        protected override PEReader ResolveCore(string simpleName)
         {
-            // Note: we use simple names instead of full names to resolve, because we can't get a full name from an assembly without reading it
-            string simpleName = name.Name;
-
             string path = null;
             if (_inputFilePaths.TryGetValue(simpleName, out path) || _referenceFilePaths.TryGetValue(simpleName, out path))
             {


### PR DESCRIPTION
This PR addresses issue https://github.com/dotnet/corert/issues/5766

`HandleKind.ModuleReference` was not handled until now and resulted in a `BadImageFormatException`.

The newly added method `ResolveModuleReference` now takes care of this scenario.

Most code could be shared with `ResolveAssemblyReference` but this required to use a plain string instead of an `AssemblyName` object in a couple of places.
