### PR TITLE
Linux\arm Use r11 as frame pointer for unwinding

### DIFF
--- a/src/Native/Runtime/arm/PInvoke.S
+++ b/src/Native/Runtime/arm/PInvoke.S
@@ -20,7 +20,7 @@
 
 NESTED_ENTRY RhpPInvoke, _TEXT, NoHandler
         str     lr, [r0, #OFFSETOF__PInvokeTransitionFrame__m_RIP]
-        str     r7, [r0, #OFFSETOF__PInvokeTransitionFrame__m_FramePointer]
+        str     r11, [r0, #OFFSETOF__PInvokeTransitionFrame__m_FramePointer]
         str     sp, [r0, #OFFSETOF__PInvokeTransitionFrame__m_PreservedRegs]
         mov     r3, #PTFF_SAVE_SP
         str     r3, [r0, #OFFSETOF__PInvokeTransitionFrame__m_Flags]

--- a/src/Native/Runtime/regdisplay.h
+++ b/src/Native/Runtime/regdisplay.h
@@ -78,8 +78,11 @@ struct REGDISPLAY
     inline PCODE GetIP() { return IP; }
     inline PTR_PCODE GetAddrOfIP() { return pIP; }
     inline UIntNative GetSP() { return SP; }
+#ifdef PROJECTN
     inline UIntNative GetFP() { return *pR7; }
-
+#else
+    inline UIntNative GetFP() { return *pR11; }
+#endif
     inline void SetIP(PCODE IP) { this->IP = IP; }
     inline void SetAddrOfIP(PTR_PCODE pIP) { this->pIP = pIP; }
     inline void SetSP(UIntNative SP) { this->SP = SP; }


### PR DESCRIPTION
The convention for frame pointer is different between CoreCLR ABI and
CoreRT ABI for historic reasons. CoreCLR ABI uses R11 as frame pointer.
It is better to follow CoreCLR ABI for CoreRT.

The commit is connected with the #5874 issue. 