### PR TITLE
Archive CoreFX test results

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -79,6 +79,11 @@ Constants.scenarios.each { scenario ->
                 Utilities.addXUnitDotNETResults(newJob, '**/testResults.xml')
                 Utilities.setMachineAffinity(newJob, os, Constants.imageVersionMap[os])
                 Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+
+                if (scenario == 'corefx') {
+                    Utilities.addArchival(newJob, 'bin/tests/CoreFX/**/testResults.xml');
+                }
+                
                 if (isPR) {
                     Utilities.addGithubPRTriggerForBranch(newJob, branch, prJobDescription)
                 }


### PR DESCRIPTION
Adding archives to debug #5823 test result reporting - test result fails correctly, but the Jenkins XUnit plug-in doesn't mark failures correctly in the `Test Results` pane.