### PR TITLE
Fix handling of StdCall intrinsic

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -246,7 +246,7 @@ namespace Internal.IL
                 if (((MetadataType)method.OwningType).HasCustomAttribute("System.Runtime.InteropServices", "McgIntrinsicsAttribute"))
                 {
                     var name = method.Name;
-                    if (name == "Call" || name == "StdCall")
+                    if (name == "Call" || name.StartsWith("StdCall"))
                     {
                         return CalliIntrinsic.EmitIL(method);
                     }

--- a/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
@@ -18,7 +18,7 @@ namespace Internal.IL.Stubs
     {
         public static MethodIL EmitIL(MethodDesc target)
         {
-            Debug.Assert(target.Name == "Call" || target.Name == "StdCall");
+            Debug.Assert(target.Name == "Call" || target.Name.StartsWith("StdCall"));
             Debug.Assert(target.Signature.Length > 0
                 && target.Signature[0] == target.Context.GetWellKnownType(WellKnownType.IntPtr));
 


### PR DESCRIPTION
The Project N compiler only needs the prefix to match, so matching the behavior here. dotnet/csharplang#1685 can't come soon enough.

https://github.com/dotnet/corert/blob/7246a7a5f32f44dc12b8a538383a4bbc7cc26d91/src/System.Private.Interop/src/Shared/McgIntrinsics.cs#L59-L67

Fixes #6042.