### PR TITLE
Update RyuJIT

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RyuJITVersion>3.0.0-preview1-26929-03</RyuJITVersion>
+    <RyuJITVersion>3.0.0-preview1-27005-01</RyuJITVersion>
     <ObjectWriterVersion>1.0.0-alpha-26412-0</ObjectWriterVersion>
     <CoreFxVersion>4.6.0-preview1-26831-01</CoreFxVersion>
     <CoreFxUapVersion>4.7.0-preview1-26831-01</CoreFxUapVersion>

--- a/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
+++ b/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Runtime.CompilerServices;
-
 namespace Internal.TypeSystem
 {
     // Additional members of MethodDesc related to code generation.
@@ -41,6 +38,29 @@ namespace Internal.TypeSystem
         /// the code of the caller methods aggressively.
         /// </summary>
         public virtual bool IsAggressiveInlining
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value specifying whether this method contains hot code and should
+        /// be aggressively optimized if possible.
+        /// </summary>
+        public virtual bool IsAggressiveOptimization
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value specifying whether this method should not be optimized.
+        /// </summary>
+        public virtual bool IsNoOptimization
         {
             get
             {
@@ -128,6 +148,22 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool IsAggressiveOptimization
+        {
+            get
+            {
+                return _methodDef.IsAggressiveOptimization;
+            }
+        }
+
+        public override bool IsNoOptimization
+        {
+            get
+            {
+                return _methodDef.IsNoOptimization;
+            }
+        }
+
         public override bool IsAggressiveInlining
         {
             get
@@ -185,6 +221,22 @@ namespace Internal.TypeSystem
             get
             {
                 return _typicalMethodDef.IsNoInlining;
+            }
+        }
+
+        public override bool IsAggressiveOptimization
+        {
+            get
+            {
+                return _typicalMethodDef.IsAggressiveOptimization;
+            }
+        }
+
+        public override bool IsNoOptimization
+        {
+            get
+            {
+                return _typicalMethodDef.IsNoOptimization;
             }
         }
 

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -2,15 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Threading;
-using System.Collections.Generic;
-
-using Internal.TypeSystem;
 
 namespace Internal.TypeSystem.Ecma
 {
@@ -28,6 +24,8 @@ namespace Internal.TypeSystem.Ecma
             public const int RuntimeImplemented     = 0x0080;
             public const int InternalCall           = 0x0100;
             public const int Synchronized           = 0x0200;
+            public const int AggressiveOptimization = 0x0400;
+            public const int NoOptimization         = 0x0800;
 
             public const int AttributeMetadataCache = 0x1000;
             public const int Intrinsic              = 0x2000;
@@ -148,6 +146,15 @@ namespace Internal.TypeSystem.Ecma
                 if ((methodImplAttributes & MethodImplAttributes.NoInlining) != 0)
                     flags |= MethodFlags.NoInlining;
 
+                // System.Reflection.Primitives we build against doesn't define AggressiveOptimization
+                const MethodImplAttributes MethodImplAttributes_AggressiveOptimization = (MethodImplAttributes)0x0200;
+
+                // No optimization bit beats aggressive optimization bit (CLR compatible behavior)
+                if ((methodImplAttributes & MethodImplAttributes.NoOptimization) != 0)
+                    flags |= MethodFlags.NoOptimization;
+                else if ((methodImplAttributes & MethodImplAttributes_AggressiveOptimization) != 0)
+                    flags |= MethodFlags.AggressiveOptimization;
+
                 if ((methodImplAttributes & MethodImplAttributes.AggressiveInlining) != 0)
                     flags |= MethodFlags.AggressiveInlining;
 
@@ -256,6 +263,22 @@ namespace Internal.TypeSystem.Ecma
             get
             {
                 return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.NoInlining) & MethodFlags.NoInlining) != 0;
+            }
+        }
+
+        public override bool IsAggressiveOptimization
+        {
+            get
+            {
+                return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.AggressiveOptimization) & MethodFlags.AggressiveOptimization) != 0;
+            }
+        }
+
+        public override bool IsNoOptimization
+        {
+            get
+            {
+                return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.NoOptimization) & MethodFlags.NoOptimization) != 0;
             }
         }
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -774,6 +774,11 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE;
             }
 
+            if (method.IsAggressiveOptimization)
+            {
+                result |= CorInfoFlag.CORINFO_FLG_AGGRESSIVE_OPT;
+            }
+
             // TODO: Cache inlining hits
             // Check for an inlining directive.
 
@@ -3788,6 +3793,9 @@ namespace Internal.JitInterface
 
             if (this.MethodBeingCompiled.IsPInvoke)
                 flags.Set(CorJitFlag.CORJIT_FLAG_IL_STUB);
+
+            if (this.MethodBeingCompiled.IsNoOptimization)
+                flags.Set(CorJitFlag.CORJIT_FLAG_MIN_OPT);
 
             return (uint)sizeof(CORJIT_FLAGS);
         }

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -623,7 +623,7 @@ namespace Internal.JitInterface
         CORINFO_FLG_NOGCCHECK = 0x00200000, // This method is FCALL that has no GC check.  Don't put alone in loops
         CORINFO_FLG_INTRINSIC = 0x00400000, // This method MAY have an intrinsic ID
         CORINFO_FLG_CONSTRUCTOR = 0x00800000, // This method is an instance or type initializer
-        //  CORINFO_FLG_UNUSED                = 0x01000000,
+        CORINFO_FLG_AGGRESSIVE_OPT = 0x01000000, // The method may contain hot code and should be aggressively optimized if possible
         //  CORINFO_FLG_UNUSED                = 0x02000000,
         CORINFO_FLG_NOSECURITYWRAP = 0x04000000, // The method requires no security checks
         CORINFO_FLG_DONT_INLINE = 0x10000000, // The method should not be inlined

--- a/src/JitInterface/src/ThunkGenerator/corinfo.h
+++ b/src/JitInterface/src/ThunkGenerator/corinfo.h
@@ -824,7 +824,7 @@ enum CorInfoFlag
     CORINFO_FLG_NOGCCHECK             = 0x00200000, // This method is FCALL that has no GC check.  Don't put alone in loops
     CORINFO_FLG_INTRINSIC             = 0x00400000, // This method MAY have an intrinsic ID
     CORINFO_FLG_CONSTRUCTOR           = 0x00800000, // This method is an instance or type initializer
-//  CORINFO_FLG_UNUSED                = 0x01000000,
+    CORINFO_FLG_AGGRESSIVE_OPT        = 0x01000000, // The method may contain hot code and should be aggressively optimized if possible
 //  CORINFO_FLG_UNUSED                = 0x02000000,
     CORINFO_FLG_NOSECURITYWRAP        = 0x04000000, // The method requires no security checks
     CORINFO_FLG_DONT_INLINE           = 0x10000000, // The method should not be inlined


### PR DESCRIPTION
Picks up the new tiering-related `MethodImpl` option added in dotnet/coreclr#20009.

I went ahead and also implemented the `NoOptimization` `MethodImpl` option because it's related and we need to have it to ship anyway.