### PR TITLE
[Interpreter] Locals and operators

### DIFF
--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -260,7 +260,223 @@ namespace Internal.IL
 
         private void ImportCompareOperation(ILOpcode opcode)
         {
-            throw new NotImplementedException();
+            bool result = default(bool);
+            StackItem op1 = PopWithValidation();
+            StackItem op2 = PopWithValidation();
+
+            switch (op1.Kind)
+            {
+                case StackValueKind.Int32:
+                    {
+                        int val1 = op1.AsInt32();
+
+                        if (op2.Kind == StackValueKind.Int32 || op2.Kind == StackValueKind.NativeInt)
+                        {
+                            int val2 = op2.Kind == StackValueKind.Int32 ? op2.AsInt32() : op2.AsIntPtr().ToInt32();
+
+                            if (opcode == ILOpcode.ceq)
+                            {
+                                result = val1 == val2;
+                            }
+                            else if (opcode == ILOpcode.cgt)
+                            {
+                                result = val2 > val1;
+                            }
+                            else if (opcode == ILOpcode.cgt_un)
+                            {
+                                result = (uint)val2 > (uint)val1;
+                            }
+                            else if (opcode == ILOpcode.clt)
+                            {
+                                result = val2 < val1;
+                            }
+                            else if (opcode == ILOpcode.clt_un)
+                            {
+                                result = (uint)val2 < (uint)val1;
+                            }
+                        }
+                        else if (op2.Kind == StackValueKind.ValueType &&
+                            (op2.AsValueType().GetType() == typeof(int) || op2.AsValueType().GetType() == typeof(IntPtr)))
+                        {
+                            ValueType valueType = op2.AsValueType();
+                            int val2 = valueType.GetType() == typeof(int) ? (int)valueType : ((IntPtr)valueType).ToInt32();
+
+                            if (opcode == ILOpcode.ceq)
+                            {
+                                result = val1 == val2;
+                            }
+                            else if (opcode == ILOpcode.cgt)
+                            {
+                                result = val2 > val1;
+                            }
+                            else if (opcode == ILOpcode.cgt_un)
+                            {
+                                result = (uint)val2 > (uint)val1;
+                            }
+                            else if (opcode == ILOpcode.clt)
+                            {
+                                result = val2 < val1;
+                            }
+                            else if (opcode == ILOpcode.clt_un)
+                            {
+                                result = (uint)val2 < (uint)val1;
+                            }
+                        }
+                        else
+                        {
+                            ThrowHelper.ThrowInvalidProgramException();
+                        }
+                    }
+                    break;
+                case StackValueKind.Int64:
+                    {
+                        long val1 = op1.AsInt64();
+
+                        if (op2.Kind == StackValueKind.Int64)
+                        {
+                            long val2 = op2.AsInt64();
+
+                            if (opcode == ILOpcode.ceq)
+                            {
+                                result = val1 == val2;
+                            }
+                            else if (opcode == ILOpcode.cgt)
+                            {
+                                result = val2 > val1;
+                            }
+                            else if (opcode == ILOpcode.cgt_un)
+                            {
+                                result = (ulong)val2 > (ulong)val1;
+                            }
+                            else if (opcode == ILOpcode.clt)
+                            {
+                                result = val2 < val1;
+                            }
+                            else if (opcode == ILOpcode.clt_un)
+                            {
+                                result = (ulong)val2 < (ulong)val1;
+                            }
+                        }
+                        else
+                        {
+                            ThrowHelper.ThrowInvalidProgramException();
+                        }
+                    }
+                    break;
+                case StackValueKind.NativeInt:
+                    {
+                        IntPtr val1 = op1.AsIntPtr();
+                        if (op2.Kind == StackValueKind.Int32
+                            || op1.Kind == StackValueKind.Int64
+                            || op2.Kind == StackValueKind.NativeInt)
+                        {
+                            IntPtr val2 = IntPtr.Zero;
+
+                            if (op2.Kind == StackValueKind.Int32)
+                            {
+                                val2 = new IntPtr(op2.AsInt32());
+                            }
+                            else if (op2.Kind == StackValueKind.Int64)
+                            {
+                                val2 = new IntPtr(op2.AsInt64());
+                            }
+                            else
+                            {
+                                val2 = op2.AsIntPtr();
+                            }
+
+                            if (opcode == ILOpcode.ceq)
+                            {
+                                result = val1 == val2;
+                            }
+                            else if (opcode == ILOpcode.cgt)
+                            {
+                                result = (ulong)val2.ToInt64() > (ulong)val1.ToInt64();
+                            }
+                            else if (opcode == ILOpcode.cgt_un)
+                            {
+                                result = ((UIntPtr)val2.ToPointer()).ToUInt64() > ((UIntPtr)val1.ToPointer()).ToUInt64();
+                            }
+                            else if (opcode == ILOpcode.clt)
+                            {
+                                result = (ulong)val2.ToInt64() < (ulong)val1.ToInt64();
+                            }
+                            else if (opcode == ILOpcode.clt_un)
+                            {
+                                result = ((UIntPtr)val2.ToPointer()).ToUInt64() < ((UIntPtr)val1.ToPointer()).ToUInt64();
+                            }
+                        }
+                    }
+                    break;
+                case StackValueKind.Float:
+                    {
+                        double val1 = op1.AsDouble();
+
+                        if (op2.Kind == StackValueKind.Float)
+                        {
+                            double val2 = op2.AsDouble();
+
+                            if (opcode == ILOpcode.ceq)
+                            {
+                                result = (double.IsNaN(val1) || double.IsNaN(val2)) ? false : val1 == val2;
+                            }
+                            else if (opcode == ILOpcode.cgt)
+                            {
+                                result = (double.IsNaN(val1) || double.IsNaN(val2)) ? false : val2 > val1;
+                            }
+                            else if (opcode == ILOpcode.cgt_un)
+                            {
+                                result = val2 > val1;
+                            }
+                            else if (opcode == ILOpcode.clt)
+                            {
+                                result = (double.IsNaN(val1) || double.IsNaN(val2)) ? false : val2 < val1;
+                            }
+                            else if (opcode == ILOpcode.clt_un)
+                            {
+                                result = val2 < val1;
+                            }
+                        }
+                        else
+                        {
+                            ThrowHelper.ThrowInvalidProgramException();
+                        }
+                    }
+                    break;
+                case StackValueKind.ObjRef:
+                    {
+                        object val1 = op1.AsObjectRef();
+
+                        if (op2.Kind == StackValueKind.ObjRef)
+                        {
+                            object val2 = op2.AsObjectRef();
+
+                            if (opcode == ILOpcode.ceq)
+                            {
+                                result = val1 == val2;
+                            }
+                            else
+                            {
+                                // TODO: Find GC addresses of objects and compare them
+                            }
+                        }
+                        else
+                        {
+                            ThrowHelper.ThrowInvalidProgramException();
+                        }
+                    }
+                    break;
+                case StackValueKind.ByRef:
+                    // TODO: Handle ByRef scenarios
+                    break;
+                case StackValueKind.ValueType:
+                case StackValueKind.Unknown:
+                default:
+                    ThrowHelper.ThrowInvalidProgramException();
+                    break;
+            }
+
+            _interpreter.EvaluationStack.Push(StackItem.FromInt32(result ? 1 : 0));
         }
 
         private void ImportConvert(WellKnownType wellKnownType, bool checkOverflow, bool unsigned)

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -255,7 +255,149 @@ namespace Internal.IL
 
         private void ImportShiftOperation(ILOpcode opcode)
         {
-            throw new NotImplementedException();
+            StackItem op1 = PopWithValidation();
+            StackItem op2 = PopWithValidation();
+
+            switch (op1.Kind)
+            {
+                case StackValueKind.Int32:
+                    {
+                        int shiftBy = op1.AsInt32();
+                        if (op2.Kind == StackValueKind.Int32)
+                        {
+                            int value = op2.AsInt32();
+                            if (opcode == ILOpcode.shl)
+                            {
+                                value = value << shiftBy;
+                            }
+                            else if (opcode == ILOpcode.shr)
+                            {
+                                value = value >> shiftBy;
+                            }
+                            else if (opcode == ILOpcode.shr_un)
+                            {
+                                value = (int)((uint)value >> shiftBy);
+                            }
+
+                            _interpreter.EvaluationStack.Push(StackItem.FromInt32(value));
+                        }
+                        else if (op2.Kind == StackValueKind.Int64)
+                        {
+                            long value = op2.AsInt64();
+                            if (opcode == ILOpcode.shl)
+                            {
+                                value = value << shiftBy;
+                            }
+                            else if (opcode == ILOpcode.shr)
+                            {
+                                value = value >> shiftBy;
+                            }
+                            else if (opcode == ILOpcode.shr_un)
+                            {
+                                value = (long)((ulong)value >> shiftBy);
+                            }
+
+                            _interpreter.EvaluationStack.Push(StackItem.FromInt64(value));
+                        }
+                        else if (op2.Kind == StackValueKind.NativeInt)
+                        {
+                            IntPtr value = op2.AsNativeInt();
+                            if (opcode == ILOpcode.shl)
+                            {
+                                value = new IntPtr(value.ToInt64() << shiftBy);
+                            }
+                            else if (opcode == ILOpcode.shr)
+                            {
+                                value = new IntPtr(value.ToInt64() >> shiftBy);
+                            }
+                            else if (opcode == ILOpcode.shr_un)
+                            {
+                                UIntPtr uintPtr = new UIntPtr(value.ToPointer());
+                                value = new IntPtr((long)(uintPtr.ToUInt64() >> shiftBy));
+                            }
+
+                            _interpreter.EvaluationStack.Push(StackItem.FromNativeInt(value));
+                        }
+                        else
+                        {
+                            ThrowHelper.ThrowInvalidProgramException();
+                        }
+                    }
+                    break;
+                case StackValueKind.NativeInt:
+                    {
+                        IntPtr shiftBy = op1.AsNativeInt();
+                        if (op2.Kind == StackValueKind.Int32)
+                        {
+                            int value = op2.AsInt32();
+                            if (opcode == ILOpcode.shl)
+                            {
+                                value = value << shiftBy.ToInt32();
+                            }
+                            else if (opcode == ILOpcode.shr)
+                            {
+                                value = value >> shiftBy.ToInt32();
+                            }
+                            else if (opcode == ILOpcode.shr_un)
+                            {
+                                value = (int)((uint)value >> shiftBy.ToInt32());
+                            }
+
+                            _interpreter.EvaluationStack.Push(StackItem.FromInt32(value));
+                        }
+                        else if (op2.Kind == StackValueKind.Int64)
+                        {
+                            long value = op2.AsInt64();
+                            if (opcode == ILOpcode.shl)
+                            {
+                                value = value << shiftBy.ToInt32();
+                            }
+                            else if (opcode == ILOpcode.shr)
+                            {
+                                value = value >> shiftBy.ToInt32();
+                            }
+                            else if (opcode == ILOpcode.shr_un)
+                            {
+                                value = (long)((ulong)value >> shiftBy.ToInt32());
+                            }
+
+                            _interpreter.EvaluationStack.Push(StackItem.FromInt64(value));
+                        }
+                        else if (op2.Kind == StackValueKind.NativeInt)
+                        {
+                            IntPtr value = op2.AsNativeInt();
+                            if (opcode == ILOpcode.shl)
+                            {
+                                value = new IntPtr(value.ToInt64() << shiftBy.ToInt32());
+                            }
+                            else if (opcode == ILOpcode.shr)
+                            {
+                                value = new IntPtr(value.ToInt64() >> shiftBy.ToInt32());
+                            }
+                            else if (opcode == ILOpcode.shr_un)
+                            {
+                                UIntPtr uintPtr = new UIntPtr(value.ToPointer());
+                                value = new IntPtr((long)(uintPtr.ToUInt64() >> shiftBy.ToInt32()));
+                            }
+
+                            _interpreter.EvaluationStack.Push(StackItem.FromNativeInt(value));
+                        }
+                        else
+                        {
+                            ThrowHelper.ThrowInvalidProgramException();
+                        }
+                    }
+                    break;
+                case StackValueKind.Unknown:
+                case StackValueKind.Int64:
+                case StackValueKind.Float:
+                case StackValueKind.ByRef:
+                case StackValueKind.ObjRef:
+                case StackValueKind.ValueType:
+                default:
+                    ThrowHelper.ThrowInvalidProgramException();
+                    break;
+            }
         }
 
         private void ImportCompareOperation(ILOpcode opcode)
