### PR TITLE
WIP: Targeted fixes for "/CoreCLR All" ILC errors (990 failures remain)

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/ILProvider.cs
@@ -15,11 +15,14 @@ namespace Internal.IL
 {
     internal sealed class ILProvider : LockFreeReaderHashtable<MethodDesc, ILProvider.MethodILData>
     {
-        private PInvokeILProvider _pinvokeILProvider;
+        private readonly PInvokeILProvider _pinvokeILProvider;
 
-        public ILProvider(PInvokeILProvider pinvokeILProvider)
+        private readonly bool _readyToRunMode;
+
+        public ILProvider(PInvokeILProvider pinvokeILProvider, bool readyToRunMode)
         {
             _pinvokeILProvider = pinvokeILProvider;
+            _readyToRunMode = readyToRunMode;
         }
 
         private MethodIL TryGetRuntimeImplementedMethodIL(MethodDesc method)
@@ -277,6 +280,10 @@ namespace Internal.IL
 
                 if (method.IsPInvoke)
                 {
+                    if (_readyToRunMode)
+                    {
+                        return null;
+                    }
                     var pregenerated = McgInteropSupport.TryGetPregeneratedPInvoke(method);
                     if (pregenerated == null)
                         return _pinvokeILProvider.EmitIL(method);

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -75,7 +75,7 @@ namespace ILCompiler
 
         private ILProvider _methodILCache;
         
-        public MethodIL GetMethodIL(MethodDesc method)
+        public virtual MethodIL GetMethodIL(MethodDesc method)
         {
             // Flush the cache when it grows too big
             if (_methodILCache.Count > 1000)

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -69,20 +69,20 @@ namespace ILCompiler
             // https://github.com/dotnet/corert/issues/2149
             if (nodeFactory.IsCppCodegenTemporaryWorkaround) forceLazyPInvokeResolution = false;
             PInvokeILProvider = new PInvokeILProvider(new PInvokeILEmitterConfiguration(forceLazyPInvokeResolution), nodeFactory.InteropStubManager.InteropStateManager);
-
-            _methodILCache = new ILProvider(PInvokeILProvider);
         }
 
         private ILProvider _methodILCache;
         
-        public virtual MethodIL GetMethodIL(MethodDesc method)
+        public MethodIL GetMethodIL(MethodDesc method)
         {
             // Flush the cache when it grows too big
-            if (_methodILCache.Count > 1000)
-                _methodILCache = new ILProvider(PInvokeILProvider);
+            if (_methodILCache == null || _methodILCache.Count > 1000)
+                _methodILCache = new ILProvider(PInvokeILProvider, IsReadyToRunMode);
 
             return _methodILCache.GetMethodIL(method);
         }
+
+        protected virtual bool IsReadyToRunMode => false;
 
         protected abstract void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj);
 

--- a/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PrecomputedMetadataManager.cs
@@ -388,7 +388,7 @@ namespace ILCompiler
             MethodDesc requiredGenericFieldsMethod = typeWithMetadataMappings.GetMethod("RequiredGenericFields", null);
             MethodDesc requiredTemplatesMethod = typeWithMetadataMappings.GetMethod("CompilerDeterminedInstantiations", null);
 
-            ILProvider ilProvider = new ILProvider(null);
+            ILProvider ilProvider = new ILProvider(null, readyToRunMode: false);
 
             MetadataLoadedInfo result = new MetadataLoadedInfo();
 
@@ -877,7 +877,7 @@ namespace ILCompiler
             if (dynamicInvokeStubDescriptorMethod == null)
                 return dynamicInvokeMapTable;
 
-            ILProvider ilProvider = new ILProvider(null);
+            ILProvider ilProvider = new ILProvider(null, readyToRunMode: false);
             ILStreamReader il = new ILStreamReader(ilProvider.GetMethodIL(dynamicInvokeStubDescriptorMethod));
             // structure is 
             // REPEAT N TIMES    

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DebugInfoTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DebugInfoTableNode.cs
@@ -91,6 +91,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         continue;
                 }
 
+                if (methodCodeNode.IsEmpty)
+                {
+                    continue;
+                }
+
                 MemoryStream methodDebugBlob = new MemoryStream();
                 
                 byte[] bounds = CreateBoundsBlobForMethod(methodCodeNode);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -210,7 +210,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         continue;
                 }
 
