### PR TITLE
WIP: Remaining CPAOT changes rebased to my latest changes

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
@@ -26,16 +26,14 @@ namespace ILCompiler
 
         public sealed override bool ContainsType(TypeDesc type)
         {
-            EcmaType ecmaType = type as EcmaType;
-
-            if (ecmaType == null)
-                return true;
-
-            if (!IsModuleInCompilationGroup(ecmaType.EcmaModule))
+            if (type is EcmaType ecmaType)
             {
-                return false;
+                return IsModuleInCompilationGroup(ecmaType.EcmaModule);
             }
-
+            if (type is InstantiatedType instantiatedType)
+            {
+                return ContainsType(instantiatedType.GetTypeDefinition());
+            }
             return true;
         }
 

--- a/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
@@ -11,6 +11,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
 using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysis.ReadyToRun;
 using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.PEWriter;
 using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
@@ -31,52 +32,57 @@ namespace ILCompiler.DependencyAnalysis
         private IEnumerable<DependencyNode> _nodes;
 
         private int _textSectionIndex;
-        private int _dataSectionIndex;
         private int _rdataSectionIndex;
+        private int _dataSectionIndex;
 
 #if DEBUG
-        Dictionary<string, ISymbolNode> _previouslyWrittenNodeNames = new Dictionary<string, ISymbolNode>();
+        Dictionary<string, (ISymbolNode Node, int NodeIndex, int SymbolIndex)> _previouslyWrittenNodeNames = new Dictionary<string, (ISymbolNode Node, int NodeIndex, int SymbolIndex)>();
 #endif
-
         public ReadyToRunObjectWriter(string objectFilePath, IEnumerable<DependencyNode> nodes, ReadyToRunCodegenNodeFactory factory)
         {
             _objectFilePath = objectFilePath;
             _nodes = nodes;
             _nodeFactory = factory;
         }
