### PR TITLE
Fix asm.js struct and alignment issues

### DIFF
--- a/src/Native/Runtime/CachedInterfaceDispatch.cpp
+++ b/src/Native/Runtime/CachedInterfaceDispatch.cpp
@@ -367,7 +367,7 @@ static void DiscardCache(InterfaceDispatchCache * pCache)
     if (pDiscardedCacheBlock != NULL)
         g_pDiscardedCacheFree = pDiscardedCacheBlock->m_pNext;
     else
-        pDiscardedCacheBlock = (DiscardedCacheBlock *)g_pAllocHeap->Alloc(sizeof(DiscardedCacheBlock));
+        pDiscardedCacheBlock = (DiscardedCacheBlock *)g_pAllocHeap->AllocAligned(sizeof(DiscardedCacheBlock), alignof(DiscardedCacheBlock));
 
     if (pDiscardedCacheBlock != NULL) // if we did NOT get the memory, we leak the discarded block
     {

--- a/src/Native/Runtime/allocheap.cpp
+++ b/src/Native/Runtime/allocheap.cpp
@@ -170,7 +170,7 @@ UInt8 * AllocHeap::Alloc(
 }
 
 //-------------------------------------------------------------------------------------------------
-UInt8 * AllocHeap::AllocAligned(
+void * AllocHeap::AllocAligned(
     UIntNative cbMem,
     UIntNative alignment
     WRITE_ACCESS_HOLDER_ARG)

--- a/src/Native/Runtime/allocheap.h
+++ b/src/Native/Runtime/allocheap.h
@@ -42,7 +42,7 @@ class AllocHeap
     // If AllocHeap was created with a MemAccessMgr, pRWAccessHolder must be non-NULL.
     // On return, the holder will permit R/W access to the allocated memory until it
     // is destructed.
-    UInt8 * AllocAligned(UIntNative cbMem,
+    void * AllocAligned(UIntNative cbMem,
                          UIntNative alignment
                          WRITE_ACCESS_HOLDER_ARG_NULL_DEFAULT);
 

--- a/src/Native/Runtime/inc/pal_endian.h
+++ b/src/Native/Runtime/inc/pal_endian.h
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*++
+
+
+
+
+
+--*/
+
+#ifndef __PAL_ENDIAN_H__
+#define __PAL_ENDIAN_H__
+
+#ifdef __cplusplus
+extern "C++" {
+inline UInt16 SWAP16(UInt16 x)
+{
+    return (x >> 8) | (x << 8);
+}
+
+inline UInt32 SWAP32(UInt32 x)
+{
+    return  (x >> 24) |
+            ((x >> 8) & 0x0000FF00L) |
+            ((x & 0x0000FF00L) << 8) |
+            (x << 24);
+}
+
+}
+#endif // __cplusplus
+
+#if BIGENDIAN
+#ifdef __cplusplus
+extern "C++" {
+inline UInt16 VAL16(UInt16 x)
+{
+    return SWAP16(x);
+}
+
+inline UInt32 VAL32(UInt32 x)
+{
+    return SWAP32(x);
+}
+
+inline UInt64 VAL64(UInt64 x)   
+{
+    return ((UInt64)VAL32(x) << 32) | VAL32(x >> 32);
+}
+
+inline void SwapString(WCHAR *szString)
+{
+    unsigned i;
+    for (i = 0; szString[i] != L'\0'; i++)
+    {
+        szString[i] = VAL16(szString[i]);
+    }
+}
+
+inline void SwapStringLength(WCHAR *szString, ULONG StringLength)
+{
+    unsigned i;
+    for (i = 0; i < StringLength; i++)
+    {
+        szString[i] = VAL16(szString[i]);
+    }
+}
+
+inline void SwapGuid(GUID *pGuid) 
+{ 
+    pGuid->Data1 = VAL32(pGuid->Data1);
+    pGuid->Data2 = VAL16(pGuid->Data2);
+    pGuid->Data3 = VAL16(pGuid->Data3);
+}
+};
+#else // __cplusplus
+/* C Version of VAL functionality.  Swap functions omitted for lack of use in C code */
+#define VAL16(x)    (((x) >> 8) | ((x) << 8))
+#define VAL32(y)    (((y) >> 24) | (((y) >> 8) & 0x0000FF00L) | (((y) & 0x0000FF00L) << 8) | ((y) << 24))
+#define VAL64(z)    (((UInt64)VAL32(z) << 32) | VAL32((z) >> 32))
+#endif // __cplusplus
+
+#else // !BIGENDIAN
+
+#define VAL16(x) x
+#define VAL32(x) x
+#define VAL64(x) x
+#define SwapString(x)
+#define SwapStringLength(x, y)
+#define SwapGuid(x)
+
+#endif  // !BIGENDIAN
+
+#ifdef BIT64
+#define VALPTR(x) VAL64(x)
+#else
+#define VALPTR(x) VAL32(x)
+#endif
+
+#if defined(_ARM_) || defined(_WASM_)
+#define LOG2_PTRSIZE    2
+#define ALIGN_ACCESS    ((1<<LOG2_PTRSIZE)-1)
+#endif // _ARM_ || _WASM_
+
+#if defined(ALIGN_ACCESS) && !defined(_MSC_VER)
+#ifdef __cplusplus
+extern "C++" {
+// Get Unaligned values from a potentially unaligned object
+inline UInt16 GET_UNALIGNED_16(const void *pObject)
+{
+    UInt16 temp;
+    memcpy(&temp, pObject, sizeof(temp));
+    return temp; 
+}
+inline UInt32 GET_UNALIGNED_32(const void *pObject)
+{
+    UInt32 temp;
+    memcpy(&temp, pObject, sizeof(temp));
+    return temp; 
+}
+inline UInt64 GET_UNALIGNED_64(const void *pObject)
+{
+    UInt64 temp;
+    memcpy(&temp, pObject, sizeof(temp));
+    return temp; 
+}
+
+// Set Value on an potentially unaligned object
+inline void SET_UNALIGNED_16(void *pObject, UInt16 Value)
+{
+    memcpy(pObject, &Value, sizeof(UInt16));
+}
+inline void SET_UNALIGNED_32(void *pObject, UInt32 Value)
+{
+    memcpy(pObject, &Value, sizeof(UInt32));
+}
+inline void SET_UNALIGNED_64(void *pObject, UInt64 Value)
+{
+    memcpy(pObject, &Value, sizeof(UInt64));
+}
+}
+#endif // __cplusplus
+
+#else // defined(ALIGN_ACCESS) && !defined(_MSC_VER)
+
+// Get Unaligned values from a potentially unaligned object
+#define GET_UNALIGNED_16(_pObject)  (*(UInt16*)(_pObject))
+#define GET_UNALIGNED_32(_pObject)  (*(UInt32*)(_pObject))
+#define GET_UNALIGNED_64(_pObject)  (*(UInt64*)(_pObject))
+
+// Set Value on an potentially unaligned object 
+#define SET_UNALIGNED_16(_pObject, _Value)  (*(UInt16 *)(_pObject)) = (UInt16)(_Value)
+#define SET_UNALIGNED_32(_pObject, _Value)  (*(UInt32 *)(_pObject)) = (UInt32)(_Value)
+#define SET_UNALIGNED_64(_pObject, _Value)  (*(UInt64 *)(_pObject)) = (UInt64)(_Value) 
+
+#endif // defined(ALIGN_ACCESS) && !defined(_MSC_VER)
+
+// Get Unaligned values from a potentially unaligned object and swap the value
+#define GET_UNALIGNED_VAL16(_pObject) VAL16(GET_UNALIGNED_16(_pObject))
+#define GET_UNALIGNED_VAL32(_pObject) VAL32(GET_UNALIGNED_32(_pObject))
+#define GET_UNALIGNED_VAL64(_pObject) VAL64(GET_UNALIGNED_64(_pObject))
+
+// Set a swap Value on an potentially unaligned object 
+#define SET_UNALIGNED_VAL16(_pObject, _Value) SET_UNALIGNED_16(_pObject, VAL16((UInt16)_Value))
+#define SET_UNALIGNED_VAL32(_pObject, _Value) SET_UNALIGNED_32(_pObject, VAL32((UInt32)_Value))
+#define SET_UNALIGNED_VAL64(_pObject, _Value) SET_UNALIGNED_64(_pObject, VAL64((UInt64)_Value))
+
+#endif // __PAL_ENDIAN_H__

--- a/src/Native/Runtime/inc/varint.h
+++ b/src/Native/Runtime/inc/varint.h
@@ -1,6 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#ifdef _WASM_
+#include "emscripten.h"
+#endif // _WASM_
+
 class VarInt
 {
 public:
@@ -9,7 +14,15 @@ public:
         UIntNative lengthBits = *pbEncoding & 0x0F;
         size_t  negLength = s_negLengthTab[lengthBits];
         UIntNative shift = s_shiftTab[lengthBits];
-        UInt32 result = *(PTR_UInt32)(pbEncoding - negLength - 4);
+        UInt32 result = 
+#if !defined(_WASM_)
+            *(PTR_UInt32)
+#else // !WASM
+            // This can be an unaligned read, which would get corrupted in asm.js if 
+            // we don't 
+            *(emscripten_align1_int*)
+#endif // !WASM
+            (pbEncoding - negLength - 4);
 
         result >>= shift;
         pbEncoding -= negLength;

--- a/src/Native/Runtime/inc/varint.h
+++ b/src/Native/Runtime/inc/varint.h
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#ifdef _WASM_
-#include "emscripten.h"
-#endif // _WASM_
+#include "pal_endian.h"
 
 class VarInt
 {
@@ -14,15 +12,7 @@ public:
         UIntNative lengthBits = *pbEncoding & 0x0F;
         size_t  negLength = s_negLengthTab[lengthBits];
         UIntNative shift = s_shiftTab[lengthBits];
-        UInt32 result = 
-#if !defined(_WASM_)
-            *(PTR_UInt32)
-#else // !WASM
-            // This can be an unaligned read, which would get corrupted in asm.js if 
-            // we don't 
-            *(emscripten_align1_int*)
-#endif // !WASM
-            (pbEncoding - negLength - 4);
+        UInt32 result = GET_UNALIGNED_32(pbEncoding - negLength - 4);
 
         result >>= shift;
         pbEncoding -= negLength;

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -22,7 +22,7 @@ internal static class Program
         int tempInt = 0;
         int tempInt2 = 0;
         (*(&tempInt)) = 9;
-        if(tempInt == 9)
+        if (tempInt == 9)
         {
             PrintLine("Hello from C#!");
         }
@@ -30,12 +30,12 @@ internal static class Program
         int* targetAddr = (tempInt > 0) ? (&tempInt2) : (&tempInt);
 
         (*targetAddr) = 1;
-        if(tempInt2 == 1 && tempInt == 9)
+        if (tempInt2 == 1 && tempInt == 9)
         {
             PrintLine("basic block stack entry Test: Ok.");
         }
 
-        if(ILHelpers.ILHelpersTest.InlineAssignByte() == 100)
+        if (ILHelpers.ILHelpersTest.InlineAssignByte() == 100)
         {
             PrintLine("Inline assign byte Test: Ok.");
         }
@@ -45,7 +45,7 @@ internal static class Program
         }
 
         int dupTestInt = 9;
-        if(ILHelpers.ILHelpersTest.DupTest(ref dupTestInt) == 209 && dupTestInt == 209)
+        if (ILHelpers.ILHelpersTest.DupTest(ref dupTestInt) == 209 && dupTestInt == 209)
         {
             PrintLine("dup test: Ok.");
         }
@@ -68,20 +68,20 @@ internal static class Program
         {
             PrintLine("value type int field test: Ok.");
         }
-        
+
         staticInt = 5;
         if (staticInt == 5)
         {
             PrintLine("static int field test: Ok.");
         }
 
-        if(threadStaticInt == 0)
+        if (threadStaticInt == 0)
         {
             PrintLine("thread static int initial value field test: Ok.");
         }
 
         threadStaticInt = 9;
-        if(threadStaticInt == 9)
+        if (threadStaticInt == 9)
         {
             PrintLine("thread static int field test: Ok.");
         }
@@ -89,7 +89,7 @@ internal static class Program
         StaticCtorTest();
 
         var boxedInt = (object)tempInt;
-        if(((int)boxedInt) == 9)
+        if (((int)boxedInt) == 9)
         {
             PrintLine("box test: Ok.");
         }
@@ -98,7 +98,7 @@ internal static class Program
             PrintLine("box test: Failed. Value:");
             PrintLine(boxedInt.ToString());
         }
-        
+
         var boxedStruct = (object)new BoxStubTest { Value = "Boxed Stub Test: Ok." };
         PrintLine(boxedStruct.ToString());
 
@@ -143,7 +143,7 @@ internal static class Program
         {
             PrintLine("unsignedShift test: Ok.");
         }
-        
+
         var switchTest0 = SwitchOp(5, 5, 0);
         if (switchTest0 == 10)
         {
@@ -173,14 +173,14 @@ internal static class Program
 #endif
 
         Func<int> staticDelegate = StaticDelegateTarget;
-        if(staticDelegate() == 7)
+        if (staticDelegate() == 7)
         {
             PrintLine("Static delegate test: Ok.");
         }
 
         tempObj.TestInt = 8;
         Func<int> instanceDelegate = tempObj.InstanceDelegateTarget;
-        if(instanceDelegate() == 8)
+        if (instanceDelegate() == 8)
         {
             PrintLine("Instance delegate test: Ok.");
         }
@@ -189,7 +189,7 @@ internal static class Program
         virtualDelegate();
 
         var arrayTest = new BoxStubTest[] { new BoxStubTest { Value = "Hello" }, new BoxStubTest { Value = "Array" }, new BoxStubTest { Value = "Test" } };
-        foreach(var element in arrayTest)
+        foreach (var element in arrayTest)
             PrintLine(element.Value);
 
         arrayTest[1].Value = "Array load/store test: Ok.";
@@ -198,9 +198,9 @@ internal static class Program
         int ii = 0;
         arrayTest[ii++].Value = "dup ref test: Ok.";
         PrintLine(arrayTest[0].Value);
-        
+
         var largeArrayTest = new long[] { Int64.MaxValue, 0, Int64.MinValue, 0 };
-        if(largeArrayTest[0] == Int64.MaxValue &&
+        if (largeArrayTest[0] == Int64.MaxValue &&
             largeArrayTest[1] == 0 &&
             largeArrayTest[2] == Int64.MinValue &&
             largeArrayTest[3] == 0)
@@ -209,13 +209,15 @@ internal static class Program
         }
 
         var smallArrayTest = new long[] { Int16.MaxValue, 0, Int16.MinValue, 0 };
-        if(smallArrayTest[0] == Int16.MaxValue &&
+        if (smallArrayTest[0] == Int16.MaxValue &&
             smallArrayTest[1] == 0 &&
             smallArrayTest[2] == Int16.MinValue &&
             smallArrayTest[3] == 0)
         {
             PrintLine("Small array load/store test: Ok.");
         }
+
+        TestNonIntAlignedStructArray();
 
         IntPtr returnedIntPtr = NewobjValueType();
         if (returnedIntPtr.ToInt32() == 3)
@@ -247,7 +249,7 @@ internal static class Program
         PrintLine(((BoxStubTest[])arrayCastingTest)[1].Value);
         PrintLine(((BoxStubTest[])arrayCastingTest)[2].Value);
         if (!(arrayCastingTest is CastingTestClass[]))
-        {   
+        {
             PrintLine("Type casting with isinst & castclass to array test: Ok.");
         }
 
@@ -276,7 +278,7 @@ internal static class Program
         else
         {
             var toInt = (int)castedDouble;
-//            PrintLine("expected 1m, but was " + castedDouble.ToString());  // double.ToString is not compiling at the time of writing, but this would be better output
+            //            PrintLine("expected 1m, but was " + castedDouble.ToString());  // double.ToString is not compiling at the time of writing, but this would be better output
             PrintLine($"(double) cast test : Failed. Back to int on next line");
             PrintLine(toInt.ToString());
         }
@@ -316,7 +318,7 @@ internal static class Program
         TestConstrainedClassCalls();
 
         TestValueTypeElementIndexing();
-        
+
         TestArrayItfDispatch();
 
         // This test should remain last to get other results before stopping the debugger
@@ -328,7 +330,7 @@ internal static class Program
     }
 
     private static int StaticDelegateTarget()
-    {         
+    {
         return 7;
     }
 
@@ -345,7 +347,7 @@ internal static class Program
             }
         }
     }
-    
+
     public static void PrintLine(string s)
     {
         PrintString(s);
@@ -381,21 +383,21 @@ internal static class Program
     {
         return a >> b;
     }
-    
+
     private static int SwitchOp(int a, int b, int mode)
     {
-        switch(mode)
+        switch (mode)
         {
-          case 0:
-            return a + b;
-          case 1:
-            return a * b;
-          case 2:
-            return a / b;
-          case 3:
-            return a - b;
-          default:
-            return 0;
+            case 0:
+                return a + b;
+            case 1:
+                return a * b;
+            case 2:
+                return a / b;
+            case 3:
+                return a - b;
+            default:
+                return 0;
         }
     }
 
@@ -427,16 +429,16 @@ internal static class Program
     {
         var ldindTarget = new TwoByteStr { first = byte.MaxValue, second = byte.MinValue };
         var ldindField = &ldindTarget.first;
-        if((*ldindField) == byte.MaxValue)
+        if ((*ldindField) == byte.MaxValue)
         {
             ldindTarget.second = byte.MaxValue;
             *ldindField = byte.MinValue;
             //ensure there isnt any overwrite of nearby fields
-            if(ldindTarget.first == byte.MinValue && ldindTarget.second == byte.MaxValue)
+            if (ldindTarget.first == byte.MinValue && ldindTarget.second == byte.MaxValue)
             {
                 PrintLine("ldind test: Ok.");
             }
-            else if(ldindTarget.first != byte.MinValue)
+            else if (ldindTarget.first != byte.MinValue)
             {
                 PrintLine("ldind test: Failed didnt update target.");
             }
@@ -510,7 +512,7 @@ internal static class Program
             PrintLine("NonBeforeFieldInit test: Ok.");
         }
         else
-        { 
+        {
             PrintLine("NonBeforeFieldInitType cctor not run");
         }
     }
@@ -531,7 +533,7 @@ internal static class Program
             PrintString(stringDirectToString);
             PrintLine("\"");
         }
-       
+
         // Generic calls on methods not defined on object
         uint dataFromBase = GenericGetData<MyBase>(new MyBase(11));
         PrintString("Generic call to base class test: ");
@@ -647,6 +649,79 @@ internal static class Program
         else
         {
             PrintLine("Failed.");
+        }
+    }
+
+    struct OddLengthStruct
+    {
+        public UInt16 a, b, c;
+    }
+
+    private static unsafe void TestNonIntAlignedStructArray()
+    {
+        PrintString("Non-int aligned struct array: ");
+
+        OddLengthStruct firstOdd = new OddLengthStruct { a = 1, b = 2, c = 3 };
+        OddLengthStruct secondOdd = new OddLengthStruct { a = 4, b = 5, c = 6 };
+
+        OddLengthStruct[] someOddStructs = new OddLengthStruct[2];
+        someOddStructs[0] = firstOdd;
+        someOddStructs[1] = secondOdd;
+
+        bool success = true;
+        if (someOddStructs[0].a != 1 || someOddStructs[0].b != 2 || someOddStructs[0].c != 3)
+        {
+            PrintLine("Failed reading from first index");
+            success = false;
+        }
+        if (someOddStructs[1].a != 4 || someOddStructs[1].b != 5 || someOddStructs[1].c != 6)
+        {
+            PrintLine("Failed reading from second index");
+            success = false;
+        }
+
+        fixed (OddLengthStruct* pArrStart = someOddStructs)
+        {
+            UInt16* pArr = (ushort*)pArrStart;
+            for (int i = 0; i < 6; i++)
+            {
+                if (*pArr != i + 1)
+                {
+                    PrintLine("Failed reading as ushort pointer");
+                    success = false;
+                }
+                pArr++;
+            }
+        }
+
+        fixed (OddLengthStruct* pArrStart2 = someOddStructs)
+        {
+            byte* pArr2 = (byte*)pArrStart2;
+            for (int i = 0; i < 12; i++)
+            {
+                if (i % 2 == 0)
+                {
+                    if (*pArr2 != ((i / 2) + 1))
+                    {
+                        PrintLine("Failed reading as byte pointer");
+                        success = false;
+                    }
+                }
+                else
+                {
+                    if (*pArr2 != 0)
+                    {
+                        PrintLine("Failed reading as byte pointer");
+                        success = false;
+                    }
+                }
+                pArr2++;
+            }
+        }
+
+        if (success)
+        {
+            PrintLine("Ok.");
         }
     }
 


### PR DESCRIPTION
Asm.js does aligned memory accesses unless forced to do otherwise. This causes occasional memory corruption on various structures that aren't 4-byte aligned (two of which get used in interface dispatch). To handle that, this change:
1. Changes the LLVM representation of managed structs to approximately match the managed representation. This fixes DispatchMapEntry, which is 3 uint16s that can be 2-byte aligned.
2. Annotates an unaligned read used by OptionalFields so the compiler can handle it.