### PR TITLE
Disable building tests in official builds

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Linux.json
+++ b/buildpipeline/DotNet-CoreRT-Linux.json
@@ -359,7 +359,7 @@
       }
     },
     {
-      "enabled": true,
+      "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Run build-tests.sh",

--- a/buildpipeline/DotNet-CoreRT-Mac.json
+++ b/buildpipeline/DotNet-CoreRT-Mac.json
@@ -91,7 +91,7 @@
       }
     },
     {
-      "enabled": true,
+      "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Build tests",

--- a/buildpipeline/DotNet-CoreRT-Windows.json
+++ b/buildpipeline/DotNet-CoreRT-Windows.json
@@ -110,7 +110,7 @@
       }
     },
     {
-      "enabled": true,
+      "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Build tests",


### PR DESCRIPTION
This is broken on Windows Release configuration due to:

```
2018-11-03T01:10:18.6793055Z   Restore completed in 10.21 ms for E:\A\_work\384\s\corert_2178969\tests\src\tools\ReadyToRun.TestHarness\ReadyToRun.TestHarness.csproj.
2018-11-03T01:10:18.7370488Z The input line is too long.
2018-11-03T01:10:18.7370842Z The syntax of the command is incorrect.
2018-11-03T01:10:18.7451961Z ##[error]Process completed with exit code 255.
```

Instead of trying to figure out why, we can just stop building these and speed up official builds in the process.

@dotnet-bot skip ci