### PR TITLE
Emit Ready-to-run header

### DIFF
--- a/src/Common/src/Internal/Runtime/ModuleHeaders.cs
+++ b/src/Common/src/Internal/Runtime/ModuleHeaders.cs
@@ -41,11 +41,30 @@ namespace Internal.Runtime
     // from each module linked into the final binary. New sections should be added at the bottom
     // of the enum and deprecated sections should not be removed to preserve ID stability.
     //
-    // Eventually this will be reconciled with ReadyToRunSectionType from 
+    // This list should be kept in sync with the runtime version at
     // https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h
     //
     public enum ReadyToRunSectionType
     {
+        //
+        // CoreCLR ReadyToRun sections
+        //
+        CompilerIdentifier = 100,
+        ImportSections = 101,
+        RuntimeFunctions = 102,
+        MethodDefEntryPoints = 103,
+        ExceptionInfo = 104,
+        DebugInfo = 105,
+        DelayLoadMethodCallThunks = 106,
+        // 107 is deprecated - it was used by an older format of AvailableTypes
+        AvailableTypes = 108,
+        InstanceMethodEntryPoints = 109,
+        InliningInfo = 110, // Added in v2.1
+        ProfileDataInfo = 111, // Added in v2.2
+
+        //
+        // CoreRT ReadyToRun sections
+        //
         StringTable = 200, // Unused
         GCStaticRegion = 201,
         ThreadStaticRegion = 202,

--- a/src/ILCompiler.Compiler/src/Compiler/ManagedEntryPointRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ManagedEntryPointRootProvider.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+using Internal.IL.Stubs.StartupCode;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Computes a compilation root based on the entrypoint of the assembly.
+    /// </summary>
+    public class ManagedEntryPointRootProvider : ICompilationRootProvider
+    {
+        private EcmaModule _module;
+
+        public ManagedEntryPointRootProvider(EcmaModule module)
+        {
+            _module = module;
+        }
+
+        public void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        {
+            MethodDesc mainMethod = _module.EntryPoint;
+            if (mainMethod == null)
+                throw new Exception("No managed entrypoint defined for executable module");
+
+            rootProvider.AddCompilationRoot(mainMethod, "Entry point method");
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Compiler\GeneratingMetadataManager.cs" />
     <Compile Include="Compiler\InternalCompilerErrorException.cs" />
     <Compile Include="Compiler\NoBlockingPolicy.cs" />
+    <Compile Include="Compiler\ManagedEntryPointRootProvider.cs" />
     <Compile Include="Compiler\PreInitFieldInfo.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenArrayNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsPreInitDataNode.cs" />

--- a/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
@@ -4,12 +4,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
+using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.PEWriter;
+using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -19,38 +23,98 @@ namespace ILCompiler.DependencyAnalysis
     internal class ReadyToRunObjectWriter
     {
         // Nodefactory for which ObjectWriter is instantiated for.
-        private NodeFactory _nodeFactory;
+        private ReadyToRunCodegenNodeFactory _nodeFactory;
         private string _inputFilePath;
         private string _objectFilePath;
-        
-        public ReadyToRunObjectWriter(string inputFilePath, string objectFilePath, NodeFactory factory, ReadyToRunCodegenCompilation compilation)
+        private IEnumerable<DependencyNode> _nodes;
+
+        private int _headerSectionIndex;
+
+#if DEBUG
+        Dictionary<string, ISymbolNode> _previouslyWrittenNodeNames = new Dictionary<string, ISymbolNode>();
+#endif
+
+        public ReadyToRunObjectWriter(string inputFilePath, string objectFilePath, IEnumerable<DependencyNode> nodes, ReadyToRunCodegenNodeFactory factory)
         {
-            _nodeFactory = factory;
             _inputFilePath = inputFilePath;
             _objectFilePath = objectFilePath;
+            _nodes = nodes;
+            _nodeFactory = factory;
         }
         
         public void EmitPortableExecutable()
         {
-            using (FileStream sr = File.OpenRead(_inputFilePath))
+            FileStream inputFileStream = File.OpenRead(_inputFilePath);
+            bool succeeded = false;
+
+            try
             {
-                PEReader peReader = new PEReader(sr);
-                // TODO: properly propagate target architecture
-                R2RPEBuilder peBuilder = new R2RPEBuilder(Machine.Amd64, peReader);
-                
-                var peBlob = new BlobBuilder();
-                peBuilder.Serialize(peBlob);
+                var peReader = new PEReader(inputFileStream);
+                var peBuilder = new R2RPEBuilder(Machine.Amd64, peReader, new ValueTuple<string, SectionCharacteristics>[0]);
+                var sectionBuilder = new SectionBuilder();
+
+                _headerSectionIndex = sectionBuilder.AddSection(R2RPEBuilder.TextSectionName, SectionCharacteristics.ContainsCode | SectionCharacteristics.MemExecute | SectionCharacteristics.MemRead, 512);
+                sectionBuilder.SetReadyToRunHeaderTable(_nodeFactory.CoreCLRReadyToRunHeader, _nodeFactory.CoreCLRReadyToRunHeader.GetData(_nodeFactory).Data.Length);
+
+                foreach (var depNode in _nodes)
+                {
+                    ObjectNode node = depNode as ObjectNode;
+                    if (node == null)
+                        continue;
+
+                    if (node.ShouldSkipEmittingObjectNode(_nodeFactory))
+                        continue;
+
+                    ObjectData nodeContents = node.GetData(_nodeFactory);
+
+#if DEBUG
+                    foreach (ISymbolNode definedSymbol in nodeContents.DefinedSymbols)
+                    {
+                        try
+                        {
+                            _previouslyWrittenNodeNames.Add(definedSymbol.GetMangledName(_nodeFactory.NameMangler), definedSymbol);
+                        }
+                        catch (ArgumentException)
+                        {
+                            ISymbolNode alreadyWrittenSymbol = _previouslyWrittenNodeNames[definedSymbol.GetMangledName(_nodeFactory.NameMangler)];
+                            Debug.Fail("Duplicate node name emitted to file",
+                            $"Symbol {definedSymbol.GetMangledName(_nodeFactory.NameMangler)} has already been written to the output object file {_objectFilePath} with symbol {alreadyWrittenSymbol}");
+                        }
+                    }
+#endif
+
+                    sectionBuilder.AddObjectData(nodeContents, _headerSectionIndex);
+                }
 
                 using (var peStream = File.Create(_objectFilePath))
                 {
-                    peBlob.WriteContentTo(peStream);
+                    sectionBuilder.EmitR2R(Machine.Amd64, peReader, peStream);
+                }
+
+                succeeded = true;
+            }
+            finally
+            {
+                inputFileStream.Dispose();
+
+                if (!succeeded)
+                {
+                    // If there was an exception while generating the OBJ file, make sure we don't leave the unfinished
+                    // object file around.
+                    try
+                    {
+                        File.Delete(_objectFilePath);
+                    }
+                    catch
+                    {
+                    }
                 }
             }
         }
 
-        public static void EmitObject(string inputFilePath, string objectFilePath, IEnumerable<DependencyNode> nodes, NodeFactory factory, ReadyToRunCodegenCompilation compilation, IObjectDumper dumper)
+        public static void EmitObject(string inputFilePath, string objectFilePath, IEnumerable<DependencyNode> nodes, ReadyToRunCodegenNodeFactory factory)
         {
-            ReadyToRunObjectWriter objectWriter = new ReadyToRunObjectWriter(inputFilePath, objectFilePath, factory, compilation);
+            ReadyToRunObjectWriter objectWriter = new ReadyToRunObjectWriter(inputFilePath, objectFilePath, nodes, factory);
             objectWriter.EmitPortableExecutable();
         }
     }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/CompilerIdentifierNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/CompilerIdentifierNode.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Internal.Runtime;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    internal class CompilerIdentifierNode : ObjectNode, ISymbolDefinitionNode
+    {
+        private static readonly string _compilerIdentifier = "CoreRT Ready-To-Run Compiler";
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+
+        public override bool IsShareable => false;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public int Offset => 0;
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+        protected override int ClassCode => 230053202;
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("__ReadyToRunHeader_CompilerIdentifier");
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.RequireInitialPointerAlignment();
+            builder.AddSymbol(this);
+            builder.EmitBytes(Encoding.ASCII.GetBytes(_compilerIdentifier));
+            return builder.ToObjectData();
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/CoreCLRReadyToRunHeaderNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/CoreCLRReadyToRunHeaderNode.cs
@@ -30,13 +30,13 @@ namespace ILCompiler.DependencyAnalysis
                 StartSymbol = startSymbol;
             }
 
-            readonly public ReadyToRunSectionType Id;
-            readonly public ObjectNode Node;
-            readonly public ISymbolNode StartSymbol;
+            public readonly ReadyToRunSectionType Id;
+            public readonly ObjectNode Node;
+            public readonly ISymbolNode StartSymbol;
         }
 
-        List<HeaderItem> _items = new List<HeaderItem>();
-        TargetDetails _target;
+        private List<HeaderItem> _items = new List<HeaderItem>();
+        private TargetDetails _target;
 
         public CoreCLRReadyToRunHeaderNode(TargetDetails target)
         {
@@ -104,12 +104,14 @@ namespace ILCompiler.DependencyAnalysis
                 builder.EmitInt((int)item.Id);
                 
                 builder.EmitReloc(item.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB);
-                builder.EmitInt(item.Node.GetData(factory).Data.Length);
+
+                if (!relocsOnly)
+                    builder.EmitInt(item.Node.GetData(factory).Data.Length);
                 
                 count++;
             }
 
-            builder.EmitInt(sectionCountReservation, checked(count));
+            builder.EmitInt(sectionCountReservation, count);
             
             return builder.ToObjectData();
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/CoreCLRReadyToRunHeaderNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/CoreCLRReadyToRunHeaderNode.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.Runtime;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    internal struct ReadyToRunHeaderConstants
+    {
+        public const uint Signature = 0x00525452; // 'RTR'
+
+        public const ushort CurrentMajorVersion = 2;
+        public const ushort CurrentMinorVersion = 1;
+    }
+
+    public class CoreCLRReadyToRunHeaderNode : ObjectNode, ISymbolDefinitionNode
+    {
+        struct HeaderItem
+        {
+            public HeaderItem(ReadyToRunSectionType id, ObjectNode node, ISymbolNode startSymbol)
+            {
+                Id = id;
+                Node = node;
+                StartSymbol = startSymbol;
+            }
+
+            readonly public ReadyToRunSectionType Id;
+            readonly public ObjectNode Node;
+            readonly public ISymbolNode StartSymbol;
+        }
+
+        List<HeaderItem> _items = new List<HeaderItem>();
+        TargetDetails _target;
+
+        public CoreCLRReadyToRunHeaderNode(TargetDetails target)
+        {
+            _target = target;
+        }
+
+        public void Add(ReadyToRunSectionType id, ObjectNode node, ISymbolNode startSymbol)
+        {
+            _items.Add(new HeaderItem(id, node, startSymbol));
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append("__ReadyToRunHeader");
+        }
+        public int Offset => 0;
+        public override bool IsShareable => false;
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override ObjectNodeSection Section
+        {
+            get
+            {
+                if (_target.IsWindows)
+                    return ObjectNodeSection.ReadOnlyDataSection;
+                else
+                    return ObjectNodeSection.DataSection;
+            }
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.RequireInitialPointerAlignment();
+            builder.AddSymbol(this);
+
+            // Don't bother sorting if we're not emitting the contents
+            if (!relocsOnly)
+                _items.Sort((x, y) => Comparer<int>.Default.Compare((int)x.Id, (int)y.Id));
+
+            // ReadyToRunHeader.Magic
+            builder.EmitInt((int)(ReadyToRunHeaderConstants.Signature));
+
+            // ReadyToRunHeader.MajorVersion
+            builder.EmitShort((short)(ReadyToRunHeaderConstants.CurrentMajorVersion));
+            builder.EmitShort((short)(ReadyToRunHeaderConstants.CurrentMinorVersion));
+
+            // ReadyToRunHeader.Flags
+            builder.EmitInt(0);
+
+            // ReadyToRunHeader.NumberOfSections
+            ObjectDataBuilder.Reservation sectionCountReservation = builder.ReserveInt();
+            
+            int count = 0;
+            foreach (var item in _items)
+            {
+                // Skip empty entries
+                if (!relocsOnly && item.Node.ShouldSkipEmittingObjectNode(factory))
+                    continue;
+
+                builder.EmitInt((int)item.Id);
+                
+                builder.EmitReloc(item.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB);
+                builder.EmitInt(item.Node.GetData(factory).Data.Length);
+                
+                count++;
+            }
+
+            builder.EmitInt(sectionCountReservation, checked(count));
+            
+            return builder.ToObjectData();
+        }
+
+        protected override int ClassCode => 627741208;
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -49,7 +49,6 @@ namespace ILCompiler.DependencyAnalysis
 
             var compilerIdentifierNode = new CompilerIdentifierNode();
             CoreCLRReadyToRunHeader.Add(Internal.Runtime.ReadyToRunSectionType.CompilerIdentifier, compilerIdentifierNode, compilerIdentifierNode);
-            graph.AddRoot(compilerIdentifierNode, "CompilerIdentifierNode is always generated");
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -25,6 +25,8 @@ namespace ILCompiler.DependencyAnalysis
             
         }
 
+        public CoreCLRReadyToRunHeaderNode CoreCLRReadyToRunHeader;
+
         protected override IMethodNode CreateMethodEntrypointNode(MethodDesc method)
         {
             throw new NotImplementedException();
@@ -42,7 +44,12 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
         {
+            CoreCLRReadyToRunHeader = new CoreCLRReadyToRunHeaderNode(Target);
+            graph.AddRoot(CoreCLRReadyToRunHeader, "ReadyToRunHeader is always generated");
 
+            var compilerIdentifierNode = new CompilerIdentifierNode();
+            CoreCLRReadyToRunHeader.Add(Internal.Runtime.ReadyToRunSectionType.CompilerIdentifier, compilerIdentifierNode, compilerIdentifierNode);
+            graph.AddRoot(compilerIdentifierNode, "CompilerIdentifierNode is always generated");
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -44,7 +44,7 @@ namespace ILCompiler
 
             var nodes = _dependencyGraph.MarkedNodeList;
 
-            ReadyToRunObjectWriter.EmitObject(_inputFilePath, outputFile, nodes, NodeFactory, this, dumper);
+            ReadyToRunObjectWriter.EmitObject(_inputFilePath, outputFile, nodes, NodeFactory);
         }
 
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" Condition="'$(IsProjectNLibrary)' != 'true'" />
   <PropertyGroup>
@@ -27,7 +27,9 @@
   
   <ItemGroup>
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\CompilerIdentifierNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunCodegenNodeFactory.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\CoreCLRReadyToRunHeaderNode.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilation.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilationBuilder.cs" />
     <Compile Include="Compiler\ReadyToRunNodeMangler.cs" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -282,7 +282,7 @@ namespace ILCompiler
 
             // TODO: compiler switch for SIMD support?
             var simdVectorLength = (_isCppCodegen || _isWasmCodegen) ? SimdVectorLength.None : SimdVectorLength.Vector128Bit;
-            var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT, simdVectorLength);
+            var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, _isReadyToRunCodeGen ? TargetAbi.Jit : TargetAbi.CoreRT, simdVectorLength);
             var typeSystemContext = new CompilerTypeSystemContext(targetDetails, genericsMode);
 
             //
@@ -351,7 +351,14 @@ namespace ILCompiler
 
                 if (entrypointModule != null)
                 {
-                    compilationRoots.Add(new MainMethodRootProvider(entrypointModule, CreateInitializerList(typeSystemContext)));
+                    if (_isReadyToRunCodeGen)
+                    {
+                        compilationRoots.Add(new ManagedEntryPointRootProvider(entrypointModule));
+                    }
+                    else
+                    {
+                        compilationRoots.Add(new MainMethodRootProvider(entrypointModule, CreateInitializerList(typeSystemContext)));
+                    }
                 }
 
                 if (_multiFile)


### PR DESCRIPTION
Write out the ready-to-run (managed native) header, which outputs directory entries for each of the various tables. Currently we write out the CompilerIdentifierNode, a simple example showing how we'll write out the other tables.

The header is very similar to the existing CoreRT ready-to-run header with a few differences. For example, the section count is Int16 on CoreRT but Int32 on CoreCLR. The section pointers are also encoded differently (pointer relocs on CoreRT, baseless RVAs on CoreCLR). Also, each section reference can have flags on CoreRT.

The image produced by ILCompiler currently is not loadable by CoreCLR, which needs further investigation.