### PR TITLE
Add R2R ILProvider

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/IL/ReadyToRunILProvider.cs
+++ b/src/ILCompiler.ReadyToRun/src/IL/ReadyToRunILProvider.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using Internal.IL.Stubs;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL
+{
+    public sealed class ReadyToRunILProvider : ILProvider
+    {
+        /// <summary>
+        /// Provides method bodies for intrinsics recognized by the compiler.
+        /// It can return null if it's not an intrinsic recognized by the compiler,
+        /// but an intrinsic e.g. recognized by codegen.
+        /// </summary>
+        private MethodIL TryGetIntrinsicMethodIL(MethodDesc method)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Provides method bodies for intrinsics recognized by the compiler that
+        /// are specialized per instantiation. It can return null if the intrinsic
+        /// is not recognized.
+        /// </summary>
+        private MethodIL TryGetPerInstantiationIntrinsicMethodIL(MethodDesc method)
+        {
+            return null;
+        }
+
+        public override MethodIL GetMethodIL(MethodDesc method)
+        {
+            if (method is EcmaMethod)
+            {
+                if (method.IsIntrinsic)
+                {
+                    MethodIL result = TryGetIntrinsicMethodIL(method);
+                    if (result != null)
+                        return result;
+                }
+
+                MethodIL methodIL = EcmaMethodIL.Create((EcmaMethod)method);
+                if (methodIL != null)
+                    return methodIL;
+
+                return null;
+            }
+            else if (method is MethodForInstantiatedType || method is InstantiatedMethod)
+            {
+                // Intrinsics specialized per instantiation
+                if (method.IsIntrinsic)
+                {
+                    MethodIL methodIL = TryGetPerInstantiationIntrinsicMethodIL(method);
+                    if (methodIL != null)
+                        return methodIL;
+                }
+
+                var methodDefinitionIL = GetMethodIL(method.GetTypicalMethodDefinition());
+                if (methodDefinitionIL == null)
+                    return null;
+                return new InstantiatedMethodIL(method, methodDefinitionIL);
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Compiler\ReadyToRunNodeMangler.cs" />
     <Compile Include="Compiler\ReadyToRunSingleAssemblyCompilationModuleGroup.cs" />
     <Compile Include="Compiler\ReadyToRunTableManager.cs" />
+    <Compile Include="IL\ReadyToRunILProvider.cs" />
     <Compile Include="JitInterface\CorInfoImpl.ReadyToRun.cs" />
     <Compile Include="ObjectWriter\SectionBuilder.cs" />
     <Compile Include="ObjectWriter\R2RPEBuilder.cs" />


### PR DESCRIPTION
Replaces the CoreRT version so that we can avoid all the intrinsic expansion that would just cause trouble for R2R.

Eventually, the provider will need to match intrinsic expansion done in CoreCLR: https://github.com/dotnet/coreclr/blob/f5f73ff2758f5c308561716fe8fb8b7cf6bc3cda/src/vm/jitinterface.cpp#L7464-L7483