### PR TITLE
Unify available types; stop emitting precodes for method calls

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TypesTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TypesTableNode.cs
@@ -38,16 +38,21 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             VertexHashtable typesHashtable = new VertexHashtable();
             section.Place(typesHashtable);
 
+            HashSet<TypeDesc> uniqueTypes = new HashSet<TypeDesc>();
+
             foreach (TypeDesc type in ((ReadyToRunTableManager)factory.MetadataManager).GetTypesWithAvailableTypes())
             {
                 int rid = 0;
                 if (type.GetTypeDefinition() is EcmaType ecmaType)
                 {
-                    rid = MetadataTokens.GetToken(ecmaType.Handle) & 0x00FFFFFF;
-                    Debug.Assert(rid != 0);
+                    if (uniqueTypes.Add(ecmaType))
+                    {
+                        rid = MetadataTokens.GetToken(ecmaType.Handle) & 0x00FFFFFF;
+                        Debug.Assert(rid != 0);
 
-                    int hashCode = ReadyToRunHashCode.TypeTableHashCode(ecmaType);
-                    typesHashtable.Append(unchecked((uint)hashCode), section.Place(new UnsignedConstant((uint)rid << 1)));
+                        int hashCode = ReadyToRunHashCode.TypeTableHashCode(ecmaType);
+                        typesHashtable.Append(unchecked((uint)hashCode), section.Place(new UnsignedConstant((uint)rid << 1)));
+                    }
                 }
                 else if (type.IsArray || type.IsMdArray)
                 {

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -301,7 +301,7 @@ namespace ILCompiler.DependencyAnalysis
                 CorCompileImportType.CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH,
                 CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
                 (byte)Target.PointerSize,
-                emitPrecode: true);
+                emitPrecode: false);
             ImportSectionsTable.AddEmbeddedObject(MethodImports);
 
             DispatchImports = new ImportSectionNode(


### PR DESCRIPTION
This change contains two conservative CPAOT fixes for deficiencies
I discovered during debugging:

1) Unify available types - as we're using GetTypeDefinition(),
we may hit the same type multiple times for generic instantiations
over different arguments; we should emit such types only once
into the available type table.

2) Use delayed load helpers, not precodes, for resolving method
calls as it's generally cheaper (previously we had to emit the
precode fixups into each method calling a particular method)
and it's what Crossgen does.

Thanks

Tomas