### PR TITLE
CorInfoImpl refactoring part #1

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -88,6 +88,12 @@ namespace ILCompiler
 
         protected abstract void CompileInternal(string outputFile, ObjectDumper dumper);
 
+        public virtual bool CanInline(MethodDesc caller, MethodDesc callee)
+        {
+            // No restrictions on inlining by default
+            return true;
+        }
+
         public DelegateCreationInfo GetDelegateCtor(TypeDesc delegateType, MethodDesc target, bool followVirtualDispatch)
         {
             // If we're creating a delegate to a virtual method that cannot be overriden, devirtualize.

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -21,7 +21,6 @@ using Internal.Runtime.CompilerServices;
 #endif
 
 using Internal.IL;
-using Internal.JitInterface;
 using Internal.TypeSystem;
 
 using ILCompiler;

--- a/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitCompilation.cs
+++ b/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitCompilation.cs
@@ -43,6 +43,12 @@ namespace ILCompiler
 
         public NameMangler NameMangler { get { return null; } }
 
+        public virtual bool CanInline(MethodDesc caller, MethodDesc callee)
+        {
+            // No inlining limits by default
+            return true;
+        }
+
         public ObjectNode GetFieldRvaData(FieldDesc field)
         {
             // Use the typical field definition in case this is an instantiated generic type


### PR DESCRIPTION
1) Refactor ComputeLookup to pass around references to the
CORINFO_RESOLVED_TOKEN instead of its tokenContext. This will be
needed in the next change to implement R2R variants of the methods.

2) Add new CanInline method to the Compilation class to be used
by CorInfoImpl to query inline-ability.

Thanks

Tomas