### PR TITLE
Generate Main method

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodCodeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodCodeNode.cs
@@ -6,7 +6,7 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    interface IMethodCodeNode : IMethodNode, ISymbolDefinitionNode
+    public interface IMethodCodeNode : IMethodNode, ISymbolDefinitionNode
     {
         void SetCode(ObjectNode.ObjectData data);
         void InitializeFrameInfos(FrameInfo[] frameInfos);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override IMethodNode CreateMethodEntrypointNode(MethodDesc method)
         {
-            throw new NotImplementedException();
+            return new MethodCodeNode(method);
         }
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -59,7 +59,7 @@ namespace ILCompiler
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
             var jitConfig = new JitConfigProvider(Enumerable.Empty<CorJitFlag>(), _ryujitOptions);
 
-            return new ReadyToRunCodegenCompilation(graph, factory, _compilationRoots, _logger, jitConfig, _inputFilePath);
+            return new ReadyToRunCodegenCompilation(graph, factory, _compilationRoots, _debugInformationProvider, _logger, _devirtualizationManager, jitConfig, _inputFilePath);
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -39,9 +39,6 @@
     <Compile Include="..\..\Common\src\System\Collections\Generic\ArrayBuilder.cs">
       <Link>Common\ArrayBuilder.cs</Link>
     </Compile>
-    <Compile Include="..\..\JitInterface\src\JitConfigProvider.cs">
-      <Link>JitInterface\JitConfigProvider.cs</Link>
-    </Compile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="'$(IsProjectNLibrary)' != 'true'" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -282,7 +282,7 @@ namespace ILCompiler
 
             // TODO: compiler switch for SIMD support?
             var simdVectorLength = (_isCppCodegen || _isWasmCodegen) ? SimdVectorLength.None : SimdVectorLength.Vector128Bit;
-            var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, _isReadyToRunCodeGen ? TargetAbi.Jit : TargetAbi.CoreRT, simdVectorLength);
+            var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT, simdVectorLength);
             var typeSystemContext = new CompilerTypeSystemContext(targetDetails, genericsMode);
 
             //
@@ -346,7 +346,8 @@ namespace ILCompiler
                         entrypointModule = module;
                     }
 
-                    compilationRoots.Add(new ExportedMethodsRootProvider(module));
+                    if (!_isReadyToRunCodeGen)
+                        compilationRoots.Add(new ExportedMethodsRootProvider(module));
                 }
 
                 if (entrypointModule != null)
@@ -384,7 +385,8 @@ namespace ILCompiler
                     if (entrypointModule == null && !_nativeLib)
                         throw new Exception("No entrypoint module");
 
-                    compilationRoots.Add(new ExportedMethodsRootProvider((EcmaModule)typeSystemContext.SystemModule));
+                    if (!_isReadyToRunCodeGen)
+                        compilationRoots.Add(new ExportedMethodsRootProvider((EcmaModule)typeSystemContext.SystemModule));
                     compilationGroup = new SingleFileCompilationModuleGroup();
                 }
 
@@ -453,7 +455,7 @@ namespace ILCompiler
 
             useScanner &= !_noScanner;
 
-            bool supportsReflection = !_isWasmCodegen && !_isCppCodegen && _systemModuleName == DefaultSystemModule;
+            bool supportsReflection = !_isReadyToRunCodeGen && !_isWasmCodegen && !_isCppCodegen && _systemModuleName == DefaultSystemModule;
 
             MetadataManager compilationMetadataManager = supportsReflection ? metadataManager : (MetadataManager)new EmptyMetadataManager(typeSystemContext);
             ILScanResults scanResults = null;

--- a/src/JitInterface/src/CorInfoBase.cs
+++ b/src/JitInterface/src/CorInfoBase.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace Internal.JitInterface
 {
-    unsafe partial class CorInfoImpl
+    public unsafe partial class CorInfoImpl
     {
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         delegate uint __getMethodAttribs(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* ftn);

--- a/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
+++ b/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
@@ -9,7 +9,7 @@ using Internal.TypeSystem;
 
 namespace Internal.JitInterface
 {
-    internal unsafe partial class CorInfoImpl
+    public unsafe partial class CorInfoImpl
     {
         private struct IntrinsicKey
         {

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -29,7 +29,7 @@ using ILCompiler.DependencyAnalysis;
 
 namespace Internal.JitInterface
 {
-    internal unsafe sealed partial class CorInfoImpl
+    public unsafe sealed partial class CorInfoImpl
     {
         //
         // Global initialization and state

--- a/src/JitInterface/src/JitConfigProvider.cs
+++ b/src/JitInterface/src/JitConfigProvider.cs
@@ -10,7 +10,7 @@ using NumberStyles = System.Globalization.NumberStyles;
 
 namespace Internal.JitInterface
 {
-    internal sealed class JitConfigProvider
+    public sealed class JitConfigProvider
     {
         private CorJitFlag[] _jitFlags;
         private Dictionary<string, string> _config = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitCompilation.cs
+++ b/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitCompilation.cs
@@ -15,7 +15,7 @@ namespace ILCompiler
     /// <summary>
     /// Version of Compilation class used for JIT compilation. Should probably be merged with the Compilation class used in AOT compilation
     /// </summary>
-    internal class Compilation
+    public class Compilation
     {
         public Compilation(TypeSystemContext context)
         {


### PR DESCRIPTION
Make the Jit available from the ILCompiler.ReadyToRun project. I have a PR to refactor the Jit into a separate project in master but didn't want to block on that.

Restrict the root providers in ready-to-run mode such that the entry point is the only thing that acts as a root (other than the ready-to-run header).

Add DebugInformationProvider and DevirtualizationManager to `ReadyToRunCodegenCompilationBuilder`. I thought we could simplify and remove them but that was wrong. Using a combination of EmptyMetadataManager, NullDebugInformationProvider, and the default implementation of DevirtualizationManager is sufficient to compile Main.