### PR TITLE
Enable thread statics

### DIFF
--- a/src/Common/src/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/DefType.FieldLayout.cs
@@ -55,7 +55,8 @@ namespace Internal.TypeSystem
         {
             public StaticsBlock NonGcStatics;
             public StaticsBlock GcStatics;
-            public StaticsBlock ThreadStatics;
+            public StaticsBlock ThreadNonGcStatics;
+            public StaticsBlock ThreadGcStatics;
         }
 
         ThreadSafeFlags _fieldLayoutFlags;
@@ -217,10 +218,10 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// How many bytes must be allocated to represent the (potentially GC visible) thread static
-        /// fields of this type.
+        /// How many bytes must be allocated to represent the non GC visible thread static fields
+        /// of this type.
         /// </summary>
-        public LayoutInt ThreadStaticFieldSize
+        public LayoutInt ThreadNonGcStaticFieldSize
         {
             get
             {
@@ -228,7 +229,39 @@ namespace Internal.TypeSystem
                 {
                     ComputeStaticFieldLayout(StaticLayoutKind.StaticRegionSizes);
                 }
-                return _staticBlockInfo == null ? LayoutInt.Zero : _staticBlockInfo.ThreadStatics.Size;
+                return _staticBlockInfo == null ? LayoutInt.Zero : _staticBlockInfo.ThreadNonGcStatics.Size;
+            }
+        }
+
+        /// <summary>
+        /// What is the alignment required for allocating the non GC visible thread static fields
+        /// of this type.
+        /// </summary>
+        public LayoutInt ThreadNonGcStaticFieldAlignment
+        {
+            get
+            {
+                if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedStaticRegionLayout))
+                {
+                    ComputeStaticFieldLayout(StaticLayoutKind.StaticRegionSizes);
+                }
+                return _staticBlockInfo == null ? LayoutInt.Zero : _staticBlockInfo.ThreadNonGcStatics.LargestAlignment;
+            }
+        }
+
+        /// <summary>
+        /// How many bytes must be allocated to represent the (potentially GC visible) thread static
+        /// fields of this type.
+        /// </summary>
+        public LayoutInt ThreadGcStaticFieldSize
+        {
+            get
+            {
+                if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedStaticRegionLayout))
+                {
+                    ComputeStaticFieldLayout(StaticLayoutKind.StaticRegionSizes);
+                }
+                return _staticBlockInfo == null ? LayoutInt.Zero : _staticBlockInfo.ThreadGcStatics.Size;
             }
         }
 
@@ -236,7 +269,7 @@ namespace Internal.TypeSystem
         /// What is the alignment required for allocating the (potentially GC visible) thread static
         /// fields of this type.
         /// </summary>
-        public LayoutInt ThreadStaticFieldAlignment
+        public LayoutInt ThreadGcStaticFieldAlignment
         {
             get
             {
@@ -244,7 +277,7 @@ namespace Internal.TypeSystem
                 {
                     ComputeStaticFieldLayout(StaticLayoutKind.StaticRegionSizes);
                 }
-                return _staticBlockInfo == null ? LayoutInt.Zero : _staticBlockInfo.ThreadStatics.LargestAlignment;
+                return _staticBlockInfo == null ? LayoutInt.Zero : _staticBlockInfo.ThreadGcStatics.LargestAlignment;
             }
         }
 
@@ -328,13 +361,15 @@ namespace Internal.TypeSystem
 
             if ((computedStaticLayout.NonGcStatics.Size != LayoutInt.Zero) ||
                 (computedStaticLayout.GcStatics.Size != LayoutInt.Zero) ||
-                (computedStaticLayout.ThreadStatics.Size != LayoutInt.Zero))
+                (computedStaticLayout.ThreadNonGcStatics.Size != LayoutInt.Zero) ||
+                (computedStaticLayout.ThreadGcStatics.Size != LayoutInt.Zero))
             {
                 var staticBlockInfo = new StaticBlockInfo
                 {
                     NonGcStatics = computedStaticLayout.NonGcStatics,
                     GcStatics = computedStaticLayout.GcStatics,
-                    ThreadStatics = computedStaticLayout.ThreadStatics
+                    ThreadNonGcStatics = computedStaticLayout.ThreadNonGcStatics,
+                    ThreadGcStatics = computedStaticLayout.ThreadGcStatics
                 };
                 _staticBlockInfo = staticBlockInfo;
             }