@@ -1124,6 +1266,9 @@ namespace Internal.IL
 
                         break;
                     }
+                default:
+                    ThrowHelper.ThrowInvalidProgramException();
+                    break;
             }
         }
 

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -533,7 +533,7 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
@@ -588,7 +588,7 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
@@ -643,7 +643,7 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
@@ -698,7 +698,7 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
@@ -752,7 +752,7 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
@@ -806,7 +806,7 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromInt32((int)result));
@@ -857,7 +857,7 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromInt64(result));
@@ -912,7 +912,7 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromInt64((long)result));
@@ -965,17 +965,117 @@ namespace Internal.IL
                         }
                         else
                         {
-
+                            // TODO: Figure out how the CLR converts an object to an integer representation
                         }
 
                         _interpreter.EvaluationStack.Push(StackItem.FromDouble(result));
                         break;
                     }
                 case WellKnownType.IntPtr:
-                    break;
+                    {
+                        IntPtr result = default(IntPtr);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = (IntPtr)value;
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = (IntPtr)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = (IntPtr)value;
+                            }
+                            else
+                            {
+                                result = (IntPtr)stackItem.AsInt64();
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            result = (IntPtr)stackItem.AsDouble();
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
+                                result = new IntPtr(value.ToPointer());
+                            }
+                            else
+                            {
+                                result = stackItem.AsNativeInt();
+                            }
+                        }
+                        else
+                        {
+                            // TODO: Figure out how the CLR converts an object to an integer representation
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromNativeInt(result));
+                        break;
+                    }
                 case WellKnownType.UIntPtr:
