### PR TITLE
Compile against CoreCLR framework

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -146,7 +146,8 @@ See the LICENSE file in the project root for more information.
     <ItemGroup>
       <ManagedBinary Condition="$(BuildingFrameworkLibrary) != 'true' and '$(BuildingReadyToRunAssembly)' != 'true'" Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
       <IlcCompileInput Include="@(ManagedBinary)" />
-      <IlcReference Include="@(DefaultFrameworkAssemblies)" />
+      <!-- Skip setting framework defaults for ready-to-run since it uses standard .NETCoreApp framework assemblies -->
+      <IlcReference Include="@(DefaultFrameworkAssemblies)" Condition="'$(NativeCodeGen)' != 'readytorun'" />
     </ItemGroup>
   </Target>
 

--- a/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
@@ -106,7 +106,7 @@ namespace ILCompiler.DependencyAnalysis
                         }
                     }
 
-                    EmitObjectData(nodeContents, name, node.Section, mapFile);
+                    EmitObjectData(nodeContents, nodeIndex, name, node.Section, mapFile);
                 }
 
                 _sectionBuilder.SetReadyToRunHeaderTable(_nodeFactory.Header, _nodeFactory.Header.GetData(_nodeFactory).Data.Length);
@@ -166,7 +166,7 @@ namespace ILCompiler.DependencyAnalysis
         /// <param name="name">Textual representation of the ObjecData blob in the map file</param>
         /// <param name="section">Section to emit the blob into</param>
         /// <param name="mapFile">Map file output stream</param>
-        private void EmitObjectData(ObjectData data, string name, ObjectNodeSection section, TextWriter mapFile)
+        private void EmitObjectData(ObjectData data, int nodeIndex, string name, ObjectNodeSection section, TextWriter mapFile)
         {
             int targetSectionIndex;
             switch (section.Type)
@@ -188,9 +188,9 @@ namespace ILCompiler.DependencyAnalysis
             }
 
 #if DEBUG
