### PR TITLE
[Interpreter] StackItem redesign

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -24,8 +24,6 @@ namespace Internal.IL
         NativeInt,
         /// <summary>Any float value.</summary>
         Float,
-        /// <summary>Any double value.</summary>
-        Double,
         /// <summary>A managed pointer.</summary>
         ByRef,
         /// <summary>An object reference.</summary>

--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -24,6 +24,8 @@ namespace Internal.IL
         NativeInt,
         /// <summary>Any float value.</summary>
         Float,
+        /// <summary>Any double value.</summary>
+        Double,
         /// <summary>A managed pointer.</summary>
         ByRef,
         /// <summary>An object reference.</summary>

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -143,7 +143,7 @@ namespace Internal.IL
 
         private void ImportLoadNull()
         {
-            _interpreter.EvaluationStack.Push(new ObjectRefStackItem(null));
+            _interpreter.EvaluationStack.Push(StackItem.FromObjectRef(null));
         }
 
         private void ImportReturn()
@@ -155,22 +155,22 @@ namespace Internal.IL
             switch (stackItem.Kind)
             {
                 case StackValueKind.Int32:
-                    _interpreter.SetReturnValue(((Int32StackItem)stackItem).Value);
+                    _interpreter.SetReturnValue((int)stackItem);
                     break;
                 case StackValueKind.Int64:
-                    _interpreter.SetReturnValue(((Int64StackItem)stackItem).Value);
+                    _interpreter.SetReturnValue((long)stackItem);
                     break;
                 case StackValueKind.Unknown:
                 case StackValueKind.NativeInt:
                 case StackValueKind.Float:
                     if (stackItem.Type == WellKnownType.Single)
-                        _interpreter.SetReturnValue(((FloatStackItem)stackItem).Value);
+                        _interpreter.SetReturnValue((float)stackItem);
                     else if (stackItem.Type == WellKnownType.Double)
-                        _interpreter.SetReturnValue(((DoubleStackItem)stackItem).Value);
+                        _interpreter.SetReturnValue((double)stackItem);
                     break;
                 case StackValueKind.ByRef:
                 case StackValueKind.ObjRef:
-                    _interpreter.SetReturnValue(((ObjectRefStackItem)stackItem).Value);
+                    _interpreter.SetReturnValue(stackItem.ToObjectRef());
                     break;
                 case StackValueKind.ValueType:
                 default:
@@ -181,19 +181,19 @@ namespace Internal.IL
         private void ImportLoadInt(long value, StackValueKind kind)
         {
             if (kind == StackValueKind.Int32)
-                _interpreter.EvaluationStack.Push(new Int32StackItem((int)value));
+                _interpreter.EvaluationStack.Push((int)value);
             else if (kind == StackValueKind.Int64)
-                _interpreter.EvaluationStack.Push(new Int64StackItem(value));
+                _interpreter.EvaluationStack.Push(value);
         }
 
         private void ImportLoadFloat(float value)
         {
-            _interpreter.EvaluationStack.Push(new FloatStackItem(value));
+            _interpreter.EvaluationStack.Push(value);
         }
 
         private void ImportLoadFloat(double value)
         {
-            _interpreter.EvaluationStack.Push(new DoubleStackItem(value));
+            _interpreter.EvaluationStack.Push(value);
         }
 
         private void ImportShiftOperation(ILOpcode opcode)
@@ -389,7 +389,7 @@ namespace Internal.IL
         private void ImportLoadString(int token)
         {
             string str = (string)_methodIL.GetObject(token);
-            _interpreter.EvaluationStack.Push(new ObjectRefStackItem(str));
+            _interpreter.EvaluationStack.Push(StackItem.FromObjectRef(str));
         }
 
         private void ImportBinaryOperation(ILOpcode opCode)

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -232,6 +232,7 @@ namespace Internal.IL
                 case TypeFlags.FunctionPointer:
                 case TypeFlags.GenericParameter:
                 default:
+                    // TODO: Support more complex return types
                     break;
             }
         }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -208,7 +208,7 @@ namespace Internal.IL
                     _interpreter.SetReturnValue(stackItem.AsIntPtr());
                     break;
                 case TypeFlags.Single:
-                    _interpreter.SetReturnValue(stackItem.AsFloat());
+                    _interpreter.SetReturnValue((float)stackItem.AsDouble());
                     break;
                 case TypeFlags.Double:
                     _interpreter.SetReturnValue(stackItem.AsDouble());
