### PR TITLE
Fix in ParameterInfo.DefaultValue path

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/EcmaFormat/DefaultValueProcessing.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/EcmaFormat/DefaultValueProcessing.cs
@@ -60,7 +60,7 @@ namespace System.Reflection.Runtime.General.EcmaFormat
         private static object ConstantValueAsObject(ConstantHandle constantHandle, MetadataReader metadataReader, Type declaredType, bool raw)
         {
             object defaultValue = ConstantValueAsRawObject(constantHandle, metadataReader);
-            if ((!raw) && declaredType.IsEnum)
+            if ((!raw) && declaredType.IsEnum && defaultValue != null)
                 defaultValue = Enum.ToObject(declaredType, defaultValue);
             return defaultValue;
         }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NativeFormat/DefaultValueParser.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/NativeFormat/DefaultValueParser.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Runtime.General.NativeFormat
             if (!(constantHandle.IsNull(reader)))
             {
                 defaultValue = constantHandle.ParseConstantValue(reader);
-                if ((!raw) && declaredType.IsEnum)
+                if ((!raw) && declaredType.IsEnum && defaultValue != null)
                     defaultValue = Enum.ToObject(declaredType, defaultValue);
                 return true;
             }


### PR DESCRIPTION
There was a bug found in CoreCLR Reflection
when attempting to take a DefaultValue in this scenario:

    public void Method<T>(T arg = default(T)) { }

    public static void Main(string[] args)
    {
        MethodInfo method = typeof(Program).GetMethod("Method").MakeGenericMethod(typeof(AttributeTargets));
        ParameterInfo argParameter = method.GetParameters()[0];
        Console.WriteLine(argParameter.DefaultValue);
    }


 (https://github.com/dotnet/corefx/issues/29570)

Project N has a bug in the same scenario. This is the fix.