-                Add(methodCodeNode, ((ReadyToRunCodegenNodeFactory)factory).RuntimeFunctionsTable.GetIndex(methodCodeNode));
+                if (!methodCodeNode.IsEmpty)
+                {
+                    Add(methodCodeNode, ((ReadyToRunCodegenNodeFactory)factory).RuntimeFunctionsTable.GetIndex(methodCodeNode));
+                }
             }
 
             NativeWriter writer = new NativeWriter();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -43,6 +43,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
+            if (relocsOnly)
+            {
+                // Method fixup signature doesn't contain any direct relocs
+                return new ObjectData(data: Array.Empty<byte>(), relocs: null, alignment: 0, definedSymbols: null);
+            }
+
             ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
             dataBuilder.AddSymbol(this);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -43,6 +43,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public MethodDesc Method => _method;
 
+        public bool IsEmpty => _methodCode.Data.Length == 0;
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             return _methodCode;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -151,22 +151,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public void AddModuleTokenForType(TypeDesc type, ModuleToken token)
         {
-            InstantiatedType instantiatedType = type as InstantiatedType;
-            if (instantiatedType != null)
-            {
-                // Collect type tokens for generic arguments
-                switch (token.TokenType)
-                {
-                    case CorTokenType.mdtTypeSpec:
-                        {
-                            TypeSpecification typeSpec = token.MetadataReader.GetTypeSpecification((TypeSpecificationHandle)token.Handle);
-                            typeSpec.DecodeSignature(new TokenResolverProvider(this, token.Module), this);
-                        }
-                        break;
+            bool specialTypeFound = false;
 
-                    default:
-                        throw new NotImplementedException();
-                }
+            // Collect underlying type tokens for type specifications
+            if (token.TokenType == CorTokenType.mdtTypeSpec)
+            {
+                TypeSpecification typeSpec = token.MetadataReader.GetTypeSpecification((TypeSpecificationHandle)token.Handle);
+                typeSpec.DecodeSignature(new TokenResolverProvider(this, token.Module), this);
+                specialTypeFound = true;
             }
 
             if (_compilationModuleGroup.ContainsType(type))
@@ -184,7 +176,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     _typeToRefTokens[ecmaType] = token;
                 }
             }
-            else if (instantiatedType == null)
+            else if (!specialTypeFound)
             {
                 throw new NotImplementedException(type.ToString());
             }
@@ -235,7 +227,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public DummyTypeInfo GetGenericMethodParameter(ModuleTokenResolver genericContext, int index)
             {
-                throw new NotImplementedException();
+                return DummyTypeInfo.Instance;
             }
 
             public DummyTypeInfo GetGenericTypeParameter(ModuleTokenResolver genericContext, int index)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -103,7 +103,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     break;
 
                 case CorTokenType.mdtMemberRef:
-                    AddModuleTokenForMemberReference(method.OwningType, token);
+                    AddModuleTokenForMethodReference(method.OwningType, token);
                     break;
 
                 default:
@@ -111,11 +111,22 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
         }
 
-        private void AddModuleTokenForMemberReference(TypeDesc owningType, ModuleToken token)
+        private void AddModuleTokenForMethodReference(TypeDesc owningType, ModuleToken token)
         {
             MemberReference memberRef = token.MetadataReader.GetMemberReference((MemberReferenceHandle)token.Handle);
             EntityHandle owningTypeHandle = memberRef.Parent;
             AddModuleTokenForType(owningType, new ModuleToken(token.Module, owningTypeHandle));
+
+            memberRef.DecodeMethodSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
+        }
+
+        private void AddModuleTokenForFieldReference(TypeDesc owningType, ModuleToken token)
+        {
+            MemberReference memberRef = token.MetadataReader.GetMemberReference((MemberReferenceHandle)token.Handle);
+            EntityHandle owningTypeHandle = memberRef.Parent;
+            AddModuleTokenForType(owningType, new ModuleToken(token.Module, owningTypeHandle));
+
+            memberRef.DecodeFieldSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
         }
 
         public void AddModuleTokenForField(FieldDesc field, ModuleToken token)
