### PR TITLE
Enable ThreadStatic GC layout test

### DIFF
--- a/src/ILCompiler.TypeSystem/tests/GCPointerMapTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/GCPointerMapTests.cs
@@ -86,8 +86,6 @@ namespace TypeSystemTests
             Assert.Equal("010100101001", map.ToString());
         }
 
-#if false
-        // TODO: enable when IsThreadStatic stops lying
         [Fact]
         public void TestThreadStaticMap()
         {
@@ -96,6 +94,5 @@ namespace TypeSystemTests
             Assert.Equal(map.Size, 14);
             Assert.Equal("00010010100110", map.ToString());
         }
-#endif
     }
 }


### PR DESCRIPTION
This was not enabled because at the time the test was written, `IsThreadStatic` was a lie. It would have caught #6041 in a much cheaper way if we haven't forgotten to enable it when thread statics were brought up.