### PR TITLE
Update CoreFX

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <RyuJITVersion>3.0.0-preview-27203-03</RyuJITVersion>
     <ObjectWriterVersion>1.0.0-alpha-26412-0</ObjectWriterVersion>
-    <CoreFxVersion>4.6.0-preview.18558.2</CoreFxVersion>
-    <CoreFxUapVersion>4.7.0-preview.18558.2</CoreFxUapVersion>
-    <MicrosoftNETCoreNativeVersion>3.0.0-preview-27108-02</MicrosoftNETCoreNativeVersion>
+    <CoreFxVersion>4.6.0-preview.18605.2</CoreFxVersion>
+    <CoreFxUapVersion>4.7.0-preview.18605.2</CoreFxUapVersion>
+    <MicrosoftNETCoreNativeVersion>3.0.0-preview-27205-02</MicrosoftNETCoreNativeVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftDotNetTestSdkVersion>15.8.0</MicrosoftDotNetTestSdkVersion>
     <XUnitPackageVersion>2.4.1-pre.build.4059</XUnitPackageVersion>


### PR DESCRIPTION
We started getting `warning : Method [System.Memory]System.Buffers.Text.FormattingHelpers.CountHexDigits(uint64) will always throw because: [TEMPORARY EXCEPTION MESSAGE] MissingMethod: UInt64 System.Runtime.Intrinsics.X86.Lzcnt.LeadingZeroCount(UInt64)` and `warning : Method [System.Numerics.Vectors]System.Numerics.Matrix4x4.op_Multiply(Matrix4x4,float32) will always throw because: [TEMPORARY EXCEPTION MESSAGE] MissingMethod: System.Runtime.Intrinsics.Vector128_1<Single> System.Runtime.Intrinsics.X86.Sse.SetAllVector128(Single)`.

My guess is stale CoreFX.