### PR TITLE
Implement RuntimeThread.CurrentOSThreadId

### DIFF
--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -1359,6 +1359,12 @@ COOP_PINVOKE_HELPER(UInt8*, RhCurrentNativeThreadId, ())
 }
 #endif // !PROJECTN
 
+// This function is used to get the OS thread identifier for the current thread.
+COOP_PINVOKE_HELPER(UInt64, RhCurrentOSThreadId, ())
+{
+    return PalGetCurrentThreadIdForLogging();
+}
+
 // Standard calling convention variant and actual implementation for RhpReversePInvokeAttachOrTrapThread
 EXTERN_C NOINLINE void FASTCALL RhpReversePInvokeAttachOrTrapThread2(ReversePInvokeFrame * pFrame)
 {

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeThread.cs
@@ -80,6 +80,14 @@ namespace Internal.Runtime.Augments
             }
         }
 
+        internal static ulong CurrentOSThreadId
+        {
+            get
+            {
+                return RuntimeImports.RhCurrentOSThreadId();
+            }
+        }
+
         // Slow path executed once per thread
         private static RuntimeThread InitializeExistingThread(bool threadPoolThread)
         {

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -573,6 +573,10 @@ namespace System.Runtime
 #endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhCurrentOSThreadId")]
+        internal static unsafe extern ulong RhCurrentOSThreadId();
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport("*", "RhGetCurrentThunkContext")]
         internal static extern IntPtr GetCurrentInteropThunkContext();
 


### PR DESCRIPTION
This internal API is required to support the new EventSource public API ```EventWrittenEventArgs.OSThreadId``` which is implemented in https://github.com/dotnet/coreclr/pull/19002.

The internal API ```RuntimeThread.CurrentOSThreadId``` is also implemented in CoreCLR as part of the above referenced PR.