-        
+
         public void EmitPortableExecutable()
         {
             bool succeeded = false;
 
+            FileStream mapFileStream = null;
+            TextWriter mapFile = null;
+
             try
             {
+                string mapFileName = Path.ChangeExtension(_objectFilePath, ".map");
+                mapFileStream = new FileStream(mapFileName, FileMode.Create, FileAccess.Write);
+                mapFile = new StreamWriter(mapFileStream);
+
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+                mapFile.WriteLine($@"R2R object emission started: {DateTime.Now}");
+
                 var peBuilder = new R2RPEBuilder(Machine.Amd64, _nodeFactory.PEReader, new ValueTuple<string, SectionCharacteristics>[0]);
                 var sectionBuilder = new SectionBuilder();
 
                 _textSectionIndex = sectionBuilder.AddSection(R2RPEBuilder.TextSectionName, SectionCharacteristics.ContainsCode | SectionCharacteristics.MemExecute | SectionCharacteristics.MemRead, 512);
-                _dataSectionIndex = sectionBuilder.AddSection(".data", SectionCharacteristics.ContainsInitializedData | SectionCharacteristics.MemWrite | SectionCharacteristics.MemRead, 512);
                 _rdataSectionIndex = sectionBuilder.AddSection(".rdata", SectionCharacteristics.ContainsInitializedData | SectionCharacteristics.MemRead, 512);
-
-                sectionBuilder.SetReadyToRunHeaderTable(_nodeFactory.Header, _nodeFactory.Header.GetData(_nodeFactory).Data.Length);
+                _dataSectionIndex = sectionBuilder.AddSection(".data", SectionCharacteristics.ContainsInitializedData | SectionCharacteristics.MemWrite | SectionCharacteristics.MemRead, 512);
 
                 foreach (var depNode in _nodes)
                 {
-                    if (depNode is MethodCodeNode methodNode)
-                    {
-                        int methodIndex = _nodeFactory.RuntimeFunctionsTable.Add(methodNode);
-                        _nodeFactory.MethodEntryPointTable.Add(methodNode, methodIndex);
-                    }
-
                     if (depNode is EETypeNode eeTypeNode)
                     {
                         _nodeFactory.TypesTable.Add(eeTypeNode);
                     }
                 }
 
+                int nodeIndex = -1;
                 foreach (var depNode in _nodes)
                 {
+                    ++nodeIndex;
                     ObjectNode node = depNode as ObjectNode;
+
                     if (node == null)
                         continue;
 
@@ -84,20 +90,20 @@ namespace ILCompiler.DependencyAnalysis
                         continue;
 
                     ObjectData nodeContents = node.GetData(_nodeFactory);
-
 #if DEBUG
-                    foreach (ISymbolNode definedSymbol in nodeContents.DefinedSymbols)
+                    for (int symbolIndex = 0; symbolIndex < nodeContents.DefinedSymbols.Length; symbolIndex++)
                     {
-                        try
+                        ISymbolNode definedSymbol = nodeContents.DefinedSymbols[symbolIndex];
+                        (ISymbolNode Node, int NodeIndex, int SymbolIndex) alreadyWrittenSymbol;
+                        string symbolName = definedSymbol.GetMangledName(_nodeFactory.NameMangler);
+                        if (_previouslyWrittenNodeNames.TryGetValue(symbolName, out alreadyWrittenSymbol))
                         {
-                            _previouslyWrittenNodeNames.Add(definedSymbol.GetMangledName(_nodeFactory.NameMangler), definedSymbol);
-                        }
-                        catch (ArgumentException)
-                        {
-                            ISymbolNode alreadyWrittenSymbol = _previouslyWrittenNodeNames[definedSymbol.GetMangledName(_nodeFactory.NameMangler)];
+                            Console.WriteLine($@"Duplicate symbol - 1st occurrence: [{alreadyWrittenSymbol.NodeIndex}:{alreadyWrittenSymbol.SymbolIndex}], {alreadyWrittenSymbol.Node.GetMangledName(_nodeFactory.NameMangler)}");
+                            Console.WriteLine($@"Duplicate symbol - 2nd occurrence: [{nodeIndex}:{symbolIndex}], {definedSymbol.GetMangledName(_nodeFactory.NameMangler)}");
                             Debug.Fail("Duplicate node name emitted to file",
                             $"Symbol {definedSymbol.GetMangledName(_nodeFactory.NameMangler)} has already been written to the output object file {_objectFilePath} with symbol {alreadyWrittenSymbol}");
                         }
+                        _previouslyWrittenNodeNames.Add(symbolName, (Node: definedSymbol, NodeIndex: nodeIndex, SymbolIndex: symbolIndex));
                     }
 #endif
 
@@ -120,18 +126,48 @@ namespace ILCompiler.DependencyAnalysis
                             throw new NotImplementedException();
                     }
 
-                    sectionBuilder.AddObjectData(nodeContents, targetSectionIndex);
+                    string name = null;
+
+                    if (mapFile != null)
+                    {
+                        name = depNode.GetType().ToString();
+                        int firstGeneric = name.IndexOf('[');
+                        if (firstGeneric < 0)
+                        {
+                            firstGeneric = name.Length;
+                        }
+                        int lastDot = name.LastIndexOf('.', firstGeneric - 1, firstGeneric);
+                        if (lastDot > 0)
+                        {
+                            name = name.Substring(lastDot + 1);
+                        }
+                    }
+                    sectionBuilder.AddObjectData(nodeContents, targetSectionIndex, name, mapFile);
                 }
+
+                sectionBuilder.SetReadyToRunHeaderTable(_nodeFactory.Header, _nodeFactory.Header.GetData(_nodeFactory).Data.Length);
 
                 using (var peStream = File.Create(_objectFilePath))
                 {
                     sectionBuilder.EmitR2R(Machine.Amd64, _nodeFactory.PEReader, peStream);
                 }
 
+                mapFile.WriteLine($@"R2R object emission finished: {DateTime.Now}, {stopwatch.ElapsedMilliseconds} msecs");
+                mapFile.Flush();
+                mapFileStream.Flush();
+
                 succeeded = true;
             }
             finally
             {
+                if (mapFile != null)
+                {
+                    mapFile.Dispose();
+                }
+                if (mapFileStream != null)
+                {
+                    mapFileStream.Dispose();
+                }
                 if (!succeeded)
                 {
                     // If there was an exception while generating the OBJ file, make sure we don't leave the unfinished
@@ -149,6 +185,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public static void EmitObject(string objectFilePath, IEnumerable<DependencyNode> nodes, ReadyToRunCodegenNodeFactory factory)
         {
+            Console.WriteLine($@"Emitting R2R PE file: {objectFilePath}");
             ReadyToRunObjectWriter objectWriter = new ReadyToRunObjectWriter(objectFilePath, nodes, factory);
             objectWriter.EmitPortableExecutable();
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// This class represents a single indirection cell used to call delay load helpers.
+    /// </summary>
+    public class DelayLoadHelperImport : Import
+    {
+        private readonly ReadyToRunHelper _helper;
+
+        private readonly DelayLoadHelperThunk _delayLoadHelper;
+
+        public DelayLoadHelperImport(ReadyToRunCodegenNodeFactory factory, ReadyToRunHelper helper, Signature instanceSignature, string callSite = null)
+            : base(factory.HelperImports, instanceSignature, callSite)
+        {
+            factory.HelperImports.AddImport(factory, this);
+            _helper = helper;
+            _delayLoadHelper = new DelayLoadHelperThunk(helper, factory, this);
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("DelayLoadHelperImport(");
+            sb.Append(_helper.ToString());
+            sb.Append(") -> ");
+            ImportSignature.AppendMangledName(nameMangler, sb);
+            if (CallSite != null)
+            {
+                sb.Append(" @ ");
+                sb.Append(CallSite);
+            }
+        }
+
+        protected override int ClassCode => 667823013;
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            // This needs to be an empty target pointer since it will be filled in with Module*
+            // when loaded by CoreCLR
+            dataBuilder.EmitReloc(_delayLoadHelper,
+                factory.Target.PointerSize == 4 ? RelocType.IMAGE_REL_BASED_HIGHLOW : RelocType.IMAGE_REL_BASED_DIR64);
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            return new DependencyListEntry[] 
+            {
+                new DependencyListEntry(_delayLoadHelper, "Delay load helper thunk for ready-to-run fixup import"),
+                new DependencyListEntry(ImportSignature, "Signature for ready-to-run fixup import"),
+            };
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperThunk.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperThunk.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// This node emits a thunk calling DelayLoad_Helper with a given instance signature
+    /// to populate its indirection cell.
+    /// </summary>
+    public class DelayLoadHelperThunk : ObjectNode, ISymbolDefinitionNode
+    {
+        private readonly ISymbolNode _helperCell;
+
+        private readonly Import _instanceCell;
+
+        private readonly ISymbolNode _moduleImport;
+
+        public DelayLoadHelperThunk(ReadyToRunHelper helperId, ReadyToRunCodegenNodeFactory factory, Import instanceCell)
+        {
+            _helperCell = factory.GetReadyToRunHelperCell(helperId);
+            _instanceCell = instanceCell;
+            _moduleImport = factory.ModuleImport;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("DelayLoadHelper->");
+            _instanceCell.AppendMangledName(nameMangler, sb);
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return "DelayLoadHelper";
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            ObjectDataBuilder builder = new ObjectDataBuilder();
+            builder.AddSymbol(this);
+
+            switch (factory.Target.Architecture)
+            {
+                case TargetArchitecture.X64:
+                    {
+                        if (!relocsOnly)
+                        {
+                            builder.RequireInitialAlignment(8);
+
+                            // lea rax, [pCell]
+                            builder.EmitByte(0x48);
+                            builder.EmitByte(0x8D);
+                            builder.EmitByte(0x05);
+                        }
+                        builder.EmitReloc(_instanceCell, RelocType.IMAGE_REL_BASED_REL32);
+
+                        if (!relocsOnly)
+                        {
+                            // push table index
+                            builder.EmitByte(0x6A);
+                            builder.EmitByte((byte)_instanceCell.Table.IndexFromBeginningOfArray);
+
+                            // push [module]
+                            builder.EmitByte(0xFF);
+                            builder.EmitByte(0x35);
+                        }
+                        builder.EmitReloc(_moduleImport, RelocType.IMAGE_REL_BASED_REL32);
+
+                        if (!relocsOnly)
+                        {
+                            // TODO: additional tricks regarding UNIX AMD64 ABI
+
+                            // jmp [helper]
+                            builder.EmitByte(0xFF);
+                            builder.EmitByte(0x25);
+                        }
+                        builder.EmitReloc(_helperCell, RelocType.IMAGE_REL_BASED_REL32);
+
+                        break;
+                    }
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            return builder.ToObjectData();
+        }
+
+        public override ObjectNodeSection Section => ObjectNodeSection.TextSection;
+
+        int ISymbolDefinitionNode.Offset => 0;
+        int ISymbolNode.Offset => 0;
+        public override bool IsShareable => false;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override int ClassCode => 433266948;
+    }
+
+    public class DelayLoadHelperThunk_Obj : DelayLoadHelperThunk
+    {
+        public DelayLoadHelperThunk_Obj(ReadyToRunCodegenNodeFactory nodeFactory, Import instanceCell)
+            : base(ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj, nodeFactory, instanceCell)
+        {
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
@@ -1,0 +1,54 @@
+﻿
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.JitInterface;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class ExternalMethodImport : Import, IMethodNode
+    {
+        private readonly MethodDesc _methodDesc;
+
+        private readonly mdToken _token;
+
+        private readonly MethodWithGCInfo _localMethod;
+
+        public ExternalMethodImport(
+            ReadyToRunCodegenNodeFactory factory,
+            ReadyToRunFixupKind fixupKind,
+            MethodDesc methodDesc,
+            mdToken token,
+            MethodWithGCInfo localMethod,
+            MethodFixupSignature.SignatureKind signatureKind)
+            : base(factory.MethodImports, factory.GetOrAddMethodSignature(fixupKind, methodDesc, token, signatureKind))
+        {
+            factory.MethodImports.AddImport(factory, this);
+            _methodDesc = methodDesc;
+            _token = token;
+            _localMethod = localMethod;
+        }
+
+        public MethodDesc Method => _methodDesc;
+
+        int ISortableSymbolNode.ClassCode => 458823351;
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            if (_localMethod == null)
+            {
+                return base.GetStaticDependencies(factory);
+            }
+            return new DependencyListEntry[] 
+            {
+                new DependencyListEntry(_localMethod, "Local method import"),
+                new DependencyListEntry(ImportSignature, "Method fixup signature"),
+            };
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
@@ -4,48 +4,83 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.JitInterface;
+using Internal.Runtime;
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using ILCompiler.DependencyAnalysis;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class ImportSectionNode : EmbeddedObjectNode
     {
         private readonly ArrayOfEmbeddedDataNode<Import> _imports;
+        // TODO: annoying - today there's no way to put signature RVA's into R/O data section
         private readonly ArrayOfEmbeddedPointersNode<Signature> _signatures;
+
         private readonly CorCompileImportType _type;
         private readonly CorCompileImportFlags _flags;
         private readonly byte _entrySize;
+        private readonly string _name;
+        private readonly bool _emitPrecode;
 
-        public ImportSectionNode(CorCompileImportType importType, CorCompileImportFlags flags, byte entrySize)
+        public ImportSectionNode(string name, CorCompileImportType importType, CorCompileImportFlags flags, byte entrySize, bool emitPrecode)
         {
+            _name = name;
             _type = importType;
             _flags = flags;
             _entrySize = entrySize;
+            _emitPrecode = emitPrecode;
 
-            _imports = new ArrayOfEmbeddedDataNode<Import>($"imports_{NodeIdentifier}_start", $"imports_{NodeIdentifier}_end", null);
-            _signatures = new ArrayOfEmbeddedPointersNode<Signature>($"signaures_{NodeIdentifier}_start", $"signatures_{NodeIdentifier}_end", null);
+            _imports = new ArrayOfEmbeddedDataNode<Import>(_name + "_ImportBegin", _name + "_ImportEnd", null);
+            _signatures = new ArrayOfEmbeddedPointersNode<Signature>(_name + "_SigBegin", _name + "_SigEnd", null);
         }
-        
-        private string NodeIdentifier => $"_{_type}_{_flags}_{_entrySize}";
 
-        public void AddImport(ReadyToRunCodegenNodeFactory factory, Import import)
+        public void AddImport(NodeFactory factory, Import import)
         {
             _imports.AddEmbeddedObject(import);
-            _signatures.AddEmbeddedObject(factory.SignatureIndirection(import.GetSignature(factory)));
+            _signatures.AddEmbeddedObject(import.ImportSignature);
         }
+
+        public string Name => _name;
+
+        public bool EmitPrecode => _emitPrecode;
 
         public override bool StaticDependenciesAreComputed => true;
 
         protected override int ClassCode => -62839441;
 
+        public bool ShouldSkipEmittingTable(NodeFactory factory)
+        {
+            return _imports.ShouldSkipEmittingObjectNode(factory);
+        }
+
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
+            if (!relocsOnly && _imports.ShouldSkipEmittingObjectNode(factory))
+            {
+                // Don't emit import section node at all if there are no entries in it
+                return;
+            }
+
             dataBuilder.EmitReloc(_imports.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, 0);
             if (!relocsOnly)
+            {
                 dataBuilder.EmitInt(_imports.GetData(factory, false).Data.Length);
 
-            dataBuilder.EmitShort((short)_flags);
-            dataBuilder.EmitByte((byte)_type);
-            dataBuilder.EmitByte(_entrySize);
+                dataBuilder.EmitShort((short)_flags);
+                dataBuilder.EmitByte((byte)_type);
+                dataBuilder.EmitByte(_entrySize);
+            }
             if (!_signatures.ShouldSkipEmittingObjectNode(factory))
             {
                 dataBuilder.EmitReloc(_signatures.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, 0);
@@ -54,7 +89,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 dataBuilder.EmitUInt(0);
             }
-            
+
+            // Todo: Auxilliary data
             dataBuilder.EmitUInt(0);
         }
 
@@ -66,7 +102,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         protected override string GetName(NodeFactory context)
         {
-            return $"ImportSectionNode_{NodeIdentifier}";
+            return _name;
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionsTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionsTableNode.cs
@@ -24,13 +24,20 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         protected override void GetElementDataForNodes(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
         {
             builder.RequireInitialPointerAlignment();
-
+            int index = 0;
             foreach (ImportSectionNode node in NodesList)
             {
-                if (!relocsOnly)
+                if (!relocsOnly && !node.ShouldSkipEmittingTable(factory))
+                {
                     node.InitializeOffsetFromBeginningOfArray(builder.CountBytes);
+                    node.InitializeIndexFromBeginningOfArray(index++);
+                }
 
                 node.EncodeData(ref builder, factory, relocsOnly);
+                if (node is ISymbolDefinitionNode symbolDef)
+                {
+                    builder.AddSymbol(symbolDef);
+                }
             }
         }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -64,7 +64,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append("__ReadyToRunInstanceEntryPointTable");
         }
 
-        public void Add(MethodCodeNode methodNode, int methodIndex)
+        public void Add(MethodWithGCInfo methodNode, int methodIndex)
         {
             // TODO: method instance table
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEHInfoNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEHInfoNode.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Internal.Text;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    class MethodEHInfoNode : ObjectNode, ISymbolDefinitionNode
+    {
+        private readonly MethodWithGCInfo _methodNode;
+
+        public MethodEHInfoNode(MethodWithGCInfo methodNode)
+        {
+            _methodNode = methodNode;
+        }
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public int Offset => 0;
+
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+
+        public override bool IsShareable => true;
+
+        protected override int ClassCode => 577012239;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("MethodEHInfoNode->");
+            _methodNode.AppendMangledName(nameMangler, sb);
+        }
+
+        public override ObjectNode.ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            ObjectData sourceNode = _methodNode.EHInfo;
+            if (sourceNode == null || sourceNode.Data.Length == 0)
+            {
+                return new ObjectNode.ObjectData(
+                    Array.Empty<byte>(),
+                    Array.Empty<Relocation>(),
+                    1,
+                    new ISymbolDefinitionNode[] { this });
+            }
+            ISymbolDefinitionNode[] augmentedSymbols = new ISymbolDefinitionNode[sourceNode.DefinedSymbols.Length + 1];
+            Array.Copy(sourceNode.DefinedSymbols, 0, augmentedSymbols, 1, sourceNode.DefinedSymbols.Length);
+            augmentedSymbols[0] = this;
+            return new ObjectData(sourceNode.Data, sourceNode.Relocs, sourceNode.Alignment, augmentedSymbols);
+        }
+
+        protected override string GetName(NodeFactory context)
+        {
+            Utf8StringBuilder sb = new Utf8StringBuilder();
+            sb.Append("MethodGCInfo->");
+            _methodNode.AppendMangledName(context.NameMangler, sb);
+            return sb.ToString();
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection.Metadata.Ecma335;
 
+using Internal.JitInterface;
 using Internal.NativeFormat;
 using Internal.Runtime;
 using Internal.Text;
@@ -20,32 +21,58 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         private struct EntryPoint
         {
-            public static EntryPoint Null = new EntryPoint(-1, -1);
-            
+            public static EntryPoint Null = new EntryPoint(-1, null);
+
             public readonly int MethodIndex;
-            public readonly int FixupIndex;
+            public readonly ObjectNode Method;
 
             public bool IsNull => (MethodIndex < 0);
             
-            public EntryPoint(int methodIndex, int fixupIndex)
+            public EntryPoint(int methodIndex, ObjectNode method)
             {
                 MethodIndex = methodIndex;
-                FixupIndex = fixupIndex;
+                Method = method;
+            }
+        }
+
+        /// <summary>
+        /// This helper structure represents the "coordinates" of a single
+        /// indirection cell in the import tables (index of the import
+        /// section table and offset within the table).
+        /// </summary>
+        private struct FixupCell
+        {
+            public static readonly IComparer<FixupCell> Comparer = new CellComparer();
+
+            public int TableIndex;
+            public int ImportOffset;
+
+            public FixupCell(int tableIndex, int importOffset)
+            {
+                TableIndex = tableIndex;
+                ImportOffset = importOffset;
+            }
+
+            private class CellComparer : IComparer<FixupCell>
+            {
+                public int Compare(FixupCell a, FixupCell b)
+                {
+                    int result = a.TableIndex.CompareTo(b.TableIndex);
+                    if (result == 0)
+                    {
+                        result = a.ImportOffset.CompareTo(b.ImportOffset);
+                    }
+                    return result;
+                }
             }
         }
 
         List<EntryPoint> _ridToEntryPoint;
 
-        List<byte[]> _uniqueFixups;
-        Dictionary<byte[], int> _uniqueFixupIndex;
-        
         public MethodEntryPointTableNode(TargetDetails target)
             : base(target)
         {
             _ridToEntryPoint = new List<EntryPoint>();
-
-            _uniqueFixups = new List<byte[]>();
-            _uniqueFixupIndex = new Dictionary<byte[], int>(ByteArrayComparer.Instance);
         }
         
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -54,59 +81,150 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append("__ReadyToRunMethodEntryPointTable");
         }
 
-        public void Add(MethodCodeNode methodNode, int methodIndex)
+        public void Add(MethodWithGCInfo methodNode, int methodIndex, NodeFactory factory)
         {
+            uint rid;
             if (methodNode.Method is EcmaMethod ecmaMethod)
             {
                 // Strip away the token type bits, keep just the low 24 bits RID
-                int rid = MetadataTokens.GetToken(ecmaMethod.Handle) & 0x00FFFFFF;
-                Debug.Assert(rid != 0);
-                
-                rid--;
-
-                // TODO: how to synthesize method fixups blob?
-                byte[] fixups = null;
-
-                while (_ridToEntryPoint.Count <= rid)
+                rid = SignatureBuilder.RidFromToken((mdToken)MetadataTokens.GetToken(ecmaMethod.Handle));
+            }
+            else if (methodNode.Method is MethodForInstantiatedType methodOnInstantiatedType)
+            {
+                if (methodOnInstantiatedType.GetTypicalMethodDefinition() is EcmaMethod ecmaTypicalMethod)
                 {
-                    _ridToEntryPoint.Add(EntryPoint.Null);
+                    rid = SignatureBuilder.RidFromToken((mdToken)MetadataTokens.GetToken(ecmaTypicalMethod.Handle));
                 }
-    
-                int fixupIndex = -1;
-                if (fixups != null)
+                else
                 {
-                    if (!_uniqueFixupIndex.TryGetValue(fixups, out fixupIndex))
-                    {
-                        fixupIndex = _uniqueFixups.Count;
-                        _uniqueFixupIndex.Add(fixups, fixupIndex);
-                        _uniqueFixups.Add(fixups);
-                    }
+                    throw new NotImplementedException();
                 }
-
-
-                _ridToEntryPoint[rid] = new EntryPoint(methodIndex, fixupIndex);
             }
             else
             {
                 throw new NotImplementedException();
             }
+
+            Debug.Assert(rid != 0);
+            rid--;
+
+            while (_ridToEntryPoint.Count <= rid)
+            {
+                _ridToEntryPoint.Add(EntryPoint.Null);
+            }
+
+            _ridToEntryPoint[(int)rid] = new EntryPoint(methodIndex, methodNode);
+        }
+
+        private byte[] GetFixupBlob(NodeFactory factory, ObjectNode node)
+        {
+            Relocation[] relocations = node.GetData(factory, relocsOnly: true).Relocs;
+
+            if (relocations == null)
+            {
+                return null;
+            }
+
+            List<FixupCell> fixupCells = null;
+
+            foreach (Relocation reloc in relocations)
+            {
+                if (reloc.Target is Import fixupCell && fixupCell.EmitPrecode)
+                {
+                    if (fixupCells == null)
+                    {
+                        fixupCells = new List<FixupCell>();
+                    }
+                    fixupCells.Add(new FixupCell(fixupCell.Table.IndexFromBeginningOfArray, fixupCell.OffsetFromBeginningOfArray));
+                }
+            }
+
+            if (fixupCells == null)
+            {
+                return null;
+            }
+
+            fixupCells.Sort(FixupCell.Comparer);
+
+            NibbleWriter writer = new NibbleWriter();
+
+            int curTableIndex = -1;
+            int curOffset = 0;
+
+            foreach (FixupCell cell in fixupCells)
+            {
+                Debug.Assert(cell.ImportOffset % factory.Target.PointerSize == 0);
+                int offset = cell.ImportOffset / factory.Target.PointerSize;
+
+                if (cell.TableIndex != curTableIndex)
+                {
+                    // Write delta relative to the previous table index
+                    Debug.Assert(cell.TableIndex > curTableIndex);
+                    if (curTableIndex != -1)
+                    {
+                        writer.WriteUInt(0); // table separator, so add except for the first entry
+                        writer.WriteUInt((uint)(cell.TableIndex - curTableIndex)); // add table index delta
+                    }
+                    else
+                    {
+                        writer.WriteUInt((uint)cell.TableIndex);
+                    }
+                    curTableIndex = cell.TableIndex;
+
+                    // This is the first fixup in the current table.
+                    // We will write it out completely (without delta-encoding)
+                    writer.WriteUInt((uint)offset);
+                }
+                else if (offset != curOffset) // ignore duplicate fixup cells
+                {
+                    // This is not the first entry in the current table.
+                    // We will write out the delta relative to the previous fixup value
+                    int delta = offset - curOffset;
+                    Debug.Assert(delta > 0);
+                    writer.WriteUInt((uint)delta);
+                }
+
+                // future entries for this table would be relative to this rva
+                curOffset = offset;
+            }
+
+            writer.WriteUInt(0); // table separator
+            writer.WriteUInt(0); // fixup list ends
+
+            return writer.ToArray();
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            NativeWriter arrayWriter = new NativeWriter();
+            if (relocsOnly)
+            {
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
+            }
 
-            Section arraySection = arrayWriter.NewSection();
+            NativeWriter writer = new NativeWriter();
+
+            Section arraySection = writer.NewSection();
             VertexArray vertexArray = new VertexArray(arraySection);
             arraySection.Place(vertexArray);
-            BlobVertex[] fixupBlobs = PlaceBlobs(arraySection, _uniqueFixups);
+
+            Section fixupSection = writer.NewSection();
+
+            Dictionary<byte[], BlobVertex> uniqueFixups = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
 
             for (int rid = 0; rid < _ridToEntryPoint.Count; rid++)
             {
                 EntryPoint entryPoint = _ridToEntryPoint[rid];
                 if (!entryPoint.IsNull)
                 {
-                    BlobVertex fixupBlobVertex = (entryPoint.FixupIndex >= 0 ? fixupBlobs[entryPoint.FixupIndex] : null);
+                    byte[] fixups = GetFixupBlob(factory, entryPoint.Method);
+
+                    BlobVertex fixupBlobVertex = null;
+                    if (fixups != null && !uniqueFixups.TryGetValue(fixups, out fixupBlobVertex))
+                    {
+                        fixupBlobVertex = new BlobVertex(fixups);
+                        fixupSection.Place(fixupBlobVertex);
+                        uniqueFixups.Add(fixups, fixupBlobVertex);
+                    }
                     EntryPointVertex entryPointVertex = new EntryPointVertex((uint)entryPoint.MethodIndex, fixupBlobVertex);
                     vertexArray.Set(rid, entryPointVertex);
                 }
@@ -115,24 +233,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             vertexArray.ExpandLayout();
 
             MemoryStream arrayContent = new MemoryStream();
-            arrayWriter.Save(arrayContent);
+            writer.Save(arrayContent);
             return new ObjectData(
                 data: arrayContent.ToArray(),
                 relocs: null,
                 alignment: 8,
                 definedSymbols: new ISymbolDefinitionNode[] { this });
-        }
-
-        private static BlobVertex[] PlaceBlobs(Section section, List<byte[]> blobs)
-        {
-            BlobVertex[] blobVertices = new BlobVertex[blobs.Count];
-            for (int blobIndex = 0; blobIndex < blobs.Count; blobIndex++)
-            {
-                BlobVertex blobVertex = new BlobVertex(blobs[blobIndex]);
-                section.Place(blobVertex);
-                blobVertices[blobIndex] = blobVertex;
-            }
-            return blobVertices;
         }
 
         protected override int ClassCode => 787556329;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.JitInterface;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class MethodFixupSignature : Signature
+    {
+        public enum SignatureKind
+        {
+            DefToken,
+            RefToken,
+            Signature,
+        }
+
+        private readonly ReadyToRunFixupKind _fixupKind;
+
+        private readonly MethodDesc _methodDesc;
+        
+        private readonly mdToken _methodToken;
+
+        private readonly SignatureKind _signatureKind;
+
+        public MethodFixupSignature(ReadyToRunFixupKind fixupKind, MethodDesc methodDesc, mdToken methodToken, SignatureKind signatureKind)
+        {
+            _fixupKind = fixupKind;
+            _methodDesc = methodDesc;
+            _methodToken = methodToken;
+            _signatureKind = signatureKind;
+        }
+
+        protected override int ClassCode => 150063499;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
+            ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
+            dataBuilder.AddSymbol(this);
+
+            dataBuilder.EmitByte((byte)_fixupKind);
+            switch (_signatureKind)
+            {
+                case SignatureKind.DefToken:
+                    dataBuilder.EmitMethodDefToken(_methodToken);
+                    break;
+
+                case SignatureKind.RefToken:
+                    dataBuilder.EmitMethodRefToken(_methodToken);
+                    break;
+
+                case SignatureKind.Signature:
+                    dataBuilder.EmitMethodSignature(_methodDesc, _methodToken, r2rFactory.SignatureContext);
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            return dataBuilder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($@"MethodFixupSignature({_fixupKind.ToString()} {(uint)_methodToken:X8}): {_methodDesc.ToString()}");
+        }
+
+        protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
+        {
+            return _methodToken.CompareTo(((MethodFixupSignature)other)._methodToken);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodGCInfoNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodGCInfoNode.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class MethodGCInfoNode : EmbeddedObjectNode, ISymbolDefinitionNode
+    {
+        private readonly MethodWithGCInfo _methodNode;
+
+        private readonly MethodEHInfoNode _ehInfoNode;
+
+        public MethodGCInfoNode(MethodWithGCInfo methodNode)
+        {
+            _methodNode = methodNode;
+            _ehInfoNode = new MethodEHInfoNode(_methodNode);
+        }
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        int ISymbolDefinitionNode.Offset => OffsetFromBeginningOfArray;
+
+        int ISymbolNode.Offset => 0;
+
+        protected override int ClassCode => 892356612;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("MethodGCInfoNode->");
+            _methodNode.AppendMangledName(nameMangler, sb);
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            if (relocsOnly)
+            {
+                return;
+            }
+
+            byte[] gcInfo = _methodNode.GCInfo;
+
+            // Temporary hotfix - this stands for the AMD64 UNWIND_INFO I don't yet know where to get from
+            dataBuilder.EmitLong(0);
+
+            if (gcInfo != null)
+            {
+                dataBuilder.EmitBytes(gcInfo);
+            }
+
+            /* TODO: This is apparently incorrect, a different encoding is needed here
+            ObjectNode.ObjectData ehInfo = _methodNode.EHInfo;
+            ISymbolNode associatedDataNode = _methodNode.GetAssociatedDataNode(factory);
+
+            foreach (FrameInfo frameInfo in _methodNode.FrameInfos)
+            {
+                FrameInfoFlags flags = frameInfo.Flags;
+                flags |= (ehInfo != null ? FrameInfoFlags.HasEHInfo : 0);
+                flags |= (associatedDataNode != null ? FrameInfoFlags.HasAssociatedData : 0);
+
+                dataBuilder.EmitBytes(frameInfo.BlobData);
+                dataBuilder.EmitByte((byte)flags);
+
+                if (associatedDataNode != null)
+                {
+                    dataBuilder.EmitReloc(associatedDataNode, RelocType.IMAGE_REL_BASED_ADDR32NB);
+                    associatedDataNode = null;
+                }
+
+                if (ehInfo != null)
+                {
+                    dataBuilder.EmitReloc(_ehInfoNode, RelocType.IMAGE_REL_BASED_ADDR32NB);
+                    ehInfo = null;
+                }
+
+                if (gcInfo != null)
+                {
+                    dataBuilder.EmitBytes(gcInfo);
+                    gcInfo = null;
+                }
+
+                // Align the record to 4 bytes
+                int alignedOffset = (dataBuilder.CountBytes + 3) & -4;
+                int paddingCount = alignedOffset - dataBuilder.CountBytes;
+                dataBuilder.EmitZeros(paddingCount);
+            }
+            */
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            return new DependencyListEntry[] { new DependencyListEntry(_ehInfoNode, "EH info for method") };
+        }
+
+        protected override string GetName(NodeFactory context)
+        {
+            Utf8StringBuilder sb = new Utf8StringBuilder();
+            sb.Append("MethodGCInfo->");
+            _methodNode.AppendMangledName(context.NameMangler, sb);
+            return sb.ToString();
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -1,0 +1,150 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+using Internal.JitInterface;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class MethodWithGCInfo : ObjectNode, IMethodCodeNode, IMethodBodyNode
+    {
+        public readonly MethodGCInfoNode GCInfoNode;
+
+        private readonly MethodDesc _method;
+        private readonly mdToken _token;
+
+        private ObjectData _methodCode;
+        private FrameInfo[] _frameInfos;
+        private byte[] _gcInfo;
+        private ObjectData _ehInfo;
+        private DebugLocInfo[] _debugLocInfos;
+        private DebugVarInfo[] _debugVarInfos;
+        private DebugEHClauseInfo[] _debugEHClauseInfos;
+
+        public MethodWithGCInfo(MethodDesc methodDesc, mdToken token)
+        {
+            GCInfoNode = new MethodGCInfoNode(this);
+            _method = methodDesc;
+            _token = token;
+        }
+
+        public void SetCode(ObjectData data)
+        {
+            Debug.Assert(_methodCode == null);
+            _methodCode = data;
+        }
+
+        public MethodDesc Method => _method;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
+        {
+            ObjectData methodCode = _methodCode;
+            if (relocsOnly)
+            {
+                int extraRelocs = 1; // GCInfoNode
+
+                Relocation[] relocs = new Relocation[methodCode.Relocs.Length + extraRelocs];
+                Array.Copy(methodCode.Relocs, relocs, methodCode.Relocs.Length);
+                int extraRelocIndex = methodCode.Relocs.Length;
+                relocs[extraRelocIndex++] = new Relocation(RelocType.IMAGE_REL_BASED_ADDR32NB, 0, GCInfoNode);
+                Debug.Assert(extraRelocIndex == relocs.Length);
+                methodCode = new ObjectData(methodCode.Data, relocs, methodCode.Alignment, methodCode.DefinedSymbols); 
+            }
+            return methodCode;
+        }
+
+        public override bool StaticDependenciesAreComputed => _methodCode != null;
+
+        public virtual void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.GetMangledMethodName(_method));
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            Utf8StringBuilder sb = new Utf8StringBuilder();
+            AppendMangledName(factory.NameMangler, sb);
+            return sb.ToString();
+        }
+
+        private const int ClassCodeValue = 315213488;
+
+        int ISortableSymbolNode.ClassCode => ClassCodeValue;
+
+        protected override int ClassCode => ClassCodeValue;
+
+        public override ObjectNodeSection Section
+        {
+            get
+            {
+                return _method.Context.Target.IsWindows ? ObjectNodeSection.ManagedCodeWindowsContentSection : ObjectNodeSection.ManagedCodeUnixContentSection;
+            }
+        }
+
+        public FrameInfo[] FrameInfos => _frameInfos;
+        public byte[] GCInfo => _gcInfo;
+        public ObjectData EHInfo => _ehInfo;
+
+        public ISymbolNode GetAssociatedDataNode(NodeFactory factory)
+        {
+            if (MethodAssociatedDataNode.MethodHasAssociatedData(factory, this))
+                return factory.MethodAssociatedData(this);
+
+            return null;
+        }
+
+        public void InitializeFrameInfos(FrameInfo[] frameInfos)
+        {
+            Debug.Assert(_frameInfos == null);
+            _frameInfos = frameInfos;
+        }
+
+        public void InitializeGCInfo(byte[] gcInfo)
+        {
+            Debug.Assert(_gcInfo == null);
+            _gcInfo = gcInfo;
+        }
+
+        public void InitializeEHInfo(ObjectData ehInfo)
+        {
+            Debug.Assert(_ehInfo == null);
+            _ehInfo = ehInfo;
+        }
+
+        public DebugLocInfo[] DebugLocInfos => _debugLocInfos;
+        public DebugVarInfo[] DebugVarInfos => _debugVarInfos;
+        public DebugEHClauseInfo[] DebugEHClauseInfos => _debugEHClauseInfos;
+
+        public void InitializeDebugLocInfos(DebugLocInfo[] debugLocInfos)
+        {
+            Debug.Assert(_debugLocInfos == null);
+            _debugLocInfos = debugLocInfos;
+        }
+
+        public void InitializeDebugVarInfos(DebugVarInfo[] debugVarInfos)
+        {
+            Debug.Assert(_debugVarInfos == null);
+            _debugVarInfos = debugVarInfos;
+        }
+
+        public void InitializeDebugEHClauseInfos(DebugEHClauseInfo[] debugEHClauseInfos)
+        {
+            Debug.Assert(_debugEHClauseInfos == null);
+            _debugEHClauseInfos = debugEHClauseInfos;
+        }
+
+        public int CompareToImpl(ISortableSymbolNode other, CompilerComparer comparer)
+        {
+            MethodWithGCInfo otherMethod = (MethodWithGCInfo)other;
+            return _token.CompareTo(otherMethod._token);
+        }
+
+        public int Offset => 0;
+        public override bool IsShareable => _method is InstantiatedMethod || EETypeNode.IsTypeNodeShareable(_method.OwningType);
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using Internal.JitInterface;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class NewArrayFixupSignature : Signature
+    {
+        private readonly ArrayType _arrayType;
+        private readonly mdToken _typeToken;
+
+        public NewArrayFixupSignature(ArrayType arrayType, mdToken typeToken)
+        {
+            _arrayType = arrayType;
+            _typeToken = typeToken;
+        }
+
+        protected override int ClassCode => 815543321;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
+            ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
+            dataBuilder.AddSymbol(this);
+
+            dataBuilder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_NewArray);
+            dataBuilder.EmitTypeSignature(_arrayType, _typeToken, r2rFactory.SignatureContext);
+
+            return dataBuilder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($@"NewArraySignature: {_arrayType.ToString()}; token: {(uint)_typeToken:X8})");
+        }
+
+        protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
+        {
+            return _typeToken.CompareTo(((NewArrayFixupSignature)other)._typeToken);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/NewObjectFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/NewObjectFixupSignature.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using Internal.JitInterface;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class NewObjectFixupSignature : Signature
+    {
+        private readonly TypeDesc _typeDesc;
+        private readonly mdToken _typeToken;
+
+        public NewObjectFixupSignature(TypeDesc typeDesc, mdToken typeToken)
+        {
+            _typeDesc = typeDesc;
+            _typeToken = typeToken;
+        }
+
+        protected override int ClassCode => 551247760;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
+            ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
+            dataBuilder.AddSymbol(this);
+
+            dataBuilder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_NewObject);
+            dataBuilder.EmitTypeSignature(_typeDesc, _typeToken, r2rFactory.SignatureContext);
+
+            return dataBuilder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($@"NewObjectSignature: {_typeDesc.ToString()}; token: {(uint)_typeToken:X8})");
+        }
+
+        protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
+        {
+            return _typeToken.CompareTo(((NewObjectFixupSignature)other)._typeToken);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperImport.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// This class represents a single indirection cell resolved using fixup table
+    /// at function startup.
+    /// </summary>
+    public class PrecodeHelperImport : Import
+    {
+        public PrecodeHelperImport(ReadyToRunCodegenNodeFactory factory, Signature signature)
+            : base(factory.PrecodeImports, signature)
+        {
+            factory.PrecodeImports.AddImport(factory, this);
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return "PrecodeHelperImport->" + ImportSignature.GetMangledName(factory.NameMangler);
+        }
+
+        protected override int ClassCode => 667823013;
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            // This needs to be an empty target pointer since it will be filled in with Module*
+            // when loaded by CoreCLR
+            dataBuilder.EmitZeroPointer();
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunHelperSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunHelperSignature.cs
@@ -9,11 +9,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class ReadyToRunHelperSignature : Signature
     {
-        private ReadyToRunHelper _helper;
+        private readonly ReadyToRunHelper _helperID;
 
         public ReadyToRunHelperSignature(ReadyToRunHelper helper)
         {
-            _helper = helper;
+            _helperID = helper;
         }
 
         protected override int ClassCode => 208107954;
@@ -21,7 +21,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
             return new ObjectData(
-                new[] { (byte)ReadyToRunFixupKind.READYTORUN_FIXUP_Helper, (byte)_helper },
+                new[] { (byte) ReadyToRunFixupKind.READYTORUN_FIXUP_Helper, (byte) _helperID },
                 Array.Empty<Relocation>(),
                 1,
                 new ISymbolDefinitionNode[] { this });
@@ -31,12 +31,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             sb.Append(nameMangler.CompilationUnitPrefix);
             sb.Append("ReadyToRunHelper_");
-            sb.Append(_helper.ToString());
+            sb.Append(_helperID.ToString());
         }
 
         protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
         {
-            return _helper.CompareTo(((ReadyToRunHelperSignature)other)._helper);
+            return _helperID.CompareTo(((ReadyToRunHelperSignature) other)._helperID);
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsGCInfoNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsGCInfoNode.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    class RuntimeFunctionsGCInfoNode : ArrayOfEmbeddedDataNode<MethodGCInfoNode>
+    {
+        public RuntimeFunctionsGCInfoNode()
+            : base("RuntimeFunctionsGCInfo_Begin", "RuntimeFunctionsGCInfo_End", null)
+        {
+        }
+
+        protected override int ClassCode => 316678892;
+
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override bool IsShareable => false;
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection.Metadata;
 
 using Internal.NativeFormat;
 using Internal.Runtime;
@@ -16,25 +17,24 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class RuntimeFunctionsTableNode : HeaderTableNode
     {
-        List<MethodCodeNode> _methodNodes;
-        
+        private readonly List<MethodWithGCInfo> _methodNodes;
+
         public RuntimeFunctionsTableNode(TargetDetails target)
             : base(target)
         {
-            _methodNodes = new List<MethodCodeNode>();
+            _methodNodes = new List<MethodWithGCInfo>();
         }
-        
+
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
             sb.Append(nameMangler.CompilationUnitPrefix);
             sb.Append("__ReadyToRunRuntimeFunctionsTable");
         }
 
-        public int Add(MethodCodeNode method)
+        public int Add(MethodWithGCInfo method)
         {
-            int methodIndex = _methodNodes.Count;
             _methodNodes.Add(method);
-            return methodIndex;
+            return _methodNodes.Count - 1;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
@@ -44,40 +44,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Add the symbol representing this object node
             runtimeFunctionsBuilder.AddSymbol(this);
 
-            int gcInfoGlobalOffset = (Target.Architecture == TargetArchitecture.X64 ? 3 : 2) * sizeof(int) * _methodNodes.Count;
-            ArrayBuilder<byte> uniqueGCInfoBuilder = new ArrayBuilder<byte>();
-            Dictionary<byte[], int> uniqueGCInfoOffsets = new Dictionary<byte[], int>(ByteArrayComparer.Instance);
-
-            foreach (MethodCodeNode methodNode in _methodNodes)
+            foreach (MethodWithGCInfo method in _methodNodes)
             {
                 // StartOffset of the runtime function
-                runtimeFunctionsBuilder.EmitReloc(methodNode, RelocType.IMAGE_REL_BASED_ADDR32NB, delta: 0);
-                if (Target.Architecture == TargetArchitecture.X64)
+                runtimeFunctionsBuilder.EmitReloc(method, RelocType.IMAGE_REL_BASED_ADDR32NB, delta: 0);
+                if (!relocsOnly && Target.Architecture == TargetArchitecture.X64)
                 {
                     // On Amd64, the 2nd word contains the EndOffset of the runtime function
-                    int methodLength = methodNode.GetData(factory, relocsOnly).Data.Length;
-                    runtimeFunctionsBuilder.EmitReloc(methodNode, RelocType.IMAGE_REL_BASED_ADDR32NB, delta: methodLength);
-                }
-                // Unify GC info of the runtime function
-                byte[] gcInfo = methodNode.GCInfo;
-                int gcInfoLocalOffset;
-                if (!uniqueGCInfoOffsets.TryGetValue(gcInfo, out gcInfoLocalOffset))
-                {
-                    gcInfoLocalOffset = uniqueGCInfoBuilder.Count;
-                    uniqueGCInfoBuilder.Append(gcInfo);
-                    uniqueGCInfoOffsets.Add(gcInfo, gcInfoLocalOffset);
+                    int methodLength = method.GetData(factory, relocsOnly).Data.Length;
+                    runtimeFunctionsBuilder.EmitReloc(method, RelocType.IMAGE_REL_BASED_ADDR32NB, delta: methodLength);
                 }
                 // Emit the GC info RVA
-                runtimeFunctionsBuilder.EmitReloc(this, RelocType.IMAGE_REL_BASED_ADDR32NB, delta: gcInfoGlobalOffset + gcInfoLocalOffset);
+                runtimeFunctionsBuilder.EmitReloc(method.GCInfoNode, RelocType.IMAGE_REL_BASED_ADDR32NB);
             }
-
-            // Note: this algorithm always emits the GC info "above" the runtime function
-            // table. If we want to be able to separate these two tables completely, we'll
-            // likely need a separate node for the GC info.
-            Debug.Assert(runtimeFunctionsBuilder.CountBytes == gcInfoGlobalOffset);
-
-            // For some weird reason, ObjectDataBuilder.EmitBytes(ArrayBuilder<byte>) is marked as internal.
-            runtimeFunctionsBuilder.EmitBytes(uniqueGCInfoBuilder.ToArray());
 
             return runtimeFunctionsBuilder.ToObjectData();
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/StringImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/StringImport.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.JitInterface;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class StringImport : Import
+    {
+        private readonly mdToken _token; // diagnostic purposes only
+
+        private int _definitionOffset;
+
+        public StringImport(ImportSectionNode table, mdToken token)
+            : base(table, new StringImportSignature(token))
+        {
+            _token = token;
+        }
+
+        protected override int ClassCode => throw new NotImplementedException();
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            _definitionOffset = dataBuilder.CountBytes;
+            // This needs to be an empty target pointer since it will be filled in with the string pointer
+            // when loaded by CoreCLR
+            dataBuilder.EmitZeroPointer();
+        }
+
+        int Offset => _definitionOffset;
+
+        public override bool RepresentsIndirectionCell => true;
+
+        protected override string GetName(NodeFactory context)
+        {
+            return "StringCell: " + ((uint)_token).ToString("X8");
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.JitInterface;
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class StringImportSignature : Signature
+    {
+        private readonly mdToken _token;
+
+        public StringImportSignature(mdToken token)
+        {
+            _token = token;
+        }
+
+        protected override int ClassCode => 324832559;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
+            ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
+            dataBuilder.AddSymbol(this);
+
+            dataBuilder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_StringHandle);
+            dataBuilder.EmitUInt(SignatureBuilder.RidFromToken(_token));
+
+            return dataBuilder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append("StringImportSignature: " + ((uint)_token).ToString("X8"));
+        }
+
+        protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
+        {
+            return _token.CompareTo(((StringImportSignature)other)._token);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using Internal.JitInterface;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class TypeFixupSignature : Signature
+    {
+        private readonly ReadyToRunFixupKind _fixupKind;
+
+        private readonly TypeDesc _typeDesc;
+
+        private readonly mdToken _typeToken;
+
+        public TypeFixupSignature(ReadyToRunFixupKind fixupKind, TypeDesc typeDesc, mdToken typeToken)
+        {
+            _fixupKind = fixupKind;
+            _typeDesc = typeDesc;
+            _typeToken = typeToken;
+        }
+
+        protected override int ClassCode => 255607008;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
+            ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
+            dataBuilder.AddSymbol(this);
+
+            dataBuilder.EmitByte((byte)_fixupKind);
+            dataBuilder.EmitTypeSignature(_typeDesc, _typeToken, r2rFactory.SignatureContext);
+
+            return dataBuilder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($@"TypeFixupSignature({_fixupKind.ToString()}): {_typeDesc.ToString()}; token: {(uint)_typeToken:X8})");
+        }
+
+        protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
+        {
+            return _typeToken.CompareTo(((TypeFixupSignature)other)._typeToken);
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -3,33 +3,49 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-
-using ILCompiler.DependencyAnalysisFramework;
-using Internal.TypeSystem;
-
 using ILCompiler.DependencyAnalysis.ReadyToRun;
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.JitInterface;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis
 {
+    using ReadyToRunHelper = ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper;
+
     public sealed class ReadyToRunCodegenNodeFactory : NodeFactory
     {
-        public ReadyToRunCodegenNodeFactory(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup, MetadataManager metadataManager,
-            InteropStubManager interopStubManager, NameMangler nameMangler, VTableSliceProvider vtableSliceProvider, DictionaryLayoutProvider dictionaryLayoutProvider)
-            : base(context, 
-                  compilationModuleGroup, 
-                  metadataManager, 
-                  interopStubManager, 
-                  nameMangler, 
-                  new LazyGenericsDisabledPolicy(), 
-                  vtableSliceProvider, 
-                  dictionaryLayoutProvider, 
+        private Dictionary<MethodDesc, IMethodNode> _importMethods;
+
+        private Dictionary<mdToken, ISymbolNode> _importStrings;
+
+        public ReadyToRunCodegenNodeFactory(
+            CompilerTypeSystemContext context, 
+            CompilationModuleGroup compilationModuleGroup,
+            MetadataManager metadataManager,
+            InteropStubManager interopStubManager, 
+            NameMangler nameMangler, 
+            VTableSliceProvider vtableSliceProvider, 
+            DictionaryLayoutProvider dictionaryLayoutProvider,
+            EcmaModule inputModule)
+            : base(context,
+                  compilationModuleGroup,
+                  metadataManager,
+                  interopStubManager,
+                  nameMangler,
+                  new LazyGenericsDisabledPolicy(),
+                  vtableSliceProvider,
+                  dictionaryLayoutProvider,
                   new ImportedNodeProviderThrowing())
         {
-            _signatureIndirectionNodes = new NodeCache<Signature, EmbeddedPointerIndirectionNode<Signature>>((Signature signature) =>
-            {
-                return new RvaEmbeddedPointerIndirectionNode<Signature>(signature);
-            });
+            _importMethods = new Dictionary<MethodDesc, IMethodNode>();
+            _importStrings = new Dictionary<mdToken, ISymbolNode>();
+            _inputModule = inputModule;
         }
 
         public PEReader PEReader;
@@ -37,6 +53,8 @@ namespace ILCompiler.DependencyAnalysis
         public HeaderNode Header;
 
         public RuntimeFunctionsTableNode RuntimeFunctionsTable;
+
+        private RuntimeFunctionsGCInfoNode _runtimeFunctionsGCInfo;
 
         public MethodEntryPointTableNode MethodEntryPointTable;
 
@@ -46,9 +64,95 @@ namespace ILCompiler.DependencyAnalysis
 
         public ImportSectionsTableNode ImportSectionsTable;
 
-        protected override IMethodNode CreateMethodEntrypointNode(MethodDesc method)
+        public Import ModuleImport;
+
+        public ImportSectionNode EagerImports;
+
+        public ImportSectionNode MethodImports;
+
+        public ImportSectionNode StringImports;
+
+        public ImportSectionNode HelperImports;
+
+        public ImportSectionNode PrecodeImports;
+
+        /// <summary>
+        /// TODO: this will need changing when compiling multiple files. Ideally this
+        /// should be switched every time we compile a method in a particular module
+        /// because this is what provides context for reference token resolution.
+        /// </summary>
+        EcmaModule _inputModule;
+
+        SignatureContext _signatureContext;
+
+        public SignatureContext SignatureContext
         {
-            return new MethodCodeNode(method);
+            get
+            {
+                if (_signatureContext == null)
+                {
+                    _signatureContext = new SignatureContext(this, _inputModule);
+                }
+                return _signatureContext;
+            }
+        }
+
+
+        Dictionary<MethodDesc, IMethodNode> _methodMap = new Dictionary<MethodDesc, IMethodNode>();
+
+        public IMethodNode MethodEntrypoint(MethodDesc method, mdToken token, bool isUnboxingStub = false)
+        {
+            IMethodNode methodNode;
+            if (!_methodMap.TryGetValue(method, out methodNode))
+            {
+                methodNode = CreateMethodEntrypointNode(method, token, isUnboxingStub);
+                _methodMap.Add(method, methodNode);
+            }
+            return methodNode;
+        }
+
+        private IMethodNode CreateMethodEntrypointNode(MethodDesc method, mdToken token, bool isUnboxingStub = false)
+        {
+            if (method is InstantiatedMethod instantiatedMethod)
+            {
+                return GetOrAddInstantiatedMethodNode(instantiatedMethod, token);
+            }
+
+            MethodWithGCInfo localMethod = null;
+            if (CompilationModuleGroup.ContainsMethodBody(method, false))
+            {
+                localMethod = new MethodWithGCInfo(method, token);
+                _runtimeFunctionsGCInfo.AddEmbeddedObject(localMethod.GCInfoNode);
+                int methodIndex = RuntimeFunctionsTable.Add(localMethod);
+                MethodEntryPointTable.Add(localMethod, methodIndex, this);
+
+                // TODO: hack - how do we distinguish between emitting main entry point and calls between
+                // methods?
+                if (token == 0)
+                {
+                    return localMethod;
+                }
+            }
+
+            return GetOrAddImportedMethodNode(method, unboxingStub: false, token: token, localMethod: localMethod);
+        }
+
+        public IMethodNode StringAllocator(MethodDesc constructor, mdToken token)
+        {
+            return MethodEntrypoint(constructor, token, isUnboxingStub: false);
+        }
+
+        public ISymbolNode StringLiteral(mdToken token)
+        {
+            ISymbolNode stringNode;
+            if (!_importStrings.TryGetValue(token, out stringNode))
+            {
+                StringImport r2rImportNode = new StringImport(StringImports, token);
+                StringImports.AddImport(this, r2rImportNode);
+                stringNode = r2rImportNode;
+                _importStrings.Add(token, stringNode);
+            }
+            return stringNode;
         }
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
@@ -56,28 +160,458 @@ namespace ILCompiler.DependencyAnalysis
             throw new NotImplementedException();
         }
 
-        protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
+        public bool CanInline(MethodDesc callerMethod, MethodDesc calleeMethod)
+        {
+            // By default impose no restrictions on inlining
+            return CompilationModuleGroup.ContainsMethodBody(calleeMethod, unboxingStub: false);
+        }
+
+        Dictionary<ReadyToRunHelperId, Dictionary<object, ISymbolNode>> _r2rHelpers = new Dictionary<ReadyToRunHelperId, Dictionary<object, ISymbolNode>>();
+
+        public ISymbolNode ReadyToRunHelper(ReadyToRunHelperId id, object target, mdToken token)
+        {
+            if (id == ReadyToRunHelperId.NecessaryTypeHandle)
+            {
+                // We treat TypeHandle and NecessaryTypeHandle the same - don't emit two copies of the same import
+                id = ReadyToRunHelperId.TypeHandle;
+            }
+
+            Dictionary<object, ISymbolNode> helperNodeMap;
+            if (!_r2rHelpers.TryGetValue(id, out helperNodeMap))
+            {
+                helperNodeMap = new Dictionary<object, ISymbolNode>();
+                _r2rHelpers.Add(id, helperNodeMap);
+            }
+
+            ISymbolNode helperNode;
+            if (helperNodeMap.TryGetValue(target, out helperNode))
+            {
+                return helperNode;
+            }
+
+            switch (id)
+            {
+                case ReadyToRunHelperId.NewHelper:
+                    helperNode = CreateNewHelper((TypeDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.NewArr1:
+                    helperNode = CreateNewArrayHelper((ArrayType)target, token);
+                    break;
+
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    helperNode = CreateGCStaticBaseHelper((TypeDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    helperNode = CreateNonGCStaticBaseHelper((TypeDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    helperNode = CreateThreadStaticBaseHelper((TypeDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.IsInstanceOf:
+                    helperNode = CreateIsInstanceOfHelper((TypeDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.CastClass:
+                    helperNode = CreateCastClassHelper((TypeDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.TypeHandle:
+                    helperNode = CreateTypeHandleHelper((TypeDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.VirtualCall:
+                    helperNode = CreateVirtualCallHelper((MethodDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.DelegateCtor:
+                    helperNode = CreateDelegateCtorHelper((DelegateCreationInfo)target, token);
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            helperNodeMap.Add(target, helperNode);
+            return helperNode;
+        }
+
+        private ISymbolNode CreateNewHelper(TypeDesc type, mdToken ctorMemberRefOrTypeRefToken)
+        {
+            MetadataReader mdReader = PEReader.GetMetadataReader();
+            mdToken typeToken;
+            EntityHandle handle = (EntityHandle)MetadataTokens.Handle((int)ctorMemberRefOrTypeRefToken);
+            switch (handle.Kind)
+            {
+                case HandleKind.TypeReference:
+                    typeToken = ctorMemberRefOrTypeRefToken;
+                    break;
+
+                case HandleKind.MemberReference:
+                    {
+                        MemberReferenceHandle memberRefHandle = (MemberReferenceHandle)handle;
+                        MemberReference memberRef = mdReader.GetMemberReference(memberRefHandle);
+                        typeToken = (mdToken)MetadataTokens.GetToken(memberRef.Parent);
+                    }
+                    break;
+
+                case HandleKind.MethodDefinition:
+                    {
+                        MethodDefinitionHandle methodDefHandle = (MethodDefinitionHandle)handle;
+                        MethodDefinition methodDef = mdReader.GetMethodDefinition(methodDefHandle);
+                        typeToken = (mdToken)MetadataTokens.GetToken(methodDef.GetDeclaringType());
+                    }
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            return new DelayLoadHelperImport(this,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                new NewObjectFixupSignature(type, typeToken));
+        }
+
+        private ISymbolNode CreateNewArrayHelper(ArrayType type, mdToken typeRefToken)
+        {
+            Debug.Assert(SignatureBuilder.TypeFromToken(typeRefToken) == CorTokenType.mdtTypeRef);
+            return new DelayLoadHelperImport(this,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                new NewArrayFixupSignature(type, typeRefToken));
+        }
+
+        private ISymbolNode CreateGCStaticBaseHelper(TypeDesc type, mdToken token)
+        {
+            return new DelayLoadHelperImport(
+                this,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                new TypeFixupSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_StaticBaseGC, type, GetTypeToken(token)));
+        }
+
+        private ISymbolNode CreateNonGCStaticBaseHelper(TypeDesc type, mdToken token)
+        {
+            return new DelayLoadHelperImport(
+                this,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                new TypeFixupSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_StaticBaseNonGC, type, GetTypeToken(token)));
+        }
+
+        private ISymbolNode CreateThreadStaticBaseHelper(TypeDesc type, mdToken token)
+        {
+            ReadyToRunFixupKind fixupKind = ReadyToRunFixupKind.READYTORUN_FIXUP_ThreadStaticBaseNonGC;
+            return new DelayLoadHelperImport(
+                this,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                new TypeFixupSignature(fixupKind, type, GetTypeToken(token)));
+        }
+
+        private mdToken GetTypeToken(mdToken token)
+        {
+            MetadataReader mdReader = PEReader.GetMetadataReader();
+            mdToken typeToken;
+            EntityHandle handle = (EntityHandle)MetadataTokens.Handle((int)token);
+            switch (handle.Kind)
+            {
+                case HandleKind.TypeReference:
+                case HandleKind.TypeDefinition:
+                    typeToken = token;
+                    break;
+
+                case HandleKind.MemberReference:
+                    {
+                        MemberReferenceHandle memberRefHandle = (MemberReferenceHandle)handle;
+                        MemberReference memberRef = mdReader.GetMemberReference(memberRefHandle);
+                        typeToken = (mdToken)MetadataTokens.GetToken(memberRef.Parent);
+                    }
+                    break;
+
+                case HandleKind.FieldDefinition:
+                    {
+                        FieldDefinitionHandle fieldDefHandle = (FieldDefinitionHandle)handle;
+                        FieldDefinition fieldDef = mdReader.GetFieldDefinition(fieldDefHandle);
+                        typeToken = (mdToken)MetadataTokens.GetToken(fieldDef.GetDeclaringType());
+                    }
+                    break;
+
+                case HandleKind.MethodDefinition:
+                    {
+                        MethodDefinitionHandle methodDefHandle = (MethodDefinitionHandle)handle;
+                        MethodDefinition methodDef = mdReader.GetMethodDefinition(methodDefHandle);
+                        typeToken = (mdToken)MetadataTokens.GetToken(methodDef.GetDeclaringType());
+                    }
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            return typeToken;
+        }
+
+        private ISymbolNode CreateIsInstanceOfHelper(TypeDesc type, mdToken typeRefToken)
+        {
+            return new DelayLoadHelperImport(this, 
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                new TypeFixupSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_IsInstanceOf, type, typeRefToken));
+        }
+
+        private ISymbolNode CreateCastClassHelper(TypeDesc type, mdToken typeRefToken)
+        {
+            return new DelayLoadHelperImport(this,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj,
+                new TypeFixupSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_ChkCast, type, typeRefToken));
+        }
+
+        private ISymbolNode CreateTypeHandleHelper(TypeDesc type, mdToken typeRefToken)
+        {
+            return new PrecodeHelperImport(this,
+                new TypeFixupSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_TypeHandle, type, typeRefToken));
+        }
+
+        private ISymbolNode CreateVirtualCallHelper(MethodDesc method, mdToken methodToken)
+        {
+            return new DelayLoadHelperImport(
+                this,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj,
+                GetOrAddMethodSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry, method, methodToken, MethodFixupSignature.SignatureKind.Signature));
+        }
+
+        private ISymbolNode CreateDelegateCtorHelper(DelegateCreationInfo info, mdToken token)
+        {
+            return info.Constructor;
+        }
+
+        Dictionary<ILCompiler.ReadyToRunHelper, ISymbolNode> _helperCache = new Dictionary<ILCompiler.ReadyToRunHelper, ISymbolNode>();
+
+        public ISymbolNode ExternSymbol(ILCompiler.ReadyToRunHelper helper)
+        {
+            ISymbolNode result;
+            if (_helperCache.TryGetValue(helper, out result))
+            {
+                return result;
+            }
+
+            switch (helper)
+            {
+                case ILCompiler.ReadyToRunHelper.Box:
+                    result = CreateBoxHelper();
+                    break;
+
+                case ILCompiler.ReadyToRunHelper.Box_Nullable:
+                    result = CreateBoxNullableHelper();
+                    break;
+
+                case ILCompiler.ReadyToRunHelper.Unbox:
+                    result = CreateUnboxHelper();
+                    break;
+
+                case ILCompiler.ReadyToRunHelper.Unbox_Nullable:
+                    result = CreateUnboxNullableHelper();
+                    break;
+
+                case ILCompiler.ReadyToRunHelper.GetRuntimeTypeHandle:
+                    result = CreateGetRuntimeTypeHandleHelper();
+                    break;
+
+                case ILCompiler.ReadyToRunHelper.RngChkFail:
+                    result = CreateRangeCheckFailureHelper();
+                    break;
+
+                case ILCompiler.ReadyToRunHelper.WriteBarrier:
+                    result = CreateWriteBarrierHelper();
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            _helperCache.Add(helper, result);
+            return result;
+        }
+
+        public ISymbolNode HelperMethodEntrypoint(ILCompiler.ReadyToRunHelper helperId, MethodDesc method)
+        {
+            return ExternSymbol(helperId);
+        }
+
+
+        private ISymbolNode CreateBoxHelper()
+        {
+            return GetReadyToRunHelperCell(ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_Box);
+        }
+
+        private ISymbolNode CreateBoxNullableHelper()
+        {
+            return GetReadyToRunHelperCell(ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_Box_Nullable);
+        }
+
+        private ISymbolNode CreateUnboxHelper()
+        {
+            return GetReadyToRunHelperCell(ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_Unbox);
+        }
+
+        private ISymbolNode CreateUnboxNullableHelper()
+        {
+            return GetReadyToRunHelperCell(ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_Unbox_Nullable);
+        }
+
+        private ISymbolNode CreateGetRuntimeTypeHandleHelper()
+        {
+            return GetReadyToRunHelperCell(ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GetRuntimeTypeHandle);
+        }
+
+        private ISymbolNode CreateRangeCheckFailureHelper()
+        {
+            return GetReadyToRunHelperCell(ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_RngChkFail);
+        }
+
+        private ISymbolNode CreateWriteBarrierHelper()
+        {
+            return GetReadyToRunHelperCell(ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_WriteBarrier);
+        }
+
+        public IMethodNode CreateUnboxingStubNode(MethodDesc method, mdToken token)
         {
             throw new NotImplementedException();
         }
 
-        private NodeCache<Signature, EmbeddedPointerIndirectionNode<Signature>> _signatureIndirectionNodes;
-
-        public EmbeddedPointerIndirectionNode<Signature> SignatureIndirection(Signature signature)
+        struct TokenAndCallSite
         {
-            return _signatureIndirectionNodes.GetOrAdd(signature);
+            public readonly mdToken Token;
+            public readonly string CallSite;
+
+            public TokenAndCallSite(mdToken token, string callSite)
+            {
+                CallSite = callSite;
+                Token = token;
+            }
+
+            public override bool Equals(object obj)
+            {
+                TokenAndCallSite other = (TokenAndCallSite)obj;
+                return CallSite == other.CallSite && Token == other.Token;
+            }
+
+            public override int GetHashCode()
+            {
+                return (CallSite != null ? CallSite.GetHashCode() : 0) + unchecked(31 * (int)Token);
+            }
+        }
+
+        Dictionary<TokenAndCallSite, ISymbolNode> _interfaceDispatchCells = new Dictionary<TokenAndCallSite, ISymbolNode>();
+
+        public ISymbolNode InterfaceDispatchCell(MethodDesc method, mdToken token, string callSite = null)
+        {
+            TokenAndCallSite cellKey = new TokenAndCallSite(token, callSite);
+            ISymbolNode dispatchCell;
+            if (!_interfaceDispatchCells.TryGetValue(cellKey, out dispatchCell))
+            {
+                dispatchCell = new DelayLoadHelperImport(this,
+                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_MethodCall,
+                    GetOrAddMethodSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry, method, token, MethodFixupSignature.SignatureKind.Signature),
+                    callSite);
+
+                _interfaceDispatchCells.Add(cellKey, dispatchCell);
+            }
+            return dispatchCell;
+        }
+
+        private Dictionary<ReadyToRunHelper, ISymbolNode> _constructedHelpers = new Dictionary<ReadyToRunHelper, ISymbolNode>();
+
+        public ISymbolNode GetReadyToRunHelperCell(ReadyToRunHelper helperId)
+        {
+            ISymbolNode helperCell;
+            if (!_constructedHelpers.TryGetValue(helperId, out helperCell))
+            {
+                helperCell = CreateReadyToRunHelperCell(helperId);
+                _constructedHelpers.Add(helperId, helperCell);
+            }
+            return helperCell;
+        }
+
+        private ISymbolNode CreateReadyToRunHelperCell(ReadyToRunHelper helperId)
+        {
+            Import helperCell = new Import(EagerImports, new ReadyToRunHelperSignature(helperId));
+            EagerImports.AddImport(this, helperCell);
+            return helperCell;
+        }
+
+        public ISymbolNode ComputeConstantLookup(ReadyToRunHelperId helperId, object entity, mdToken token)
+        {
+            return ReadyToRunHelper(helperId, entity, token);
+        }
+
+        Dictionary<MethodDesc, ISortableSymbolNode> _genericDictionaryCache = new Dictionary<MethodDesc, ISortableSymbolNode>();
+
+        public ISortableSymbolNode MethodGenericDictionary(MethodDesc method, mdToken token)
+        {
+            ISortableSymbolNode genericDictionary;
+            if (!_genericDictionaryCache.TryGetValue(method, out genericDictionary))
+            {
+                genericDictionary = new DelayLoadHelperImport(this,
+                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                    GetOrAddMethodSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_MethodDictionary, method, token, MethodFixupSignature.SignatureKind.Signature));
+                _genericDictionaryCache.Add(method, genericDictionary);
+            }
+            return genericDictionary;
+        }
+
+        struct TokenAndFixupKind
+        {
+            public readonly mdToken Token;
+            public readonly ReadyToRunFixupKind FixupKind;
+
+            public TokenAndFixupKind(mdToken token, ReadyToRunFixupKind fixupKind)
+            {
+                Token = token;
+                FixupKind = fixupKind;
+            }
+
+            public override bool Equals(object obj)
+            {
+                TokenAndFixupKind other = (TokenAndFixupKind)obj;
+                return Token == other.Token && FixupKind == other.FixupKind;
+            }
+
+            public override int GetHashCode()
+            {
+                return (int)Token ^ unchecked(31 * (int)FixupKind);
+            }
+        }
+
+        Dictionary<TokenAndFixupKind, MethodFixupSignature> _methodSignatures = new Dictionary<TokenAndFixupKind, MethodFixupSignature>();
+
+        public MethodFixupSignature GetOrAddMethodSignature(
+            ReadyToRunFixupKind fixupKind,
+            MethodDesc methodDesc,
+            mdToken token,
+            MethodFixupSignature.SignatureKind signatureKind)
+        {
+            TokenAndFixupKind signatureKey = new TokenAndFixupKind(token, fixupKind);
+            MethodFixupSignature signature;
+            if (!_methodSignatures.TryGetValue(signatureKey, out signature))
+            {
+                signature = new MethodFixupSignature(fixupKind, methodDesc, token, signatureKind);
+                _methodSignatures.Add(signatureKey, signature);
+            }
+            return signature;
         }
 
         public override void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
         {
             Header = new HeaderNode(Target);
-            graph.AddRoot(Header, "ReadyToRunHeader is always generated");
 
             var compilerIdentifierNode = new CompilerIdentifierNode(Target);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.CompilerIdentifier, compilerIdentifierNode, compilerIdentifierNode);
 
             RuntimeFunctionsTable = new RuntimeFunctionsTableNode(Target);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.RuntimeFunctions, RuntimeFunctionsTable, RuntimeFunctionsTable);
+
+            _runtimeFunctionsGCInfo = new RuntimeFunctionsGCInfoNode();
+            graph.AddRoot(_runtimeFunctionsGCInfo, "GC info is always generated");
 
             MethodEntryPointTable = new MethodEntryPointTableNode(Target);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.MethodDefEntryPoints, MethodEntryPointTable, MethodEntryPointTable);
@@ -91,13 +625,129 @@ namespace ILCompiler.DependencyAnalysis
             ImportSectionsTable = new ImportSectionsTableNode(Target);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.ImportSections, ImportSectionsTable, ImportSectionsTable.StartSymbol);
 
-            ImportSectionNode eagerImports = new ImportSectionNode(CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN, CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_EAGER, (byte)Target.PointerSize);
-            ImportSectionsTable.AddEmbeddedObject(eagerImports);
+            EagerImports = new ImportSectionNode(
+                "EagerImports", 
+                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN, 
+                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_EAGER,
+                (byte)Target.PointerSize,
+                emitPrecode: false);
+            ImportSectionsTable.AddEmbeddedObject(EagerImports);
 
             // All ready-to-run images have a module import helper which gets patched by the runtime on image load
-            var moduleImport = new ModuleImport();
-            eagerImports.AddImport(this, moduleImport);
-            graph.AddRoot(moduleImport, "Module import is always generated");
+            ModuleImport = new Import(EagerImports, new ReadyToRunHelperSignature(
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_Module));
+            EagerImports.AddImport(this, ModuleImport);
+
+            MethodImports = new ImportSectionNode(
+                "MethodImports",
+                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_EXTERNAL_METHOD,
+                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
+                (byte)Target.PointerSize,
+                emitPrecode: true);
+            ImportSectionsTable.AddEmbeddedObject(MethodImports);
+
+            HelperImports = new ImportSectionNode(
+                "HelperImports",
+                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN,
+                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
+                (byte)Target.PointerSize,
+                emitPrecode: false);
+            ImportSectionsTable.AddEmbeddedObject(HelperImports);
+
+            PrecodeImports = new ImportSectionNode(
+                "PrecodeImports",
+                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN,
+                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
+                (byte)Target.PointerSize,
+                emitPrecode: true);
+            ImportSectionsTable.AddEmbeddedObject(PrecodeImports);
+
+            StringImports = new ImportSectionNode(
+                "StringImports",
+                CorCompileImportType.CORCOMPILE_IMPORT_TYPE_STRING_HANDLE,
+                CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_UNKNOWN,
+                (byte)Target.PointerSize,
+                emitPrecode: true);
+            ImportSectionsTable.AddEmbeddedObject(StringImports);
+
+            graph.AddRoot(ImportSectionsTable, "Import sections table is always generated");
+            graph.AddRoot(ModuleImport, "Module import is always generated");
+            graph.AddRoot(EagerImports, "Eager imports are always generated");
+            graph.AddRoot(MethodImports, "Method imports are always generated");
+            graph.AddRoot(HelperImports, "Helper imports are always generated");
+            graph.AddRoot(PrecodeImports, "Precode imports are always generated");
+            graph.AddRoot(StringImports, "String imports are always generated");
+            graph.AddRoot(Header, "ReadyToRunHeader is always generated");
+        }
+
+        public IMethodNode GetOrAddImportedMethodNode(MethodDesc method, bool unboxingStub, mdToken token, MethodWithGCInfo localMethod)
+        {
+            ReadyToRunFixupKind fixupKind;
+            MethodFixupSignature.SignatureKind signatureKind;
+            CorTokenType tokenType = SignatureBuilder.TypeFromToken(token);
+            switch (tokenType)
+            {
+                case CorTokenType.mdtMethodDef:
+                    fixupKind = ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry_DefToken;
+                    signatureKind = MethodFixupSignature.SignatureKind.DefToken;
+                    break;
+
+                case CorTokenType.mdtMemberRef:
+                    fixupKind = ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry_RefToken;
+                    signatureKind = MethodFixupSignature.SignatureKind.RefToken;
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+            IMethodNode methodImport;
+            if (!_importMethods.TryGetValue(method, out methodImport))
+            {
+                // First time we see a given external method - emit indirection cell and the import entry
+                ExternalMethodImport indirectionCell = new ExternalMethodImport(this, fixupKind, method, token, localMethod, signatureKind);
+                _importMethods.Add(method, indirectionCell);
+                methodImport = indirectionCell;
+            }
+            return methodImport;
+        }
+
+        Dictionary<InstantiatedMethod, IMethodNode> _instantiatedMethodImports = new Dictionary<InstantiatedMethod, IMethodNode>();
+
+        private IMethodNode GetOrAddInstantiatedMethodNode(InstantiatedMethod method, mdToken token)
+        {
+            IMethodNode methodImport;
+            if (!_instantiatedMethodImports.TryGetValue(method, out methodImport))
+            {
+                methodImport = new ExternalMethodImport(
+                    this,
+                    ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry, 
+                    method, 
+                    token, 
+                    localMethod: null,
+                    MethodFixupSignature.SignatureKind.Signature);
+                _instantiatedMethodImports.Add(method, methodImport);
+            }
+            return methodImport;
+        }
+
+        public IMethodNode ShadowConcreteMethod(MethodDesc method, mdToken token, bool isUnboxingStub = false)
+        {
+            return MethodEntrypoint(method, token, isUnboxingStub);
+        }
+
+        protected override IMethodNode CreateMethodEntrypointNode(MethodDesc method)
+        {
+            if (!CompilationModuleGroup.ContainsMethodBody(method, unboxingStub: false))
+            {
+                // Cannot encode external methods without tokens
+                throw new NotImplementedException();
+            }
+            return MethodEntrypoint(method, default(mdToken), isUnboxingStub: false);
+        }
+
+        protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -64,13 +64,13 @@ namespace ILCompiler
         {
             foreach (DependencyNodeCore<NodeFactory> dependency in obj)
             {
-                var methodCodeNodeNeedingCode = dependency as MethodCodeNode;
+                var methodCodeNodeNeedingCode = dependency as MethodWithGCInfo;
                 if (methodCodeNodeNeedingCode == null)
                 {
                     // To compute dependencies of the shadow method that tracks dictionary
                     // dependencies we need to ensure there is code for the canonical method body.
                     var dependencyMethod = (ShadowConcreteMethodNode)dependency;
-                    methodCodeNodeNeedingCode = (MethodCodeNode)dependencyMethod.CanonicalMethodNode;
+                    methodCodeNodeNeedingCode = (MethodWithGCInfo)dependencyMethod.CanonicalMethodNode;
                 }
 
                 // We might have already compiled this method.
@@ -78,7 +78,6 @@ namespace ILCompiler
                     continue;
 
                 MethodDesc method = methodCodeNodeNeedingCode.Method;
-
                 if (Logger.IsVerbose)
                 {
                     string methodName = method.ToString();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -70,7 +70,8 @@ namespace ILCompiler
                 interopStubManager, 
                 _nameMangler,
                 _vtableSliceProvider, 
-                _dictionaryLayoutProvider);
+                _dictionaryLayoutProvider,
+                _context.GetModuleFromPath(_inputFilePath));
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
 
             List<CorJitFlag> corJitFlags = new List<CorJitFlag>();

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\..\ILCompiler.MetadataWriter\src\ILCompiler.MetadataWriter.csproj" />
     <ProjectReference Include="..\..\ILCompiler.TypeSystem\src\ILCompiler.TypeSystem.csproj" />
     <ProjectReference Include="..\..\ILCompiler.Compiler\src\ILCompiler.Compiler.csproj" />
-    <ProjectReference Include="..\..\ILCompiler.RyuJit\src\ILCompiler.RyuJit.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,23 +28,37 @@
   
   <ItemGroup>
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadHelperImport.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadHelperThunk.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DevirtualizationManager.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ExternalMethodImport.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\FixupConstants.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ImportSectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunCodegenNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ByteArrayComparer.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CompilerIdentifierNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DevirtualizationManager.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\HeaderNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\HelperSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Import.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ImportSectionsTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\InstanceEntryPointTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodEHInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodEntryPointTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodFixupSignature.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodGCInfoNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodWithGCInfo.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\NewArrayFixupSignature.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\NewObjectFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\NibbleWriter.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RvaEmbeddedPointerIndirectionNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\PrecodeHelperImport.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ReadyToRunHelperSignature.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RuntimeFunctionsGCInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RuntimeFunctionsTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RvaEmbeddedPointerIndirectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Signature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\SignatureBuilder.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\StringImport.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\StringImportSignature.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypeFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypesTableNode.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilation.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilationBuilder.cs" />
@@ -61,6 +74,11 @@
   <ItemGroup>
     <Compile Include="..\..\Common\src\System\Collections\Generic\ArrayBuilder.cs">
       <Link>Common\ArrayBuilder.cs</Link>
+    </Compile>
+
+    <!-- To clean this up, we should move IMethodCodeNode to a common location -->
+    <Compile Include="..\..\ILCompiler.RyuJit\src\Compiler\DependencyAnalysis\IMethodCodeNode.cs">
+      <Link>DependencyAnalysis\IMethodCodeNode.cs</Link>
     </Compile>
 
     <!--
@@ -81,6 +99,15 @@
     </Compile>
     <Compile Include="..\..\JitInterface\src\CorInfoImpl.cs">
       <Link>JitInterface\CorInfoImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JitInterface\src\CorInfoHelpFunc.cs">
+      <Link>JitInterface\CorInfoHelpFunc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JitInterface\src\CorInfoTypes.cs">
+      <Link>JitInterface\CorInfoTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\..\JitInterface\src\JitConfigProvider.cs">
+      <Link>JitInterface\JitConfigProvider.cs</Link>
     </Compile>
     <Compile Include="..\..\JitInterface\src\CorInfoImpl.Intrinsics.cs">
       <Link>JitInterface\CorInfoImpl.Intrinsics.cs</Link>

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 
 using Internal.IL;
+using Internal.JitInterface;
 using Internal.TypeSystem;
 
 using ILCompiler;
@@ -24,6 +25,7 @@ namespace Internal.JitInterface
         {
             _compilation = compilation;
         }
+
         private void ComputeLookup(ref CORINFO_RESOLVED_TOKEN pResolvedToken, object entity, ReadyToRunHelperId helperId, ref CORINFO_LOOKUP lookup)
         {
             if (_compilation.NeedsRuntimeLookup(helperId, entity))
@@ -79,7 +81,7 @@ namespace Internal.JitInterface
             else
             {
                 lookup.lookupKind.needsRuntimeLookup = false;
-                ISymbolNode constLookup = _compilation.ComputeConstantLookup(helperId, entity);
+                ISymbolNode constLookup = _compilation.NodeFactory.ComputeConstantLookup(helperId, entity, pResolvedToken.token);
                 lookup.constLookup = CreateConstLookupToSymbol(constLookup);
             }
         }
@@ -95,7 +97,7 @@ namespace Internal.JitInterface
                         if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
                             return false;
 
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.NewHelper, type));
+                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.NewHelper, type, pResolvedToken.token));
                     }
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_NEWARR_1:
@@ -105,7 +107,7 @@ namespace Internal.JitInterface
                         if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
                             return false;
 
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.NewArr1, type));
+                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.NewArr1, type, pResolvedToken.token));
                     }
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_ISINSTANCEOF:
@@ -118,7 +120,7 @@ namespace Internal.JitInterface
                         if (type.IsNullable)
                             type = type.Instantiation[0];
 
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.IsInstanceOf, type));
+                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.IsInstanceOf, type, pResolvedToken.token));
                     }
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_CHKCAST:
@@ -131,7 +133,7 @@ namespace Internal.JitInterface
                         if (type.IsNullable)
                             type = type.Instantiation[0];
 
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.CastClass, type));
+                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.CastClass, type, pResolvedToken.token));
                     }
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_STATIC_BASE:
@@ -140,7 +142,7 @@ namespace Internal.JitInterface
                         if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
                             return false;
 
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.GetNonGCStaticBase, type));
+                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.GetNonGCStaticBase, type, pResolvedToken.token));
                     }
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE:
@@ -210,7 +212,7 @@ namespace Internal.JitInterface
             else
             {
                 pLookup.lookupKind.needsRuntimeLookup = false;
-                pLookup.constLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.DelegateCtor, delegateInfo));
+                pLookup.constLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.DelegateCtor, delegateInfo, pTargetMethod.token));
             }
         }
 
