### PR TITLE
[WIP] Make the generic composition details relative addresses

### DIFF
--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using Internal.NativeFormat;
+using Internal.Runtime.CompilerServices;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -167,6 +169,22 @@ namespace Internal.Runtime
 
                 // Reached end of stream without getting a match. Field is not present so return default value.
                 return uiDefaultValue;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the statically generated data structures use relative pointers.
+        /// </summary>
+        internal static bool SupportsRelativePointers
+        {
+            [Intrinsic]
+            get
+            {
+#if PROJECTN
+                return true;
+#else
+                throw new NotImplementedException();
+#endif
             }
         }
 
@@ -416,11 +434,10 @@ namespace Internal.Runtime
             get
             {
                 Debug.Assert(IsGeneric);
-                uint cbOffset = GetFieldOffset(EETypeField.ETF_GenericDefinition);
-                fixed (EEType* pThis = &this)
-                {
-                    return ((EETypeRef*)((byte*)pThis + cbOffset))->Value;
-                }
+                if (IsDynamicType || !SupportsRelativePointers)
+                    return GetField<IatAwarePointer<EEType>>(EETypeField.ETF_GenericDefinition).Value;
+
+                return GetField<IatAwareRelativePointer<EEType>>(EETypeField.ETF_GenericDefinition).Value;
             }
 #if TYPE_LOADER_IMPLEMENTATION
             set
@@ -435,17 +452,41 @@ namespace Internal.Runtime
 #endif
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        private struct GenericComposition
+        {
+            public readonly ushort Arity;
+
+            private readonly EETypeRef _genericArgument1;
+            public EETypeRef* GenericArguments
+            {
+                get
+                {
+                    fixed (EETypeRef* pArg1 = &this._genericArgument1)
+                    {
+                        return pArg1;
+                    }
+                }
+            }
+
+            public GenericVariance* GenericVariance
+            {
+                get
+                {
+                    return (GenericVariance*)(GenericArguments + Arity);
+                }
+            }
+        }
+
         internal uint GenericArity
         {
             get
             {
                 Debug.Assert(IsGeneric);
-                uint cbOffset = GetFieldOffset(EETypeField.ETF_GenericComposition);
-                fixed (EEType* pThis = &this)
-                {
-                    // Number of generic arguments is the first UInt16 of the composition stream.
-                    return **(ushort**)((byte*)pThis + cbOffset);
-                }
+                if (IsDynamicType || !SupportsRelativePointers)
+                    return GetField<Pointer<GenericComposition>>(EETypeField.ETF_GenericComposition).Value->Arity;
+
+                return GetField<RelativePointer<GenericComposition>>(EETypeField.ETF_GenericComposition).Value->Arity;
             }
         }
 
@@ -454,13 +495,10 @@ namespace Internal.Runtime
             get
             {
                 Debug.Assert(IsGeneric);
-                uint cbOffset = GetFieldOffset(EETypeField.ETF_GenericComposition);
-                fixed (EEType* pThis = &this)
-                {
-                    // Generic arguments follow after a (padded) UInt16 specifying their count
-                    // in the generic composition stream.
-                    return ((*(EETypeRef**)((byte*)pThis + cbOffset)) + 1);
-                }
+                if (IsDynamicType || !SupportsRelativePointers)
+                    return GetField<Pointer<GenericComposition>>(EETypeField.ETF_GenericComposition).Value->GenericArguments;
+
+                return GetField<RelativePointer<GenericComposition>>(EETypeField.ETF_GenericComposition).Value->GenericArguments;
             }
         }
 
@@ -473,12 +511,10 @@ namespace Internal.Runtime
                 if (!HasGenericVariance)
                     return null;
 
-                uint cbOffset = GetFieldOffset(EETypeField.ETF_GenericComposition);
-                fixed (EEType* pThis = &this)
-                {
-                    // Variance info follows immediatelly after the generic arguments
-                    return (GenericVariance*)(GenericArguments + GenericArity);
-                }
+                if (IsDynamicType || !SupportsRelativePointers)
+                    return GetField<Pointer<GenericComposition>>(EETypeField.ETF_GenericComposition).Value->GenericVariance;
+
+                return GetField<RelativePointer<GenericComposition>>(EETypeField.ETF_GenericComposition).Value->GenericVariance;
             }
         }
 
