### PR TITLE
Fix GC Stack Reporting bug in Release builds

### DIFF
--- a/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
@@ -417,8 +417,8 @@ UIntNative CoffNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Metho
     }
     else
     {
-        bool rbp = GetFramePointer(pMethodInfo, pRegisterSet) == NULL;
-        if (!rbp) 
+        // Check for a pushed RBP value
+        if (GetFramePointer(pMethodInfo, pRegisterSet) == NULL)
         {
             // Unwind the current method context to get the caller's stack pointer
             // and obtain the upper bound of the callee is the value just below the caller's return address on the stack


### PR DESCRIPTION
This turned out to be an embarrassingly simple bug, but it only manifested in release multimodule builds and even then with a bit of experimentation in the testing environment.
This should fix intermittent failures in #5714 