### PR TITLE
Add null checking for callvirt

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1667,7 +1667,7 @@ namespace Internal.IL
             }
 
             int offset = GetTotalParameterOffset() + GetTotalLocalOffset();
-            LLVMValueRef shadowStack = LLVM.BuildGEP(_builder, LLVM.GetFirstParam(_llvmFunction),
+            LLVMValueRef shadowStack = LLVM.BuildGEP(builder, LLVM.GetFirstParam(_llvmFunction),
                 new LLVMValueRef[] { LLVM.ConstInt(LLVM.Int32Type(), (uint)offset, LLVMMisc.False) },
                 String.Empty);
             var castShadowStack = LLVM.BuildPointerCast(builder, shadowStack, LLVM.PointerType(LLVM.Int8Type(), 0), "castshadowstack");
@@ -1704,7 +1704,7 @@ namespace Internal.IL
                 }
 
                 LLVMTypeRef valueType = GetLLVMTypeForTypeDesc(argType);
-                LLVMValueRef argValue = toStore.ValueAsType(valueType, _builder);
+                LLVMValueRef argValue = toStore.ValueAsType(valueType, builder);
 
                 // Pass arguments as parameters if possible
                 if (!isThisParameter && CanStoreTypeOnStack(argType))
@@ -1724,7 +1724,7 @@ namespace Internal.IL
             }
 
 
-            LLVMValueRef llvmReturn = LLVM.BuildCall(_builder, fn, llvmArgs.ToArray(), string.Empty);
+            LLVMValueRef llvmReturn = LLVM.BuildCall(builder, fn, llvmArgs.ToArray(), string.Empty);
             
             if (!returnType.IsVoid)
             {

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1694,6 +1694,16 @@ namespace Internal.IL
                 AddMethodReference(callee);
             }
 
+            LLVMValueRef fn;
+            if (opcode == ILOpcode.calli)
+            {
+                fn = calliTarget;
+            }
+            else
+            {
+                fn = LLVMFunctionForMethod(callee, signature.IsStatic ? null : argumentValues[0], opcode == ILOpcode.callvirt, constrainedType);
+            }
+
             LLVMValueRef shadowStack = LLVM.BuildGEP(builder, baseShadowStack, new LLVMValueRef[] {LLVM.ConstInt(LLVM.Int32Type(), (uint) offset, LLVMMisc.False)}, String.Empty);
             var castShadowStack = LLVM.BuildPointerCast(builder, shadowStack, LLVM.PointerType(LLVM.Int8Type(), 0), "castshadowstack");
 
@@ -1747,7 +1757,6 @@ namespace Internal.IL
                     argOffset += argType.GetElementSize().AsInt;
                 }
             }
-
 
             LLVMValueRef llvmReturn = LLVM.BuildCall(builder, fn, llvmArgs.ToArray(), string.Empty);
             return llvmReturn;

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -115,6 +115,7 @@ namespace Internal.IL
         static LLVMValueRef DebugtrapFunction = default(LLVMValueRef);
         static LLVMValueRef TrapFunction = default(LLVMValueRef);
         static LLVMValueRef DoNothingFunction = default(LLVMValueRef);
+        static LLVMValueRef NullRefFunction = default(LLVMValueRef);
 
         private static IEnumerable<string> GetParameterNamesForMethod(MethodDesc method)
         {


### PR DESCRIPTION
@morganbr 

Fixes #5772
I've implemented this as a function to avoid messing with the basic blocks directly. I expect that in a release build this will effectively be inline anyway. In support of this I've changed some signatures to pass the LLVMBuilderRef so I can reuse the infrastructure for creating the exception object. This seems a little bit dangerous as some of the affected paths (pinvoke) have dependencies on things like the shadow stack of the original routine. These paths are obviously not taken in my planned usage but I'm not sure If I need to be putting some sort of guard here to prevent misuse, and if so what form should it take.

Once this PR is done it should be pretty easy to do the same thing for index out of range in the array instructions.