### PR TITLE
Fix decimal parsing for "-1e-400"

### DIFF
--- a/src/System.Private.CoreLib/src/System/Number.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Number.CoreRT.cs
@@ -369,7 +369,7 @@ namespace System
             {
                 // Parsing a large scale zero can give you more precision than fits in the decimal.
                 // This should only happen for actual zeros or very small numbers that round to zero.
-                value = new decimal(0, 0, 0, false, DecimalPrecision - 1);
+                value = new decimal(0, 0, 0, number.sign, DecimalPrecision - 1);
             }
             else
             {


### PR DESCRIPTION
This fixes an edge case parsing difference between +0/-0 from #6091 (discussion in https://github.com/dotnet/coreclr/pull/18868 and https://github.com/dotnet/corefx/pull/31085)