### PR TITLE
Maintain "one assembly = one version bubble" per JanK's suggestion

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -207,9 +207,10 @@ See the LICENSE file in the project root for more information.
     </ItemGroup>
 
     <ItemGroup Condition="'$(NativeCodeGen)' == 'readytorun'">
+      <IlcCompileInput2 Include="@(IlcCompileInput)" />
       <IlcCmd Include="@(IlcCompileInput)">
         <ResponseFileName>%(IlcCompileInput.FileName).ilc.rsp</ResponseFileName>
-        <CommandLine>%(IlcCompileInput.Identity);-o:$(NativeIntermediateOutputPath)%(IlcCompileInput.Filename).ni%(IlcCompileInput.Extension);@(IlcArg)</CommandLine>
+        <CommandLine>%(IlcCompileInput.Identity);@(IlcCompileInput2 -> '-r:%(Identity);');-o:$(NativeIntermediateOutputPath)%(IlcCompileInput.Filename).ni%(IlcCompileInput.Extension);@(IlcArg)</CommandLine>
       </IlcCmd>
     </ItemGroup>
 

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -207,6 +207,8 @@ See the LICENSE file in the project root for more information.
     </ItemGroup>
 
     <ItemGroup Condition="'$(NativeCodeGen)' == 'readytorun'">
+      <!-- We need to copy the item group under a different name so that we can -->
+      <!-- expand it within each iteration of the top loop over @(IlcCompileInput) -->
       <IlcCompileInput2 Include="@(IlcCompileInput)" />
       <IlcCmd Include="@(IlcCompileInput)">
         <ResponseFileName>%(IlcCompileInput.FileName).ilc.rsp</ResponseFileName>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -175,16 +175,18 @@ See the LICENSE file in the project root for more information.
       Outputs="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
+    <PropertyGroup>
+      <ManagedBinaryFilename>%(ManagedBinary.Filename)</ManagedBinaryFilename>
+    </PropertyGroup>
+
     <ItemGroup>
-      <IlcArg Include="@(IlcCompileInput)" />
-      <IlcArg Include="-o:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)" />
       <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
-      <IlcArg Condition="$(IlcGenerateMetadataLog) == 'true'" Include="--metadatalog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).metadata.csv" />
+      <IlcArg Condition="$(IlcGenerateMetadataLog) == 'true'" Include="--metadatalog:$(NativeIntermediateOutputPath)$(ManagedBinaryFilename).metadata.csv" />
       <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
       <IlcArg Condition="$(DebugSymbols) == 'true'" Include="-g" />
-      <IlcArg Condition="$(IlcGenerateMapFile) == 'true'" Include="--map:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).map.xml" />
+      <IlcArg Condition="$(IlcGenerateMapFile) == 'true'" Include="--map:$(NativeIntermediateOutputPath)$(ManagedBinaryFilename).map.xml" />
       <IlcArg Include="@(RdXmlFile->'--rdxml:%(Identity)')" />
       <IlcArg Condition="$(OutputType) == 'Library' and $(NativeLib) != ''" Include="--nativelib" />
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
@@ -196,13 +198,28 @@ See the LICENSE file in the project root for more information.
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />
-    <WriteLinesToFile File="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp" Lines="@(IlcArg)" Overwrite="true" />
+
+    <ItemGroup Condition="'$(NativeCodeGen)' != 'readytorun'">
+      <IlcCmd Include="$(ManagedBinaryFilename)">
+        <ResponseFileName>$(ManagedBinaryFilename).ilc.rsp</ResponseFileName>
+        <CommandLine>@(IlcCompileInput);-o:$(NativeIntermediateOutputPath)$(ManagedBinaryFilename)$(IlcOutputFileExt);@(IlcArg)</CommandLine>
+      </IlcCmd>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(NativeCodeGen)' == 'readytorun'">
+      <IlcCmd Include="@(IlcCompileInput)">
+        <ResponseFileName>%(IlcCompileInput.FileName).ilc.rsp</ResponseFileName>
+        <CommandLine>%(IlcCompileInput.Identity);-o:$(NativeIntermediateOutputPath)%(IlcCompileInput.Filename).ni%(IlcCompileInput.Extension);@(IlcArg)</CommandLine>
+      </IlcCmd>
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)%(IlcCmd.ResponseFileName)" Lines="%(IlcCmd.CommandLine)" Overwrite="true" />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeObject)))" />
 
     <Message Text="Generating native code" Importance="high" />
 
