### PR TITLE
Change the load expression to extend to double when stored typed is float and the requested a double

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -456,11 +456,6 @@ namespace Internal.IL
 
         protected override LLVMValueRef ValueAsTypeInternal(LLVMTypeRef type, LLVMBuilderRef builder, bool signExtend)
         {
-            if (Type.IsWellKnownType(WellKnownType.Single) && type.TypeKind == LLVMTypeKind.LLVMDoubleTypeKind)
-            {
-                var loadedVal = ILImporter.LoadValue(builder, RawLLVMValue, Type, LLVMTypeRef.FloatType(), signExtend, $"fpext_Load{Name}");
-                return LLVM.BuildFPExt(builder, loadedVal, type, $"fpext{Name}");
-            }
             return ILImporter.LoadValue(builder, RawLLVMValue, Type, type, signExtend, $"Load{Name}");
         }
     }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -456,6 +456,11 @@ namespace Internal.IL
 
         protected override LLVMValueRef ValueAsTypeInternal(LLVMTypeRef type, LLVMBuilderRef builder, bool signExtend)
         {
+            if (Type.IsWellKnownType(WellKnownType.Single) && type.TypeKind == LLVMTypeKind.LLVMDoubleTypeKind)
+            {
+                var loadedVal = ILImporter.LoadValue(builder, RawLLVMValue, Type, LLVMTypeRef.FloatType(), signExtend, $"fpext_Load{Name}");
+                return LLVM.BuildFPExt(builder, loadedVal, type, $"fpext{Name}");
+            }
             return ILImporter.LoadValue(builder, RawLLVMValue, Type, type, signExtend, $"Load{Name}");
         }
     }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -558,7 +558,7 @@ namespace Internal.IL
                 LLVMValueRef loadValueRef = CastIfNecessaryAndLoad(builder, address, underlyingSourceType, loadName);
                 return CastIntValue(builder, loadValueRef, targetType, signExtend);
             }
-            else if (targetType.TypeKind == LLVMTypeKind.LLVMDoubleTypeKind && underlyingSourceType.IsPrimitive && !underlyingSourceType.IsPointer)
+            else if (targetType.TypeKind == LLVMTypeKind.LLVMDoubleTypeKind)
             {
                 LLVMValueRef loadValueRef = CastIfNecessaryAndLoad(builder, address, underlyingSourceType, loadName);
                 return CastDoubleValue(builder, loadValueRef, targetType);

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -555,15 +555,26 @@ namespace Internal.IL
             var underlyingSourceType = sourceType.UnderlyingType;
             if (targetType.TypeKind == LLVMTypeKind.LLVMIntegerTypeKind && underlyingSourceType.IsPrimitive && !underlyingSourceType.IsPointer)
             {
-                var sourceLLVMType = ILImporter.GetLLVMTypeForTypeDesc(underlyingSourceType);
-                var typedAddress = CastIfNecessary(builder, address, LLVM.PointerType(sourceLLVMType, 0));
-                return CastIntValue(builder, LLVM.BuildLoad(builder, typedAddress, loadName ?? "ldvalue"), targetType, signExtend);
+                LLVMValueRef loadValueRef = CastIfNecessaryAndLoad(builder, address, underlyingSourceType, loadName);
+                return CastIntValue(builder, loadValueRef, targetType, signExtend);
+            }
+            else if (targetType.TypeKind == LLVMTypeKind.LLVMDoubleTypeKind && underlyingSourceType.IsPrimitive && !underlyingSourceType.IsPointer)
+            {
+                LLVMValueRef loadValueRef = CastIfNecessaryAndLoad(builder, address, underlyingSourceType, loadName);
+                return CastDoubleValue(builder, loadValueRef, targetType);
             }
             else
             {
                 var typedAddress = CastIfNecessary(builder, address, LLVM.PointerType(targetType, 0));
                 return LLVM.BuildLoad(builder, typedAddress, loadName ?? "ldvalue");
             }
+        }
+
+        private static LLVMValueRef CastIfNecessaryAndLoad(LLVMBuilderRef builder, LLVMValueRef address, TypeDesc sourceTypeDesc, string loadName)
+        {
+            LLVMTypeRef sourceLLVMType = ILImporter.GetLLVMTypeForTypeDesc(sourceTypeDesc);
+            LLVMValueRef typedAddress = CastIfNecessary(builder, address, LLVM.PointerType(sourceLLVMType, 0));
+            return LLVM.BuildLoad(builder, typedAddress, loadName ?? "ldvalue");
         }
 
         private static LLVMValueRef CastIntValue(LLVMBuilderRef builder, LLVMValueRef value, LLVMTypeRef type, bool signExtend)
@@ -601,6 +612,16 @@ namespace Internal.IL
                 Debug.Assert(typeKind == LLVMTypeKind.LLVMIntegerTypeKind);
                 return LLVM.BuildIntCast(builder, value, type, "intcast");
             }
+        }
+
+        private static LLVMValueRef CastDoubleValue(LLVMBuilderRef builder, LLVMValueRef value, LLVMTypeRef type)
+        {
+            if (LLVM.TypeOf(value).Pointer == type.Pointer)
+            {
+                return value;
+            }
+            Debug.Assert(LLVM.TypeOf(value).TypeKind == LLVMTypeKind.LLVMFloatTypeKind);
+            return LLVM.BuildFPExt(builder, value, type, "fpext");
         }
 
         private LLVMValueRef LoadVarAddress(int index, LocalVarKind kind, out TypeDesc type)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -267,35 +267,7 @@ internal static class Program
         if (testMdArrayInstantiation != null && testMdArrayInstantiation.GetLength(0) == 2 && testMdArrayInstantiation.GetLength(1) == 2)
             PrintLine("Multi-dimension array instantiation test: Ok.");
 
