### PR TITLE
Fix reflection-rooting of generic virtual methods

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -414,10 +414,17 @@ namespace ILCompiler
             {
                 Debug.Assert(method.IsVirtual);
 
-                // Virtual method use is tracked on the slot defining method only.
-                MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
-                if (!_factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
-                    _graph.AddRoot(_factory.VirtualMethodUse(slotDefiningMethod), reason);
+                if (method.HasInstantiation)
+                {
+                    _graph.AddRoot(_factory.GVMDependencies(method), reason);
+                }
+                else
+                {
+                    // Virtual method use is tracked on the slot defining method only.
+                    MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                    if (!_factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
+                        _graph.AddRoot(_factory.VirtualMethodUse(slotDefiningMethod), reason);
+                }
 
                 if (method.IsAbstract)
                 {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
@@ -44,18 +44,7 @@ namespace Internal.Runtime.TypeLoader
                     return qTypeDefinition.NativeFormatHandle.GetFullName(qTypeDefinition.NativeFormatReader);
             }
 
-            result = "EEType:0x";
-            ulong num = (ulong)RuntimeAugments.GetPointerFromTypeHandle(rtth);
-
-            int shift = IntPtr.Size * 8;
-            const string HexDigits = "0123456789ABCDEF";
-            while (shift > 0)
-            {
-                shift -= 4;
-                int digit = (int)((num >> shift) & 0xF);
-                result += HexDigits[digit];
-            }
-            return result;
+            return rtth.LowLevelToStringRawEETypeAddress();
         }
 #endif
 
@@ -522,7 +511,19 @@ namespace Internal.Runtime.TypeLoader
 
                     if (!TryGetGenericVirtualMethodPointer(targetTypeHandle, targetMethodNameAndSignature, genericArguments, out methodPointer, out dictionaryPointer))
                     {
-                        Environment.FailFast("GVM method pointer lookup failure");
+                        var sb = new System.Text.StringBuilder();
+                        sb.AppendLine("Generic virtual method pointer lookup failure.");
+                        sb.AppendLine();
+                        sb.AppendLine("Declaring type handle: " + declaringType.LowLevelToStringRawEETypeAddress());
+                        sb.AppendLine("Target type handle: " + targetTypeHandle.LowLevelToStringRawEETypeAddress());
+                        sb.AppendLine("Method name: " + targetMethodNameAndSignature.Name);
+                        sb.AppendLine("Instantiation:");
+                        for (int i = 0; i < genericArguments.Length; i++)
+                        {
+                            sb.AppendLine("  Argument " + i.LowLevelToString() + ": " + genericArguments[i].LowLevelToStringRawEETypeAddress());
+                        }
+
+                        Environment.FailFast(sb.ToString());
                     }
 
                     return true;


### PR DESCRIPTION
Referencing a generic virtual method from RD.XML didn't result in it being tracked as a generic virtual method in the dependency system (in fact, Debug version of the compiler was hitting an assert because we tried to track it as a normal virtual method).

I'm also improving the resolution failure `FailFast` message to be more useful.

Fixes #6478.