@@ -1300,7 +1336,12 @@ namespace Internal.Runtime
                 return cbOffset;
             }
             if (IsGeneric)
-                cbOffset += (uint)IntPtr.Size;
+            {
+                if ((rareFlags & EETypeRareFlags.IsDynamicTypeFlag) != 0 || !SupportsRelativePointers)
+                    cbOffset += (uint)IntPtr.Size;
+                else
+                    cbOffset += 4;
+            }
 
             if (eField == EETypeField.ETF_GenericComposition)
             {
@@ -1308,7 +1349,12 @@ namespace Internal.Runtime
                 return cbOffset;
             }
             if (IsGeneric)
-                cbOffset += (uint)IntPtr.Size;
+            {
+                if ((rareFlags & EETypeRareFlags.IsDynamicTypeFlag) != 0 || !SupportsRelativePointers)
+                    cbOffset += (uint)IntPtr.Size;
+                else
+                    cbOffset += 4;
+            }
 
             if (eField == EETypeField.ETF_DynamicModule)
             {
@@ -1352,6 +1398,12 @@ namespace Internal.Runtime
 
             Debug.Assert(false, "Unknown EEType field type");
             return 0;
+        }
+
+        public ref T GetField<T>(EETypeField eField)
+        {
+            fixed (EEType* pThis = &this)
+                return ref Unsafe.AddByteOffset(ref Unsafe.As<EEType, T>(ref *pThis), (IntPtr)GetFieldOffset(eField));
         }
 
 #if TYPE_LOADER_IMPLEMENTATION
@@ -1412,6 +1464,84 @@ namespace Internal.Runtime
                 _value = (byte*)value;
             }
 #endif
+        }
+    }
+
+    // Wrapper around pointers
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct Pointer<T> where T : unmanaged
+    {
+        private readonly T* _value;
+
+        public T* Value
+        {
+            get
+            {
+                return _value;
+            }
+        }
+    }
+
+    // Wrapper around pointers that might be indirected through IAT
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct IatAwarePointer<T> where T : unmanaged
+    {
+        private readonly T* _value;
+
+        public T* Value
+        {
+            get
+            {
+                if (((int)_value & IndirectionConstants.IndirectionCellPointer) == 0)
+                    return _value;
+                return *(T**)((byte*)_value - IndirectionConstants.IndirectionCellPointer);
+            }
+        }
+    }
+
+    // Wrapper around relative pointers
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct RelativePointer<T> where T : unmanaged
+    {
+        private readonly int _value;
+
+        public T* Value
+        {
+            get
+            {
+                fixed (int* pValue = &_value)
+                {
+                    return (T*)((byte*)pValue + _value);
+                }
+            }
+        }
+    }
+
+    // Wrapper around relative pointers that might be indirected through IAT
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct IatAwareRelativePointer<T> where T : unmanaged
+    {
+        private readonly int _value;
+
+        public T* Value
+        {
+            get
+            {
+                if ((_value & IndirectionConstants.IndirectionCellPointer) == 0)
+                {
+                    fixed (int* pValue = &_value)
+                    {
+                        return (T*)((byte*)pValue + _value);
+                    }
+                }
+                else
+                {
+                    fixed (int* pValue = &_value)
+                    {
+                        return *(T**)((byte*)pValue + (_value & ~IndirectionConstants.IndirectionCellPointer));
+                    }
+                }
+            }
         }
     }
 

--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -49,7 +49,11 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Jit runtime ABI
         /// </summary>
-        Jit
+        Jit,
+        /// <summary>
+        /// Cross-platform portable C++ codegen
+        /// </summary>
+        CppCodegen,
     }
 
     /// <summary>
@@ -99,6 +103,14 @@ namespace Internal.TypeSystem
                     default:
                         throw new NotSupportedException();
                 }