-        int intToCast = 1;
-        double castedDouble = (double)intToCast;
-        if (castedDouble == 1d)
-        {
-            PrintLine("(double) cast test: Ok.");
-        }
-        else
-        {
-            var toInt = (int)castedDouble;
-//            PrintLine("expected 1m, but was " + castedDouble.ToString());  // double.ToString is not compiling at the time of writing, but this would be better output
-            PrintLine($"(double) cast test : Failed. Back to int on next line");
-            PrintLine(toInt.ToString());
-        }
-
-        if (1f < 2d && 1d < 2f && 1f == 1d)
-        {
-            PrintLine("different width float comparisons: Ok.");
-        }
-
-        // floats are 7 digits precision, so check some double more precise to make sure there is no loss occurring through some inadvertent cast to float
-        if (10.23456789d != 10.234567891d)
-        {
-            PrintLine("double precision comparison: Ok.");
-        }
-
-        if (12.34567f == 12.34567f && 12.34567f != 12.34568f)
-        {
-            PrintLine("float comparison: Ok.");
-        }
+        floatDoubleTest();
 
         // Create a ByReference<char> through the ReadOnlySpan ctor and call the ByReference.Value via the indexer.
         var span = "123".AsSpan();
@@ -641,6 +613,50 @@ internal static class Program
         var chars = new[] { 'i', 'p', 's', 'u', 'm' };
         PrintString("Value type element indexing: ");
         if (chars[0] == 'i' && chars[1] == 'p' && chars[2] == 's' && chars[3] == 'u' && chars[4] == 'm')
+        {
+            PrintLine("Ok.");
+        }
+        else
+        {
+            PrintLine("Failed.");
+        }
+    }
+
+    private static void floatDoubleTest()
+    {
+        int intToCast = 1;
+        double castedDouble = (double)intToCast;
+        if (castedDouble == 1d)
+        {
+            PrintLine("(double) cast test: Ok.");
+        }
+        else
+        {
+            var toInt = (int)castedDouble;
+            //            PrintLine("expected 1m, but was " + castedDouble.ToString());  // double.ToString is not compiling at the time of writing, but this would be better output
+            PrintLine($"(double) cast test : Failed. Back to int on next line");
+            PrintLine(toInt.ToString());
+        }
+
+        if (1f < 2d && 1d < 2f && 1f == 1d)
+        {
+            PrintLine("different width float comparisons: Ok.");
+        }
+
+        // floats are 7 digits precision, so check some double more precise to make sure there is no loss occurring through some inadvertent cast to float
+        if (10.23456789d != 10.234567891d)
+        {
+            PrintLine("double precision comparison: Ok.");
+        }
+
+        if (12.34567f == 12.34567f && 12.34567f != 12.34568f)
+        {
+            PrintLine("float comparison: Ok.");
+        }
+
+        PrintString("Test comparison of float constant: ");
+        var maxFloat = Single.MaxValue;
+        if (maxFloat == Single.MaxValue)
         {
             PrintLine("Ok.");
         }

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -267,7 +267,7 @@ internal static class Program
         if (testMdArrayInstantiation != null && testMdArrayInstantiation.GetLength(0) == 2 && testMdArrayInstantiation.GetLength(1) == 2)
             PrintLine("Multi-dimension array instantiation test: Ok.");
 
-        floatDoubleTest();
+        FloatDoubleTest();
 
         // Create a ByReference<char> through the ReadOnlySpan ctor and call the ByReference.Value via the indexer.
         var span = "123".AsSpan();
@@ -622,7 +622,7 @@ internal static class Program
         }
     }
 
-    private static void floatDoubleTest()
+    private static void FloatDoubleTest()
     {
         int intToCast = 1;
         double castedDouble = (double)intToCast;
@@ -664,6 +664,18 @@ internal static class Program
         {
             PrintLine("Failed.");
         }
+
+        PrintString("Test comparison of double constant: ");
+        var maxDouble = Double.MaxValue;
+        if (maxDouble == Double.MaxValue)
+        {
+            PrintLine("Ok.");
+        }
+        else
+        {
+            PrintLine("Failed.");
+        }
+
     }
 
     [DllImport("*")]


### PR DESCRIPTION
Fixes #6500 

This extend floats to doubles when doing comparisons such as ceq.  Previously it was bit stuffing the float into a double.

@morganbr Not sure what you'll think of this? It changes the LLVM for the load expression to:
```
  store float 0x47EFFFFFE0000000, float* %maxFloat_local2_, !dbg !6860
  %fpext_Loadloc2_ = load float, float* %maxFloat_local2_, !dbg !6861
  %fpextloc2_ = fpext float %fpext_Loadloc2_ to double, !dbg !6861
  %ceq13 = fcmp oeq double %fpextloc2_, 0x47EFFFFFE0000000, !dbg !6861
```
Which looks fine and passes the tests.  Its not efficient if both operands are floats (like here) as we could presumably just do `fcmp oeq float` but there's no specific enum entry for `StackValueKind` for a single float as opposed to a double.  It could be done differently by pushing this into `ILImporter.ImportCompareOperation` and having some conditional logic depending on the widths and types of the operands which is what I started with but then I thought "why do I need this for floats when there's nothing here for ints/longs?".