@@ -130,7 +141,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             switch (token.TokenType)
             {
                 case CorTokenType.mdtMemberRef:
-                    AddModuleTokenForMemberReference(field.OwningType, token);
+                    AddModuleTokenForFieldReference(field.OwningType, token);
                     break;
 
                 default:
@@ -209,12 +220,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public DummyTypeInfo GetByReferenceType(DummyTypeInfo elementType)
             {
-                throw new NotImplementedException();
+                return DummyTypeInfo.Instance;
             }
 
             public DummyTypeInfo GetFunctionPointerType(MethodSignature<DummyTypeInfo> signature)
             {
-                throw new NotImplementedException();
+                return DummyTypeInfo.Instance;
             }
 
             public DummyTypeInfo GetGenericInstantiation(DummyTypeInfo genericType, ImmutableArray<DummyTypeInfo> typeArguments)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
@@ -60,9 +60,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         continue;
                 }
 
-                _methodNodes.Add(methodCodeNode);
-                _insertedMethodNodes[methodCodeNode] = runtimeFunctionIndex;
-                runtimeFunctionIndex += methodCodeNode.FrameInfos.Length;
+                if (!methodCodeNode.IsEmpty)
+                {
+                    _methodNodes.Add(methodCodeNode);
+                    _insertedMethodNodes[methodCodeNode] = runtimeFunctionIndex;
+                    runtimeFunctionIndex += methodCodeNode.FrameInfos.Length;
+                }
             }
         }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -438,12 +438,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public void EmitFieldSignature(FieldDesc field, SignatureContext context)
         {
-            ModuleToken fieldRefToken = context.GetModuleTokenForField(field);
-            switch (fieldRefToken.TokenType)
+            ModuleToken fieldToken = context.GetModuleTokenForField(field);
+            switch (fieldToken.TokenType)
             {
                 case CorTokenType.mdtMemberRef:
                     EmitUInt((uint)ReadyToRunFieldSigFlags.READYTORUN_FIELD_SIG_MemberRefToken);
-                    EmitTokenRid(fieldRefToken.Token);
+                    EmitTokenRid(fieldToken.Token);
+                    break;
+
+                case CorTokenType.mdtFieldDef:
+                    EmitUInt((uint)0);
+                    EmitTokenRid(fieldToken.Token);
                     break;
 
                 default:

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -109,9 +109,7 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             MethodWithGCInfo localMethod = null;
-            // TODO-PERF: for now, we never emit native code for array methods as Crossgen ignores
-            // them too. At some point we might be able to "exceed Crossgen CQ" by adding this support.
-            if (CompilationModuleGroup.ContainsMethodBody(method, false) && !(method is ArrayMethod))
+            if (CompilationModuleGroup.ContainsMethodBody(method, false))
             {
                 localMethod = new MethodWithGCInfo(method, signatureContext);
             }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -109,7 +109,9 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             MethodWithGCInfo localMethod = null;
-            if (CompilationModuleGroup.ContainsMethodBody(method, false))
+            // TODO-PERF: for now, we never emit native code for array methods as Crossgen ignores
+            // them too. At some point we might be able to "exceed Crossgen CQ" by adding this support.
+            if (CompilationModuleGroup.ContainsMethodBody(method, false) && !(method is ArrayMethod))
             {
                 localMethod = new MethodWithGCInfo(method, signatureContext);
             }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -640,6 +640,12 @@ namespace ILCompiler.DependencyAnalysis
                     r2rHelper = ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_FltRound;
                     break;
 
+                case ILCompiler.ReadyToRunHelper.GetRefAny:
+                    // TODO-PERF: currently not implemented in Crossgen
+                    ThrowHelper.ThrowInvalidProgramException();
+                    // ThrowInvalidProgramException should never return
+                    throw new NotImplementedException();
+
                 default:
                     throw new NotImplementedException(helper.ToString());
             }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection.PortableExecutable;
 
+using Internal.IL;
 using Internal.JitInterface;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -123,6 +124,10 @@ namespace ILCompiler
                     Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because: {ex.Message}");
                 }
             }