+            }
+        }
+
+        public bool SupportsRelativePointers
+        {
+            get
+            {
+                return Abi != TargetAbi.CppCodegen;
             }
         }
 

--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -78,6 +78,16 @@ namespace Internal.IL
                             return GetCanonTypeIntrinsic.EmitIL(method);
                     }
                     break;
+                case "EEType":
+                    {
+                        if (owningType.Namespace == "Internal.Runtime" && method.Name == "get_SupportsRelativePointers")
+                        {
+                            ILOpcode value = method.Context.Target.SupportsRelativePointers ?
+                                ILOpcode.ldc_i4_1 : ILOpcode.ldc_i4_0;
+                            return new ILStubMethodIL(method, new byte[] { (byte)value, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
+                        }
+                    }
+                    break;
             }
 
             return null;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -846,7 +846,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (_type.HasInstantiation && !_type.IsTypeDefinition)
             {
-                objData.EmitPointerRelocOrIndirectionReference(factory.NecessaryTypeSymbol(_type.GetTypeDefinition()));
+                IEETypeNode typeDefNode = factory.NecessaryTypeSymbol(_type.GetTypeDefinition());
+                if (factory.Target.SupportsRelativePointers)
+                    objData.EmitRelativeRelocOrIndirectionReference(typeDefNode);
+                else
+                    objData.EmitPointerRelocOrIndirectionReference(typeDefNode);
 
                 GenericCompositionDetails details;
                 if (_type.GetTypeDefinition() == factory.ArrayOfTEnumeratorType)
@@ -864,7 +868,11 @@ namespace ILCompiler.DependencyAnalysis
                 else
                     details = new GenericCompositionDetails(_type);
 
-                objData.EmitPointerReloc(factory.GenericComposition(details));
+                ISymbolNode compositionNode = factory.GenericComposition(details);
+                if (factory.Target.SupportsRelativePointers)
+                    objData.EmitReloc(compositionNode, RelocType.IMAGE_REL_BASED_RELPTR32);
+                else
+                    objData.EmitPointerReloc(compositionNode);
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -69,7 +69,7 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.AddSymbol(this);
 
             // +1 for SyncBlock (in CoreRT static size already includes EEType)
-            Debug.Assert(factory.Target.Abi == TargetAbi.CoreRT);
+            Debug.Assert(factory.Target.Abi == TargetAbi.CoreRT || factory.Target.Abi == TargetAbi.CppCodegen);
             int totalSize = (_gcMap.Size + 1) * _target.PointerSize;
 
             // We only need to check for containsPointers because ThreadStatics are always allocated

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -65,7 +65,7 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             dependencyList.Add(factory.GCStaticsRegion, "GCStatics Region");
-            if (factory.Target.Abi == TargetAbi.CoreRT)
+            if (factory.Target.Abi != TargetAbi.ProjectN)
             {
                 dependencyList.Add(GetGCStaticEETypeNode(factory), "GCStatic EEType");
                 if (_preInitFieldInfos != null)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IndirectionExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Runtime;
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    static class IndirectionExtensions
+    {
+        /// <summary>
+        /// Use this api to generate a reloc to a symbol that may be an indirection cell or not as a pointer
+        /// </summary>
+        /// <param name="symbol">symbol to reference</param>
+        /// <param name="indirectionBit">value to OR in to the reloc to represent to runtime code that this pointer is an indirection. Defaults to IndirectionConstants.IndirectionCellPointer</param>
+        /// <param name="delta">Delta from symbol start for value</param>
+        public static void EmitPointerRelocOrIndirectionReference(ref this ObjectDataBuilder builder, ISymbolNode symbol, int delta = 0, int indirectionBit = IndirectionConstants.IndirectionCellPointer)
+        {
+            if (symbol.RepresentsIndirectionCell)
+                delta |= indirectionBit;
+
+            builder.EmitReloc(symbol, (builder.TargetPointerSize == 8) ? RelocType.IMAGE_REL_BASED_DIR64 : RelocType.IMAGE_REL_BASED_HIGHLOW, delta);
+        }
+
+        public static void EmitRelativeRelocOrIndirectionReference(ref this ObjectDataBuilder builder, ISymbolNode symbol, int delta = 0, int indirectionBit = IndirectionConstants.IndirectionCellPointer)
+        {
+            if (symbol.RepresentsIndirectionCell)
+                delta = delta | indirectionBit;
+
+            builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_RELPTR32, delta);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using Internal.TypeSystem;
-using Internal.Runtime;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -290,20 +289,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public void EmitPointerReloc(ISymbolNode symbol, int delta = 0)
         {
-            EmitReloc(symbol, (_target.PointerSize == 8) ? RelocType.IMAGE_REL_BASED_DIR64 : RelocType.IMAGE_REL_BASED_HIGHLOW, delta);
-        }
-
-        /// <summary>
-        /// Use this api to generate a reloc to a symbol that may be an indirection cell or not as a pointer
-        /// </summary>
-        /// <param name="symbol">symbol to reference</param>
-        /// <param name="indirectionBit">value to OR in to the reloc to represent to runtime code that this pointer is an indirection. Defaults to IndirectionConstants.IndirectionCellPointer</param>
-        /// <param name="delta">Delta from symbol start for value</param>
-        public void EmitPointerRelocOrIndirectionReference(ISymbolNode symbol, int indirectionBit = IndirectionConstants.IndirectionCellPointer, int delta = 0)
-        {
-            if (symbol.RepresentsIndirectionCell)
-                delta |= indirectionBit;
-
             EmitReloc(symbol, (_target.PointerSize == 8) ? RelocType.IMAGE_REL_BASED_DIR64 : RelocType.IMAGE_REL_BASED_HIGHLOW, delta);
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -20,7 +20,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public ThreadStaticsNode(MetadataType type, NodeFactory factory)
         {
-            Debug.Assert(factory.Target.Abi == TargetAbi.CoreRT);
+            Debug.Assert(factory.Target.Abi == TargetAbi.CoreRT || factory.Target.Abi == TargetAbi.CppCodegen);
             _type = type;
         }
 

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Compiler\DependencyAnalysis\DefaultConstructorMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsWithIndirectionImportedNodeProvider.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\IndirectionExtensions.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MrtImportImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MrtImports.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MrtProcessedExportAddressTableNode.cs" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -278,7 +278,8 @@ namespace ILCompiler
 
             // TODO: compiler switch for SIMD support?
             var simdVectorLength = (_isCppCodegen || _isWasmCodegen) ? SimdVectorLength.None : SimdVectorLength.Vector128Bit;
-            var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT, simdVectorLength);
+            var targetAbi = _isCppCodegen ? TargetAbi.CppCodegen : TargetAbi.CoreRT;
+            var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, targetAbi, simdVectorLength);
             var typeSystemContext = new CompilerTypeSystemContext(targetDetails, genericsMode);
 
             //

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -568,23 +568,7 @@ public:
     bool HasDynamicallyAllocatedDispatchMap()
         { return (get_RareFlags() & HasDynamicallyAllocatedDispatchMapFlag) != 0; }
 
-    // Retrieve the generic type definition EEType for this generic instance
-    void set_GenericDefinition(EEType *pTypeDef);
-
-    // Retrieve the generic type definition EEType for this generic instance
-    EETypeRef & get_GenericDefinition();
-
     inline void set_GenericComposition(GenericComposition *);
-    inline GenericComposition *get_GenericComposition();
-
-    // Retrieve the number of generic arguments for this generic type instance
-    UInt32 get_GenericArity();
-
-    // Retrieve the generic arguments to this type
-    EETypeRef * get_GenericArguments();
-
-    // Retrieve the generic variance associated with this type
-    GenericVarianceType* get_GenericVariance();
 
     // Retrieve template used to create the dynamic type
     EEType * get_DynamicTemplateType();

--- a/src/Native/Runtime/inc/eetype.inl
+++ b/src/Native/Runtime/inc/eetype.inl
@@ -372,63 +372,13 @@ inline UInt8 EEType::GetNullableValueOffset()
     return pOptFields->GetNullableValueOffset(0) + 1;
 }
 
-inline void EEType::set_GenericDefinition(EEType *pTypeDef)
-{
-    ASSERT(IsGeneric());
-
-    UInt32 cbOffset = GetFieldOffset(ETF_GenericDefinition);
-
-    *(EEType**)((UInt8*)this + cbOffset) = pTypeDef;
-}
-
-inline EETypeRef & EEType::get_GenericDefinition()
-{
-    ASSERT(IsGeneric());
-
-    UInt32 cbOffset = GetFieldOffset(ETF_GenericDefinition);
-
-    return *(EETypeRef *)((UInt8*)this + cbOffset);
-}
-
 inline void EEType::set_GenericComposition(GenericComposition *pGenericComposition)
 {
-    ASSERT(IsGeneric());
+    ASSERT(IsGeneric() && IsDynamicType());
 
     UInt32 cbOffset = GetFieldOffset(ETF_GenericComposition);
 
     *(GenericComposition **)((UInt8*)this + cbOffset) = pGenericComposition;
-}
-
-inline GenericComposition *EEType::get_GenericComposition()
-{
-    ASSERT(IsGeneric());
-
-    UInt32 cbOffset = GetFieldOffset(ETF_GenericComposition);
-
-    GenericComposition *pGenericComposition = *(GenericComposition **)((UInt8*)this + cbOffset);
-
-    return pGenericComposition;
-}
-
-inline UInt32 EEType::get_GenericArity()
-{
-    GenericComposition *pGenericComposition = get_GenericComposition();
-
-    return pGenericComposition->GetArity();
-}
-
-inline EETypeRef* EEType::get_GenericArguments()
-{
-    GenericComposition *pGenericComposition = get_GenericComposition();
-
-    return pGenericComposition->GetArguments();
-}
-
-inline GenericVarianceType* EEType::get_GenericVariance()
-{
-    GenericComposition *pGenericComposition = get_GenericComposition();
-
-    return pGenericComposition->GetVariance();
 }
 
 inline EEType * EEType::get_DynamicTemplateType()
@@ -570,7 +520,7 @@ inline DynamicModule * EEType::get_DynamicModule()
         + (fRequiresOptionalFields ? sizeof(UIntTarget) : 0)
         + (fRequiresNullableType ? sizeof(UIntTarget) : 0)
         + (fHasSealedVirtuals ? sizeof(Int32) : 0)
-        + (fHasGenericInfo ? sizeof(UIntTarget)*2 : 0);
+        + (fHasGenericInfo ? sizeof(UInt32)*2 : 0);
 }
 
 #if !defined(BINDER) && !defined(DACCESS_COMPILE)
@@ -673,7 +623,7 @@ __forceinline UInt32 EEType::GetFieldOffset(EETypeField eField)
         return cbOffset;
     }
     if (IsGeneric())
