### PR TITLE
Add support for sealed vtables in CppCodegen

### DIFF
--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -1035,7 +1035,7 @@ namespace Internal.Runtime
 
             fixed (EEType* pThis = &this)
             {
-                if (IsDynamicType)
+                if (IsDynamicType || !SupportsRelativePointers)
                 {
                     uint cbSealedVirtualSlotsTypeOffset = GetFieldOffset(EETypeField.ETF_SealedVirtualSlots);
                     IntPtr* pSealedVirtualsSlotTable = *(IntPtr**)((byte*)pThis + cbSealedVirtualSlotsTypeOffset);
@@ -1318,7 +1318,7 @@ namespace Internal.Runtime
 
             // in the case of sealed vtable entries on static types, we have a UInt sized relative pointer
             if ((rareFlags & EETypeRareFlags.HasSealedVTableEntriesFlag) != 0)
-                cbOffset += (IsDynamicType ? (uint)IntPtr.Size : 4);
+                cbOffset += (IsDynamicType || !SupportsRelativePointers ? (uint)IntPtr.Size : 4);
 
             if (eField == EETypeField.ETF_DynamicDispatchMap)
             {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -774,7 +774,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 // Final NewSlot methods cannot be overridden, and therefore can be placed in the sealed-vtable to reduce the size of the vtable
                 // of this type and any type that inherits from it.
-                if (declMethod.CanMethodBeInSealedVTable() && !declType.IsArrayTypeWithoutGenericInterfaces() && !factory.IsCppCodegenTemporaryWorkaround)
+                if (declMethod.CanMethodBeInSealedVTable() && !declType.IsArrayTypeWithoutGenericInterfaces())
                     continue;
 
                 if (!implMethod.IsAbstract)
@@ -838,7 +838,12 @@ namespace ILCompiler.DependencyAnalysis
                 SealedVTableNode sealedVTable = factory.SealedVTable(_type.ConvertToCanonForm(CanonicalFormKind.Specific));
 
                 if (sealedVTable.BuildSealedVTableSlots(factory, relocsOnly) && sealedVTable.NumSealedVTableEntries > 0)
-                    objData.EmitReloc(sealedVTable, RelocType.IMAGE_REL_BASED_RELPTR32);
+                {
+                    if (factory.Target.SupportsRelativePointers)
+                        objData.EmitReloc(sealedVTable, RelocType.IMAGE_REL_BASED_RELPTR32);
+                    else
+                        objData.EmitPointerReloc(sealedVTable);
+                }
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/VirtualMethodCallHelper.cs
@@ -18,9 +18,7 @@ namespace ILCompiler
         /// </summary>
         public static int GetVirtualMethodSlot(NodeFactory factory, MethodDesc method, TypeDesc implType, bool countDictionarySlots = true)
         {
-            // CppCodegen does not yet support sealed vtables.
-
-            if (method.CanMethodBeInSealedVTable() && !factory.IsCppCodegenTemporaryWorkaround)
+            if (method.CanMethodBeInSealedVTable())
             {
                 // If the method is a sealed newslot method, it will be put in the sealed vtable instead of the type's vtable. In this
                 // case, the slot index return should be the index in the sealed vtable, plus the total number of vtable slots.
@@ -71,7 +69,7 @@ namespace ILCompiler
                 int numSealedVTableEntries = 0;
                 for (int slot = 0; slot < virtualSlots.Count; slot++)
                 {
-                    if (virtualSlots[slot].CanMethodBeInSealedVTable() && !factory.IsCppCodegenTemporaryWorkaround)
+                    if (virtualSlots[slot].CanMethodBeInSealedVTable())
                     {
                         numSealedVTableEntries++;
                         continue;
@@ -133,7 +131,7 @@ namespace ILCompiler
                 foreach (var vtableMethod in baseVirtualSlots)
                 {
                     // Methods in the sealed vtable should be excluded from the count
-                    if (vtableMethod.CanMethodBeInSealedVTable() && !factory.IsCppCodegenTemporaryWorkaround)
+                    if (vtableMethod.CanMethodBeInSealedVTable())
                         continue;
                     baseSlots++;
                 }

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
@@ -815,7 +815,7 @@ namespace ILCompiler.CppCodeGen
                     string mangledName = ((ISymbolNode)node).GetMangledName(factory.NameMangler);
 
                     // Rename generic composition and optional fields nodes to avoid name clash with types
-                    bool shouldReplaceNamespaceQualifier = node is GenericCompositionNode || node is EETypeOptionalFieldsNode;
+                    bool shouldReplaceNamespaceQualifier = node is GenericCompositionNode || node is EETypeOptionalFieldsNode || node is SealedVTableNode;
                     nodeCode.Append(shouldReplaceNamespaceQualifier ? mangledName.Replace("::", "_") : mangledName);
                 }
                 nodeCode.Append("()");
@@ -903,10 +903,15 @@ namespace ILCompiler.CppCodeGen
                 relocCode.Append("()");
             }
             // Node is either an non-emitted type or a generic composition - both are ignored for CPP codegen
-            else if ((reloc.Target is TypeManagerIndirectionNode || reloc.Target is InterfaceDispatchMapNode || reloc.Target is EETypeOptionalFieldsNode || reloc.Target is GenericCompositionNode) && !(reloc.Target as ObjectNode).ShouldSkipEmittingObjectNode(factory))
+            else if ((reloc.Target is TypeManagerIndirectionNode ||
+                reloc.Target is InterfaceDispatchMapNode ||
+                reloc.Target is EETypeOptionalFieldsNode ||
+                reloc.Target is GenericCompositionNode ||
+                reloc.Target is SealedVTableNode
+                ) && !(reloc.Target as ObjectNode).ShouldSkipEmittingObjectNode(factory))
             {
                 string mangledTargetName = reloc.Target.GetMangledName(factory.NameMangler);
-                bool shouldReplaceNamespaceQualifier = reloc.Target is GenericCompositionNode || reloc.Target is EETypeOptionalFieldsNode;
+                bool shouldReplaceNamespaceQualifier = reloc.Target is GenericCompositionNode || reloc.Target is EETypeOptionalFieldsNode || reloc.Target is SealedVTableNode;
                 relocCode.Append(shouldReplaceNamespaceQualifier ? mangledTargetName.Replace("::", "_") : mangledTargetName);
                 relocCode.Append("()");
             }
@@ -1037,7 +1042,11 @@ namespace ILCompiler.CppCodeGen
             {
                 if (node is EETypeNode)
                     OutputTypeNode(node as EETypeNode, factory, typeDefinitions, methodTables);
-                else if ((node is EETypeOptionalFieldsNode || node is TypeManagerIndirectionNode || node is GenericCompositionNode || node is BlobNode) && !(node as ObjectNode).ShouldSkipEmittingObjectNode(factory))
+                else if ((node is EETypeOptionalFieldsNode ||
+                    node is TypeManagerIndirectionNode ||
+                    node is GenericCompositionNode ||
+                    node is BlobNode ||
+                    node is SealedVTableNode) && !(node as ObjectNode).ShouldSkipEmittingObjectNode(factory))
                     additionalNodes.Append(GetCodeForObjectNode(node as ObjectNode, factory));
                 else if (node is ArrayOfEmbeddedPointersNode<InterfaceDispatchMapNode> dispatchMap)
                 {


### PR DESCRIPTION
This cleans up the codebase by removing a bunch of workarounds. This was pretty easy after 045a28051c6b85b82fe42e944fcb2267768ebbe2 gave us the option to emit different data structures for places that don't support relative pointers and be able to switch dynamically at runtime.