### PR TITLE
Make thread statics faster

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -88,6 +88,20 @@ namespace ILCompiler.DependencyAnalysis.X64
             }
         }
 
+        public void EmitJE(ISymbolNode symbol)
+        {
+            if (symbol.RepresentsIndirectionCell)
+            {
+                throw new NotImplementedException();
+            }
+            else
+            {
+                Builder.EmitByte(0x0f);
+                Builder.EmitByte(0x84);
+                Builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_REL32);
+            }
+        }
+
         public void EmitINT3()
         {
             Builder.EmitByte(0xCC);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -127,7 +127,11 @@ namespace ILCompiler.DependencyAnalysis
                         else
                         {
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target), - NonGCStaticsNode.GetClassConstructorContextStorageSize(factory.Target, target));
-                            // TODO: performance optimization - inline the check verifying whether we need to trigger the cctor
+
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg2, null, factory.Target.PointerSize, 0, AddrModeSize.Int32);
+                            encoder.EmitCMP(ref initialized, 1);
+                            encoder.EmitJE(factory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType));
+
                             encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
                         }
                     }

--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -1336,10 +1336,10 @@ Boolean Thread::SetThreadStaticStorageForModule(Object * pStorage, UInt32 module
     return TRUE;
 }
 
-COOP_PINVOKE_HELPER(Array*, RhGetThreadStaticStorageForModule, (UInt32 moduleIndex))
+COOP_PINVOKE_HELPER(Object*, RhGetThreadStaticStorageForModule, (UInt32 moduleIndex))
 {
     Thread * pCurrentThread = ThreadStore::RawGetCurrentThread();
-    return (Array*)pCurrentThread->GetThreadStaticStorageForModule(moduleIndex);
+    return pCurrentThread->GetThreadStaticStorageForModule(moduleIndex);
 }
 
 COOP_PINVOKE_HELPER(Boolean, RhSetThreadStaticStorageForModule, (Array * pStorage, UInt32 moduleIndex))

--- a/src/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
@@ -22,7 +22,7 @@ namespace Internal.Runtime
         {
             // Get the array that holds thread static memory blocks for each type in the given module
             int moduleIndex = pModuleData->ModuleIndex;
-            object[] storage = (object[])RuntimeImports.RhGetThreadStaticStorageForModule(moduleIndex);
+            object[] storage = RuntimeImports.RhGetThreadStaticStorageForModule(moduleIndex);
 
             // Check whether thread static storage has already been allocated for this module and type.
             if ((storage != null) && (typeTlsIndex < storage.Length) && (storage[typeTlsIndex] != null))

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -561,11 +561,11 @@ namespace System.Runtime
 #if !PROJECTN
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetThreadStaticStorageForModule")]
-        internal static unsafe extern Array RhGetThreadStaticStorageForModule(int moduleIndex);
+        internal static unsafe extern object[] RhGetThreadStaticStorageForModule(int moduleIndex);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhSetThreadStaticStorageForModule")]
-        internal static unsafe extern bool RhSetThreadStaticStorageForModule(Array storage, int moduleIndex);
+        internal static unsafe extern bool RhSetThreadStaticStorageForModule(object[] storage, int moduleIndex);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhCurrentNativeThreadId")]


### PR DESCRIPTION
This is a thing I noticed when I profiled the TechEmpower plaintext benchmark and it's a piece of pretty low hanging fruit.

* Fix the TODO to inline `.cctor` check into the R2R helper. This avoids a some method calls and stack frame setup.
* Remove array cast from the hot path. The runtime doesn't care what type the storage is, as long as it's a managed reference - in fact, it seems to be treated as an `Object` in `pCurrentThread->GetThreadStaticStorageForModule` anyway. I considered replacing the cast with an `Unsafe.As`, but just redeclaring the signatures as returning `object[]` seemed better (because now we actually guarantee the classlib won't pass anything but `object[]` to `RhSetThreadStaticStorageForModule`).

For a simple program:

```csharp
class Program
{
    [ThreadStatic]
    static int X; // = 456;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static void Set() => X = 123;

    static void Main(string[] args)
    {
        var sw = Stopwatch.StartNew();

        for (int i = 0; i < 10000000; i++)
        {
            Set();
        }

        Console.WriteLine(sw.ElapsedMilliseconds);
    }
}
```

This leads to following improvements:

|     | Before | After |
| ------------- |:-------------:| -----:|
| Program.cs without static constructor | 70 ms | 45 ms |
| Program.cs with static constructor | 164 ms | 46 ms |

The running times are comparable with the desktop CLR now.