### PR TITLE
Fix a comment in Decimal.DecCalc.cs

### DIFF
--- a/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -1892,7 +1892,7 @@ ThrowOverflow:
             //**********************************************************************
             internal static double VarR8FromDec(ref Decimal pdecIn)
             {
-                // Value taken via reverse engineering the double that corrisponds to 2^65. (oleaut32 has ds2to64 = DEFDS(0, 0, DBLBIAS + 65, 0))
+                // Value taken via reverse engineering the double that corresponds to 2^64. (oleaut32 has ds2to64 = DEFDS(0, 0, DBLBIAS + 65, 0))
                 const double ds2to64 = 1.8446744073709552e+019;
 
                 double dbl = ((double)pdecIn.Low64 +


### PR DESCRIPTION
`1.8446744073709552e+019` is indeed `2^64`
And oleaut32 really has `ds2to64 = DEFDS(0, 0, DBLBIAS + 65, 0)`, this is true: https://github.com/dotnet/coreclr/blob/32f0f9721afb584b4a14d69135bea7ddc129f755/src/palrt/decconv.cpp#L63