### PR TITLE
Simple R2R fixes in NativeFormatWriter and R2R helper signature

### DIFF
--- a/src/Common/src/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/Common/src/Internal/NativeFormat/NativeFormatWriter.cs
@@ -1779,6 +1779,8 @@ namespace Internal.NativeFormat
                     Debug.Assert(pop == second);
                     if (place)
                     {
+                        pop = _section.Pop();
+                        Debug.Assert(pop == tree);
                         _section.Place(second);
                     }
     

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunHelperSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunHelperSignature.cs
@@ -20,11 +20,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            return new ObjectData(
-                new[] { (byte) ReadyToRunFixupKind.READYTORUN_FIXUP_Helper, (byte) _helperID },
-                Array.Empty<Relocation>(),
-                1,
-                new ISymbolDefinitionNode[] { this });
+            ObjectDataSignatureBuilder builder = new ObjectDataSignatureBuilder();
+            builder.AddSymbol(this);
+            builder.EmitUInt((uint)ReadyToRunFixupKind.READYTORUN_FIXUP_Helper);
+            builder.EmitUInt((uint)_helperID);
+            return builder.ToObjectData();
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)


### PR DESCRIPTION
This is the first part of my recent changes, hopefully comprising
non-controversial straightforward bug fixes.

In NativeFormatWriter, this is hopefully the last piece I missed
in my original rewrite; it started failing once we enabled testing
of larger test suites with more functions.

In the helper signature, the fiuxp and helper need to use the
signature compressed uint encoding, not plain byte formatting
(I hit this with the personality routine which has helper code
0xF0 with 2-byte compressed encoding.

Thanks

Tomas