### PR TITLE
[armel tizen] Fixed unwinding support for ARM #5874

### DIFF
--- a/src/Native/ObjWriter/objwriter.cpp
+++ b/src/Native/ObjWriter/objwriter.cpp
@@ -921,13 +921,13 @@ void ObjectWriter::EmitARMExIdxCode(int Offset, const char *Blob)
     ATS.emitPad(CfiCode->Offset);
     break;
   case CFI_REL_OFFSET:
-    RegList.push_back(CfiCode->DwarfReg);
+    RegList.push_back(CfiCode->DwarfReg + 14); // See ARMRegEncodingTable in ARMGenRegisterInfo.inc by getEncodingValue
     ATS.emitRegSave(RegList, false);
     break;
   case CFI_DEF_CFA_REGISTER:
     assert(CfiCode->Offset == 0 &&
            "Unexpected Offset Value for OpDefCfaRegister");
-    ATS.emitMovSP(CfiCode->DwarfReg, 0);
+    ATS.emitMovSP(CfiCode->DwarfReg + 14, 0); // See ARMRegEncodingTable in ARMGenRegisterInfo.inc by getEncodingValue
     break;
   default:
     assert(false && "Unrecognized CFI");


### PR DESCRIPTION
Resolved the problem with reversing of generated unwind info in the object file. See the latest comment in https://github.com/dotnet/corert/issues/5874

@jkotas @alpencolt @iarischenko 
Please review