### PR TITLE
Add ReadyToRun mode to ILCompiler

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
@@ -27,7 +27,7 @@ namespace ILCompiler
         {
         }
 
-        public static KeyValuePair<string, string>[] ParseJitOptions(IEnumerable<string> options)
+        public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
         {
             var builder = new ArrayBuilder<KeyValuePair<string, string>>();
 
@@ -47,12 +47,7 @@ namespace ILCompiler
                 builder.Add(new KeyValuePair<string, string>(name, value));
             }
 
-            return builder.ToArray();
-        }
-
-        public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
-        {
-            _ryujitOptions = ParseJitOptions(options);
+            _ryujitOptions = builder.ToArray();
 
             return this;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RyuJitCompilationBuilder.cs
@@ -27,7 +27,7 @@ namespace ILCompiler
         {
         }
 
-        public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
+        public static KeyValuePair<string, string>[] ParseJitOptions(IEnumerable<string> options)
         {
             var builder = new ArrayBuilder<KeyValuePair<string, string>>();
 
@@ -47,7 +47,12 @@ namespace ILCompiler
                 builder.Add(new KeyValuePair<string, string>(name, value));
             }
 
-            _ryujitOptions = builder.ToArray();
+            return builder.ToArray();
+        }
+
+        public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
+        {
+            _ryujitOptions = ParseJitOptions(options);
 
             return this;
         }

