### PR TITLE
Update RyuJIT

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RyuJITVersion>3.0.0-preview-27107-01</RyuJITVersion>
+    <RyuJITVersion>3.0.0-preview-27109-03</RyuJITVersion>
     <ObjectWriterVersion>1.0.0-alpha-26412-0</ObjectWriterVersion>
     <CoreFxVersion>4.6.0-preview.18558.2</CoreFxVersion>
     <CoreFxUapVersion>4.7.0-preview.18558.2</CoreFxUapVersion>

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -80,6 +80,12 @@ namespace ILCompiler
             }
         }
 
+        internal bool IsInheritanceChainLayoutFixedInCurrentVersionBubble(TypeDesc type)
+        {
+            // TODO: implement
+            return true;
+        }
+
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)
         {
             foreach (DependencyNodeCore<NodeFactory> dependency in obj)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1243,6 +1243,10 @@ namespace Internal.JitInterface
 
             Debug.Assert(!type.IsValueType);
             Debug.Assert(type.IsDefType);
+            Debug.Assert(!type.IsString);
+#if READYTORUN
+            Debug.Assert(_compilation.IsInheritanceChainLayoutFixedInCurrentVersionBubble(type));
+#endif
 
             return (uint)((DefType)type).InstanceByteCount.AsInt;
         }
@@ -1256,7 +1260,10 @@ namespace Internal.JitInterface
 
             bool result = !type.HasFinalizer;
 
-            // TODO: for ready to run, check whether inheritance chain is within the version bubble
+#if READYTORUN
+            if (!_compilation.IsInheritanceChainLayoutFixedInCurrentVersionBubble(type))
+                result = false;
+#endif
 
             return result;
         }
@@ -1337,8 +1344,6 @@ namespace Internal.JitInterface
             uint result = 0;
 
             DefType type = (DefType)HandleToObject(cls);
-
-            Debug.Assert(type.IsValueType);
 
             int pointerSize = PointerSize;
 


### PR DESCRIPTION
...mostly because I don't want us to forget to pick up the matching JitInterface change from dotnet/coreclr#20814. No JitInterface change this time.

Object stack allocation doesn't work yet for R2R compilations because we seem to be pattern matching against `ALLOCOBJ  ref`, when in ready to run we have `CALL help ref    HELPER.CORINFO_HELP_READYTORUN_NEW`.

It doesn't seem like we need to port the changes in `getClassGClayout` because CoreRT class layout information includes the EEType field in reference types, whereas CoreCLR doesn't.