+        }
+        public override MethodIL GetMethodIL(MethodDesc method)
+        {
+            return null;
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -125,9 +125,7 @@ namespace ILCompiler
                 }
             }
         }
-        public override MethodIL GetMethodIL(MethodDesc method)
-        {
-            return null;
-        }
+
+        protected override bool IsReadyToRunMode => true;
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -40,5 +40,16 @@ namespace ILCompiler
                 return _r2rFieldLayoutAlgorithm;
             }
         }
+
+        protected override bool ComputeHasGCStaticBase(FieldDesc field)
+        {
+            Debug.Assert(field.IsStatic);
+
+            TypeDesc fieldType = field.FieldType;
+            if (fieldType.IsValueType)
+                return ((DefType)fieldType).ContainsGCPointers;
+            else
+                return fieldType.IsGCPointer;
+        }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -43,6 +43,13 @@ namespace ILCompiler
 
         public sealed override bool ContainsMethodBody(MethodDesc method, bool unboxingStub)
         {
+            if (method is ArrayMethod)
+            {
+                // TODO-PERF: for now, we never emit native code for array methods as Crossgen ignores
+                // them too. At some point we might be able to "exceed Crossgen CQ" by adding this support.
+                return false;
+            }
+
             if (method.HasInstantiation)
                 return true;
 

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -62,12 +62,17 @@ namespace ILCompiler.PEWriter
         /// Name of the text section.
         /// </summary>
         public const string TextSectionName = ".text";
-        
+
+        /// <summary>
+        /// Name of the initialized data section.
+        /// </summary>
+        public const string SDataSectionName = ".sdata";
+
         /// <summary>
         /// Name of the resource section.
         /// </summary>
         public const string RsrcSectionName = ".rsrc";
-        
+
         /// <summary>
         /// Name of the relocation section.
         /// </summary>
@@ -155,6 +160,7 @@ namespace ILCompiler.PEWriter
             ImmutableArray<Section>.Builder sectionListBuilder = ImmutableArray.CreateBuilder<Section>();
 
             int textSectionIndex = -1;
+            int sdataSectionIndex = -1;
             int rsrcSectionIndex = -1;
             int relocSectionIndex = -1;
             
@@ -165,7 +171,11 @@ namespace ILCompiler.PEWriter
                     case TextSectionName:
                         textSectionIndex = sectionIndex;
                         break;
-                    
+
+                    case SDataSectionName:
+                        sdataSectionIndex = sectionIndex;
+                        break;
+
                     case RsrcSectionName:
                         rsrcSectionIndex = sectionIndex;
                         break;
@@ -192,6 +202,12 @@ namespace ILCompiler.PEWriter
                 {
                     sectionListBuilder.Add(new Section(nameCharPair.SectionName, nameCharPair.Characteristics));
                 }
+            }
+
+            if (sdataSectionIndex >= 0 && !sectionNames.Any((sc) => sc.SectionName == SDataSectionName))
+            {
+                SectionHeader sectionHeader = peReader.PEHeaders.SectionHeaders[sdataSectionIndex];
+                sectionListBuilder.Add(new Section(sectionHeader.Name, sectionHeader.SectionCharacteristics));
             }
 
             if (rsrcSectionIndex >= 0 && !sectionNames.Any((sc) => sc.SectionName == RsrcSectionName))

