### PR TITLE
Avoid crashing the compilation on bad InternalCall

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ILScanNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ILScanNodeFactory.cs
@@ -37,10 +37,6 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     return new RuntimeImportMethodNode(method);
                 }
-
-                // On CLR this would throw a SecurityException with "ECall methods must be packaged into a system module."
-                // This is a corner case that nobody is likely to care about.
-                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramSpecific, method);
             }
 
             if (CompilationModuleGroup.ContainsMethodBody(method, false))

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -34,10 +34,6 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     return new RuntimeImportMethodNode(method);
                 }
-
-                // On CLR this would throw a SecurityException with "ECall methods must be packaged into a system module."
-                // This is a corner case that nobody is likely to care about.
-                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramSpecific, method);
             }
 
             if (CompilationModuleGroup.ContainsMethodBody(method, false))


### PR DESCRIPTION
CoClasses have an `extern`/`InternalCall` constructor that the compiler is choking on because we would hit it in a place where we can't recover. With the check removed, we're going to emit a warning and generate a throwing method body for the constructor.

This is really just about taking the `extern` without `InternalCall` code path for this.

Fixes the failure mode reported in #6359.