-                    break;
+                    {
+                        UIntPtr result = default(UIntPtr);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = (UIntPtr)value;
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = (UIntPtr)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = (UIntPtr)value;
+                            }
+                            else
+                            {
+                                result = (UIntPtr)stackItem.AsInt64();
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            result = (UIntPtr)stackItem.AsDouble();
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                result = (UIntPtr)stackItem.AsNativeInt().ToPointer();
+                            }
+                            else
+                            {
+                                result = new UIntPtr(stackItem.AsNativeInt().ToPointer());
+                            }
+                        }
+                        else
+                        {
+                            // TODO: Figure out how the CLR converts an object to an integer representation
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromNativeInt(new IntPtr(result.ToPointer())));
+                        break;
+                    }
                 default:
+                    ThrowHelper.ThrowInvalidProgramException();
                     break;
             }
         }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -211,7 +211,7 @@ namespace Internal.IL
                     break;
                 case TypeFlags.IntPtr:
                 case TypeFlags.UIntPtr:
-                    _interpreter.SetReturnValue(stackItem.AsIntPtr());
+                    _interpreter.SetReturnValue(stackItem.AsNativeInt());
                     break;
                 case TypeFlags.Single:
                     _interpreter.SetReturnValue((float)stackItem.AsDouble());
@@ -272,7 +272,7 @@ namespace Internal.IL
 
                         if (op2.Kind == StackValueKind.Int32 || op2.Kind == StackValueKind.NativeInt)
                         {
-                            int val2 = op2.Kind == StackValueKind.Int32 ? op2.AsInt32() : op2.AsIntPtr().ToInt32();
+                            int val2 = op2.Kind == StackValueKind.Int32 ? op2.AsInt32() : op2.AsNativeInt().ToInt32();
 
                             if (opcode == ILOpcode.ceq)
                             {
@@ -365,7 +365,7 @@ namespace Internal.IL
                     break;
                 case StackValueKind.NativeInt:
                     {
-                        IntPtr val1 = op1.AsIntPtr();
+                        IntPtr val1 = op1.AsNativeInt();
                         if (op2.Kind == StackValueKind.Int32
                             || op1.Kind == StackValueKind.Int64
                             || op2.Kind == StackValueKind.NativeInt)
@@ -382,7 +382,7 @@ namespace Internal.IL
                             }
                             else
                             {
-                                val2 = op2.AsIntPtr();
+                                val2 = op2.AsNativeInt();
                             }
 
                             if (opcode == ILOpcode.ceq)
@@ -522,12 +522,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = checkOverflow ? Convert.ToSByte(value.ToUInt64()) : (sbyte)value;
                             }
                             else
                             {
-                                IntPtr value = stackItem.AsIntPtr();
+                                IntPtr value = stackItem.AsNativeInt();
                                 result = checkOverflow ? Convert.ToSByte(value.ToInt64()) : (sbyte)value;
                             }
                         }
