### PR TITLE
Revert change that broke ReadyToRunUnit test

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2729,7 +2729,7 @@ namespace Internal.JitInterface
                     {
                         pResult.codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
 #if READYTORUN
-                            _compilation.NodeFactory.MethodEntrypoint(constrainedType != null ? method : targetMethod, constrainedType, _signatureContext)
+                            _compilation.NodeFactory.MethodEntrypoint(targetMethod, constrainedType, _signatureContext)
 #else
                             _compilation.NodeFactory.MethodEntrypoint(targetMethod)
 #endif


### PR DESCRIPTION
Part of https://github.com/dotnet/corert/commit/b88927096310ee60d3965626d2fdad49fad7ac50 broke the interface dispatch to IDisposable.Dispose for the struct case. I am not sure what the intent of this specific change is for. Removing it fixes ReadyToRunUnit but regresses two CoreCLR tests:
```
JIT._SIMD_VectorRelOp_r_VectorRelOp_r_._SIMD_VectorRelOp_r_VectorRelOp_r_cmd
JIT._SIMD_VectorRelOp_ro_VectorRelOp_ro_._SIMD_VectorRelOp_ro_VectorRelOp_ro_cmd
```