### PR TITLE
[Interpreter] Load Constants

### DIFF
--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -143,7 +143,7 @@ namespace Internal.IL
 
         private void ImportLoadNull()
         {
-            throw new NotImplementedException();
+            _interpreter.EvaluationStack.Push(new ObjectRefStackItem(null));
         }
 
         private void ImportReturn()
@@ -163,8 +163,15 @@ namespace Internal.IL
                 case StackValueKind.Unknown:
                 case StackValueKind.NativeInt:
                 case StackValueKind.Float:
+                    if (stackItem.Type == WellKnownType.Single)
+                        _interpreter.SetReturnValue(((FloatStackItem)stackItem).Value);
+                    else if (stackItem.Type == WellKnownType.Double)
+                        _interpreter.SetReturnValue(((DoubleStackItem)stackItem).Value);
+                    break;
                 case StackValueKind.ByRef:
                 case StackValueKind.ObjRef:
+                    _interpreter.SetReturnValue(((ObjectRefStackItem)stackItem).Value);
+                    break;
                 case StackValueKind.ValueType:
                 default:
                     break;
@@ -179,9 +186,14 @@ namespace Internal.IL
                 _interpreter.EvaluationStack.Push(new Int64StackItem(value));
         }
 
+        private void ImportLoadFloat(float value)
+        {
+            _interpreter.EvaluationStack.Push(new FloatStackItem(value));
+        }
+
         private void ImportLoadFloat(double value)
         {
-            throw new NotImplementedException();
+            _interpreter.EvaluationStack.Push(new DoubleStackItem(value));
         }
 
         private void ImportShiftOperation(ILOpcode opcode)
@@ -374,9 +386,10 @@ namespace Internal.IL
             throw new NotImplementedException();
         }
 
-        private void ImportLoadString(int v)
+        private void ImportLoadString(int token)
         {
-            throw new NotImplementedException();
+            string str = (string)_methodIL.GetObject(token);
+            _interpreter.EvaluationStack.Push(new ObjectRefStackItem(str));
         }
 
         private void ImportBinaryOperation(ILOpcode opCode)

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
@@ -4,56 +4,66 @@
 
 using System;
 using Internal.IL;
+using Internal.TypeSystem;
 
 namespace Internal.Runtime.Interpreter
 {
     internal abstract class StackItem
     {
-        public StackValueKind Kind { get; set; }
+        public StackValueKind Kind { get; protected set; }
+        public WellKnownType Type { get; protected set; }
     }
 
     internal class StackItem<T> : StackItem
     {
         public T Value { get; }
 
-        public StackItem(T value, StackValueKind kind)
+        public StackItem(T value, StackValueKind kind, WellKnownType type)
         {
             Value = value;
             Kind = kind;
+            Type = type;
         }
     }
 
     internal class Int32StackItem : StackItem<int>
     {
-        public Int32StackItem(int value) : base(value, StackValueKind.Int32)
+        public Int32StackItem(int value) : base(value, StackValueKind.Int32, WellKnownType.Int32)
         {
         }
     }
 
     internal class Int64StackItem : StackItem<long>
     {
-        public Int64StackItem(long value) : base(value, StackValueKind.Int64)
+        public Int64StackItem(long value) : base(value, StackValueKind.Int64, WellKnownType.Int64)
         {
         }
     }
 
-    internal class FloatStackItem : StackItem<double>
+    internal class FloatStackItem : StackItem<float>
     {
-        public FloatStackItem(double value) : base(value, StackValueKind.Float)
+        public FloatStackItem(float value) : base(value, StackValueKind.Float, WellKnownType.Single)
+        {
+        }
+    }
+
+    internal class DoubleStackItem : StackItem<double>
+    {
+        public DoubleStackItem(double value) : base(value, StackValueKind.Float, WellKnownType.Double)
         {
         }
     }
 
     internal class ValueTypeStackItem : StackItem<ValueType>
     {
-        public ValueTypeStackItem(ValueType value) : base(value, StackValueKind.ValueType)
+        public ValueTypeStackItem(ValueType value) : base(value, StackValueKind.ValueType, WellKnownType.ValueType)
         {
         }
     }
 
     internal class ObjectRefStackItem : StackItem<Object>
     {
-        public ObjectRefStackItem(Object value) : base(value, StackValueKind.ObjRef)
+        public ObjectRefStackItem(Object value) : base(value, StackValueKind.ObjRef, WellKnownType.Object)
         {
         }
     }


### PR DESCRIPTION
This PR adds support for loading constants to the interpreter. The following OpCodes are now supported:

* `ldc.*`
* `ldnull`
* `ldstr`

The following method signatures can now be interpreted when compiled in `Release` mode

```csharp
public static int GetInt()
{
    return 100;
}

public static byte GetByte()
{
    return 128;
}

public static bool GetBool()
{
    return false;
}

public static char GetChar()
{
    return 'A';
}

public static float GetFloat()
{
    return 1.5F;
}

public static double GetDouble()
{
    return 3.142;
}

public static string GetString()
{
    return "Hello World";
}

public static object GetNull()
{
    return null;
}
```

Signed and unsigned variants of numeric constants are also supported. Compilation of interpreted assembly in release mode will no longer be required once I add support for locals in a follow-up PR to this.

#5011 