### PR TITLE
Add environment variables support for Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.EnvironGetSystemEnvironment.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.EnvironGetSystemEnvironment.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal unsafe partial class Sys
+    {
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_EnvironGetSystemEnvironment")]
+        internal static extern unsafe IntPtr EnvironGetSystemEnvironment();
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.GetEnviron.cs
+++ b/src/Common/src/Interop/Unix/System.Private.CoreLib.Native/Interop.GetEnviron.cs
@@ -3,14 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     internal unsafe partial class Sys
     {
-        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_EnvironGetSystemEnvironment")]
-        internal static extern unsafe IntPtr EnvironGetSystemEnvironment();
+        [DllImport(Interop.Libraries.CoreLibNative, EntryPoint = "CoreLibNative_GetEnviron")]
+        internal static extern unsafe IntPtr GetEnviron();
     }
 }

--- a/src/Native/System.Private.CoreLib.Native/config.h.in
+++ b/src/Native/System.Private.CoreLib.Native/config.h.in
@@ -6,3 +6,4 @@
 #cmakedefine01 HAVE_MACH_ABSOLUTE_TIME
 #cmakedefine01 HAVE_SCHED_GETCPU
 #cmakedefine01 HAVE_GNU_LIBNAMES_H
+#cmakedefine01 HAVE__NSGETENVIRON

--- a/src/Native/System.Private.CoreLib.Native/configure.cmake
+++ b/src/Native/System.Private.CoreLib.Native/configure.cmake
@@ -1,6 +1,7 @@
 include(CheckCXXSourceCompiles)
 include(CheckCXXSourceRuns)
 include(CheckLibraryExists)
+include(CheckFunctionExists)
 
 check_library_exists(pthread pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
 
@@ -61,6 +62,8 @@ int main(void)
 set(CMAKE_REQUIRED_LIBRARIES)
 
 check_include_files(gnu/lib-names.h HAVE_GNU_LIBNAMES_H)
+
+check_function_exists(_NSGetEnviron HAVE__NSGETENVIRON)
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in

--- a/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
@@ -10,6 +10,7 @@
 #if HAVE_SCHED_GETCPU
 #include <sched.h>
 #endif
+#include <unistd.h>
 
 
 extern "C" char* CoreLibNative_GetEnv(const char* variable)
@@ -31,7 +32,7 @@ extern "C" void CoreLibNative_Exit(int32_t exitCode)
     exit(exitCode);
 }
 
