### PR TITLE
Fix sealed vtable calls on Wasm

### DIFF
--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -110,7 +110,7 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return Abi != TargetAbi.CppCodegen;
+                return (Abi != TargetAbi.CppCodegen) && (Architecture != TargetArchitecture.Wasm32);
             }
         }
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
@@ -606,6 +606,10 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     Relocation reloc = relocs[nextRelocIndex];
 
+                    // Make sure we've gotten the correct size for the reloc
+                    Debug.Assert(reloc.RelocType == RelocType.IMAGE_REL_BASED_DIR64 ||
+                        reloc.RelocType == RelocType.IMAGE_REL_BASED_HIGHLOW);
+
                     long delta;
                     unsafe
                     {

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -454,6 +454,17 @@ internal static class Program
         {
             PrintLine("Struct interface test: Ok.");
         }
+
+        ClassWithSealedVTable classWithSealedVTable = new ClassWithSealedVTable();
+        PrintString("Interface dispatch with sealed vtable test: ");
+        if (CallItf(classWithSealedVTable) == 37)
+        {
+            PrintLine("Ok.");
+        }
+        else
+        {
+            PrintLine("Failed.");
+        }
     }
 
     // Calls the ITestItf interface via a generic to ensure the concrete type is known and
@@ -461,6 +472,11 @@ internal static class Program
     private static int ItfCaller<T>(T obj) where T : ITestItf
     {
         return obj.GetValue();
+    }
+
+    private static int CallItf(ISomeItf asItf)
+    {
+        return asItf.GetValue();
     }
 
     private static void StaticCtorTest()
@@ -850,4 +866,17 @@ public sealed class SealedDerived : MyBase
     {
         return _data * 3;
     }
+}
+
+class ClassWithSealedVTable : ISomeItf
+{
+    public int GetValue()
+    {
+        return 37;
+    }
+}
+
+interface ISomeItf
+{
+    int GetValue();
 }


### PR DESCRIPTION
Fix calls on sealed vtables by disabling relative pointers for WebAssembly.

Fixes #6330.