### PR TITLE
Compile CoreCLR framework assemblies

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Debug = System.Diagnostics.Debug;
 
 using Internal.TypeSystem;
@@ -38,6 +39,16 @@ namespace ILCompiler
                 Debug.Assert(_r2rFieldLayoutAlgorithm != null);
                 return _r2rFieldLayoutAlgorithm;
             }
+        }
+
+        /// <summary>
+        /// Prevent any synthetic methods being added to types in the base CompilerTypeSystemContext
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        protected override IEnumerable<MethodDesc> GetAllMethods(TypeDesc type)
+        {
+            return type.GetMethods();
         }
 
         protected override bool ComputeHasGCStaticBase(FieldDesc field)

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -183,10 +183,6 @@ namespace ILCompiler.PEWriter
                     case RelocSectionName:
                         relocSectionIndex = sectionIndex;
                         break;
-                    
-                    default:
-                        // Unexpected section in MSIL file
-                        throw new NotSupportedException();
                 }
             }
 

--- a/tests/CoreCLR/CompileAssembly.csproj
+++ b/tests/CoreCLR/CompileAssembly.csproj
@@ -1,0 +1,22 @@
+<Project DefaultTargets="LinkNative" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!-- <TargetName>$(TestFileName)</TargetName> -->
+    <TargetName>$([System.IO.Path]::GetFileNameWithoutExtension('$(TestFileName)'))</TargetName>
+    <TargetExt>.dll</TargetExt>
+    <OutputType>Library</OutputType>
+    <OutputPath>$(CoreRT_CoreCLRRuntimeDir)\</OutputPath>
+    <IntermediateOutputPath>$(CoreRT_CoreCLRRuntimeDir)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- For Ready To Run testing, use the CoreCLR framework assemblies instead of the AOT ones -->
+    <IlcReference Condition="'$(NativeCodeGen)' == 'readytorun'" Include="$(CoreRT_CoreCLRRuntimeDir)\*.dll" />
+  </ItemGroup>
+
+  <!-- Since tests are already compiled, override Compile target to prevent CSC running -->
+  <Target Name="Compile" />
+
+  <Import Project="$(IlcPath)\build\Microsoft.NETCore.Native.targets" />
+
+</Project>

--- a/tests/CoreCLR/compile-framework.cmd
+++ b/tests/CoreCLR/compile-framework.cmd
@@ -1,0 +1,46 @@
+::
+:: Produce ready-to-run images for the framework assemblies
+::
+:: Report methods that were not compilable
+::
+
+@if not defined _echo @echo off
+setlocal EnableDelayedExpansion
+
+if "%CoreRT_CoreCLRRuntimeDir%" == "" (
+    echo set CoreRT_CoreCLRRuntimeDir to CoreCLR folder or run from runtest.cmd
+    exit /b 1
+)
+
+for %%x in (%CoreRT_CoreCLRRuntimeDir%\Microsoft.*.dll %CoreRT_CoreCLRRuntimeDir%\System.*.dll) do (
+    echo %%x
+    call :CompileAssembly %%x
+)
+
+goto :eof
+
+::
+:: Compile a single framework assembly
+::
+:: Parameters:
+:: %1 Path to assembly to compile
+:CompileAssembly
+
+echo Compiling %1
+set TestFileName=%1
+set MsBuildCommandLine=msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" /p:DisableFrameworkLibGeneration=true /t:CopyNative %~dp0CompileAssembly.csproj
+echo %MsBuildCommandLine%
+%MsBuildCommandLine%
+
+set /a SavedErrorLevel=%ErrorLevel%
+
+if "%SavedErrorLevel%" == "1000" (
+    echo %1 is not a managed assembly.
+    exit /b 0
+)
+
+if %SavedErrorLevel% neq 0 (
+    exit /b !ERRORLEVEL!
+)
+
+goto :eof

--- a/tests/CoreCLR/compile-framework.cmd
+++ b/tests/CoreCLR/compile-framework.cmd
@@ -7,13 +7,14 @@
 @if not defined _echo @echo off
 setlocal EnableDelayedExpansion
 
