### PR TITLE
Use --as-needed command line switch with the Unix linker

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -81,6 +81,7 @@ See the LICENSE file in the project root for more information.
       <LinkerArg Include="@(NativeLibrary)" />
       <LinkerArg Include="-g" />
       <LinkerArg Include="-Wl,-rpath,'$ORIGIN'" />
+      <LinkerArg Include="-Wl,--as-needed" />
       <LinkerArg Include="-pthread" />
       <LinkerArg Include="-lstdc++" />
       <LinkerArg Include="-ldl" />
@@ -94,7 +95,7 @@ See the LICENSE file in the project root for more information.
       <LinkerArg Include="-shared" Condition="'$(TargetOS)' != 'OSX' and '$(NativeLib)' == 'Shared'" />
       <LinkerArg Include="@(NativeFramework->'-framework %(Identity)')" Condition="'$(TargetOS)' == 'OSX'" />
     </ItemGroup>
-    
+
     <Exec Command="command -v $(CppLinker)" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_WhereLinker"/>
     </Exec>


### PR DESCRIPTION
Removes unused native symbol references from the native binary

Fixes #6191