### PR TITLE
Update CoreCLR.issues.targets

### DIFF
--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -2,6 +2,12 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
   <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
 
+    <!-- Pinvoke calli -->
+    <!-- https://github.com/dotnet/corert/issues/5587 -->
+    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_dbgcatchfinally_ind\_il_dbgcatchfinally_ind.*" />
+    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_relcatchfinally_ind\_il_relcatchfinally_ind.*" />
+    <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b487364\b487364\b487364.*" />
+
     <!-- Infinite generic expansion -->
     <!-- https://github.com/dotnet/corert/issues/363 -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\inlining\bug505642\test\test.*" />


### PR DESCRIPTION
These tests started failing after RyuJIT update in #5969.

```
             at System.Diagnostics.Debug.Assert(Boolean condition, String message, String detailMessage)
             at Internal.JitInterface.CorInfoImpl.convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN& pResolvedToken, Boolean mustConvert) in D:\j\workspace\debug_windows_nt28ae10f6\src\JitInterface\src\CorInfoImpl.cs:line 3453
             at Internal.JitInterface.CorInfoImpl._convertPInvokeCalliToCall(IntPtr thisHandle, IntPtr* ppException, CORINFO_RESOLVED_TOKEN& pResolvedToken, Boolean mustConvert) in D:\j\workspace\debug_windows_nt28ae10f6\src\JitInterface\src\CorInfoBase.cs:line 2488
```


@dotnet-bot skip ci