### PR TITLE
Update WebApi sample to 2.1

### DIFF
--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -48,6 +48,8 @@ services.AddMvc();
 to
 
 ```csharp
+services.Add(new ServiceDescriptor(typeof(ApplicationPartManager), new ApplicationPartManager()));
+
 services.AddMvcCore().AddJsonFormatters();
 ```
 

--- a/samples/WebApi/Startup.cs
+++ b/samples/WebApi/Startup.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -27,6 +28,9 @@ namespace SampleWebApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            // Override automatic discovery of Application parts done by MVC. It is not compatible with single file compilation.
+            services.Add(new ServiceDescriptor(typeof(ApplicationPartManager), new ApplicationPartManager()));
+
             services.AddMvcCore().AddJsonFormatters();
         }
 

--- a/samples/WebApi/rd.xml
+++ b/samples/WebApi/rd.xml
@@ -6,9 +6,9 @@
             <Type Name="Microsoft.AspNetCore.Server.Kestrel.Core.Internal.KestrelServerOptionsSetup" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="Microsoft.AspNetCore.Server.Kestrel" Dynamic="Required All"/>
-        <Assembly Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv">
-            <Type Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.LibuvTransportFactory" Dynamic="Required All" />
-            <Type Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.LibuvTransportOptions" Dynamic="Required All" />
+        <Assembly Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets">
+            <Type Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="Microsoft.Extensions.DependencyInjection" Dynamic="Required All">
             <Type Name="Microsoft.Extensions.DependencyInjection.DefaultServiceProviderFactory" Dynamic="Required All" />

--- a/samples/WebApi/rd.xml
+++ b/samples/WebApi/rd.xml
@@ -12,7 +12,6 @@
         </Assembly>
         <Assembly Name="Microsoft.Extensions.DependencyInjection" Dynamic="Required All">
             <Type Name="Microsoft.Extensions.DependencyInjection.DefaultServiceProviderFactory" Dynamic="Required All" />
-            <Type Name="Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteExpressionBuilder" Dynamic="Required All" />
             <Type Name="Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver" Dynamic="Required All" />
             <Type Name="Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator" Dynamic="Required All" />
         </Assembly>
@@ -32,6 +31,7 @@
         <Assembly Name="Microsoft.AspNetCore.Mvc.Formatters.Json">
             <Type Name="Microsoft.AspNetCore.Mvc.Formatters.Json.Internal.MvcJsonMvcOptionsSetup" Dynamic="Required All" />
             <Type Name="Microsoft.AspNetCore.Mvc.MvcJsonOptions" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Mvc.MvcJsonOptionsConfigureCompatibilityOptions" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="Microsoft.AspNetCore.Authorization">
             <Type Name="Microsoft.AspNetCore.Authorization.DefaultAuthorizationPolicyProvider" Dynamic="Required All" />
@@ -40,8 +40,12 @@
         <Assembly Name="Microsoft.AspNetCore.Http">
             <Type Name="Microsoft.AspNetCore.Http.HttpContextFactory" Dynamic="Required All" />
         </Assembly>
+        <Assembly Name="Microsoft.AspNetCore.HostFiltering">
+            <Type Name="Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware" Dynamic="Required All" />
+        </Assembly>
         <Assembly Name="Microsoft.AspNetCore.Hosting" Dynamic="Required All">
             <Type Name="Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime" Dynamic="Required All" />
+            <Type Name="Microsoft.AspNetCore.Hosting.Internal.StartupLoader+ConfigureServicesDelegateBuilder`1[[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="Microsoft.Extensions.Logging.Abstractions">
             <Type Name="Microsoft.Extensions.Logging.Logger`1[[Microsoft.AspNetCore.Hosting.Internal.WebHost,Microsoft.AspNetCore.Hosting]]" Dynamic="Required All" />
@@ -49,9 +53,15 @@
         <Assembly Name="Microsoft.Extensions.Logging">
             <Type Name="Microsoft.Extensions.Logging.LoggerFactory" Dynamic="Required All" />
         </Assembly>
+        <Assembly Name="Microsoft.Extensions.Logging.Configuration">
+            <Type Name="Microsoft.Extensions.Logging.Configuration.LoggerProviderConfigurationFactory" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Logging.Configuration.LoggerProviderConfiguration`1[[Microsoft.Extensions.Logging.Console.ConsoleLoggerProvider,Microsoft.Extensions.Logging.Console]]" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Logging.Configuration.LoggerProviderOptionsChangeTokenSource`2[[Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions,Microsoft.Extensions.Logging.Console],[Microsoft.Extensions.Logging.Console.ConsoleLoggerProvider,Microsoft.Extensions.Logging.Console]]"  Dynamic="Required All" />
+        </Assembly>
         <Assembly Name="Microsoft.Extensions.Logging.Console">
             <Type Name="Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions" Dynamic="Required All" />
             <Type Name="Microsoft.Extensions.Logging.Console.ConsoleLoggerProvider" Dynamic="Required All" />
