### PR TITLE
Further CPAOT infra fixes for release mode support

### DIFF
--- a/tests/CoreCLR/CompileAssembly.csproj
+++ b/tests/CoreCLR/CompileAssembly.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <OutputPath>$(CoreRT_CoreCLRRuntimeDir)\</OutputPath>
     <IntermediateOutputPath>$(CoreRT_CoreCLRRuntimeDir)\</IntermediateOutputPath>
+    <Optimize Condition="'$(Configuration)' == 'Release'">true</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CoreCLR/Test.csproj
+++ b/tests/CoreCLR/Test.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <OutputPath>$(MSBuildProjectDirectory)\</OutputPath>
     <IntermediateOutputPath>$(MSBuildProjectDirectory)\</IntermediateOutputPath>
+    <Optimize Condition="'$(Configuration)' == 'Release'">true</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -536,9 +536,10 @@ goto :eof
     echo.
     set CLRCustomTestLauncher=%CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd
     set XunitTestBinBase=!CoreRT_TestExtRepo_CoreCLR!
+
     pushd %CoreRT_TestRoot%\CoreCLR\runtest
 
-    "%CoreRT_CliDir%\dotnet.exe" msbuild /t:Restore /p:RepoLocalBuild=true src\TestWrappersConfig\XUnitTooling.depproj
+    "%CoreRT_CliDir%\dotnet.exe" msbuild /t:Restore /p:RepoLocalBuild=true /p:Configuration=%CoreRT_BuildType% /p:Platform=%CoreRT_BuildArch% src\TestWrappersConfig\XUnitTooling.depproj
     if errorlevel 1 (
         exit /b 1
     )

--- a/tests/src/Simple/ReadyToRunMultiModule/ReadyToRunMultiModule.cmd
+++ b/tests/src/Simple/ReadyToRunMultiModule/ReadyToRunMultiModule.cmd
@@ -2,7 +2,7 @@
 setlocal
 
 REM The arguments to invoke a ready-to-run test with ETW logging of jitted methods look like
-REM dotnet run --project --corerun tests\src\tools\ReadyToRun.TestHarness bin\obj\<Build>\CoreCLRRuntime\CoreRun.exe --in bin\Debug\<arch>\native\<test>.ni.exe --whitelist methodWhiteList.txt
+REM dotnet run --project --corerun tests\src\tools\ReadyToRun.TestHarness bin\obj\<Build>\CoreCLRRuntime\CoreRun.exe --in bin\<cfg>\<arch>\native\<test>.ni.exe --whitelist methodWhiteList.txt
 echo %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt
 call %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt
 

--- a/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.cmd
+++ b/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.cmd
@@ -2,7 +2,7 @@
 setlocal
 
 REM The arguments to invoke a ready-to-run test with ETW logging of jitted methods look like
-REM dotnet run --project --corerun tests\src\tools\ReadyToRun.TestHarness bin\obj\<Build>\CoreCLRRuntime\CoreRun.exe --in bin\Debug\<arch>\native\<test>.ni.exe --whitelist methodWhiteList.txt
+REM dotnet run --project --corerun tests\src\tools\ReadyToRun.TestHarness bin\obj\<Build>\CoreCLRRuntime\CoreRun.exe --in bin\<cfg>\<arch>\native\<test>.ni.exe --whitelist methodWhiteList.txt
 echo %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt --testargs %~dp0TestTextFile.txt
 call %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt --testargs %~dp0TestTextFile.txt
 


### PR DESCRIPTION
1) Pass the proper configuration and architecture to msbuild when
restoring XUnitTooling so that it gets restored into the proper
folder - this fixes building the CoreCLR tests in release mode.

2) Set the 'Optimize' property for Microsoft.NetCore.Native.targets
in CoreCLR test and framework assembly build to actually make a
difference w.r.t. release codegen by passing '-O' to ILC.

3) Update comments in the R2R test scripts to indicate we now
support per-configuration output folders.

Thanks

Tomas

P.S. Top200 tests have approximately the same pass rate in
debug and release mode (debug reports 6-8 errors, release 8-9 errors
in my local testing).

Framework assembly compilation in release mode has somewhat worse
pass rate, 110 out of the 152 assemblies build amounting to about
72% pass rate.