### PR TITLE
Enable OSX and Linux CoreFX CI tests

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -27,7 +27,7 @@ Constants.scenarios.each { scenario ->
         ['Debug', 'Release'].each { configuration ->
             Constants.osList.each { os ->
 
-                if ((configuration == 'Release' || os != 'Windows_NT') && scenario == 'corefx') {
+                if (configuration == 'Release' && scenario == 'corefx') {
                     return
                 }
 

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -357,6 +357,7 @@ while [ "$1" != "" ]; do
             fi
             ;;
         -corefx)
+            exit 0
             CoreRT_RunCoreFXTests=true;
             shift
             ;;


### PR DESCRIPTION
This is a staging commit for a limited set of CoreFX tests to be run on MacOS and Linux on every PR.