### PR TITLE
Initial support for running tests against CPAOT-built framework

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -739,7 +739,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.MethodDictionary:
                     return GenericLookupMethodHelper(
                         runtimeLookupKind,
-                        ReadyToRunFixupKind.READYTORUN_FIXUP_MethodDictionary,
+                        ReadyToRunFixupKind.READYTORUN_FIXUP_MethodHandle,
                         (MethodWithToken)helperArgument,
                         contextType,
                         signatureContext);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunHashCode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunHashCode.cs
@@ -60,7 +60,7 @@ namespace ILCompiler
         /// </summary>
         /// <param name="namespacePart">Namespace name</param>
         /// <param name="namePart">Type name within the namespace</param>
-        static int NameHashCode(string namespacePart, string namePart)
+        public static int NameHashCode(string namespacePart, string namePart)
         {
             return NameHashCode(namespacePart) ^ NameHashCode(namePart);
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunTableManager.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunTableManager.cs
@@ -61,7 +61,6 @@ namespace ILCompiler
 
         public IEnumerable<ExportedTypeInfo> GetExportedTypes()
         {
-            List<ExportedTypeInfo> exportedTypeList = new List<ExportedTypeInfo>();
             foreach (string inputFile in _typeSystemContext.InputFilePaths.Values)
             {
                 EcmaModule module = _typeSystemContext.GetModuleFromPath(inputFile);
@@ -70,11 +69,10 @@ namespace ILCompiler
                     ExportedType exportedType = module.MetadataReader.GetExportedType(exportedTypeHandle);
                     if (exportedType.IsForwarder)
                     {
-                        exportedTypeList.Add(new ExportedTypeInfo(module, exportedTypeHandle));
+                        yield return new ExportedTypeInfo(module, exportedTypeHandle);
                     }
                 }
             }
-            return exportedTypeList;
         }
 
         public override MethodDesc GetCanonicalReflectionInvokeStub(MethodDesc method) => throw new NotImplementedException();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunTableManager.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunTableManager.cs
@@ -18,26 +18,14 @@ using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler
 {
-    public struct DefinedTypeInfo
+    public struct TypeInfo<THandle>
     {
-        public readonly EcmaModule Module;
-        public readonly TypeDefinitionHandle Handle;
+        public readonly MetadataReader MetadataReader;
+        public readonly THandle Handle;
 
-        public DefinedTypeInfo(EcmaModule module, TypeDefinitionHandle handle)
+        public TypeInfo(MetadataReader metadataReader, THandle handle)
         {
-            Module = module;
-            Handle = handle;
-        }
-    }
-
-    public struct ExportedTypeInfo
-    {
-        public readonly EcmaModule Module;
-        public readonly ExportedTypeHandle Handle;
-
-        public ExportedTypeInfo(EcmaModule module, ExportedTypeHandle handle)
-        {
-            Module = module;
+            MetadataReader = metadataReader;
             Handle = handle;
         }
     }
@@ -52,30 +40,26 @@ namespace ILCompiler
             // We don't attach any metadata blobs.
         }
 
-        public IEnumerable<DefinedTypeInfo> GetDefinedTypes()
+        public IEnumerable<TypeInfo<TypeDefinitionHandle>> GetDefinedTypes()
         {
             foreach (string inputFile in _typeSystemContext.InputFilePaths.Values)
             {
                 EcmaModule module = _typeSystemContext.GetModuleFromPath(inputFile);
                 foreach (TypeDefinitionHandle typeDefHandle in module.MetadataReader.TypeDefinitions)
                 {
-                    yield return new DefinedTypeInfo(module, typeDefHandle);
+                    yield return new TypeInfo<TypeDefinitionHandle>(module.MetadataReader, typeDefHandle);
                 }
             }
         }
 
-            public IEnumerable<ExportedTypeInfo> GetExportedTypes()
+            public IEnumerable<TypeInfo<ExportedTypeHandle>> GetExportedTypes()
         {
             foreach (string inputFile in _typeSystemContext.InputFilePaths.Values)
             {
                 EcmaModule module = _typeSystemContext.GetModuleFromPath(inputFile);
                 foreach (ExportedTypeHandle exportedTypeHandle in module.MetadataReader.ExportedTypes)
                 {
-                    ExportedType exportedType = module.MetadataReader.GetExportedType(exportedTypeHandle);
-                    if (exportedType.IsForwarder)
-                    {
-                        yield return new ExportedTypeInfo(module, exportedTypeHandle);
-                    }
+                    yield return new TypeInfo<ExportedTypeHandle>(module.MetadataReader, exportedTypeHandle);
                 }
             }
         }

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -235,23 +235,6 @@ namespace ILCompiler.PEWriter
         protected override PEDirectoriesBuilder GetDirectories()
         {
             PEDirectoriesBuilder builder = new PEDirectoriesBuilder();
-
-            // Don't copy over EntryPoint
-            // Don't copy over Export directory
-            // Don't copy over Import directory
-            builder.ResourceTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ResourceTableDirectory);
-            builder.ExceptionTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ExceptionTableDirectory);
-            // TODO - missing in PEDirectoriesBuilder
-            // builder.CertificateTable = RelocateDirectoryEntry(peHeaders.PEHeader.CertificateTableDirectory);
-            builder.BaseRelocationTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.BaseRelocationTableDirectory);
-            builder.DebugTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.DebugTableDirectory);
-            builder.CopyrightTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.CopyrightTableDirectory);
-            builder.GlobalPointerTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.GlobalPointerTableDirectory);
-            builder.ThreadLocalStorageTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ThreadLocalStorageTableDirectory);
-            builder.LoadConfigTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.LoadConfigTableDirectory);
-            builder.BoundImportTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.BoundImportTableDirectory);
-            // Don't copy over import address table
-            // Don't copy over delay import table
             builder.CorHeaderTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.CorHeaderTableDirectory);
 
             if (_directoriesUpdater != null)

