### PR TITLE
Gracefully handle non-compilable methods

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DebugInfoTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DebugInfoTableNode.cs
@@ -91,6 +91,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         continue;
                 }
 
+                if (methodCodeNode.IsEmpty)
+                {
+                    continue;
+                }
+
                 MemoryStream methodDebugBlob = new MemoryStream();
                 
                 byte[] bounds = CreateBoundsBlobForMethod(methodCodeNode);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -210,7 +210,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         continue;
                 }
 
-                Add(methodCodeNode, ((ReadyToRunCodegenNodeFactory)factory).RuntimeFunctionsTable.GetIndex(methodCodeNode));
+                if (!methodCodeNode.IsEmpty)
+                {
+                    Add(methodCodeNode, ((ReadyToRunCodegenNodeFactory)factory).RuntimeFunctionsTable.GetIndex(methodCodeNode));
+                }
             }
 
             NativeWriter writer = new NativeWriter();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -43,6 +43,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
+            if (relocsOnly)
+            {
+                // Method fixup signature doesn't contain any direct relocs
+                return new ObjectData(data: Array.Empty<byte>(), relocs: null, alignment: 0, definedSymbols: null);
+            }
+
             ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
             dataBuilder.AddSymbol(this);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -43,6 +43,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public MethodDesc Method => _method;
 
+        public bool IsEmpty => _methodCode.Data.Length == 0;
+
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
             return _methodCode;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -142,6 +142,7 @@ namespace Internal.JitInterface
 
         private void CompileMethodInternal(IMethodNode methodCodeNodeNeedingCode, MethodIL methodIL = null)
         {
+            bool codeGotPublished = false;
             try
             {
                 _isFallbackBodyCompilation = methodIL != null;
@@ -212,9 +213,14 @@ namespace Internal.JitInterface
                 }
 
                 PublishCode();
+                codeGotPublished = true;
             }
             finally
             {
+                if (!codeGotPublished)
+                {
+                    PublishEmptyCode();
+                }
                 CompileMethodCleanup();
             }
         }
@@ -250,6 +256,12 @@ namespace Internal.JitInterface
 
             _methodCodeNode.InitializeDebugLocInfos(_debugLocInfos);
             _methodCodeNode.InitializeDebugVarInfos(_debugVarInfos);
+        }
+
+        private void PublishEmptyCode()
+        {
+            _methodCodeNode.SetCode(new ObjectNode.ObjectData(Array.Empty<byte>(), null, 1, Array.Empty<ISymbolDefinitionNode>()));
+            _methodCodeNode.InitializeFrameInfos(Array.Empty<FrameInfo>());
         }
 
         private MethodDesc MethodBeingCompiled


### PR DESCRIPTION
This is another part of my WIP PR. Previously, any method compilation
failure has torn down the entire compilation due to the fact that,
once a method didn't compile, its code never got published and the
clause

        public override bool StaticDependenciesAreComputed => _methodCode != null;

hit an assertion failure in the dependency graph walker. I'm proposing
to populate uncompilable methods with a dummy code object with
the potential to satisfy most compile-time checks while being
unresolvable by itself which is important as we don't want to
silently tolerate calls to the uncompiled method.

Thanks

Tomas