### PR TITLE
wasm: add method reference for delegate parameters to pinvokes

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2044,6 +2044,10 @@ namespace Internal.IL
                     targetLLVMFunction = LLVMFunctionForMethod(method, thisPointer, true, null);
                     AddVirtualMethodReference(method);
                 }
+                else
+                {
+                    AddMethodReference(method);
+                }
             }
             else
             {

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -312,8 +312,6 @@ internal static class Program
             PrintLine(rvaFieldValue.ToString());
         }
 
-        TestRegisterOfNativeCallback();
-
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -700,21 +698,6 @@ internal static class Program
         }
 
     }
-
-    private delegate void EmCallbackFunc();
-
-    private static void DoNothing() { }
-
-    private static void TestRegisterOfNativeCallback()
-    {
-        PrintString("Register callback with native call: ");
-        var callback = new EmCallbackFunc(DoNothing);
-        emscripten_set_main_loop(callback, 1, 1);
-        PrintLine("Ok.");
-    }
-
-    [DllImport("*")]
-    private static unsafe extern void emscripten_set_main_loop(EmCallbackFunc callback, int fps, int simulate_infinite_loop);
 
     [DllImport("*")]
     private static unsafe extern int printf(byte* str, byte* unused);

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -312,6 +312,8 @@ internal static class Program
             PrintLine(rvaFieldValue.ToString());
         }
 
+        TestRegisterOfNativeCallback();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -698,6 +700,21 @@ internal static class Program
         }
 
     }
+
+    private delegate void EmCallbackFunc();
+
+    private static void DoNothing() { }
+
+    private static void TestRegisterOfNativeCallback()
+    {
+        PrintString("Register callback with native call: ");
+        var callback = new EmCallbackFunc(DoNothing);
+        emscripten_set_main_loop(callback, 1, 1);
+        PrintLine("Ok.");
+    }
+
+    [DllImport("*")]
+    private static unsafe extern void emscripten_set_main_loop(EmCallbackFunc callback, int fps, int simulate_infinite_loop);
 
     [DllImport("*")]
     private static unsafe extern int printf(byte* str, byte* unused);


### PR DESCRIPTION
This change gets the delegate wrapper for the pinvoke added to the dependencies so the function is defined in the LLVM and not just declared.  This would resolve #6525 but, I think, it is subject to the same problem as #6415.  This is the stacktrace from the test included here which is similar:

```
exception thrown: abort() at jsStackTrace@http://localhost:6931/HelloWasm.js:1059:13
stackTrace@http://localhost:6931/HelloWasm.js:1076:12
abort@http://localhost:6931/HelloWasm.js:7982:44
_abort@http://localhost:6931/HelloWasm.js:5751:7
__Z6AssertPKcS0_jS0_@http://localhost:6931/HelloWasm.wasm:wasm-function[19635]:0x9d23da
_RhGetCommonStubAddress@http://localhost:6931/HelloWasm.wasm:wasm-function[21362]:0xad0a87
_S_P_CoreLib_System_Runtime_InteropServices_PInvokeMarshal__AllocateThunk@http://localhost:6931/HelloWasm.wasm:wasm-function[2087]:0x15cc1b
_S_P_CoreLib_System_Runtime_CompilerServices_ConditionalWeakTable_2_CreateValueCallback_S_P_CoreLib_System_Delegate__S_P_CoreLib_System_Runtime_InteropServices_PInvokeMarshal_PInvokeDelegateThunk___InvokeOpenStaticThunk@http://localhost:6931/HelloWasm.wasm:wasm-function[2088]:0x15cf57
_S_P_CoreLib_System_Runtime_CompilerServices_ConditionalWeakTable_2_CreateValueCallback_S_P_CoreLib_System_Delegate__S_P_CoreLib_System_Runtime_InteropServices_PInvokeMarshal_PInvokeDelegateThunk___Invoke@http://localhost:6931/HelloWasm.wasm:wasm-function[3097]:0x1c76e7
_S_P_CoreLib_System_Runtime_CompilerServices_ConditionalWeakTable_2_S_P_CoreLib_System_Delegate__S_P_CoreLib_System_Runtime_InteropServices_PInvokeMarshal_PInvokeDelegateThunk___GetValueLocked@http://localhost:6931/HelloWasm.wasm:wasm-function[2091]:0x15d403
_S_P_CoreLib_System_Runtime_CompilerServices_ConditionalWeakTable_2_S_P_CoreLib_System_Delegate__S_P_CoreLib_System_Runtime_InteropServices_PInvokeMarshal_PInvokeDelegateThunk___GetValue@http://localhost:6931/HelloWasm.wasm:wasm-function[2089]:0x15d173
_S_P_CoreLib_System_Runtime_InteropServices_PInvokeMarshal__GetFunctionPointerForDelegate@http://localhost:6931/HelloWasm.wasm:wasm-function[1351]:0x117a5e
_S_P_CoreLib_Internal_Runtime_CompilerHelpers_InteropHelpers__GetFunctionPointerForDelegate@http://localhost:6931/HelloWasm.wasm:wasm-function[1349]:0x11765d
_HelloWasm_Program__emscripten_set_main_loop@http://localhost:6931/HelloWasm.wasm:wasm-function[682]:0xd8c04
_HelloWasm_Program__TestRegisterOfNativeCallback@http://localhost:6931/HelloWasm.wasm:wasm-function[675]:0xd887f
_HelloWasm_Program__Main@http://localhost:6931/HelloWasm.wasm:wasm-function[344]:0xb2eb0
_HelloWasm__Module___MainMethodWrapper@http://localhost:6931/HelloWasm.wasm:wasm-function[338]:0xaf2f2
_StartupCodeMain@http://localhost:6931/HelloWasm.wasm:wasm-function[327]:0xaee49
___managed__Main@http://localhost:6931/HelloWasm.wasm:wasm-function[19633]:0x9d238d
_main@http://localhost:6931/HelloWasm.wasm:wasm-function[21492]:0xad74c0
Module._main@http://localhost:6931/HelloWasm.js:7546:10
callMain@http://localhost:6931/HelloWasm.js:7855:15
doRun@http://localhost:6931/HelloWasm.js:7913:42
run/<@http://localhost:6931/HelloWasm.js:7924:7
```

@morganbr this also gets me closer to creating a PR for #5842 as it removes the undefined function so if you think its worthwhile it could be merged, without the test?