### PR TITLE
Fix stack slot kind for ByReference.get_Value in CppCodegen

### DIFF
--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -1004,7 +1004,7 @@ namespace Internal.IL
                     {
                         var thisRef = _stack.Pop();
 
-                        PushExpression(StackValueKind.ValueType, ((ExpressionEntry)thisRef).Name + "->_value", method.Signature.ReturnType);
+                        PushExpression(StackValueKind.ByRef, ((ExpressionEntry)thisRef).Name + "->_value", method.Signature.ReturnType);
                         return true;
                     }
                     break;

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -1003,8 +1003,9 @@ namespace Internal.IL
                     if (IsTypeName(method, "System", "ByReference`1"))
                     {
                         var thisRef = _stack.Pop();
-
-                        PushExpression(StackValueKind.ByRef, ((ExpressionEntry)thisRef).Name + "->_value", method.Signature.ReturnType);
+                        PushExpression(StackValueKind.ByRef,
+                            String.Concat("(", GetSignatureTypeNameAndAddReference(method.Signature.ReturnType), ")", ((ExpressionEntry)thisRef).Name, "->_value"),
+                            method.Signature.ReturnType);
                         return true;
                     }
                     break;


### PR DESCRIPTION
This should be tracked as a ByRef.

This was the reason why the compiler was considering `MemoryMarshal.GetNonNullPinnableReference` invalid IL and we were generating a throwing body for it while compiling Hello World.