### PR TITLE
Skip native libraries in CPAOT build of CoreCLR framework

### DIFF
--- a/tests/CoreCLR/compile-framework.cmd
+++ b/tests/CoreCLR/compile-framework.cmd
@@ -31,6 +31,9 @@ goto :eof
 :: %1 Path to assembly to compile
 :CompileAssembly
 
+:: Skip native libraries picked up by the wildcard spec - currently there's just one
+if /I [%~n1] == [Microsoft.DiaSymReader.Native.amd64] goto :eof
+
 echo Compiling %1
 set TestFileName=%1
 set MsBuildCommandLine=msbuild 


### PR DESCRIPTION
Currently there's just one native library that gets picked up
by the above wildcard spec - Microsoft.DiaSymReader.Native.amd64 -
so I have excluded it explicitly in the script as I don't expect
this list of exclusions to fluctuate too wildly. We would need
something smarter if we wanted to be able to automatically
orchestrate builds of complete folders (e.g. a UWP app).

Thanks

Tomas