### PR TITLE
Two changes to make local debugging of ILC failures easier

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -179,14 +179,19 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(ServerGarbageCollection) != ''" Include="--runtimeopt:RH_UseServerGC=1" />
     </ItemGroup>
 
-    <MakeDir Directories="$(NativeIntermediateOutputPath)" />
-    <WriteLinesToFile File="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp" Lines="@(IlcArg)" Overwrite="true" />
+    <PropertyGroup>
+      <IlcResponseFolder>$(IntermediateOutputPath)</IlcResponseFolder>
+      <IlcResponseFile>$(IlcResponseFolder)%(ManagedBinary.Filename).ilc.rsp</IlcResponseFile>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(IlcResponseFolder)" />
+    <WriteLinesToFile File="$(IlcResponseFile)" Lines="@(IlcArg)" Overwrite="true" />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeObject)))" />
 
     <Message Text="Generating native code" Importance="high" />
 
-    <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;" />
+    <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(IlcResponseFile)&quot;" />
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Windows.props" Condition="'$(TargetOS)' == 'Windows_NT'" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.CommandLine;
 using System.Runtime.InteropServices;
@@ -237,6 +238,9 @@ namespace ILCompiler
 
             if (_outputFilePath == null)
                 throw new CommandLineException("Output filename must be specified (/out <file>)");
+
+            // Create the output directory if it doesn't exist yet
+            Directory.CreateDirectory(Path.GetDirectoryName(_outputFilePath));
 
             //
             // Set target Architecture and OS


### PR DESCRIPTION
1) Put the .ilc.rsp file to the $(IntermediateOutputPath), not
into $(NativeIntermediateOutputPath) folder as the latter one
gets deleted after each run. The response file is typically
less then 1 K in size and so it should pose no threat to
the lab disk space.

2) Opportunistically create the output directory in the
ILCompiler so that, once we copy & paste the @(sometest.ilc.rsp)
file from the test log into the ILCompiler VS project,
we can directly run the compiler without manually recreating
the previously deleted "native" subdirectory.

Thanks

Tomas