### PR TITLE
Add wasm debug info

### DIFF
--- a/Documentation/how-to-build-WebAssembly.md
+++ b/Documentation/how-to-build-WebAssembly.md
@@ -37,6 +37,7 @@ This is Windows only for now.
 
 # Useful tips #
 * To manually make ILC compile to WebAssembly, add ```--wasm``` to the command line.
+* To debug C# source, add ```-g4``` to the emcc command line and change ```-s WASM=1``` to ```-s WASM=0```. This will generate a JavaScript source map that browser debuggers and Visual Studio Code can work with. Using Visual Studio Code's Chrome debugger works particularly well.
 * Add ```-g3``` to the emcc command line to generate more debuggable output and a .wast file with the text form of the WebAssembly.
-* Omit ```-s WASM=1``` from the emcc command line to generate asm.js. Browser debuggers currently work better with asm.js and it's often a bit more readable than wast.
+* Change ```-s WASM=1``` to ```-s WASM=0``` in the emcc command line to generate asm.js. Browser debuggers currently work better with asm.js and it's often a bit more readable than wast.
 * Add ```-O2 --llvm-lto 2``` to the emcc command line to enable optimizations. This makes the generated WebAssembly as much as 75% smaller as well as more efficient.

--- a/src/ILCompiler.WebAssembly/src/CodeGen/DebugMetadata.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/DebugMetadata.cs
@@ -11,7 +11,13 @@ namespace ILCompiler.WebAssembly
 {
     class DebugMetadata
     {
-        public LLVMMetadataRef CompileUnit { get; set; }
-        public LLVMMetadataRef File { get; set; }
+        public DebugMetadata(LLVMMetadataRef file, LLVMMetadataRef compileUnit)
+        {
+            File = file;
+            CompileUnit = compileUnit;
+        }
+
+        public LLVMMetadataRef CompileUnit { get; }
+        public LLVMMetadataRef File { get; }
     }
 }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/DebugMetadata.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/DebugMetadata.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using LLVMSharp;
+
+namespace ILCompiler.WebAssembly
+{
+    class DebugMetadata
+    {
+        public LLVMMetadataRef CompileUnit { get; set; }
+        public LLVMMetadataRef File { get; set; }
+    }
+}

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -112,7 +112,9 @@ namespace Internal.IL
             _builder = LLVM.CreateBuilder();
             _pointerSize = compilation.NodeFactory.Target.PointerSize;
 
-            if (_method is EcmaMethod ecmaMethod && ecmaMethod.Module.PdbReader != null)
+            // Get debug metadata for the uninstantiated version of the method
+            MethodDesc typicalMethod = _method.GetTypicalMethodDefinition();
+            if (typicalMethod is EcmaMethod ecmaMethod && ecmaMethod.Module.PdbReader != null)
             {
                 _debugInformation = new EcmaMethodDebugInformation(ecmaMethod);
             }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/LLVMPInvokes.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/LLVMPInvokes.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using LLVMSharp;
