### PR TITLE
Add support for setting AppContext switches 

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -170,6 +170,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
       <ILcArg Condition="'$(Platform)' == 'wasm'" Include="--wasm" />
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
+      <IlcArg Include="@(AppContextSwitchOverrides->'--appcontextswitch:%(Identity)')" />
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/AppContextInitializerMethod.Sorting.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/AppContextInitializerMethod.Sorting.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs.StartupCode
+{
+    partial class AppContextInitializerMethod
+    {
+        protected override int ClassCode => 15749517;
+
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        {
+            // Should be a singleton
+            Debug.Assert(this == other);
+            return 0;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/AppContextInitializerMethod.cs
+++ b/src/ILCompiler.Compiler/src/IL/Stubs/StartupCode/AppContextInitializerMethod.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+
+namespace Internal.IL.Stubs.StartupCode
+{
+    public sealed partial class AppContextInitializerMethod : ILStubMethod
+    {
+        private TypeDesc _owningType;
+        private MethodSignature _signature;
+        private IReadOnlyCollection<string> _switches;
+
+        public AppContextInitializerMethod(TypeDesc owningType, IEnumerable<string> switches)
+        {
+            _owningType = owningType;
+            _switches = new List<string>(switches);
+        }
+
+        public override TypeSystemContext Context
+        {
+            get
+            {
+                return _owningType.Context;
+            }
+        }
+
+        public override TypeDesc OwningType
+        {
+            get
+            {
+                return _owningType;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return "SetAppContextSwitches";
+            }
+        }
+
+        public override MethodIL EmitIL()
+        {
+            ILEmitter emitter = new ILEmitter();
+            ILCodeStream codeStream = emitter.NewCodeStream();
+
+            MetadataType appContextType = Context.SystemModule.GetKnownType("System", "AppContext");
+            MethodDesc setSwitchMethod = appContextType.GetKnownMethod("SetSwitch", null);
+            ILToken setSwitchToken = emitter.NewToken(setSwitchMethod);
+
+            foreach (string switchName in _switches)
+            {
+                codeStream.Emit(ILOpcode.ldstr, emitter.NewToken(switchName));
+                codeStream.EmitLdc(1);
+                codeStream.Emit(ILOpcode.call, setSwitchToken);
+            }
+
+            codeStream.Emit(ILOpcode.ret);
+
+            return emitter.Link(this);
+        }
+
+        public override MethodSignature Signature
+        {
+            get
+            {
+                if (_signature == null)
+                {
+                    _signature = new MethodSignature(MethodSignatureFlags.Static, 0,
+                            Context.GetWellKnownType(WellKnownType.Void),
+                            TypeDesc.EmptyTypes);
+                }
+
+                return _signature;
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -352,6 +352,8 @@
     <Compile Include="Compiler\WindowsNodeMangler.cs" />
     <Compile Include="IL\ILImporter.Scanner.cs" />
     <Compile Include="IL\Stubs\PInvokeILProvider.cs" />
+    <Compile Include="IL\Stubs\StartupCode\AppContextInitializerMethod.cs" />
+    <Compile Include="IL\Stubs\StartupCode\AppContextInitializerMethod.Sorting.cs" />
     <Compile Include="IL\Stubs\StartupCode\StartupCodeMainMethod.cs" />
     <Compile Include="IL\Stubs\StartupCode\StartupCodeMainMethod.Sorting.cs" />
     <Compile Include="IL\Stubs\StartupCode\NativeLibraryStartupMethod.cs" />

--- a/src/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.cs
@@ -551,7 +551,18 @@ namespace System
 
             Array values = GetEnumInfo(enumType).Values;
             int count = values.Length;
+#if PROJECTN
             Array result = Array.CreateInstance(enumType, count);
+#else
+            // Without universal shared generics, chances are slim that we'll have the appropriate
+            // array type available. Offer an escape hatch that avoids a MissingMetadataException
+            // at the cost of a small appcompat risk.
+            Array result;
+            if (AppContext.TryGetSwitch("Switch.System.Enum.RelaxedGetValues", out bool isRelaxed) && isRelaxed)
+                result = Array.CreateInstance(Enum.GetUnderlyingType(enumType), count);
+            else
+                result = Array.CreateInstance(enumType, count);
+#endif
             Array.CopyImplValueTypeArrayNoInnerGcRefs(values, 0, result, 0, count);
             return result;
         }

--- a/tests/CoreFX/runtest/CoreFXTestHarness/Test.csproj
+++ b/tests/CoreFX/runtest/CoreFXTestHarness/Test.csproj
@@ -19,6 +19,7 @@
 
     <ItemGroup>
         <RdXmlFile Include="default.rd.xml" />
+        <AppContextSwitchOverrides Include="Switch.System.Enum.RelaxedGetValues" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="xunit.abstractions">


### PR DESCRIPTION
Two commits:

* Adds an `--appcontextswitch` argument to the compiler (and accompanying `AppContextSwitchOverrides` MSBuild `ItemGroup`) to influence class library behaviors. This is a general purpose feature that Project N has, but we didn't have it yet.
* Add possibility to opt out of strict `Enum.GetValues` semantic and use it in CoreFX test runner. This fixes 39 CoreFX System.Collections tests.