### PR TITLE
Fix bogus assert in ArraySortHelper

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs
@@ -654,10 +654,10 @@ namespace System.Collections.Generic
         private static void SwapIfGreaterWithItems(TKey[] keys, TValue[] values, IComparer<TKey> comparer, int a, int b)
         {
             Debug.Assert(keys != null);
-            Debug.Assert(values != null && values.Length >= keys.Length);
+            Debug.Assert(values != null);
             Debug.Assert(comparer != null);
-            Debug.Assert(0 <= a && a < keys.Length);
-            Debug.Assert(0 <= b && b < keys.Length);
+            Debug.Assert(0 <= a && a < keys.Length && a < values.Length);
+            Debug.Assert(0 <= b && b < keys.Length && b < values.Length);
 
             if (a != b)
             {

--- a/tests/TopN.CoreFX.Windows.issues.json
+++ b/tests/TopN.CoreFX.Windows.issues.json
@@ -776,18 +776,6 @@
             "classes": null,
             "methods": [
                 {
-                    "name": "System.Tests.TupleTests.CompareTo",
-                    "reason": "https://github.com/dotnet/corert/issues/6015"
-                },
-                {
-                    "name": "System.Tests.TupleTests.Equals_GetHashCode",
-                    "reason": "https://github.com/dotnet/corert/issues/6015"
-                },
-                {
-                    "name": "System.Tests.ArrayTests.Sort_Array_Array_NonGeneric",
-                    "reason": "https://github.com/dotnet/corert/issues/6016"
-                },
-                {
                     "name": "System.Reflection.Tests.MethodInfoTests.TestEquality2",
                     "reason": "Xunit.Sdk.EqualException"
                 },


### PR DESCRIPTION
Fixes #6016.
Resolves #6015.

Regression test that will also hit the code path in CoreCLR is in dotnet/corefx#30664.