--- a/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
+++ b/src/Common/src/TypeSystem/Common/FieldDesc.FieldLayout.cs
@@ -33,8 +33,7 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// For static fields, represents whether or not the field is held in the GC or non GC statics region
-        /// Does not apply to thread static fields.
+        /// For static fields, represents whether or not the field is held in the GC or non GC statics region.
         /// </summary>
         public bool HasGCStaticBase
         {
@@ -42,7 +41,6 @@ namespace Internal.TypeSystem
             {
                 // If this assert fires then make sure the caller checks the IsThreadStatic attribute
                 // of FieldDesc before checking its HasGCStaticBase property.
-                Debug.Assert(IsStatic && !IsThreadStatic);
                 return Context.ComputeHasGCStaticBase(this);
             }
         }

--- a/src/Common/src/TypeSystem/Common/FieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/FieldLayoutAlgorithm.cs
@@ -101,7 +101,8 @@ namespace Internal.TypeSystem
     {
         public StaticsBlock NonGcStatics;
         public StaticsBlock GcStatics;
-        public StaticsBlock ThreadStatics;
+        public StaticsBlock ThreadNonGcStatics;
+        public StaticsBlock ThreadGcStatics;
 
         /// <summary>
         /// If Offsets is non-null, then all field based layout is complete.

--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -185,7 +185,8 @@ namespace Internal.TypeSystem
             ComputedStaticFieldLayout result;
             result.GcStatics = new StaticsBlock();
             result.NonGcStatics = new StaticsBlock();
-            result.ThreadStatics = new StaticsBlock();
+            result.ThreadGcStatics = new StaticsBlock();
+            result.ThreadNonGcStatics = new StaticsBlock();
 
             if (numStaticFields == 0)
             {
@@ -228,10 +229,15 @@ namespace Internal.TypeSystem
             return result;
         }
 
-        private ref StaticsBlock GetStaticsBlockForField(ref ComputedStaticFieldLayout layout, FieldDesc field)
+        protected virtual ref StaticsBlock GetStaticsBlockForField(ref ComputedStaticFieldLayout layout, FieldDesc field)
         {
             if (field.IsThreadStatic)
-                return ref layout.ThreadStatics;
+            {
+                if (field.HasGCStaticBase)
+                    return ref layout.ThreadGcStatics;
+                else
+                    return ref layout.ThreadNonGcStatics;
+            }
             else if (field.HasGCStaticBase)
                 return ref layout.GcStatics;
             else

--- a/src/Common/src/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
@@ -45,7 +45,8 @@ namespace Internal.TypeSystem
             {
                 NonGcStatics = new StaticsBlock() { Size = LayoutInt.Zero, LargestAlignment = LayoutInt.Zero },
                 GcStatics = new StaticsBlock() { Size = LayoutInt.Zero, LargestAlignment = LayoutInt.Zero },
-                ThreadStatics = new StaticsBlock() { Size = LayoutInt.Zero, LargestAlignment = LayoutInt.Zero },
+                ThreadNonGcStatics = new StaticsBlock() { Size = LayoutInt.Zero, LargestAlignment = LayoutInt.Zero },
+                ThreadGcStatics = new StaticsBlock() { Size = LayoutInt.Zero, LargestAlignment = LayoutInt.Zero },
                 Offsets = Array.Empty<FieldAndOffset>()
             };
         }

--- a/src/Common/src/TypeSystem/Common/Utilities/GCPointerMap.Algorithm.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/GCPointerMap.Algorithm.cs
@@ -61,7 +61,7 @@ namespace Internal.TypeSystem
         /// </summary>
         public static GCPointerMap FromThreadStaticLayout(DefType type)
         {
-            GCPointerMapBuilder builder = new GCPointerMapBuilder(type.ThreadStaticFieldSize.AsInt, type.Context.Target.PointerSize);
+            GCPointerMapBuilder builder = new GCPointerMapBuilder(type.ThreadGcStaticFieldSize.AsInt, type.Context.Target.PointerSize);
 
             foreach (FieldDesc field in type.GetFields())
             {
@@ -85,7 +85,7 @@ namespace Internal.TypeSystem
                 }
             }
 
-            Debug.Assert(builder.ToGCMap().Size * type.Context.Target.PointerSize >= type.ThreadStaticFieldSize.AsInt);
+            Debug.Assert(builder.ToGCMap().Size * type.Context.Target.PointerSize >= type.ThreadGcStaticFieldSize.AsInt);
             return builder.ToGCMap();
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -372,7 +372,7 @@ namespace ILCompiler
                 Debug.Assert(!type.IsGenericDefinition);
 
                 MetadataType metadataType = type as MetadataType;
-                if (metadataType != null && metadataType.ThreadStaticFieldSize.AsInt > 0)
+                if (metadataType != null && metadataType.ThreadGcStaticFieldSize.AsInt > 0)
                 {
                     _graph.AddRoot(_factory.TypeThreadStaticIndex(metadataType), reason);
 

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerMetadataFieldLayoutAlgorithm.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 
 using Internal.TypeSystem;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace ILCompiler
 {
     internal class CompilerMetadataFieldLayoutAlgorithm : MetadataFieldLayoutAlgorithm
@@ -15,7 +17,7 @@ namespace ILCompiler
         {
             // GC statics start with a pointer to the "EEType" that signals the size and GCDesc to the GC
             layout.GcStatics.Size = context.Target.LayoutPointerSize;
-            layout.ThreadStatics.Size = context.Target.LayoutPointerSize;
+            layout.ThreadGcStatics.Size = context.Target.LayoutPointerSize;
         }
 
         protected override void FinalizeRuntimeSpecificStaticFieldLayout(TypeSystemContext context, ref ComputedStaticFieldLayout layout)
@@ -26,10 +28,24 @@ namespace ILCompiler
             {
                 layout.GcStatics.Size = LayoutInt.Zero;
             }
-            if (layout.ThreadStatics.Size == context.Target.LayoutPointerSize)
+            if (layout.ThreadGcStatics.Size == context.Target.LayoutPointerSize)
             {
-                layout.ThreadStatics.Size = LayoutInt.Zero;
+                layout.ThreadGcStatics.Size = LayoutInt.Zero;
             }
+
+            // CoreRT makes no distinction between Gc / non-Gc thread statics. All are placed into ThreadGcStatics since thread statics
+            // are typically rare.
+            Debug.Assert(layout.ThreadNonGcStatics.Size == LayoutInt.Zero);
+        }
+
+        protected override ref StaticsBlock GetStaticsBlockForField(ref ComputedStaticFieldLayout layout, FieldDesc field)
+        {
+            if (field.IsThreadStatic)
+                return ref layout.ThreadGcStatics;
+            else if (field.HasGCStaticBase)
+                return ref layout.GcStatics;
+            else
+                return ref layout.NonGcStatics;
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -982,7 +982,7 @@ namespace ILCompiler.DependencyAnalysis
                     yield return new DependencyListEntry(GetStaticsNode(context, out ignored), "type gc static info");
                 }
 
-                if (_type.GetClosestDefType().ThreadStaticFieldSize.AsInt > 0)
+                if (_type.GetClosestDefType().ThreadGcStaticFieldSize.AsInt > 0)
                 {
                     BagElementKind ignored;
                     yield return new DependencyListEntry(GetThreadStaticsNode(context, out ignored), "type thread static info");
@@ -1201,9 +1201,9 @@ namespace ILCompiler.DependencyAnalysis
                     layoutInfo.AppendUnsigned(staticDescBagType, gcStaticsSymbolIndex);
                 }
 
-                if (closestDefType.ThreadStaticFieldSize.AsInt != 0)
+                if (closestDefType.ThreadGcStaticFieldSize.AsInt != 0)
                 {
-                    layoutInfo.AppendUnsigned(BagElementKind.ThreadStaticDataSize, checked((uint)closestDefType.ThreadStaticFieldSize.AsInt));
+                    layoutInfo.AppendUnsigned(BagElementKind.ThreadStaticDataSize, checked((uint)closestDefType.ThreadGcStaticFieldSize.AsInt));
                     BagElementKind threadStaticDescBagType;
                     ISymbolNode threadStaticsDescSymbol = GetThreadStaticsNode(factory, out threadStaticDescBagType);
                     uint threadStaticsSymbolIndex = factory.MetadataManager.NativeLayoutInfo.StaticsReferences.GetIndex(threadStaticsDescSymbol);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -22,6 +22,7 @@ namespace ILCompiler.DependencyAnalysis
         GetNonGCStaticBase,
         GetGCStaticBase,
         GetThreadStaticBase,
+        GetThreadNonGcStaticBase,
         DelegateCtor,
         ResolveVirtualFunction,
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
@@ -70,7 +70,7 @@ namespace ILCompiler.DependencyAnalysis
                     dependencies.Add(factory.Indirection(factory.TypeNonGCStaticsSymbol(metadataType)), "Non-GC statics indirection for StaticsInfoHashtable");
                 }
 
-                if (metadataType.ThreadStaticFieldSize.AsInt > 0)
+                if (metadataType.ThreadGcStaticFieldSize.AsInt > 0)
                 {
                     if (factory.Target.Abi == TargetAbi.ProjectN)
                     {
@@ -116,7 +116,7 @@ namespace ILCompiler.DependencyAnalysis
                     ISymbolNode nonGCStaticIndirection = factory.Indirection(factory.TypeNonGCStaticsSymbol(metadataType));
                     bag.AppendUnsigned(BagElementKind.NonGcStaticData, _nativeStaticsReferences.GetIndex(nonGCStaticIndirection));
                 }
-                if (metadataType.ThreadStaticFieldSize.AsInt > 0)
+                if (metadataType.ThreadGcStaticFieldSize.AsInt > 0)
                 {
                     if (factory.Target.Abi == TargetAbi.ProjectN)
                     {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcThreadStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcThreadStaticsNode.cs
@@ -58,7 +58,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
             builder.RequireInitialPointerAlignment();
-            builder.EmitZeros(_type.ThreadStaticFieldSize.AsInt);
+            builder.EmitZeros(_type.ThreadGcStaticFieldSize.AsInt);
             builder.AddSymbol(this);
             return builder.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -540,7 +540,7 @@ namespace ILCompiler
                     }
                 }
 
-                if (metadataType.ThreadStaticFieldSize.AsInt > 0)
+                if (metadataType.ThreadGcStaticFieldSize.AsInt > 0)
                 {
                     dependencies.Add(((UtcNodeFactory)factory).TypeThreadStaticsOffsetSymbol(metadataType), "Thread statics for ReflectionFieldMap entry");
                 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -293,8 +293,9 @@ namespace ILCompiler.DependencyAnalysis
             ReadyToRunFixupKind fixupKind = ReadyToRunFixupKind.READYTORUN_FIXUP_ThreadStaticBaseGC;
             return new DelayLoadHelperImport(
                 this,
+                HelperImports,
                 ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
-                new TypeFixupSignature(this, fixupKind, type, GetTypeToken(token)));
+                new TypeFixupSignature(Resolver, fixupKind, type, GetTypeToken(token)));
         }
 
         private ISymbolNode CreateThreadNonGcStaticBaseHelper(TypeDesc type, ModuleToken token)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -187,7 +187,11 @@ namespace ILCompiler.DependencyAnalysis
                     break;
 
                 case ReadyToRunHelperId.GetThreadStaticBase:
-                    helperNode = CreateThreadStaticBaseHelper((TypeDesc)target, token);
+                    helperNode = CreateThreadGcStaticBaseHelper((TypeDesc)target, token);
+                    break;
+
+                case ReadyToRunHelperId.GetThreadNonGcStaticBase:
+                    helperNode = CreateThreadNonGcStaticBaseHelper((TypeDesc)target, token);
                     break;
 
                 case ReadyToRunHelperId.IsInstanceOf:
@@ -284,7 +288,16 @@ namespace ILCompiler.DependencyAnalysis
                 new TypeFixupSignature(Resolver, ReadyToRunFixupKind.READYTORUN_FIXUP_StaticBaseNonGC, type, GetTypeToken(token)));
         }
 
