### PR TITLE
Add InterfaceImplHasDuplicate/ValidType check

### DIFF
--- a/src/ILVerification/src/ILVerification.csproj
+++ b/src/ILVerification/src/ILVerification.csproj
@@ -21,6 +21,7 @@
     <Compile Include="ILImporter.StackValue.cs" />
     <Compile Include="SimpleArrayOfTRuntimeInterfacesAlgorithm.cs" />
     <Compile Include="ILVerifyTypeSystemContext.cs" />
+    <Compile Include="TypeVerifier.cs" />
     <Compile Include="Verifier.cs" />
     <Compile Include="VerifierError.cs" />
     <Compile Include="TypeSystemHelpers.cs" />

--- a/src/ILVerification/src/Resources/Strings.resx
+++ b/src/ILVerification/src/Resources/Strings.resx
@@ -438,4 +438,7 @@
   <data name="Volatile" xml:space="preserve">
     <value>Missing ldsfld, stsfld, ldind, stind, ldfld, stfld, ldobj, stobj, initblk, or cpblk.</value>
   </data>
+  <data name="InterfaceImplHasDuplicate" xml:space="preserve">
+    <value>Interface implementation has a duplicate. Class '{0}' Interface: '{1}'</value>
+  </data>
 </root>

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Resources;
+using ILVerify;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace Internal.TypeVerifier
+{
+    internal class TypeVerifier
+    {
+        private EcmaModule _module;
+        private readonly TypeDefinitionHandle _typeDefinitionHandle;
+        private readonly Lazy<ResourceManager> _stringResourceManager;
+
+        public Action<ErrorArgument[], VerifierError, string> ReportVerificationError
+        {
+            set;
+            private get;
+        }
+
+        public TypeVerifier(EcmaModule module, TypeDefinitionHandle typeDefinitionHandle, Lazy<ResourceManager> stringResourceManager)
+        {
+            _module = module;
+            _typeDefinitionHandle = typeDefinitionHandle;
+            _stringResourceManager = stringResourceManager;
+        }
+
+        public void Verify()
+        {
+            VerifyInterfaces();
+        }
+
+        public void VerifyInterfaces()
+        {
+            TypeDefinition typeDefinition = _module.MetadataReader.GetTypeDefinition(_typeDefinitionHandle);
+            EcmaType type = (EcmaType)_module.GetType(_typeDefinitionHandle);
+
+            // if not interface or abstract
+            if (!type.IsInterface && !type.IsAbstract)
+            {
+                InterfaceImplementationHandleCollection interfaceHandles = typeDefinition.GetInterfaceImplementations();
+                int count = interfaceHandles.Count;
+                if (count == 0)
+                {
+                    return;
+                }
+
+                // Look for duplicates.
+                List<InterfaceMetadataObjects> implementedInterfaces = new List<InterfaceMetadataObjects>();
+                foreach (InterfaceImplementationHandle interfaceHandle in interfaceHandles)
+                {
+                    InterfaceImplementation interfaceImplementation = _module.MetadataReader.GetInterfaceImplementation(interfaceHandle);
+                    DefType interfaceType = _module.GetType(interfaceImplementation.Interface) as DefType;
+                    if (interfaceType == null)
+                    {
+                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadBadFormat, type);
+                    }
+
+                    InterfaceMetadataObjects imo = new InterfaceMetadataObjects
+                    {
+                        DefType = interfaceType,
+                        InterfaceImplementationHandle = interfaceHandle
+                    };
+
+                    if (!implementedInterfaces.Contains(imo))
+                    {
+                        implementedInterfaces.Add(imo);
+                    }
+                    else
+                    {
+                        var args = new ErrorArgument[]
+                        {
+                            new ErrorArgument("TokenClass", _module.MetadataReader.GetToken(_typeDefinitionHandle)),
+                            new ErrorArgument("TokenInterface", _module.MetadataReader.GetToken(interfaceHandle))
+                        };
+                        string message = _stringResourceManager.Value.GetString(VerifierError.InterfaceImplHasDuplicate.ToString(), CultureInfo.InvariantCulture);
+                        ReportVerificationError(args, VerifierError.InterfaceImplHasDuplicate, string.Format(message, type.ToString(), interfaceType.ToString()));
+                    }
+                }
+            }
+        }
+
+        private class InterfaceMetadataObjects : IEquatable<InterfaceMetadataObjects>
+        {
+            public DefType DefType { get; set; }
+            public InterfaceImplementationHandle InterfaceImplementationHandle { get; set; }
+            public bool Equals(InterfaceMetadataObjects other)
+            {
+                return other.DefType == DefType;
+            }
+        }
+    }
+}

--- a/src/ILVerification/src/VerifierError.cs
+++ b/src/ILVerification/src/VerifierError.cs
@@ -189,5 +189,6 @@ namespace ILVerify
         //IDS_E_ILERROR        "[IL]: Error: "
         //IDS_E_GLOBAL         "<GlobalFunction>"
         //IDS_E_MDTOKEN        "[mdToken=0x%x]"
