### PR TITLE
Improve repro project config

### DIFF
--- a/src/ILCompiler/repro/repro.csproj
+++ b/src/ILCompiler/repro/repro.csproj
@@ -8,10 +8,16 @@
     <SkipSigning>true</SkipSigning>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
+    
+    <!-- Supress warnings that often happen in repro code -->
+    <NoWarn>169;414</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App">
       <Version>$(MicrosoftNETCoreAppPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
+      <Version>4.5.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* `S.R.CompilerServices.Unsafe` is often useful in repro code
* We treat warnings as errors in all of CoreRT, but warnings about unused fields or unused assignments often happen and are not helpful in repro project.