### PR TITLE
Small fixes to R2R PE builder based on initial debugging of CoreCLR loader

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
@@ -35,7 +35,8 @@ namespace ILCompiler.DependencyAnalysis
             using (FileStream sr = File.OpenRead(_inputFilePath))
             {
                 PEReader peReader = new PEReader(sr);
-                R2RPEBuilder peBuilder = new R2RPEBuilder(peReader);
+                // TODO: properly propagate target architecture
+                R2RPEBuilder peBuilder = new R2RPEBuilder(Machine.Amd64, peReader);
                 
                 var peBlob = new BlobBuilder();
                 peBuilder.Serialize(peBlob);

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/RelocationHelper.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/RelocationHelper.cs
@@ -148,10 +148,16 @@ namespace ILCompiler.PEWriter
                     return;
                     
                 case RelocType.IMAGE_REL_BASED_HIGHLOW:
-                case RelocType.IMAGE_REL_BASED_ADDR32NB:
                     {
                         relocationLength = 4;
                         delta = unchecked(targetRVA + (int)_defaultImageBase);
+                        break;
+                    }
+
+                case RelocType.IMAGE_REL_BASED_ADDR32NB:
+                    {
+                        relocationLength = 4;
+                        delta = targetRVA;
                         break;
                     }
                 

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/SectionBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/SectionBuilder.cs
@@ -839,11 +839,13 @@ namespace ILCompiler.PEWriter
         /// Emit built sections using the R2R PE writer.
         /// </summary>
         /// <param name="builder">Section builder to emit</param>
+        /// <param name="machine">Target machine architecture</param>
         /// <param name="inputReader">Input MSIL reader</param>
         /// <param name="outputStream">Output stream for the final R2R PE file</param>
-        public static void EmitR2R(this SectionBuilder builder, PEReader inputReader, Stream outputStream)
+        public static void EmitR2R(this SectionBuilder builder, Machine machine, PEReader inputReader, Stream outputStream)
         {
             R2RPEBuilder r2rBuilder = new R2RPEBuilder(
+                machine: machine,
                 peReader: inputReader,
                 sectionNames: builder.GetSections(),
                 sectionSerializer: builder.SerializeSection,


### PR DESCRIPTION
1) Added support for propagating target machine architecture;

2) Removed a bit of dead code;

3) Incorporated Simon's fix for the ADDR32NB relocation as it's
a simple bugfix unrelated to the R2R header work.

Thanks

Tomas