+
+namespace ILCompiler.WebAssembly
+{
+    // LLVM P/Invokes copied from LLVMSharp that match the current LLVM surface area.
+    // If we get a new version of LLVMSharp containing these, this file should be removed.
+    internal class LLVMPInvokes
+    {
+        const string libraryPath = "libLLVM";
+        [DllImport(libraryPath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern LLVMDIBuilderRef LLVMCreateDIBuilder(LLVMModuleRef M);
+
+        [DllImport(libraryPath, EntryPoint = "LLVMDIBuilderCreateCompileUnit", CallingConvention = CallingConvention.Cdecl)]
+        public static extern LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(LLVMDIBuilderRef @Builder, LLVMDWARFSourceLanguage @Lang, LLVMMetadataRef @FileRef, [MarshalAs(UnmanagedType.LPStr)] string @Producer, size_t @ProducerLen, LLVMBool @isOptimized, [MarshalAs(UnmanagedType.LPStr)] string @Flags, size_t @FlagsLen, uint @RuntimeVer, [MarshalAs(UnmanagedType.LPStr)] string @SplitName, size_t @SplitNameLen, LLVMDWARFEmissionKind @Kind, uint @DWOId, LLVMBool @SplitDebugInlining, LLVMBool @DebugInfoForProfiling);
+
+        [DllImport(libraryPath, EntryPoint = "LLVMDIBuilderCreateFile", CallingConvention = CallingConvention.Cdecl)]
+        public static extern LLVMMetadataRef LLVMDIBuilderCreateFile(LLVMDIBuilderRef @Builder, [MarshalAs(UnmanagedType.LPStr)] string @Filename, size_t @FilenameLen, [MarshalAs(UnmanagedType.LPStr)] string @Directory, size_t @DirectoryLen);
+
+        [DllImport(libraryPath, EntryPoint = "LLVMDIBuilderCreateDebugLocation", CallingConvention = CallingConvention.Cdecl)]
+        public static extern LLVMMetadataRef LLVMDIBuilderCreateDebugLocation(LLVMContextRef @Ctx, uint @Line, uint @Column, LLVMMetadataRef @Scope, LLVMMetadataRef @InlinedAt);
+    }
+
+    internal enum LLVMDWARFSourceLanguage : int
+    {
+        @LLVMDWARFSourceLanguageC89 = 0,
+        @LLVMDWARFSourceLanguageC = 1,
+        @LLVMDWARFSourceLanguageAda83 = 2,
+        @LLVMDWARFSourceLanguageC_plus_plus = 3,
+        @LLVMDWARFSourceLanguageCobol74 = 4,
+        @LLVMDWARFSourceLanguageCobol85 = 5,
+        @LLVMDWARFSourceLanguageFortran77 = 6,
+        @LLVMDWARFSourceLanguageFortran90 = 7,
+        @LLVMDWARFSourceLanguagePascal83 = 8,
+        @LLVMDWARFSourceLanguageModula2 = 9,
+        @LLVMDWARFSourceLanguageJava = 10,
+        @LLVMDWARFSourceLanguageC99 = 11,
+        @LLVMDWARFSourceLanguageAda95 = 12,
+        @LLVMDWARFSourceLanguageFortran95 = 13,
+        @LLVMDWARFSourceLanguagePLI = 14,
+        @LLVMDWARFSourceLanguageObjC = 15,
+        @LLVMDWARFSourceLanguageObjC_plus_plus = 16,
+        @LLVMDWARFSourceLanguageUPC = 17,
+        @LLVMDWARFSourceLanguageD = 18,
+        @LLVMDWARFSourceLanguagePython = 19,
+        @LLVMDWARFSourceLanguageOpenCL = 20,
+        @LLVMDWARFSourceLanguageGo = 21,
+        @LLVMDWARFSourceLanguageModula3 = 22,
+        @LLVMDWARFSourceLanguageHaskell = 23,
+        @LLVMDWARFSourceLanguageC_plus_plus_03 = 24,
+        @LLVMDWARFSourceLanguageC_plus_plus_11 = 25,
+        @LLVMDWARFSourceLanguageOCaml = 26,
+        @LLVMDWARFSourceLanguageRust = 27,
+        @LLVMDWARFSourceLanguageC11 = 28,
+        @LLVMDWARFSourceLanguageSwift = 29,
+        @LLVMDWARFSourceLanguageJulia = 30,
+        @LLVMDWARFSourceLanguageDylan = 31,
+        @LLVMDWARFSourceLanguageC_plus_plus_14 = 32,
+        @LLVMDWARFSourceLanguageFortran03 = 33,
+        @LLVMDWARFSourceLanguageFortran08 = 34,
+        @LLVMDWARFSourceLanguageRenderScript = 35,
+        @LLVMDWARFSourceLanguageBLISS = 36,
+        @LLVMDWARFSourceLanguageMips_Assembler = 37,
+        @LLVMDWARFSourceLanguageGOOGLE_RenderScript = 38,
+        @LLVMDWARFSourceLanguageBORLAND_Delphi = 39,
+    }
+
+    internal enum LLVMDWARFEmissionKind : int
+    {
+        @LLVMDWARFEmissionNone = 0,
+        @LLVMDWARFEmissionFull = 1,
+        @LLVMDWARFEmissionLineTablesOnly = 2,
+    }
+}

--- a/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
@@ -144,6 +144,8 @@ namespace ILCompiler.DependencyAnalysis
         // this is the llvm instance.
         public LLVMModuleRef Module { get; }
 
+        public LLVMDIBuilderRef DIBuilder { get; }
+
         // This is used to build mangled names
         private Utf8StringBuilder _sb = new Utf8StringBuilder();
 
@@ -181,6 +183,9 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             EmitNativeMain();
+
+            EmitDebugMetadata();
+
             LLVM.WriteBitcodeToFile(Module, _objectFilePath);
 #if DEBUG
             LLVM.PrintModuleToFile(Module, Path.ChangeExtension(_objectFilePath, ".txt"), out string unused2);
@@ -188,6 +193,25 @@ namespace ILCompiler.DependencyAnalysis
             LLVM.VerifyModule(Module, LLVMVerifierFailureAction.LLVMAbortProcessAction, out string unused);
 
             //throw new NotImplementedException(); // This function isn't complete
+        }
+
+        private void EmitDebugMetadata()
+        {
+            var dwarfVersion = LLVM.MDNode(new[]
+                        {
+                LLVM.ConstInt(LLVM.Int32Type(), 2, false),
+                LLVM.MDString("Dwarf Version", 13),
+                LLVM.ConstInt(LLVM.Int32Type(), 4, false)
+            });
+            var dwarfSchemaVersion = LLVM.MDNode(new[]
+            {
+                LLVM.ConstInt(LLVM.Int32Type(), 2, false),
+                LLVM.MDString("Debug Info Version", 18),
+                LLVM.ConstInt(LLVM.Int32Type(), 3, false)
+            });
+            LLVM.AddNamedMetadataOperand(Module, "llvm.module.flags", dwarfVersion);
+            LLVM.AddNamedMetadataOperand(Module, "llvm.module.flags", dwarfSchemaVersion);
+            LLVM.DIBuilderFinalize(DIBuilder);
         }
 
         public static LLVMValueRef GetConstZeroArray(int length)
@@ -645,6 +669,7 @@ namespace ILCompiler.DependencyAnalysis
             _nodeFactory = factory;
             _objectFilePath = objectFilePath;
             Module = compilation.Module;
+            DIBuilder = compilation.DIBuilder;
         }
 
         public void Dispose()

