### PR TITLE
Add two xunit packages to runtime.depproj to unblock about 90 tests

### DIFF
--- a/tests/external/runtime/runtime.depproj
+++ b/tests/external/runtime/runtime.depproj
@@ -8,6 +8,8 @@
     <NugetTargetMoniker>.NETCoreApp,Version=v3.0</NugetTargetMoniker>
     <NugetTargetMonikerShort>netcoreapp3.0</NugetTargetMonikerShort>
     <RidSpecificAssets>true</RidSpecificAssets>
+    <CoreFXXUnitPackageVersion>2.2.0-beta2-build3300</CoreFXXUnitPackageVersion>
+    <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>
     <OutputPath>$(IntermediateOutputRootPath)CoreClrRuntime</OutputPath>
   </PropertyGroup>
 
@@ -20,6 +22,12 @@
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>4.6.0-preview.18571.1</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.core">
+      <Version>$(CoreFXXUnitPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.performance.core">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
     </PackageReference>
     
   </ItemGroup>

--- a/tests/external/runtime/runtime.depproj
+++ b/tests/external/runtime/runtime.depproj
@@ -8,8 +8,6 @@
     <NugetTargetMoniker>.NETCoreApp,Version=v3.0</NugetTargetMoniker>
     <NugetTargetMonikerShort>netcoreapp3.0</NugetTargetMonikerShort>
     <RidSpecificAssets>true</RidSpecificAssets>
-    <CoreFXXUnitPackageVersion>2.2.0-beta2-build3300</CoreFXXUnitPackageVersion>
-    <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>
     <OutputPath>$(IntermediateOutputRootPath)CoreClrRuntime</OutputPath>
   </PropertyGroup>
 
@@ -24,10 +22,10 @@
       <Version>4.6.0-preview.18571.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.core">
-      <Version>$(CoreFXXUnitPackageVersion)</Version>
+      <Version>2.2.0-beta2-build3300</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.core">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
+      <Version>1.0.0-beta-build0015</Version>
     </PackageReference>
     
   </ItemGroup>


### PR DESCRIPTION
This change adds the packages "xunit.core" and "xunit.performance.core"
required by some CoreCLR tests to external test dependencies. I have
copied the clauses from external.depproj in CoreCLR and their versions
from dependency.props. This change reduces the number of failures from
346 to 254.

Thanks

Tomas