### PR TITLE
CppCodeGen: fix emitting code for object node

### DIFF
--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
@@ -788,11 +788,11 @@ namespace ILCompiler.CppCodeGen
                 }
                 else
                 {
-                    i++;
                     if (i + 1 == nextRelocOffset || i + 1 == nodeData.Data.Length)
                     {
                         nodeDataSections.Add(new NodeDataSection(NodeDataSectionType.ByteData, (i + 1) - lastByteIndex));
                     }
+                    i++;
                 }
             }
 


### PR DESCRIPTION
This patch fixes problem with missing 1-byte data fields.