### PR TITLE
Enable R2R tests in release mode

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -167,12 +167,6 @@ namespace ILCompiler.DependencyAnalysis
             throw new NotImplementedException();
         }
 
-        public bool CanInline(MethodDesc callerMethod, MethodDesc calleeMethod)
-        {
-            // By default impose no restrictions on inlining
-            return CompilationModuleGroup.ContainsMethodBody(calleeMethod, unboxingStub: false);
-        }
-
         private ModuleToken GetTypeToken(ModuleToken token)
         {
             if (token.IsNull)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -140,5 +140,11 @@ namespace ILCompiler
                 }
             }
         }
+
+        public override bool CanInline(MethodDesc callerMethod, MethodDesc calleeMethod)
+        {
+            // Allow inlining if the target method is within the same version bubble
+            return NodeFactory.CompilationModuleGroup.ContainsMethodBody(calleeMethod, unboxingStub: false);
+        }
     }
 }

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -222,11 +222,9 @@ for /f "delims=" %%a in ('dir /s /aD /b %CoreRT_TestRoot%\src\%CoreRT_TestName%'
             if /i not "%CoreRT_TestCompileMode%" == "cpp" (
                 if /i not "%CoreRT_TestCompileMode%" == "wasm" (
                     if exist "!__SourceFolder!\readytorun" (
-                        if /i not "%CoreRT_BuildType%" == "release" (
-                            set __Mode=readytorun
-                            Call :CompileFile !__SourceFolder! !__SourceFileName! !__SourceFileProj! %__LogDir%\!__RelativePath!
-                            set /a __ReadyToRunTotalTests=!__ReadyToRunTotalTests!+1
-                        )
+                        set __Mode=readytorun
+                        Call :CompileFile !__SourceFolder! !__SourceFileName! !__SourceFileProj! %__LogDir%\!__RelativePath!
+                        set /a __ReadyToRunTotalTests=!__ReadyToRunTotalTests!+1
                     )
                 )
             )

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -117,7 +117,7 @@ goto :SkipBuildTests
 :BuildTests
 REM The test build handles restoring external dependencies such as CoreCLR runtime and its test host
 REM Trigger the test build so it will build but not run tests before we run them here
-call %CoreRT_TestRoot%..\buildscripts\build-tests.cmd buildtests
+call %CoreRT_TestRoot%..\buildscripts\build-tests.cmd %CoreRT_BuildType% %CoreRT_BuildArch% buildtests
 
 IF ERRORLEVEL 1 (
     echo Tests will not be run due to build-tests.cmd failing with error code !ErrorLevel!


### PR DESCRIPTION
This change enables R2R tests in release mode. It seems to me that
previously the tests were disabled in release mode because they
were crashing the CPAOT compiler due to a bug I made months ago -
apparently I put the CanInline method in the wrong class so it got
never exercised. In release mode, when inlining is active, this bug
ended up inlining bits of framework into the test app that we
couldn't express with the available ref tokens.

Thanks

Tomas

P.S. I'm still hitting some issues when trying to run the CoreCLR
tests in release mode, I'll address them in a separate change.