### PR TITLE
Rename IlogB -> ILogB

### DIFF
--- a/src/System.Private.CoreLib/src/System/Math.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Math.CoreRT.cs
@@ -114,7 +114,7 @@ namespace System
         }
 
         [Intrinsic]
-        public static int IlogB(double x)
+        public static int ILogB(double x)
         {
             return RuntimeImports.ilogb(x);
         }

--- a/src/System.Private.CoreLib/src/System/MathF.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/MathF.CoreRT.cs
@@ -102,7 +102,7 @@ namespace System
         }
 
         [Intrinsic]
-        public static int IlogB(float x)
+        public static int ILogB(float x)
         {
             return RuntimeImports.ilogbf(x);
         }


### PR DESCRIPTION
This was updated in dotnet/coreclr#20912. Fortunately, ApiCompat found it in dotnet/corefx#33956.