--- a/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
+++ b/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
@@ -230,7 +230,9 @@ namespace Internal.JitInterface
                     break;
 
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_RTH_GetValueInternal:
+#if !READYTORUN
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_InitializeArray:
+#endif
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Ctor:
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Value:
                     if (pMustExpand != null)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2723,7 +2723,7 @@ namespace Internal.JitInterface
                     {
                         pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
 #if READYTORUN
-                            _compilation.NodeFactory.MethodEntrypoint(targetMethod, constrainedType, _signatureContext)
+                            _compilation.NodeFactory.MethodEntrypoint(constrainedType != null ? method : targetMethod, constrainedType, _signatureContext)
 #else
                             _compilation.NodeFactory.MethodEntrypoint(targetMethod)
 #endif

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -977,6 +977,9 @@ namespace Internal.JitInterface
             else
             {
                 TypeDesc type = (TypeDesc)result;
+#if READYTORUN
+                _compilation.NodeFactory.Resolver.AddModuleTokenForType(type, new ModuleToken(_tokenContext, (mdToken)pResolvedToken.token));
+#endif
                 if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Newarr)
                 {
                     if (type.IsVoid)
@@ -985,10 +988,6 @@ namespace Internal.JitInterface
                     type = type.MakeArrayType();
                 }
                 pResolvedToken.hClass = ObjectToHandle(type);
-
-#if READYTORUN
-                _compilation.NodeFactory.Resolver.AddModuleTokenForType(type, new ModuleToken(_tokenContext, (mdToken)pResolvedToken.token));
-#endif
             }
 
             pResolvedToken.pTypeSpec = null;
@@ -2586,6 +2585,7 @@ namespace Internal.JitInterface
 
             pResult.codePointerOrStubLookup.lookupKind.needsRuntimeLookup = false;
 
+#if !READYTORUN
             bool allowInstParam = (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_ALLOWINSTPARAM) != 0;
 
             if (directCall && !allowInstParam && targetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific).RequiresInstArg())
@@ -2621,7 +2621,9 @@ namespace Internal.JitInterface
                         CreateConstLookupToSymbol(_compilation.NodeFactory.FatFunctionPointer(targetMethod));
                 }
             }
-            else if (directCall)
+            else
+#endif
+            if (directCall)
             {
                 bool referencingArrayAddressMethod = false;
 
@@ -2642,7 +2644,9 @@ namespace Internal.JitInterface
                 }
 
                 MethodDesc concreteMethod = targetMethod;
+#if !READYTORUN
                 targetMethod = targetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
+#endif
 
                 pResult.kind = CORINFO_CALL_KIND.CORINFO_CALL;
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -209,6 +209,9 @@ namespace Internal.JitInterface
             }
             finally
             {
+#if READYTORUN
+                PublishEmptyCode();
+#endif
                 CompileMethodCleanup();
             }
         }
@@ -245,6 +248,14 @@ namespace Internal.JitInterface
             _methodCodeNode.InitializeDebugLocInfos(_debugLocInfos);
             _methodCodeNode.InitializeDebugVarInfos(_debugVarInfos);
         }
+
+#if READYTORUN
+        private void PublishEmptyCode()
+        {
+            _methodCodeNode.SetCode(new ObjectNode.ObjectData(Array.Empty<byte>(), null, 1, new ISymbolDefinitionNode[] { _methodCodeNode }));
+            _methodCodeNode.InitializeFrameInfos(Array.Empty<FrameInfo>());
+        }
+#endif
 
         private MethodDesc MethodBeingCompiled
         {

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -207,11 +207,15 @@ namespace Internal.JitInterface
 
                 PublishCode();
             }
-            finally
+            catch (Exception)
             {
 #if READYTORUN
                 PublishEmptyCode();
 #endif
+                throw;
+            }
+            finally
+            {
                 CompileMethodCleanup();
             }
         }

--- a/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitCompilation.cs
+++ b/src/System.Private.Jit/src/Internal/Runtime/JitSupport/JitCompilation.cs
@@ -22,7 +22,7 @@ namespace ILCompiler
             _typeSystemContext = context;
             _typeGetTypeMethodThunks = new TypeGetTypeMethodThunkCache(context.GetWellKnownType(WellKnownType.Object));
             _pInvokeILProvider = new PInvokeILProvider(new PInvokeILEmitterConfiguration(forceLazyResolution: true), null);
-            _methodILCache = new ILProvider(_pInvokeILProvider);
+            _methodILCache = new ILProvider(_pInvokeILProvider, readyToRunMode: false);
             _nodeFactory = new NodeFactory(context);
             _devirtualizationManager = new DevirtualizationManager();
         }
@@ -60,7 +60,7 @@ namespace ILCompiler
         {
             // Flush the cache when it grows too big
             if (_methodILCache.Count > 1000)
-                _methodILCache = new ILProvider(_pInvokeILProvider);
+                _methodILCache = new ILProvider(_pInvokeILProvider, readyToRunMode: false);
 
             return _methodILCache.GetMethodIL(method);
         }