-        cbOffset += sizeof(UIntTarget);
+        cbOffset += (IsDynamicType() ? sizeof(UIntTarget) : sizeof(UInt32));
 
     if (eField == ETF_GenericComposition)
     {
@@ -681,7 +631,7 @@ __forceinline UInt32 EEType::GetFieldOffset(EETypeField eField)
         return cbOffset;
     }
     if (IsGeneric())
-        cbOffset += sizeof(UIntTarget);
+        cbOffset += (IsDynamicType() ? sizeof(UIntTarget) : sizeof(UInt32));
 
     if (eField == ETF_DynamicModule)
     {
@@ -795,7 +745,7 @@ __forceinline UInt32 EEType::GetFieldOffset(EETypeField eField)
         {
             return cbOffset;
         }
-        cbOffset += sizeof(UIntTarget);
+        cbOffset += sizeof(UInt32);
 
         if (eField == ETF_GenericComposition)
         {

--- a/src/Runtime.Base/src/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/Runtime.Base/src/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -21,8 +21,22 @@ namespace Internal.Runtime.CompilerServices
     /// <summary>
     /// Contains generic, low-level functionality for manipulating pointers.
     /// </summary>
-    public static class Unsafe
+    public static unsafe class Unsafe
     {
+        /// <summary>
+        /// Returns a pointer to the given by-ref parameter.
+        /// </summary>
+        [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void* AsPointer<T>(ref T value)
+        {
+            throw new PlatformNotSupportedException();
+
+            // ldarg.0
+            // conv.u
+            // ret
+        }
+
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int SizeOf<T>()
@@ -82,6 +96,16 @@ namespace Internal.Runtime.CompilerServices
         public static ref T Add<T>(ref T source, int elementOffset)
         {
             return ref AddByteOffset(ref source, (IntPtr)(elementOffset * (nint)SizeOf<T>()));
+        }
+
+        /// <summary>
+        /// Reinterprets the given location as a reference to a value of type <typeparamref name="T"/>.
+        /// </summary>
+        [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T AsRef<T>(in T source)
+        {
+            throw new PlatformNotSupportedException();
         }
     }
 }

--- a/src/Runtime.Base/src/Runtime.Base.csproj
+++ b/src/Runtime.Base/src/Runtime.Base.csproj
@@ -77,6 +77,7 @@
     <Compile Include="System\Runtime\CompilerServices\MethodImplAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpers.cs" />
     <Compile Include="System\Runtime\CompilerServices\UnsafeValueTypeAttribute.cs" />
+    <Compile Include="System\Runtime\InteropServices\UnmanagedType.cs" />
     <Compile Include="System\Runtime\InteropServices\CallingConvention.cs" />
     <Compile Include="System\Runtime\InteropServices\CharSet.cs" />
     <Compile Include="System\Runtime\InteropServices\DllImportAttribute.cs" />

--- a/src/Runtime.Base/src/System/Runtime/InteropServices/UnmanagedType.cs
+++ b/src/Runtime.Base/src/System/Runtime/InteropServices/UnmanagedType.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.InteropServices
+{
+    internal class UnmanagedType { }
+}

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/McgIntrinsics.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/McgIntrinsics.cs
@@ -5,6 +5,13 @@
 
 using System;
 
+namespace System.Runtime.CompilerServices
+{
+    internal sealed class IntrinsicAttribute : Attribute
+    {
+    }
+}
+
 namespace System.Runtime.InteropServices
 {
     [AttributeUsage((System.AttributeTargets.Method | System.AttributeTargets.Class))]

--- a/src/Test.CoreLib/src/Test.CoreLib.csproj
+++ b/src/Test.CoreLib/src/Test.CoreLib.csproj
@@ -75,6 +75,9 @@
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\InteropServices\UnsafeGCHandle.cs">
       <Link>Runtime.Base\src\System\Runtime\InteropServices\UnsafeGCHandle.cs</Link>
     </Compile>
+    <Compile Include="..\..\Runtime.Base\src\System\Runtime\InteropServices\UnmanagedType.cs">
+      <Link>Runtime.Base\src\System\Runtime\InteropServices\UnmanagedType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Runtime.Base\src\RhBaseName.cs">
       <Link>Runtime.Base\src\RhBaseName.cs</Link>
     </Compile>


### PR DESCRIPTION
Marking this as WIP because eventually I'll need to submit this through the TFS side and update rhbind as well. I would like to do most of the code review through Git though because CoreRT is just a nicer place to prototype in.

I'm looking at size regressions between .NET Native 1.7 and the current mainline branch. A thing that stood out is universally bigger EETypes. A contributor to this was getting rid of GenericInstanceDescs between 1.7 and 2.0 and replacing them by direct references to generic composition details from the EEType. Size-wise, this was mostly a wash, but we can actually do better - these new fields are not critical to be pointer-sized.

This change turns them into relative pointers. This saves 33 kB on a hello world app. I expect around 100 kB savings on the UWP People app based on my back-of-the-envelope calculation.

We could apply the same treatment to the optional fields pointer and the generic composition data.