@@ -577,12 +577,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = checkOverflow ? Convert.ToByte(value.ToUInt64()) : (byte)value;
                             }
                             else
                             {
-                                IntPtr value = stackItem.AsIntPtr();
+                                IntPtr value = stackItem.AsNativeInt();
                                 result = checkOverflow ? Convert.ToByte(value.ToInt64()) : (byte)value;
                             }
                         }
@@ -632,12 +632,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = checkOverflow ? Convert.ToInt16(value.ToUInt64()) : (short)value;
                             }
                             else
                             {
-                                IntPtr value = stackItem.AsIntPtr();
+                                IntPtr value = stackItem.AsNativeInt();
                                 result = checkOverflow ? Convert.ToInt16(value.ToInt64()) : (short)value;
                             }
                         }
@@ -687,12 +687,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = checkOverflow ? Convert.ToUInt16(value.ToUInt64()) : (ushort)value;
                             }
                             else
                             {
-                                IntPtr value = stackItem.AsIntPtr();
+                                IntPtr value = stackItem.AsNativeInt();
                                 result = checkOverflow ? Convert.ToUInt16(value.ToInt64()) : (ushort)value;
                             }
                         }
@@ -741,12 +741,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = checkOverflow ? Convert.ToInt32(value.ToUInt64()) : (int)value;
                             }
                             else
                             {
-                                IntPtr value = stackItem.AsIntPtr();
+                                IntPtr value = stackItem.AsNativeInt();
                                 result = checkOverflow ? Convert.ToInt32(value.ToInt64()) : (int)value;
                             }
                         }