-extern "C" char** CoreLibNative_EnvironGetSystemEnvironment()
+extern "C" char** CoreLibNative_GetEnviron()
 {
     char** sysEnviron;
 

--- a/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
@@ -10,7 +10,9 @@
 #if HAVE_SCHED_GETCPU
 #include <sched.h>
 #endif
-#include <unistd.h>
+#if HAVE__NSGETENVIRON
+#include <crt_externs.h>
+#endif
 
 
 extern "C" char* CoreLibNative_GetEnv(const char* variable)

--- a/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
+++ b/src/Native/System.Private.CoreLib.Native/pal_environment.cpp
@@ -30,3 +30,17 @@ extern "C" void CoreLibNative_Exit(int32_t exitCode)
 {
     exit(exitCode);
 }
+
+extern "C" char** CoreLibNative_EnvironGetSystemEnvironment()
+{
+    char** sysEnviron;
+
+#if HAVE__NSGETENVIRON
+    sysEnviron = *(_NSGetEnviron());
+#else   // HAVE__NSGETENVIRON
+    extern char **environ;
+    sysEnviron = environ;
+#endif  // HAVE__NSGETENVIRON
+
+    return sysEnviron;
+}

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Unix.cs
@@ -30,7 +30,89 @@ namespace Internal.Runtime.Augments
             if ("".Length != 0)
                 throw new NotImplementedException(); // Need to return something better than an empty environment block.
 
-            return Array.Empty<KeyValuePair<string,string>>();
+            unsafe
+            {
+                // Get byte** of environment variables from native interop
+                var unsafeBlock = (byte**)Interop.Sys.EnvironGetSystemEnvironment();
+                if (unsafeBlock == (byte**)0)
+                    throw new OutOfMemoryException();
+                
+                // Find total length of two-dimensional byte**
+                int rowIndex = 0;
+                int totalLength = 0;
+                while (unsafeBlock[rowIndex] != null && unsafeBlock[rowIndex][0] != 0)
+                {
+                    byte* p = unsafeBlock[rowIndex];
+                    while (*p != 0) // Continue until end-of-line char '\0'
+                    {
+                        p++;
+                    }
+                    totalLength += checked((int)(p - unsafeBlock[rowIndex] + 1));
+                    rowIndex++;
+                }
+
+                // Copy two-dimensional byte** to a flat char[] for parsing
+                rowIndex = 0;
+                var blockIndex = 0;
+                char[] block = new char[totalLength];
+                while (unsafeBlock[rowIndex] != null && unsafeBlock[rowIndex][0] != 0)
+                {
+                    byte* p = unsafeBlock[rowIndex];
+                    while (*p != 0) // Continue until end-of-line char '\0'
+                    {
+                        p++;
+                    }
+                    var rowLength = checked((int)(p - unsafeBlock[rowIndex] + 1));
+                    for (int i = 0; i < rowLength; i++)
+                    {
+                        // Copy original byte to a Unicode char in our flat char[]
+                        block[blockIndex++] = Convert.ToChar(unsafeBlock[rowIndex][i]);
+                    }
+                    rowIndex++;
+                }
+
+                // Parse flat char[] and return
+                return EnumerateEnvironmentVariables(block);
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> EnumerateEnvironmentVariables(char[] block)
+        {
+            // To maintain complete compatibility with prior versions we need to return a Hashtable.
+            // We did ship a prior version of Core with LowLevelDictionary, which does iterate the
+            // same (e.g. yields DictionaryEntry), but it is not a public type.
+            //
+            // While we could pass Hashtable back from CoreCLR the type is also defined here. We only
+            // want to surface the local Hashtable.
+            for (int i = 0; i < block.Length; i++)
+            {
+                int startKey = i;
+
+                // Skip to key. On some old OS, the environment block can be corrupted.
+                // Some will not have '=', so we need to check for '\0'. 
+                while (block[i] != '=' && block[i] != '\0')
+                    i++;
+                if (block[i] == '\0')
+                    continue;
+
+                // Skip over environment variables starting with '='
+                if (i - startKey == 0)
+                {
+                    while (block[i] != 0)
+                        i++;
+                    continue;
+                }
+
+                string key = new string(block, startKey, i - startKey);
+                i++;  // skip over '='
+
+                int startValue = i;
+                while (block[i] != 0)
+                    i++; // Read to end of this entry 
+                string value = new string(block, startValue, i - startValue); // skip over 0 handled by for loop's i++
+
+                yield return new KeyValuePair<string, string>(key, value);
+            }
         }
 
         private static void ExitRaw()

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Unix.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/EnvironmentAugments.Unix.cs
@@ -33,7 +33,7 @@ namespace Internal.Runtime.Augments
 
             // Per man page, environment variables come back as an array of pointers to strings
             // Parse each pointer of strings individually
-            while (ParseEntry(ref block, out string key, out string value))
+            while (ParseEntry(block, out string key, out string value))
             {
                 if (key != null && value != null)
                     yield return new KeyValuePair<string, string>(key, value);
@@ -43,7 +43,7 @@ namespace Internal.Runtime.Augments
             }
 
             // Use a local, unsafe function since we cannot use `yield return` inside of an `unsafe` block
-            unsafe bool ParseEntry(ref IntPtr current, out string key, out string value)
+            unsafe bool ParseEntry(IntPtr current, out string key, out string value)
             {
                 // Setup
                 key = null; 

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -608,8 +608,8 @@
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.ErrNo.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.ErrNo.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.EnvironGetSystemEnvironment.cs">
-      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.EnvironGetSystemEnvironment.cs</Link>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.GetEnviron.cs">
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.GetEnviron.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -608,6 +608,9 @@
     <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.ErrNo.cs">
       <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.ErrNo.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Interop\Unix\System.Private.CoreLib.Native\Interop.EnvironGetSystemEnvironment.cs">
+      <Link>Interop\Unix\System.Private.CoreLib.Native\Interop.EnvironGetSystemEnvironment.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">


### PR DESCRIPTION
Implement support for enumerating environment variables in Unix (`EnvironmentAugments.EnumerateEnvironmentVariables()`). Fixes #6204.