### PR TITLE
Disable PInvoke inlining

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -760,7 +760,13 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_SHAREDINST;
 
             if (method.IsPInvoke)
+            {
                 result |= CorInfoFlag.CORINFO_FLG_PINVOKE;
+
+                // TODO: Enable PInvoke inlining
+                // https://github.com/dotnet/corert/issues/6063
+                result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE;
+            }
 
             // TODO: Cache inlining hits
             // Check for an inlining directive.


### PR DESCRIPTION
PInvoke inlining makes us drop delegate required marshaling data. Proper fix is tracked by https://github.com/dotnet/corert/issues/6063.

Fixes #6060