@@ -243,11 +243,6 @@ namespace Internal.IL
                 _interpreter.EvaluationStack.Push(StackItem.FromInt32((int)value));
             else if (kind == StackValueKind.Int64)
                 _interpreter.EvaluationStack.Push(StackItem.FromInt64(value));
-        }
-
-        private void ImportLoadFloat(float value)
-        {
-            _interpreter.EvaluationStack.Push(StackItem.FromFloat(value));
         }
 
         private void ImportLoadFloat(double value)

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -172,8 +172,7 @@ namespace Internal.IL
             switch (category)
             {
                 case TypeFlags.Boolean:
-                    Debug.Assert(integer >= 0 && integer <= 1);
-                    _interpreter.SetReturnValue(integer == 1);
+                    _interpreter.SetReturnValue(integer != 0);
                     break;
                 case TypeFlags.Char:
                     Debug.Assert(integer >= char.MinValue && integer <= char.MaxValue);
@@ -218,15 +217,12 @@ namespace Internal.IL
                     break;
                 case TypeFlags.Interface:
                 case TypeFlags.Class:
-                    _interpreter.SetReturnValue(stackItem.AsObjectRef());
-                    break;
-                case TypeFlags.CategoryMask:
-                case TypeFlags.Unknown:
-                case TypeFlags.Void:
-                case TypeFlags.Enum:
-                case TypeFlags.Nullable:
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
+                    _interpreter.SetReturnValue(stackItem.AsObjectRef());
+                    break;
+                case TypeFlags.Enum:
+                case TypeFlags.Nullable:
                 case TypeFlags.ByRef:
                 case TypeFlags.Pointer:
                 case TypeFlags.FunctionPointer:

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -161,42 +161,33 @@ namespace Internal.IL
             var returnType = _method.Signature.ReturnType;
             if (returnType.IsVoid)
                 return;
-
-            int integer = 0;
+            
             StackItem stackItem = PopWithValidation();
-
-            if (stackItem.Kind == StackValueKind.Int32)
-                integer = stackItem.AsInt32();
-
             TypeFlags category = returnType.Category;
+
             switch (category)
             {
                 case TypeFlags.Boolean:
-                    _interpreter.SetReturnValue(integer != 0);
+                    _interpreter.SetReturnValue(stackItem.AsInt32() != 0);
                     break;
                 case TypeFlags.Char:
-                    Debug.Assert(integer >= char.MinValue && integer <= char.MaxValue);
-                    _interpreter.SetReturnValue((char)integer);
+                    _interpreter.SetReturnValue((char)stackItem.AsInt32());
                     break;
                 case TypeFlags.SByte:
-                    Debug.Assert(integer >= sbyte.MinValue && integer <= sbyte.MaxValue);
-                    _interpreter.SetReturnValue((sbyte)integer);
+                    _interpreter.SetReturnValue((sbyte)stackItem.AsInt32());
                     break;
                 case TypeFlags.Byte:
-                    Debug.Assert(integer >= byte.MinValue && integer <= byte.MaxValue);
-                    _interpreter.SetReturnValue((byte)integer);
+                    _interpreter.SetReturnValue((byte)stackItem.AsInt32());
                     break;
                 case TypeFlags.Int16:
-                    Debug.Assert(integer >= short.MinValue && integer <= short.MaxValue);
-                    _interpreter.SetReturnValue((short)integer);
+                    _interpreter.SetReturnValue((short)stackItem.AsInt32());
                     break;
                 case TypeFlags.UInt16:
-                    Debug.Assert(integer >= ushort.MinValue && integer <= ushort.MaxValue);
-                    _interpreter.SetReturnValue((ushort)integer);
+                    _interpreter.SetReturnValue((ushort)stackItem.AsInt32());
                     break;
                 case TypeFlags.Int32:
                 case TypeFlags.UInt32:
-                    _interpreter.SetReturnValue(integer);
+                    _interpreter.SetReturnValue(stackItem.AsInt32());
                     break;
                 case TypeFlags.Int64:
                 case TypeFlags.UInt64:

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -106,7 +106,7 @@ namespace Internal.IL
         {
             bool hasStackItem = _interpreter.EvaluationStack.TryPop(out StackItem stackItem);
             if (!hasStackItem)
-                throw new InvalidProgramException();
+                ThrowHelper.ThrowInvalidProgramException();
 
             return stackItem;
         }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -18,22 +18,10 @@ namespace Internal.Runtime.Interpreter
         private readonly LowLevelStack<StackItem> _stack;
 
         private CallInterceptorArgs _callInterceptorArgs;
-        
-        public LowLevelStack<StackItem> EvaluationStack
-        {
-            get
-            {
-                return _stack;
-            }
-        }
 
-        public TypeSystemContext TypeSystemContext
-        {
-            get
-            {
-                return _context;
-            }
-        }
+        public LowLevelStack<StackItem> EvaluationStack => _stack;
+
+        public TypeSystemContext TypeSystemContext => _context;
 
         public ILInterpreter(TypeSystemContext context, MethodDesc method, MethodIL methodIL)
         {

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
@@ -3,68 +3,137 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 using Internal.IL;
 using Internal.TypeSystem;
 
 namespace Internal.Runtime.Interpreter
 {
-    internal abstract class StackItem
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct StackItem
     {
-        public StackValueKind Kind { get; protected set; }
-        public WellKnownType Type { get; protected set; }
-    }
+        [FieldOffset(0)]
+        private StackValueKind _kind;
 
-    internal class StackItem<T> : StackItem
-    {
-        public T Value { get; }
+        [FieldOffset(8)]
+        private WellKnownType _type;
 
-        public StackItem(T value, StackValueKind kind, WellKnownType type)
+        [FieldOffset(16)]
+        private int _int32;
+
+        [FieldOffset(16)]
+        private long _int64;
+
+        [FieldOffset(16)]
+        private IntPtr _nativeInt;
+
+        [FieldOffset(16)]
+        private float _float;
+
+        [FieldOffset(16)]
+        private double _double;
+
+        [FieldOffset(16)]
+        private void* _ptr;
+
+        [FieldOffset(24)]
+        private ValueType _valueType;
+
+        [FieldOffset(24)]
+        private object _objref;
+
+        public StackValueKind Kind => _kind;
+        public WellKnownType Type => _type;
+
+        public static implicit operator StackItem(int int32)
         {
-            Value = value;
-            Kind = kind;
-            Type = type;
+            return new StackItem { _int32 = int32, _type = WellKnownType.Int32, _kind = StackValueKind.Int32 };
         }
-    }
 
-    internal class Int32StackItem : StackItem<int>
-    {
-        public Int32StackItem(int value) : base(value, StackValueKind.Int32, WellKnownType.Int32)
+        public static explicit operator int(StackItem stackItem)
         {
+            if (stackItem._type != WellKnownType.Int32)
+                throw new InvalidCastException();
+
+            return stackItem._int32;
         }
-    }
 
-    internal class Int64StackItem : StackItem<long>
-    {
-        public Int64StackItem(long value) : base(value, StackValueKind.Int64, WellKnownType.Int64)
+        public static implicit operator StackItem(long int64)
         {
+            return new StackItem { _int64 = int64, _type = WellKnownType.Int64, _kind = StackValueKind.Int64 };
         }
-    }
 
-    internal class FloatStackItem : StackItem<float>
-    {
-        public FloatStackItem(float value) : base(value, StackValueKind.Float, WellKnownType.Single)
+        public static explicit operator long(StackItem stackItem)
         {
+            if (stackItem._type != WellKnownType.Int64)
+                throw new InvalidCastException();
+
+            return stackItem._int64;
         }
-    }
 
-    internal class DoubleStackItem : StackItem<double>
-    {
-        public DoubleStackItem(double value) : base(value, StackValueKind.Float, WellKnownType.Double)
+        public static implicit operator StackItem(IntPtr ptr)
         {
+            return new StackItem { _nativeInt = ptr, _type = WellKnownType.IntPtr, _kind = StackValueKind.NativeInt };
         }
-    }
 
-    internal class ValueTypeStackItem : StackItem<ValueType>
-    {
-        public ValueTypeStackItem(ValueType value) : base(value, StackValueKind.ValueType, WellKnownType.ValueType)
+        public static explicit operator IntPtr(StackItem stackItem)
         {
+            if (stackItem._type != WellKnownType.IntPtr)
+                throw new InvalidCastException();
+
+            return stackItem._nativeInt;
         }
-    }
 
-    internal class ObjectRefStackItem : StackItem<Object>
-    {
-        public ObjectRefStackItem(Object value) : base(value, StackValueKind.ObjRef, WellKnownType.Object)
+        public static implicit operator StackItem(float single)
         {
+            return new StackItem { _float = single, _type = WellKnownType.Single, _kind = StackValueKind.Float };
+        }
+
+        public static explicit operator float(StackItem stackItem)
+        {
+            if (stackItem._type != WellKnownType.Single)
+                throw new InvalidCastException();
+
+            return stackItem._float;
+        }
+
+        public static implicit operator StackItem(double d)
+        {
+            return new StackItem { _double = d, _type = WellKnownType.Double, _kind = StackValueKind.Float };
+        }
+
+        public static explicit operator double(StackItem stackItem)
+        {
+            if (stackItem._type != WellKnownType.Double)
+                throw new InvalidCastException();
+
+            return stackItem._double;
+        }
+
+        public static StackItem FromValueType(ValueType valueType)
+        {
+            return new StackItem { _valueType = valueType, _type = WellKnownType.ValueType, _kind = StackValueKind.ValueType };
+        }
+
+        public ValueType ToValueType()
+        {
+            if (_type != WellKnownType.ValueType)
+                throw new InvalidCastException();
+
+            return _valueType;
+        }
+
+        public static StackItem FromObjectRef(object obj)
+        {
+            return new StackItem { _objref = obj, _type = WellKnownType.Object, _kind = StackValueKind.ObjRef };
+        }
+
+        public object ToObjectRef()
+        {
+            if (_type != WellKnownType.Object)
+                throw new InvalidCastException();
+
+            return _objref;
         }
     }
 }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Internal.IL;
 using Internal.TypeSystem;
@@ -16,123 +17,116 @@ namespace Internal.Runtime.Interpreter
         private StackValueKind _kind;
 
         [FieldOffset(8)]
-        private WellKnownType _type;
-
-        [FieldOffset(16)]
         private int _int32;
 
-        [FieldOffset(16)]
+        [FieldOffset(8)]
         private long _int64;
 
-        [FieldOffset(16)]
+        [FieldOffset(8)]
         private IntPtr _nativeInt;
 
-        [FieldOffset(16)]
+        [FieldOffset(8)]
         private float _float;
 
-        [FieldOffset(16)]
+        [FieldOffset(8)]
         private double _double;
 
-        [FieldOffset(16)]
+        [FieldOffset(8)]
         private void* _ptr;
 
-        [FieldOffset(24)]
+        [FieldOffset(16)]
         private ValueType _valueType;
 
-        [FieldOffset(24)]
+        [FieldOffset(16)]
         private object _objref;
 
         public StackValueKind Kind => _kind;
-        public WellKnownType Type => _type;
 
-        public static implicit operator StackItem(int int32)
+        public static StackItem FromInt32(int int32)
         {
-            return new StackItem { _int32 = int32, _type = WellKnownType.Int32, _kind = StackValueKind.Int32 };
+            return new StackItem { _int32 = int32, _kind = StackValueKind.Int32 };
         }
 
-        public static explicit operator int(StackItem stackItem)
+        public int AsInt32()
         {
-            if (stackItem._type != WellKnownType.Int32)
-                throw new InvalidCastException();
-
-            return stackItem._int32;
+            Debug.Assert(_kind == StackValueKind.Int32);
+            return _int32;
         }
 
-        public static implicit operator StackItem(long int64)
+        public static StackItem FromInt64(long int64)
         {
-            return new StackItem { _int64 = int64, _type = WellKnownType.Int64, _kind = StackValueKind.Int64 };
+            return new StackItem { _int64 = int64, _kind = StackValueKind.Int64 };
         }
 
-        public static explicit operator long(StackItem stackItem)
+        public long AsInt64()
         {
-            if (stackItem._type != WellKnownType.Int64)
-                throw new InvalidCastException();
-
-            return stackItem._int64;
+            Debug.Assert(_kind == StackValueKind.Int64);
+            return _int64;
         }
 
-        public static implicit operator StackItem(IntPtr ptr)
+        public static StackItem FromIntPtr(IntPtr nativeInt)
         {
-            return new StackItem { _nativeInt = ptr, _type = WellKnownType.IntPtr, _kind = StackValueKind.NativeInt };
+            return new StackItem { _nativeInt = nativeInt, _kind = StackValueKind.NativeInt };
         }
 
-        public static explicit operator IntPtr(StackItem stackItem)
+        public IntPtr AsIntPtr()
         {
-            if (stackItem._type != WellKnownType.IntPtr)
-                throw new InvalidCastException();
-
-            return stackItem._nativeInt;
+            Debug.Assert(_kind == StackValueKind.NativeInt);
+            return _nativeInt;
         }
 
-        public static implicit operator StackItem(float single)
+        public static StackItem FromFloat(float single)
         {
-            return new StackItem { _float = single, _type = WellKnownType.Single, _kind = StackValueKind.Float };
+            return new StackItem { _float = single, _kind = StackValueKind.Float };
         }
 
-        public static explicit operator float(StackItem stackItem)
+        public float AsFloat()
         {
-            if (stackItem._type != WellKnownType.Single)
-                throw new InvalidCastException();
-
-            return stackItem._float;
+            Debug.Assert(_kind == StackValueKind.Float);
+            return _float;
         }
 
-        public static implicit operator StackItem(double d)
+        public static StackItem FromDouble(double d)
         {
-            return new StackItem { _double = d, _type = WellKnownType.Double, _kind = StackValueKind.Float };
+            return new StackItem { _double = d, _kind = StackValueKind.Float };
         }
 
-        public static explicit operator double(StackItem stackItem)
+        public double AsDouble()
         {
-            if (stackItem._type != WellKnownType.Double)
-                throw new InvalidCastException();
+            Debug.Assert(_kind == StackValueKind.Float);
+            return _double;
+        }
 
-            return stackItem._double;
+        public static StackItem FromUnknown(void* ptr)
+        {
+            return new StackItem { _ptr = ptr, _kind = StackValueKind.Unknown };
+        }
+
+        public void* AsUnknown()
+        {
+            Debug.Assert(_kind == StackValueKind.Unknown);
+            return _ptr;
         }
 
         public static StackItem FromValueType(ValueType valueType)
         {
-            return new StackItem { _valueType = valueType, _type = WellKnownType.ValueType, _kind = StackValueKind.ValueType };
+            return new StackItem { _valueType = valueType, _kind = StackValueKind.ValueType };
         }
 
-        public ValueType ToValueType()
+        public ValueType AsValueType()
         {
-            if (_type != WellKnownType.ValueType)
-                throw new InvalidCastException();
-
+            Debug.Assert(_kind == StackValueKind.ValueType);
             return _valueType;
         }
 
         public static StackItem FromObjectRef(object obj)
         {
-            return new StackItem { _objref = obj, _type = WellKnownType.Object, _kind = StackValueKind.ObjRef };
+            return new StackItem { _objref = obj, _kind = StackValueKind.ObjRef };
         }
 
-        public object ToObjectRef()
+        public object AsObjectRef()
         {
-            if (_type != WellKnownType.Object)
-                throw new InvalidCastException();
-
+            Debug.Assert(_kind == StackValueKind.ObjRef);
             return _objref;
         }
     }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
@@ -31,9 +31,6 @@ namespace Internal.Runtime.Interpreter
         [FieldOffset(8)]
         private double _double;
 
-        [FieldOffset(8)]
-        private void* _ptr;
-
         [FieldOffset(16)]
         private ValueType _valueType;
 
@@ -95,17 +92,6 @@ namespace Internal.Runtime.Interpreter
         {
             Debug.Assert(_kind == StackValueKind.Float);
             return _double;
-        }
-
-        public static StackItem FromUnknown(void* ptr)
-        {
-            return new StackItem { _ptr = ptr, _kind = StackValueKind.Unknown };
-        }
-
-        public void* AsUnknown()
-        {
-            Debug.Assert(_kind == StackValueKind.Unknown);
-            return _ptr;
         }
 
         public static StackItem FromValueType(ValueType valueType)

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
@@ -85,7 +85,7 @@ namespace Internal.Runtime.Interpreter
 
         public static StackItem FromDouble(double d)
         {
-            return new StackItem { _double = d, _kind = StackValueKind.Float };
+            return new StackItem { _double = d, _kind = StackValueKind.Double };
         }
 
         public double AsDouble()

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
@@ -26,9 +26,6 @@ namespace Internal.Runtime.Interpreter
         private IntPtr _nativeInt;
 
         [FieldOffset(8)]
-        private float _float;
-
-        [FieldOffset(8)]
         private double _double;
 
         [FieldOffset(16)]
@@ -72,20 +69,9 @@ namespace Internal.Runtime.Interpreter
             return _nativeInt;
         }
 
-        public static StackItem FromFloat(float single)
-        {
-            return new StackItem { _float = single, _kind = StackValueKind.Float };
-        }
-
-        public float AsFloat()
-        {
-            Debug.Assert(_kind == StackValueKind.Float);
-            return _float;
-        }
-
         public static StackItem FromDouble(double d)
         {
-            return new StackItem { _double = d, _kind = StackValueKind.Double };
+            return new StackItem { _double = d, _kind = StackValueKind.Float };
         }
 
         public double AsDouble()


### PR DESCRIPTION
Based on conversations in #6284, I've updated the `StackItem` class to instead be an explicitly layed out struct. It makes sense to open this as a separate PR since it's a design decision that is core to how the interpreter functions

#5011 