+        InterfaceImplHasDuplicate             // InterfaceImpl has a duplicate
     }
 }

--- a/src/ILVerification/tests/ILTests/InterfaceDefinition.il
+++ b/src/ILVerification/tests/ILTests/InterfaceDefinition.il
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly InterfaceDefinition
+{
+}
+
+.assembly extern System.Runtime
+{
+}
+
+.class interface public auto ansi abstract Interface
+{	
+	.method public hidebysig newslot abstract virtual 
+		instance void M1 () cil managed 
+	{
+	}
+
+	.method public hidebysig newslot abstract virtual 
+		instance void M2 () cil managed 
+	{
+	}
+
+	.method public hidebysig newslot abstract virtual 
+		instance void M3 (
+			int32 i
+		) cil managed 
+	{
+	}
+
+	.method public hidebysig newslot abstract virtual 
+		instance int32 M4 (
+			int32 i
+		) cil managed 
+	{
+	}
+}

--- a/src/ILVerification/tests/ILTests/InterfaceDefinition.ilproj
+++ b/src/ILVerification/tests/ILTests/InterfaceDefinition.ilproj
@@ -1,0 +1,3 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ILTests.targets" />
+</Project>

--- a/src/ILVerification/tests/ILTests/InterfaceImplementation.il
+++ b/src/ILVerification/tests/ILTests/InterfaceImplementation.il
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly InterfaceImplementation
+{
+}
+
+.assembly extern System.Runtime
+{
+}
+
+.assembly extern InterfaceDefinition
+{
+}
+
+.class public auto ansi beforefieldinit Valid_ValidType_Valid
+	extends [System.Runtime]System.Object
+	implements [InterfaceDefinition]Interface
+{
+	.method public final hidebysig newslot virtual 
+		instance void M1 () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ret
+	}
+
+	.method public final hidebysig newslot virtual 
+		instance void M2 () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ret
+	}
+
+	.method public final hidebysig newslot virtual 
+		instance void M3 (
+			int32 i
+		) cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ret
+	}
+
+	.method public final hidebysig newslot virtual 
+		instance int32 M4 (
+			int32 i
+		) cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ldc.i4.0
+		IL_0001: ret
+	}
+
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: ret
+	}
+}
+
+.class public auto ansi beforefieldinit InterfaceImplHasDuplicate_InvalidType_InterfaceImplHasDuplicate
+	extends [System.Runtime]System.Object
+	implements [InterfaceDefinition]Interface, [InterfaceDefinition]Interface
+{	
+	.method public final hidebysig newslot virtual 
+		instance void M1 () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ret
+	}
+
+	.method public final hidebysig newslot virtual 
+		instance void M2 () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ret
+	}
+
+	.method public final hidebysig newslot virtual 
+		instance void M3 (
+			int32 i
+		) cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ret
+	}
+
+	.method public final hidebysig newslot virtual 
+		instance int32 M4 (
+			int32 i
+		) cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ldc.i4.0
+		IL_0001: ret
+	}
+
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: ret
+	}
+}

--- a/src/ILVerification/tests/ILTests/InterfaceImplementation.ilproj
+++ b/src/ILVerification/tests/ILTests/InterfaceImplementation.ilproj
@@ -1,0 +1,3 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ILTests.targets" />
+</Project>

--- a/src/ILVerify/src/Program.cs
+++ b/src/ILVerify/src/Program.cs
@@ -328,7 +328,10 @@ namespace ILVerify
 
         private void PrintVerifyTypesResult(VerificationResult result, EcmaModule module, string pathOrModuleName)
         {
-
+            if (result.Code == VerifierError.InterfaceImplHasDuplicate)
+            {
+                Console.WriteLine($"[MD]: Error: {result.Message}, token={result.GetArgumentValue<int>("TokenInterface").ToString("X8")}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
contributes to https://github.com/dotnet/corert/issues/6203

Added check:
1) ValidType
2) Double interface implementation https://github.com/lewischeng-ms/sscli/blob/master/clr/src/md/compiler/mdvalidator.cpp#L2696

I've got other checks ready...but before I want to "standardise" code for check and report.

Output is a bit different from PEVerify because I think it's more clear, let me know if it makes sense

PEVerify `[MD]: Error: InterfaceImpl has a duplicate, token=0x09000002. [token:0x09000001]` <- **I don't understand how extract this [second token](https://github.com/lewischeng-ms/sscli/blob/master/clr/src/tools/peverify/main.cpp#L324)**

ILVerify `[MD]: Error: Interface implementation has a duplicate. Class '[InterfaceImplementation]InterfaceImplHasDuplicate_InvalidType_InterfaceImplHasDuplicate' Interface: '[InterfaceDefinition]Interface', token=09000003`


/cc @jkotas @MichalStrehovsky 