+rd /s /q %CoreRT_CoreCLRRuntimeDir%\native
+
 if "%CoreRT_CoreCLRRuntimeDir%" == "" (
     echo set CoreRT_CoreCLRRuntimeDir to CoreCLR folder or run from runtest.cmd
     exit /b 1
 )
 
 for %%x in (%CoreRT_CoreCLRRuntimeDir%\Microsoft.*.dll %CoreRT_CoreCLRRuntimeDir%\System.*.dll) do (
-    echo %%x
     call :CompileAssembly %%x
 )
 
@@ -28,16 +29,18 @@ goto :eof
 
 echo Compiling %1
 set TestFileName=%1
-set MsBuildCommandLine=msbuild /ConsoleLoggerParameters:ForceNoAlign "/p:IlcPath=%CoreRT_ToolchainDir%" "/p:Configuration=%CoreRT_BuildType%" "/p:RepoLocalBuild=true" "/p:FrameworkLibPath=%~dp0..\..\bin\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\lib" "/p:FrameworkObjPath=%~dp0..\..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\Framework" /p:DisableFrameworkLibGeneration=true /t:CopyNative %~dp0CompileAssembly.csproj
+set MsBuildCommandLine=msbuild 
+set MsBuildCommandLine=%MsBuildCommandLine% /ConsoleLoggerParameters:ForceNoAlign
+set MsBuildCommandLine=%MsBuildCommandLine% "/p:IlcPath=%CoreRT_ToolchainDir%"
+set MsBuildCommandLine=%MsBuildCommandLine% "/p:Configuration=%CoreRT_BuildType%"
+set MsBuildCommandLine=%MsBuildCommandLine% "/p:RepoLocalBuild=true"
+set MsBuildCommandLine=%MsBuildCommandLine% /t:CopyNative
+set MsBuildCommandLine=%MsBuildCommandLine% %~dp0CompileAssembly.csproj
+
 echo %MsBuildCommandLine%
 %MsBuildCommandLine%
 
 set /a SavedErrorLevel=%ErrorLevel%
-
-if "%SavedErrorLevel%" == "1000" (
-    echo %1 is not a managed assembly.
-    exit /b 0
-)
 
 if %SavedErrorLevel% neq 0 (
     exit /b !ERRORLEVEL!

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -151,7 +151,7 @@ call "!VS150COMNTOOLS!\..\..\VC\Auxiliary\Build\vcvarsall.bat" %CoreRT_HostArch%
 
 :: Eventually we'll always want to compile the framework with r2r before running tests.
 :: During bringup, it's an opt-in separate step.
-if "%CoreRT_R2RFramework%"=="true" goto :TextExtRepoCoreCLRFramework
+if "%CoreRT_R2RFramework%"=="true" goto :TestExtRepoCoreCLRFramework
 if "%CoreRT_RunCoreCLRTests%"=="true" goto :TestExtRepoCoreCLR
 if "%CoreRT_RunCoreFXTests%"=="true" goto :TestExtRepoCoreFX
 
@@ -482,7 +482,7 @@ goto :eof
     echo CoreCLR tests restored from %TESTS_REMOTE_URL% > %TESTS_SEMAPHORE%
     exit /b 0
 
-:TextExtRepoCoreCLRFramework
+:TestExtRepoCoreCLRFramework
     echo Running external tests
     if "%CoreRT_TestExtRepo_CoreCLR%" == "" (
         set CoreRT_TestExtRepo_CoreCLR=%CoreRT_TestRoot%\..\tests_downloaded\CoreCLR


### PR DESCRIPTION
Add /r2rframework switch to runtest.cmd which runs the CPAOT compiler in
ready-to-run mode against the managed framework assemblies in CoreCLR.

I made a couple small bug fixes to unblock compilation of 30 framework
assemblies with code in them. There are also many small facade
assemblies with no code that we put a ready-to-run header in but don't
do anything interesting. Overall, currently, we produce ready-to-run
images for 84 / 214 assemblies.

The produced images are placed in bin\obj\<build>\CoreClrRuntime\native.
This folder also includes the .rsp file to compile specific assemblies
again for investigation.