### PR TITLE
Fix for trivial copy & paste typo in the signature builder

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -256,7 +256,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     return;
 
                 case TypeFlags.Double:
-                    EmitElementType(CorElementType.ELEMENT_TYPE_R4);
+                    EmitElementType(CorElementType.ELEMENT_TYPE_R8);
                     return;
 
                 case TypeFlags.Interface:


### PR DESCRIPTION
While analyzing the CoreCLR Top200 results I found a trivial bug
in the signature encoder - it ended up silently changing doubles
to floats causing weird issues in quite a few tests.

Thanks

Tomas