### PR TITLE
Add /NoCleanup switch to runtest.cmd

### DIFF
--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -20,6 +20,9 @@ set TestFileName=%~n2
 
 copy /Y %~dp0\Test.csproj %TestFolder%
 
+:: Cleanup previous test run artifacts since the test may have been run with /NoCleanup
+rd /s /q %TestFolder%\native
+
 ::
 :: The CoreCLR test system configures the VS environment as 32-bit by default,
 :: so override if we're doing a 64-bit test run
@@ -91,7 +94,9 @@ set TestExitCode=!ERRORLEVEL!
 :: CoreCLR pri-0 tests at ~50MB of native artifacts per test, we can easily use 300GB
 :: of disk space and clog up the CI machines
 ::
-rd /s /q %TestFolder%\native
+if not "%CoreRT_NoCleanup%"=="true" (
+    rd /s /q %TestFolder%\native
+)
 
 
 ::

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -58,6 +58,7 @@ if /i "%1" == "/runtest" (set CoreRT_TestRun=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/dotnetclipath" (set CoreRT_CliDir=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/multimodule" (set CoreRT_MultiFileConfiguration=MultiModule&shift&goto ArgLoop)
 if /i "%1" == "/determinism" (set CoreRT_DeterminismMode=true&shift&goto ArgLoop)
+if /i "%1" == "/nocleanup" (set CoreRT_NoCleanup=true&shift&goto ArgLoop)
 
 echo Invalid command line argument: %1
 goto :Usage
@@ -76,6 +77,7 @@ echo                   : Run a single CoreCLR repo test
 echo     /multimodule  : Compile the framework as a .lib and link tests against it (only supports ryujit)
 echo     /determinism  : Compile the test twice with randomized dependency node mark stack to validate
 echo                      compiler determinism in multi-threaded compilation.
+echo     /nocleanup    : Do not delete compiled test artifacts after running each test
 echo.
 echo     --- CoreCLR Subset ---
 echo        Top200     : Runs broad coverage / CI validation (~200 tests).


### PR DESCRIPTION
Prevent the CoreCLR test suite from cleaning up compiled artifacts and response files when /NoCleanup is pass to runtest.cmd.