### PR TITLE
Partial delegate support

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
@@ -19,7 +19,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public DelayLoadHelperImport(ReadyToRunCodegenNodeFactory factory, ReadyToRunHelper helper, Signature instanceSignature, string callSite = null)
             : base(factory.HelperImports, instanceSignature, callSite)
         {
-            factory.HelperImports.AddImport(factory, this);
             _helper = helper;
             _delayLoadHelper = new DelayLoadHelperThunk(helper, factory, this);
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Internal.TypeSystem;
 
 using Internal.Text;
+using ILCompiler.DependencyAnalysisFramework;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
@@ -44,11 +45,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ObjectDataSignatureBuilder builder = new ObjectDataSignatureBuilder();
             builder.AddSymbol(this);
 
-            if (relocsOnly)
-            {
-                builder.EmitReloc(_targetMethod, RelocType.IMAGE_REL_BASED_REL32);
-            }
-            else
+            if (!relocsOnly)
             {
                 builder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_DelegateCtor);
                 builder.EmitMethodSignature(_targetMethod.Method, _targetMethodToken, _targetMethodToken.SignatureContext(_factory));
@@ -56,6 +53,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             return builder.ToObjectData();
+        }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            return new DependencyList(
+                new DependencyListEntry[]
+                {
+                    new DependencyListEntry(_targetMethod, "Delegate target method")
+                }
+            );
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class DelegateCtorSignature : Signature
+    {
+        private readonly ReadyToRunCodegenNodeFactory _factory;
+
+        private readonly TypeDesc _delegateType;
+
+        private readonly ModuleToken _delegateTypeToken;
+
+        private readonly IMethodNode _targetMethod;
+
+        private readonly ModuleToken _targetMethodToken;
+
+        public DelegateCtorSignature(
+            ReadyToRunCodegenNodeFactory factory,
+            TypeDesc delegateType, 
+            ModuleToken delegateTypeToken,
+            IMethodNode targetMethod,
+            ModuleToken targetMethodToken)
+        {
+            _factory = factory;
+            _delegateType = delegateType;
+            _delegateTypeToken = delegateTypeToken;
+            _targetMethod = targetMethod;
+            _targetMethodToken = targetMethodToken;
+        }
+
+        protected override int ClassCode => 99885741;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataSignatureBuilder builder = new ObjectDataSignatureBuilder();
+            builder.AddSymbol(this);
+
+            if (relocsOnly)
+            {
+                builder.EmitReloc(_targetMethod, RelocType.IMAGE_REL_BASED_REL32);
+            }
+            else
+            {
+                builder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_DelegateCtor);
+                builder.EmitMethodSignature(_targetMethod.Method, _targetMethodToken, _targetMethodToken.SignatureContext(_factory));
+                builder.EmitTypeSignature(_delegateType, _delegateTypeToken, _delegateTypeToken.SignatureContext(_factory));
+            }
+
+            return builder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($@"DelegateCtor({_delegateType} -> {_targetMethod.Method})");
+        }
+
+        protected override int CompareToImpl(SortableDependencyNode other, CompilerComparer comparer)
+        {
+            DelegateCtorSignature otherSignature = (DelegateCtorSignature)other;
+            int result = _delegateTypeToken.CompareTo(otherSignature._delegateTypeToken);
+            if (result == 0)
+            {
+                result = _targetMethodToken.CompareTo(otherSignature._targetMethodToken);
+            }
+            return result;
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
@@ -26,7 +26,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             MethodFixupSignature.SignatureKind signatureKind)
             : base(factory.MethodImports, factory.GetOrAddMethodSignature(fixupKind, methodDesc, token, signatureKind))
         {
-            factory.MethodImports.AddImport(factory, this);
             _methodDesc = methodDesc;
             _token = token;
             _localMethod = localMethod;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/Import.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/Import.cs
@@ -25,6 +25,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ImportSignature = new RvaEmbeddedPointerIndirectionNode<Signature>(importSignature, callSite);
         }
 
+        protected override void OnMarked(NodeFactory factory)
+        {
+            Table.AddImport(factory, this);
+        }
+
         protected override string GetName(NodeFactory factory)
         {
             Utf8StringBuilder sb = new Utf8StringBuilder();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -80,7 +80,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append("__ReadyToRunMethodEntryPointTable");
         }
 
