### PR TITLE
Extract class library composition into `.targets`

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -79,6 +79,15 @@ See the LICENSE file in the project root for more information.
   </PropertyGroup>
 
   <ItemGroup>
+    <AutoInitializedAssemblies Include="System.Private.CoreLib" />
+    <AutoInitializedAssemblies Include="System.Private.TypeLoader" />
+    <AutoInitializedAssemblies Include="System.Private.Reflection.Execution" />
+    <AutoInitializedAssemblies Include="System.Private.DeveloperExperience.Console" />
+    <AutoInitializedAssemblies Include="System.Private.Interop" />
+    <AutoInitializedAssemblies Include="System.Private.StackTraceMetadata" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" />
   </ItemGroup>
   <ItemGroup>
@@ -160,6 +169,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(OutputType) == 'Library' and $(NativeLib) != ''" Include="--nativelib" />
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
       <ILcArg Condition="'$(Platform)' == 'wasm'" Include="--wasm" />
+      <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />

--- a/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/LibraryInitializers.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 using Internal.TypeSystem;
 
-using AssemblyName = System.Reflection.AssemblyName;
 using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler
@@ -17,37 +15,22 @@ namespace ILCompiler
     /// </summary>
     public sealed class LibraryInitializers
     {
-        private const string ClassLibraryPlaceHolderString = "*ClassLibrary*";
         private const string LibraryInitializerContainerNamespaceName = "Internal.Runtime.CompilerHelpers";
         private const string LibraryInitializerContainerTypeName = "LibraryInitializer";
         private const string LibraryInitializerMethodName = "InitializeLibrary";
 
-        private static readonly LibraryInitializerInfo[] s_assembliesWithLibraryInitializers =
-            {
-                new LibraryInitializerInfo(ClassLibraryPlaceHolderString),
-                new LibraryInitializerInfo("System.Private.TypeLoader"),
-                new LibraryInitializerInfo("System.Private.Reflection.Execution"),
-                new LibraryInitializerInfo("System.Private.DeveloperExperience.Console"),
-                new LibraryInitializerInfo("System.Private.Interop"),
-                new LibraryInitializerInfo("System.Private.StackTraceMetadata"),
-            };
-
         private List<MethodDesc> _libraryInitializerMethods;
 
         private readonly TypeSystemContext _context;
-        private readonly bool _isCppCodeGen;
+        private IReadOnlyCollection<ModuleDesc> _librariesWithInitializers;
 
-        public LibraryInitializers(TypeSystemContext context, bool isCppCodeGen)
+        public LibraryInitializers(TypeSystemContext context, IEnumerable<ModuleDesc> librariesWithInitalizers)
         {
             _context = context;
-            //
-            // We should not care which code-gen is being used but for the time being
-            // this can be useful to workaround CppCodeGen bugs.
-            //
-            _isCppCodeGen = isCppCodeGen;
+            _librariesWithInitializers = new List<ModuleDesc>(librariesWithInitalizers);
         }
 
-        public IList<MethodDesc> LibraryInitializerMethods
+        public IReadOnlyCollection<MethodDesc> LibraryInitializerMethods
         {
             get
             {
@@ -64,18 +47,8 @@ namespace ILCompiler
             
             _libraryInitializerMethods = new List<MethodDesc>();
 
-            foreach (var entry in s_assembliesWithLibraryInitializers)
+            foreach (var assembly in _librariesWithInitializers)
             {
-                if (_isCppCodeGen && !entry.UseWithCppCodeGen)
-                    continue;
-
-                ModuleDesc assembly = entry.Assembly == ClassLibraryPlaceHolderString
-                    ? _context.SystemModule
-                    : _context.ResolveAssembly(new AssemblyName(entry.Assembly), false);
-
-                if (assembly == null)
-                    continue;
-
                 TypeDesc containingType = assembly.GetType(LibraryInitializerContainerNamespaceName, LibraryInitializerContainerTypeName, false);
                 if (containingType == null)
                     continue;
@@ -85,18 +58,6 @@ namespace ILCompiler
                     continue;
 
                 _libraryInitializerMethods.Add(initializerMethod);
-            }
-        }
-
-        private sealed class LibraryInitializerInfo
-        {
-            public string Assembly { get; }
-            public bool UseWithCppCodeGen { get; }
-
-            public LibraryInitializerInfo(string assembly, bool useWithCppCodeGen = true)
-            {
-                Assembly = assembly;
-                UseWithCppCodeGen = useWithCppCodeGen;
             }
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/MainMethodRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MainMethodRootProvider.cs
@@ -22,9 +22,9 @@ namespace ILCompiler
         public const string ManagedEntryPointMethodName = "__managed__Main";
 
         private EcmaModule _module;
-        private IList<MethodDesc> _libraryInitializers;
+        private IReadOnlyCollection<MethodDesc> _libraryInitializers;
 
-        public MainMethodRootProvider(EcmaModule module, IList<MethodDesc> libraryInitializers)
+        public MainMethodRootProvider(EcmaModule module, IReadOnlyCollection<MethodDesc> libraryInitializers)
         {
             _module = module;
             _libraryInitializers = libraryInitializers;

--- a/src/ILCompiler.Compiler/src/Compiler/NativeLibraryInitializerRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NativeLibraryInitializerRootProvider.cs
@@ -21,9 +21,9 @@ namespace ILCompiler
         public const string ManagedEntryPointMethodName = "__managed__Startup";
 
         private ModuleDesc _module;
-        private IList<MethodDesc> _libraryInitializers;
+        private IReadOnlyCollection<MethodDesc> _libraryInitializers;
 
-        public NativeLibraryInitializerRootProvider(ModuleDesc module, IList<MethodDesc> libraryInitializers)
+        public NativeLibraryInitializerRootProvider(ModuleDesc module, IReadOnlyCollection<MethodDesc> libraryInitializers)
         {
             _module = module;
             _libraryInitializers = libraryInitializers;

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/NativeLibraryStartupMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/NativeLibraryStartupMethod.cs
@@ -17,9 +17,9 @@ namespace Internal.IL.Stubs.StartupCode
     {
         private TypeDesc _owningType;
         private MethodSignature _signature;
-        private IList<MethodDesc> _libraryInitializers;
+        private IReadOnlyCollection<MethodDesc> _libraryInitializers;
 
-        public NativeLibraryStartupMethod(TypeDesc owningType, IList<MethodDesc> libraryInitializers)
+        public NativeLibraryStartupMethod(TypeDesc owningType, IReadOnlyCollection<MethodDesc> libraryInitializers)
         {
             _owningType = owningType;
             _libraryInitializers = libraryInitializers;

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -21,9 +21,9 @@ namespace Internal.IL.Stubs.StartupCode
         private TypeDesc _owningType;
         private MainMethodWrapper _mainMethod;
         private MethodSignature _signature;
-        private IList<MethodDesc> _libraryInitializers;
+        private IReadOnlyCollection<MethodDesc> _libraryInitializers;
 
-        public StartupCodeMainMethod(TypeDesc owningType, MethodDesc mainMethod, IList<MethodDesc> libraryInitializers)
+        public StartupCodeMainMethod(TypeDesc owningType, MethodDesc mainMethod, IReadOnlyCollection<MethodDesc> libraryInitializers)
         {
             _owningType = owningType;
             _mainMethod = new MainMethodWrapper(owningType, mainMethod);


### PR DESCRIPTION
Contributes to #5662. Still not putting that library under a `Condition = Exe` because I'm not quite sure how many concepts `System.Private.DeveloperExperience.Console` is conflating (it doesn't seem like it's doing only what the name implies).

I'm doing this mostly so that the compiler is more hack-friendly for an after work project of mine.