-        private ISymbolNode CreateThreadStaticBaseHelper(TypeDesc type, ModuleToken token)
+        private ISymbolNode CreateThreadGcStaticBaseHelper(TypeDesc type, ModuleToken token)
+        {
+            ReadyToRunFixupKind fixupKind = ReadyToRunFixupKind.READYTORUN_FIXUP_ThreadStaticBaseGC;
+            return new DelayLoadHelperImport(
+                this,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                new TypeFixupSignature(this, fixupKind, type, GetTypeToken(token)));
+        }
+
+        private ISymbolNode CreateThreadNonGcStaticBaseHelper(TypeDesc type, ModuleToken token)
         {
             ReadyToRunFixupKind fixupKind = ReadyToRunFixupKind.READYTORUN_FIXUP_ThreadStaticBaseNonGC;
             return new DelayLoadHelperImport(

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -32,7 +32,8 @@ namespace ILCompiler
         {
             layout.NonGcStatics.Size = _initialNonGcStaticsOffset;
             layout.GcStatics.Size = LayoutInt.Zero;
-            layout.ThreadStatics.Size = LayoutInt.Zero;
+            layout.ThreadNonGcStatics.Size = LayoutInt.Zero;
+            layout.ThreadGcStatics.Size = LayoutInt.Zero;
         }
 
         protected override void FinalizeRuntimeSpecificStaticFieldLayout(TypeSystemContext context, ref ComputedStaticFieldLayout layout)

--- a/src/ILCompiler.TypeSystem/tests/TestMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestMetadataFieldLayoutAlgorithm.cs
@@ -15,7 +15,7 @@ namespace TypeSystemTests
         {
             // GC statics start with a pointer to the "EEType" that signals the size and GCDesc to the GC
             layout.GcStatics.Size = context.Target.LayoutPointerSize;
-            layout.ThreadStatics.Size = context.Target.LayoutPointerSize;
+            layout.ThreadGcStatics.Size = context.Target.LayoutPointerSize;
         }
 
         protected override void FinalizeRuntimeSpecificStaticFieldLayout(TypeSystemContext context, ref ComputedStaticFieldLayout layout)
@@ -26,10 +26,20 @@ namespace TypeSystemTests
             {
                 layout.GcStatics.Size = LayoutInt.Zero;
             }
-            if (layout.ThreadStatics.Size == context.Target.LayoutPointerSize)
+            if (layout.ThreadGcStatics.Size == context.Target.LayoutPointerSize)
             {
-                layout.ThreadStatics.Size = LayoutInt.Zero;
+                layout.ThreadGcStatics.Size = LayoutInt.Zero;
             }
+        }
+
+        protected override ref StaticsBlock GetStaticsBlockForField(ref ComputedStaticFieldLayout layout, FieldDesc field)
+        {
+            if (field.IsThreadStatic)
+                return ref layout.ThreadGcStatics;
+            else if (field.HasGCStaticBase)
+                return ref layout.GcStatics;
+            else
+                return ref layout.NonGcStatics;
         }
     }
 }

