### PR TITLE
Optimize Decimal.Remainder

### DIFF
--- a/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -79,14 +79,6 @@ namespace System
         /// </summary>
         private static class DecCalc
         {
-            // Constant representing the negative number that is the closest possible
-            // Decimal value to -0m.
-            private const Decimal NearNegativeZero = -0.000000000000000000000000001m;
-
-            // Constant representing the positive number that is the closest possible
-            // Decimal value to +0m.
-            private const Decimal NearPositiveZero = +0.000000000000000000000000001m;
-
             private const int DEC_SCALE_MAX = 28;
 
             private const uint TenToPowerNine = 1000000000;
@@ -1979,7 +1971,7 @@ ThrowOverflow:
                     //
                     uint den = d2.Low;
                     if (den == 0)
-                        throw new DivideByZeroException(SR.Overflow_Decimal);
+                        throw new DivideByZeroException();
 
                     bufQuo.Low64 = d1.Low64;
                     bufQuo.U2 = d1.High;
@@ -2239,52 +2231,60 @@ ThrowOverflow:
             //**********************************************************************
             // VarDecMod - Computes the remainder between two decimals
             //**********************************************************************
-            internal static Decimal VarDecMod(ref Decimal d1, ref Decimal d2)
+            internal static void VarDecMod(ref Decimal d1, ref Decimal d2)
             {
-                // OleAut doesn't provide a VarDecMod.            
+                if ((d2.lo | d2.mid | d2.hi) == 0)
+                    throw new DivideByZeroException();
+
+                if ((d1.lo | d1.mid | d1.hi) == 0)
+                    return;
 
                 // In the operation x % y the sign of y does not matter. Result will have the sign of x.
                 d2.uflags = (d2.uflags & ~SignMask) | (d1.uflags & SignMask);
 
+                int cmp = VarDecCmpSub(ref d1, ref d2);
+                if (cmp == 0)
+                {
+                    d1.lo = 0;
+                    d1.mid = 0;
+                    d1.hi = 0;
+                    if (d2.uflags > d1.uflags)
+                        d1.uflags = d2.uflags;
+                    return;
+                }
+                if ((cmp ^ (int)(d1.uflags & SignMask)) < 0)
+                    return;
 
                 // This piece of code is to work around the fact that Dividing a decimal with 28 digits number by decimal which causes
                 // causes the result to be 28 digits, can cause to be incorrectly rounded up.
                 // eg. Decimal.MaxValue / 2 * Decimal.MaxValue will overflow since the division by 2 was rounded instead of being truncked.
-                if (Math.Abs(d1) < Math.Abs(d2))
-                {
-                    return d1;
-                }
-                d1 -= d2;
-
-                if (d1 == 0)
-                {
-                    // The sign of D1 will be wrong here. Fall through so that we still get a DivideByZeroException
-                    d1.uflags = (d1.uflags & ~SignMask) | (d2.uflags & SignMask);
-                }
+                Decimal tmp = d2;
+                DecAddSub(ref d1, ref tmp, true);
 
                 // Formula:  d1 - (RoundTowardsZero(d1 / d2) * d2)            
-                Decimal dividedResult = Truncate(d1 / d2);
-                Decimal multipliedResult = dividedResult * d2;
-                Decimal result = d1 - multipliedResult;
+                tmp = d1;
+                VarDecDiv(ref tmp, ref d2);
+                Truncate(ref tmp);
+                VarDecMul(ref tmp, ref d2);
+                uint flags = d1.uflags;
+                DecAddSub(ref d1, ref tmp, true);
                 // See if the result has crossed 0
-                if ((d1.uflags & SignMask) != (result.uflags & SignMask))
+                if (((flags ^ d1.uflags) & SignMask) != 0)
                 {
-                    if (NearNegativeZero <= result && result <= NearPositiveZero)
+                    if ((d1.Low | d1.Mid | d1.High) == 0 || d1.Scale == DEC_SCALE_MAX && d1.Low64 == 1 && d1.High == 0)
                     {
                         // Certain Remainder operations on decimals with 28 significant digits round
-                        // to [+-]0.000000000000000000000000001m instead of [+-]0m during the intermediate calculations. 
+                        // to [+-]0.0000000000000000000000000001m instead of [+-]0m during the intermediate calculations. 
                         // 'zero' results just need their sign corrected.
-                        result.uflags = (result.uflags & ~SignMask) | (d1.uflags & SignMask);
+                        d1.uflags ^= SignMask;
                     }
                     else
                     {
                         // If the division rounds up because it runs out of digits, the multiplied result can end up with a larger
                         // absolute value and the result of the formula crosses 0. To correct it can add the divisor back.
-                        result += d2;
+                        DecAddSub(ref d1, ref d2, false);
                     }
                 }
-
-                return result;
             }
 
             internal enum RoundingMode

--- a/src/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/System.Private.CoreLib/src/System/Decimal.cs
@@ -605,10 +605,10 @@ namespace System
             return ref DecCalc.VarDecCmp(ref d1, ref d2) < 0 ? ref d1 : ref d2;
         }
 
-
         public static Decimal Remainder(Decimal d1, Decimal d2)
         {
-            return DecCalc.VarDecMod(ref d1, ref d2);
+            DecCalc.VarDecMod(ref d1, ref d2);
+            return d1;
         }
 
         // Multiplies two Decimal values.


### PR DESCRIPTION
In addition to better performance this contributes to making decimal a readonly struct.
I'll add new tests to CoreFX also.
Contributes to https://github.com/dotnet/coreclr/issues/18249.
### x64
|  Method |      Mean |     Error |    StdDev | Scaled |
|-------- |----------:|----------:|----------:|-------:|
|  Native | 169.42 ns | 0.3258 ns | 0.1162 ns |   1.00 |
| CoreRT2 |  78.66 ns | 0.0869 ns | 0.0310 ns |   0.46 |
### x86
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
|  Native | 128.0 ns | 0.1594 ns | 0.0568 ns |   1.00 |
| CoreRT2 | 120.4 ns | 0.2057 ns | 0.0734 ns |   0.94 |

@jkotas I have a WIP [readonly decimal branch](https://github.com/pentp/corert/commit/ee175a15451c95eddb5941b720219b0b13d47ba5), it doesn't compile yet because of `VarDecMod` and `NumberBufferToDecimal`, but can you check if I'm on the right track?