### PR TITLE
Update XmlDoc for GenericVirtualMethodTableNode

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
@@ -13,7 +13,7 @@ using Internal.NativeFormat;
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
-    /// Represents a map between reflection metadata and generated method bodies.
+    /// Represents a map of generic virtual method implementations.
     /// </summary>
     internal sealed class GenericVirtualMethodTableNode : ObjectNode, ISymbolDefinitionNode
     {


### PR DESCRIPTION
The existing XmlDoc comment is an obvious copypaste from `ReflectionInvokeMapNode` and simply misleading.

Noticed this when responding on #6147.

@dotnet-bot skip ci please