### PR TITLE
Make dependency analysis viewer work with CoreRT

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -330,8 +330,6 @@ namespace ILCompiler
                 dumper.Begin();
             }
 
-            // In multi-module builds, set the compilation unit prefix to prevent ambiguous symbols in linked object files
-            NameMangler.CompilationUnitPrefix = _nodeFactory.CompilationModuleGroup.IsSingleFileCompilation ? "" : Path.GetFileNameWithoutExtension(outputFile);
             CompileInternal(outputFile, dumper);
 
             if (dumper != null)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -44,6 +44,12 @@ namespace ILCompiler
             return this;
         }
 
+        public CompilationBuilder UseCompilationUnitPrefix(string prefix)
+        {
+            _nameMangler.CompilationUnitPrefix = prefix;
+            return this;
+        }
+
         public CompilationBuilder UseDependencyTracking(DependencyTrackingLevel trackingLevel)
         {
             _dependencyTrackingLevel = trackingLevel;

--- a/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
@@ -78,7 +78,6 @@ namespace ILCompiler
 
         ILScanResults IILScanner.Scan()
         {
-            _nodeFactory.NameMangler.CompilationUnitPrefix = "";
             _dependencyGraph.ComputeMarkedNodes();
 
             return new ILScanResults(_dependencyGraph, _nodeFactory);

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -412,6 +412,9 @@ namespace ILCompiler
             else
                 builder = new RyuJitCompilationBuilder(typeSystemContext, compilationGroup);
 
+            string compilationUnitPrefix = _multiFile ? System.IO.Path.GetFileNameWithoutExtension(_outputFilePath) : "";
+            builder.UseCompilationUnitPrefix(compilationUnitPrefix);
+
             var stackTracePolicy = _emitStackTraceData ?
                 (StackTraceEmissionPolicy)new EcmaMethodStackTraceEmissionPolicy() : new NoStackTraceEmissionPolicy();
 


### PR DESCRIPTION
I always used a local hack to make the dependency analysis viewer tool work. The tool was crashing the compilation because with the viewer attached we started asking for node names before the compilation unit prefix was set.

At some point we should make CompilationUnitPrefix immutable like everything else to prevent this sort of bugs.