### PR TITLE
Switch back to SC_NPROCESSORS_ONLN for WebAssembly

### DIFF
--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -835,7 +835,7 @@ bool QueryLogicalProcessorCount()
 {
 #if HAVE_SYSCONF
     int sysConfName;
-#if defined(_TARGET_WASM_)
+#if defined(_WASM_)
     sysConfName = _SC_NPROCESSORS_ONLN;
 #else
     sysConfName = _SC_NPROCESSORS_CONF;
@@ -1276,7 +1276,7 @@ bool InitializeSystemInfo()
 
 #if HAVE_SYSCONF
     int sysConfName;
-#if defined(_TARGET_WASM_)
+#if defined(_WASM_)
     sysConfName = _SC_NPROCESSORS_ONLN;
 #else
     sysConfName = _SC_NPROCESSORS_CONF;

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -834,7 +834,14 @@ bool QueryCacheSize()
 bool QueryLogicalProcessorCount()
 {
 #if HAVE_SYSCONF
-    g_cLogicalCpus = sysconf(_SC_NPROCESSORS_CONF);
+    int sysConfName;
+#if defined(_TARGET_WASM_)
+    sysConfName = _SC_NPROCESSORS_ONLN;
+#else
+    sysConfName = _SC_NPROCESSORS_CONF;
+#endif
+
+    g_cLogicalCpus = sysconf(sysConfName);
     if (g_cLogicalCpus < 1)
     {
         ASSERT_UNCONDITIONALLY("sysconf failed for _SC_NPROCESSORS_CONF\n");
@@ -1268,7 +1275,13 @@ bool InitializeSystemInfo()
     int nrcpus = 0;
 
 #if HAVE_SYSCONF
-    nrcpus = sysconf(_SC_NPROCESSORS_CONF);
+    int sysConfName;
+#if defined(_TARGET_WASM_)
+    sysConfName = _SC_NPROCESSORS_ONLN;
+#else
+    sysConfName = _SC_NPROCESSORS_CONF;
+#endif
+    nrcpus = sysconf(sysConfName);
     if (nrcpus < 1)
     {
         ASSERT_UNCONDITIONALLY("sysconf failed for _SC_NPROCESSORS_CONF\n");

--- a/src/Native/gc/unix/gcenv.unix.cpp
+++ b/src/Native/gc/unix/gcenv.unix.cpp
@@ -84,7 +84,14 @@ static pthread_mutex_t g_flushProcessWriteBuffersMutex;
 bool GCToOSInterface::Initialize()
 {
     // Calculate and cache the number of processors on this machine
-    int cpuCount = sysconf(_SC_NPROCESSORS_CONF);
+    int sysConfName;
+#if defined(_TARGET_WASM_)
+    sysConfName = _SC_NPROCESSORS_ONLN;
+#else
+    sysConfName = _SC_NPROCESSORS_CONF;
+#endif
+
+    int cpuCount = sysconf(sysConfName);
     if (cpuCount == -1)
     {
         return false;


### PR DESCRIPTION
Switch back to SC_NPROCESSORS_ONLN for WebAssembly because SC_NPROCESSORS_CONF isn't implemented in Emscripten. Fixes an assert on startup.