### PR TITLE
Make sure metadata nodes don't show up in the graph

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -419,7 +419,11 @@ namespace ILCompiler
 
             public void RootModuleMetadata(ModuleDesc module, string reason)
             {
-                _graph.AddRoot(_factory.ModuleMetadata(module), reason);
+                // RootModuleMetadata is kind of a hack - this is pretty much only used to force include
+                // type forwarders from assemblies metadata generator would normally not look at.
+                // This will go away when the temporary RD.XML parser goes away.
+                if (_factory.MetadataManager is UsageBasedMetadataManager)
+                    _graph.AddRoot(_factory.ModuleMetadata(module), reason);
             }
 
             public void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -912,6 +912,9 @@ namespace ILCompiler.DependencyAnalysis
 
         internal TypeMetadataNode TypeMetadata(MetadataType type)
         {
+            // These are only meaningful for UsageBasedMetadataManager. We should not have them
+            // in the dependency graph otherwise.
+            Debug.Assert(MetadataManager is UsageBasedMetadataManager);
             return _typesWithMetadata.GetOrAdd(type);
         }
 
@@ -919,6 +922,9 @@ namespace ILCompiler.DependencyAnalysis
 
         internal MethodMetadataNode MethodMetadata(MethodDesc method)
         {
+            // These are only meaningful for UsageBasedMetadataManager. We should not have them
+            // in the dependency graph otherwise.
+            Debug.Assert(MetadataManager is UsageBasedMetadataManager);
             return _methodsWithMetadata.GetOrAdd(method);
         }
 
@@ -926,6 +932,9 @@ namespace ILCompiler.DependencyAnalysis
 
         internal FieldMetadataNode FieldMetadata(FieldDesc field)
         {
+            // These are only meaningful for UsageBasedMetadataManager. We should not have them
+            // in the dependency graph otherwise.
+            Debug.Assert(MetadataManager is UsageBasedMetadataManager);
             return _fieldsWithMetadata.GetOrAdd(field);
         }
 
@@ -933,6 +942,9 @@ namespace ILCompiler.DependencyAnalysis
 
         internal ModuleMetadataNode ModuleMetadata(ModuleDesc module)
         {
+            // These are only meaningful for UsageBasedMetadataManager. We should not have them
+            // in the dependency graph otherwise.
+            Debug.Assert(MetadataManager is UsageBasedMetadataManager);
             return _modulesWithMetadata.GetOrAdd(module);
         }
 


### PR DESCRIPTION
RD.XML root provider was adding ModuleMetadataNodes into the dependency graph even though we were not doing metadata analysis (analysis already happened during the scanning phase). This was crashing the code I added yesterday with an invalid cast because metadata nodes don't expect to be in the graph if we're not analyzing (nobody is going to look at them). The crash only happens if one has RD.XML so we didn't catch it in the CI.