### PR TITLE
PE builder and devirtualization manager fixes

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -15,11 +15,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _compilationModuleGroup = compilationModuleGroup;
         }
 
-        public override bool IsEffectivelySealed(TypeDesc type)
-        {
-            return !(type is RuntimeDeterminedType) && base.IsEffectivelySealed(type);
-        }
-
         protected override MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType)
         {
             if (_compilationModuleGroup.ContainsMethodBody(declMethod, unboxingStub: false) &&

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -15,6 +15,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _compilationModuleGroup = compilationModuleGroup;
         }
 
+        public override bool IsEffectivelySealed(TypeDesc type)
+        {
+            return !(type is RuntimeDeterminedType) && base.IsEffectivelySealed(type);
+        }
+
         protected override MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType)
         {
             if (_compilationModuleGroup.ContainsMethodBody(declMethod, unboxingStub: false) &&

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -236,8 +236,9 @@ namespace ILCompiler.PEWriter
         {
             PEDirectoriesBuilder builder = new PEDirectoriesBuilder();
 
-            builder.ExportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ExportTableDirectory);
-            builder.ImportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ImportTableDirectory);
+            // Don't copy over EntryPoint
+            // Don't copy over Export directory
+            // Don't copy over Import directory
             builder.ResourceTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ResourceTableDirectory);
             builder.ExceptionTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ExceptionTableDirectory);
             // TODO - missing in PEDirectoriesBuilder
@@ -249,8 +250,8 @@ namespace ILCompiler.PEWriter
             builder.ThreadLocalStorageTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ThreadLocalStorageTableDirectory);
             builder.LoadConfigTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.LoadConfigTableDirectory);
             builder.BoundImportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.BoundImportTableDirectory);
-            builder.ImportAddressTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ImportAddressTableDirectory);
-            builder.DelayImportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.DelayImportTableDirectory);
+            // Don't copy over import address table
+            // Don't copy over delay import table
             builder.CorHeaderTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.CorHeaderTableDirectory);
 
             if (_directoriesUpdater != null)

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -236,12 +236,6 @@ namespace ILCompiler.PEWriter
         {
             PEDirectoriesBuilder builder = new PEDirectoriesBuilder();
 
-            if ((_peReader.PEHeaders.CoffHeader.Characteristics & Characteristics.Dll) == 0)
-            {
-                // Only copy over the entrypoint if not building a DLL
-                builder.AddressOfEntryPoint = RelocateRVA(_peReader.PEHeaders.PEHeader.AddressOfEntryPoint);
-            }
-
             builder.ExportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ExportTableDirectory);
             builder.ImportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ImportTableDirectory);
             builder.ResourceTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ResourceTableDirectory);


### PR DESCRIPTION
These are a few targeted fixes I made while investigating various
framework & CoreCLR test failures:

1) Don't emit the original MSIL entry point to the R2R PE binary
for a DLL;

2) Tweak COFF header characteristics to match the targeting
architecture;

3) Check for RuntimeDeterminedType in the R2R devirtualization
manager as these types crash the base class.

Thanks

Tomas