@@ -448,18 +450,7 @@ namespace Internal.JitInterface
                     throw new NotImplementedException(ftnNum.ToString());
             }
 
-            string mangledName;
-            MethodDesc methodDesc;
-            JitHelper.GetEntryPoint(_compilation.TypeSystemContext, id, out mangledName, out methodDesc);
-            Debug.Assert(mangledName != null || methodDesc != null);
-
-            ISymbolNode entryPoint;
-            if (mangledName != null)
-                entryPoint = _compilation.NodeFactory.ExternSymbol(mangledName);
-            else
-                entryPoint = _compilation.NodeFactory.MethodEntrypoint(methodDesc);
-
-            return entryPoint;
+            return _compilation.NodeFactory.ExternSymbol(id);
         }
 
         private void getFunctionEntryPoint(CORINFO_METHOD_STRUCT_* ftn, ref CORINFO_CONST_LOOKUP pResult, CORINFO_ACCESS_FLAGS accessFlags)
@@ -475,11 +466,9 @@ namespace Internal.JitInterface
 
         private InfoAccessType constructStringLiteral(CORINFO_MODULE_STRUCT_* module, mdToken metaTok, ref void* ppValue)
         {
-            MethodIL methodIL = (MethodIL)HandleToObject((IntPtr)module);
-            object literal = methodIL.GetObject((int)metaTok);
-            ISymbolNode stringObject = _compilation.NodeFactory.SerializedStringObject((string)literal);
+            ISymbolNode stringObject = _compilation.NodeFactory.StringLiteral(metaTok);
             ppValue = (void*)ObjectToHandle(stringObject);
-            return stringObject.RepresentsIndirectionCell ? InfoAccessType.IAT_PVALUE : InfoAccessType.IAT_VALUE;
+            return InfoAccessType.IAT_PPVALUE;
         }
     }
 }