--- a/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILCompiler.DependencyAnalysisFramework;
+using ILCompiler.PEWriter;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Object writer using R2RPEReader to directly emit Windows Portable Executable binaries
+    /// </summary>
+    internal class ReadyToRunObjectWriter
+    {
+        // Nodefactory for which ObjectWriter is instantiated for.
+        private NodeFactory _nodeFactory;
+        private string _inputFilePath;
+        private string _objectFilePath;
+        
+        public ReadyToRunObjectWriter(string inputFilePath, string objectFilePath, NodeFactory factory, ReadyToRunCodegenCompilation compilation)
+        {
+            _nodeFactory = factory;
+            _inputFilePath = inputFilePath;
+            _objectFilePath = objectFilePath;
+        }
+        
+        public void EmitPortableExecutable()
+        {
+            using (FileStream sr = File.OpenRead(_inputFilePath))
+            {
+                PEReader peReader = new PEReader(sr);
+                R2RPEBuilder peBuilder = new R2RPEBuilder(peReader);
+                
+                var peBlob = new BlobBuilder();
+                peBuilder.Serialize(peBlob);
+
+                using (var peStream = File.Create(_objectFilePath))
+                {
+                    peBlob.WriteContentTo(peStream);
+                }
+            }
+        }
+
+        public static void EmitObject(string inputFilePath, string objectFilePath, IEnumerable<DependencyNode> nodes, NodeFactory factory, ReadyToRunCodegenCompilation compilation, IObjectDumper dumper)
+        {
+            ReadyToRunObjectWriter objectWriter = new ReadyToRunObjectWriter(inputFilePath, objectFilePath, factory, compilation);
+            objectWriter.EmitPortableExecutable();
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public sealed class ReadyToRunCodegenNodeFactory : NodeFactory
+    {
+        
+        public ReadyToRunCodegenNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager,
+            InteropStubManager interopStubManager, NameMangler nameMangler, VTableSliceProvider vtableSliceProvider, DictionaryLayoutProvider dictionaryLayoutProvider)
+            : base(context, 
+                  compilationModuleGroup, 
+                  metadataManager, 
+                  interopStubManager, 
+                  nameMangler, 
+                  new LazyGenericsDisabledPolicy(), 
+                  vtableSliceProvider, 
+                  dictionaryLayoutProvider, 
+                  new ImportedNodeProviderThrowing())
+        {
+            
+        }
+
+        protected override IMethodNode CreateMethodEntrypointNode(MethodDesc method)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
+        {
+
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -10,7 +10,6 @@ namespace ILCompiler.DependencyAnalysis
 {
     public sealed class ReadyToRunCodegenNodeFactory : NodeFactory
     {
-        
         public ReadyToRunCodegenNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager,
             InteropStubManager interopStubManager, NameMangler nameMangler, VTableSliceProvider vtableSliceProvider, DictionaryLayoutProvider dictionaryLayoutProvider)
             : base(context, 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.JitInterface;
+using Internal.TypeSystem;
+
+using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysisFramework;
+
+namespace ILCompiler
+{
+    public sealed class ReadyToRunCodegenCompilation : Compilation
+    {
+        private JitConfigProvider _jitConfigProvider;
+        string _inputFilePath;
+
+        public new ReadyToRunCodegenNodeFactory NodeFactory { get; }
+        internal ReadyToRunCodegenCompilation(
+            DependencyAnalyzerBase<NodeFactory> dependencyGraph,
+            ReadyToRunCodegenNodeFactory nodeFactory,
+            IEnumerable<ICompilationRootProvider> roots,
+            Logger logger,
+            JitConfigProvider configProvider,
+            string inputFilePath)
+            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), null, null, logger)
+        {
+            NodeFactory = nodeFactory;
+            _jitConfigProvider = configProvider;
+            _inputFilePath = inputFilePath;
+        }
+
+        private static IEnumerable<ICompilationRootProvider> GetCompilationRoots(IEnumerable<ICompilationRootProvider> existingRoots, NodeFactory factory)
+        {
+            // Todo: Eventually this should return an interesting set of roots, such as the ready-to-run header
+            yield break;
+        }
+
+        protected override void CompileInternal(string outputFile, ObjectDumper dumper)
+        {
+            _dependencyGraph.ComputeMarkedNodes();
+
+            var nodes = _dependencyGraph.MarkedNodeList;
+
+            ReadyToRunObjectWriter.EmitObject(_inputFilePath, outputFile, nodes, NodeFactory, this, dumper);
+        }
+
+        protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)
+        {
+            // Prevent the CoreRT NodeFactory adding various tables that aren't needed for ready-to-run images.
+            // Ie, module header, metadata table, various type system tables.
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.JitInterface;
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    public sealed class ReadyToRunCodegenCompilationBuilder : CompilationBuilder
+    {
+        // These need to provide reasonable defaults so that the user can optionally skip
+        // calling the Use/Configure methods and still get something reasonable back.
+        private KeyValuePair<string, string>[] _ryujitOptions = Array.Empty<KeyValuePair<string, string>>();
+        string _inputFilePath;
+
+        public ReadyToRunCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group, string inputFilePath)
+            : base(context, group, new CoreRTNameMangler(new ReadyToRunNodeMangler(), false))
+        {
+            _inputFilePath = inputFilePath;
+        }
+
+        public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
+        {
+            _ryujitOptions = RyuJitCompilationBuilder.ParseJitOptions(options);
+
+            return this;
+        }
+
+        public override ICompilation ToCompilation()
+        {
+            var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
+            ReadyToRunCodegenNodeFactory factory = new ReadyToRunCodegenNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
+            DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
+            var jitConfig = new JitConfigProvider(Enumerable.Empty<CorJitFlag>(), _ryujitOptions);
+
+            return new ReadyToRunCodegenCompilation(graph, factory, _compilationRoots, _logger, jitConfig, _inputFilePath);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -29,7 +29,25 @@ namespace ILCompiler
 
         public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
         {
-            _ryujitOptions = RyuJitCompilationBuilder.ParseJitOptions(options);
+            var builder = new ArrayBuilder<KeyValuePair<string, string>>();
+
+            foreach (string param in options)
+            {
+                int indexOfEquals = param.IndexOf('=');
+
+                // We're skipping bad parameters without reporting.
+                // This is not a mainstream feature that would need to be friendly.
+                // Besides, to really validate this, we would also need to check that the config name is known.
+                if (indexOfEquals < 1)
+                    continue;
+
+                string name = param.Substring(0, indexOfEquals);
+                string value = param.Substring(indexOfEquals + 1);
+
+                builder.Add(new KeyValuePair<string, string>(name, value));
+            }
+
+            _ryujitOptions = builder.ToArray();
 
             return this;
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunNodeMangler.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunNodeMangler.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Text;
+using Internal.TypeSystem;
+using System.Diagnostics;
+
+namespace ILCompiler
+{
+    public sealed class ReadyToRunNodeMangler : NodeMangler
+    {
+        // Mangled name of boxed version of a type
+        public sealed override string MangledBoxedTypeName(TypeDesc type)
+        {
+            Debug.Assert(type.IsValueType);
+            return "Boxed_" + NameMangler.GetMangledTypeName(type);
+        }
+
+        public sealed override string EEType(TypeDesc type)
+        {
+            return "__EEType_" + NameMangler.GetMangledTypeName(type);
+        }
+
+        public sealed override string GCStatics(TypeDesc type)
+        {
+            return "__GCStaticBase_" + NameMangler.GetMangledTypeName(type);
+        }
+
+        public sealed override string NonGCStatics(TypeDesc type)
+        {
+            return "__NonGCStaticBase_" + NameMangler.GetMangledTypeName(type);
+        }
+
+        public sealed override string ThreadStatics(TypeDesc type)
+        {
+            return "__ThreadStaticBase_" + NameMangler.GetMangledTypeName(type);
+        }
+
+        public sealed override string TypeGenericDictionary(TypeDesc type)
+        {
+            return GenericDictionaryNamePrefix + NameMangler.GetMangledTypeName(type);
+        }
+
+        public sealed override string MethodGenericDictionary(MethodDesc method)
+        {
+            return GenericDictionaryNamePrefix + NameMangler.GetMangledMethodName(method);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" Condition="'$(IsProjectNLibrary)' != 'true'" />
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">
+    <ProjectReference Include="..\..\ILCompiler.DependencyAnalysisFramework\src\ILCompiler.DependencyAnalysisFramework.csproj" />
+    <ProjectReference Include="..\..\ILCompiler.MetadataTransform\src\ILCompiler.MetadataTransform.csproj" />
+    <ProjectReference Include="..\..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj" />
+    <ProjectReference Include="..\..\ILCompiler.TypeSystem\src\ILCompiler.TypeSystem.csproj" />
+    <ProjectReference Include="..\..\ILCompiler.Compiler\src\ILCompiler.Compiler.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.Metadata">
+      <Version>1.4.2</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRunCodegenNodeFactory.cs" />
+    <Compile Include="Compiler\ReadyToRunCodegenCompilation.cs" />
+    <Compile Include="Compiler\ReadyToRunCodegenCompilationBuilder.cs" />
+    <Compile Include="Compiler\ReadyToRunNodeMangler.cs" />
+    <Compile Include="ObjectWriter\R2RPEBuilder.cs" />
+    <Compile Include="..\..\Common\src\System\Collections\Generic\ArrayBuilder.cs">
+      <Link>Common\ArrayBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JitInterface\src\JitConfigProvider.cs">
+      <Link>JitInterface\JitConfigProvider.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="'$(IsProjectNLibrary)' != 'true'" />
+</Project>

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -1,0 +1,438 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILCompiler.PEWriter
+{
+    /// <summary>
+    /// Ready-to-run PE builder combines copying the input MSIL PE executable with managed
+    /// metadata and IL and adding new code and data representing the R2R JITted code and
+    /// additional runtime structures (R2R header and tables).
+    /// </summary>
+    public class R2RPEBuilder : PEBuilder
+    {
+        /// <summary>
+        /// PE reader representing the input MSIL PE file we're copying to the output composite PE file.
+        /// </summary>
+        private PEReader _peReader;
+        
+        /// <summary>
+        /// Complete list of section names includes the sections present in the input MSIL file
+        /// (.text, optionally .rsrc and .reloc) and extra questions injected during the R2R PE
+        /// creation.
+        /// </summary>
+        private ImmutableArray<Section> _sections;
+
+        /// <summary>
+        /// Callback which is called to emit the data for each section.
+        /// </summary>
+        private Func<string, SectionLocation, BlobBuilder> _sectionSerializer;
+
+        /// <summary>
+        /// For each copied section, we store its initial and end RVA in the source PE file
+        /// and the RVA difference between the old and new file. We use this table to relocate
+        /// directory entries in the PE file header.
+        /// </summary>
+        private List<Tuple<int, int, int>> _sectionRvaDeltas;
+
+        /// <summary>
+        /// Constructor initializes the various control structures and combines the section list.
+        /// </summary>
+        /// <param name="peReader">Input MSIL PE file reader</param>
+        /// <param name="sectionNames">Custom section names to add to the output PE</param>
+        /// <param name="sectionSerializer">Callback for emission of data for the individual sections</param>
+        public R2RPEBuilder(
+            PEReader peReader,
+            IEnumerable<Tuple<string, SectionCharacteristics>> sectionNames = null,
+            Func<string, SectionLocation, BlobBuilder> sectionSerializer = null)
+            : base(PEHeaderCopier.Copy(peReader.PEHeaders), deterministicIdProvider: null)
+        {
+            _peReader = peReader;
+            _sectionSerializer = sectionSerializer;
+            
+            _sectionRvaDeltas = new List<Tuple<int, int, int>>();
+            
+            PEHeaders headers = peReader.PEHeaders;
+
+            PEHeaderBuilder peHeaderBuilder = PEHeaderCopier.Copy(headers);
+
+            ImmutableArray<Section>.Builder sectionListBuilder = ImmutableArray.CreateBuilder<Section>();
+
+            foreach (SectionHeader sectionHeader in peReader.PEHeaders.SectionHeaders)
+            {
+                if (sectionHeader.Name == ".text")
+                {
+                    sectionListBuilder.Add(new Section(sectionHeader.Name, sectionHeader.SectionCharacteristics));
+                }
+            }
+
+            if (sectionNames != null)
+            {
+                foreach (Tuple<string, SectionCharacteristics> nameCharPair in sectionNames)
+                {
+                    if (!peReader.PEHeaders.SectionHeaders.Any((header) => header.Name == nameCharPair.Item1))
+                    {
+                        sectionListBuilder.Add(new Section(nameCharPair.Item1, nameCharPair.Item2));
+                    }
+                }
+            }
+
+            foreach (SectionHeader sectionHeader in peReader.PEHeaders.SectionHeaders)
+            {
+                if (sectionHeader.Name != ".text")
+                {
+                    sectionListBuilder.Add(new Section(sectionHeader.Name, sectionHeader.SectionCharacteristics));
+                }
+            }
+            
+            _sections = sectionListBuilder.ToImmutable();
+        }
+        
+        /// <summary>
+        /// Copy all directory entries and the address of entry point, relocating them along the way.
+        /// </summary>
+        protected override PEDirectoriesBuilder GetDirectories()
+        {
+            PEDirectoriesBuilder builder = new PEDirectoriesBuilder();
+
+            builder.AddressOfEntryPoint = RelocateRVA(_peReader.PEHeaders.PEHeader.AddressOfEntryPoint);
+            builder.ExportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ExportTableDirectory);
+            builder.ImportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ImportTableDirectory);
+            builder.ResourceTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ResourceTableDirectory);
+            builder.ExceptionTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ExceptionTableDirectory);
+            // TODO - missing in PEDirectoriesBuilder
+            // builder.CertificateTable = RelocateDirectoryEntry(peHeaders.PEHeader.CertificateTableDirectory);
+            builder.BaseRelocationTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.BaseRelocationTableDirectory);
+            builder.DebugTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.DebugTableDirectory);
+            builder.CopyrightTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.CopyrightTableDirectory);
+            builder.GlobalPointerTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.GlobalPointerTableDirectory);
+            builder.ThreadLocalStorageTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ThreadLocalStorageTableDirectory);
+            builder.LoadConfigTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.LoadConfigTableDirectory);
+            builder.BoundImportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.BoundImportTableDirectory);
+            builder.ImportAddressTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ImportAddressTableDirectory);
+            builder.DelayImportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.DelayImportTableDirectory);
+            builder.CorHeaderTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.CorHeaderTableDirectory);
+            return builder;
+        }
+
+        /// <summary>
+        /// Relocate a single directory entry.
+        /// </summary>
+        /// <param name="entry">Directory entry to allocate</param>
+        /// <returns>Relocated directory entry</returns>
+        private DirectoryEntry RelocateDirectoryEntry(DirectoryEntry entry)
+        {
+            return new DirectoryEntry(RelocateRVA(entry.RelativeVirtualAddress), entry.Size);
+        }
+        
+        /// <summary>
+        /// Relocate a given RVA using the section offset table produced during section serialization.
+        /// </summary>
+        /// <param name="rva">RVA to relocate</param>
+        /// <returns>Relocated RVA</returns>
+        private int RelocateRVA(int rva)
+        {
+            if (rva == 0)
+            {
+                // Zero RVA is normally used as NULL
+                return rva;
+            }
+            foreach (Tuple<int, int, int> rangeMap in _sectionRvaDeltas)
+            {
+                if (rva >= rangeMap.Item1 && rva < rangeMap.Item2)
+                {
+                    // We found the input section holding the RVA, apply its specific delt (output RVA - input RVA).
+                    return rva + rangeMap.Item3;
+                }
+            }
+            Debug.Assert(false, "RVA is not within any of the input sections - output PE may be inconsistent");
+            return rva;
+        }
+
+        /// <summary>
+        /// Provide an array of sections for the PEBuilder to use.
+        /// </summary>
+        protected override ImmutableArray<Section> CreateSections()
+        {
+            return _sections;
+        }
+
+        /// <summary>
+        /// Output the section with a given name. For sections existent in the source MSIL PE file
+        /// (.text, optionally .rsrc and .reloc), we first copy the content of the input MSIL PE file
+        /// and then call the section serialization callback to emit the extra content after the input
+        /// section content.
+        /// </summary>
+        /// <param name="name">Section name</param>
+        /// <param name="location">RVA and file location where the section will be put</param>
+        /// <returns>Blob builder representing the section data</returns>
+        protected override BlobBuilder SerializeSection(string name, SectionLocation location)
+        {
+            BlobBuilder sectionDataBuilder = new BlobBuilder();
+            int sectionIndex = _peReader.PEHeaders.SectionHeaders.Count() - 1;
+            while (sectionIndex >= 0 && _peReader.PEHeaders.SectionHeaders[sectionIndex].Name != name)
+            {
+                sectionIndex--;
+            }
+            if (sectionIndex >= 0)
+            {
+                SectionHeader sectionHeader = _peReader.PEHeaders.SectionHeaders[sectionIndex];
+                int sectionOffset = (_peReader.IsLoadedImage ? sectionHeader.VirtualAddress : sectionHeader.PointerToRawData);
+                int rvaDelta = location.RelativeVirtualAddress - sectionHeader.VirtualAddress;
+                
+                _sectionRvaDeltas.Add(new Tuple<int, int, int>(
+                    sectionHeader.VirtualAddress,
+                    sectionHeader.VirtualAddress + Math.Max(sectionHeader.VirtualSize, sectionHeader.SizeOfRawData),
+                    rvaDelta));
+                
+                unsafe
+                {
+                    int bytesToRead = Math.Min(sectionHeader.SizeOfRawData, sectionHeader.VirtualSize);
+                    BlobReader inputSectionReader = _peReader.GetEntireImage()
+                        .GetReader(sectionOffset, sectionHeader.SizeOfRawData);
+                        
+                    if (name == ".rsrc")
+                    {
+                        // There seems to be a bug in BlobBuilder - when we LinkSuffix to an empty blob builder,
+                        // the blob data goes out of sync and WriteContentTo outputs garbage.
+                        sectionDataBuilder = PEResourceHelper.Relocate(inputSectionReader, rvaDelta);
+                    }
+                    else
+                    {
+                        sectionDataBuilder.WriteBytes(inputSectionReader.StartPointer, bytesToRead);
+                    }
+
+                    if (sectionHeader.VirtualSize > bytesToRead)
+                    {
+                        // If the number of bytes read from the source PE file is less than the virtual size,
+                        // zero pad to the end of virtual size before emitting extra section data
+                        sectionDataBuilder.WriteBytes(0, sectionHeader.VirtualSize - bytesToRead);
+                    }
+                    location = new SectionLocation(
+                        location.RelativeVirtualAddress + sectionDataBuilder.Count,
+                        location.PointerToRawData + sectionDataBuilder.Count);
+                }
+            }
+            if (_sectionSerializer != null)
+            {
+                BlobBuilder extraData = _sectionSerializer(name, location);
+                if (sectionIndex < 0)
+                {
+                    // See above - there's a bug due to which LinkSuffix to an empty BlobBuilder screws up the blob content.
+                    sectionDataBuilder = extraData;
+                }
+                else
+                {
+                    sectionDataBuilder.LinkSuffix(extraData);
+                }
+            }
+            
+            return sectionDataBuilder;
+        }
+    }
+
+    /// <summary>
+    /// When copying PE contents we may need to move the resource section, however its internal
+    /// ResourceDataEntry records hold RVA's so they need to be relocated. Thankfully the resource
+    /// data model is very simple so that we just traverse the structure using offset constants.
+    /// </summary>
+    unsafe sealed class PEResourceHelper
+    {
+        /// <summary>
+        /// Field offsets in the resource directory table.
+        /// </summary>
+        private static class DirectoryTable
+        {
+            public const int Characteristics = 0x0;
+            public const int TimeDateStamp = 0x04;
+            public const int MajorVersion = 0x08;
+            public const int MinorVersion = 0x0A;
+            public const int NumberOfNameEntries = 0x0C;
+            public const int NumberOfIDEntries = 0x0E;
+            public const int Size = 0x10;
+        }
+        
+        /// <summary>
+        /// Field offsets in the resource directory entry.
+        /// </summary>
+        private static class DirectoryEntry
+        {
+            public const int NameOffsetOrID = 0x0;
+            public const int DataOrSubdirectoryOffset = 0x4;
+            public const int Size = 0x8;
+        }
+
+        /// <summary>
+        /// When the 4-byte value at the offset DirectoryEntry.DataOrSubdirectoryOffset
+        /// has 31-st bit set, it's a subdirectory table entry; when it's clear, it's a
+        /// resource data entry.
+        /// </summary>
+        private const int EntryOffsetIsSubdirectory = unchecked((int)0x80000000u);
+        
+        /// <summary>
+        /// Field offsets in the resource data entry.
+        /// </summary>
+        private static class DataEntry
+        {
+            public const int RVA = 0x0;
+            public const int Size = 0x4;
+            public const int Codepage = 0x8;
+            public const int Reserved = 0xC;
+        }
+        
+        /// <summary>
+        /// Blob reader representing the input resource section.
+        /// </summary>
+        private BlobReader _reader;
+
+        /// <summary>
+        /// This BlobBuilder holds the relocated resource section after the ctor finishes.
+        /// </summary>
+        private BlobBuilder _builder;
+
+        /// <summary>
+        /// Relocation delta (the difference between input and output RVA of the resource section).
+        /// </summary>
+        private int _delta;
+
+        /// <summary>
+        /// Offsets within the resource section representing RVA's in the resource data entries
+        /// that need relocating.
+        /// </summary>
+        private List<int> _offsetsOfRvasToRelocate;
+        
+        /// <summary>
+        /// Public API receives the input resource section reader and the relocation delta
+        /// and returns a blob builder representing the relocated resource section.
+        /// </summary>
+        /// <param name="reader">Blob reader representing the input resource section</param>
+        /// <param name="delta">Relocation delta to apply (value to add to RVA's)</param>
+        public static BlobBuilder Relocate(BlobReader reader, int delta)
+        {
+            return new PEResourceHelper(reader, delta)._builder;
+        }
+        
+        /// <summary>
+        /// Private constructor first traverses the internal graph of resource tables
+        /// and collects offsets to RVA's that need relocation; after that we sort the list of
+        /// offsets and do a linear copying pass patching the RVA cells with the updated values.
+        /// </summary>
+        /// <param name="reader">Blob reader representing the input resource section</param>
+        /// <param name="delta">Relocation delta to apply (value to add to RVA's)</param>
+        private PEResourceHelper(BlobReader reader, int delta)
+        {
+            _reader = reader;
+            _builder = new BlobBuilder();
+            _delta = delta;
+            
+            _offsetsOfRvasToRelocate = new List<int>();
+            
+            TraverseDirectoryTable(tableOffset: 0);
+
+            _offsetsOfRvasToRelocate.Sort();
+            int currentOffset = 0;
+            
+            _reader.Reset();
+            foreach (int offsetOfRvaToRelocate in _offsetsOfRvasToRelocate)
+            {
+                int bytesToCopy = offsetOfRvaToRelocate - currentOffset;
+                Debug.Assert(bytesToCopy >= 0);
+                if (bytesToCopy > 0)
+                {
+                    _builder.WriteBytes(_reader.CurrentPointer, bytesToCopy);
+                    _reader.Offset += bytesToCopy;
+                    currentOffset += bytesToCopy;
+                }
+                int rva = _reader.ReadInt32();
+                _builder.WriteInt32(rva + delta);
+                currentOffset += sizeof(int);
+            }
+            if (_reader.RemainingBytes > 0)
+            {
+                _builder.WriteBytes(_reader.CurrentPointer, _reader.RemainingBytes);
+            }
+        }
+        
+        /// <summary>
+        /// Traverse a single directory table at a given offset within the resource section.
+        /// Please note the method might end up calling itself recursively through the call graph
+        /// TraverseDirectoryTable -&gt; TraverseDirectoryEntry -&gt; TraverseDirectoryTable.
+        /// Maximum depth is equal to depth of the table graph - today resources use 3.
+        /// </summary>
+        /// <param name="tableOffset">Offset of the resource directory table within the resource section</param>
+        private void TraverseDirectoryTable(int tableOffset)
+        {
+            _reader.Offset = tableOffset + DirectoryTable.NumberOfNameEntries;
+            int numberOfNameEntries = _reader.ReadInt16();
+            int numberOfIDEntries = _reader.ReadInt16();
+            int totalEntries = numberOfNameEntries + numberOfIDEntries;
+            for (int entryIndex = 0; entryIndex < totalEntries; entryIndex++)
+            {
+                TraverseDirectoryEntry(tableOffset + DirectoryTable.Size + entryIndex * DirectoryEntry.Size);
+            }
+        }
+        
+        /// <summary>
+        /// Traverse a single directory entry (name- and ID-based directory entries are processed
+        /// the same way as we're not really interested in the entry identifier, just in the
+        /// data / table pointers.
+        /// </summary>
+        /// <param name="entryOffset">Offset of the resource directory entry within the resource section</param>
+        private void TraverseDirectoryEntry(int entryOffset)
+        {
+            _reader.Offset = entryOffset + DirectoryEntry.DataOrSubdirectoryOffset;
+            int dataOrSubdirectoryOffset = _reader.ReadInt32();
+            if ((dataOrSubdirectoryOffset & EntryOffsetIsSubdirectory) != 0)
+            {
+                // subdirectory offset
+                TraverseDirectoryTable(dataOrSubdirectoryOffset & ~EntryOffsetIsSubdirectory);
+            }
+            else
+            {
+                // data entry offset
+                _offsetsOfRvasToRelocate.Add(dataOrSubdirectoryOffset + DataEntry.RVA);
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Simple helper for copying the various global values in the PE header.
+    /// </summary>
+    static class PEHeaderCopier
+    {
+        /// <summary>
+        /// Copy PE headers into a PEHeaderBuilder used by PEBuilder.
+        /// </summary>
+        /// <param name="peHeaders">Headers to copy</param>
+        public static PEHeaderBuilder Copy(PEHeaders peHeaders)
+        {
+            return new PEHeaderBuilder(
+                machine: peHeaders.CoffHeader.Machine,
+                sectionAlignment: peHeaders.PEHeader.SectionAlignment,
+                fileAlignment: peHeaders.PEHeader.FileAlignment,
+                imageBase: peHeaders.PEHeader.ImageBase,
+                majorLinkerVersion: peHeaders.PEHeader.MajorLinkerVersion,
+                minorLinkerVersion: peHeaders.PEHeader.MinorLinkerVersion,
+                majorOperatingSystemVersion: peHeaders.PEHeader.MajorOperatingSystemVersion,
+                minorOperatingSystemVersion: peHeaders.PEHeader.MinorOperatingSystemVersion,
+                majorImageVersion: peHeaders.PEHeader.MajorImageVersion,
+                minorImageVersion: peHeaders.PEHeader.MinorImageVersion,
+                majorSubsystemVersion: peHeaders.PEHeader.MajorSubsystemVersion,
+                minorSubsystemVersion: peHeaders.PEHeader.MinorSubsystemVersion,
+                subsystem: peHeaders.PEHeader.Subsystem,
+                dllCharacteristics: peHeaders.PEHeader.DllCharacteristics,
+                imageCharacteristics: peHeaders.CoffHeader.Characteristics,
+                sizeOfStackReserve: peHeaders.PEHeader.SizeOfStackReserve,
+                sizeOfStackCommit: peHeaders.PEHeader.SizeOfStackCommit,
+                sizeOfHeapReserve: peHeaders.PEHeader.SizeOfHeapReserve,
+                sizeOfHeapCommit: peHeaders.PEHeader.SizeOfHeapCommit);
+        }
+    }
+}

--- a/src/ILCompiler/ILCompiler.sln
+++ b/src/ILCompiler/ILCompiler.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "desktop", "desktop\desktop.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.Build.Tasks", "..\ILCompiler.Build.Tasks\src\ILCompiler.Build.Tasks.csproj", "{44DE7F7B-AD73-40EA-87CC-554F2F57C38A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.ReadyToRun", "..\ILCompiler.ReadyToRun\src\ILCompiler.ReadyToRun.csproj", "{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\System.Private.CoreLib\shared\System.Private.CoreLib.Shared.projitems*{be95c560-b508-4588-8907-f9fc5bc1a0cf}*SharedItemsImports = 4
@@ -375,6 +377,34 @@ Global
 		{44DE7F7B-AD73-40EA-87CC-554F2F57C38A}.Release|x64.Build.0 = Release|x64
 		{44DE7F7B-AD73-40EA-87CC-554F2F57C38A}.Release|x86.ActiveCfg = Release|x86
 		{44DE7F7B-AD73-40EA-87CC-554F2F57C38A}.Release|x86.Build.0 = Release|x86
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|arm.ActiveCfg = Debug|arm
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|arm.Build.0 = Debug|arm
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|arm64.ActiveCfg = Debug|arm64
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|arm64.Build.0 = Debug|arm64
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|armel.ActiveCfg = Debug|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|armel.Build.0 = Debug|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|wasm.ActiveCfg = Debug|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|wasm.Build.0 = Debug|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|x64.ActiveCfg = Debug|x64
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|x64.Build.0 = Debug|x64
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|x86.ActiveCfg = Debug|x86
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Debug|x86.Build.0 = Debug|x86
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|arm.ActiveCfg = Release|arm
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|arm.Build.0 = Release|arm
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|arm64.ActiveCfg = Release|arm64
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|arm64.Build.0 = Release|arm64
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|armel.ActiveCfg = Release|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|armel.Build.0 = Release|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|wasm.ActiveCfg = Release|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|wasm.Build.0 = Release|Any CPU
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|x64.ActiveCfg = Release|x64
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|x64.Build.0 = Release|x64
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|x86.ActiveCfg = Release|x86
+		{5FB7EFC5-2E58-4A65-A611-C9B68CC6A78D}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -96,6 +96,9 @@
       <Project>{5d796936-ccc1-4e9d-b1a9-36a5aba9b499}</Project>
       <Name>ILCompiler.WebAssembly</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\ILCompiler.ReadyToRun\src\ILCompiler.ReadyToRun.csproj">
+      <Name>ILCompiler.ReadyToRun</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\bin\Windows_NT.$(Platform).$(Configuration)\tools\jitinterface.dll">

--- a/src/ILCompiler/src/ILCompiler.csproj
+++ b/src/ILCompiler/src/ILCompiler.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\ILCompiler.Compiler\src\ILCompiler.Compiler.csproj" />
     <ProjectReference Include="..\..\ILCompiler.CppCodeGen\src\ILCompiler.CppCodeGen.csproj" />
     <ProjectReference Include="..\..\ILCompiler.WebAssembly\src\ILCompiler.WebAssembly.csproj" />
+    <ProjectReference Include="..\..\ILCompiler.ReadyToRun\src\ILCompiler.ReadyToRun.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.CommandLine">


### PR DESCRIPTION
Adds a ready-to-run compilation mode to ILCompiler which will live in ILCompiler.ReadyToRun library. Created separate versions of a few main classes (NodeFactory, Compilation, CompilationBuilder) specific to ready-to-run, whose implementations will be filled out as we build out ready-to-run support.

Also includes Tomas' PE file builder, which currently produces a valid executable round tripped from an input IL assembly.