### PR TITLE
Dynamic statics cleanup

### DIFF
--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -182,7 +182,6 @@ namespace Internal.TypeSystem
         /// </summary>
         public static int MaximumLog2PrimitiveSize
         {
-
             get
             {
                 return 3;


### PR DESCRIPTION
This change cleans up my change for initial dynamic statics support
per Zach's PR feedback. I have introduced new symbolic constants
and propagated them through the relevant code to mark up where
we're referring to the regular vs. thread-local static indices.

Thanks

Tomas