### PR TITLE
R2R Test Release Build Fix

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Linux.json
+++ b/buildpipeline/DotNet-CoreRT-Linux.json
@@ -359,7 +359,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Run build-tests.sh",

--- a/buildpipeline/DotNet-CoreRT-Linux.json
+++ b/buildpipeline/DotNet-CoreRT-Linux.json
@@ -377,7 +377,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Commit changes",
@@ -395,7 +395,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Remove container",

--- a/buildpipeline/DotNet-CoreRT-Mac.json
+++ b/buildpipeline/DotNet-CoreRT-Mac.json
@@ -91,7 +91,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Build tests",

--- a/buildpipeline/DotNet-CoreRT-Windows.json
+++ b/buildpipeline/DotNet-CoreRT-Windows.json
@@ -110,7 +110,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Build tests",

--- a/buildscripts/build-tests.cmd
+++ b/buildscripts/build-tests.cmd
@@ -36,7 +36,7 @@ IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
 call "!VS%__VSProductVersion%COMNTOOLS!\VsDevCmd.bat"
 echo Commencing build of test components for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
-"%__DotNetCliPath%\dotnet.exe" msbuild /ConsoleLoggerParameters:ForceNoAlign "%__ProjectDir%\tests\dirs.proj" %__ExtraMsBuildParams% /p:RepoPath="%__ProjectDir%" /p:RepoLocalBuild="true" /p:NuPkgRid=%__NugetRuntimeId% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__TestBuildLog%"
+"%__DotNetCliPath%\dotnet.exe" msbuild /ConsoleLoggerParameters:ForceNoAlign "%__ProjectDir%\tests\dirs.proj" %__ExtraMsBuildParams% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% /p:RepoPath="%__ProjectDir%" /p:RepoLocalBuild="true" /p:NuPkgRid=%__NugetRuntimeId% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__TestBuildLog%"
 IF NOT ERRORLEVEL 1 (
   findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%__TestBuildLog%"
   goto AfterTestBuild

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -104,7 +104,7 @@ if "%CoreRT_MultiFileConfiguration%"=="MultiModule" (
 )
 
 set CoreRT_CoreCLRRuntimeDir=%CoreRT_TestRoot%..\bin\obj\%CoreRT_BuildOS%.%CoreRT_BuildArch%.%CoreRT_BuildType%\CoreClrRuntime
-set CoreRT_ReadyToRunTestHarness=%CoreRT_TestRoot%src\tools\ReadyToRun.TestHarness\bin\Debug\netcoreapp2.1\ReadyToRun.TestHarness.dll
+set CoreRT_ReadyToRunTestHarness=%CoreRT_TestRoot%src\tools\ReadyToRun.TestHarness\bin\%CoreRT_BuildArch%\%CoreRT_BuildType%\netcoreapp2.1\ReadyToRun.TestHarness.dll
 
 rem When using pre-built R2R framework, switch the CoreCLRRuntime folder to its "native" subfolder
 rem where we copy over the CoreCLRRuntime folder and emit the R2R versions of the framework assemblies.


### PR DESCRIPTION
CoreRT Release builds were failing because of a loop between `build-test.cmd` and `runtest.cmd`.  
The script was looking for `ReadyToRun.TestHarness.dll` in just the Debug folder, which broke in Release configurations. I've also added an Architecture property to the build path. 