### PR TITLE
Produce image with executable Main

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedObjectNode.cs
@@ -43,13 +43,13 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        internal void InitializeOffsetFromBeginningOfArray(int offset)
+        public void InitializeOffsetFromBeginningOfArray(int offset)
         {
             Debug.Assert(_offset == InvalidOffset || _offset == offset);
             _offset = offset;
         }
 
-        internal void InitializeIndexFromBeginningOfArray(int index)
+        public void InitializeIndexFromBeginningOfArray(int index)
         {
             Debug.Assert(_index == InvalidOffset || _index == index);
             _index = index;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.DependencyAnalysis
         /// </summary>
         public TTarget Target => _targetNode;
 
-        internal EmbeddedPointerIndirectionNode(TTarget target)
+        protected internal EmbeddedPointerIndirectionNode(TTarget target)
         {
             _targetNode = target;
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/FixupConstants.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/FixupConstants.cs
@@ -1,0 +1,214 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public enum CorCompileImportType : byte
+    {
+        CORCOMPILE_IMPORT_TYPE_UNKNOWN = 0,
+        CORCOMPILE_IMPORT_TYPE_EXTERNAL_METHOD = 1,
+        CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH = 2,
+        CORCOMPILE_IMPORT_TYPE_STRING_HANDLE = 3,
+        CORCOMPILE_IMPORT_TYPE_TYPE_HANDLE = 4,
+        CORCOMPILE_IMPORT_TYPE_METHOD_HANDLE = 5,
+        CORCOMPILE_IMPORT_TYPE_VIRTUAL_METHOD = 6,
+    };
+
+    public enum CorCompileImportFlags : ushort
+    {
+        CORCOMPILE_IMPORT_FLAGS_EAGER = 0x0001,   // Section at module load time.
+        CORCOMPILE_IMPORT_FLAGS_CODE = 0x0002,   // Section contains code.
+        CORCOMPILE_IMPORT_FLAGS_PCODE = 0x0004,   // Section contains pointers to code.
+    };
+
+    public enum ReadyToRunFixupKind
+    {
+        READYTORUN_FIXUP_ThisObjDictionaryLookup = 0x07,
+        READYTORUN_FIXUP_TypeDictionaryLookup = 0x08,
+        READYTORUN_FIXUP_MethodDictionaryLookup = 0x09,
+
+        READYTORUN_FIXUP_TypeHandle = 0x10,
+        READYTORUN_FIXUP_MethodHandle = 0x11,
+        READYTORUN_FIXUP_FieldHandle = 0x12,
+
+        READYTORUN_FIXUP_MethodEntry = 0x13, /* For calling a method entry point */
+        READYTORUN_FIXUP_MethodEntry_DefToken = 0x14, /* Smaller version of MethodEntry - method is def token */
+        READYTORUN_FIXUP_MethodEntry_RefToken = 0x15, /* Smaller version of MethodEntry - method is ref token */
+
+        READYTORUN_FIXUP_VirtualEntry = 0x16, /* For invoking a virtual method */
+        READYTORUN_FIXUP_VirtualEntry_DefToken = 0x17, /* Smaller version of VirtualEntry - method is def token */
+        READYTORUN_FIXUP_VirtualEntry_RefToken = 0x18, /* Smaller version of VirtualEntry - method is ref token */
+        READYTORUN_FIXUP_VirtualEntry_Slot = 0x19, /* Smaller version of VirtualEntry - type & slot */
+
+        READYTORUN_FIXUP_Helper = 0x1A, /* Helper */
+        READYTORUN_FIXUP_StringHandle = 0x1B, /* String handle */
+
+        READYTORUN_FIXUP_NewObject = 0x1C, /* Dynamically created new helper */
+        READYTORUN_FIXUP_NewArray = 0x1D,
+
+        READYTORUN_FIXUP_IsInstanceOf = 0x1E, /* Dynamically created casting helper */
+        READYTORUN_FIXUP_ChkCast = 0x1F,
+
+        READYTORUN_FIXUP_FieldAddress = 0x20, /* For accessing a cross-module static fields */
+        READYTORUN_FIXUP_CctorTrigger = 0x21, /* Static constructor trigger */
+
+        READYTORUN_FIXUP_StaticBaseNonGC = 0x22, /* Dynamically created static base helpers */
+        READYTORUN_FIXUP_StaticBaseGC = 0x23,
+        READYTORUN_FIXUP_ThreadStaticBaseNonGC = 0x24,
+        READYTORUN_FIXUP_ThreadStaticBaseGC = 0x25,
+
+        READYTORUN_FIXUP_FieldBaseOffset = 0x26, /* Field base offset */
+        READYTORUN_FIXUP_FieldOffset = 0x27, /* Field offset */
+
+        READYTORUN_FIXUP_TypeDictionary = 0x28,
+        READYTORUN_FIXUP_MethodDictionary = 0x29,
+
+        READYTORUN_FIXUP_Check_TypeLayout = 0x2A, /* size, alignment, HFA, reference map */
+        READYTORUN_FIXUP_Check_FieldOffset = 0x2B,
+
+        READYTORUN_FIXUP_DelegateCtor = 0x2C, /* optimized delegate ctor */
+        READYTORUN_FIXUP_DeclaringTypeHandle = 0x2D,
+    };
+
+    //
+    // Intrinsics and helpers
+    //
+
+    public enum ReadyToRunHelper
+    {
+        READYTORUN_HELPER_Invalid = 0x00,
+
+        // Not a real helper - handle to current module passed to delay load helpers.
+        READYTORUN_HELPER_Module = 0x01,
+        READYTORUN_HELPER_GSCookie = 0x02,
+
+        //
+        // Delay load helpers
+        //
+
+        // All delay load helpers use custom calling convention:
+        // - scratch register - address of indirection cell. 0 = address is inferred from callsite.
+        // - stack - section index, module handle
+        READYTORUN_HELPER_DelayLoad_MethodCall = 0x08,
+
+        READYTORUN_HELPER_DelayLoad_Helper = 0x10,
+        READYTORUN_HELPER_DelayLoad_Helper_Obj = 0x11,
+        READYTORUN_HELPER_DelayLoad_Helper_ObjObj = 0x12,
+
+        // JIT helpers
+
+        // Exception handling helpers
+        READYTORUN_HELPER_Throw = 0x20,
+        READYTORUN_HELPER_Rethrow = 0x21,
+        READYTORUN_HELPER_Overflow = 0x22,
+        READYTORUN_HELPER_RngChkFail = 0x23,
+        READYTORUN_HELPER_FailFast = 0x24,
+        READYTORUN_HELPER_ThrowNullRef = 0x25,
+        READYTORUN_HELPER_ThrowDivZero = 0x26,
+
+        // Write barriers
+        READYTORUN_HELPER_WriteBarrier = 0x30,
+        READYTORUN_HELPER_CheckedWriteBarrier = 0x31,
+        READYTORUN_HELPER_ByRefWriteBarrier = 0x32,
+
+        // Array helpers
+        READYTORUN_HELPER_Stelem_Ref = 0x38,
+        READYTORUN_HELPER_Ldelema_Ref = 0x39,
+
+        READYTORUN_HELPER_MemSet = 0x40,
+        READYTORUN_HELPER_MemCpy = 0x41,
+
+        // Get string handle lazily
+        READYTORUN_HELPER_GetString = 0x50,
+
+        // Used by /Tuning for Profile optimizations
+        READYTORUN_HELPER_LogMethodEnter = 0x51,
+
+        // Reflection helpers
+        READYTORUN_HELPER_GetRuntimeTypeHandle = 0x54,
+        READYTORUN_HELPER_GetRuntimeMethodHandle = 0x55,
+        READYTORUN_HELPER_GetRuntimeFieldHandle = 0x56,
+
+        READYTORUN_HELPER_Box = 0x58,
+        READYTORUN_HELPER_Box_Nullable = 0x59,
+        READYTORUN_HELPER_Unbox = 0x5A,
+        READYTORUN_HELPER_Unbox_Nullable = 0x5B,
+        READYTORUN_HELPER_NewMultiDimArr = 0x5C,
+        READYTORUN_HELPER_NewMultiDimArr_NonVarArg = 0x5D,
+
+        // Helpers used with generic handle lookup cases
+        READYTORUN_HELPER_NewObject = 0x60,
+        READYTORUN_HELPER_NewArray = 0x61,
+        READYTORUN_HELPER_CheckCastAny = 0x62,
+        READYTORUN_HELPER_CheckInstanceAny = 0x63,
+        READYTORUN_HELPER_GenericGcStaticBase = 0x64,
+        READYTORUN_HELPER_GenericNonGcStaticBase = 0x65,
+        READYTORUN_HELPER_GenericGcTlsBase = 0x66,
+        READYTORUN_HELPER_GenericNonGcTlsBase = 0x67,
+        READYTORUN_HELPER_VirtualFuncPtr = 0x68,
+
+        // Long mul/div/shift ops
+        READYTORUN_HELPER_LMul = 0xC0,
+        READYTORUN_HELPER_LMulOfv = 0xC1,
+        READYTORUN_HELPER_ULMulOvf = 0xC2,
+        READYTORUN_HELPER_LDiv = 0xC3,
+        READYTORUN_HELPER_LMod = 0xC4,
+        READYTORUN_HELPER_ULDiv = 0xC5,
+        READYTORUN_HELPER_ULMod = 0xC6,
+        READYTORUN_HELPER_LLsh = 0xC7,
+        READYTORUN_HELPER_LRsh = 0xC8,
+        READYTORUN_HELPER_LRsz = 0xC9,
+        READYTORUN_HELPER_Lng2Dbl = 0xCA,
+        READYTORUN_HELPER_ULng2Dbl = 0xCB,
+
+        // 32-bit division helpers
+        READYTORUN_HELPER_Div = 0xCC,
+        READYTORUN_HELPER_Mod = 0xCD,
+        READYTORUN_HELPER_UDiv = 0xCE,
+        READYTORUN_HELPER_UMod = 0xCF,
+
+        // Floating point conversions
+        READYTORUN_HELPER_Dbl2Int = 0xD0,
+        READYTORUN_HELPER_Dbl2IntOvf = 0xD1,
+        READYTORUN_HELPER_Dbl2Lng = 0xD2,
+        READYTORUN_HELPER_Dbl2LngOvf = 0xD3,
+        READYTORUN_HELPER_Dbl2UInt = 0xD4,
+        READYTORUN_HELPER_Dbl2UIntOvf = 0xD5,
+        READYTORUN_HELPER_Dbl2ULng = 0xD6,
+        READYTORUN_HELPER_Dbl2ULngOvf = 0xD7,
+
+        // Floating point ops
+        READYTORUN_HELPER_DblRem = 0xE0,
+        READYTORUN_HELPER_FltRem = 0xE1,
+        READYTORUN_HELPER_DblRound = 0xE2,
+        READYTORUN_HELPER_FltRound = 0xE3,
+
+        // Personality rountines
+        READYTORUN_HELPER_PersonalityRoutine = 0xF0,
+        READYTORUN_HELPER_PersonalityRoutineFilterFunclet = 0xF1,
+
+        //
+        // Deprecated/legacy
+        //
+
+        // JIT32 x86-specific write barriers
+        READYTORUN_HELPER_WriteBarrier_EAX = 0x100,
+        READYTORUN_HELPER_WriteBarrier_EBX = 0x101,
+        READYTORUN_HELPER_WriteBarrier_ECX = 0x102,
+        READYTORUN_HELPER_WriteBarrier_ESI = 0x103,
+        READYTORUN_HELPER_WriteBarrier_EDI = 0x104,
+        READYTORUN_HELPER_WriteBarrier_EBP = 0x105,
+        READYTORUN_HELPER_CheckedWriteBarrier_EAX = 0x106,
+        READYTORUN_HELPER_CheckedWriteBarrier_EBX = 0x107,
+        READYTORUN_HELPER_CheckedWriteBarrier_ECX = 0x108,
+        READYTORUN_HELPER_CheckedWriteBarrier_ESI = 0x109,
+        READYTORUN_HELPER_CheckedWriteBarrier_EDI = 0x10A,
+        READYTORUN_HELPER_CheckedWriteBarrier_EBP = 0x10B,
+
+        // JIT32 x86-specific exception handling
+        READYTORUN_HELPER_EndCatch = 0x110,
+    };
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/HelperSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/HelperSignature.cs
@@ -20,13 +20,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            ObjectDataBuilder dataBuilder = new ObjectDataBuilder();
-            dataBuilder.AddSymbol(this);
-
-            dataBuilder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_Helper);
-            dataBuilder.EmitByte((byte)_helper);
-
-            return dataBuilder.ToObjectData();
+            return new ObjectData(
+                new[] { (byte)ReadyToRunFixupKind.READYTORUN_FIXUP_Helper, (byte)_helper },
+                Array.Empty<Relocation>(),
+                1,
+                new ISymbolDefinitionNode[] { this });
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/HelperSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/HelperSignature.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class ReadyToRunHelperSignature : Signature
+    {
+        private ReadyToRunHelper _helper;
+
+        public ReadyToRunHelperSignature(ReadyToRunHelper helper)
+        {
+            _helper = helper;
+        }
+
+        protected override int ClassCode => 208107954;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder dataBuilder = new ObjectDataBuilder();
+            dataBuilder.AddSymbol(this);
+
+            dataBuilder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_Helper);
+            dataBuilder.EmitByte((byte)_helper);
+
+            return dataBuilder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append("ReadyToRunHelper_");
+            sb.Append(_helper.ToString());
+        }
+
+        protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
+        {
+            return _helper.CompareTo(((ReadyToRunHelperSignature)other)._helper);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/Import.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/Import.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public abstract class Import : EmbeddedObjectNode
+    {
+        public abstract EmbeddedPointerIndirectionNode<Signature> GetSignature(NodeFactory factory);
+    }
+
+    public class ModuleImport : Import
+    {
+        EmbeddedPointerIndirectionNode<Signature> _signature;
+
+        public ModuleImport()
+        {
+            _signature = new RvaEmbeddedPointerIndirectionNode<Signature>(new ReadyToRunHelperSignature(ReadyToRunHelper.READYTORUN_HELPER_Module));
+        }
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override int ClassCode => throw new NotImplementedException();
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            // This needs to be an empty target pointer since it will be filled in with Module*
+            // when loaded by CoreCLR
+            dataBuilder.EmitZeroPointer();
+        }
+
+        public override EmbeddedPointerIndirectionNode<Signature> GetSignature(NodeFactory factory)
+        {
+            //
+            // Todo: Get this from factory once we decide on the API for making signatures
+            //
+            return _signature;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            var signature = GetSignature(factory);
+            if (signature != null)
+                yield return new DependencyListEntry(signature, "Signature for ready-to-run fixup import");
+        }
+
+        protected override string GetName(NodeFactory context)
+        {
+            return "ModuleImport";
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
@@ -9,8 +9,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class ImportSectionNode : EmbeddedObjectNode
     {
-        private ArrayOfEmbeddedDataNode<Import> _imports;
-        private ArrayOfEmbeddedPointersNode<Signature> _signatures;
+        private readonly ArrayOfEmbeddedDataNode<Import> _imports;
+        private readonly ArrayOfEmbeddedPointersNode<Signature> _signatures;
         private readonly CorCompileImportType _type;
         private readonly CorCompileImportFlags _flags;
         private readonly byte _entrySize;
@@ -27,14 +27,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         
         private string NodeIdentifier => $"_{_type}_{_flags}_{_entrySize}";
 
-        public void AddImport(NodeFactory factory, Import import)
+        public void AddImport(ReadyToRunCodegenNodeFactory factory, Import import)
         {
             _imports.AddEmbeddedObject(import);
 
             var signature = import.GetSignature(factory);
             if (signature != null)
             {
-                _signatures.AddEmbeddedObject(signature);
+                _signatures.AddEmbeddedObject(factory.SignatureIndirection(signature));
             }
         }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
@@ -30,12 +30,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public void AddImport(ReadyToRunCodegenNodeFactory factory, Import import)
         {
             _imports.AddEmbeddedObject(import);
-
-            var signature = import.GetSignature(factory);
-            if (signature != null)
-            {
-                _signatures.AddEmbeddedObject(factory.SignatureIndirection(signature));
-            }
+            _signatures.AddEmbeddedObject(factory.SignatureIndirection(import.GetSignature(factory)));
         }
 
         public override bool StaticDependenciesAreComputed => true;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class ImportSectionNode : EmbeddedObjectNode
+    {
+        private ArrayOfEmbeddedDataNode<Import> _imports;
+        private ArrayOfEmbeddedPointersNode<Signature> _signatures;
+        private readonly CorCompileImportType _type;
+        private readonly CorCompileImportFlags _flags;
+        private readonly byte _entrySize;
+
+        public ImportSectionNode(CorCompileImportType importType, CorCompileImportFlags flags, byte entrySize)
+        {
+            _type = importType;
+            _flags = flags;
+            _entrySize = entrySize;
+
+            _imports = new ArrayOfEmbeddedDataNode<Import>($"imports_{NodeIdentifier}_start", $"imports_{NodeIdentifier}_end", null);
+            _signatures = new ArrayOfEmbeddedPointersNode<Signature>($"signaures_{NodeIdentifier}_start", $"signatures_{NodeIdentifier}_end", null);
+        }
+        
+        private string NodeIdentifier => $"_{_type}_{_flags}_{_entrySize}";
+
+        public void AddImport(NodeFactory factory, Import import)
+        {
+            _imports.AddEmbeddedObject(import);
+
+            var signature = import.GetSignature(factory);
+            if (signature != null)
+            {
+                _signatures.AddEmbeddedObject(signature);
+            }
+        }
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override int ClassCode => -62839441;
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            dataBuilder.EmitReloc(_imports.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, 0);
+            if (!relocsOnly)
+                dataBuilder.EmitInt(_imports.GetData(factory, false).Data.Length);
+
+            dataBuilder.EmitShort((short)_flags);
+            dataBuilder.EmitByte((byte)_type);
+            dataBuilder.EmitByte(_entrySize);
+            if (!_signatures.ShouldSkipEmittingObjectNode(factory))
+            {
+                dataBuilder.EmitReloc(_signatures.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, 0);
+            }
+            else
+            {
+                dataBuilder.EmitUInt(0);
+            }
+            
+            dataBuilder.EmitUInt(0);
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            yield return new DependencyListEntry(_imports, "Import section fixup data");
+            yield return new DependencyListEntry(_signatures, "Import section signatures");
+        }
+
+        protected override string GetName(NodeFactory context)
+        {
+            return $"ImportSectionNode_{NodeIdentifier}";
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/Signature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/Signature.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public abstract class Signature : ObjectNode, ISymbolDefinitionNode, ISortableSymbolNode
+    {
+        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override bool IsShareable => true;
+        public override bool StaticDependenciesAreComputed => true;
+
+        public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
+        public int Offset => 0;
+        int ISortableSymbolNode.ClassCode => ClassCode;
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        int ISortableSymbolNode.CompareToImpl(ISortableSymbolNode other, CompilerComparer comparer)
+        {
+            return CompareToImpl((SortableDependencyNode)other, comparer);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -75,7 +75,15 @@ namespace ILCompiler.DependencyAnalysis
             Header.Add(Internal.Runtime.ReadyToRunSectionType.AvailableTypes, TypesTable, TypesTable);
 
             ImportSectionsTable = new ImportSectionsTableNode(Target);
-            Header.Add(Internal.Runtime.ReadyToRunSectionType.ImportSections, ImportSectionsTable, ImportSectionsTable);
+            Header.Add(Internal.Runtime.ReadyToRunSectionType.ImportSections, ImportSectionsTable, ImportSectionsTable.StartSymbol);
+
+            ImportSectionNode eagerImports = new ImportSectionNode(CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN, CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_EAGER, (byte)Target.PointerSize);
+            ImportSectionsTable.AddEmbeddedObject(eagerImports);
+
+            // All ready-to-run images have a module import helper which gets patched by the runtime on image load
+            var moduleImport = new ModuleImport();
+            eagerImports.AddImport(this, moduleImport);
+            graph.AddRoot(moduleImport, "Module import is always generated");
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -24,7 +24,10 @@ namespace ILCompiler.DependencyAnalysis
                   dictionaryLayoutProvider, 
                   new ImportedNodeProviderThrowing())
         {
-            
+            _signatureIndirectionNodes = new NodeCache<Signature, EmbeddedPointerIndirectionNode<Signature>>((Signature signature) =>
+            {
+                return new RvaEmbeddedPointerIndirectionNode<Signature>(signature);
+            });
         }
 
         public HeaderNode Header;
@@ -52,6 +55,13 @@ namespace ILCompiler.DependencyAnalysis
         protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
         {
             throw new NotImplementedException();
+        }
+
+        private NodeCache<Signature, EmbeddedPointerIndirectionNode<Signature>> _signatureIndirectionNodes;
+
+        public EmbeddedPointerIndirectionNode<Signature> SignatureIndirection(Signature signature)
+        {
+            return _signatureIndirectionNodes.GetOrAdd(signature);
         }
 
         public override void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/RvaEmbeddedPointerIndirectionNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/RvaEmbeddedPointerIndirectionNode.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    class RvaEmbeddedPointerIndirectionNode<TTarget> : EmbeddedPointerIndirectionNode<TTarget>
+        where TTarget : ISortableSymbolNode
+    {
+        public RvaEmbeddedPointerIndirectionNode(TTarget target)
+            : base(target) { }
+
+        protected override string GetName(NodeFactory factory) => $"Embedded pointer to {Target.GetMangledName(factory.NameMangler)}";
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            return new[]
+            {
+                    new DependencyListEntry(Target, "reloc"),
+                };
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            dataBuilder.RequireInitialPointerAlignment();
+            dataBuilder.EmitReloc(Target, RelocType.IMAGE_REL_BASED_ADDR32NB);
+        }
+
+        protected override int ClassCode => -66002498;
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/RvaEmbeddedPointerIndirectionNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/RvaEmbeddedPointerIndirectionNode.cs
@@ -18,8 +18,8 @@ namespace ILCompiler.DependencyAnalysis
         {
             return new[]
             {
-                    new DependencyListEntry(Target, "reloc"),
-                };
+                new DependencyListEntry(Target, "reloc"),
+            };
         }
 
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -27,15 +27,21 @@
   
   <ItemGroup>
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\FixupConstants.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ImportSectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunCodegenNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ByteArrayComparer.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CompilerIdentifierNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\HeaderNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\HelperSignature.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Import.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ImportSectionsTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\InstanceEntryPointTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodEntryPointTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RuntimeFunctionsTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Signature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypesTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\RvaEmbeddedPointerIndirectionNode.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilation.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilationBuilder.cs" />
     <Compile Include="Compiler\ReadyToRunNodeMangler.cs" />

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/SectionBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/SectionBuilder.cs
@@ -320,13 +320,17 @@ namespace ILCompiler.PEWriter
         {
             Section section = _sections[sectionIndex];
 
-            // Calculate alignment padding
-            int alignedOffset = (section.Content.Count + objectData.Alignment - 1) & -objectData.Alignment;
-            int padding = alignedOffset - section.Content.Count;
-
-            if (padding > 0)
+            // Calculate alignment padding - apparently ObjectDataBuilder can produce an alignment of 0
+            int alignedOffset = section.Content.Count;
+            if (objectData.Alignment > 1)
             {
-                section.Content.WriteBytes(0, padding);
+                alignedOffset = (section.Content.Count + objectData.Alignment - 1) & -objectData.Alignment;
+                int padding = alignedOffset - section.Content.Count;
+
+                if (padding > 0)
+                {
+                    section.Content.WriteBytes(0, padding);
+                }
             }
 
             section.Content.WriteBytes(objectData.Data);
@@ -341,7 +345,7 @@ namespace ILCompiler.PEWriter
                 }
             }
 
-            if (objectData.Relocs != null)
+            if (objectData.Relocs != null && objectData.Relocs.Length != 0)
             {
                 section.Relocations.Add(new ObjectDataRelocations(alignedOffset, objectData.Relocs));
             }


### PR DESCRIPTION
Define nodes for some of the key data strucures emitted into the
ready-to-run image. This includes `ImportSectionNode` which contains
imports of a like kind (ie, eager fixups) along with optionally a set of
signatures describing the import target.

Currently we emit the module import cell and can specialize from here
adding others.

Fix an alignment issue where the SectionBuilder didn't understand zero
alignment. Maybe the default should just be 1.