--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -57,9 +57,10 @@ shift
 
 :: Typically arguments on the command line are separated by spaces. The R2R test harness uses System.CommandLine which uses
 :: a comma to separate multiple arguments in an argument list.
-set "Delimiter=--testargs "
+set "Delimiter="
 set "DelimiterTemplate= "
 if /i "%NativeCodeGen%" == "readytorun" (
+    set "Delimiter=--testargs "
     set "DelimiterTemplate= --testargs "
 )
 

--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -57,13 +57,13 @@ shift
 
 :: Typically arguments on the command line are separated by spaces. The R2R test harness uses System.CommandLine which uses
 :: a comma to separate multiple arguments in an argument list.
+set "Delimiter=--testargs "
 set "DelimiterTemplate= "
 if /i "%NativeCodeGen%" == "readytorun" (
-    set "DelimiterTemplate=,"
+    set "DelimiterTemplate= --testargs "
 )
 
 set TestParameters=
-set Delimiter=
 :GetNextParameter
 if "%1"=="" goto :RunTest
 set "TestParameters=%TestParameters%%Delimiter%%1"
@@ -73,10 +73,7 @@ goto :GetNextParameter
 
 :RunTest
 
-set CoreRunCommandLine="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarness% --corerun %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe --in %TestFolder%native\%TestFileName%.ni.exe --noetl
-if not "%TestParameters%" == "" (
-    set CoreRunCommandLine=%CoreRunCommandLine% --testargs %TestParameters%
-)
+set CoreRunCommandLine="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarness% --corerun %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe --in %TestFolder%native\%TestFileName%.ni.exe --noetl %TestParameters%
 
 if /i "%NativeCodeGen%" == "readytorun" (
     echo %CoreRunCommandLine%

--- a/tests/src/Simple/ReadyToRunUnit/Program.cs
+++ b/tests/src/Simple/ReadyToRunUnit/Program.cs
@@ -9,11 +9,13 @@ using System.Text;
 
 internal class Program
 {
+    const int LineCountInitialValue = 0x12345678;
+    
     [ThreadStatic]
     private static string TextFileName = @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\clientexclusionlist.xml";
 
     [ThreadStatic]
-    private static int LineCount = 0x12345678;
+    private static int LineCount = LineCountInitialValue;
 
     private static List<string> _passedTests;
 
@@ -59,6 +61,15 @@ internal class Program
             Console.Error.WriteLine($@"Object is not an int: {obj}");
             return false;
         }
+    }
+    
+    private unsafe static bool CheckNonGCThreadLocalStatic()
+    {
+        fixed (int *lineCountPtr = &LineCount)
+        {
+            Console.WriteLine($@"LineCount: 0x{LineCount:X8}, @ = 0x{(ulong)lineCountPtr:X8}");
+        }
+        return LineCount == LineCountInitialValue;
     }
     
     private static bool ChkCast()
@@ -431,6 +442,7 @@ internal class Program
         RunTest("WriteLine", WriteLine());
         RunTest("IsInstanceOf", IsInstanceOf());
         RunTest("IsInstanceOfValueType", IsInstanceOfValueType());
+        RunTest("CheckNonGCThreadLocalStatic", CheckNonGCThreadLocalStatic());
         RunTest("ChkCast", ChkCast());
         RunTest("ChkCastValueType", ChkCastValueType());
         RunTest("BoxUnbox", BoxUnbox());


### PR DESCRIPTION
1) Don't try to emit method signature in relocsOnly mode as we don't
yet have all the necessary tokens available in this early phase.

2) Fix one more case concerning constrained types (we need to pass
around the original method, typically IDisposable.Dispose, not
any particular specialization as that may not be representable
as a R2R signature).

3) Per David Wrighton's suggestion, I have explicitly suppressed
emitting native code for ArrayMethod's, leaving them up to runtime
JIT. I have attached a TODO-PERF code comment stating that this is
a potential opportunity to exceed Crossgen CQ.

Thanks

Tomas