@@ -795,12 +795,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = checkOverflow ? Convert.ToUInt32(value.ToUInt64()) : (uint)value;
                             }
                             else
                             {
-                                IntPtr value = stackItem.AsIntPtr();
+                                IntPtr value = stackItem.AsNativeInt();
                                 result = checkOverflow ? Convert.ToUInt32(value.ToInt64()) : (uint)value;
                             }
                         }
@@ -847,12 +847,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = (long)value.ToUInt64();
                             }
                             else
                             {
-                                result = stackItem.AsIntPtr().ToInt64();
+                                result = stackItem.AsNativeInt().ToInt64();
                             }
                         }
                         else
@@ -901,12 +901,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = value.ToUInt64();
                             }
                             else
                             {
-                                IntPtr value = stackItem.AsIntPtr();
+                                IntPtr value = stackItem.AsNativeInt();
                                 result = checkOverflow ? Convert.ToUInt64(value.ToInt64()) : (ulong)value;
                             }
                         }
@@ -955,12 +955,12 @@ namespace Internal.IL
                         {
                             if (unsigned)
                             {
-                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                UIntPtr value = (UIntPtr)stackItem.AsNativeInt().ToPointer();
                                 result = (double)value;
                             }
                             else
                             {
-                                result = (double)stackItem.AsIntPtr();
+                                result = (double)stackItem.AsNativeInt();
                             }
                         }
                         else

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -177,7 +177,7 @@ namespace Internal.IL
             var returnType = _method.Signature.ReturnType;
             if (returnType.RuntimeTypeHandle.Value == typeof(void).TypeHandle.Value)
                 return;
-            
+
             StackItem stackItem = PopWithValidation();
             TypeFlags category = returnType.Category;
 
