### PR TITLE
Properly report intrinsic fields

### DIFF
--- a/src/Common/src/TypeSystem/CodeGen/FieldDesc.CodeGen.cs
+++ b/src/Common/src/TypeSystem/CodeGen/FieldDesc.CodeGen.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    // Additional members of FieldDesc related to code generation.
+    partial class FieldDesc
+    {
+        /// <summary>
+        /// Gets a value indicating whether this is a field that needs to be treated
+        /// specially.
+        /// </summary>
+        public virtual bool IsIntrinsic
+        {
+            get
+            {
+                return false;
+            }
+        }
+    }
+
+    partial class FieldForInstantiatedType
+    {
+        public override bool IsIntrinsic
+        {
+            get
+            {
+                return _fieldDef.IsIntrinsic;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaField.CodeGen.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.CodeGen.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem.Ecma
+{
+    partial class EcmaField
+    {
+        public override bool IsIntrinsic
+        {
+            get
+            {
+                return (GetFieldFlags(FieldFlags.AttributeMetadataCache | FieldFlags.Intrinsic) & FieldFlags.Intrinsic) != 0;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaField.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.cs
@@ -24,6 +24,7 @@ namespace Internal.TypeSystem.Ecma
 
             public const int AttributeMetadataCache = 0x0100;
             public const int ThreadStatic           = 0x0200;
+            public const int Intrinsic              = 0x0400;
         };
 
         private EcmaType _type;
@@ -151,12 +152,15 @@ namespace Internal.TypeSystem.Ecma
                     if (!metadataReader.GetAttributeNamespaceAndName(attributeHandle, out namespaceHandle, out nameHandle))
                         continue;
 
-                    if (metadataReader.StringComparer.Equals(namespaceHandle, "System"))
+                    if (metadataReader.StringComparer.Equals(nameHandle, "ThreadStaticAttribute")
+                        && metadataReader.StringComparer.Equals(namespaceHandle, "System"))
                     {
-                        if (metadataReader.StringComparer.Equals(nameHandle, "ThreadStaticAttribute"))
-                        {
-                            flags |= FieldFlags.ThreadStatic;
-                        }
+                        flags |= FieldFlags.ThreadStatic;
+                    }
+                    else if (metadataReader.StringComparer.Equals(nameHandle, "IntrinsicAttribute")
+                        && metadataReader.StringComparer.Equals(namespaceHandle, "System.Runtime.CompilerServices"))
+                    {
+                        flags |= FieldFlags.Intrinsic;
                     }
                 }
 

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatField.CodeGen.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatField.CodeGen.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem.NativeFormat
+{
+    partial class NativeFormatField
+    {
+        public override bool IsIntrinsic
+        {
+            get
+            {
+                return (GetFieldFlags(FieldFlags.AttributeMetadataCache | FieldFlags.Intrinsic) & FieldFlags.Intrinsic) != 0;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatField.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatField.cs
@@ -13,7 +13,7 @@ using Internal.TypeSystem;
 
 namespace Internal.TypeSystem.NativeFormat
 {
-    public sealed class NativeFormatField : FieldDesc, NativeFormatMetadataUnit.IHandleObject
+    public sealed partial class NativeFormatField : FieldDesc, NativeFormatMetadataUnit.IHandleObject
     {
         private static class FieldFlags
         {
@@ -25,7 +25,8 @@ namespace Internal.TypeSystem.NativeFormat
 
             public const int AttributeMetadataCache = 0x0100;
             public const int ThreadStatic = 0x0200;
-        };
+            public const int Intrinsic = 0x0400;
+        }
 
         private NativeFormatType _type;
         private FieldHandle _handle;
@@ -167,12 +168,15 @@ namespace Internal.TypeSystem.NativeFormat
                     if (!metadataReader.GetAttributeNamespaceAndName(attributeHandle, out namespaceName, out nameHandle))
                         continue;
 
-                    if (namespaceName.Equals("System"))
+                    if (nameHandle.StringEquals("ThreadStaticAttribute", metadataReader)
+                        && namespaceName.Equals("System"))
                     {
-                        if (nameHandle.StringEquals("ThreadStaticAttribute", metadataReader))
-                        {
-                            flags |= FieldFlags.ThreadStatic;
-                        }
+                        flags |= FieldFlags.ThreadStatic;
+                    }
+                    else if (nameHandle.StringEquals("IntrinsicAttribute", metadataReader)
+                        && namespaceName.Equals("System.Runtime.CompilerServices"))
+                    {
+                        flags |= FieldFlags.Intrinsic;
                     }
                 }
 

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -76,6 +76,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Canon\TypeSystemContext.Canon.cs">
       <Link>TypeSystem\Canon\TypeSystemContext.Canon.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\CodeGen\FieldDesc.CodeGen.cs">
+      <Link>TypeSystem\CodeGen\FieldDesc.CodeGen.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\MethodDesc.CodeGen.cs">
       <Link>TypeSystem\CodeGen\MethodDesc.CodeGen.cs</Link>
     </Compile>
@@ -294,6 +297,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.Sorting.cs">
       <Link>Ecma\EcmaField.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.CodeGen.cs">
+      <Link>Ecma\EcmaField.CodeGen.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaGenericParameter.Sorting.cs">
       <Link>Ecma\EcmaGenericParameter.Sorting.cs</Link>

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1804,6 +1804,8 @@ namespace Internal.JitInterface
 
         private CORINFO_FIELD_ACCESSOR getFieldIntrinsic(FieldDesc field)
         {
+            Debug.Assert(field.IsIntrinsic);
+
             var owningType = field.OwningType;
             if ((owningType.IsWellKnownType(WellKnownType.IntPtr) ||
                     owningType.IsWellKnownType(WellKnownType.UIntPtr)) &&
@@ -1928,7 +1930,8 @@ namespace Internal.JitInterface
 
                     ReadyToRunHelperId helperId = ReadyToRunHelperId.Invalid;
                     CORINFO_FIELD_ACCESSOR intrinsicAccessor;
-                    if ((flags & CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_GET) != 0 &&
+                    if (field.IsIntrinsic &&
+                        (flags & CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_GET) != 0 &&
                         (intrinsicAccessor = getFieldIntrinsic(field)) != (CORINFO_FIELD_ACCESSOR)(-1))
                     {
                         fieldAccessor = intrinsicAccessor;

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -1123,6 +1123,7 @@ namespace Internal.JitInterface
 
         CORINFO_FIELD_INTRINSIC_ZERO,           // intrinsic zero (IntPtr.Zero, UIntPtr.Zero)
         CORINFO_FIELD_INTRINSIC_EMPTY_STRING,   // intrinsic emptry string (String.Empty)
+        CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN, // intrinsic BitConverter.IsLittleEndian
     }
 
     // Set of flags returned in CORINFO_FIELD_INFO::fieldFlags

--- a/src/System.Private.CoreLib/shared/System/BitConverter.cs
+++ b/src/System.Private.CoreLib/shared/System/BitConverter.cs
@@ -20,8 +20,10 @@ namespace System
         // The value is set to true if the architecture is
         // little endian; false if it is big endian.
 #if BIGENDIAN
+        [Intrinsic]
         public static readonly bool IsLittleEndian /* = false */;
 #else
+        [Intrinsic]
         public static readonly bool IsLittleEndian = true;
 #endif
 

--- a/src/System.Private.CoreLib/src/System/String.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/String.CoreRT.cs
@@ -90,6 +90,7 @@ namespace System
 
 #pragma warning restore
 
+        [Intrinsic]
         public static readonly string Empty = "";
 
         [System.Runtime.CompilerServices.IndexerName("Chars")]

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -58,6 +58,9 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(DynamicCodeSupport)' == 'true'">
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\TypeDesc.CodeGen.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\CodeGen\FieldDesc.CodeGen.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.CodeGen.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\NativeFormat\NativeFormatField.CodeGen.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ByRefType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\DefType.RuntimeDetermined.cs" />


### PR DESCRIPTION
We were hitting an assert in RyuJIT because we were reporting IntPtr.Zero as an intrinsic even if we were not trying to `CORINFO_ACCESS_GET`.

I fixed that part and also went ahead to port the rest of getFieldIntrinsic from CoreCLR. We'll need this anyway.