--- a/src/ILCompiler/repro/Program.cs
+++ b/src/ILCompiler/repro/Program.cs
@@ -3,11 +3,540 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 internal class Program
 {
-    private static void Main(string[] args)
+    // [ThreadStatic]
+    private static string TextFileName = @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\clientexclusionlist.xml";
+
+    //[ThreadStatic]
+    private static int LineCount = 0x12345678;
+
+    //*
+    private static bool NewString()
     {
-        Console.WriteLine("Hello world");
+        string s = new string('x', 10);
+        return s.Length == 10;
     }
+
+    private static bool WriteLine()
+    {
+        Console.WriteLine("Hello CoreRT R2R running on CoreCLR!");
+        return true;
+    }
+    //*/
+
+    //*
+    private static bool IsInstanceOf()
+    {
+        object obj = TextFileName;
+        if (obj is string str)
+        {
+            Console.WriteLine($@"Object is string: {str}");
+            return true;
+        }
+        else
+        {
+            Console.Error.WriteLine($@"Object is not a string: {obj}");
+            return false;
+        }
+    }
+
+    private static bool IsInstanceOfValueType()
+    {
+        object obj = LineCount;
+        if (obj is int i)
+        {
+            Console.WriteLine($@"Object {obj:X8} is int: {i:X8}");
+            return true;
+        }
+        else
+        {
+            Console.Error.WriteLine($@"Object is not an int: {obj}");
+            return false;
+        }
+    }
+    //*/
+
+    //*
+    private static bool ChkCast()
+    {
+        object obj = TextFileName;
+        string objString = (string)obj;
+        Console.WriteLine($@"String: {objString}");
+        return objString == TextFileName;
+    }
+
+    private static bool ChkCastValueType()
+    {
+        object obj = LineCount;
+        int objInt = (int)obj;
+        Console.WriteLine($@"Int: {objInt:X8}");
+        return objInt == LineCount;
+    }
+    //*/
+
+    //*
+    private static bool BoxUnbox()
+    {
+        bool success = true;
+        object intAsObject = LineCount;
+        int unboxedInt = (int)intAsObject;
+        if (unboxedInt == LineCount)
+        {
+            Console.WriteLine($@"unbox == box: original {LineCount}, boxed {intAsObject:X8}, unboxed {unboxedInt:X8}");
+        }
+        else
+        {
+            Console.Error.WriteLine($@"unbox != box: original {LineCount}, boxed {intAsObject:X8}, unboxed {unboxedInt:X8}");
+            success = false;
+        }
+        int? nullableInt = LineCount;
+        object nullableIntAsObject = nullableInt;
+        int? unboxedNullable = (int?)nullableIntAsObject;
+        if (unboxedNullable == nullableInt)
+        {
+            Console.WriteLine($@"unbox_nullable == box_nullable: original {nullableInt:X8}, boxed {nullableIntAsObject:X8}, unboxed {unboxedNullable:X8}");
+        }
+        else
+        {
+            Console.Error.WriteLine($@"unbox_nullable != box_nullable: original {nullableInt:X8}, boxed {nullableIntAsObject:X8}, unboxed {unboxedNullable:X8}");
+            success = false;
+        }
+        return success;
+    }
+    //*/
+
+    //*
+    private static bool TypeHandle()
+    {
+        Console.WriteLine(TextFileName.GetType().ToString());
+        Console.WriteLine(LineCount.GetType().ToString());
+        return true;
+    }
+
+    private static bool RuntimeTypeHandle()
+    {
+        Console.WriteLine(typeof(string).ToString());
+        return true;
+    }
+
+    private static bool ReadAllText()
+    {
+        Console.WriteLine($@"Dumping file: {TextFileName}");
+        string textFile = File.ReadAllText(TextFileName);
+        if (textFile.Length > 100)
+        {
+            textFile = textFile.Substring(0, 100) + "...";
+        }
+        Console.WriteLine(textFile);
+
+        return textFile.Length > 0;
+    }
+
+    private static bool StreamReaderReadLine()
+    {
+        Console.WriteLine($@"Dumping file: {TextFileName}");
+        using (StreamReader reader = new StreamReader(TextFileName, System.Text.Encoding.UTF8))
+        {
+            Console.WriteLine("StreamReader created ...");
+            string line1 = reader.ReadLine();
+            Console.WriteLine($@"Line 1: {line1}");
+            string line2 = reader.ReadLine();
+            Console.WriteLine($@"Line 2: {line2}");
+            return line2 != null;
+        }
+    }
+    //*/
+
+    //*
+    private static bool ConstructListOfInt()
+    {
+        List<int> listOfInt = new List<int>();
+        if (listOfInt.Count == 0)
+        {
+            Console.WriteLine("Successfully constructed empty List<int>!");
+            return true;
+        }
+        else
+        {
+            Console.WriteLine($@"Invalid element count in List<int>: {listOfInt.Count}");
+            return false;
+        }
+    }
+    //*/
+
+    //*
+    private static bool ManipulateListOfInt()
+    {
+        List<int> listOfInt = new List<int>();
+        const int ItemCount = 100;
+        for (int index = ItemCount; index > 0; index--)
+        {
+            listOfInt.Add(index);
+        }
+        listOfInt.Sort();
+        //listOfInt.Sort((a, b) => a.CompareTo(b));
+        for (int index = 0; index < listOfInt.Count; index++)
+        {
+            Console.Write($@"{listOfInt[index]} ");
+            if (index > 0 && listOfInt[index] <= listOfInt[index - 1])
+            {
+                // The list should be monotonically increasing now
+                return false;
+            }
+        }
+        Console.WriteLine();
+        return listOfInt.Count == ItemCount;
+    }
+
+    private static bool ConstructListOfString()
+    {
+        List<string> listOfString = new List<string>();
+        return listOfString.Count == 0;
+    }
+
+    private static bool ManipulateListOfString()
+    {
+        List<string> listOfString = new List<string>();
+        const int ItemCount = 100;
+        for (int index = ItemCount; index > 0; index--)
+        {
+            listOfString.Add(index.ToString());
+        }
+        listOfString.Sort();
+        //listOfInt.Sort((a, b) => a.CompareTo(b));
+        for (int index = 0; index < listOfString.Count; index++)
+        {
+            Console.Write($@"{listOfString[index]} ");
+            if (index > 0 && listOfString[index].CompareTo(listOfString[index - 1]) <= 0)
+            {
+                // The list should be monotonically increasing now
+                return false;
+            }
+        }
+        Console.WriteLine();
+        return listOfString.Count == ItemCount;
+    }
+    //*/
+
+    private static bool EmptyArray()
+    {
+        int[] emptyIntArray = Array.Empty<int>();
+        Console.WriteLine("Successfully constructed Array.Empty<int>!");
+        return emptyIntArray.Length == 0;
+    }
+
+    private delegate char CharFilterDelegate(char inputChar);
+
+    private static bool CharFilterDelegateTest()
+    {
+        string transformedString = TransformStringUsingCharFilter(TextFileName, CharFilterUpperCase);
+        Console.WriteLine(transformedString);
+        return transformedString.Length == TextFileName.Length;
+    }
+
+    private static string TransformStringUsingCharFilter(string inputString, CharFilterDelegate charFilter)
+    {
+        StringBuilder outputBuilder = new StringBuilder(inputString.Length);
+        foreach (char c in inputString)
+        {
+            char filteredChar = charFilter(c);
+            if (filteredChar != '\0')
+            {
+                outputBuilder.Append(filteredChar);
+            }
+        }
+        return outputBuilder.ToString();
+    }
+
+    private static char CharFilterUpperCase(char c)
+    {
+        return Char.ToUpperInvariant(c);
+    }
+
+    //*
+    private static bool EnumerateEmptyArray()
+    {
+        foreach (int element in Array.Empty<int>())
+        {
+            Console.Error.WriteLine($@"Error: Array.Empty<int> has an element {element}!");
+            return false;
+        }
+        foreach (string element in Array.Empty<string>())
+        {
+            Console.Error.WriteLine($@"Error: Array.Empty<string> has an element {element}");
+            return false;
+        }
+        return true;
+    }
+    //*/
+
+    public static int Main()
+    {
+        /*
+        StreamReader reader = new StreamReader(TextFileName, System.Text.Encoding.UTF8);
+
+        Console.WriteLine("StreamReader created ...");
+        string line1 = reader.ReadLine();
+        Console.WriteLine($@"Line 1: {line1}");
+
+        MemoryStream memoryStream = new MemoryStream();
+        memoryStream.WriteByte(10);
+
+        return o != null ? 100 : 101;
+        */
+
+        const int Success = 1;
+        const int Failure = 0;
+
+        int[] TestCounts = new int[2];
+
+        //*
+        TestCounts[NewString() ? Success : Failure]++;
+        TestCounts[WriteLine() ? Success : Failure]++;
+        TestCounts[IsInstanceOf() ? Success : Failure]++;
+        TestCounts[IsInstanceOfValueType() ? Success : Failure]++;
+        TestCounts[ChkCast() ? Success : Failure]++;
+        TestCounts[ChkCastValueType() ? Success : Failure]++;
+        TestCounts[BoxUnbox() ? Success : Failure]++;
+        TestCounts[TypeHandle() ? Success : Failure]++;
+        TestCounts[RuntimeTypeHandle() ? Success : Failure]++;
+        TestCounts[ReadAllText() ? Success : Failure]++;
+        TestCounts[StreamReaderReadLine() ? Success : Failure]++;
+        // TestCounts[CharFilterDelegateTest() ? Success : Failure]++;
+        //*/
+
+        TestCounts[ConstructListOfInt() ? Success : Failure]++;
+        TestCounts[ManipulateListOfInt() ? Success : Failure]++;
+        TestCounts[ConstructListOfString() ? Success : Failure]++;
+        TestCounts[ManipulateListOfString() ? Success : Failure]++;
+        
+        TestCounts[EmptyArray() ? Success : Failure]++;
+        // TestCounts[EnumerateEmptyArray() ? Success : Failure]++;
+
+        //*
+        if (TestCounts[Failure] == 0)
+        {
+            Console.WriteLine($@"All {TestCounts[Success]} tests pass!");
+            return 100;
+        }
+        else
+        {
+            Console.Error.WriteLine($@"{TestCounts[Failure]} test failed, {TestCounts[Success]} suceeded.");
+            return 1;
+        }
+        //*/
+    }
+    //*/
+
+    /*
+    public static int Main()
+    {
+        Console.WriteLine("Hello world!");
+        return NewString() ? 100 : 1;
+    }
+    //*/
+
+    /*
+    public static int Main()
+    {
+        return 100;
+    }
+    //*/
+
+    /// <summary>
+    /// This table demonstrates progress in implementing R2R fixups in CoreRT.
+    /// For those fixups the status of which has already been assessed, I have
+    /// commented their enum values out with the following description:
+    /// // DONE - fixup has been implemented
+    /// // JIT - fixup implementation is blocked on larger JIT interface changes
+    /// // UNNEEDED - fixup is not needed (additional info should be supplied)
+    /// </summary>
+    public enum ReadyToRunFixupKind
+    {
+        READYTORUN_FIXUP_ThisObjDictionaryLookup = 0x07,
+        READYTORUN_FIXUP_TypeDictionaryLookup = 0x08,
+        READYTORUN_FIXUP_MethodDictionaryLookup = 0x09,
+
+        // DONE: READYTORUN_FIXUP_TypeHandle = 0x10,
+        // JIT: READYTORUN_FIXUP_MethodHandle = 0x11,
+        // JIT: READYTORUN_FIXUP_FieldHandle = 0x12,
+
+        // UNNEEDED: READYTORUN_FIXUP_MethodEntry = 0x13, // In CoreRT, we always refer to external methods by Def/RefTokens
+        // DONE: READYTORUN_FIXUP_MethodEntry_DefToken = 0x14,
+        // DONE: READYTORUN_FIXUP_MethodEntry_RefToken = 0x15, /* Smaller version of MethodEntry - method is ref token */
+
+        // UNNEEDED?: READYTORUN_FIXUP_VirtualEntry = 0x16,
+        // UNNEEDED?: READYTORUN_FIXUP_VirtualEntry_DefToken = 0x17,
+        // UNNEEDED?: READYTORUN_FIXUP_VirtualEntry_RefToken = 0x18, /* Smaller version of VirtualEntry - method is ref token */
+        // UNNEEDED: EADYTORUN_FIXUP_VirtualEntry_Slot = 0x19, // In CoreRT, we always refer to external methods by Def/RefTokens
+
+        READYTORUN_FIXUP_Helper = 0x1A, /* Helper */
+        // DONE: READYTORUN_FIXUP_StringHandle = 0x1B, /* String handle */
+
+        // DONE: READYTORUN_FIXUP_NewObject = 0x1C, /* Dynamically created new helper */
+        // DONE: READYTORUN_FIXUP_NewArray = 0x1D,
+
+        // DONE: READYTORUN_FIXUP_IsInstanceOf = 0x1E, /* Dynamically created casting helper */
+        // DONE: READYTORUN_FIXUP_ChkCast = 0x1F,
+
+        READYTORUN_FIXUP_FieldAddress = 0x20, /* For accessing a cross-module static fields */
+        READYTORUN_FIXUP_CctorTrigger = 0x21, /* Static constructor trigger */
+
+        // DONE: READYTORUN_FIXUP_StaticBaseNonGC = 0x22, /* Dynamically created static base helpers */
+        // DONE: READYTORUN_FIXUP_StaticBaseGC = 0x23,
+        // DONE: READYTORUN_FIXUP_ThreadStaticBaseNonGC = 0x24,
+        // DONE: READYTORUN_FIXUP_ThreadStaticBaseGC = 0x25,
+
+        READYTORUN_FIXUP_FieldBaseOffset = 0x26, /* Field base offset */
+        READYTORUN_FIXUP_FieldOffset = 0x27, /* Field offset */
+
+        READYTORUN_FIXUP_TypeDictionary = 0x28,
+        READYTORUN_FIXUP_MethodDictionary = 0x29,
+
+        READYTORUN_FIXUP_Check_TypeLayout = 0x2A, /* size, alignment, HFA, reference map */
+        READYTORUN_FIXUP_Check_FieldOffset = 0x2B,
+
+        READYTORUN_FIXUP_DelegateCtor = 0x2C, /* optimized delegate ctor */
+        READYTORUN_FIXUP_DeclaringTypeHandle = 0x2D,
+    }
+
+    public enum ReadyToRunHelper
+    {
+        // UNNEEDED: READYTORUN_HELPER_Invalid = 0x00,
+
+        // Not a real helper - handle to current module passed to delay load helpers.
+        // DONE: READYTORUN_HELPER_Module = 0x01,
+        READYTORUN_HELPER_GSCookie = 0x02,
+
+        //
+        // Delay load helpers
+        //
+
+        // All delay load helpers use custom calling convention:
+        // - scratch register - address of indirection cell. 0 = address is inferred from callsite.
+        // - stack - section index, module handle
+        // DONE: READYTORUN_HELPER_DelayLoad_MethodCall = 0x08,
+
+        // DONE: READYTORUN_HELPER_DelayLoad_Helper = 0x10,
+        // DONE: READYTORUN_HELPER_DelayLoad_Helper_Obj = 0x11,
+        READYTORUN_HELPER_DelayLoad_Helper_ObjObj = 0x12,
+
+        // JIT helpers
+
+        // Exception handling helpers
+        READYTORUN_HELPER_Throw = 0x20,
+        READYTORUN_HELPER_Rethrow = 0x21,
+        READYTORUN_HELPER_Overflow = 0x22,
+        // DONE: READYTORUN_HELPER_RngChkFail = 0x23,
+        READYTORUN_HELPER_FailFast = 0x24,
+        READYTORUN_HELPER_ThrowNullRef = 0x25,
+        READYTORUN_HELPER_ThrowDivZero = 0x26,
+
+        // Write barriers
+        // DONE: READYTORUN_HELPER_WriteBarrier = 0x30,
+        READYTORUN_HELPER_CheckedWriteBarrier = 0x31,
+        READYTORUN_HELPER_ByRefWriteBarrier = 0x32,
+
+        // Array helpers
+        READYTORUN_HELPER_Stelem_Ref = 0x38,
+        READYTORUN_HELPER_Ldelema_Ref = 0x39,
+
+        READYTORUN_HELPER_MemSet = 0x40,
+        READYTORUN_HELPER_MemCpy = 0x41,
+
+        // Get string handle lazily
+        READYTORUN_HELPER_GetString = 0x50,
+
+        // Used by /Tuning for Profile optimizations
+        READYTORUN_HELPER_LogMethodEnter = 0x51,
+
+        // Reflection helpers
+        // DONE: READYTORUN_HELPER_GetRuntimeTypeHandle = 0x54,
+        READYTORUN_HELPER_GetRuntimeMethodHandle = 0x55,
+        READYTORUN_HELPER_GetRuntimeFieldHandle = 0x56,
+
+        // DONE: READYTORUN_HELPER_Box = 0x58,
+        // DONE: READYTORUN_HELPER_Box_Nullable = 0x59,
+        // DONE: READYTORUN_HELPER_Unbox = 0x5A,
+        // DONE: READYTORUN_HELPER_Unbox_Nullable = 0x5B,
+        READYTORUN_HELPER_NewMultiDimArr = 0x5C,
+        READYTORUN_HELPER_NewMultiDimArr_NonVarArg = 0x5D,
+
+        // Helpers used with generic handle lookup cases
+        // DONE: READYTORUN_HELPER_NewObject = 0x60,
+        READYTORUN_HELPER_NewArray = 0x61,
+        READYTORUN_HELPER_CheckCastAny = 0x62,
+        READYTORUN_HELPER_CheckInstanceAny = 0x63,
+        READYTORUN_HELPER_GenericGcStaticBase = 0x64,
+        READYTORUN_HELPER_GenericNonGcStaticBase = 0x65,
+        READYTORUN_HELPER_GenericGcTlsBase = 0x66,
+        READYTORUN_HELPER_GenericNonGcTlsBase = 0x67,
+        READYTORUN_HELPER_VirtualFuncPtr = 0x68,
+
+        // Long mul/div/shift ops
+        READYTORUN_HELPER_LMul = 0xC0,
+        READYTORUN_HELPER_LMulOfv = 0xC1,
+        READYTORUN_HELPER_ULMulOvf = 0xC2,
+        READYTORUN_HELPER_LDiv = 0xC3,
+        READYTORUN_HELPER_LMod = 0xC4,
+        READYTORUN_HELPER_ULDiv = 0xC5,
+        READYTORUN_HELPER_ULMod = 0xC6,
+        READYTORUN_HELPER_LLsh = 0xC7,
+        READYTORUN_HELPER_LRsh = 0xC8,
+        READYTORUN_HELPER_LRsz = 0xC9,
+        READYTORUN_HELPER_Lng2Dbl = 0xCA,
+        READYTORUN_HELPER_ULng2Dbl = 0xCB,
+
+        // 32-bit division helpers
+        READYTORUN_HELPER_Div = 0xCC,
+        READYTORUN_HELPER_Mod = 0xCD,
+        READYTORUN_HELPER_UDiv = 0xCE,
+        READYTORUN_HELPER_UMod = 0xCF,
+
+        // Floating point conversions
+        READYTORUN_HELPER_Dbl2Int = 0xD0,
+        READYTORUN_HELPER_Dbl2IntOvf = 0xD1,
+        READYTORUN_HELPER_Dbl2Lng = 0xD2,
+        READYTORUN_HELPER_Dbl2LngOvf = 0xD3,
+        READYTORUN_HELPER_Dbl2UInt = 0xD4,
+        READYTORUN_HELPER_Dbl2UIntOvf = 0xD5,
+        READYTORUN_HELPER_Dbl2ULng = 0xD6,
+        READYTORUN_HELPER_Dbl2ULngOvf = 0xD7,
+
+        // Floating point ops
+        READYTORUN_HELPER_DblRem = 0xE0,
+        READYTORUN_HELPER_FltRem = 0xE1,
+        READYTORUN_HELPER_DblRound = 0xE2,
+        READYTORUN_HELPER_FltRound = 0xE3,
+
+        // Personality rountines
+        READYTORUN_HELPER_PersonalityRoutine = 0xF0,
+        READYTORUN_HELPER_PersonalityRoutineFilterFunclet = 0xF1,
+
+        //
+        // Deprecated/legacy
+        //
+
+        // JIT32 x86-specific write barriers
+        READYTORUN_HELPER_WriteBarrier_EAX = 0x100,
+        READYTORUN_HELPER_WriteBarrier_EBX = 0x101,
+        READYTORUN_HELPER_WriteBarrier_ECX = 0x102,
+        READYTORUN_HELPER_WriteBarrier_ESI = 0x103,
+        READYTORUN_HELPER_WriteBarrier_EDI = 0x104,
+        READYTORUN_HELPER_WriteBarrier_EBP = 0x105,
+        READYTORUN_HELPER_CheckedWriteBarrier_EAX = 0x106,
+        READYTORUN_HELPER_CheckedWriteBarrier_EBX = 0x107,
+        READYTORUN_HELPER_CheckedWriteBarrier_ECX = 0x108,
+        READYTORUN_HELPER_CheckedWriteBarrier_ESI = 0x109,
+        READYTORUN_HELPER_CheckedWriteBarrier_EDI = 0x10A,
+        READYTORUN_HELPER_CheckedWriteBarrier_EBP = 0x10B,
+
+        // JIT32 x86-specific exception handling
+        READYTORUN_HELPER_EndCatch = 0x110,
+    };
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2017,7 +2017,13 @@ namespace Internal.JitInterface
 
                     if (helperId != ReadyToRunHelperId.Invalid)
                     {
-                        pResult.fieldLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(helperId, field.OwningType));
+                        pResult.fieldLookup = CreateConstLookupToSymbol(
+#if READYTORUN
+                            _compilation.NodeFactory.ReadyToRunHelper(helperId, field.OwningType, pResolvedToken.token)
+#else
+                            _compilation.NodeFactory.ReadyToRunHelper(helperId, field.OwningType)
+#endif
+                            );
                     }
                 }
             }
