### PR TITLE
Fix case sensitive gss for osx linker

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -73,7 +73,7 @@ See the LICENSE file in the project root for more information.
     <ItemGroup Condition="'$(TargetOS)' == 'OSX'">
       <NativeFramework Include="CoreFoundation" />
       <NativeFramework Include="Security" />
-      <NativeFramework Include="gss" />
+      <NativeFramework Include="GSS" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
if filesystem is case sensitive gss must be GSS.