### PR TITLE
Support readytorun mode for CoreCLR tests

### DIFF
--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -24,19 +24,21 @@ copy /Y %~dp0\Test.csproj %TestFolder%
 :: The CoreCLR test system configures the VS environment as 32-bit by default,
 :: so override if we're doing a 64-bit test run
 ::
-if not "%NativeCodeGen%" == "readytorun" (
+if /i not "%NativeCodeGen%" == "readytorun" (
     if "%CoreRT_BuildArch%" == "x64" (
         call "%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" x64
     )
 )
 
 set ExtraArgs=
-if "%NativeCodeGen%" == "readytorun" (
+if /i "%NativeCodeGen%" == "readytorun" (
     echo READY TO RUN MODE
     set ExtraArgs="/t:CopyNative"
 )
-echo msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" /p:DisableFrameworkLibGeneration=true %ExtraArgs% %TestFolder%\Test.csproj
-msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" /p:DisableFrameworkLibGeneration=true %ExtraArgs% %TestFolder%\Test.csproj
+
+set MsBuildCommandLine=msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" /p:DisableFrameworkLibGeneration=true %ExtraArgs% %TestFolder%\Test.csproj
+echo %MsBuildCommandLine%
+%MsBuildCommandLine%
 if errorlevel 1 (
     set TestExitCode=!ERRORLEVEL!
     goto :Cleanup
@@ -60,9 +62,11 @@ shift
 goto :GetNextParameter
 
 :RunTest
-if "%NativeCodeGen%" == "readytorun" (
-    echo %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe %TestFolder%\native\%TestFileName%.ni.exe %TestParameters%
-    %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe %TestFolder%\native\%TestFileName%.ni.exe %TestParameters%
+
+set CoreRunCommandLine=%CoreRT_CoreCLRRuntimeDir%\CoreRun.exe %TestFolder%\native\%TestFileName%.ni.exe %TestParameters%
+if /i "%NativeCodeGen%" == "readytorun" (
+    echo %CoreRunCommandLine%
+    %CoreRunCommandLine%
 ) else (
     %TestFolder%\native\%TestExecutable% %TestParameters%
 )

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -494,6 +494,11 @@ goto :eof
         msbuild /m /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:OSGroup=%CoreRT_BuildOS%" "/p:Platform=%CoreRT_BuildArch%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%CoreRT_TestRoot%..\bin\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" /t:CreateLib %CoreRT_TestRoot%\..\src\BuildIntegration\BuildFrameworkNativeObjects.proj
     )
 
+    if "%CoreRT_TestCompileMode%" == "readytorun" (
+        set NativeCodeGen=readytorun
+        set IlcMultiModule=
+    )
+
     echo.
     set CLRCustomTestLauncher=%CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd
     set XunitTestBinBase=!CoreRT_TestExtRepo_CoreCLR!


### PR DESCRIPTION
Running `runtest.cmd /CoreCLR KnownGood /mode readytorun` will run the CoreCLR test suite, compiling each test assembly for R2R beforehand.

Currently 226 / 1829 tests pass (12.4%) from the KnownGood subset.