@@ -2927,8 +2933,14 @@ namespace Internal.JitInterface
                 if (targetMethod.IsConstructor && targetMethod.OwningType.IsString)
                 {
                     // Calling a string constructor doesn't call the actual constructor.
-                    pResult.codePointerOrStubLookup.constLookup = 
-                        CreateConstLookupToSymbol(_compilation.NodeFactory.StringAllocator(targetMethod));
+                    pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
+#if READYTORUN
+                        _compilation.NodeFactory.StringAllocator(targetMethod, pResolvedToken.token)
+
+#else
+                        _compilation.NodeFactory.StringAllocator(targetMethod)
+#endif
+                        );
                 }
                 else if (pResult.exactContextNeedsRuntimeLookup)
                 {
@@ -2938,8 +2950,13 @@ namespace Internal.JitInterface
                     // codegen emitted at crossgen time)
 
                     Debug.Assert(!forceUseRuntimeLookup);
-                    pResult.codePointerOrStubLookup.constLookup = 
-                        CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
+                    pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
+#if READYTORUN
+                        _compilation.NodeFactory.MethodEntrypoint(targetMethod, pResolvedToken.token)
+#else
+                        _compilation.NodeFactory.MethodEntrypoint(targetMethod)
+#endif
+                        );
                 }
                 else
                 {
@@ -2947,7 +2964,11 @@ namespace Internal.JitInterface
 
                     if (targetMethod.RequiresInstMethodDescArg())
                     {
+#if READYTORUN
+                        instParam = _compilation.NodeFactory.MethodGenericDictionary(concreteMethod, pResolvedToken.token);
+#else
                         instParam = _compilation.NodeFactory.MethodGenericDictionary(concreteMethod);
+#endif
                     }
                     else if (targetMethod.RequiresInstMethodTableArg() || referencingArrayAddressMethod)
                     {
@@ -2961,27 +2982,47 @@ namespace Internal.JitInterface
 
                         if (!referencingArrayAddressMethod)
                         {
-                            pResult.codePointerOrStubLookup.constLookup = 
-                                CreateConstLookupToSymbol(_compilation.NodeFactory.ShadowConcreteMethod(concreteMethod));
+                            pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
+#if READYTORUN
+                                _compilation.NodeFactory.ShadowConcreteMethod(concreteMethod, pResolvedToken.token)
+#else
+                                _compilation.NodeFactory.ShadowConcreteMethod(concreteMethod)
+#endif
+                                );
                         }
                         else
                         {
                             // We don't want array Address method to be modeled in the generic dependency analysis.
                             // The method doesn't actually have runtime determined dependencies (won't do
                             // any generic lookups).
-                            pResult.codePointerOrStubLookup.constLookup = 
-                                CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
+                            pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
+#if READYTORUN
+                                _compilation.NodeFactory.MethodEntrypoint(targetMethod, pResolvedToken.token)
+#else
+                                _compilation.NodeFactory.MethodEntrypoint(targetMethod)
+#endif
+                                );
                         }
                     }
                     else if (targetMethod.AcquiresInstMethodTableFromThis())
                     {
-                        pResult.codePointerOrStubLookup.constLookup = 
-                            CreateConstLookupToSymbol(_compilation.NodeFactory.ShadowConcreteMethod(concreteMethod));
+                        pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
+#if READYTORUN
+                            _compilation.NodeFactory.ShadowConcreteMethod(concreteMethod, pResolvedToken.token)
+#else
+                            _compilation.NodeFactory.ShadowConcreteMethod(concreteMethod)
+#endif
+                            );
                     }
                     else
                     {
-                        pResult.codePointerOrStubLookup.constLookup = 
-                            CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
+                        pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
+#if READYTORUN
+                            _compilation.NodeFactory.MethodEntrypoint(targetMethod, pResolvedToken.token)
+#else
+                            _compilation.NodeFactory.MethodEntrypoint(targetMethod)
+#endif
+                            );
                     }
                 }
 
