### PR TITLE
Escape native library paths in Microsoft.NETCore.Native.Windows.props

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -64,7 +64,7 @@ See the LICENSE file in the project root for more information.
     
     <ItemGroup>
       <LinkerArg Condition="$(NativeLib) == 'Shared'" Include="/DLL" />
-      <LinkerArg Include="@(NativeLibrary)" />
+      <LinkerArg Include="@(NativeLibrary->'&quot;%(Identity)&quot;')" />
       <LinkerArg Include="/NOLOGO /DEBUG /MANIFEST:NO" />
       <!-- The runtime is not compatible with jump stubs inserted by incremental linking. -->
       <LinkerArg Include="/INCREMENTAL:NO" />


### PR DESCRIPTION
Fixes  #5915.