-        public void Add(MethodWithGCInfo methodNode, int methodIndex, NodeFactory factory)
+        public void Add(MethodWithGCInfo methodNode, int methodIndex)
         {
             uint rid;
             if (methodNode.Method is EcmaMethod ecmaMethod)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using ILCompiler.DependencyAnalysisFramework;
 using Internal.Text;
 using Internal.TypeSystem;
 
@@ -50,19 +51,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
-            ObjectData methodCode = _methodCode;
-            if (relocsOnly)
-            {
-                int extraRelocs = 1; // GCInfoNode
+            return _methodCode;
+        }
 
-                Relocation[] relocs = new Relocation[methodCode.Relocs.Length + extraRelocs];
-                Array.Copy(methodCode.Relocs, relocs, methodCode.Relocs.Length);
-                int extraRelocIndex = methodCode.Relocs.Length;
-                relocs[extraRelocIndex++] = new Relocation(RelocType.IMAGE_REL_BASED_ADDR32NB, 0, GCInfoNode);
-                Debug.Assert(extraRelocIndex == relocs.Length);
-                methodCode = new ObjectData(methodCode.Data, relocs, methodCode.Alignment, methodCode.DefinedSymbols); 
-            }
-            return methodCode;
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            return new DependencyList(
+                new DependencyListEntry[]
+                {
+                    new DependencyListEntry(GCInfoNode, "GC info"),
+                }
+            );
         }
 
         public override bool StaticDependenciesAreComputed => _methodCode != null;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -39,6 +39,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public MethodDesc Method => _method;
 
+        protected override void OnMarked(NodeFactory factory)
+        {
+            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
+            // Marked method - add runtime & entry point table entry
+            r2rFactory.RuntimeFunctionsGCInfo.AddEmbeddedObject(GCInfoNode);
+            int index = r2rFactory.RuntimeFunctionsTable.Add(this);
+            r2rFactory.MethodEntryPointTable.Add(this, index);
+        }
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             ObjectData methodCode = _methodCode;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperImport.cs
@@ -16,7 +16,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public PrecodeHelperImport(ReadyToRunCodegenNodeFactory factory, Signature signature)
             : base(factory.PrecodeImports, signature)
         {
-            factory.PrecodeImports.AddImport(factory, this);
         }
 
         protected override string GetName(NodeFactory factory)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsGCInfoNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsGCInfoNode.cs
@@ -4,7 +4,7 @@
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
-    class RuntimeFunctionsGCInfoNode : ArrayOfEmbeddedDataNode<MethodGCInfoNode>
+    public class RuntimeFunctionsGCInfoNode : ArrayOfEmbeddedDataNode<MethodGCInfoNode>
     {
         public RuntimeFunctionsGCInfoNode()
             : base("RuntimeFunctionsGCInfo_Begin", "RuntimeFunctionsGCInfo_End", null)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -402,6 +402,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _builder.EmitByte(data);
         }
 
+        public void EmitReloc(ISymbolNode symbol, RelocType relocType, int delta = 0)
+        {
+            _builder.EmitReloc(symbol, relocType, delta);
+        }
+
         public ObjectNode.ObjectData ToObjectData()
         {
             return _builder.ToObjectData();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -52,7 +52,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public RuntimeFunctionsTableNode RuntimeFunctionsTable;
 
-        private RuntimeFunctionsGCInfoNode _runtimeFunctionsGCInfo;
+        public RuntimeFunctionsGCInfoNode RuntimeFunctionsGCInfo;
 
         public MethodEntryPointTableNode MethodEntryPointTable;
 
@@ -584,8 +584,8 @@ namespace ILCompiler.DependencyAnalysis
             RuntimeFunctionsTable = new RuntimeFunctionsTableNode(Target);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.RuntimeFunctions, RuntimeFunctionsTable, RuntimeFunctionsTable);
 
-            _runtimeFunctionsGCInfo = new RuntimeFunctionsGCInfoNode();
-            graph.AddRoot(_runtimeFunctionsGCInfo, "GC info is always generated");
+            RuntimeFunctionsGCInfo = new RuntimeFunctionsGCInfoNode();
+            graph.AddRoot(RuntimeFunctionsGCInfo, "GC info is always generated");
 
             MethodEntryPointTable = new MethodEntryPointTableNode(Target);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.MethodDefEntryPoints, MethodEntryPointTable, MethodEntryPointTable);
