### PR TITLE
Fix ETW harness name handling around generics

### DIFF
--- a/tests/src/tools/ReadyToRun.TestHarness/ReadyToRunEtlMethodFilter.cs
+++ b/tests/src/tools/ReadyToRun.TestHarness/ReadyToRunEtlMethodFilter.cs
@@ -60,14 +60,15 @@ namespace ReadyToRun.TestHarness
             var signature = "";
             var signatureWithReturnType = data.MethodSignature;
             var openParenIndex = signatureWithReturnType.IndexOf('(');
-            
+
             if (0 <= openParenIndex)
             {
                 signature = signatureWithReturnType.Substring(openParenIndex);
             }
 
             var className = data.MethodNamespace;
-            var lastDot = className.LastIndexOf('.');
+            var firstBox = className.IndexOf('[');
+            var lastDot = className.LastIndexOf('.', firstBox >= 0 ? firstBox : className.Length - 1);
             if (0 <= lastDot)
             {
                 className = className.Substring(lastDot + 1);


### PR DESCRIPTION
Generic type markers in the ETW events used by the ready-to-run harness messed up the name mangling. Don't consider any generic arguments as part of the name when formatting the method to remove namespaces so we don't mistake a period in the generic type for part of the method's type's namespace.