### PR TITLE
Use System.Linq optimized for size

### DIFF
--- a/src/Framework/Framework-uapaot.depproj
+++ b/src/Framework/Framework-uapaot.depproj
@@ -25,11 +25,14 @@
     <FileToInclude Include="mscorlib" />
 
     <!-- Pickup a few selected aot-specific files from uapaot instead -->
-    <FileToInclude Include="System.Linq" />
     <FileToInclude Include="System.Linq.Expressions" />
     <FileToInclude Include="System.Text.RegularExpressions" />
     <FileToInclude Include="System.Private.Xml" />
     <FileToInclude Include="System.Private.Xml.Linq" />
+
+    <!-- System.Linq is built with optimizations for size on AoT -->
+    <!-- See: https://github.com/dotnet/corefx/pull/31025 -->
+    <FileToInclude Include="System.Linq" />
 
     <FileToInclude Include="System.Private.Reflection.Metadata.Ecma335" />
   </ItemGroup>

--- a/src/Framework/Framework-uapaot.depproj
+++ b/src/Framework/Framework-uapaot.depproj
@@ -25,6 +25,7 @@
     <FileToInclude Include="mscorlib" />
 
     <!-- Pickup a few selected aot-specific files from uapaot instead -->
+    <FileToInclude Include="System.Linq" />
     <FileToInclude Include="System.Linq.Expressions" />
     <FileToInclude Include="System.Text.RegularExpressions" />
     <FileToInclude Include="System.Private.Xml" />

--- a/src/Framework/Framework.depproj
+++ b/src/Framework/Framework.depproj
@@ -35,6 +35,7 @@
     <FileToExclude Include="mscorlib" />
 
     <!-- Pickup a few selected aot-specific files from uapaot instead -->
+    <FileToExclude Include="System.Linq" />
     <FileToExclude Include="System.Linq.Expressions" />
     <FileToExclude Include="System.Text.RegularExpressions" />
     <FileToExclude Include="System.Private.Xml" />

--- a/src/Framework/Framework.depproj
+++ b/src/Framework/Framework.depproj
@@ -35,11 +35,13 @@
     <FileToExclude Include="mscorlib" />
 
     <!-- Pickup a few selected aot-specific files from uapaot instead -->
-    <FileToExclude Include="System.Linq" />
     <FileToExclude Include="System.Linq.Expressions" />
     <FileToExclude Include="System.Text.RegularExpressions" />
     <FileToExclude Include="System.Private.Xml" />
     <FileToExclude Include="System.Private.Xml.Linq" />
+
+    <!-- System.Linq in the aot-specific package is optimized for size -->
+    <FileToExclude Include="System.Linq" />
 
     <!-- TODO: Upstack framework -->
     <FileToExclude Include="System.Private.DataContractSerialization" />


### PR DESCRIPTION
The UapAot version of System.Linq is optimized for size and we should use that.

Shrinks the ASP.NET WebApi sample by 1.2 MB.