### PR TITLE
Add ready-to-run CoreCLR tests to CI

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -127,6 +127,9 @@ def static calculateBuildCommands(def os, def configuration, def scenario, def i
                 if (isPR) {
                     // Run a small set of BVTs during PR validation
                     buildCommands += testScriptString + "Top200"
+
+                    // Run the set of tests known to work with Ready To Run
+                    buildCommands += testScriptString + "ReadyToRun /mode ReadyToRun"
                 }
                 else {
                     // Run the full set of known passing tests in the post-commit job

--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -82,4 +82,29 @@ set TestExitCode=!ERRORLEVEL!
 ::
 rd /s /q %TestFolder%\native
 
+
+::
+:: Dev bring-up aid to help populate the inclusion / exclusion files. Ie, tests\ReadyToRun.CoreCLR.issues.targets.
+:: All failing tests will have a file named exclude.txt containing the test cmd file path.
+:: All passing tests will have a file named include.txt containing the test cmd file path.
+::
+:: From <root>\tests_downloaded\CoreCLR gather all the test cmd file names:
+::
+::  for /r %f in (include.txt) do type "%f" >> passed.txt
+::
+::   Or
+::
+::  for /r %f in (exclude.txt) do type "%f" >> failed.txt
+::
+:: You can find / replace to massage the list into the XML format needed in the issues.targets file.
+::
+del %TestFolder%\include.txt
+del %TestFolder%\exclude.txt
+
+if "!TestExitCode!" == "100" (
+    echo %TestFolder%%TestFileName%.cmd > %TestFolder%\include.txt
+) else (
+    echo %TestFolder%%TestFileName%.cmd > %TestFolder%\exclude.txt
+)
+
 exit /b !TestExitCode!

--- a/tests/ReadyToRun.CoreCLR.issues.targets
+++ b/tests/ReadyToRun.CoreCLR.issues.targets
@@ -1,0 +1,34 @@
+<!--
+
+    Running all 7000 Pri-0 CoreCLR tests would take forever. Exclude down to a set that provides
+    broad coverage and an expected reasonable run time (< 30 minutes)
+
+-->
+<Project DefaultTargets = "GetListOfTestCmds" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
+  <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
+    <Includelist Include="$(xunitteStbiNBAse)\baseservices\threading\DeadThreads\DeadThreads\DeadThreads.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\API\GC\Collect0\Collect0.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\API\GC\Collect1\Collect1.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\API\GCHandleCollector\Count\Count.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\API\WeakReference\Finalize2\Finalize2.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\Coverage\LargeObjectAlloc\LargeObjectAlloc.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\Regressions\v2.0-beta2\452950\452950\452950.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\Regressions\v2.0-beta2\460373\460373\460373.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\Scenarios\FinalizeTimeout\FinalizeTimeout\FinalizeTimeout.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\Scenarios\GCStress\gcstress\gcstress.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\Scenarios\NDPin\ndpin\ndpin.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\GC\Scenarios\RanCollect\rancollect\rancollect.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\opt\Inline\tests\calli\calli.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\opt\Inline\tests\mathfunc\mathfunc.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\AbsGeneric_r\AbsGeneric_r.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\AbsSqrt_r\AbsSqrt_r.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\AddingSequence_r\AddingSequence_r.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\CtorFromArray_r\CtorFromArray_r.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\Matrix4x4_r\Matrix4x4_r.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\MinMax_r\MinMax_r.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\Mul_ro\Mul_ro.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\SqrtGeneric_r\SqrtGeneric_r.cmd" /> 
+    <Includelist Include="$(xunitteStbiNBAse)\JIT\SIMD\Vector3_r\Vector3_r.cmd" />    
+  </ItemGroup>
+</Project>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -40,6 +40,7 @@ if /i "%1" == "/coreclr"  (
     )
 
     if /i "!SelectedTests!" == "Top200" set CoreRT_CoreCLRTargetsFile=%CoreRT_TestRoot%\Top200.CoreCLR.issues.targets&&goto :ExtRepoTestsOk
+    if /i "!SelectedTests!" == "ReadyToRun" set CoreRT_CoreCLRTargetsFile=%CoreRT_TestRoot%\ReadyToRun.CoreCLR.issues.targets&&goto :ExtRepoTestsOk
     if /i "!SelectedTests!" == "KnownGood" set CoreRT_CoreCLRTargetsFile=%CoreRT_TestRoot%\CoreCLR.issues.targets&&goto :ExtRepoTestsOk
     if /i "!SelectedTests!" == "Interop" set CoreRT_CoreCLRTargetsFile=%CoreRT_TestRoot%\Interop.CoreCLR.issues.targets&&goto :ExtRepoTestsOk
 
@@ -80,6 +81,7 @@ echo     --- CoreCLR Subset ---
 echo        Top200     : Runs broad coverage / CI validation (~200 tests).
 echo        KnownGood  : Runs tests known to pass on CoreRT (~6000 tests).
 echo        Interop    : Runs only the interop tests (~43 tests).
+echo        ReadyToRun : Runs tests known to pass using CoreCLR Ready To Run (~23 tests).
 echo        All        : Runs all tests. There will be many failures (~7000 tests).
 exit /b 2
 


### PR DESCRIPTION
* Run CoreCLR tests that are known to pass in ready-to-run during CI
* Add a mechanism to easily collect the list of passing / failing tests for use in inclusion / exclusion lists.