@@ -722,17 +722,6 @@ namespace ILCompiler.DependencyAnalysis
         protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
         {
             throw new NotImplementedException();
-        }
-
-        public void NewMarkedNode(DependencyNodeCore<NodeFactory> node)
-        {
-            if (node is MethodWithGCInfo methodWithGCInfo)
-            {
-                // Marked method - add runtime & entry point table entry
-                _runtimeFunctionsGCInfo.AddEmbeddedObject(methodWithGCInfo.GCInfoNode);
-                int index = RuntimeFunctionsTable.Add(methodWithGCInfo);
-                MethodEntryPointTable.Add(methodWithGCInfo, index);
-            }
         }
 
         struct TypeAndMethod

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -452,7 +452,7 @@ namespace ILCompiler.DependencyAnalysis
             throw new NotImplementedException();
         }
 
-        struct MethodAndCallSite
+        struct MethodAndCallSite : IEquatable<MethodAndCallSite>
         {
             public readonly MethodDesc Method;
             public readonly string CallSite;
@@ -463,10 +463,14 @@ namespace ILCompiler.DependencyAnalysis
                 Method = method;
             }
 
+            public bool Equals(MethodAndCallSite other)
+            {
+                return CallSite == other.CallSite && Method == other.Method;
+            }
+
             public override bool Equals(object obj)
             {
-                MethodAndCallSite other = (MethodAndCallSite)obj;
-                return CallSite == other.CallSite && Method == other.Method;
+                return obj is MethodAndCallSite other && Equals(other);
             }
 
             public override int GetHashCode()
@@ -533,7 +537,7 @@ namespace ILCompiler.DependencyAnalysis
             return genericDictionary;
         }
 
-        struct MethodAndFixupKind
+        struct MethodAndFixupKind : IEquatable<MethodAndFixupKind>
         {
             public readonly MethodDesc Method;
             public readonly ReadyToRunFixupKind FixupKind;
@@ -544,10 +548,14 @@ namespace ILCompiler.DependencyAnalysis
                 FixupKind = fixupKind;
             }
 
+            public bool Equals(MethodAndFixupKind other)
+            {
+                return Method == other.Method && FixupKind == other.FixupKind;
+            }
+
             public override bool Equals(object obj)
             {
-                MethodAndFixupKind other = (MethodAndFixupKind)obj;
-                return Method == other.Method && FixupKind == other.FixupKind;
+                return obj is MethodAndFixupKind other && Equals(other);
             }
 
             public override int GetHashCode()
@@ -724,7 +732,7 @@ namespace ILCompiler.DependencyAnalysis
             throw new NotImplementedException();
         }
 
-        struct TypeAndMethod
+        struct TypeAndMethod : IEquatable<TypeAndMethod>
         {
             public readonly TypeDesc Type;
             public readonly MethodDesc Method;
@@ -735,9 +743,14 @@ namespace ILCompiler.DependencyAnalysis
                 Method = method;
             }
 
+            public bool Equals(TypeAndMethod other)
+            {
+                return Type == other.Type && Method == other.Method;
+            }
+
             public override bool Equals(object obj)
             {
-                return obj is TypeAndMethod other && Type == other.Type && Method == other.Method;
+                return obj is TypeAndMethod other && Equals(other);
             }
 
             public override int GetHashCode()

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -13,6 +13,7 @@ using ILCompiler.DependencyAnalysisFramework;
 
 using Internal.JitInterface;
 using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -97,9 +98,6 @@ namespace ILCompiler.DependencyAnalysis
             if (CompilationModuleGroup.ContainsMethodBody(method, false))
             {
                 localMethod = new MethodWithGCInfo(method, token);
-                _runtimeFunctionsGCInfo.AddEmbeddedObject(localMethod.GCInfoNode);
-                int methodIndex = RuntimeFunctionsTable.Add(localMethod);
-                MethodEntryPointTable.Add(localMethod, methodIndex, this);
 
                 // TODO: hack - how do we distinguish between emitting main entry point and calls between
                 // methods?
@@ -109,7 +107,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            return GetOrAddImportedMethodNode(method, unboxingStub: false, token: token, localMethod: localMethod);
+            return ImportedMethodNode(method, unboxingStub: false, token: token, localMethod: localMethod);
         }
 
         public IMethodNode StringAllocator(MethodDesc constructor, ModuleToken token)