--- a/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
@@ -198,7 +198,7 @@ namespace ILCompiler.DependencyAnalysis
         private void EmitDebugMetadata()
         {
             var dwarfVersion = LLVM.MDNode(new[]
-                        {
+            {
                 LLVM.ConstInt(LLVM.Int32Type(), 2, false),
                 LLVM.MDString("Dwarf Version", 13),
                 LLVM.ConstInt(LLVM.Int32Type(), 4, false)

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
@@ -9,6 +9,7 @@ using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 using LLVMSharp;
+using ILCompiler.WebAssembly;
 
 namespace ILCompiler
 {
@@ -17,6 +18,8 @@ namespace ILCompiler
         internal WebAssemblyCodegenConfigProvider Options { get; }
         internal LLVMModuleRef Module { get; }
         public new WebAssemblyCodegenNodeFactory NodeFactory { get; }
+        internal LLVMDIBuilderRef DIBuilder { get; }
+        internal Dictionary<string, DebugMetadata> DebugMetadataMap { get; }
         internal WebAssemblyCodegenCompilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
             WebAssemblyCodegenNodeFactory nodeFactory,
@@ -29,6 +32,8 @@ namespace ILCompiler
             Module = LLVM.ModuleCreateWithName("netscripten");
             LLVM.SetTarget(Module, "asmjs-unknown-emscripten");
             Options = options;
+            DIBuilder = LLVMPInvokes.LLVMCreateDIBuilder(Module);
+            DebugMetadataMap = new Dictionary<string, DebugMetadata>();
         }
 
         private static IEnumerable<ICompilationRootProvider> GetCompilationRoots(IEnumerable<ICompilationRootProvider> existingRoots, NodeFactory factory)

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
@@ -24,9 +24,10 @@ namespace ILCompiler
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
             WebAssemblyCodegenNodeFactory nodeFactory,
             IEnumerable<ICompilationRootProvider> roots,
+            DebugInformationProvider debugInformationProvider,
             Logger logger,
             WebAssemblyCodegenConfigProvider options)
-            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), null, null, logger)
+            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), debugInformationProvider, null, logger)
         {
             NodeFactory = nodeFactory;
             Module = LLVM.ModuleCreateWithName("netscripten");

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
@@ -34,8 +34,7 @@ namespace ILCompiler
             var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
             WebAssemblyCodegenNodeFactory factory = new WebAssemblyCodegenNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-
-            return new WebAssemblyCodegenCompilation(graph, factory, _compilationRoots, _logger, _config);
+            return new WebAssemblyCodegenCompilation(graph, factory, _compilationRoots, _debugInformationProvider, _logger, _config);
         }
     }
 