-            for (int symbolIndex = 0; symbolIndex < nodeContents.DefinedSymbols.Length; symbolIndex++)
+            for (int symbolIndex = 0; symbolIndex < data.DefinedSymbols.Length; symbolIndex++)
             {
-                ISymbolNode definedSymbol = nodeContents.DefinedSymbols[symbolIndex];
+                ISymbolNode definedSymbol = data.DefinedSymbols[symbolIndex];
                 (ISymbolNode Node, int NodeIndex, int SymbolIndex) alreadyWrittenSymbol;
                 string symbolName = definedSymbol.GetMangledName(_nodeFactory.NameMangler);
                 if (_previouslyWrittenNodeNames.TryGetValue(symbolName, out alreadyWrittenSymbol))

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
+using Debug = System.Diagnostics.Debug;
 
 using Internal.TypeSystem;
 
@@ -12,16 +12,20 @@ namespace ILCompiler
     public partial class ReadyToRunCompilerContext : CompilerTypeSystemContext
     {
         private FieldLayoutAlgorithm _r2rFieldLayoutAlgorithm;
+        private SystemObjectFieldLayoutAlgorithm _systemObjectFieldLayoutAlgorithm;
 
         public ReadyToRunCompilerContext(TargetDetails details, SharedGenericsMode genericsMode)
             : base(details, genericsMode)
         {
             _r2rFieldLayoutAlgorithm = new ReadyToRunMetadataFieldLayoutAlgorithm();
+            _systemObjectFieldLayoutAlgorithm = new SystemObjectFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
         }
 
         public override FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)
         {
-            if (type == UniversalCanonType)
+            if (type.IsObject)
+                return _systemObjectFieldLayoutAlgorithm;
+            else if (type == UniversalCanonType)
                 throw new NotImplementedException();
             else if (type.IsRuntimeDeterminedType)
                 throw new NotImplementedException();
@@ -45,6 +49,15 @@ namespace ILCompiler
                 return ((DefType)fieldType).ContainsGCPointers;
             else
                 return fieldType.IsGCPointer;
+        }
+
+        /// <summary>
+        /// CoreCLR has no Array`1 type to hang the various generic interfaces off.
+        /// Return nothing at compile time so the runtime figures it out.
+        /// </summary>
+        protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
+        {
+            return BaseTypeRuntimeInterfacesAlgorithm.Instance;
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -43,6 +43,13 @@ namespace ILCompiler
 
         public sealed override bool ContainsMethodBody(MethodDesc method, bool unboxingStub)
         {
+            if (method is ArrayMethod)
+            {
+                // TODO-PERF: for now, we never emit native code for array methods as Crossgen ignores
+                // them too. At some point we might be able to "exceed Crossgen CQ" by adding this support.
+                return false;
+            }
+
             if (method.HasInstantiation)
                 return true;
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/SystemObjectFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/SystemObjectFieldLayoutAlgorithm.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Represents an algorithm that adds a target pointer of space at the beggining of all types
+    /// deriving from System.Object used for the MethodTable pointer in the CoreCLR runtime.
+    /// </summary>
+    internal class SystemObjectFieldLayoutAlgorithm : FieldLayoutAlgorithm
+    {
+        private readonly FieldLayoutAlgorithm _fallbackAlgorithm;
+
+        public SystemObjectFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm)
+        {
+            _fallbackAlgorithm = fallbackAlgorithm;
+        }
+
+        public override ComputedInstanceFieldLayout ComputeInstanceLayout(DefType defType, InstanceLayoutKind layoutKind)
+        {
+            TargetDetails targetDetails = defType.Context.Target;
+            ComputedInstanceFieldLayout layoutFromMetadata = _fallbackAlgorithm.ComputeInstanceLayout(defType, layoutKind);
+
+            // System.Object has an EEType field in the standard AOT version used in this repo.
+            // Make sure that we always use the CoreCLR version which (currently) has no fields.
+            Debug.Assert(0 == layoutFromMetadata.Offsets.Length, "Incompatible system library. The CoreCLR System.Private.CoreLib must be used when compiling in ready-to-run mode.");
+
+            return new ComputedInstanceFieldLayout
+            {
+                ByteCountUnaligned = targetDetails.LayoutPointerSize,
+                ByteCountAlignment = targetDetails.LayoutPointerSize,
+                FieldAlignment = layoutFromMetadata.FieldAlignment,
+                FieldSize = layoutFromMetadata.FieldSize,
+                Offsets = layoutFromMetadata.Offsets,
+            };
+        }
+
+        public unsafe override ComputedStaticFieldLayout ComputeStaticFieldLayout(DefType defType, StaticLayoutKind layoutKind)
+        {
+            return _fallbackAlgorithm.ComputeStaticFieldLayout(defType, layoutKind);
+        }
+
+        public override bool ComputeContainsGCPointers(DefType type)
+        {
+            return false;
+        }
+
+        public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
+        {
+            return _fallbackAlgorithm.ComputeValueTypeShapeCharacteristics(type);
+        }
+
+        public override DefType ComputeHomogeneousFloatAggregateElementType(DefType type)
+        {
+            return _fallbackAlgorithm.ComputeHomogeneousFloatAggregateElementType(type);
+        }
+
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>READYTORUN</DefineConstants>
+    <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(IsProjectNLibrary)' != 'true'">
@@ -81,6 +81,7 @@
     <Compile Include="Compiler\ReadyToRunNodeMangler.cs" />
     <Compile Include="Compiler\ReadyToRunSingleAssemblyCompilationModuleGroup.cs" />
     <Compile Include="Compiler\ReadyToRunTableManager.cs" />
+    <Compile Include="Compiler\SystemObjectFieldLayoutAlgorithm.cs" />
     <Compile Include="IL\ReadyToRunILProvider.cs" />
     <Compile Include="JitInterface\CorInfoImpl.ReadyToRun.cs" />
     <Compile Include="ObjectWriter\SectionBuilder.cs" />

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -315,11 +315,10 @@ namespace Internal.JitInterface
 
 #if !READYTORUN
             _sequencePoints = null;
-            _debugLocInfos = null;
-            _debugVarInfos = null;
             _variableToTypeDesc = null;
 #endif
-
+            _debugLocInfos = null;
+            _debugVarInfos = null;
             _lastException = null;
         }
 

--- a/tests/CoreCLR/Test.csproj
+++ b/tests/CoreCLR/Test.csproj
@@ -11,6 +11,9 @@
   <ItemGroup>
     <!-- Some tests consist of multiple assemblies - make sure ILC sees them -->
     <IlcCompileInput Include="$(MSBuildProjectDirectory)\*.dll" />
+
+    <!-- For Ready To Run testing, use the CoreCLR framework assemblies instead of the AOT ones -->
+    <IlcReference Condition="'$(NativeCodeGen)' == 'readytorun'" Include="$(CoreRT_CoreCLRRuntimeDir)\*.dll" />
   </ItemGroup>
 
   <!-- Since tests are already compiled, override Compile target to prevent CSC running -->

--- a/tests/CoreCLR/build-and-run-test.cmd
+++ b/tests/CoreCLR/build-and-run-test.cmd
@@ -39,7 +39,7 @@ if /i "%NativeCodeGen%" == "readytorun" (
     set ExtraArgs="/t:CopyNative"
 )
 
-set MsBuildCommandLine=msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" /p:DisableFrameworkLibGeneration=true %ExtraArgs% %TestFolder%\Test.csproj
+set MsBuildCommandLine=msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" /p:DisableFrameworkLibGeneration=true "/p:CoreRT_CoreCLRRuntimeDir=%CoreRT_CoreCLRRuntimeDir%" %ExtraArgs% %TestFolder%\Test.csproj
 echo %MsBuildCommandLine%
 %MsBuildCommandLine%
 if errorlevel 1 (

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -104,16 +104,21 @@ if "%CoreRT_MultiFileConfiguration%"=="MultiModule" (
 set CoreRT_CoreCLRRuntimeDir=%CoreRT_TestRoot%..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\CoreClrRuntime
 set CoreRT_ReadyToRunTestHarness=%CoreRT_TestRoot%src\tools\ReadyToRun.TestHarness\bin\Debug\netcoreapp2.1\ReadyToRun.TestHarness.dll
 
-if not exist %CoreRT_CoreCLRRuntimeDir% (
-    REM The test build handles restoring external dependencies such as CoreCLR runtime and its test host
-    REM Trigger the test build so it will build but not run tests before we run them here
-    call %CoreRT_TestRoot%..\buildscripts\build-tests.cmd buildtests
+if not exist %CoreRT_CoreCLRRuntimeDir% goto :BuildTests
+if not exist %CoreRT_ReadyToRunTestHarness% goto :BuildTests
+goto :SkipBuildTests
 
-    IF ERRORLEVEL 1 (
-        echo Tests will not be run due to build-tests.cmd failing with error code !ErrorLevel!
-        exit /b !ErrorLevel!
-    )
+:BuildTests
+REM The test build handles restoring external dependencies such as CoreCLR runtime and its test host
+REM Trigger the test build so it will build but not run tests before we run them here
+call %CoreRT_TestRoot%..\buildscripts\build-tests.cmd buildtests
+
+IF ERRORLEVEL 1 (
+    echo Tests will not be run due to build-tests.cmd failing with error code !ErrorLevel!
+    exit /b !ErrorLevel!
 )
+
+:SkipBuildTests
 
 call %CoreRT_TestRoot%testenv.cmd
 

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -27,6 +27,11 @@
     <RestoreOutputPath>$(IntermediateOutputRootPath)\repro</RestoreOutputPath>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- For Ready To Run testing, use the CoreCLR framework assemblies instead of the AOT ones -->
+    <IlcReference Condition="'$(NativeCodeGen)' == 'readytorun'" Include="$(CoreRT_CoreCLRRuntimeDir)\*.dll" />
+  </ItemGroup>
+
   <!--
     When building a library as a reference, the returned build outputs include both the 
     IL assembly produced by CSC and the native obj produced by Ilc. Separate the native


### PR DESCRIPTION
In ready-to-run mode, use the CoreCLR shared framework implementation
assemblies to generate test R2R images instead of the AOT versions
currently used in standard RyuJit mode.

System.Object has a pointer field for the EEType in each object header
in the AOT implementation of System.Private.CoreLib. The CoreCLR
System.Object does not have this field, and instead the runtime adds an
implicit pointer field for the MethodTable. Handle this in the R2R
compiler by allowing target runtimes to specify the size and alignment
requirements of the part of System.Object that precedes all fields.

Somewhat awkwardly.. fix constants used to compile ILCompiler.ReadyToRun so that asserts actually fire..

Adjust the test scripting to consume the CoreCLR framework.
Assert if we accidentally pass in the AOT System.Private.CoreLib in R2R
mode.

CoreCLR all tests pass rate improved by 21 tests to 1370/2347 passing
(58.4%).