### PR TITLE
Improve R2R test harness reliability

### DIFF
--- a/tests/src/tools/ReadyToRun.TestHarness/ReadyToRunEtlMethodFilter.cs
+++ b/tests/src/tools/ReadyToRun.TestHarness/ReadyToRunEtlMethodFilter.cs
@@ -45,7 +45,12 @@ namespace ReadyToRun.TestHarness
             };
         }
 
-        public IEnumerable<(string methodName, bool readyToRunRejected)> JittedMethods => _methodsJitted;
+        public IEnumerable<(string MethodName, bool ReadyToRunRejected)> JittedMethods => _methodsJitted;
+
+        /// <summary>
+        /// Returns the number of test assemblies that were loaded by the runtime
+        /// </summary>
+        public int AssembliesWithEventsCount => _testModuleIds.Count;
 
         //
         // Builds a method name from event data of the form Class.Method(arg1, arg2)


### PR DESCRIPTION
If for some reason (ie a test harness bug or user error) no assembly load events are fired, the harness will see the absence of jitted methods as a sign that all code ran R2R perfectly. Add a smell test that checks we at least saw one test module loaded.

Fix up tabs and some unused variables.