@@ -3008,8 +3049,12 @@ namespace Internal.JitInterface
                 // move that assert to some place later though.
                 targetIsFatFunctionPointer = true;
             }
-            else if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0
+            else
+// In ReadyToRun, we always use the dispatch stub to call virtual methods
+#if !READYTORUN
+            if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0
                 && targetMethod.OwningType.IsInterface)
+#endif // !READYTORUN
             {
                 pResult.kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_STUB;
 
@@ -3026,14 +3071,20 @@ namespace Internal.JitInterface
                     pResult.codePointerOrStubLookup.lookupKind.needsRuntimeLookup = false;
                     pResult.codePointerOrStubLookup.constLookup.accessType = InfoAccessType.IAT_PVALUE;
                     pResult.codePointerOrStubLookup.constLookup.addr = (void*)ObjectToHandle(
+#if READYTORUN
+                        _compilation.NodeFactory.InterfaceDispatchCell(targetMethod, pResolvedToken.token
+#else
                         _compilation.NodeFactory.InterfaceDispatchCell(targetMethod
 #if !SUPPORT_JIT
                         , _compilation.NameMangler.GetMangledMethodName(MethodBeingCompiled).ToString()
 #endif
+#endif // READYTORUN
                         ));
                 }
             }
-            else if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0
+#if !READYTORUN
+            else
+            if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0
                 && _compilation.HasFixedSlotVTable(targetMethod.OwningType))
             {
                 pResult.kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_VTABLE;
@@ -3087,6 +3138,7 @@ namespace Internal.JitInterface
                 // TODO: Optimize this
                 pResult.nullInstanceCheck = true;
             }
