### PR TITLE
Add an option to only generate metadata for complete types

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -51,6 +51,23 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(factory.MethodMetadata(_type.GetMethod("Invoke", null)), "Delegate invoke method metadata");
             }
 
+            // If the user asked for complete metadata to be generated for all types that are getting metadata, ensure that.
+            var mdManager = (UsageBasedMetadataManager)factory.MetadataManager;
+            if ((mdManager._generationOptions & UsageBasedMetadataGenerationOptions.CompleteTypesOnly) != 0)
+            {
+                foreach (MethodDesc method in _type.GetMethods())
+                {
+                    if (!mdManager.IsReflectionBlocked(method))
+                        dependencies.Add(factory.MethodMetadata(method), "Complete metadata for type");
+                }
+
+                foreach (FieldDesc field in _type.GetFields())
+                {
+                    if (!mdManager.IsReflectionBlocked(field))
+                        dependencies.Add(factory.FieldMetadata(field), "Complete metadata for type");
+                }
+            }
+
             return dependencies;
         }
 

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -50,6 +50,7 @@ namespace ILCompiler
         private string _mapFileName;
         private string _metadataLogFileName;
         private bool _noMetadataBlocking;
+        private bool _completeTypesMetadata;
 
         private string _singleMethodTypeName;
         private string _singleMethodName;
@@ -159,6 +160,7 @@ namespace ILCompiler
                 syntax.DefineOption("map", ref _mapFileName, "Generate a map file");
                 syntax.DefineOption("metadatalog", ref _metadataLogFileName, "Generate a metadata log file");
                 syntax.DefineOption("nometadatablocking", ref _noMetadataBlocking, "Ignore metadata blocking for internal implementation details");
+                syntax.DefineOption("completetypemetadata", ref _completeTypesMetadata, "Generate complete metadata for types");
                 syntax.DefineOption("scan", ref _useScanner, "Use IL scanner to generate optimized code (implied by -O)");
                 syntax.DefineOption("noscan", ref _noScanner, "Do not use IL scanner to generate optimized code");
                 syntax.DefineOption("ildump", ref _ilDump, "Dump IL assembly listing for compiler-generated IL");
@@ -418,13 +420,19 @@ namespace ILCompiler
 
             ManifestResourceBlockingPolicy resBlockingPolicy = new NoManifestResourceBlockingPolicy();
 
+            UsageBasedMetadataGenerationOptions metadataGenerationOptions = UsageBasedMetadataGenerationOptions.None;
+            if (_completeTypesMetadata)
+                metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.CompleteTypesOnly;
+
             UsageBasedMetadataManager metadataManager = new UsageBasedMetadataManager(
                 compilationGroup,
                 typeSystemContext,
                 mdBlockingPolicy,
                 resBlockingPolicy,
                 _metadataLogFileName,
-                stackTracePolicy);
+                stackTracePolicy,
+                metadataGenerationOptions
+                );
 
             // Unless explicitly opted in at the command line, we enable scanner for retail builds by default.
             // We don't do this for CppCodegen and Wasm, because those codegens are behind.


### PR DESCRIPTION
When the option is set, metadata generation at the type level becomes all or nothing - either the entire type gets metadata, or none of it gets it. This makes a certain class of missing metadata issues easier to troubleshoot.

In particular, the failure mode of this program:

```csharp
using System;

internal class Program
{
    public static void Do()
    {
        Console.WriteLine("Hello world");
    }

    private static void Main(string[] args)
    {
        typeof(Program).GetMethod("Do").Invoke(null, Array.Empty<object>());
    }
}
```

Changes from a `NullReferenceException` at the `.Invoke` part to a `"This object cannot be invoked because it was metadata-enabled for browsing only: 'Program.Do()' For more information, please visit  http://go.microsoft.com/fwlink/?LinkID=616867"` message.

Should turn #6142 and similar into a self-service solution.