### PR TITLE
Bump up default CPAOT test timeout to 2 minutes

### DIFF
--- a/tests/src/tools/ReadyToRun.TestHarness/Program.cs
+++ b/tests/src/tools/ReadyToRun.TestHarness/Program.cs
@@ -25,7 +25,7 @@ namespace ReadyToRun.TestHarness
     class Program
     {
         // Default timeout in milliseconds
-        private const int DefaultTestTimeOut = 30000;
+        private const int DefaultTestTimeOut = 2 * 60 * 1000;
 
         // Error code returned when events get lost. Use this to re-run the test a few times.
         private const int StatusTestErrorEventsLost = -101;


### PR DESCRIPTION
Early on in CPAOT bring-up I asked Simon to set a short timeout
for test executions as many tests were timing out due to compiler
bugs. This is no longer the case - we only have a handful of
remaining failing tests and some of them are now suffering from
the short timeout. For now I have bumped up the timeout from 30
seconds to 2 minutes and that seems to be fixing all Top200 tests
that used to fail with the -103 exit code (about 5 tests overall).

Thanks

Tomas