### PR TITLE
Make CustomAttributeData's AttributeType virtual

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
@@ -12,7 +12,7 @@ namespace System.Reflection
     {
         protected CustomAttributeData() { }
 
-        public Type AttributeType
+        public virtual Type AttributeType
         {
             get
             {


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/31614

This will allow Reflection providers the option
to supply the attribute type without building
an entire constructor.