### PR TITLE
Correct Unix CI Command generation

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -155,14 +155,14 @@ def static calculateBuildCommands(def os, def configuration, def scenario, def i
                     // shell(testScriptString + "KnownGood")
                 }
             }
-            else if (scenario == 'corefx')
-            {
-                // CoreFX tests are currently run only under Debug, so skip the configuration check
-                testScriptString = "tests/runtest.sh ${configuration} -corefx "
-                
-                //Todo: Add json config files for different testing scenarios
-                buildCommands += testScriptString                 
-            }
+        }
+        else if (scenario == 'corefx')
+        {
+            // CoreFX tests are currently run only under Debug, so skip the configuration check
+            testScriptString = "tests/runtest.sh ${configuration} -corefx "
+            
+            //Todo: Add json config files for different testing scenarios
+            buildCommands += testScriptString                 
         }
     }
 


### PR DESCRIPTION
The logic in netci.groovy would not correctly generate the test running commands.