@@ -122,9 +120,7 @@ namespace ILCompiler.DependencyAnalysis
             ISymbolNode stringNode;
             if (!_importStrings.TryGetValue(token, out stringNode))
             {
-                StringImport r2rImportNode = new StringImport(StringImports, token);
-                StringImports.AddImport(this, r2rImportNode);
-                stringNode = r2rImportNode;
+                stringNode = new StringImport(StringImports, token);
                 _importStrings.Add(token, stringNode);
             }
             return stringNode;
@@ -513,9 +509,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private ISymbolNode CreateReadyToRunHelperCell(ReadyToRunHelper helperId)
         {
-            Import helperCell = new Import(EagerImports, new ReadyToRunHelperSignature(helperId));
-            EagerImports.AddImport(this, helperCell);
-            return helperCell;
+            return new Import(EagerImports, new ReadyToRunHelperSignature(helperId));
         }
 
         public ISymbolNode ComputeConstantLookup(ReadyToRunHelperId helperId, object entity, ModuleToken token)
@@ -660,7 +654,7 @@ namespace ILCompiler.DependencyAnalysis
             graph.AddRoot(Header, "ReadyToRunHeader is always generated");
         }
 
-        public IMethodNode GetOrAddImportedMethodNode(MethodDesc method, bool unboxingStub, ModuleToken token, MethodWithGCInfo localMethod)
+        public IMethodNode ImportedMethodNode(MethodDesc method, bool unboxingStub, ModuleToken token, MethodWithGCInfo localMethod)
         {
             ReadyToRunFixupKind fixupKind;
             MethodFixupSignature.SignatureKind signatureKind;
@@ -728,6 +722,68 @@ namespace ILCompiler.DependencyAnalysis
         protected override IMethodNode CreateUnboxingStubNode(MethodDesc method)
         {
             throw new NotImplementedException();
+        }
+
+        public void NewMarkedNode(DependencyNodeCore<NodeFactory> node)
+        {
+            if (node is MethodWithGCInfo methodWithGCInfo)
+            {
+                // Marked method - add runtime & entry point table entry
+                _runtimeFunctionsGCInfo.AddEmbeddedObject(methodWithGCInfo.GCInfoNode);
+                int index = RuntimeFunctionsTable.Add(methodWithGCInfo);
+                MethodEntryPointTable.Add(methodWithGCInfo, index);
+            }
+        }
+
+        struct TypeAndMethod
+        {
+            public readonly TypeDesc Type;
+            public readonly MethodDesc Method;
+
+            public TypeAndMethod(TypeDesc type, MethodDesc method)
+            {
+                Type = type;
+                Method = method;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is TypeAndMethod other && Type == other.Type && Method == other.Method;
+            }
+
+            public override int GetHashCode()
+            {
+                return Type.GetHashCode() ^ unchecked(Method.GetHashCode() * 31);
+            }
+        }
+
+        private Dictionary<TypeAndMethod, ISymbolNode> _delegateCtors = new Dictionary<TypeAndMethod, ISymbolNode>();
+
+        public ISymbolNode DelegateCtor(TypeDesc delegateType, MethodDesc targetMethod, ModuleToken methodToken)
+        {
+            ISymbolNode ctorNode;
+            TypeAndMethod ctorKey = new TypeAndMethod(delegateType, targetMethod);
+            if (!_delegateCtors.TryGetValue(ctorKey, out ctorNode))
+            {
+                ModuleToken delegateTypeToken;
+                if (CompilationModuleGroup.ContainsType(delegateType) && delegateType is EcmaType ecmaType)
+                {
+                    delegateTypeToken = new ModuleToken(ecmaType.EcmaModule, (mdToken)MetadataTokens.GetToken(ecmaType.Handle));
+                }
+                else
+                {
+                    // TODO: reverse typedef lookup within the version bubble
+                    throw new NotImplementedException();
+                }
+
+                IMethodNode targetMethodNode = MethodEntrypoint(targetMethod, methodToken, isUnboxingStub: false);
+
+                ctorNode = new DelayLoadHelperImport(this,
+                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                    new DelegateCtorSignature(this, delegateType, delegateTypeToken, targetMethodNode, methodToken));
+                _delegateCtors.Add(ctorKey, ctorNode);
+            }
+            return ctorNode;
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -71,7 +71,6 @@ namespace ILCompiler
                 _dictionaryLayoutProvider);
 
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
-            graph.NewMarkedNode += factory.NewMarkedNode;
 
             List<CorJitFlag> corJitFlags = new List<CorJitFlag>();
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -69,7 +69,9 @@ namespace ILCompiler
                 _nameMangler,
                 _vtableSliceProvider,
                 _dictionaryLayoutProvider);
