### PR TITLE
WIP: wasm:Enables Interop.GetRandomBytes for wasm

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
@@ -10,12 +10,50 @@ internal partial class Interop
 {
     internal unsafe partial class Sys
     {
+#if WASM
+        [DllImport("*")]
+        internal static extern unsafe int rand();
+#else
         [DllImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_GetNonCryptographicallySecureRandomBytes")]
         internal static extern unsafe void GetNonCryptographicallySecureRandomBytes(byte* buffer, int length);
+#endif
     }
 
     internal static unsafe void GetRandomBytes(byte* buffer, int length)
     {
+#if WASM
+        // what to do here, handle any size int, assert on sizeof(int) != 4?
+        for (int i = 0; i < length / 4; i++)
+        {
+            int r = Sys.rand();
+            *buffer = (byte)(r >> 24);
+            buffer++;
+            *buffer = (byte)(r >> 16);
+            buffer++;
+            *buffer = (byte)(r >> 8);
+            buffer++;
+            *buffer = (byte)r;
+            buffer++;
+        }
+        int remaining = length % 4;
+        if(remaining > 0)
+        {
+            int r = Sys.rand();
+            if(remaining >= 3)
+            {
+                *buffer = (byte)(r >> 24);
+                buffer++;
+            }
+            if(remaining >= 2)
+            {
+                *buffer = (byte)(r >> 16);
+                buffer++;
+            }
+            *buffer = (byte)(r >> 8);
+            buffer++;
+        }
+#else
         Sys.GetNonCryptographicallySecureRandomBytes(buffer, length);
+#endif
     }
 }

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -319,6 +319,8 @@ internal static class Program
         
         TestArrayItfDispatch();
 
+        TestStringGetHashCode();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -641,6 +643,21 @@ internal static class Program
         var chars = new[] { 'i', 'p', 's', 'u', 'm' };
         PrintString("Value type element indexing: ");
         if (chars[0] == 'i' && chars[1] == 'p' && chars[2] == 's' && chars[3] == 'u' && chars[4] == 'm')
+        {
+            PrintLine("Ok.");
+        }
+        else
+        {
+            PrintLine("Failed.");
+        }
+    }
+
+    private static void TestStringGetHashCode()
+    {
+        int hashCode1 = "TestStringGetHashCode".GetHashCode();
+        int hashCode2 = "TestStringGetHashCode".GetHashCode();
+        PrintString("String.GetHashCode() to exercise Interop.GetRandomBytes: ");
+        if (hashCode1 == hashCode2)
         {
             PrintLine("Ok.");
         }


### PR DESCRIPTION
@morganbr @MichalStrehovsky I've made this PR to enable `GetHashcode` for strings as it uses `Marvin.DefaultSeed` and hence `Interop.GetRandomBytes`.  However, I don't know where this should go as where I've put it I think is wrong as I believe this file `src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.GetRandomBytes.cs` is shared with Corefx/CoreCLR.  Where should this go?  Perhaps its not even necessary as the Unix implementation in `Interop.Libraries.SystemNative` may will be enough with a different `DllImport`?  If it is required could you comment on whether we can safely assume `sizeof(int)==4` in wasm?

Thanks