### PR TITLE
Add opt-in switch to disable metadata blocking

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/NoBlockingPolicy.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NoBlockingPolicy.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Represents a metadata blocking policy that doesn't block any metadata.
+    /// </summary>
+    public sealed class NoBlockingPolicy : MetadataBlockingPolicy
+    {
+        public override bool IsBlocked(MetadataType type) => !(type is EcmaType);
+
+        public override bool IsBlocked(FieldDesc field) => !(field is EcmaField);
+
+        private MetadataType _arrayOfTType;
+        private MetadataType InitializeArrayOfTType(TypeSystemEntity contextEntity)
+        {
+            _arrayOfTType = contextEntity.Context.SystemModule.GetType("System", "Array`1");
+            return _arrayOfTType;
+        }
+        private MetadataType GetArrayOfTType(TypeSystemEntity contextEntity)
+        {
+            if (_arrayOfTType != null)
+            {
+                return _arrayOfTType;
+            }
+            return InitializeArrayOfTType(contextEntity);
+        }
+
+        public override bool IsBlocked(MethodDesc method)
+        {
+            if (method is EcmaMethod ecmaMethod)
+            {
+                // Methods on Array`1<T> are implementation details that implement the generic interfaces on
+                // arrays. They should not generate metadata or be reflection invokable.
+                // We can get rid of this special casing if we make these methods stop being regular EcmaMethods
+                // with Array<T> as their owning type
+                if (ecmaMethod.OwningType == GetArrayOfTType(ecmaMethod))
+                    return true;
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ImportedNodeProvider.cs" />
     <Compile Include="Compiler\GeneratingMetadataManager.cs" />
     <Compile Include="Compiler\InternalCompilerErrorException.cs" />
+    <Compile Include="Compiler\NoBlockingPolicy.cs" />
     <Compile Include="Compiler\PreInitFieldInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenArrayNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsPreInitDataNode.cs" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -49,6 +49,7 @@ namespace ILCompiler
         private bool _emitStackTraceData;
         private string _mapFileName;
         private string _metadataLogFileName;
+        private bool _noMetadataBlocking;
 
         private string _singleMethodTypeName;
         private string _singleMethodName;
@@ -155,6 +156,7 @@ namespace ILCompiler
                 syntax.DefineOptionList("rdxml", ref _rdXmlFilePaths, "RD.XML file(s) for compilation");
                 syntax.DefineOption("map", ref _mapFileName, "Generate a map file");
                 syntax.DefineOption("metadatalog", ref _metadataLogFileName, "Generate a metadata log file");
+                syntax.DefineOption("nometadatablocking", ref _noMetadataBlocking, "Ignore metadata blocking for internal implementation details");
                 syntax.DefineOption("scan", ref _useScanner, "Use IL scanner to generate optimized code (implied by -O)");
                 syntax.DefineOption("noscan", ref _noScanner, "Do not use IL scanner to generate optimized code");
                 syntax.DefineOption("ildump", ref _ilDump, "Dump IL assembly listing for compiler-generated IL");
@@ -407,10 +409,13 @@ namespace ILCompiler
             var stackTracePolicy = _emitStackTraceData ?
                 (StackTraceEmissionPolicy)new EcmaMethodStackTraceEmissionPolicy() : new NoStackTraceEmissionPolicy();
 
+            MetadataBlockingPolicy mdBlockingPolicy = _noMetadataBlocking ?
+                (MetadataBlockingPolicy)new NoBlockingPolicy() : new BlockedInternalsBlockingPolicy();
+
             UsageBasedMetadataManager metadataManager = new UsageBasedMetadataManager(
                 compilationGroup,
                 typeSystemContext,
-                new BlockedInternalsBlockingPolicy(),
+                mdBlockingPolicy,
                 _metadataLogFileName,
                 stackTracePolicy);
 


### PR DESCRIPTION
This adds a compiler option to disable the behavior that blocks metadata generation for framework implementation details.

Enabling the option regresses the size of a Hello world app from 3,891,200 bytes to 5,970,432. We don't want to enable this by default because normal apps have no business in reflecting on the implementation details of the framework. Implementation details vary from version to version and from runtime to runtime.

This is likely going to be needed for #5838 (the CoreFX tests try to access implementation details to test these - we did the work to disable any such tests on UAPAOT, but that's not the flavor of tests we run in CoreRT repo). Fixes #5951.