### PR TITLE
Add back most CreateInstance APIs to AppDomain and Activator

### DIFF
--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -148,11 +148,10 @@ namespace System
         }
 
         private const BindingFlags ConstructorDefault = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance;
-
-        // https://github.com/dotnet/corefx/issues/30845
+        
         public static ObjectHandle CreateInstance(string assemblyName, string typeName) 
         {
-            throw new PlatformNotSupportedException(); 
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/corefx/issues/30845
         }
 
         public static ObjectHandle CreateInstance(string assemblyName, 
@@ -164,12 +163,12 @@ namespace System
                                                   CultureInfo culture, 
                                                   object[] activationAttributes) 
         { 
-            throw new PlatformNotSupportedException(); 
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/corefx/issues/30845
         }
 
         public static ObjectHandle CreateInstance(string assemblyName, string typeName, object[] activationAttributes) 
         { 
-            throw new PlatformNotSupportedException(); 
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/corefx/issues/30845
         }
 
         public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName) 

--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -147,6 +147,13 @@ namespace System
         }
 
         private const BindingFlags ConstructorDefault = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance;
+
+        public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName) { throw new PlatformNotSupportedException(); }
+        public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName) { throw new PlatformNotSupportedException(); }
+        public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
     }
 }
 

--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -150,17 +150,49 @@ namespace System
         private const BindingFlags ConstructorDefault = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance;
 
         // https://github.com/dotnet/corefx/issues/30845
-        public static ObjectHandle CreateInstance(string assemblyName, string typeName) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstance(string assemblyName, string typeName) 
+        {
+            throw new PlatformNotSupportedException(); 
+        }
 
-        public static ObjectHandle CreateInstance(string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstance(string assemblyName, 
+                                                  string typeName, 
+                                                  bool ignoreCase, 
+                                                  BindingFlags bindingAttr, 
+                                                  Binder binder, 
+                                                  object[] args, 
+                                                  System.Globalization.CultureInfo culture, 
+                                                  object[] activationAttributes) 
+        { 
+            throw new PlatformNotSupportedException(); 
+        }
 
-        public static ObjectHandle CreateInstance(string assemblyName, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstance(string assemblyName, string typeName, object[] activationAttributes) 
+        { 
+            throw new PlatformNotSupportedException(); 
+        }
 
-        public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName) 
+        {
+            throw new PlatformNotSupportedException(); 
+        }
 
-        public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstanceFrom(string assemblyFile, 
+                                                      string typeName, 
+                                                      bool ignoreCase, 
+                                                      BindingFlags bindingAttr, 
+                                                      Binder binder, 
+                                                      object[] args, 
+                                                      CultureInfo culture, 
+                                                      object[] activationAttributes) 
+        { 
+            throw new PlatformNotSupportedException(); 
+        }
 
-        public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, object[] activationAttributes) 
+        { 
+            throw new PlatformNotSupportedException(); 
+        }
     }
 }
 

--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -149,10 +149,15 @@ namespace System
         private const BindingFlags ConstructorDefault = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance;
 
         public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName) { throw new PlatformNotSupportedException(); }
+
         public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+
         public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+
         public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName) { throw new PlatformNotSupportedException(); }
+
         public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+
         public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -161,7 +161,7 @@ namespace System
                                                   BindingFlags bindingAttr, 
                                                   Binder binder, 
                                                   object[] args, 
-                                                  System.Globalization.CultureInfo culture, 
+                                                  CultureInfo culture, 
                                                   object[] activationAttributes) 
         { 
             throw new PlatformNotSupportedException(); 

--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Remoting;
 using System.Runtime;
 
 using Internal.Reflection.Augments;
@@ -148,17 +149,18 @@ namespace System
 
         private const BindingFlags ConstructorDefault = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance;
 
-        public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName) { throw new PlatformNotSupportedException(); }
+        // https://github.com/dotnet/corefx/issues/30845
+        public static ObjectHandle CreateInstance(string assemblyName, string typeName) { throw new PlatformNotSupportedException(); }
 
-        public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstance(string assemblyName, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
 
-        public static System.Runtime.Remoting.ObjectHandle CreateInstance(string assemblyName, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstance(string assemblyName, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
 
-        public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName) { throw new PlatformNotSupportedException(); }
 
-        public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, object[] args, System.Globalization.CultureInfo culture, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
 
-        public static System.Runtime.Remoting.ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
+        public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName, object[] activationAttributes) { throw new PlatformNotSupportedException(); }
     }
 }
 


### PR DESCRIPTION
Contributes to  https://github.com/dotnet/corefx/issues/30190

As advised by @jkotas  https://github.com/dotnet/corefx/pull/30809#issuecomment-402680660 we need to add new Activator.CreateInstance apis to allow compilation.
