### PR TITLE
[ILVerify]Check interface method implementation

### DIFF
--- a/src/ILVerification/src/ILVerifyTypeSystemContext.cs
+++ b/src/ILVerification/src/ILVerifyTypeSystemContext.cs
@@ -20,6 +20,7 @@ namespace ILVerify
 
         private RuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
         private MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
+        private MetadataVirtualMethodAlgorithm _metadataVirtualMethodAlgorithm = new MetadataVirtualMethodAlgorithm();
 
         private readonly Dictionary<PEReader, EcmaModule> _modulesCache = new Dictionary<PEReader, EcmaModule>();
 
@@ -88,6 +89,11 @@ namespace ILVerify
         protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForDefType(DefType type)
         {
             return _metadataRuntimeInterfacesAlgorithm;
+        }
+
+        public override VirtualMethodAlgorithm GetVirtualMethodAlgorithmForType(TypeDesc type)
+        {
+            return _metadataVirtualMethodAlgorithm;
         }
 
         internal EcmaModule GetModule(PEReader peReader, IAssemblyDesc containingAssembly = null)

--- a/src/ILVerification/src/Resources/Strings.resx
+++ b/src/ILVerification/src/Resources/Strings.resx
@@ -441,4 +441,7 @@
   <data name="InterfaceImplHasDuplicate" xml:space="preserve">
     <value>Interface implementation has a duplicate. Class '{0}' Interface: '{1}', token=0x{2:X8}</value>
   </data>
+  <data name="InterfaceMethodNotImplemented" xml:space="preserve">
+    <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Method: {2}(class:{3:X8} interface:{4:X8} method:{5:X8}).</value>
+  </data>
 </root>

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -84,13 +84,16 @@ namespace Internal.TypeVerifier
                     VerificationError(VerifierError.InterfaceImplHasDuplicate, type, interfaceType, _module.MetadataReader.GetToken(interfaceHandle));
                 }
 
-                // Look for missing method implementation
-                foreach (MethodDesc method in imo.DefType.GetAllMethods())
-                {
-                    MethodDesc resolvedMethod = virtualMethodAlg.ResolveInterfaceMethodToVirtualMethodOnType(method, type);
-                    if (resolvedMethod is null)
+                if (!type.IsAbstract)
+                { 
+                    // Look for missing method implementation
+                    foreach (MethodDesc method in imo.DefType.GetAllMethods())
                     {
-                        VerificationError(VerifierError.InterfaceMethodNotImplemented, type, imo.DefType, method, _module.MetadataReader.GetToken(_typeDefinitionHandle), _module.MetadataReader.GetToken(imo.InterfaceImplementationHandle), _module.MetadataReader.GetToken(((EcmaMethod)method).Handle));
+                        MethodDesc resolvedMethod = virtualMethodAlg.ResolveInterfaceMethodToVirtualMethodOnType(method, type);
+                        if (resolvedMethod is null)
+                        {
+                            VerificationError(VerifierError.InterfaceMethodNotImplemented, type, imo.DefType, method, _module.MetadataReader.GetToken(_typeDefinitionHandle), _module.MetadataReader.GetToken(imo.InterfaceImplementationHandle), _module.MetadataReader.GetToken(((EcmaMethod)method).Handle));
+                        }
                     }
                 }
             }

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -247,7 +247,7 @@ namespace ILVerify
 
             try
             {
-                TypeVerifier typeVerifier = new TypeVerifier(module, typeHandle);
+                TypeVerifier typeVerifier = new TypeVerifier(module, typeHandle, _typeSystemContext);
 
                 typeVerifier.ReportVerificationError = (code, args) =>
                 {

--- a/src/ILVerification/src/VerifierError.cs
+++ b/src/ILVerification/src/VerifierError.cs
@@ -189,6 +189,7 @@ namespace ILVerify
         //IDS_E_ILERROR        "[IL]: Error: "
         //IDS_E_GLOBAL         "<GlobalFunction>"
         //IDS_E_MDTOKEN        "[mdToken=0x%x]"
-        InterfaceImplHasDuplicate             // InterfaceImpl has a duplicate
+        InterfaceImplHasDuplicate,            // InterfaceImpl has a duplicate
+        InterfaceMethodNotImplemented         // Class implements interface but not method 
     }
 }

--- a/src/ILVerification/tests/ILTests/InterfaceImplementation.il
+++ b/src/ILVerification/tests/ILTests/InterfaceImplementation.il
@@ -154,3 +154,40 @@
 		IL_0006: ret
 	}
 }
+
+.class public auto ansi abstract beforefieldinit MissingMethod_ValidType_AbstractClass
+	extends [System.Runtime]System.Object
+	implements [InterfaceDefinition]Interface
+{
+	.method public final hidebysig newslot virtual 
+		instance void M2 () cil managed 
+	{
+		.maxstack 8
+ 		IL_0000: ret
+	}
+ 	.method public final hidebysig newslot virtual 
+		instance void M3 (
+			int32 i
+		) cil managed 
+	{
+		.maxstack 8
+ 		IL_0000: ret
+	}
+ 	.method public final hidebysig newslot virtual 
+		instance int32 M4 (
+			int32 i
+		) cil managed 
+	{
+		.maxstack 8
+ 		IL_0000: ldc.i4.0
+		IL_0001: ret
+	}
+ 	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		.maxstack 8
+ 		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: ret
+	}
+}

--- a/src/ILVerification/tests/ILTests/InterfaceImplementation.il
+++ b/src/ILVerification/tests/ILTests/InterfaceImplementation.il
@@ -117,3 +117,40 @@
 		IL_0006: ret
 	}
 }
+
+.class public auto ansi beforefieldinit MissingMethod_InvalidType_InterfaceMethodNotImplemented
+	extends [System.Runtime]System.Object
+	implements [InterfaceDefinition]Interface
+{
+	.method public final hidebysig newslot virtual 
+		instance void M2 () cil managed 
+	{
+		.maxstack 8
+ 		IL_0000: ret
+	}
+ 	.method public final hidebysig newslot virtual 
+		instance void M3 (
+			int32 i
+		) cil managed 
+	{
+		.maxstack 8
+ 		IL_0000: ret
+	}
+ 	.method public final hidebysig newslot virtual 
+		instance int32 M4 (
+			int32 i
+		) cil managed 
+	{
+		.maxstack 8
+ 		IL_0000: ldc.i4.0
+		IL_0001: ret
+	}
+ 	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		.maxstack 8
+ 		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: ret
+	}
+}


### PR DESCRIPTION
closes https://github.com/dotnet/corert/issues/6203
Output message:
```
[MD]: Error: Class implements interface but not method, Class: '[InterfaceImplementation]MissingMethod_InvalidType_InterfaceMethodNotImplemented' Interface: '[InterfaceDefinition]Interface' Method: [InterfaceDefinition]Interface.M1()(class:02000004 interface:09000004 method:06000001).
```

/cc @jkotas @MichalStrehovsky