### PR TITLE
Add cumulative error checking to CoreFX tests

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/EventWaitHandle.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/EventWaitHandle.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Diagnostics;
 
 namespace System.Threading
 {
@@ -23,7 +24,8 @@ namespace System.Threading
         {
             if (mode != EventResetMode.AutoReset && mode != EventResetMode.ManualReset)
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(mode));
-
+            // Added to test CI Failure
+            Debug.Assert(name == null);
             CreateEventCore(initialState, mode, name, out createdNew);
         }
 

--- a/src/System.Private.CoreLib/shared/System/Threading/EventWaitHandle.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/EventWaitHandle.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Diagnostics;
 
 namespace System.Threading
 {
@@ -24,8 +23,7 @@ namespace System.Threading
         {
             if (mode != EventResetMode.AutoReset && mode != EventResetMode.ManualReset)
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(mode));
-            // Added to test CI Failure
-            Debug.Assert(name == null);
+
             CreateEventCore(initialState, mode, name, out createdNew);
         }
 

--- a/tests/CoreFX/runtest/runtest.cmd
+++ b/tests/CoreFX/runtest/runtest.cmd
@@ -72,7 +72,7 @@ if not defined FXCustomTestLauncher (
     exit /b 1
 )
 
-
+set SAVED_ERROR_LEVEL=0
 :: Iterate through unzipped CoreFX tests 
 for /D %%i in ("%XunitTestBinBase%\*" ) do (
     set TestFolderName=%%i
@@ -80,10 +80,15 @@ for /D %%i in ("%XunitTestBinBase%\*" ) do (
 
     echo %FXCustomTestLauncher% !TestFolderName! !TestFileName!
     call %FXCustomTestLauncher% !TestFolderName! !TestFileName!
+    set TestExitCode=!errorlevel!
+    if !TestExitCode! neq 0 (
+        echo Test !TestFileName! failed with !TestExitCode!
+        set SAVED_ERROR_LEVEL=!TestExitCode!
+    )
 
 )
 
-exit /b 0
+exit /b !SAVED_ERROR_LEVEL!
 
 :Usage
 echo.

--- a/tests/TopN.CoreFX.Windows.issues.json
+++ b/tests/TopN.CoreFX.Windows.issues.json
@@ -777,15 +777,15 @@
             "methods": [
                 {
                     "name": "System.Tests.TupleTests.CompareTo",
-                    "reason": "Access Violation"
+                    "reason": "https://github.com/dotnet/corert/issues/6015"
                 },
                 {
                     "name": "System.Tests.TupleTests.Equals_GetHashCode",
-                    "reason": "Access Violation"
+                    "reason": "https://github.com/dotnet/corert/issues/6015"
                 },
                 {
                     "name": "System.Tests.ArrayTests.Sort_Array_Array_NonGeneric",
-                    "reason": "Access Violation"
+                    "reason": "https://github.com/dotnet/corert/issues/6016"
                 },
                 {
                     "name": "System.Reflection.Tests.MethodInfoTests.TestEquality2",

--- a/tests/TopN.CoreFX.Windows.issues.json
+++ b/tests/TopN.CoreFX.Windows.issues.json
@@ -776,6 +776,18 @@
             "classes": null,
             "methods": [
                 {
+                    "name": "System.Tests.TupleTests.CompareTo",
+                    "reason": "Access Violation"
+                },
+                {
+                    "name": "System.Tests.TupleTests.Equals_GetHashCode",
+                    "reason": "Access Violation"
+                },
+                {
+                    "name": "System.Tests.ArrayTests.Sort_Array_Array_NonGeneric",
+                    "reason": "Access Violation"
+                },
+                {
                     "name": "System.Reflection.Tests.MethodInfoTests.TestEquality2",
                     "reason": "Xunit.Sdk.EqualException"
                 },


### PR DESCRIPTION
The check was being done on Unix, but not on Windows.
This fixes the issues @jkotas pointed out in #6007. Also fixes #5901 .