### PR TITLE
Refactor the CPAOT compiler to stop using ValueTuple

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -144,7 +144,7 @@ namespace ILCompiler.PEWriter
         public R2RPEBuilder(
             Machine machine,
             PEReader peReader,
-            IEnumerable<(string SectionName, SectionCharacteristics Characteristics)> sectionNames = null,
+            IEnumerable<SectionInfo> sectionNames = null,
             Func<string, SectionLocation, BlobBuilder> sectionSerializer = null,
             Action<PEDirectoriesBuilder> directoriesUpdater = null)
             : base(PEHeaderCopier.Copy(peReader.PEHeaders, machine), deterministicIdProvider: null)
@@ -194,9 +194,9 @@ namespace ILCompiler.PEWriter
 
             if (sectionNames != null)
             {
-                foreach ((string SectionName, SectionCharacteristics Characteristics) nameCharPair in sectionNames)
+                foreach (SectionInfo sectionInfo in sectionNames)
                 {
-                    sectionListBuilder.Add(new Section(nameCharPair.SectionName, nameCharPair.Characteristics));
+                    sectionListBuilder.Add(new Section(sectionInfo.SectionName, sectionInfo.Characteristics));
                 }
             }
 

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/SectionBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/SectionBuilder.cs
@@ -75,7 +75,19 @@ namespace ILCompiler.PEWriter
             Relocs = relocs;
         }
     }
-    
+
+    public struct SectionInfo
+    {
+        public readonly string SectionName;
+        public readonly SectionCharacteristics Characteristics;
+
+        public SectionInfo(string sectionName, SectionCharacteristics characteristics)
+        {
+            SectionName = sectionName;
+            Characteristics = characteristics;
+        }
+    }
+
     /// <summary>
     /// Section represents a contiguous area of code or data with the same characteristics.
     /// </summary>
@@ -403,23 +415,20 @@ namespace ILCompiler.PEWriter
         /// We filter out name duplicates as we'll end up merging builder sections with the same name
         /// into a single output physical section.
         /// </summary>
-        public IEnumerable<(string SectionName, SectionCharacteristics Characteristics)> GetSections()
+        public IEnumerable<SectionInfo> GetSections()
         {
-            List<(string SectionName, SectionCharacteristics Characteristics)> sectionList =
-                new List<(string SectionName, SectionCharacteristics Characteristics)>();
+            List<SectionInfo> sectionList = new List<SectionInfo>();
             foreach (Section section in _sections)
             {
                 if (!sectionList.Any((sc) => sc.SectionName == section.Name))
                 {
-                    sectionList.Add((SectionName: section.Name, Characteristics: section.Characteristics));
+                    sectionList.Add(new SectionInfo(section.Name, section.Characteristics));
                 }
             }
 
             if (_exportSymbols.Count != 0 && FindSection(".edata") == null)
             {
-                sectionList.Add((SectionName: ".edata", Characteristics:
-                    SectionCharacteristics.ContainsInitializedData |
-                    SectionCharacteristics.MemRead));
+                sectionList.Add(new SectionInfo(".edata", SectionCharacteristics.ContainsInitializedData | SectionCharacteristics.MemRead));
             }
 
             return sectionList;


### PR DESCRIPTION
Per Michal's suggestion I have removed the two value tuple types
I used in my initial CPAOT changes. I have verified by manually
copying over the modified files that with these changes I can build
the ILCompiler.ReadyToRUn project from within ProjectN. I'll send
out the CR adding the new project once this change has been
merged into CoreRT and integrated to ProjectN.

Thanks

Tomas