### PR TITLE
Fixed and optimized Decimal.GetHashCode

### DIFF
--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -409,25 +409,7 @@ namespace System
 
         // Returns the hash code for this Decimal.
         //
-        public unsafe override int GetHashCode()
-        {
-            double dbl = DecCalc.VarR8FromDec(ref this);
-            if (dbl == 0.0)
-                // Ensure 0 and -0 have the same hash code
-                return 0;
-
-            // conversion to double is lossy and produces rounding errors so we mask off the lowest 4 bits
-            // 
-            // For example these two numerically equal decimals with different internal representations produce
-            // slightly different results when converted to double:
-            //
-            // decimal a = new decimal(new int[] { 0x76969696, 0x2fdd49fa, 0x409783ff, 0x00160000 });
-            //                     => (decimal)1999021.176470588235294117647000000000 => (double)1999021.176470588
-            // decimal b = new decimal(new int[] { 0x3f0f0f0f, 0x1e62edcc, 0x06758d33, 0x00150000 }); 
-            //                     => (decimal)1999021.176470588235294117647000000000 => (double)1999021.1764705882
-            //
-            return (int)(((((uint*)&dbl)[0]) & 0xFFFFFFF0) ^ ((uint*)&dbl)[1]);
-        }
+        public override int GetHashCode() => DecCalc.GetHashCode(ref this);
 
         // Compares two Decimal values for equality. Returns true if the two
         // Decimal values are equal, or false if they are not equal.


### PR DESCRIPTION
This fixes https://github.com/dotnet/coreclr/issues/2944 and contributes to https://github.com/dotnet/coreclr/issues/18249.
I'll add tests to CoreFX that break the current imprecise implementation.
I'm not sure if `HashCode.Combine` should be used here instead of a simple xor - it would be twice as slow.
And this also raises a question about decimal to double conversion - ideally, it should be normalized before conversion, but from a compatibility perspective it's not that clear.

_Updated benchmark with different input data sets:_
#### x64 (mostly normalized)
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 5.365 ns | 0.0127 ns | 0.0033 ns |   1.00 |
| CoreRT2 | 2.706 ns | 0.0103 ns | 0.0037 ns |   0.51 |

#### x64 (denormalized)
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 5.575 ns | 0.0275 ns | 0.0098 ns |   1.00 |
| CoreRT2 | 4.750 ns | 0.0243 ns | 0.0087 ns |   0.85 |

#### x64 (heavily denormalized)
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 6.162 ns | 0.0159 ns | 0.0057 ns |   1.00 |
| CoreRT2 | 6.482 ns | 0.0128 ns | 0.0046 ns |   1.05 |

#### x86 (mostly normalized)
|  Method |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native |  7.706 ns | 0.1061 ns | 0.0378 ns |   1.00 |
| CoreRT2 |  4.093 ns | 0.0345 ns | 0.0123 ns |   0.54 |

#### x86 (denormalized)
|  Method |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native |  7.870 ns | 0.0355 ns | 0.0127 ns |   1.00 |
| CoreRT2 | 14.292 ns | 0.0621 ns | 0.0222 ns |   1.82 |

#### x86 (heavily denormalized)
|  Method |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native |  8.408 ns | 0.0426 ns | 0.0152 ns |   1.00 |
| CoreRT2 | 26.775 ns | 0.1536 ns | 0.0548 ns |   3.18 |

## x86 DIV
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 116.6 ns | 0.1997 ns | 0.0712 ns |   1.00 |
|  CoreRT | 235.5 ns | 1.0579 ns | 0.3773 ns |   2.02 |
| CoreRT2 | 113.9 ns | 0.2593 ns | 0.0674 ns |   0.98 |