+
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
+            graph.NewMarkedNode += factory.NewMarkedNode;
 
             List<CorJitFlag> corJitFlags = new List<CorJitFlag>();
 

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -33,6 +33,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CompilerIdentifierNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadHelperImport.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadHelperThunk.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelegateCtorSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DevirtualizationManager.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ExternalMethodImport.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\FixupConstants.cs" />

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -19,8 +19,9 @@ namespace Internal.JitInterface
 {
     unsafe partial class CorInfoImpl
     {
-
         private const CORINFO_RUNTIME_ABI TargetABI = CORINFO_RUNTIME_ABI.CORINFO_CORECLR_ABI;
+
+        private uint OffsetOfDelegateFirstTarget => (uint)(3 * PointerSize); // Delegate::m_functionPointer
 
         private readonly ReadyToRunCodegenCompilation _compilation;
 

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -205,6 +205,7 @@ namespace Internal.JitInterface
                 targetMethod = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pTargetMethod);
             }
 
+            /* TODO
             bool isLdvirtftn = pTargetMethod.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Ldvirtftn;
             DelegateCreationInfo delegateInfo = _compilation.GetDelegateCtor(delegateTypeDesc, targetMethod, isLdvirtftn);
 
@@ -222,9 +223,11 @@ namespace Internal.JitInterface
                 pLookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(delegateInfo);
             }
             else
+            */
             {
                 pLookup.lookupKind.needsRuntimeLookup = false;
-                pLookup.constLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.DelegateCtor, delegateInfo, new ModuleToken(_tokenContext, pTargetMethod.token)));
+                pLookup.constLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.DelegateCtor(
+                    delegateTypeDesc, targetMethod, new ModuleToken(_tokenContext, pTargetMethod.token)));
             }
         }
 

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -17,6 +17,8 @@ namespace Internal.JitInterface
     {
         private const CORINFO_RUNTIME_ABI TargetABI = CORINFO_RUNTIME_ABI.CORINFO_CORERT_ABI;
 
+        private uint OffsetOfDelegateFirstTarget => (uint)(4 * PointerSize); // Delegate::m_functionPointer
+
         private Compilation _compilation;
 
         public CorInfoImpl(Compilation compilation, JitConfigProvider jitConfig)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2373,7 +2373,11 @@ namespace Internal.JitInterface
             pEEInfoOut.inlinedCallFrameInfo.size = this.SizeOfPInvokeTransitionFrame;
 
             pEEInfoOut.offsetOfDelegateInstance = (uint)pointerSize;            // Delegate::m_firstParameter
+#if READYTORUN
+            pEEInfoOut.offsetOfDelegateFirstTarget = (uint)(3 * pointerSize);   // Delegate::m_functionPointer
+#else
             pEEInfoOut.offsetOfDelegateFirstTarget = (uint)(4 * pointerSize);   // Delegate::m_functionPointer
+#endif
 
             pEEInfoOut.offsetOfObjArrayData = (uint)(2 * pointerSize);
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2373,11 +2373,7 @@ namespace Internal.JitInterface
             pEEInfoOut.inlinedCallFrameInfo.size = this.SizeOfPInvokeTransitionFrame;
 
             pEEInfoOut.offsetOfDelegateInstance = (uint)pointerSize;            // Delegate::m_firstParameter
-#if READYTORUN
-            pEEInfoOut.offsetOfDelegateFirstTarget = (uint)(3 * pointerSize);   // Delegate::m_functionPointer
-#else
-            pEEInfoOut.offsetOfDelegateFirstTarget = (uint)(4 * pointerSize);   // Delegate::m_functionPointer
-#endif
+            pEEInfoOut.offsetOfDelegateFirstTarget = OffsetOfDelegateFirstTarget;
 
             pEEInfoOut.offsetOfObjArrayData = (uint)(2 * pointerSize);
 


### PR DESCRIPTION
I have refactored imports, runtime functions and method entrypoints
for lazy entry registration in accordance with Michal's suggestion.
The change also implements the new delegate ctor helper siganture
encoding. For now I have ignored the runtime lookup part with
a TODO comment.

Thanks

Tomas