@@ -270,7 +270,45 @@ namespace Internal.IL
 
         private void ImportUnaryOperation(ILOpcode opCode)
         {
-            throw new NotImplementedException();
+            StackItem stackItem = PopWithValidation();
+            switch (opCode)
+            {
+                case ILOpcode.neg:
+                    {
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            int value = stackItem.AsInt32();
+                            _interpreter.EvaluationStack.Push(StackItem.FromInt32(-value));
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            long value = stackItem.AsInt64();
+                            _interpreter.EvaluationStack.Push(StackItem.FromInt64(-value));
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            _interpreter.EvaluationStack.Push(StackItem.FromDouble(-value));
+                        }
+                        break;
+                    }
+                case ILOpcode.not:
+                    {
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            int value = stackItem.AsInt32();
+                            _interpreter.EvaluationStack.Push(StackItem.FromInt32(~value));
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            long value = stackItem.AsInt64();
+                            _interpreter.EvaluationStack.Push(StackItem.FromInt64(~value));
+                        }
+                        break;
+                    }
+                default:
+                    break;
+            }
         }
 
         private void ImportCpOpj(int token)

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -9,7 +9,7 @@ using Internal.TypeSystem;
 
 namespace Internal.IL
 {
-    partial class ILImporter
+    unsafe partial class ILImporter
     {
         private class BasicBlock
         {
@@ -265,7 +265,503 @@ namespace Internal.IL
 
         private void ImportConvert(WellKnownType wellKnownType, bool checkOverflow, bool unsigned)
         {
-            throw new NotImplementedException();
+            StackItem stackItem = PopWithValidation();
+            switch (wellKnownType)
+            {
+                case WellKnownType.SByte:
+                    {
+                        sbyte result = default(sbyte);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToSByte(value) : (sbyte)value;
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToSByte(value) : (sbyte)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToSByte(value) : (sbyte)value;
+                            }
+                            else
+                            {
+                                long value = stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToSByte(value) : (sbyte)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            result = checkOverflow ? Convert.ToSByte(value) : (sbyte)value;
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = checkOverflow ? Convert.ToSByte(value.ToUInt64()) : (sbyte)value;
+                            }
+                            else
+                            {
+                                IntPtr value = stackItem.AsIntPtr();
+                                result = checkOverflow ? Convert.ToSByte(value.ToInt64()) : (sbyte)value;
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
+                        break;
+                    }
+                case WellKnownType.Byte:
+                    {
+                        byte result = default(byte);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToByte(value) : (byte)value;
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToByte(value) : (byte)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToByte(value) : (byte)value;
+                            }
+                            else
+                            {
+                                long value = stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToByte(value) : (byte)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            result = checkOverflow ? Convert.ToByte(value) : (byte)value;
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = checkOverflow ? Convert.ToByte(value.ToUInt64()) : (byte)value;
+                            }
+                            else
+                            {
+                                IntPtr value = stackItem.AsIntPtr();
+                                result = checkOverflow ? Convert.ToByte(value.ToInt64()) : (byte)value;
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
+                        break;
+                    }
+                case WellKnownType.Int16:
+                    {
+                        short result = default(short);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToInt16(value) : (short)value;
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToInt16(value) : (short)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToInt16(value) : (short)value;
+                            }
+                            else
+                            {
+                                long value = stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToInt16(value) : (short)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            result = checkOverflow ? Convert.ToInt16(value) : (short)value;
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = checkOverflow ? Convert.ToInt16(value.ToUInt64()) : (short)value;
+                            }
+                            else
+                            {
+                                IntPtr value = stackItem.AsIntPtr();
+                                result = checkOverflow ? Convert.ToInt16(value.ToInt64()) : (short)value;
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
+                        break;
+                    }
+                case WellKnownType.UInt16:
+                    {
+                        ushort result = default(ushort);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToUInt16(value) : (ushort)value;
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToUInt16(value) : (ushort)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToUInt16(value) : (ushort)value;
+                            }
+                            else
+                            {
+                                long value = stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToUInt16(value) : (ushort)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            result = checkOverflow ? Convert.ToUInt16(value) : (ushort)value;
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = checkOverflow ? Convert.ToUInt16(value.ToUInt64()) : (ushort)value;
+                            }
+                            else
+                            {
+                                IntPtr value = stackItem.AsIntPtr();
+                                result = checkOverflow ? Convert.ToUInt16(value.ToInt64()) : (ushort)value;
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
+                        break;
+                    }
+                case WellKnownType.Int32:
+                    {
+                        int result = default(int);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToInt32(value) : (int)value;
+                            }
+                            else
+                            {
+                                result = stackItem.AsInt32();
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToInt32(value) : (int)value;
+                            }
+                            else
+                            {
+                                long value = stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToInt32(value) : (int)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            result = checkOverflow ? Convert.ToInt32(value) : (int)value;
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = checkOverflow ? Convert.ToInt32(value.ToUInt64()) : (int)value;
+                            }
+                            else
+                            {
+                                IntPtr value = stackItem.AsIntPtr();
+                                result = checkOverflow ? Convert.ToInt32(value.ToInt64()) : (int)value;
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromInt32(result));
+                        break;
+                    }
+                case WellKnownType.UInt32:
+                    {
+                        uint result = default(uint);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                result = (uint)stackItem.AsInt32();
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToUInt32(value) : (uint)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToUInt32(value) : (uint)value;
+                            }
+                            else
+                            {
+                                long value = stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToUInt32(value) : (uint)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            result = checkOverflow ? Convert.ToUInt32(value) : (uint)value;
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = checkOverflow ? Convert.ToUInt32(value.ToUInt64()) : (uint)value;
+                            }
+                            else
+                            {
+                                IntPtr value = stackItem.AsIntPtr();
+                                result = checkOverflow ? Convert.ToUInt32(value.ToInt64()) : (uint)value;
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromInt32((int)result));
+                        break;
+                    }
+                case WellKnownType.Int64:
+                    {
+                        long result = default(long);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                result = (uint)stackItem.AsInt32();
+                            }
+                            else
+                            {
+                                result = stackItem.AsInt32();
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToInt64(value) : (long)value;
+                            }
+                            else
+                            {
+                                result = stackItem.AsInt64();
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            result = checkOverflow ? Convert.ToInt64(value) : (long)value;
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = (long)value.ToUInt64();
+                            }
+                            else
+                            {
+                                result = stackItem.AsIntPtr().ToInt64();
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromInt64(result));
+                        break;
+                    }
+                case WellKnownType.UInt64:
+                    {
+                        ulong result = default(ulong);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToUInt64(value) : (ulong)value;
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = checkOverflow ? Convert.ToUInt64(value) : (ulong)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToUInt64(value) : (ulong)value;
+                            }
+                            else
+                            {
+                                long value = stackItem.AsInt64();
+                                result = checkOverflow ? Convert.ToUInt64(value) : (ulong)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            double value = stackItem.AsDouble();
+                            result = checkOverflow ? Convert.ToUInt64(value) : (ulong)value;
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = value.ToUInt64();
+                            }
+                            else
+                            {
+                                IntPtr value = stackItem.AsIntPtr();
+                                result = checkOverflow ? Convert.ToUInt64(value.ToInt64()) : (ulong)value;
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromInt64((long)result));
+                        break;
+                    }
+                case WellKnownType.Single:
+                case WellKnownType.Double:
+                    {
+                        double result = default(double);
+                        if (stackItem.Kind == StackValueKind.Int32)
+                        {
+                            if (unsigned)
+                            {
+                                uint value = (uint)stackItem.AsInt32();
+                                result = (double)value;
+                            }
+                            else
+                            {
+                                int value = stackItem.AsInt32();
+                                result = (double)value;
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Int64)
+                        {
+                            if (unsigned)
+                            {
+                                ulong value = (ulong)stackItem.AsInt64();
+                                result = (double)value;
+                            }
+                            else
+                            {
+                                result = (double)stackItem.AsInt64();
+                            }
+                        }
+                        else if (stackItem.Kind == StackValueKind.Float)
+                        {
+                            result = stackItem.AsDouble();
+                        }
+                        else if (stackItem.Kind == StackValueKind.NativeInt)
+                        {
+                            if (unsigned)
+                            {
+                                UIntPtr value = (UIntPtr)stackItem.AsIntPtr().ToPointer();
+                                result = (double)value;
+                            }
+                            else
+                            {
+                                result = (double)stackItem.AsIntPtr();
+                            }
+                        }
+                        else
+                        {
+
+                        }
+
+                        _interpreter.EvaluationStack.Push(StackItem.FromDouble(result));
+                        break;
+                    }
+                case WellKnownType.IntPtr:
+                    break;
+                case WellKnownType.UIntPtr:
+                    break;
+                default:
+                    break;
+            }
         }
 
         private void ImportUnaryOperation(ILOpcode opCode)