+#endif // !READYTORUN
 
             pResult.hMethod = ObjectToHandle(targetMethod);
 


### PR DESCRIPTION
This change represents the remainder of my CoreRT R2R bring-up changes
from the last two weeks. Amy, Simon and myself managed to gradually
siphon parts of the complex change off to separate commits so that the
remaining bits have become easier to manage and review.

The only way to further split this remaining change, if desired, would
be basically by replicating the bring-up process - enabling just a
subset of the import cells and taking the appropriate parts of the
RTRNF / CII.RTR changes; but I don't think the change is that complex
as is to merit what would otherwise be just busywork.

Feel free to leave out the map file emission if you want to even though
I find it quite useful myself. I want to improve it in the future by
making it a full-fledged map file - storing the entries until the
final relocation phase and then outputting them in section order and
with the full RVA's, that would be much easier for looking up the
various indirection cells. Of course we should probably produce the file
under some switch, I haven't wired that up yet as I'm using the map
all the time.

To expedite the review process, I'm sending this change out for PR
as WIP even though I most likely won't be able to finish the review
process. The main purpose of this review is to solicit early feedback
from Jan and Michal.

One potentially problematic thing is the modification to
MultiFileCompilationModuleGroup. Michal and / or Jan should say whether
we need to derive a new ReadyToRunCompilationModuleGroup and move this
functionality there.

