### PR TITLE
Fixes to allow non-.NET base class libraries

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -402,8 +402,8 @@ namespace Internal.TypeSystem.Ecma
                 return null;
             }
 
-            // TODO: Better exception type. Should be: "CoreLib doesn't have a required thing in it".
-            throw new NotImplementedException();
+            // Class library doesn't have finalizers
+            return null;
         }
 
         public override IEnumerable<FieldDesc> GetFields()

--- a/src/Common/src/TypeSystem/IL/TypeSystemContext.EnumMethods.cs
+++ b/src/Common/src/TypeSystem/IL/TypeSystemContext.EnumMethods.cs
@@ -71,6 +71,13 @@ namespace Internal.TypeSystem
 
         protected virtual IEnumerable<MethodDesc> GetAllMethodsForEnum(TypeDesc enumType)
         {
+            if (_objectEqualsMethod == null)
+                _objectEqualsMethod = GetWellKnownType(WellKnownType.Object).GetMethod("Equals", null);
+
+            // If the classlib doesn't have Object.Equals, we don't need this.
+            if (_objectEqualsMethod == null)
+                yield break;
+
             TypeDesc enumTypeDefinition = enumType.GetTypeDefinition();
             EnumInfo info = _enumInfoHashtable.GetOrCreateValue(enumTypeDefinition);
 

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
@@ -466,7 +466,7 @@ namespace Internal.TypeSystem.NativeFormat
                 return null;
             }
 
-            ThrowHelper.ThrowTypeLoadException(objectType);
+            // Class library doesn't have finalizers
             return null;
         }
 

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -343,6 +343,7 @@ namespace ILCompiler
             {
                 // Either single file, or multifile library, or multifile consumption.
                 EcmaModule entrypointModule = null;
+                bool systemModuleIsInputModule = false;
                 foreach (var inputFile in typeSystemContext.InputFilePaths)
                 {
                     EcmaModule module = typeSystemContext.GetModuleFromPath(inputFile.Value);
@@ -353,6 +354,9 @@ namespace ILCompiler
                             throw new Exception("Multiple EXE modules");
                         entrypointModule = module;
                     }
+
+                    if (module == typeSystemContext.SystemModule)
+                        systemModuleIsInputModule = true;
 
                     if (!_isReadyToRunCodeGen)
                         compilationRoots.Add(new ExportedMethodsRootProvider(module));
@@ -412,7 +416,7 @@ namespace ILCompiler
                     if (entrypointModule == null && !_nativeLib)
                         throw new Exception("No entrypoint module");
 
-                    if (!_isReadyToRunCodeGen)
+                    if (!systemModuleIsInputModule)
                         compilationRoots.Add(new ExportedMethodsRootProvider((EcmaModule)typeSystemContext.SystemModule));
                     compilationGroup = new SingleFileCompilationModuleGroup();
                 }

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -77,6 +77,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DelegateThunks.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\DynamicInvokeMethodThunk.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\EnumThunks.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\ValueTypeGetFieldHelperMethodOverride.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\HelperExtensions.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILDisassembler.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILOpcode.cs" />
@@ -90,6 +91,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.DelegateInfo.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.DynamicInvoke.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.EnumMethods.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.ValueTypeMethods.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\TypeSystemContext.GeneratedAssembly.cs" />
     <Compile Include="Internal\TypeSystem\ILStubMethod.Runtime.cs" />
     <Compile Include="Internal\TypeSystem\MethodForRuntimeDeterminedType.Runtime.cs" />


### PR DESCRIPTION
A couple fixes so that we can compile base class libraries that don't look like regular .NET base class libraries. This is for a weekend project, but general purpose enough.