### PR TITLE
Targeted fixes for CoreCLR test compilation & execution

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -438,12 +438,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public void EmitFieldSignature(FieldDesc field, SignatureContext context)
         {
-            ModuleToken fieldRefToken = context.GetModuleTokenForField(field);
-            switch (fieldRefToken.TokenType)
+            ModuleToken fieldToken = context.GetModuleTokenForField(field);
+            switch (fieldToken.TokenType)
             {
                 case CorTokenType.mdtMemberRef:
                     EmitUInt((uint)ReadyToRunFieldSigFlags.READYTORUN_FIELD_SIG_MemberRefToken);
-                    EmitTokenRid(fieldRefToken.Token);
+                    EmitTokenRid(fieldToken.Token);
+                    break;
+
+                case CorTokenType.mdtFieldDef:
+                    EmitUInt((uint)0);
+                    EmitTokenRid(fieldToken.Token);
                     break;
 
                 default:

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -640,6 +640,12 @@ namespace ILCompiler.DependencyAnalysis
                     r2rHelper = ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_FltRound;
                     break;
 
+                case ILCompiler.ReadyToRunHelper.GetRefAny:
+                    // TODO-PERF: currently not implemented in Crossgen
+                    ThrowHelper.ThrowInvalidProgramException();
+                    // ThrowInvalidProgramException should never return
+                    throw new NotImplementedException();
+
                 default:
                     throw new NotImplementedException(helper.ToString());
             }

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -62,7 +62,12 @@ namespace ILCompiler.PEWriter
         /// Name of the text section.
         /// </summary>
         public const string TextSectionName = ".text";
-        
+
+        /// <summary>
+        /// Name of the initialized data section.
+        /// </summary>
+        public const string SDataSectionName = ".sdata";
+
         /// <summary>
         /// Name of the resource section.
         /// </summary>
@@ -155,6 +160,7 @@ namespace ILCompiler.PEWriter
             ImmutableArray<Section>.Builder sectionListBuilder = ImmutableArray.CreateBuilder<Section>();
 
             int textSectionIndex = -1;
+            int sdataSectionIndex = -1;
             int rsrcSectionIndex = -1;
             int relocSectionIndex = -1;
             
@@ -165,7 +171,11 @@ namespace ILCompiler.PEWriter
                     case TextSectionName:
                         textSectionIndex = sectionIndex;
                         break;
-                    
+
+                    case SDataSectionName:
+                        sdataSectionIndex = sectionIndex;
+                        break;
+
                     case RsrcSectionName:
                         rsrcSectionIndex = sectionIndex;
                         break;
@@ -192,6 +202,12 @@ namespace ILCompiler.PEWriter
                 {
                     sectionListBuilder.Add(new Section(nameCharPair.SectionName, nameCharPair.Characteristics));
                 }
+            }
+
+            if (sdataSectionIndex >= 0 && !sectionNames.Any((sc) => sc.SectionName == SDataSectionName))
+            {
+                SectionHeader sectionHeader = peReader.PEHeaders.SectionHeaders[sdataSectionIndex];
+                sectionListBuilder.Add(new Section(sectionHeader.Name, sectionHeader.SectionCharacteristics));
             }
 
             if (rsrcSectionIndex >= 0 && !sectionNames.Any((sc) => sc.SectionName == RsrcSectionName))

--- a/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
+++ b/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
@@ -230,7 +230,9 @@ namespace Internal.JitInterface
                     break;
 
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_RTH_GetValueInternal:
+#if !READYTORUN
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_InitializeArray:
+#endif
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Ctor:
                 case CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Value:
                     if (pMustExpand != null)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -968,6 +968,10 @@ namespace Internal.JitInterface
             else
             {
                 TypeDesc type = (TypeDesc)result;
+#if READYTORUN
+                _compilation.NodeFactory.Resolver.AddModuleTokenForType(type, new ModuleToken(_tokenContext, (mdToken)pResolvedToken.token));
+#endif
+
                 if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Newarr)
                 {
                     if (type.IsVoid)
@@ -976,10 +980,6 @@ namespace Internal.JitInterface
                     type = type.MakeArrayType();
                 }
                 pResolvedToken.hClass = ObjectToHandle(type);
-
-#if READYTORUN
-                _compilation.NodeFactory.Resolver.AddModuleTokenForType(type, new ModuleToken(_tokenContext, (mdToken)pResolvedToken.token));
-#endif
             }
 
             pResolvedToken.pTypeSpec = null;
@@ -2729,7 +2729,7 @@ namespace Internal.JitInterface
                     {
                         pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
 #if READYTORUN
-                            _compilation.NodeFactory.MethodEntrypoint(targetMethod, constrainedType, _signatureContext)
+                            _compilation.NodeFactory.MethodEntrypoint(constrainedType != null ? method : targetMethod, constrainedType, _signatureContext)
 #else
                             _compilation.NodeFactory.MethodEntrypoint(targetMethod)
 #endif


### PR DESCRIPTION
This is a subset of the modifications I presented in the long-running
https://github.com/dotnet/corert/pull/6345/files PR. I believe these to be well-defined and hopefully non-controversial.
The change basically improves synthetic token harvesting and fixes
a bunch of corner cases I identified in local debugging of the CoreCLR
tests using the CPAOT compiler. My initial assumption is that most of
the changes should be self-explanatory, please let me know if your
perception is different so that I can improve naming, comments or whatever.

Thanks

Tomas