### PR TITLE
Use elaborated type specifiers to prevent meaning changes

### DIFF
--- a/src/Native/ObjWriter/cordebuginfo.h
+++ b/src/Native/ObjWriter/cordebuginfo.h
@@ -294,15 +294,15 @@ public:
 
         union
         {
-            vlReg           vlReg;
-            vlStk           vlStk;
-            vlRegReg        vlRegReg;
-            vlRegStk        vlRegStk;
-            vlStkReg        vlStkReg;
-            vlStk2          vlStk2;
-            vlFPstk         vlFPstk;
-            vlFixedVarArg   vlFixedVarArg;
-            vlMemory        vlMemory;
+            ICorDebugInfo::vlReg           vlReg;
+            ICorDebugInfo::vlStk           vlStk;
+            ICorDebugInfo::vlRegReg        vlRegReg;
+            ICorDebugInfo::vlRegStk        vlRegStk;
+            ICorDebugInfo::vlStkReg        vlStkReg;
+            ICorDebugInfo::vlStk2          vlStk2;
+            ICorDebugInfo::vlFPstk         vlFPstk;
+            ICorDebugInfo::vlFixedVarArg   vlFixedVarArg;
+            ICorDebugInfo::vlMemory        vlMemory;
         };
     };
 


### PR DESCRIPTION
Fixes ObjWriter build error with GCC8 & LLVM5 when following the [build doc.](https://github.com/dotnet/corert/blob/master/Documentation/how-to-build-ObjectWriter.md)

See PR #6340 for info