### PR TITLE
Remove references to ShadowConcreteMethod in CorInfoImpl

### DIFF
--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -619,27 +619,9 @@ namespace Internal.IL
                     if (instParam != null)
                     {
                         _dependencies.Add(instParam, reason);
+                    }
 
-                        if (!referencingArrayAddressMethod)
-                        {
-                            _dependencies.Add(_compilation.NodeFactory.ShadowConcreteMethod(concreteMethod), reason);
-                        }
-                        else
-                        {
-                            // We don't want array Address method to be modeled in the generic dependency analysis.
-                            // The method doesn't actually have runtime determined dependencies (won't do
-                            // any generic lookups).
-                            _dependencies.Add(_compilation.NodeFactory.MethodEntrypoint(targetMethod), reason);
-                        }
-                    }
-                    else if (targetMethod.AcquiresInstMethodTableFromThis())
-                    {
-                        _dependencies.Add(_compilation.NodeFactory.ShadowConcreteMethod(concreteMethod), reason);
-                    }
-                    else
-                    {
-                        _dependencies.Add(_compilation.NodeFactory.MethodEntrypoint(targetMethod), reason);
-                    }
+                    _dependencies.Add(_compilation.NodeFactory.MethodEntrypoint(targetMethod), reason);
                 }
             }
             else if (method.HasInstantiation)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -3267,31 +3267,10 @@ namespace Internal.JitInterface
                     if (instParam != null)
                     {
                         pResult->instParamLookup = CreateConstLookupToSymbol(instParam);
+                    }
 
-                        if (!referencingArrayAddressMethod)
-                        {
-                            pResult->codePointerOrStubLookup.constLookup = 
-                                CreateConstLookupToSymbol(_compilation.NodeFactory.ShadowConcreteMethod(concreteMethod));
-                        }
-                        else
-                        {
-                            // We don't want array Address method to be modeled in the generic dependency analysis.
-                            // The method doesn't actually have runtime determined dependencies (won't do
-                            // any generic lookups).
-                            pResult->codePointerOrStubLookup.constLookup = 
-                                CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
-                        }
-                    }
-                    else if (targetMethod.AcquiresInstMethodTableFromThis())
-                    {
-                        pResult->codePointerOrStubLookup.constLookup = 
-                            CreateConstLookupToSymbol(_compilation.NodeFactory.ShadowConcreteMethod(concreteMethod));
-                    }
-                    else
-                    {
-                        pResult->codePointerOrStubLookup.constLookup = 
-                            CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
-                    }
+                    pResult->codePointerOrStubLookup.constLookup = 
+                        CreateConstLookupToSymbol(_compilation.NodeFactory.MethodEntrypoint(targetMethod));
                 }
 
                 pResult->nullInstanceCheck = resolvedCallVirt;


### PR DESCRIPTION
This is a leftover from when we were trying to track the exact instantiations of methods referenced from method bodies. This would potentially let us emit generic dictionaries with holes in them, but it complicates depenedency analysis so we pretty much gave up on it in the rest of the system (NUTC doesn't do that optimization either).

These days generic dictionaries ensure that the proper `ShadowConcreteMethod` for the specific instantiation gets created if there is a new canonical method body in the system.