--- a/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
+++ b/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
@@ -37,8 +37,10 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\HelperExtensions.cs">
       <Link>IL\HelperExtensions.cs</Link>
     </Compile>
+    <Compile Include="CodeGen\DebugMetadata.cs" />
     <Compile Include="CodeGen\ILToWebAssemblyImporter_Statics.cs" />
     <Compile Include="CodeGen\LLVMMisc.cs" />
+    <Compile Include="CodeGen\LLVMPInvokes.cs" />
     <Compile Include="CodeGen\WebAssemblyObjectWriter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RawMainMethodRootProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\WebAssemblyCodegenNodeFactory.cs" />
@@ -56,13 +58,13 @@
     <Content Include="..\..\..\packages\llvmsharp\5.0.0\lib\netstandard1.1\LLVMSharp.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\..\packages\libllvm\4.0.0\runtimes\osx\native\libLLVM.dylib" Condition="'$(NuPkgRid)' == 'osx-x64'">
+    <Content Include="..\..\..\packages\libllvm\6.0.0-beta1\runtimes\osx\native\libLLVM.dylib" Condition="'$(NuPkgRid)' == 'osx-x64'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\..\packages\libllvm\4.0.0\runtimes\linux-x64\native\libLLVM.so" Condition="'$(NuPkgRid)' == 'linux-x64'">
+    <Content Include="..\..\..\packages\libllvm\6.0.0-beta1\runtimes\linux-x64\native\libLLVM.so" Condition="'$(NuPkgRid)' == 'linux-x64'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\..\packages\libllvm\4.0.0\runtimes\win-x64\native\libLLVM.dll" Condition="'$(NuPkgRid)' == 'win-x64' or '$(NuPkgRid)' == ''">
+    <Content Include="..\..\..\packages\libllvm\6.0.0-beta1\runtimes\win-x64\native\libLLVM.dll" Condition="'$(NuPkgRid)' == 'win-x64' or '$(NuPkgRid)' == ''">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/ILCompiler.WebAssembly/src/libLLVMdep.depproj
+++ b/src/ILCompiler.WebAssembly/src/libLLVMdep.depproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="libLLVM">
-      <Version>4.0.0</Version>
+      <Version>6.0.0-beta1</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Adds source line debug metadata along with friendlier names for some locals and arguments. Together, these make debugging much friendlier (see screenshot with a working breakpoint, arguments and locals). It currently works in asm.js mode. In theory, it should work in WebAssembly mode too, but something's wrong with emscripten's file path processing that prevents it from actually mapping sources. Actually getting the mapping requires manually changing the emcc flags to include ```-s WASM=0 -g4``` (the first switches to asm.js, the second enables source map generation).

This required upgrading to the latest version (6 beta) of libllvm. Because its debug info surface area is slightly different from the latest llvmsharp NuGet package, this change includes some P/Invokes copied from the llvmsharp's source.

![image](https://user-images.githubusercontent.com/11641665/43772478-2166f05c-99f7-11e8-8298-a6b7a50e819c.png)
