### PR TITLE
fix apparent typo when retrieving a 64 bit value

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -213,7 +213,7 @@ namespace Internal.IL
 
         public LLVMValueRef ValueAsInt64(LLVMBuilderRef builder, bool signExtend)
         {
-            return ValueAsTypeInternal(LLVM.Int32Type(), builder, signExtend);
+            return ValueAsTypeInternal(LLVM.Int64Type(), builder, signExtend);
         }
 
         protected abstract LLVMValueRef ValueAsTypeInternal(LLVMTypeRef type, LLVMBuilderRef builder, bool signExtend);

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2394,6 +2394,7 @@ namespace Internal.IL
 
             LLVMValueRef valueToShiftValue = valueToShift.ValueForStackKind(valueToShift.Kind, _builder, false);
 
+            // while it seems excessive that the bits to shift should need to be 64 bits, the LLVM docs say that both operands must be the same type and a compilation failure results if this is not the case.
             LLVMValueRef rhs;
             if (valueToShiftValue.TypeOf().Equals(LLVM.Int64Type()))
             {

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2394,16 +2394,25 @@ namespace Internal.IL
 
             LLVMValueRef valueToShiftValue = valueToShift.ValueForStackKind(valueToShift.Kind, _builder, false);
 
+            LLVMValueRef rhs;
+            if (valueToShiftValue.TypeOf().Equals(LLVM.Int64Type()))
+            {
+                rhs = numBitsToShift.ValueAsInt64(_builder, false);
+            }
+            else
+            {
+                rhs = numBitsToShift.ValueAsInt32(_builder, false);
+            }
             switch (opcode)
             {
                 case ILOpcode.shl:
-                    result = LLVM.BuildShl(_builder, valueToShiftValue, numBitsToShift.ValueAsInt32(_builder, false), "shl");
+                    result = LLVM.BuildShl(_builder, valueToShiftValue, rhs, "shl");
                     break;
                 case ILOpcode.shr:
-                    result = LLVM.BuildAShr(_builder, valueToShiftValue, numBitsToShift.ValueAsInt32(_builder, false), "shr");
+                    result = LLVM.BuildAShr(_builder, valueToShiftValue, rhs, "shr");
                     break;
                 case ILOpcode.shr_un:
-                    result = LLVM.BuildLShr(_builder, valueToShiftValue, numBitsToShift.ValueAsInt32(_builder, false), "shr");
+                    result = LLVM.BuildLShr(_builder, valueToShiftValue, rhs, "shr");
                     break;
                 default:
                     throw new InvalidOperationException(); // Should be unreachable

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -297,6 +297,16 @@ internal static class Program
             PrintLine("float comparison: Ok.");
         }
 
+        long l = 0x1;
+        if (l > 0x7FF0000000000000)
+        {
+            PrintLine("long comparison: Failed");
+        }
+        else
+        {
+            PrintLine("long comparison: Ok");
+        }
+
         // Create a ByReference<char> through the ReadOnlySpan ctor and call the ByReference.Value via the indexer.
         var span = "123".AsSpan();
         if (span[0] != '1'


### PR DESCRIPTION
Fixes #6506 
Also shift 64 bit ints using 64bit operand as per the docs at https://llvm.org/docs/LangRef.html#shl-instruction.
This was causing a problem with long comparisons and consequently double.IsNan/Math.Min(double, double)