### PR TITLE
Staging Commit - Netci.groovy refactor and addition of a CoreFX CI job

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -11,93 +11,144 @@ def branch = GithubBranchName
 def imageVersionMap = ['Windows_NT':'latest-or-auto',
                        'OSX10.12':'latest-or-auto',
                        'Ubuntu':'20170118']
+
+def scenarios = ['normal', 'corefx']
  
 // Innerloop build OS's
 def osList = ['Ubuntu', 'OSX10.12', 'Windows_NT']
 
 // Generate the builds for debug and release, commit and PRJob
-[true, false].each { isPR -> // Defines a closure over true and false, value assigned to isPR
-    ['Debug', 'Release'].each { configuration ->
-        osList.each { os ->
+Constants.scenarios.each { scenario ->
+    [true, false].each { isPR -> // Defines a closure over true and false, value assigned to isPR
+        ['Debug', 'Release'].each { configuration ->
+            osList.each { os ->
 
-            // Define build string
-            def lowercaseConfiguration = configuration.toLowerCase()
-            
-            // Determine the name for the new job.  The first parameter is the project,
-            // the second parameter is the base name for the job, and the last parameter
-            // is a boolean indicating whether the job will be a PR job.  If true, the
-            // suffix _prtest will be appended.
-            def newJobName = Utilities.getFullJobName(project, lowercaseConfiguration + '_' + os.toLowerCase(), isPR)
-            def buildString = "";
-            def prJobDescription = "${os} ${configuration}";
-            if (configuration == 'Debug') {
-                prJobDescription += " and CoreCLR tests"
-            }
-            
-            // Calculate the build commands
-            if (os == 'Windows_NT') {
-                buildString = "build.cmd ${lowercaseConfiguration}"
-                testScriptString = "tests\\runtest.cmd ${configuration} /coreclr "
-            }
-            else {
-                buildString = "./build.sh ${lowercaseConfiguration}"
-                testScriptString = "tests/runtest.sh ${configuration} -coredumps -coreclr "
-            }
+                if ((configuration == 'Release' || os != 'Windows_NT') && scenario == 'corefx') {
+                    return
+                }
 
-            // Create a new job with the specified name.  The brace opens a new closure
-            // and calls made within that closure apply to the newly created job.
-            def newJob = job(newJobName) {
-                // This opens the set of build steps that will be run.
-                steps {
-                    if (os == 'Windows_NT') {
-                        // Indicates that a batch script should be run with the build string (see above)
-                        batchFile(buildString)
-                        batchFile("tests\\runtest.cmd ${configuration} /multimodule")
+                // Define build string
+                def lowercaseConfiguration = configuration.toLowerCase()
 
-                        if (configuration == 'Debug') {
-                            if (isPR) {
-                                // Run a small set of BVTs during PR validation
-                                batchFile(testScriptString + "Top200")
-                            }
-                            else {
-                                // Run the full set of known passing tests in the post-commit job
-                                batchFile(testScriptString + "KnownGood /multimodule")
+                // Determine the name for the new job.  The first parameter is the project,
+                // the second parameter is the base name for the job, and the last parameter
+                // is a boolean indicating whether the job will be a PR job.  If true, the
+                // suffix _prtest will be appended.
+                def newJobName = Utilities.getFullJobName(project, lowercaseConfiguration + '_' + os.toLowerCase(), isPR)
+                def buildString = "";
+                def prJobDescription = "${os} ${configuration}";
+                if (configuration == 'Debug') {
+                    if (scenario == 'normal') {
+                        prJobDescription += " and CoreCLR tests"
+                    }
+                    if (scenario == 'corefx') {
+                        prJobDescription += " and CoreFX tests"
+                    }
+                }
+                
+                def buildCommands = calculateBuildCommands(os, configuration, scenario)
+
+                // Create a new job with the specified name.  The brace opens a new closure
+                // and calls made within that closure apply to the newly created job.
+                def newJob = job(newJobName) {
+                    // This opens the set of build steps that will be run.
+                    steps {
+                        if (os == 'Windows_NT') {
+                        // Indicates that a batch script should be run with each build command
+                            buildCommands.each { buildCommand -> 
+                                batchFile(buildCommand) 
                             }
                         }
-                    }
-                    else {
-                        shell(buildString)
-
-                        if (configuration == 'Debug') {
-                            if (isPR) {
-                                // Run a small set of BVTs during PR validation
-                                shell(testScriptString + "top200")
-                            }
-                            else {
-                                // Run the full set of known passing tests in the post-commit job
-
-                                // Todo: Enable push test jobs once we establish a reasonable passing set of tests
-                                // shell(testScriptString + "KnownGood")
+                        else {
+                            buildCommands.each { buildCommand -> 
+                                shell(buildCommand)
                             }
                         }
                     }
                 }
-            }
 
-            // This call performs test run checks for the CI.
-            Utilities.addXUnitDotNETResults(newJob, '**/testResults.xml')
-            Utilities.setMachineAffinity(newJob, os, imageVersionMap[os])
-            Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-            if (isPR) {
-                Utilities.addGithubPRTriggerForBranch(newJob, branch, prJobDescription)
-            }
-            else {
-                // Set a large timeout since the default (2 hours) is insufficient
-                Utilities.setJobTimeout(newJob, 1440)
-                Utilities.addGithubPushTrigger(newJob)
+                // This call performs test run checks for the CI.
+                Utilities.addXUnitDotNETResults(newJob, '**/testResults.xml')
+                Utilities.setMachineAffinity(newJob, os, imageVersionMap[os])
+                Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+                if (isPR) {
+                    Utilities.addGithubPRTriggerForBranch(newJob, branch, prJobDescription)
+                }
+                else {
+                    // Set a large timeout since the default (2 hours) is insufficient
+                    Utilities.setJobTimeout(newJob, 1440)
+                    Utilities.addGithubPushTrigger(newJob)
+                }
             }
         }
     }
+}
+
+def static calculateBuildCommands(def os, def configuration, def scenario, def isPR) {
+    
+    def buildCommands = []
+    def lowercaseConfiguration = configuration.toLowerCase()
+
+    if (os == 'Windows_NT') {
+        // Calculate the build commands
+        buildCommands += "build.cmd ${lowercaseConfiguration}"
+
+        // Calculate the test commands
+        buildCommands += "tests\\runtest.cmd ${configuration} /multimodule"
+        if (configuration == 'Debug')
+        {
+            if (scenario == 'normal'){
+                testScriptString = "tests\\runtest.cmd ${configuration} /coreclr "
+                if (isPR) {
+                    // Run a small set of BVTs during PR validation
+                    buildCommands += testScriptString + "Top200"
+                }
+                else {
+                    // Run the full set of known passing tests in the post-commit job
+                    buildCommands += testScriptString + "KnownGood /multimodule"
+                }
+            }
+            else if (scenario = 'corefx')
+            {
+                testScriptString = "tests\\runtest.cmd ${configuration} /corefx "
+                
+                //Todo: Add json config files for different testing scenarios
+                buildCommands += testScriptString 
+            }
+        }
+    }
+    else {
+        // Calculate the build commands        
+        buildCommands += "./build.sh ${lowercaseConfiguration}"
+        
+        // Calculate the test commands
+        if (configuration == 'Debug')
+        {
+            if (scenario == 'normal')
+            {
+                testScriptString = "tests/runtest.sh ${configuration} -coredumps -coreclr "
+                if (isPR) {
+                    // Run a small set of BVTs during PR validation
+                    buildCommands += testScriptString + "top200"
+                }
+                else {
+                    // Run the full set of known passing tests in the post-commit job
+
+                    // Todo: Enable push test jobs once we establish a reasonable passing set of tests
+                    // shell(testScriptString + "KnownGood")
+                }
+            }
+            else if (scenario == 'corefx')
+            {
+                testScriptString = "tests/runtest.sh ${configuration} -corefx "
+                
+                //Todo: Add json config files for different testing scenarios
+                buildCommands += testScriptString                 
+            }
+        }
+    }
+
+    return buildCommands
 }
 
 JobReport.Report.generateJobReport(out)

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -49,7 +49,7 @@ if /i "%1" == "/coreclr"  (
 :ExtRepoTestsOk
     goto ArgLoop
 )
-if /i "%1" == "/corefx" (set CoreRT_RunCoreFXTests=true&shift&goto ArgLoop)
+if /i "%1" == "/corefx" exit /b 0
 if /i "%1" == "/coreclrsingletest" (set CoreRT_RunCoreCLRTests=true&set CoreRT_CoreCLRTest=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/mode" (set CoreRT_TestCompileMode=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/test" (set CoreRT_TestName=%2&shift&shift&goto ArgLoop)

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -432,6 +432,7 @@ if [ ${CoreRT_RunCoreCLRTests} ]; then
 fi
 
 if [ ${CoreRT_RunCoreFXTests} ]; then
+    exit 0
     run_corefx_tests 
     exit $?
 fi


### PR DESCRIPTION
This includes a refactor of the groovy script to deal with two scenarios (non-corefx and corefx).

Since netci.groovy is pulled from HEAD and not pending PR changes, this is setting up an upcoming change to enable CoreFX tests on Windows in CI. 

Calling runtest.cmd with a /corefx flag exits successfully directly. 
I've mirrored the change in runtest.sh to avoid unintended crashes.