### PR TITLE
Fix: call memory allocation instead of return

### DIFF
--- a/src/Native/Runtime/arm/AllocFast.S
+++ b/src/Native/Runtime/arm/AllocFast.S
@@ -469,7 +469,7 @@ LOCAL_LABEL(BoxAlloc8Failed):
         // finalization.
         mov         r0, r4 // restore EEType
         mov         r1, #(GC_ALLOC_ALIGN8 | GC_ALLOC_ALIGN8_BIAS)
-        EPILOG_POP  "{r4,pc}"
+        EPILOG_POP  "{r4,lr}"
         b           C_FUNC(RhpNewObject)
 
 LEAF_END RhpNewFastMisalign, _TEXT


### PR DESCRIPTION
The code EPILOG_POP  "{r4,pc}" arm/AllocFast.S:472 RhpNewFastMisalign()
returns from the RhpNewFastMisalign function without memory allocation,
the input parameter (EEType pointer) is returned as result of memory allocation.
It leads to using the EEType as object and application crashed with SIGSEGV.