### PR TITLE
Initial support for cross-module signatures; improving method signatures

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
@@ -22,6 +22,10 @@ namespace ILCompiler
     public abstract class CompilationModuleGroup
     {
         /// <summary>
+        /// If true, "module" is in the set of input assemblies being compiled
+        /// </summary>
+        public abstract bool ContainsModule(ModuleDesc module);
+        /// <summary>
         /// If true, "type" is in the set of input assemblies being compiled
         /// </summary>
         public abstract bool ContainsType(TypeDesc type);

--- a/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MultiFileCompilationModuleGroup.cs
@@ -24,6 +24,11 @@ namespace ILCompiler
             _compilationModuleSet.Add(context.GeneratedAssembly);
         }
 
+        public sealed override bool ContainsModule(ModuleDesc moduleDesc)
+        {
+            return _compilationModuleSet.Contains(moduleDesc);
+        }
+
         public sealed override bool ContainsType(TypeDesc type)
         {
             EcmaType ecmaType = type as EcmaType;

--- a/src/ILCompiler.Compiler/src/Compiler/SingleFileCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleFileCompilationModuleGroup.cs
@@ -10,6 +10,11 @@ namespace ILCompiler
 {
     public class SingleFileCompilationModuleGroup : CompilationModuleGroup
     {
+        public sealed override bool ContainsModule(ModuleDesc module)
+        {
+            return false;
+        }
+
         public override bool ContainsType(TypeDesc type)
         {
             return true;

--- a/src/ILCompiler.Compiler/src/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 
 using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler
 {
@@ -27,6 +28,11 @@ namespace ILCompiler
             {
                 return false;
             }
+        }
+
+        public sealed override bool ContainsModule(ModuleDesc module)
+        {
+            return _method.GetTypicalMethodDefinition() is EcmaMethod ecmaMethod && ecmaMethod.Module == module;
         }
 
         public override bool ContainsMethodBody(MethodDesc method, bool unboxingStub)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
@@ -40,8 +40,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
-            // This needs to be an empty target pointer since it will be filled in with Module*
-            // when loaded by CoreCLR
+            // Initially the DelayLoadHelper import cell points at a generated assembly thunk.
             dataBuilder.EmitReloc(_delayLoadHelper,
                 factory.Target.PointerSize == 4 ? RelocType.IMAGE_REL_BASED_HIGHLOW : RelocType.IMAGE_REL_BASED_DIR64);
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
@@ -13,8 +13,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         private readonly MethodDesc _methodDesc;
 
-        private readonly SignatureContext _signatureContext;
-
         public ExternalMethodImport(
             ReadyToRunCodegenNodeFactory factory,
             ReadyToRunFixupKind fixupKind,
@@ -37,7 +35,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                       isInstantiatingStub: false))
         {
             _methodDesc = methodDesc;
-            _signatureContext = signatureContext;
         }
 
         public MethodDesc Method => _methodDesc;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
@@ -251,6 +251,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         READYTORUN_HELPER_FLAG_VSD = 0x10000000,
     }
 
+    [Flags]
     public enum CorElementType : byte
     {
         ELEMENT_TYPE_END = 0,
@@ -291,6 +292,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         ELEMENT_TYPE_HANDLE = 64,
         ELEMENT_TYPE_SENTINEL = 65,
-        ELEMENT_TYPE_PINNED = 69
+        ELEMENT_TYPE_PINNED = 69,
+
+        ELEMENT_TYPE_MODULE_OVERRIDE = 128,  // Followed by encoded uint representing the "other module" indirection cell
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -52,11 +52,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 {
                     int methodIndex = r2rFactory.RuntimeFunctionsTable.GetIndex(method);
 
+                    ModuleToken token = method.MethodToken;
+                    if (token.TokenType != Internal.JitInterface.CorTokenType.mdtMethodDef)
+                    {
+                        token = default(ModuleToken);
+                    }
+
                     ArraySignatureBuilder signatureBuilder = new ArraySignatureBuilder();
                     signatureBuilder.EmitMethodSignature(
                         method.Method, 
                         constrainedType: null,
-                        default(ModuleToken),
+                        methodToken: token,
                         enforceDefEncoding: true,
                         method.SignatureContext,
                         isUnboxingStub: false, 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/LocalMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/LocalMethodImport.cs
@@ -19,6 +19,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ReadyToRunCodegenNodeFactory factory,
             ReadyToRunFixupKind fixupKind,
             MethodWithGCInfo localMethod,
+            TypeDesc constrainedType,
+            ModuleToken methodToken,
             bool isUnboxingStub,
             SignatureContext signatureContext)
             : base(
@@ -28,8 +30,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                   factory.MethodSignature(
                       fixupKind,
                       localMethod.Method,
-                      constrainedType: null,
-                      methodToken: default(ModuleToken),
+                      constrainedType: constrainedType,
+                      methodToken: methodToken,
                       signatureContext,
                       isUnboxingStub,
                       isInstantiatingStub: false))
@@ -45,9 +47,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            foreach (DependencyListEntry entry in base.GetStaticDependencies(factory))
+            foreach (DependencyListEntry baseEntry in base.GetStaticDependencies(factory))
             {
-                yield return entry;
+                yield return baseEntry;
             }
             yield return new DependencyListEntry(_localMethod, "Local method import");
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -57,7 +57,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             foreach (MethodWithGCInfo method in r2rFactory.EnumerateCompiledMethods())
             {
-                if (method.Method is EcmaMethod ecmaMethod)
+                if (method.Method is EcmaMethod ecmaMethod && ecmaMethod.Module == r2rFactory.InputModuleContext.Module)
                 {
                     // Strip away the token type bits, keep just the low 24 bits RID
                     uint rid = SignatureBuilder.RidFromToken((mdToken)MetadataTokens.GetToken(ecmaMethod.Handle));

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -18,6 +18,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         public readonly MethodGCInfoNode GCInfoNode;
 
+        public readonly ModuleToken MethodToken;
+
         private readonly MethodDesc _method;
         public SignatureContext SignatureContext { get; }
 
@@ -29,9 +31,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private NativeVarInfo[] _debugVarInfos;
         private DebugEHClauseInfo[] _debugEHClauseInfos;
 
-        public MethodWithGCInfo(MethodDesc methodDesc, SignatureContext signatureContext)
+        public MethodWithGCInfo(MethodDesc methodDesc, ModuleToken methodToken, SignatureContext signatureContext)
         {
             GCInfoNode = new MethodGCInfoNode(this);
+            MethodToken = methodToken;
+
             _method = methodDesc;
             SignatureContext = signatureContext;
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleImportSectionNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleImportSectionNode.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class ModuleImportSectionNode : ImportSectionNode
+    {
+        public List<uint> ModuleCells { get; } = new List<uint>();
+
+        private readonly byte _pointerSize;
+
+        public ModuleImportSectionNode(byte pointerSize)
+            : base("ModuleImports", CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN, CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_EAGER, pointerSize, false)
+        {
+            _pointerSize = pointerSize;
+        }
+
+        public int AddModuleCell(ushort assemblyRowid, ushort moduleRowid)
+        {
+            int index = ModuleCells.Count;
+            ModuleCells.Add(assemblyRowid | ((uint)moduleRowid << 16));
+            return index;
+        }
+
+        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            foreach(uint cell in ModuleCells)
+            {
+                dataBuilder.EmitUInt(cell);
+                dataBuilder.EmitZeros(_pointerSize - sizeof(uint));
+            }
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleToken.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleToken.cs
@@ -78,7 +78,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public SignatureContext SignatureContext(ModuleTokenResolver resolver)
         {
-            return new SignatureContext(resolver);
+            return new SignatureContext(resolver, Module);
         }
 
         public MetadataReader MetadataReader => Module.PEReader.GetMetadataReader();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -29,19 +29,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly Dictionary<FieldDesc, ModuleToken> _fieldToRefTokens = new Dictionary<FieldDesc, ModuleToken>();
 
-        private readonly CompilationModuleGroup _compilationModuleGroup;
+        private readonly ReadyToRunCodegenNodeFactory _nodeFactory;
 
         private readonly CompilerTypeSystemContext _typeSystemContext;
 
-        public ModuleTokenResolver(CompilationModuleGroup compilationModuleGroup, CompilerTypeSystemContext typeSystemContext)
+        public ModuleTokenResolver(ReadyToRunCodegenNodeFactory nodeFactory, CompilerTypeSystemContext typeSystemContext)
         {
-            _compilationModuleGroup = compilationModuleGroup;
+            _nodeFactory = nodeFactory;
             _typeSystemContext = typeSystemContext;
         }
 
         public ModuleToken GetModuleTokenForType(EcmaType type, bool throwIfNotFound = true)
         {
-            if (_compilationModuleGroup.ContainsType(type))
+            if (_nodeFactory.CompilationModuleGroup.ContainsType(type))
             {
                 return new ModuleToken(type.EcmaModule, (mdToken)MetadataTokens.GetToken(type.Handle));
             }
@@ -65,7 +65,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public ModuleToken GetModuleTokenForMethod(MethodDesc method, bool throwIfNotFound = true)
         {
-            if (_compilationModuleGroup.ContainsMethodBody(method, unboxingStub: false) &&
+            if (_nodeFactory.CompilationModuleGroup.ContainsMethodBody(method, unboxingStub: false) &&
                 method is EcmaMethod ecmaMethod)
             {
                 return new ModuleToken(ecmaMethod.Module, ecmaMethod.Handle);
@@ -84,7 +84,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public ModuleToken GetModuleTokenForField(FieldDesc field, bool throwIfNotFound = true)
         {
-            if (_compilationModuleGroup.ContainsType(field.OwningType) && field is EcmaField ecmaField)
+            if (_nodeFactory.CompilationModuleGroup.ContainsType(field.OwningType) && field is EcmaField ecmaField)
             {
                 return new ModuleToken(ecmaField.Module, ecmaField.Handle);
             }
@@ -97,6 +97,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 return default(ModuleToken);
             }
+        }
+
+        public int GetModuleIndex(EcmaModule module)
+        {
+            return _nodeFactory.ModuleIndex(module);
         }
 
         public void AddModuleTokenForMethod(MethodDesc method, ModuleToken token)
@@ -125,7 +130,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public void AddModuleTokenForField(FieldDesc field, ModuleToken token)
         {
-            if (_compilationModuleGroup.ContainsType(field.OwningType))
+            if (_nodeFactory.CompilationModuleGroup.ContainsType(field.OwningType))
             {
                 // We don't need to store handles within the current compilation group
                 // as we can read them directly from the ECMA objects.
@@ -154,7 +159,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 specialTypeFound = true;
             }
 
-            if (_compilationModuleGroup.ContainsType(type))
+            if (_nodeFactory.CompilationModuleGroup.ContainsType(type))
             {
                 // We don't need to store handles within the current compilation group
                 // as we can read them directly from the ECMA objects.

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
@@ -15,11 +15,23 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class SignatureContext
     {
+        /// <summary>
+        /// Token resolver is used to translate typesystem objects into tokens relative to 
+        /// input modules within the versioning bubble. We must not hardcode tokens relative
+        /// to modules outside of version bubble as these can change arbitrarily.
+        /// </summary>
         private readonly ModuleTokenResolver _resolver;
 
-        public SignatureContext(ModuleTokenResolver resolver)
+        /// <summary>
+        /// Default context module for signatures. When encoding a type in a different
+        /// assembly (within the same version bubble), we must use module override.
+        /// </summary>
+        private readonly EcmaModule _contextModule;
+
+        public SignatureContext(ModuleTokenResolver resolver, EcmaModule contextModule)
         {
             _resolver = resolver;
+            _contextModule = contextModule;
         }
 
         public ModuleToken GetModuleTokenForType(EcmaType type, bool throwIfNotFound = true)
@@ -36,5 +48,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             return _resolver.GetModuleTokenForField(field, throwIfNotFound);
         }
+
+        public int GetModuleIndex(EcmaModule targetModule)
+        {
+            if (targetModule == _contextModule)
+            {
+                return -1;
+            }
+            return _resolver.GetModuleIndex(targetModule);
+        }
+
+        public EcmaModule Module => _contextModule;
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TypesTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TypesTableNode.cs
@@ -32,6 +32,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (relocsOnly)
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
 
+            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             NativeWriter writer = new NativeWriter();
             Section section = writer.NewSection();
 
@@ -45,7 +46,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 int rid = 0;
                 if (type.GetTypeDefinition() is EcmaType ecmaType)
                 {
-                    if (uniqueTypes.Add(ecmaType))
+                    if (ecmaType.EcmaModule == r2rFactory.InputModuleContext.Module && uniqueTypes.Add(ecmaType))
                     {
                         rid = MetadataTokens.GetToken(ecmaType.Handle) & 0x00FFFFFF;
                         Debug.Assert(rid != 0);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -681,7 +681,7 @@ namespace ILCompiler.DependencyAnalysis
                 return LookupKind == other.LookupKind &&
                     FixupKind == other.FixupKind &&
                     RuntimeDeterminedTypeHelper.Equals(TypeArgument, other.TypeArgument) &&
-                    MethodArgument == other.MethodArgument &&
+                    RuntimeDeterminedTypeHelper.Equals(MethodArgument?.Method ?? null, other.MethodArgument?.Method ?? null) &&
                     ContextType == other.ContextType;
             }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -75,9 +75,6 @@ namespace ILCompiler
         {
             var interopStubManager = new EmptyInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
 
-            ModuleTokenResolver moduleTokenResolver = new ModuleTokenResolver(_compilationGroup, _context);
-            SignatureContext signatureContext = new SignatureContext(moduleTokenResolver);
-
             ReadyToRunCodegenNodeFactory factory = new ReadyToRunCodegenNodeFactory(
                 _context,
                 _compilationGroup,
@@ -86,8 +83,7 @@ namespace ILCompiler
                 _nameMangler,
                 _vtableSliceProvider,
                 _dictionaryLayoutProvider,
-                moduleTokenResolver,
-                signatureContext);
+                _inputModule);
 
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -23,6 +23,11 @@ namespace ILCompiler
             _compilationModuleSet.Add(context.GeneratedAssembly);
         }
 
+        public sealed override bool ContainsModule(ModuleDesc module)
+        {
+            return _compilationModuleSet.Contains(module);
+        }
+
         public sealed override bool ContainsType(TypeDesc type)
         {
             if (type is EcmaType ecmaType)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/RuntimeDeterminedTypeHelper.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/RuntimeDeterminedTypeHelper.cs
@@ -41,6 +41,11 @@ namespace ILCompiler
                 return true;
             }
 
+            if (type1 == null || type2 == null)
+            {
+                return type1 == null && type2 == null;
+            }
+
             RuntimeDeterminedType runtimeDeterminedType1 = type1 as RuntimeDeterminedType;
             RuntimeDeterminedType runtimeDeterminedType2 = type2 as RuntimeDeterminedType;
             if (runtimeDeterminedType1 != null || runtimeDeterminedType2 != null)
@@ -68,6 +73,12 @@ namespace ILCompiler
             {
                 return true;
             }
+
+            if (method1 == null || method2 == null)
+            {
+                return method1 == null && method2 == null;
+            }
+
             if (!Equals(method1.OwningType, method2.OwningType) ||
                 method1.Signature.Length != method2.Signature.Length ||
                 !Equals(method1.Instantiation, method2.Instantiation) ||
@@ -184,6 +195,7 @@ namespace ILCompiler
             WriteTo(method.Signature.ReturnType, sb);
             sb.Append(" ");
             WriteTo(method.OwningType, sb);
+            sb.Append(".");
             sb.Append(method.Name);
             if (method.HasInstantiation)
             {

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodGCInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodWithGCInfo.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ModuleImportSectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ModuleToken.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ModuleTokenResolver.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\NewArrayFixupSignature.cs" />

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -53,7 +53,7 @@ namespace Internal.JitInterface
         {
             _compilation = compilation;
             _tokenContext = tokenContext;
-            _signatureContext = new SignatureContext(_compilation.NodeFactory.Resolver);
+            _signatureContext = new SignatureContext(_compilation.NodeFactory.Resolver, _tokenContext);
         }
 
         public void CompileMethod(IReadyToRunMethodCodeNode methodCodeNodeNeedingCode)


### PR DESCRIPTION
This change lays down the preparatory framework for support of
cross-module signatures. Sadly these don't yet fully work at the
CoreCLR side so this will be somewhat tricky to pull off in sync
with Andon working on the CoreCLR-side support.

The change also contains a bunch of fixes related to my somewhat
improved understanding of constrained type calls. It looks like
in some cases these are used to call instance methods on valuetypes
where the eetype is separated from the actual instance value.
In light of this fact I had to put back the constrained type info
even to the LocalMethodImport class.

Thanks

Tomas

P.S. CoreCLR Pri#0 tests report 419 errors or 82% pass rate with
this change and with inclusion of the the CoreCLR runtime fix
regarding Module::GetModuleFromIndex I described 
in the CPAOT planning e-mail.