### PR TITLE
Fix for Enum thunks in CPAOT per GitHub issue #6315

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -73,6 +73,16 @@ namespace ILCompiler
             return BaseTypeRuntimeInterfacesAlgorithm.Instance;
         }
 
+        protected override IEnumerable<MethodDesc> GetAllMethodsForEnum(TypeDesc enumType)
+        {
+            return enumType.GetMethods();
+        }
+
+        protected override IEnumerable<MethodDesc> GetAllMethodsForValueType(TypeDesc valueType)
+        {
+            return valueType.GetMethods();
+        }
+
         private class VectorFieldLayoutAlgorithm : FieldLayoutAlgorithm
         {
             private FieldLayoutAlgorithm _fallbackAlgorithm;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2627,12 +2627,14 @@ namespace Internal.JitInterface
                 // to call.
 
                 MethodDesc directMethod = constrainedType.GetClosestDefType().TryResolveConstraintMethodApprox(exactType, method, out forceUseRuntimeLookup);
+#if !READYTORUN
                 if (directMethod == null && constrainedType.IsEnum)
                 {
                     // Constrained calls to methods on enum methods resolve to System.Enum's methods. System.Enum is a reference
                     // type though, so we would fail to resolve and box. We have a special path for those to avoid boxing.
                     directMethod = _compilation.TypeSystemContext.TryResolveConstrainedEnumMethod(constrainedType, method);
                 }
+#endif
 
                 if (directMethod != null)
                 {


### PR DESCRIPTION
This change implements the fixes described by Michal in the
quoted issue and, in doing so, fixes two issues caused by
invalid casts of the enum helpers in CPAOT build of CoreCLR
framework.

Thanks

Tomas