### PR TITLE
Increase WebAssembly test timeout

### DIFF
--- a/tests/src/Simple/HelloWasm/HelloWasm.cmd
+++ b/tests/src/Simple/HelloWasm/HelloWasm.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-call emrun --browser=firefox --browser_args=-headless --safe_firefox_profile --silence_timeout 10 "%1\%2" 
+call emrun --browser=firefox --browser_args=-headless --safe_firefox_profile --silence_timeout 100 "%1\%2" 
 
 IF "%errorlevel%"=="100" (
     echo %~n0: Pass


### PR DESCRIPTION
Raise the timeout in the WebAssembly test to account for slow Firefoxfirst starts on CI machines. Hopefully this will stop the intermittent WebAssembly CI failures.