### PR TITLE
Expose Exception.set_HResult as Public

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Windows.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.Windows.cs
@@ -99,7 +99,7 @@ namespace Internal.Runtime.Augments
             // Throw an ApplicationException for compatibility with CoreCLR. First save the error code.
             int errorCode = Marshal.GetLastWin32Error();
             var ex = new ApplicationException();
-            ex.SetErrorCode(errorCode);
+            ex.HResult = errorCode;
             throw ex;
         }
 

--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -177,14 +177,6 @@ namespace System
         }
 
         /// <summary>
-        /// Allow System.Private.Interop to set HRESULT of an exception
-        /// </summary>
-        internal void SetErrorCode(int hr)
-        {
-            HResult = hr;
-        }
-
-        /// <summary>
         /// Allow System.Private.Interop to set message of an exception
         /// </summary>
         internal void SetMessage(string msg)

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -358,6 +358,12 @@ namespace System.Runtime.InteropServices
             return RuntimeImports.RhHandleCompareExchangeVariableType(handle, oldType, newType);
         }
         
+#if PROJECTN
+         public static void SetExceptionErrorCode(Exception exception, int hr)
+         {
+             // TODO: delete
+         }
+#endif
         public static void SetExceptionMessage(Exception exception, string message)
         {
             exception.SetMessage(message);

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -357,12 +357,7 @@ namespace System.Runtime.InteropServices
         {
             return RuntimeImports.RhHandleCompareExchangeVariableType(handle, oldType, newType);
         }
-
-        public static void SetExceptionErrorCode(Exception exception, int hr)
-        {
-            exception.SetErrorCode(hr);
-        }
-
+        
         public static void SetExceptionMessage(Exception exception, string message)
         {
             exception.SetMessage(message);

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -358,12 +358,11 @@ namespace System.Runtime.InteropServices
             return RuntimeImports.RhHandleCompareExchangeVariableType(handle, oldType, newType);
         }
         
-#if PROJECTN
-         public static void SetExceptionErrorCode(Exception exception, int hr)
-         {
-             // TODO: delete
-         }
-#endif
+        public static void SetExceptionErrorCode(Exception exception, int hr)
+        {
+            exception.HResult = hr;
+        }
+        
         public static void SetExceptionMessage(Exception exception, string message)
         {
             exception.SetMessage(message);

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.CpuUtilizationReader.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.CpuUtilizationReader.Windows.cs
@@ -28,7 +28,7 @@ namespace System.Threading
                     {
                         int error = Marshal.GetLastWin32Error();
                         var exception = new OutOfMemoryException();
-                        exception.SetErrorCode(error);
+                        exception.HResult = error;
                         throw exception;
                     }
 

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.Windows.cs
@@ -27,7 +27,7 @@ namespace System.Threading
             {
                 var error = Marshal.GetLastWin32Error();
                 var exception = new OutOfMemoryException();
-                exception.SetErrorCode(error);
+                exception.HResult = error;
                 throw exception;
             }
             Release(initialSignalCount);
@@ -48,7 +48,7 @@ namespace System.Threading
                 {
                     var lastError = Marshal.GetLastWin32Error();
                     var exception = new OutOfMemoryException();
-                    exception.SetErrorCode(lastError);
+                    exception.HResult = lastError;
                     throw exception;
                 }
             }

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Windows.cs
@@ -51,7 +51,7 @@ namespace System.Threading
                 if (lastError != Interop.Errors.ERROR_TIMEOUT)
                 {
                     var exception = new OutOfMemoryException();
-                    exception.SetErrorCode(lastError);
+                    exception.HResult = lastError;
                     throw exception;
                 }
             }

--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
@@ -260,7 +260,7 @@ namespace System.Threading
 
                 default:
                     var ex = new Exception();
-                    ex.SetErrorCode(errorCode);
+                    ex.HResult = errorCode;
                     throw ex;
             }
         }
@@ -300,7 +300,7 @@ namespace System.Threading
 
                 default:
                     Exception ex = new Exception();
-                    ex.SetErrorCode(errorCode);
+                    ex.HResult = errorCode;
                     throw ex;
             }
         }

--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
@@ -406,7 +406,7 @@ namespace System.Threading
         internal static void ThrowInvalidHandleException()
         {
             var ex = new InvalidOperationException(SR.InvalidOperation_InvalidHandle);
-            ex.SetErrorCode(HResults.E_HANDLE);
+            ex.HResult = HResults.E_HANDLE;
             throw ex;
         }
     }

--- a/src/System.Private.Interop/src/InteropExtensions/InteropExtensions.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/InteropExtensions.cs
@@ -374,6 +374,11 @@ namespace System.Runtime.InteropServices
         {
             throw new NotSupportedException("RuntimeHandleCompareExchangeVariableType");
         }
