### PR TITLE
Remove StringBuilderCache from S.P.CoreLib.csproj

### DIFF
--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -287,7 +287,6 @@
     <Compile Include="System\Text\EncodingData.cs" />
     <Compile Include="System\Text\EncodingTable.cs" />
     <Compile Include="System\Text\StringBuilder.CoreRT.cs" />
-    <Compile Include="System\Text\StringBuilderCache.cs" />
     <Compile Include="System\Threading\CancellationToken.cs" />
     <Compile Include="System\Threading\CancellationTokenRegistration.cs" />
     <Compile Include="System\Threading\CancellationTokenSource.cs" />


### PR DESCRIPTION
To be cherry-picked once https://github.com/dotnet/coreclr/pull/17964 is merged and mirrored.