### PR TITLE
Fix CoreCLR job name

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -38,7 +38,11 @@ Constants.scenarios.each { scenario ->
                 // the second parameter is the base name for the job, and the last parameter
                 // is a boolean indicating whether the job will be a PR job.  If true, the
                 // suffix _prtest will be appended.
-                def newJobName = Utilities.getFullJobName(project, lowercaseConfiguration + '_' + os.toLowerCase() + "--" + scenario, isPR)
+                def baseJobName = lowercaseConfiguration + '_' + os.toLowerCase()
+                if (scenario != 'coreclr') {
+                    baseJobName += '_' + scenario
+                }
+                def newJobName = Utilities.getFullJobName(project, baseJobName, isPR)
                 def buildString = "";
                 def prJobDescription = "${os} ${configuration}";
                 if (configuration == 'Debug') {


### PR DESCRIPTION
#5822 renamed the default job and broke the build status links we have in `README.md`.

@dotnet-bot skip ci please