### PR TITLE
Use ReadyToRun harness in CoreCLR tests

### DIFF
--- a/buildscripts/build-tests.cmd
+++ b/buildscripts/build-tests.cmd
@@ -29,14 +29,14 @@ exit /b %ERRORLEVEL%
 
 if defined __SkipTests exit /b 0
 
-echo "%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\tests\external\dirs.proj" /nologo /t:Restore /flp:v=normal;LogFile=build-tests-restore.log /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
-"%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\tests\external\dirs.proj" /nologo /t:Restore /flp:v=normal;LogFile=build-tests-restore.log /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
+echo "%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\tests\dirs.proj" /nologo /t:Restore /flp:v=normal;LogFile=build-tests-restore.log /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
+"%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\tests\dirs.proj" /nologo /t:Restore /flp:v=normal;LogFile=build-tests-restore.log /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
 IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
 
 call "!VS%__VSProductVersion%COMNTOOLS!\VsDevCmd.bat"
 echo Commencing build of test components for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
-%_msbuildexe% /ConsoleLoggerParameters:ForceNoAlign "%__ProjectDir%\tests\external\dirs.proj" %__ExtraMsBuildParams% /p:RepoPath="%__ProjectDir%" /p:RepoLocalBuild="true" /p:NuPkgRid=%__NugetRuntimeId% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__TestBuildLog%"
+"%__DotNetCliPath%\dotnet.exe" msbuild /ConsoleLoggerParameters:ForceNoAlign "%__ProjectDir%\tests\dirs.proj" %__ExtraMsBuildParams% /p:RepoPath="%__ProjectDir%" /p:RepoLocalBuild="true" /p:NuPkgRid=%__NugetRuntimeId% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__TestBuildLog%"
 IF NOT ERRORLEVEL 1 (
   findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%__TestBuildLog%"
   goto AfterTestBuild

--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -52,18 +52,29 @@ copy %TestFolder%\*.dll %TestFolder%\native\
 shift
 shift
 
+:: Typically arguments on the command line are separated by spaces. The R2R test harness uses System.CommandLine which uses
+:: a comma to separate multiple arguments in an argument list.
+set "DelimiterTemplate= "
+if /i "%NativeCodeGen%" == "readytorun" (
+    set "DelimiterTemplate=,"
+)
+
 set TestParameters=
 set Delimiter=
 :GetNextParameter
 if "%1"=="" goto :RunTest
 set "TestParameters=%TestParameters%%Delimiter%%1"
-set "Delimiter= "
+set "Delimiter=%DelimiterTemplate%"
 shift
 goto :GetNextParameter
 
 :RunTest
 
-set CoreRunCommandLine=%CoreRT_CoreCLRRuntimeDir%\CoreRun.exe %TestFolder%\native\%TestFileName%.ni.exe %TestParameters%
+set CoreRunCommandLine="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarness% --corerun %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe --in %TestFolder%native\%TestFileName%.ni.exe --noetl
+if not "%TestParameters%" == "" (
+    set CoreRunCommandLine=%CoreRunCommandLine% --testargs %TestParameters%
+)
+
 if /i "%NativeCodeGen%" == "readytorun" (
     echo %CoreRunCommandLine%
     %CoreRunCommandLine%

--- a/tests/dirs.proj
+++ b/tests/dirs.proj
@@ -1,0 +1,10 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+
+  <ItemGroup>
+    <Project Include="external\dirs.proj" />
+    <Project Include="src\tools\dirs.proj" />
+  </ItemGroup>
+
+  <Import Project="..\dir.traversal.targets" />
+</Project>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -100,7 +100,7 @@ if "%CoreRT_MultiFileConfiguration%"=="MultiModule" (
 )
 
 set CoreRT_CoreCLRRuntimeDir=%CoreRT_TestRoot%..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\CoreClrRuntime
-set CoreRT_ReadyToRunTestHarnessDir=%CoreRT_TestRoot%src\tools\ReadyToRun.TestHarness
+set CoreRT_ReadyToRunTestHarness=%CoreRT_TestRoot%src\tools\ReadyToRun.TestHarness\bin\Debug\netcoreapp2.1\ReadyToRun.TestHarness.dll
 
 if not exist %CoreRT_CoreCLRRuntimeDir% (
     REM The test build handles restoring external dependencies such as CoreCLR runtime and its test host
@@ -364,7 +364,7 @@ goto :eof
         set __ExtraTestRunArgs=
         if "%__Mode%"=="readytorun" (
             set __Extension=ni.exe
-            set __ExtraTestRunArgs="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarnessDir% %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe
+            set __ExtraTestRunArgs="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarness% %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe
         )
 
         if "!__SavedErrorLevel!"=="0" (

--- a/tests/src/Simple/ReadyToRunMultiModule/ReadyToRunMultiModule.cmd
+++ b/tests/src/Simple/ReadyToRunMultiModule/ReadyToRunMultiModule.cmd
@@ -3,8 +3,8 @@ setlocal
 
 REM The arguments to invoke a ready-to-run test with ETW logging of jitted methods look like
 REM dotnet run --project --corerun tests\src\tools\ReadyToRun.TestHarness bin\obj\<Build>\CoreCLRRuntime\CoreRun.exe --in bin\Debug\<arch>\native\<test>.ni.exe --whitelist methodWhiteList.txt
-echo %3 run --project %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt
-call %3 run --project %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt
+echo %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt
+call %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt
 
 IF "%errorlevel%"=="100" (
     echo %~n0: Pass

--- a/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.cmd
+++ b/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.cmd
@@ -3,8 +3,8 @@ setlocal
 
 REM The arguments to invoke a ready-to-run test with ETW logging of jitted methods look like
 REM dotnet run --project --corerun tests\src\tools\ReadyToRun.TestHarness bin\obj\<Build>\CoreCLRRuntime\CoreRun.exe --in bin\Debug\<arch>\native\<test>.ni.exe --whitelist methodWhiteList.txt
-echo %3 run --project %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt --testargs %~dp0TestTextFile.txt
-call %3 run --project %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt --testargs %~dp0TestTextFile.txt
+echo %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt --testargs %~dp0TestTextFile.txt
+call %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt --testargs %~dp0TestTextFile.txt
 
 IF "%errorlevel%"=="100" (
     echo %~n0: Pass

--- a/tests/src/tools/dirs.proj
+++ b/tests/src/tools/dirs.proj
@@ -1,0 +1,10 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\dir.props" />
+
+  <ItemGroup>
+    <Project Include="ReadyToRun.TestHarness/ReadyToRun.TestHarness.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\..\dir.targets" />
+  <Import Project="..\..\..\dir.traversal.targets" />
+</Project>


### PR DESCRIPTION
* The ready-to-run harness includes time out logic to kill tests that get stuck. Use it to run CoreCLR tests since many tests get stuck in an infinite loop at the moment.
* Add an option to disable ETL tracing when using the harness. Instead, it just runs the app with `Process.Start()` and calls `WaitForExit()`. The CoreCLR tests are too noisy right now to run with ETL on.
* Make some build system changes so that the harness is run from pre-built binaries instead of using `dotnet run`. This is much faster and required for tests running in parallel. Using `dotnet run` on the same project in parallel hits file in use errors.
* Fix harness to allow multiple arguments passed to tests
* Properly kill the test process when it times out
* Reduce the timeout to 30 seconds. None of our tests, when running correctly, approach this timeout so it is still a conservative setting.

Fixes https://github.com/dotnet/corert/issues/6329