Please note that, while the code has been refactored to avoid
using MethodCodeNode, it still does use IMethodCodeNode
as we need this contract to fill in the various fields once the method
gets compiled - I don't see what should be different here in R2R.
Perhaps we should move IMethodCodeNode to some common
location as a cleanup change - why not into JitInterface considering
it's in fact a CorInfoImpl contract?

The GC info is still unfinished - in particular, I don't know how to
get to the unwind info. IIRC the code today emits something like an
ulong(0) which should mean "no unwind info" before the GC info. This
is something we'll need to look into soon to unblock larger-scale
testing - not necessarily saying it needs fixing in this change.

As for the conditional directives in getCallInfo / getFieldInfo,
it seems to me that they use just about 2-3 different constructs so
that we might be able to further simplify this by creating
forked helpers for them in the two files CII.RJ / CII.RTR and
remove the conditional compilations.

I leave it up to Simon / Amy to decide whether they want to finish
the review I started by pushing additional commits into my remote
GIT repository and by removing the WIP status or whether they'll
start their own review (or series of reviews) in case of more
substantial modifications to my changes.

In its current form the change also still includes the change to the
repro Program.cs making it the "R2R unit test suite". This shouldn't
be merged in to the repro location. We need to figure out where
to put it, I would definitely love to not throw it away, certainly
not before we have some other testing up and running. For bringing
up the individual helpers it's just awesome.

Thanks

Tomas