+        
+        public static void SetExceptionErrorCode(Exception exception, int hr)
+        {
+            throw new NotSupportedException("SetExceptionErrorCode");
+        }
 
         public static Exception CreateDataMisalignedException(string message)
         {

--- a/src/System.Private.Interop/src/InteropExtensions/InteropExtensions.cs
+++ b/src/System.Private.Interop/src/InteropExtensions/InteropExtensions.cs
@@ -375,11 +375,6 @@ namespace System.Runtime.InteropServices
             throw new NotSupportedException("RuntimeHandleCompareExchangeVariableType");
         }
 
-        public static void SetExceptionErrorCode(Exception exception, int hr)
-        {
-            throw new NotSupportedException("SetExceptionErrorCode");
-        }
-
         public static Exception CreateDataMisalignedException(string message)
         {
             return new DataMisalignedException(message);

--- a/src/System.Private.Interop/src/Shared/McgMarshal.cs
+++ b/src/System.Private.Interop/src/Shared/McgMarshal.cs
@@ -147,11 +147,6 @@ namespace System.Runtime.InteropServices
         }
 
 #if ENABLE_MIN_WINRT
-        public static unsafe void SetExceptionErrorCode(Exception exception, int errorCode)
-        {
-            InteropExtensions.SetExceptionErrorCode(exception, errorCode);
-        }
-
         /// <summary>
         /// Used in Marshalling code
         /// Gets the handle of the CriticalHandle

--- a/src/System.Private.Interop/src/Shared/McgMarshal.cs
+++ b/src/System.Private.Interop/src/Shared/McgMarshal.cs
@@ -148,10 +148,10 @@ namespace System.Runtime.InteropServices
 
 #if ENABLE_MIN_WINRT
         public static unsafe void SetExceptionErrorCode(Exception exception, int errorCode)	
-        {	
-           // TODO: Delete
+        {
+            InteropExtensions.SetExceptionErrorCode(exception, errorCode);
         }
-        
+
         /// <summary>
         /// Used in Marshalling code
         /// Gets the handle of the CriticalHandle

--- a/src/System.Private.Interop/src/Shared/McgMarshal.cs
+++ b/src/System.Private.Interop/src/Shared/McgMarshal.cs
@@ -147,6 +147,11 @@ namespace System.Runtime.InteropServices
         }
 
 #if ENABLE_MIN_WINRT
+        public static unsafe void SetExceptionErrorCode(Exception exception, int errorCode)	
+        {	
+           // TODO: Delete
+        }
+        
         /// <summary>
         /// Used in Marshalling code
         /// Gets the handle of the CriticalHandle

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/WindowsRuntime/CustomPropertyImpl.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/WindowsRuntime/CustomPropertyImpl.cs
@@ -133,7 +133,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                     );
 
                     // We need to make sure it has the same HR that we were returning in desktop
-                    InteropExtensions.SetExceptionErrorCode(ex, __HResults.COR_E_METHODACCESS);
+                    ex.HResult = __HResults.COR_E_METHODACCESS;
                     throw ex;
                 }
             }

--- a/src/System.Private.Interop/src/System/Runtime/InteropServices/WindowsRuntime/PropertyValueImpl.cs
+++ b/src/System.Private.Interop/src/System/Runtime/InteropServices/WindowsRuntime/PropertyValueImpl.cs
@@ -419,9 +419,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             PropertyType type,
             PropertyType unboxType)
         {
-            System.InvalidCastException ex = new System.InvalidCastException(SR.Format(SR.PropertyValue_InvalidCast, type, unboxType));
-            McgMarshal.SetExceptionErrorCode(ex, Interop.COM.TYPE_E_TYPEMISMATCH);
-            return ex;
+            return new System.InvalidCastException(SR.Format(SR.PropertyValue_InvalidCast, type, unboxType), Interop.COM.TYPE_E_TYPEMISMATCH);
         }
 
         private static System.InvalidCastException CreateExceptionForInvalidCoersion(
@@ -430,9 +428,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             PropertyType unboxType,
             int hr)
         {
-            InvalidCastException ex = new InvalidCastException(SR.Format(SR.PropertyValue_InvalidCoersion, type, value, unboxType));
-            McgMarshal.SetExceptionErrorCode(ex, hr);
-            return ex;
+            return new InvalidCastException(SR.Format(SR.PropertyValue_InvalidCoersion, type, value, unboxType), hr);
         }
     }
 

--- a/src/System.Private.Interop/src/WinRT/ExceptionHelpers.cs
+++ b/src/System.Private.Interop/src/WinRT/ExceptionHelpers.cs
@@ -719,7 +719,7 @@ namespace System.Runtime.InteropServices
                 InteropExtensions.SetExceptionMessage(exception, message);
             }
 
-            InteropExtensions.SetExceptionErrorCode(exception, errorCode);
+            exception.HResult = errorCode;
 
             return exception;
         }


### PR DESCRIPTION
This is to change Excetion.set_HResult from protected to public, so that others can set HResult value for a given exception.

Approved API: dotnet/corefx#29696
Related Corefx Change(ref assembly): dotnet/corefx#29986
Related CoreCLR PR(S.P.Corelib change): dotnet/coreclr#18203