-    <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;" />
+    <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(IlcCmd.ResponseFileName)&quot;" />
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Windows.props" Condition="'$(TargetOS)' == 'Windows_NT'" />

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -104,6 +104,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (token.TokenType == CorTokenType.mdtMethodSpec)
             {
                 MethodSpecification methodSpec = token.MetadataReader.GetMethodSpecification((MethodSpecificationHandle)token.Handle);
+                methodSpec.DecodeSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
                 token = new ModuleToken(token.Module, methodSpec.Method);
             }
             if (token.TokenType == CorTokenType.mdtMemberRef)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -110,6 +110,11 @@ namespace ILCompiler.DependencyAnalysis
             SignatureContext signatureContext, 
             bool isUnboxingStub = false)
         {
+            if (targetMethod == originalMethod)
+            {
+                constrainedType = null;
+            }
+
             if (!CompilationModuleGroup.ContainsMethodBody(targetMethod, false))
             {
                 return ImportedMethodNode(constrainedType != null ? originalMethod : targetMethod, constrainedType, methodToken, signatureContext, isUnboxingStub);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -681,7 +681,7 @@ namespace ILCompiler.DependencyAnalysis
                 return LookupKind == other.LookupKind &&
                     FixupKind == other.FixupKind &&
                     RuntimeDeterminedTypeHelper.Equals(TypeArgument, other.TypeArgument) &&
-                    MethodArgument == other.MethodArgument &&
+                    RuntimeDeterminedTypeHelper.Equals(MethodArgument?.Method ?? null, other.MethodArgument?.Method ?? null) &&
                     ContextType == other.ContextType;
             }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/RuntimeDeterminedTypeHelper.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/RuntimeDeterminedTypeHelper.cs
@@ -53,6 +53,30 @@ namespace ILCompiler
                     runtimeDeterminedType1.RuntimeDeterminedDetailsType.Kind == runtimeDeterminedType2.RuntimeDeterminedDetailsType.Kind;
             }
 
+            ArrayType arrayType1 = type1 as ArrayType;
+            ArrayType arrayType2 = type2 as ArrayType;
+            if (arrayType1 != null || arrayType2 != null)
+            {
+                if (arrayType1 == null || arrayType2 == null)
+                {
+                    return false;
+                }
+                return arrayType1.Rank == arrayType2.Rank &&
+                    arrayType1.IsSzArray == arrayType2.IsSzArray &&
+                    Equals(arrayType1.ElementType, arrayType2.ElementType);
+            }
+
+            ByRefType byRefType1 = type1 as ByRefType;
+            ByRefType byRefType2 = type2 as ByRefType;
+            if (byRefType1 != null || byRefType2 != null)
+            {
+                if (byRefType1 == null || byRefType2 == null)
+                {
+                    return false;
+                }
+                return Equals(byRefType1.ParameterType, byRefType2.ParameterType);
+            }
+
             if (type1.GetTypeDefinition() != type2.GetTypeDefinition() ||
                 !Equals(type1.Instantiation, type2.Instantiation))
             {
@@ -184,6 +208,7 @@ namespace ILCompiler
             WriteTo(method.Signature.ReturnType, sb);
             sb.Append(" ");
             WriteTo(method.OwningType, sb);
+            sb.Append(".");
             sb.Append(method.Name);
             if (method.HasInstantiation)
             {


### PR DESCRIPTION
This change fixes the inconsistency where multi-module tests were
treated as belonging to the same versioning bubble however CoreCLR
runtime doesn't yet fully support this concept.

Based on JanK's suggestion I have fixed the ILC compiler to be
strictly single-assembly version bubble. I have added an opt-in
switch "--inputbubble" that activates the pre-existing behavior of
all test assemblies belonging to the same version bubble for future
experiments towards enabling the larger version bubble scenario.

I have also fixed the build script MS.NETCore.Native.targets to run
ILC multiple times in CPAOT builds to compile the individual test
assemblies.

I have also included a minor fix in MethodEntrypoint - when the
target and original methods are the same, there is no need to
encode the constrained type.

With this change, Top200 CoreCLR tests report 11 failures or about
90% pass rate; in Pri#0 CoreCLR tests, 535 tests fail amounting to
about 78% pass rate.

Thanks

Tomas