--- a/src/ILCompiler.TypeSystem/tests/UniversalGenericFieldLayoutTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/UniversalGenericFieldLayoutTests.cs
@@ -200,8 +200,8 @@ namespace TypeSystemTests
             Assert.Equal(LayoutInt.Zero, context.UniversalCanonType.GCStaticFieldSize);
             Assert.Equal(LayoutInt.Zero, context.UniversalCanonType.NonGCStaticFieldAlignment);
             Assert.Equal(LayoutInt.Zero, context.UniversalCanonType.NonGCStaticFieldSize);
-            Assert.Equal(LayoutInt.Zero, context.UniversalCanonType.ThreadStaticFieldAlignment);
-            Assert.Equal(LayoutInt.Zero, context.UniversalCanonType.ThreadStaticFieldSize);
+            Assert.Equal(LayoutInt.Zero, context.UniversalCanonType.ThreadGcStaticFieldAlignment);
+            Assert.Equal(LayoutInt.Zero, context.UniversalCanonType.ThreadGcStaticFieldSize);
         }
         [Fact]
         public void TestLayoutOfUniversalCanonType()

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1973,7 +1973,18 @@ namespace Internal.JitInterface
                         // Find out what kind of base do we need to look up.
                         if (field.IsThreadStatic)
                         {
+#if READYTORUN
+                            if (field.HasGCStaticBase)
+                            {
+                                helperId = ReadyToRunHelperId.GetThreadStaticBase;
+                            }
+                            else
+                            {
+                                helperId = ReadyToRunHelperId.GetThreadNonGcStaticBase;
+                            }
+#else
                             helperId = ReadyToRunHelperId.GetThreadStaticBase;
+#endif
                         }
                         else if (field.HasGCStaticBase)
                         {
@@ -2010,7 +2021,18 @@ namespace Internal.JitInterface
                     ReadyToRunHelperId helperId = ReadyToRunHelperId.Invalid;
                     if (field.IsThreadStatic)
                     {
+#if READYTORUN
+                        if (field.HasGCStaticBase)
+                        {
+                            helperId = ReadyToRunHelperId.GetThreadStaticBase;
+                        }
+                        else
+                        {
+                            helperId = ReadyToRunHelperId.GetThreadNonGcStaticBase;
+                        }
+#else
                         helperId = ReadyToRunHelperId.GetThreadStaticBase;
+#endif
                     }
                     else if (field.HasGCStaticBase)
                     {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutFieldAlgorithm.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NativeLayoutFieldAlgorithm.cs
@@ -120,7 +120,8 @@ namespace Internal.Runtime.TypeLoader
             {
                 layout.GcStatics = new StaticsBlock() { Size = position[(int)NativeFormat.FieldStorage.GCStatic], LargestAlignment = DefType.MaximumAlignmentPossible };
                 layout.NonGcStatics = new StaticsBlock() { Size = position[(int)NativeFormat.FieldStorage.NonGCStatic], LargestAlignment = DefType.MaximumAlignmentPossible };
-                layout.ThreadStatics = new StaticsBlock() { Size = position[(int)NativeFormat.FieldStorage.TLSStatic], LargestAlignment = DefType.MaximumAlignmentPossible };
+                layout.ThreadGcStatics = new StaticsBlock() { Size = position[(int)NativeFormat.FieldStorage.TLSStatic], LargestAlignment = DefType.MaximumAlignmentPossible };
+                layout.ThreadNonGcStatics = new StaticsBlock() { Size = LayoutInt.Zero, LargestAlignment = LayoutInt.Zero };
             }
 
             int curStaticField = 0;
@@ -179,7 +180,8 @@ namespace Internal.Runtime.TypeLoader
                 GcStatics = new StaticsBlock() { Size = gcDataSize, LargestAlignment = DefType.MaximumAlignmentPossible },
                 NonGcStatics = new StaticsBlock() { Size = nonGcDataSize, LargestAlignment = DefType.MaximumAlignmentPossible },
                 Offsets = null, // We're not computing field offsets here, so return null
-                ThreadStatics = new StaticsBlock() { Size = threadDataSize, LargestAlignment = DefType.MaximumAlignmentPossible },
+                ThreadGcStatics = new StaticsBlock() { Size = threadDataSize, LargestAlignment = DefType.MaximumAlignmentPossible },
+                ThreadNonGcStatics = new StaticsBlock() { Size = LayoutInt.Zero, LargestAlignment = LayoutInt.Zero },
             };
 
             return staticLayout;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NoMetadataFieldLayoutAlgorithm.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/NoMetadataFieldLayoutAlgorithm.cs
@@ -83,7 +83,8 @@ namespace Internal.Runtime.TypeLoader
                 GcStatics = default(StaticsBlock),
                 NonGcStatics = default(StaticsBlock),
                 Offsets = Array.Empty<FieldAndOffset>(), // No fields are considered to exist for completely NoMetadataTypes
-                ThreadStatics = default(StaticsBlock),
+                ThreadGcStatics = default(StaticsBlock),
+                ThreadNonGcStatics = default(StaticsBlock),
             };
             return staticLayout;
         }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -507,7 +507,7 @@ namespace Internal.Runtime.TypeLoader
                 DefType defType = TypeBeingBuilt as DefType;
                 if (defType != null && !defType.IsGenericDefinition)
                 {
-                    return defType.ThreadStaticFieldSize.AsInt;
+                    return defType.ThreadGcStaticFieldSize.AsInt;
                 }
                 else
                 {
@@ -532,7 +532,7 @@ namespace Internal.Runtime.TypeLoader
         public uint NumSealedVTableEntries;
         public int[] GenericVarianceFlags;
 
-        // Sentinel static to allow us to initializae _instanceLayout to something
+        // Sentinel static to allow us to initialize _instanceLayout to something
         // and then detect that InstanceGCLayout should return null
         private static LowLevelList<bool> s_emptyLayout = new LowLevelList<bool>();
 

--- a/tests/src/Simple/ReadyToRunUnit/Program.cs
+++ b/tests/src/Simple/ReadyToRunUnit/Program.cs
@@ -9,10 +9,10 @@ using System.Text;
 
 internal class Program
 {
-    // [ThreadStatic]
+    [ThreadStatic]
     private static string TextFileName = @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\clientexclusionlist.xml";
 
-    //[ThreadStatic]
+    [ThreadStatic]
     private static int LineCount = 0x12345678;
 
     private static List<string> _passedTests;


### PR DESCRIPTION
This change is in two parts:

1. Type system work to support CoreCLR style of statics where there are 4 buckets: Gc / non-Gc statics, Gc / non-Gc thread-statics. CoreRT overrides the static layout algorithm to merge both thread-statics into the Gc thread-static block. This commit can ideally be ported to master immediately. I opted to make classifying the statics into 4 tables the default in `MetadataFieldLayoutAlgorithm`, with CoreRT overriding that behavior.

2. R2R compiler changes to properly categorize the 4 statics kinds.