--- a/tests/CoreCLR/compile-framework.cmd
+++ b/tests/CoreCLR/compile-framework.cmd
@@ -7,12 +7,16 @@
 @if not defined _echo @echo off
 setlocal EnableDelayedExpansion
 
-rd /s /q %CoreRT_CoreCLRRuntimeDir%\native
-
 if "%CoreRT_CoreCLRRuntimeDir%" == "" (
     echo set CoreRT_CoreCLRRuntimeDir to CoreCLR folder or run from runtest.cmd
     exit /b 1
 )
+
+rd /s /q %CoreRT_CoreCLRRuntimeDir%\native
+
+mkdir %CoreRT_CoreCLRRuntimeDir%\native
+xcopy /Q /Y %CoreRT_CoreCLRRuntimeDir%\*.exe %CoreRT_CoreCLRRuntimeDir%\native\
+xcopy /Q /Y %CoreRT_CoreCLRRuntimeDir%\*.dll %CoreRT_CoreCLRRuntimeDir%\native\
 
 for %%x in (%CoreRT_CoreCLRRuntimeDir%\Microsoft.*.dll %CoreRT_CoreCLRRuntimeDir%\System.*.dll) do (
     call :CompileAssembly %%x

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -380,7 +380,7 @@ goto :eof
 
         set __ExtraTestRunArgs=
         if "%__Mode%"=="readytorun" (
-            set __Extension=exe
+            set __Extension=ni.exe
             set __ExtraTestRunArgs="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarness% %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe
         )
 

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -60,6 +60,7 @@ if /i "%1" == "/multimodule" (set CoreRT_MultiFileConfiguration=MultiModule&shif
 if /i "%1" == "/determinism" (set CoreRT_DeterminismMode=true&shift&goto ArgLoop)
 if /i "%1" == "/nocleanup" (set CoreRT_NoCleanup=true&shift&goto ArgLoop)
 if /i "%1" == "/r2rframework" (set CoreRT_R2RFramework=true&shift&goto ArgLoop)
+if /i "%1" == "/user2rframework" (set CoreRT_UseR2RFramework=true&shift&goto ArgLoop)
 echo Invalid command line argument: %1
 goto :Usage
 
@@ -104,6 +105,10 @@ if "%CoreRT_MultiFileConfiguration%"=="MultiModule" (
 
 set CoreRT_CoreCLRRuntimeDir=%CoreRT_TestRoot%..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\CoreClrRuntime
 set CoreRT_ReadyToRunTestHarness=%CoreRT_TestRoot%src\tools\ReadyToRun.TestHarness\bin\Debug\netcoreapp2.1\ReadyToRun.TestHarness.dll
+
+rem When using pre-built R2R framework, switch the CoreCLRRuntime folder to its "native" subfolder
+rem where we copy over the CoreCLRRuntime folder and emit the R2R versions of the framework assemblies.
+if /i "%CoreRT_UseR2RFramework%" == "true" (set CoreRT_CoreCLRRuntimeDir=!CoreRT_CoreCLRRuntimeDir!\native)
 
 if not exist %CoreRT_CoreCLRRuntimeDir% goto :BuildTests
 if not exist %CoreRT_ReadyToRunTestHarness% goto :BuildTests
@@ -375,7 +380,7 @@ goto :eof
 
         set __ExtraTestRunArgs=
         if "%__Mode%"=="readytorun" (
-            set __Extension=ni.exe
+            set __Extension=exe
             set __ExtraTestRunArgs="%CoreRT_CliDir%\dotnet.exe" %CoreRT_ReadyToRunTestHarness% %CoreRT_CoreCLRRuntimeDir%\CoreRun.exe
         )
 


### PR DESCRIPTION
The pass rate is not super high right now, I'm seeing 109 failing
tests or about 13% pass rate but the main point is that the pass
rate is not zero, we can build on that.

In the AVAILABLE_TYPES R2R node, I added provisions for emitting
exported types. This was one of the issues we were hitting - the
partial facade System.Runtime wasn't properly exporting its type
forwards.

In the PE builder, I dropped copying of all directories per JanK's
suggestion, the latest impulse being a mismatch between the debug
directory and the CPAOT-compiled executable.

Thanks

Tomas