@@ -290,6 +786,7 @@ namespace Internal.IL
                             double value = stackItem.AsDouble();
                             _interpreter.EvaluationStack.Push(StackItem.FromDouble(-value));
                         }
+
                         break;
                     }
                 case ILOpcode.not:
@@ -304,10 +801,13 @@ namespace Internal.IL
                             long value = stackItem.AsInt64();
                             _interpreter.EvaluationStack.Push(StackItem.FromInt64(~value));
                         }
+                        else
+                        {
+                            ThrowHelper.ThrowInvalidProgramException();
+                        }
+
                         break;
                     }
-                default:
-                    break;
             }
         }
 

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILImporter.Interpreter.cs
@@ -111,6 +111,15 @@ namespace Internal.IL
             return stackItem;
         }
 
+        public StackItem PeekWithValidation()
+        {
+            bool hasStackItem = _interpreter.EvaluationStack.TryPeek(out StackItem stackItem);
+            if (!hasStackItem)
+                ThrowHelper.ThrowInvalidProgramException();
+
+            return stackItem;
+        }
+
         private void ImportNop()
         {
             // Do nothing!
@@ -123,12 +132,19 @@ namespace Internal.IL
 
         private void ImportLoadVar(int index, bool argument)
         {
-            throw new NotImplementedException();
+            if (argument)
+                return;
+
+            StackItem stackItem = _interpreter.GetVariable(index);
+            _interpreter.EvaluationStack.Push(stackItem);
         }
 
         private void ImportStoreVar(int index, bool argument)
         {
-            throw new NotImplementedException();
+            if (argument)
+                return;
+
+            _interpreter.SetVariable(index, PopWithValidation());
         }
 
         private void ImportAddressOfVar(int index, bool argument)
@@ -138,12 +154,12 @@ namespace Internal.IL
 
         private void ImportDup()
         {
-            throw new NotImplementedException();
+            _interpreter.EvaluationStack.Push(PeekWithValidation());
         }
 
         private void ImportPop()
         {
-            throw new NotImplementedException();
+            PopWithValidation();
         }
 
         private void ImportCalli(int token)
@@ -159,7 +175,7 @@ namespace Internal.IL
         private void ImportReturn()
         {
             var returnType = _method.Signature.ReturnType;
-            if (returnType.IsVoid)
+            if (returnType.RuntimeTypeHandle.Value == typeof(void).TypeHandle.Value)
                 return;
             
             StackItem stackItem = PopWithValidation();

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -17,6 +17,8 @@ namespace Internal.Runtime.Interpreter
         private readonly TypeSystemContext _context;
         private readonly LowLevelStack<StackItem> _stack;
 
+        private StackItem[] _locals;
+
         private CallInterceptorArgs _callInterceptorArgs;
 
         public LowLevelStack<StackItem> EvaluationStack => _stack;
@@ -28,6 +30,7 @@ namespace Internal.Runtime.Interpreter
             _context = context;
             _method = method;
             _methodIL = methodIL;
+            _locals = new StackItem[methodIL.GetLocals().Length];
             _stack = new LowLevelStack<StackItem>();
         }
 
@@ -36,6 +39,16 @@ namespace Internal.Runtime.Interpreter
             _callInterceptorArgs = callInterceptorArgs;
             ILImporter importer = new ILImporter(this, _method, _methodIL);
             importer.Interpret();
+        }
+
+        public StackItem GetVariable(int index)
+        {
+            return _locals[index];
+        }
+
+        public void SetVariable(int index, StackItem stackItem)
+        {
+            _locals[index] = stackItem;
         }
 
         public void SetReturnValue<T>(T value)

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StackItem.cs
@@ -58,12 +58,12 @@ namespace Internal.Runtime.Interpreter
             return _int64;
         }
 
-        public static StackItem FromIntPtr(IntPtr nativeInt)
+        public static StackItem FromNativeInt(IntPtr nativeInt)
         {
             return new StackItem { _nativeInt = nativeInt, _kind = StackValueKind.NativeInt };
         }
 
-        public IntPtr AsIntPtr()
+        public IntPtr AsNativeInt()
         {
             Debug.Assert(_kind == StackValueKind.NativeInt);
             return _nativeInt;


### PR DESCRIPTION
The PR extends the interpreter to support locals and some operator opcodes:

### Locals

* stloc.*
* ldloc.*

### Unary operators

* not
* neg
* pop
* dup

### Conversion operators

* conv.*
* conv.ovf.*

### Bitwise Shift operators

* shl
* shr*

The CoreCLR interpreter (https://github.com/dotnet/coreclr/blob/master/src/vm/interpreter.cpp) was used as a development reference. However, I'm still not very confident about my implementation of the conversion and bitwise shift operators especially around things relating to type casting and general code structure.

cc @jkotas @MichalStrehovsky @morganbr 
