### PR TITLE
Limit exposure to delegate DynamicInvoke thunk

### DIFF
--- a/src/Common/src/TypeSystem/IL/DelegateInfo.cs
+++ b/src/Common/src/TypeSystem/IL/DelegateInfo.cs
@@ -124,7 +124,6 @@ namespace Internal.IL
         private MethodDesc _openStaticThunk;
         private MethodDesc _multicastThunk;
         private MethodDesc _closedStaticThunk;
-        private MethodDesc _invokeThunk;
         private MethodDesc _closedInstanceOverGeneric;
         private MethodDesc _reversePInvokeThunk;
         private MethodDesc _invokeObjectArrayThunk;
@@ -215,17 +214,6 @@ namespace Internal.IL
                     _openInstanceThunk = new DelegateInvokeOpenInstanceThunk(owningDelegate);
                 }
             }
-
-            //
-            // Check whether we have a dynamic invoke stub
-            //
-
-            if ((owningDelegate.SupportedFeatures & DelegateFeature.DynamicInvoke) != 0 &&
-                DynamicInvokeMethodThunk.SupportsSignature(delegateSignature))
-            {
-                var sig = new DynamicInvokeMethodSignature(delegateSignature);
-                _invokeThunk = owningDelegate.Type.Context.GetDynamicInvokeThunk(sig);
-            }
         }
 
         #region Temporary interop logic
@@ -289,8 +277,6 @@ namespace Internal.IL
                         return _multicastThunk;
                     case DelegateThunkKind.ClosedStaticThunk:
                         return _closedStaticThunk;
-                    case DelegateThunkKind.DelegateInvokeThunk:
-                        return _invokeThunk;
                     case DelegateThunkKind.ClosedInstanceThunkOverGenericMethod:
                         return _closedInstanceOverGeneric;
                     case DelegateThunkKind.ReversePinvokeThunk:


### PR DESCRIPTION
The DynamicInvoke thunk is special because they're shared with reflection invoke. They're not instance methods on delegate like the rest of the invoke thunks.

I noticed we were accidentally reporting them from `GetAllMethods` on delegate types even though they're not instance methods. Moving the handling of these to `DelegateThunks` to prevent exposure from places that don't expect them and limit the special casing to a single file (DelegateThunks was already special casing them).