### PR TITLE
WIP: incomplete fixes for LDVIRTFTN and other framework build issues

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -222,7 +222,7 @@ See the LICENSE file in the project root for more information.
 
     <Message Text="Generating native code" Importance="high" />
 
-    <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(IlcCmd.ResponseFileName)&quot;" />
+    <Exec Command="&quot;$(IlcPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(IlcCmd.ResponseFileName)&quot;" IgnoreExitCode="true" />
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Windows.props" Condition="'$(TargetOS)' == 'Windows_NT'" />

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -264,11 +264,13 @@ namespace Internal.JitInterface
             MethodDesc targetMethod = HandleToObject(pTargetMethod.hMethod);
             TypeDesc delegateTypeDesc = HandleToObject(delegateType);
 
+#if !READYTORUN
             if (targetMethod.IsSharedByGenericInstantiations)
             {
                 // If the method is not exact, fetch it as a runtime determined method.
                 targetMethod = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pTargetMethod);
             }
+#endif
 
             /* TODO
             bool isLdvirtftn = pTargetMethod.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Ldvirtftn;
@@ -399,6 +401,13 @@ namespace Internal.JitInterface
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_DIRECT:
                     id = ReadyToRunHelper.NewArray;
+                    break;
+
+                case CorInfoHelpFunc.CORINFO_HELP_VIRTUAL_FUNC_PTR:
+                    id = ReadyToRunHelper.VirtualFuncPtr;
+                    break;
+                case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR:
+                    id = ReadyToRunHelper.VirtualFuncPtr;
                     break;
 
                 case CorInfoHelpFunc.CORINFO_HELP_LMUL:


### PR DESCRIPTION
This change includes several experimental hotfixes I made to fix
LDVIRTFTN and other issues is CPAOT framework compilation:

1) The infra change to Microsoft.NetCore.Native.targets to ignore
CSC exit code is required to receive meaningful results for the ASP.NET
test build, otherwise the build stops as soon as we hit the first error
in ILC assembly builds.

2) I tried to reverse engineer Crossgen behavior with JanV's help
and use the info to properly implement LDVIRTFTN but apparently the
changes are still not completely correct, about 15 framework assemblies
are failing an assert in JIT that we're passing CORINFO_VIRTUALCALL_STUB
to some method that only expects CORINFO_CALL or CORINFO_CALL_CODE_POINTER.

3) I added a throw clause to abort JIT compilation of methods that
previously ended up crashing due to the Enum thunks.

Thanks

Tomas