### PR TITLE
Exception handling info fix

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExceptionInfoLookupTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExceptionInfoLookupTableNode.cs
@@ -136,9 +136,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 exceptionInfoLookupBuilder.EmitReloc(_ehInfoNode, RelocType.IMAGE_REL_BASED_ADDR32NB, _ehInfoOffsets[index]);
             }
 
-            // Sentinel record - method RVA = -1, EH info offset = total EH info size
+            // Sentinel record - method RVA = -1, EH info offset = end of the EH info block
             exceptionInfoLookupBuilder.EmitUInt(~0u);
-            exceptionInfoLookupBuilder.EmitUInt((uint)_ehInfoNode.Count);
+            exceptionInfoLookupBuilder.EmitReloc(_ehInfoNode, RelocType.IMAGE_REL_BASED_ADDR32NB, _ehInfoNode.Count);
 
             return exceptionInfoLookupBuilder.ToObjectData();
         }

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -505,9 +505,9 @@ namespace Internal.JitInterface
         {
             Flags = 0,
             TryOffset = 1,
-            TryLength = 2,
+            TryEnd = 2,
             HandlerOffset = 3,
-            HandlerLength = 4,
+            HandlerEnd = 4,
             ClassTokenOrOffset = 5,
 
             Length
@@ -525,9 +525,9 @@ namespace Internal.JitInterface
                 Array.Copy(BitConverter.GetBytes((uint)clause.Flags), 0, ehInfoData, clauseOffset + (int)EHInfoFields.Flags * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.TryOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryOffset * sizeof(uint), sizeof(uint));
                 // JIT in fact returns the end offset in the length field
-                Array.Copy(BitConverter.GetBytes((uint)(clause.TryLength)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryLength * sizeof(uint), sizeof(uint));
+                Array.Copy(BitConverter.GetBytes((uint)(clause.TryLength)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryEnd * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.HandlerOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerOffset * sizeof(uint), sizeof(uint));
-                Array.Copy(BitConverter.GetBytes((uint)(clause.HandlerLength)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerLength * sizeof(uint), sizeof(uint));
+                Array.Copy(BitConverter.GetBytes((uint)(clause.HandlerLength)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerEnd * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.ClassTokenOrOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.ClassTokenOrOffset * sizeof(uint), sizeof(uint));
             }
             return new ObjectNode.ObjectData(ehInfoData, Array.Empty<Relocation>(), alignment: 1, definedSymbols: Array.Empty<ISymbolDefinitionNode>());

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -525,9 +525,9 @@ namespace Internal.JitInterface
                 Array.Copy(BitConverter.GetBytes((uint)clause.Flags), 0, ehInfoData, clauseOffset + (int)EHInfoFields.Flags * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.TryOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryOffset * sizeof(uint), sizeof(uint));
                 // JIT in fact returns the end offset in the length field
-                Array.Copy(BitConverter.GetBytes((uint)(clause.TryLength - clause.TryOffset)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryLength * sizeof(uint), sizeof(uint));
+                Array.Copy(BitConverter.GetBytes((uint)(clause.TryLength)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryLength * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.HandlerOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerOffset * sizeof(uint), sizeof(uint));
-                Array.Copy(BitConverter.GetBytes((uint)(clause.HandlerLength - clause.HandlerOffset)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerLength * sizeof(uint), sizeof(uint));
+                Array.Copy(BitConverter.GetBytes((uint)(clause.HandlerLength)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerLength * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.ClassTokenOrOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.ClassTokenOrOffset * sizeof(uint), sizeof(uint));
             }
             return new ObjectNode.ObjectData(ehInfoData, Array.Empty<Relocation>(), alignment: 1, definedSymbols: Array.Empty<ISymbolDefinitionNode>());

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -505,9 +505,9 @@ namespace Internal.JitInterface
         {
             Flags = 0,
             TryOffset = 1,
-            TryEnd = 2,
+            TryLength = 2,
             HandlerOffset = 3,
-            HandlerEnd = 4,
+            HandlerLength = 4,
             ClassTokenOrOffset = 5,
 
             Length
@@ -524,9 +524,10 @@ namespace Internal.JitInterface
                 int clauseOffset = (int)EHInfoFields.Length * sizeof(uint) * i;
                 Array.Copy(BitConverter.GetBytes((uint)clause.Flags), 0, ehInfoData, clauseOffset + (int)EHInfoFields.Flags * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.TryOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryOffset * sizeof(uint), sizeof(uint));
-                Array.Copy(BitConverter.GetBytes((uint)(clause.TryOffset + clause.TryLength)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryEnd * sizeof(uint), sizeof(uint));
+                // JIT in fact returns the end offset in the length field
+                Array.Copy(BitConverter.GetBytes((uint)(clause.TryLength - clause.TryOffset)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.TryLength * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.HandlerOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerOffset * sizeof(uint), sizeof(uint));
-                Array.Copy(BitConverter.GetBytes((uint)(clause.HandlerOffset + clause.HandlerLength)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerEnd * sizeof(uint), sizeof(uint));
+                Array.Copy(BitConverter.GetBytes((uint)(clause.HandlerLength - clause.HandlerOffset)), 0, ehInfoData, clauseOffset + (int)EHInfoFields.HandlerLength * sizeof(uint), sizeof(uint));
                 Array.Copy(BitConverter.GetBytes((uint)clause.ClassTokenOrOffset), 0, ehInfoData, clauseOffset + (int)EHInfoFields.ClassTokenOrOffset * sizeof(uint), sizeof(uint));
             }
             return new ObjectNode.ObjectData(ehInfoData, Array.Empty<Relocation>(), alignment: 1, definedSymbols: Array.Empty<ISymbolDefinitionNode>());


### PR DESCRIPTION
I found out I somewhat messed up the EH info. CoreCLR expects the
EH info to contain the lengths of the try and catch block whereas
JIT passes around the end offsets of these clauses disguised as the
"length" fields - initially I missed that and I implemented the
exact opposite.

Thanks

Tomas