+            <Type Name="Microsoft.Extensions.Logging.Console.ConsoleLoggerOptionsSetup" Dynamic="Required All" />
         </Assembly>
         <Assembly Name="Microsoft.Extensions.Logging.Debug">
             <Type Name="Microsoft.Extensions.Logging.Debug.DebugLogger" Dynamic="Required All" />


### PR DESCRIPTION
Will fail with
```

  Restore completed in 62.94 ms for C:\GitHub\corert\samples\WebApi\SampleWebApi.csproj.
  SampleWebApi -> C:\GitHub\corert\samples\WebApi\bin\Release\netcoreapp2.1\win-x64\SampleWebApi.dll
  Generating native code
EXEC : warning : RD.XML processing will change before release (https://github.com/dotnet/corert/issues/5001) [C:\GitHub\corert\samples\WebApi\SampleWebApi.csproj]
EXEC : error : [TEMPORARY EXCEPTION MESSAGE] 
ClassLoadGeneral: System.Reflection.Emit.ILGenerator, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a [C:\GitHub\corert\samples\WebApi\SampleWebApi.csproj]
  Internal.TypeSystem.TypeSystemException+TypeLoadException: [TEMPORARY EXCEPTION MESSAGE] ClassLoadGeneral: System.Reflection.Emit.ILGenerator, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
     at Internal.TypeSystem.ThrowHelper.ThrowTypeLoadException(ExceptionStringID id, String typeName, String assemblyName)
     at Internal.TypeSystem.Ecma.EcmaModule.GetType(String nameSpace, String name, Boolean throwIfNotFound)
     at Internal.TypeSystem.Ecma.EcmaModule.GetType(String nameSpace, String name, Boolean throwIfNotFound)
     at Internal.TypeSystem.Ecma.EcmaModule.ResolveTypeReference(TypeReferenceHandle handle)
     at Internal.TypeSystem.Ecma.EcmaModule.EcmaObjectLookupHashtable.CreateValueFromKey(EntityHandle handle)
     at Internal.TypeSystem.LockFreeReaderHashtable`2.CreateValueAndEnsureValueIsInTable(TKey key)
     at Internal.TypeSystem.Ecma.EcmaModule.GetObject(EntityHandle handle)
     at Internal.TypeSystem.Ecma.EcmaModule.GetType(EntityHandle handle)
     at Internal.TypeSystem.Ecma.EcmaSignatureParser.ParseType(SignatureTypeCode typeCode)
     at Internal.TypeSystem.Ecma.EcmaSignatureParser.ParseFieldSignature()
     at Internal.TypeSystem.Ecma.EcmaField.InitializeFieldType()
     at Internal.TypeSystem.MetadataFieldLayoutAlgorithm.ComputeInstanceLayout(DefType defType, InstanceLayoutKind layoutKind)
     at Internal.TypeSystem.DefType.ComputeInstanceLayout(InstanceLayoutKind layoutKind)
     at ILCompiler.DependencyAnalysis.EETypeNode.CheckCanGenerateEEType(NodeFactory factory, TypeDesc type)
     at ILCompiler.DependencyAnalysis.NodeFactory.<CreateNodeCaches>b__36_1(TypeDesc type)
     at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
     at ILCompiler.Compilation.RootingServiceProvider.AddCompilationRoot(TypeDesc type, String reason)
     at ILCompiler.RdXmlRootProvider.RootType(IRootingServiceProvider rootProvider, TypeDesc type)
     at ILCompiler.RdXmlRootProvider.ProcessAssemblyDirective(IRootingServiceProvider rootProvider, XElement assemblyElement)
     at ILCompiler.RdXmlRootProvider.AddCompilationRoots(IRootingServiceProvider rootProvider)
     at ILCompiler.Compilation..ctor(DependencyAnalyzerBase`1 dependencyGraph, NodeFactory nodeFactory, IEnumerable`1 compilationRoots, DebugInformationProvider debugInformationProvider, DevirtualizationManager devirtualizationManager, Logger logger)
     at ILCompiler.ILScannerBuilder.ToILScanner()
     at ILCompiler.Program.Run(String[] args)
     at ILCompiler.Program.Main(String[] args)
C:\Users\thund\.nuget\packages\microsoft.dotnet.ilcompiler\1.0.0-alpha-26529-02\build\Microsoft.NETCore.Native.targets(183,5): error MSB3073: The command ""C:\Users\thund\.nuget\packages\runtime.win-x64.microsoft.dotnet.ilcompiler\1.0.0-alpha-26529-02\tools\ilc" @"obj\Release\netcoreapp2.1\win-x64\native\SampleWebApi.ilc.rsp"" exited with code 1. [C:\GitHub\corert\samples\WebApi\SampleWebApi.csproj
```