### PR TITLE
Use uapaot mscorlib facade

### DIFF
--- a/src/Framework/Framework-uapaot.depproj
+++ b/src/Framework/Framework-uapaot.depproj
@@ -19,9 +19,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- System.Runtime.InteropServices implementation has to be forwarded to System.Private.Interop -->
+    <!-- TODO https://github.com/dotnet/corert/issues/3231 -->
+    <FileToInclude Include="System.Runtime.InteropServices" />
+    <FileToInclude Include="mscorlib" />
+
     <!-- Pickup a few selected aot-specific files from uapaot instead -->
     <FileToInclude Include="System.Linq.Expressions" />
-    <FileToInclude Include="System.Runtime.InteropServices" />
     <FileToInclude Include="System.Text.RegularExpressions" />
     <FileToInclude Include="System.Private.Xml" />
     <FileToInclude Include="System.Private.Xml.Linq" />

--- a/src/Framework/Framework.depproj
+++ b/src/Framework/Framework.depproj
@@ -29,9 +29,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- System.Runtime.InteropServices implementation has to be forwarded to System.Private.Interop -->
+    <!-- TODO https://github.com/dotnet/corert/issues/3231 -->
+    <FileToExclude Include="System.Runtime.InteropServices" />
+    <FileToExclude Include="mscorlib" />
+
     <!-- Pickup a few selected aot-specific files from uapaot instead -->
     <FileToExclude Include="System.Linq.Expressions" />
-    <FileToExclude Include="System.Runtime.InteropServices" />
     <FileToExclude Include="System.Text.RegularExpressions" />
     <FileToExclude Include="System.Private.Xml" />
     <FileToExclude Include="System.Private.Xml.Linq" />


### PR DESCRIPTION
This is required to use the correct forwarder for System.Runtime.InteropServices types that still
have a different home between CoreCLR and CoreRT.

Workaround for #3231
Fixes #6062