### PR TITLE
Fix test command-line arguments in the CoreCLR test runner script

### DIFF
--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -57,9 +57,10 @@ shift
 
 :: Typically arguments on the command line are separated by spaces. The R2R test harness uses System.CommandLine which uses
 :: a comma to separate multiple arguments in an argument list.
-set "Delimiter=--testargs "
+set "Delimiter="
 set "DelimiterTemplate= "
 if /i "%NativeCodeGen%" == "readytorun" (
+    set "Delimiter=--testargs "
     set "DelimiterTemplate= --testargs "
 )
 

--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -57,13 +57,13 @@ shift
 
 :: Typically arguments on the command line are separated by spaces. The R2R test harness uses System.CommandLine which uses
 :: a comma to separate multiple arguments in an argument list.
+set "Delimiter=--testargs "
 set "DelimiterTemplate= "
 if /i "%NativeCodeGen%" == "readytorun" (
-    set "DelimiterTemplate=,"
+    set "DelimiterTemplate= --testargs "
 )
 
 set TestParameters=
-set Delimiter=
 :GetNextParameter
 if "%1"=="" goto :RunTest
 set "TestParameters=%TestParameters%%Delimiter%%1"
@@ -73,10 +73,7 @@ goto :GetNextParameter
 
 :RunTest
 
-set CoreRunCommandLine="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarness% --corerun %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe --in %TestFolder%native\%TestFileName%.ni.exe --noetl
-if not "%TestParameters%" == "" (
-    set CoreRunCommandLine=%CoreRunCommandLine% --testargs %TestParameters%
-)
+set CoreRunCommandLine="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarness% --corerun %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe --in %TestFolder%native\%TestFileName%.ni.exe --noetl %TestParameters%
 
 if /i "%NativeCodeGen%" == "readytorun" (
     echo %CoreRunCommandLine%


### PR DESCRIPTION
Apparently some of the CoreCLR tests were failing with complaints
towards incorrect command-line syntax. I tried to go over the
archived source code for the System.CommandLine package but I have
found no trace of automated splitting of argument values. For this
reason I have adjusted the script to pass multiple --testargs
arguments in such case. I believe that at the end of the day it
simplified the script overall.

Thanks

Tomas