### PR TITLE
Unify versions of System.Reflection.Metadata used in CoreRT

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -9,5 +9,6 @@
     <MicrosoftDotNetTestSdkVersion>15.8.0</MicrosoftDotNetTestSdkVersion>
     <XUnitPackageVersion>2.4.1-pre.build.4059</XUnitPackageVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>2.4.0-beta.18420.3</MicrosoftDotNetXUnitExtensionsVersion>
+    <SystemReflectionMetadataVersion>1.4.3</SystemReflectionMetadataVersion>
   </PropertyGroup>
 </Project>

--- a/src/ILCompiler.Build.Tasks/src/ILCompiler.Build.Tasks.csproj
+++ b/src/ILCompiler.Build.Tasks/src/ILCompiler.Build.Tasks.csproj
@@ -18,7 +18,7 @@
     <Version>15.3.409</Version>
   </PackageReference>
   <PackageReference Include="System.Reflection.Metadata">
-    <Version>1.4.2</Version>
+    <Version>$(SystemReflectionMetadataVersion)</Version>
   </PackageReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="'$(IsProjectNLibrary)' != 'true'" />

--- a/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler.MetadataTransform.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection.Metadata">
-      <Version>1.4.2</Version>
+      <Version>$(SystemReflectionMetadataVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -12,7 +12,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
-      <Version>1.4.2</Version>
+      <Version>$(SystemReflectionMetadataVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.DiaSymReader">
       <Version>1.0.8</Version>

--- a/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
+++ b/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
@@ -16,7 +16,7 @@
       <Version>$(MicrosoftDotNetXUnitExtensionsVersion)</Version>
     </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
-      <Version>1.4.2</Version>
+      <Version>$(SystemReflectionMetadataVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ILCompiler/netcoreapp/ilc.csproj
+++ b/src/ILCompiler/netcoreapp/ilc.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>1.3.1</Version>
+      <Version>1.3.2</Version>
     </PackageReference>
     <PackageReference Include="System.IO.MemoryMappedFiles">
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
-      <Version>1.4.2</Version>
+      <Version>$(SystemReflectionMetadataVersion)</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>4.3.0</Version>

--- a/src/ILCompiler/netcoreapp/ilc.csproj
+++ b/src/ILCompiler/netcoreapp/ilc.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,7 +13,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
-      <Version>$(SystemReflectionMetadataVersion)</Version>
+      <Version>1.4.3</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>4.3.0</Version>

--- a/src/ILVerification/src/ILVerification.csproj
+++ b/src/ILVerification/src/ILVerification.csproj
@@ -312,7 +312,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.IO.MemoryMappedFiles" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.4.1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
This change adds a new entry to dependencies.props to define the
version of System.Reflection.Metadata used by the various CoreRT
projects. I have also increased the change to 1.4.3 which includes
the value for ARM64 in the Machine enumeration.

Thanks

Tomas