### PR TITLE
Initial support for GC ref map emission in the CPAOT compiler

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -1,0 +1,1935 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+//
+// This file is a line by line port of CallingConvention.h from the desktop CLR. See reference source in the ReferenceSource directory
+//
+#if ARM
+#define _TARGET_ARM_
+#define CALLDESCR_ARGREGS                          // CallDescrWorker has ArgumentRegister parameter
+#define CALLDESCR_FPARGREGS                        // CallDescrWorker has FloatArgumentRegisters parameter
+#define ENREGISTERED_RETURNTYPE_MAXSIZE
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+#define FEATURE_HFA
+#elif ARM64
+#define _TARGET_ARM64_
+#define CALLDESCR_ARGREGS                          // CallDescrWorker has ArgumentRegister parameter
+#define CALLDESCR_FPARGREGS                        // CallDescrWorker has FloatArgumentRegisters parameter
+#define ENREGISTERED_RETURNTYPE_MAXSIZE
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+#define ENREGISTERED_PARAMTYPE_MAXSIZE
+#define FEATURE_HFA
+#elif X86
+#define _TARGET_X86_
+#define ENREGISTERED_RETURNTYPE_MAXSIZE
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+#define CALLDESCR_ARGREGS                          // CallDescrWorker has ArgumentRegister parameter
+#elif AMD64
+#if UNIXAMD64
+#define UNIX_AMD64_ABI
+#define CALLDESCR_ARGREGS                          // CallDescrWorker has ArgumentRegister parameter
+#else
+#endif
+#define CALLDESCR_FPARGREGS                        // CallDescrWorker has FloatArgumentRegisters parameter
+#define _TARGET_AMD64_
+#define ENREGISTERED_RETURNTYPE_MAXSIZE
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+#define ENREGISTERED_PARAMTYPE_MAXSIZE
+#elif WASM
+#define _TARGET_WASM_
+#else
+#error Unknown architecture!
+#endif
+
+// Provides an abstraction over platform specific calling conventions (specifically, the calling convention
+// utilized by the JIT on that platform). The caller enumerates each argument of a signature in turn, and is 
+// provided with information mapping that argument into registers and/or stack locations.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.Runtime;
+using Internal.NativeFormat;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public enum CORCOMPILE_GCREFMAP_TOKENS : byte
+    {
+        GCREFMAP_SKIP = 0,
+        GCREFMAP_REF = 1,
+        GCREFMAP_INTERIOR = 2,
+        GCREFMAP_METHOD_PARAM = 3,
+        GCREFMAP_TYPE_PARAM = 4,
+        GCREFMAP_VASIG_COOKIE = 5,
+    };
+
+    public enum CallingConventions
+    {
+        ManagedInstance,
+        ManagedStatic,
+        StdCall,
+        /*FastCall, CDecl */
+    }
+
+    public static class CallingConventionInfo
+    {
+        public static bool TypeUsesReturnBuffer(TypeDesc returnType, bool methodWithReturnTypeIsVarArg)
+        {
+            TypeHandle thReturnType = new TypeHandle(returnType);
+            CorElementType typeReturnType = thReturnType.GetCorElementType();
+
+            bool usesReturnBuffer;
+            uint fpReturnSizeIgnored;
+            ArgIterator.ComputeReturnValueTreatment(typeReturnType, thReturnType, methodWithReturnTypeIsVarArg, out usesReturnBuffer, out fpReturnSizeIgnored);
+
+            return usesReturnBuffer;
+        }
+    }
+
+    internal unsafe struct TypeHandle
+    {
+        public TypeHandle(TypeDesc type)
+        {
+            _type = type;
+            _isByRef = _type.IsByRef;
+            if (_isByRef)
+            {
+                _type = ((ByRefType)_type).ParameterType;
+            }
+        }
+
+        private readonly TypeDesc _type;
+        private readonly bool _isByRef;
+
+        public bool Equals(TypeHandle other)
+        {
+            return _isByRef == other._isByRef && _type == other._type;
+        }
+
+        public override int GetHashCode() { return (int)_type.GetHashCode(); }
+
+        public bool IsNull() { return _type == null && !_isByRef; }
+        public bool IsValueType() { if (_isByRef) return false; return _type.IsValueType; }
+        public bool IsPointerType() { if (_isByRef) return false; return _type.IsPointer; }
+
+        public unsafe uint GetSize()
+        {
+            if (IsValueType())
+                return (uint)_type.GetElementSize().AsInt;
+            else
+                return (uint)IntPtr.Size;
+        }
+
+        public bool RequiresAlign8()
+        {
+#if !ARM
+            return false;
+#else
+            if (_isByRef)
+            {
+                return false;
+            }
+            return _type.RequiresAlign8;
+#endif
+        }
+        public bool IsHFA()
+        {
+#if !ARM && !ARM64
+            return false;
+#else
+            if (_isByRef)
+            {
+                return false;
+            }
+            return _type.IsHFA;
+#endif
+        }
+
+        public CorElementType GetHFAType()
+        {
+            Debug.Assert(IsHFA());
+#if ARM
+            if (RequiresAlign8())
+            {
+                return CorElementType.ELEMENT_TYPE_R8;
+            }
+#elif ARM64
+            if (_type.FieldAlignmentRequirement == IntPtr.Size)
+            {
+                return CorElementType.ELEMENT_TYPE_R8;
+            }
+#endif
+            return CorElementType.ELEMENT_TYPE_R4;
+        }
+
+        public CorElementType GetCorElementType()
+        {
+            if (_isByRef)
+            {
+                return CorElementType.ELEMENT_TYPE_BYREF;
+            }
+
+            // The core redhawk runtime has a slightly different concept of what CorElementType should be for a type. It matches for primitive and enum types
+            // but for other types, it doesn't match the needs in this file.
+            Internal.TypeSystem.TypeFlags typeFlags = _type.Category;
+
+            if (((typeFlags >= Internal.TypeSystem.TypeFlags.Boolean) && (typeFlags <= Internal.TypeSystem.TypeFlags.Double)) ||
+                    (typeFlags == Internal.TypeSystem.TypeFlags.IntPtr) ||
+                    (typeFlags == Internal.TypeSystem.TypeFlags.UIntPtr))
+            {
+                return (CorElementType)typeFlags; // If Redhawk thinks the corelementtype is a primitive type, then it agree with the concept of corelement type needed in this codebase.
+            }
+            else if (_type.IsVoid)
+            {
+                return CorElementType.ELEMENT_TYPE_VOID;
+            }
+            else if (IsValueType())
+            {
+                return CorElementType.ELEMENT_TYPE_VALUETYPE;
+            }
+            else if (_type.IsPointer)
+            {
+                return CorElementType.ELEMENT_TYPE_PTR;
+            }
+            else
+            {
+                return CorElementType.ELEMENT_TYPE_CLASS;
+            }
+        }
+
+        private static int[] s_elemSizes = new int[]
+            {
+                0, //ELEMENT_TYPE_END          0x0
+                0, //ELEMENT_TYPE_VOID         0x1
+                1, //ELEMENT_TYPE_BOOLEAN      0x2
+                2, //ELEMENT_TYPE_CHAR         0x3
+                1, //ELEMENT_TYPE_I1           0x4
+                1, //ELEMENT_TYPE_U1           0x5
+                2, //ELEMENT_TYPE_I2           0x6
+                2, //ELEMENT_TYPE_U2           0x7
+                4, //ELEMENT_TYPE_I4           0x8
+                4, //ELEMENT_TYPE_U4           0x9
+                8, //ELEMENT_TYPE_I8           0xa
+                8, //ELEMENT_TYPE_U8           0xb
+                4, //ELEMENT_TYPE_R4           0xc
+                8, //ELEMENT_TYPE_R8           0xd
+                -2,//ELEMENT_TYPE_STRING       0xe
+                -2,//ELEMENT_TYPE_PTR          0xf
+                -2,//ELEMENT_TYPE_BYREF        0x10
+                -1,//ELEMENT_TYPE_VALUETYPE    0x11
+                -2,//ELEMENT_TYPE_CLASS        0x12
+                0, //ELEMENT_TYPE_VAR          0x13
+                -2,//ELEMENT_TYPE_ARRAY        0x14
+                0, //ELEMENT_TYPE_GENERICINST  0x15
+                0, //ELEMENT_TYPE_TYPEDBYREF   0x16
+                0, // UNUSED                   0x17
+                -2,//ELEMENT_TYPE_I            0x18
+                -2,//ELEMENT_TYPE_U            0x19
+                0, // UNUSED                   0x1a
+                -2,//ELEMENT_TYPE_FPTR         0x1b
+                -2,//ELEMENT_TYPE_OBJECT       0x1c
+                -2,//ELEMENT_TYPE_SZARRAY      0x1d
+            };
+
+        unsafe public static int GetElemSize(CorElementType t, TypeHandle thValueType)
+        {
+            if (((int)t) <= 0x1d)
+            {
+                int elemSize = s_elemSizes[(int)t];
+                if (elemSize == -1)
+                {
+                    return (int)thValueType.GetSize();
+                }
+                if (elemSize == -2)
+                {
+                    return IntPtr.Size;
+                }
+                return elemSize;
+            }
+            return 0;
+        }
+
+        public TypeDesc GetRuntimeTypeHandle() { return _type; }
+    }
+
+    // Describes how a single argument is laid out in registers and/or stack locations when given as an input to a
+    // managed method as part of a larger signature.
+    //
+    // Locations are split into floating point registers, general registers and stack offsets. Registers are
+    // obviously architecture dependent but are represented as a zero-based index into the usual sequence in which
+    // such registers are allocated for input on the platform in question. For instance:
+    //      X86: 0 == ecx, 1 == edx
+    //      ARM: 0 == r0, 1 == r1, 2 == r2 etc.
+    //
+    // Stack locations are represented as offsets from the stack pointer (at the point of the call). The offset is
+    // given as an index of a pointer sized slot. Similarly the size of data on the stack is given in slot-sized
+    // units. For instance, given an index of 2 and a size of 3:
+    //      X86:   argument starts at [ESP + 8] and is 12 bytes long
+    //      AMD64: argument starts at [RSP + 16] and is 24 bytes long
+    //
+    // The structure is flexible enough to describe an argument that is split over several (consecutive) registers
+    // and possibly on to the stack as well.
+    internal struct ArgLocDesc
+    {
+        public int m_idxFloatReg;  // First floating point register used (or -1)
+        public int m_cFloatReg;    // Count of floating point registers used (or 0)
+
+        public int m_idxGenReg;    // First general register used (or -1)
+        public int m_cGenReg;      // Count of general registers used (or 0)
+
+        public int m_idxStack;     // First stack slot used (or -1)
+        public int m_cStack;       // Count of stack slots used (or 0)
+
+#if _TARGET_ARM64_
+        public bool m_isSinglePrecision;        // For determining if HFA is single or double precision
+#endif
+
+#if _TARGET_ARM_
+        public bool m_fRequires64BitAlignment;  // True if the argument should always be aligned (in registers or on the stack
+#endif
+
+        // Initialize to represent a non-placed argument (no register or stack slots referenced).
+        public void Init()
+        {
+            m_idxFloatReg = -1;
+            m_cFloatReg = 0;
+            m_idxGenReg = -1;
+            m_cGenReg = 0;
+            m_idxStack = -1;
+            m_cStack = 0;
+
+#if _TARGET_ARM64_
+            m_isSinglePrecision = false;
+#endif
+
+#if _TARGET_ARM_
+            m_fRequires64BitAlignment = false;
+#endif
+        }
+    };
+
+    // The ArgDestination class represents a destination location of an argument.
+    internal class ArgDestination
+    {
+        // Offset of the argument relative to the m_base. On AMD64 on Unix, it can have a special
+        // value that represent a struct that contain both general purpose and floating point fields 
+        // passed in registers.
+        int _offset;
+        // For structs passed in registers, this member points to an ArgLocDesc that contains
+        // details on the layout of the struct in general purpose and floating point registers.
+        ArgLocDesc? _argLocDescForStructInRegs;
+
+        // Construct the ArgDestination
+        public ArgDestination(int offset, ArgLocDesc? argLocDescForStructInRegs)
+        {
+            _offset = offset;
+            _argLocDescForStructInRegs = argLocDescForStructInRegs;
+        }
+
+        public void GcMark(CORCOMPILE_GCREFMAP_TOKENS[] frame, int delta, bool interior)
+        {
+            frame[_offset + delta] = interior ? CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_INTERIOR : CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_REF;
+        }
+
+#if _TARGET_ARM64_
+
+        // Returns true if the ArgDestination represents an HFA struct
+        bool IsHFA()
+        {
+            return _argLocDescForStructInRegs.HasValue;
+        }
+#endif // _TARGET_ARM64_
+
+#if UNIX_AMD64_ABI
+
+        // Returns true if the ArgDestination represents a struct passed in registers.
+        public bool IsStructPassedInRegs()
+        {
+            LIMITED_METHOD_CONTRACT;
+            return m_offset == TransitionBlock.StructInRegsOffset;
+        }
+
+        // Report managed object pointers in the struct in registers
+        // Arguments:
+        //  fn - promotion function to apply to each managed object pointer
+        //  sc - scan context to pass to the promotion function
+        //  fieldBytes - size of the structure
+        void ReportPointersFromStructInRegisters(promote_func* fn, ScanContext* sc, int fieldBytes)
+        {
+            LIMITED_METHOD_CONTRACT;
+
+            // SPAN-TODO: GC reporting - https://github.com/dotnet/coreclr/issues/8517
+
+            _ASSERTE(IsStructPassedInRegs());
+
+            TADDR genRegDest = dac_cast<TADDR>(GetStructGenRegDestinationAddress());
+            INDEBUG(int remainingBytes = fieldBytes;)
+
+            EEClass* eeClass = m_argLocDescForStructInRegs->m_eeClass;
+            _ASSERTE(eeClass != NULL);
+
+            for (int i = 0; i < eeClass->GetNumberEightBytes(); i++)
+            {
+                int eightByteSize = eeClass->GetEightByteSize(i);
+                SystemVClassificationType eightByteClassification = eeClass->GetEightByteClassification(i);
+
+                _ASSERTE(remainingBytes >= eightByteSize);
+
+                if (eightByteClassification != SystemVClassificationTypeSSE)
+                {
+                    if ((eightByteClassification == SystemVClassificationTypeIntegerReference) ||
+                        (eightByteClassification == SystemVClassificationTypeIntegerByRef))
+                    {
+                        _ASSERTE(eightByteSize == 8);
+                        _ASSERTE(IS_ALIGNED((SIZE_T)genRegDest, 8));
+
+                        uint32_t flags = eightByteClassification == SystemVClassificationTypeIntegerByRef ? GC_CALL_INTERIOR : 0;
+                        (*fn)(dac_cast<PTR_PTR_Object>(genRegDest), sc, flags);
+                    }
+
+                    genRegDest += eightByteSize;
+                }
+
+                INDEBUG(remainingBytes -= eightByteSize;)
+            }
+
+            _ASSERTE(remainingBytes == 0);
+        }
+
+#endif // UNIX_AMD64_ABI
+    }
+
+    internal class ArgIteratorData
+    {
+        public ArgIteratorData(bool hasThis,
+                        bool isVarArg,
+                        TypeHandle[] parameterTypes,
+                        TypeHandle returnType)
+        {
+            _hasThis = hasThis;
+            _isVarArg = isVarArg;
+            _parameterTypes = parameterTypes;
+            _returnType = returnType;
+        }
+
+        private bool _hasThis;
+        private bool _isVarArg;
+        private TypeHandle[] _parameterTypes;
+        private TypeHandle _returnType;
+
+        public override bool Equals(object obj)
+        {
+            if (this == obj)
+                return true;
+
+            ArgIteratorData other = obj as ArgIteratorData;
+            if (other == null)
+                return false;
+
+            if (_hasThis != other._hasThis || _isVarArg != other._isVarArg || !_returnType.Equals(other._returnType))
+                return false;
+
+            if (_parameterTypes == null)
+                return other._parameterTypes == null;
+
+            if (other._parameterTypes == null || _parameterTypes.Length != other._parameterTypes.Length)
+                return false;
+
+            for (int i = 0; i < _parameterTypes.Length; i++)
+                if (!_parameterTypes[i].Equals(other._parameterTypes[i]))
+                    return false;
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return 37 + (_parameterTypes == null ?
+                _returnType.GetHashCode() :
+                TypeHashingAlgorithms.ComputeGenericInstanceHashCode(_returnType.GetHashCode(), _parameterTypes));
+        }
+
+        public bool HasThis() { return _hasThis; }
+        public bool IsVarArg() { return _isVarArg; }
+        public int NumFixedArgs() { return _parameterTypes != null ? _parameterTypes.Length : 0; }
+
+        // Argument iteration.
+        public CorElementType GetArgumentType(int argNum, out TypeHandle thArgType)
+        {
+            thArgType = _parameterTypes[argNum];
+            CorElementType returnValue = thArgType.GetCorElementType();
+            return returnValue;
+        }
+
+        public TypeHandle GetByRefArgumentType(int argNum)
+        {
+            return (argNum < _parameterTypes.Length && _parameterTypes[argNum].GetCorElementType() == CorElementType.ELEMENT_TYPE_BYREF) ?
+                _parameterTypes[argNum] :
+                default(TypeHandle);
+        }
+
+        public CorElementType GetReturnType(out TypeHandle thRetType)
+        {
+            thRetType = _returnType;
+            return thRetType.GetCorElementType();
+        }
+
+#if CCCONVERTER_TRACE
+        public string GetEETypeDebugName(int argNum)
+        {
+            Internal.TypeSystem.TypeSystemContext context = TypeSystemContextFactory.Create();
+            var result = context.ResolveRuntimeTypeHandle(_parameterTypes[argNum].GetRuntimeTypeHandle()).ToString();
+            TypeSystemContextFactory.Recycle(context);
+            return result;
+        }
+#endif
+    }
+
+    //-----------------------------------------------------------------------
+    // ArgIterator is helper for dealing with calling conventions.
+    // It is tightly coupled with TransitionBlock. It uses offsets into
+    // TransitionBlock to represent argument locations for efficiency
+    // reasons. Alternatively, it can also return ArgLocDesc for less
+    // performance critical code.
+    //
+    // The ARGITERATOR_BASE argument of the template is provider of the parsed
+    // method signature. Typically, the arg iterator works on top of MetaSig. 
+    // Reflection invoke uses alternative implementation to save signature parsing
+    // time because of it has the parsed signature available.
+    //-----------------------------------------------------------------------
+    //template<class ARGITERATOR_BASE>
+    internal unsafe struct ArgIterator //: public ARGITERATOR_BASE
+    {
+        private readonly TypeSystemContext _context;
+
+        private bool _hasThis;
+        private bool _hasParamType;
+        private bool _extraFunctionPointerArg;
+        private ArgIteratorData _argData;
+        private bool[] _forcedByRefParams;
+        private bool _skipFirstArg;
+        private bool _extraObjectFirstArg;
+        private CallingConventions _interpreterCallingConvention;
+
+        public bool HasThis() { return _hasThis; }
+        public bool IsVarArg() { return _argData.IsVarArg(); }
+        public bool HasParamType() { return _hasParamType; }
+        public int NumFixedArgs() { return _argData.NumFixedArgs() + (_extraFunctionPointerArg ? 1 : 0) + (_extraObjectFirstArg ? 1 : 0); }
+
+        // Argument iteration.
+        public CorElementType GetArgumentType(int argNum, out TypeHandle thArgType, out bool forceByRefReturn)
+        {
+            forceByRefReturn = false;
+
+            if (_extraObjectFirstArg && argNum == 0)
+            {
+                thArgType = new TypeHandle(_context.GetWellKnownType(WellKnownType.Object));
+                return CorElementType.ELEMENT_TYPE_CLASS;
+            }
+
+            argNum = _extraObjectFirstArg ? argNum - 1 : argNum;
+            Debug.Assert(argNum >= 0);
+
+            if (_forcedByRefParams != null && (argNum + 1) < _forcedByRefParams.Length)
+                forceByRefReturn = _forcedByRefParams[argNum + 1];
+
+            if (_extraFunctionPointerArg && argNum == _argData.NumFixedArgs())
+            {
+                thArgType = new TypeHandle(_context.GetWellKnownType(WellKnownType.IntPtr));
+                return CorElementType.ELEMENT_TYPE_I;
+            }
+
+            return _argData.GetArgumentType(argNum, out thArgType);
+        }
+
+        public CorElementType GetReturnType(out TypeHandle thRetType, out bool forceByRefReturn)
+        {
+            if (_forcedByRefParams != null && _forcedByRefParams.Length > 0)
+                forceByRefReturn = _forcedByRefParams[0];
+            else
+                forceByRefReturn = false;
+
+            return _argData.GetReturnType(out thRetType);
+        }
+
+#if CCCONVERTER_TRACE
+        public string GetEETypeDebugName(int argNum)
+        {
+            if (_extraObjectFirstArg && argNum == 0)
+                return "System.Object";
+            return _argData.GetEETypeDebugName(_extraObjectFirstArg ? argNum - 1 : argNum);
+        }
+#endif
+
+        public void Reset()
+        {
+            _argType = default(CorElementType);
+            _argTypeHandle = default(TypeHandle);
+            _argSize = 0;
+            _argNum = 0;
+            _argForceByRef = false;
+            _ITERATION_STARTED = false;
+        }
+
+        //public:
+        //------------------------------------------------------------
+        // Constructor
+        //------------------------------------------------------------
+        public ArgIterator(
+            TypeSystemContext context,
+            ArgIteratorData argData, 
+            CallingConventions callConv, 
+            bool hasParamType, 
+            bool extraFunctionPointerArg, 
+            bool[] forcedByRefParams, 
+            bool skipFirstArg, 
+            bool extraObjectFirstArg)
+        {
+            this = default(ArgIterator);
+            _context = context;
+            _argData = argData;
+            _hasThis = callConv == CallingConventions.ManagedInstance;
+            _hasParamType = hasParamType;
+            _extraFunctionPointerArg = extraFunctionPointerArg;
+            _forcedByRefParams = forcedByRefParams;
+            _skipFirstArg = skipFirstArg;
+            _extraObjectFirstArg = extraObjectFirstArg;
+            _interpreterCallingConvention = callConv;
+        }
+
+        public void SetHasParamTypeAndReset(bool value)
+        {
+            _hasParamType = value;
+            Reset();
+        }
+
+        public void SetHasThisAndReset(bool value)
+        {
+            _hasThis = value;
+            Reset();
+        }
+
+        private uint SizeOfArgStack()
+        {
+            //        WRAPPER_NO_CONTRACT;
+            if (!_SIZE_OF_ARG_STACK_COMPUTED)
+                ForceSigWalk();
+            Debug.Assert(_SIZE_OF_ARG_STACK_COMPUTED);
+            return (uint)_nSizeOfArgStack;
+        }
+
+        // For use with ArgIterator. This function computes the amount of additional
+        // memory required above the TransitionBlock.  The parameter offsets
+        // returned by ArgIterator::GetNextOffset are relative to a
+        // FramedMethodFrame, and may be in either of these regions.
+        public int SizeOfFrameArgumentArray()
+        {
+            //        WRAPPER_NO_CONTRACT;
+
+            uint size = SizeOfArgStack();
+
+#if _TARGET_AMD64_ && !UNIX_AMD64_ABI
+            // The argument registers are not included in the stack size on AMD64
+            size += ArchitectureConstants.ARGUMENTREGISTERS_SIZE;
+#endif
+
+            return (int)size;
+        }
+
+        //------------------------------------------------------------------------
+
+        public uint CbStackPop()
+        {
+#if _TARGET_X86_
+            //        WRAPPER_NO_CONTRACT;
+
+            if (this.IsVarArg())
+                return 0;
+            else
+                return SizeOfArgStack();
+#else
+            throw new NotImplementedException();
+#endif
+        }
+
+        // Is there a hidden parameter for the return parameter? 
+        //
+        public bool HasRetBuffArg()
+        {
+            //        WRAPPER_NO_CONTRACT;
+            if (!_RETURN_FLAGS_COMPUTED)
+                ComputeReturnFlags();
+            return _RETURN_HAS_RET_BUFFER;
+        }
+
+        public uint GetFPReturnSize()
+        {
+            //        WRAPPER_NO_CONTRACT;
+            if (!_RETURN_FLAGS_COMPUTED)
+                ComputeReturnFlags();
+            return _fpReturnSize;
+        }
+
+#if _TARGET_X86_
+        //=========================================================================
+        // Indicates whether an argument is to be put in a register using the
+        // default IL calling convention. This should be called on each parameter
+        // in the order it appears in the call signature. For a non-static meethod,
+        // this function should also be called once for the "this" argument, prior
+        // to calling it for the "real" arguments. Pass in a typ of ELEMENT_TYPE_CLASS.
+        //
+        //  *pNumRegistersUsed:  [in,out]: keeps track of the number of argument
+        //                       registers assigned previously. The caller should
+        //                       initialize this variable to 0 - then each call
+        //                       will update it.
+        //
+        //  typ:                 the signature type
+        //=========================================================================
+        private static bool IsArgumentInRegister(ref int pNumRegistersUsed, CorElementType typ, TypeHandle thArgType)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+            if ((pNumRegistersUsed) < ArchitectureConstants.NUM_ARGUMENT_REGISTERS)
+            {
+                switch (typ)
+                {
+                    case CorElementType.ELEMENT_TYPE_BOOLEAN:
+                    case CorElementType.ELEMENT_TYPE_CHAR:
+                    case CorElementType.ELEMENT_TYPE_I1:
+                    case CorElementType.ELEMENT_TYPE_U1:
+                    case CorElementType.ELEMENT_TYPE_I2:
+                    case CorElementType.ELEMENT_TYPE_U2:
+                    case CorElementType.ELEMENT_TYPE_I4:
+                    case CorElementType.ELEMENT_TYPE_U4:
+                    case CorElementType.ELEMENT_TYPE_STRING:
+                    case CorElementType.ELEMENT_TYPE_PTR:
+                    case CorElementType.ELEMENT_TYPE_BYREF:
+                    case CorElementType.ELEMENT_TYPE_CLASS:
+                    case CorElementType.ELEMENT_TYPE_ARRAY:
+                    case CorElementType.ELEMENT_TYPE_I:
+                    case CorElementType.ELEMENT_TYPE_U:
+                    case CorElementType.ELEMENT_TYPE_FNPTR:
+                    case CorElementType.ELEMENT_TYPE_OBJECT:
+                    case CorElementType.ELEMENT_TYPE_SZARRAY:
+                        pNumRegistersUsed++;
+                        return true;
+
+                    case CorElementType.ELEMENT_TYPE_VALUETYPE:
+                        {
+                            // On ProjectN valuetypes of integral size are passed enregistered
+                            int structSize = TypeHandle.GetElemSize(typ, thArgType);
+                            switch (structSize)
+                            {
+                                case 1:
+                                case 2:
+                                case 4:
+                                    pNumRegistersUsed++;
+                                    return true;
+                            }
+                            break;
+                        }
+                }
+            }
+
+            return (false);
+        }
+#endif // _TARGET_X86_
+
+#if ENREGISTERED_PARAMTYPE_MAXSIZE
+
+        // Note that this overload does not handle varargs
+        public static bool IsArgPassedByRef(TypeHandle th)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+
+            Debug.Assert(!th.IsNull());
+
+            // This method only works for valuetypes. It includes true value types, 
+            // primitives, enums and TypedReference.
+            Debug.Assert(th.IsValueType());
+
+            uint size = th.GetSize();
+#if _TARGET_AMD64_
+            return IsArgPassedByRef((int)size);
+#elif _TARGET_ARM64_
+            // Composites greater than 16 bytes are passed by reference
+            return ((size > ArchitectureConstants.ENREGISTERED_PARAMTYPE_MAXSIZE) && !th.IsHFA());
+#else
+#error ArgIterator::IsArgPassedByRef
+#endif
+        }
+
+#if _TARGET_AMD64_
+        // This overload should only be used in AMD64-specific code only.
+        private static bool IsArgPassedByRef(int size)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+
+            // If the size is bigger than ENREGISTERED_PARAM_TYPE_MAXSIZE, or if the size is NOT a power of 2, then
+            // the argument is passed by reference.
+            return (size > ArchitectureConstants.ENREGISTERED_PARAMTYPE_MAXSIZE) || ((size & (size - 1)) != 0);
+        }
+#endif
+
+        // This overload should be used for varargs only.
+        private static bool IsVarArgPassedByRef(int size)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+
+#if _TARGET_AMD64_
+            return IsArgPassedByRef(size);
+#else
+            return (size > ArchitectureConstants.ENREGISTERED_PARAMTYPE_MAXSIZE);
+#endif
+        }
+#endif // ENREGISTERED_PARAMTYPE_MAXSIZE
+
+        public bool IsArgPassedByRef()
+        {
+            //        LIMITED_METHOD_CONTRACT;
+            if (IsArgForcedPassedByRef())
+            {
+                return true;
+            }
+
+            if (_argType == CorElementType.ELEMENT_TYPE_BYREF)
+            {
+                return true;
+            }
+#if ENREGISTERED_PARAMTYPE_MAXSIZE
+#if _TARGET_AMD64_
+            return IsArgPassedByRef(_argSize);
+#elif _TARGET_ARM64_
+            if (_argType == CorElementType.ELEMENT_TYPE_VALUETYPE)
+            {
+                Debug.Assert(!_argTypeHandle.IsNull());
+                return ((_argSize > ArchitectureConstants.ENREGISTERED_PARAMTYPE_MAXSIZE) && (!_argTypeHandle.IsHFA() || IsVarArg()));
+            }
+            return false;
+#else
+#error PORTABILITY_ASSERT("ArgIterator::IsArgPassedByRef");
+#endif
+#else // ENREGISTERED_PARAMTYPE_MAXSIZE
+            return false;
+#endif // ENREGISTERED_PARAMTYPE_MAXSIZE
+        }
+
+        private bool IsArgForcedPassedByRef()
+        {
+            // This should be true for valuetypes instantiated over T in a generic signature using universal shared generic calling convention
+            return _argForceByRef;
+        }
+
+        //------------------------------------------------------------
+        // Return the offsets of the special arguments
+        //------------------------------------------------------------
+
+        public static int GetThisOffset()
+        {
+            return TransitionBlock.GetThisOffset();
+        }
+
+        public unsafe int GetRetBuffArgOffset()
+        {
+            //            WRAPPER_NO_CONTRACT;
+
+            Debug.Assert(this.HasRetBuffArg());
+
+#if _TARGET_X86_
+            // x86 is special as always
+            // DESKTOP BEHAVIOR            ret += this.HasThis() ? ArgumentRegisters.GetOffsetOfEdx() : ArgumentRegisters.GetOffsetOfEcx();
+            int ret = TransitionBlock.GetOffsetOfArgs();
+#else
+            // RetBuf arg is in the first argument register by default
+            int ret = TransitionBlock.GetOffsetOfArgumentRegisters();
+
+#if _TARGET_ARM64_
+            ret += ArgumentRegisters.GetOffsetOfx8();
+#else
+            // But if there is a this pointer, push it to the second.
+            if (this.HasThis())
+                ret += IntPtr.Size;
+#endif  // _TARGET_ARM64_
+#endif  // _TARGET_X86_
+
+            return ret;
+        }
+
+        unsafe public int GetVASigCookieOffset()
+        {
+            //            WRAPPER_NO_CONTRACT;
+
+            Debug.Assert(this.IsVarArg());
+
+#if _TARGET_X86_
+            // x86 is special as always
+            return sizeof(TransitionBlock);
+#else
+            // VaSig cookie is after this and retbuf arguments by default.
+            int ret = TransitionBlock.GetOffsetOfArgumentRegisters();
+
+            if (this.HasThis())
+            {
+                ret += IntPtr.Size;
+            }
+
+            if (this.HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
+            {
+                ret += IntPtr.Size;
+            }
+
+            return ret;
+#endif
+        }
+
+        unsafe public int GetParamTypeArgOffset()
+        {
+            Debug.Assert(this.HasParamType());
+
+#if _TARGET_X86_
+            // x86 is special as always
+            if (!_SIZE_OF_ARG_STACK_COMPUTED)
+                ForceSigWalk();
+
+            switch (_paramTypeLoc)
+            {
+                case ParamTypeLocation.Ecx:// PARAM_TYPE_REGISTER_ECX:
+                    return TransitionBlock.GetOffsetOfArgumentRegisters() + ArgumentRegisters.GetOffsetOfEcx();
+                case ParamTypeLocation.Edx:
+                    return TransitionBlock.GetOffsetOfArgumentRegisters() + ArgumentRegisters.GetOffsetOfEdx();
+                default:
+                    break;
+            }
+
+            // The param type arg is last stack argument otherwise
+            return sizeof(TransitionBlock);
+#else
+            // The hidden arg is after this and retbuf arguments by default.
+            int ret = TransitionBlock.GetOffsetOfArgumentRegisters();
+
+            if (this.HasThis())
+            {
+                ret += IntPtr.Size;
+            }
+
+            if (this.HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
+            {
+                ret += IntPtr.Size;
+            }
+
+            return ret;
+#endif
+        }
+
+        //------------------------------------------------------------
+        // Each time this is called, this returns a byte offset of the next
+        // argument from the TransitionBlock* pointer. This offset can be positive *or* negative.
+        //
+        // Returns TransitionBlock::InvalidOffset once you've hit the end 
+        // of the list.
+        //------------------------------------------------------------
+        public unsafe int GetNextOffset()
+        {
+            //            WRAPPER_NO_CONTRACT;
+            //            SUPPORTS_DAC;
+
+            if (!_ITERATION_STARTED)
+            {
+                int numRegistersUsed = 0;
+#if _TARGET_X86_
+                int initialArgOffset = 0;
+#endif 
+                if (this.HasThis())
+                    numRegistersUsed++;
+
+                if (this.HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
+                {
+#if !_TARGET_X86_
+                    numRegistersUsed++;
+#else
+                    // DESKTOP BEHAVIOR is to do nothing here, as ret buf is never reached by the scan algorithm that walks backwards
+                    // but in .NET Native, the x86 argument scan is a forward scan, so we need to skip the ret buf arg (which is always
+                    // on the stack)
+                    initialArgOffset = IntPtr.Size;
+#endif
+                }
+
+                Debug.Assert(!this.IsVarArg() || !this.HasParamType());
+
+                // DESKTOP BEHAVIOR - This block is disabled for x86 as the param arg is the last argument on desktop x86.
+                if (this.HasParamType())
+                {
+                    numRegistersUsed++;
+                }
+
+#if !_TARGET_X86_
+                if (this.IsVarArg())
+                {
+                    numRegistersUsed++;
+                }
+#endif
+
+#if _TARGET_X86_
+                if (this.IsVarArg())
+                {
+                    numRegistersUsed = ArchitectureConstants.NUM_ARGUMENT_REGISTERS; // Nothing else gets passed in registers for varargs
+                }
+
+#if FEATURE_INTERPRETER
+                switch (_interpreterCallingConvention)
+                {
+                    case CallingConventions.StdCall:
+                        _numRegistersUsed = ArchitectureConstants.NUM_ARGUMENT_REGISTERS;
+                        _curOfs = TransitionBlock.GetOffsetOfArgs() + numRegistersUsed * IntPtr.Size + initialArgOffset;
+                        break;
+
+                    case CallingConventions.ManagedStatic:
+                    case CallingConventions.ManagedInstance:
+                        _numRegistersUsed = numRegistersUsed;
+                        // DESKTOP BEHAVIOR     _curOfs = (int)(TransitionBlock.GetOffsetOfArgs() + SizeOfArgStack());
+                        _curOfs = (int)(TransitionBlock.GetOffsetOfArgs() + initialArgOffset);
+                        break;
+
+                    default:
+                        Environment.FailFast("Unsupported calling convention.");
+                        break;
+                }
+#else
+                        _numRegistersUsed = numRegistersUsed;
+// DESKTOP BEHAVIOR     _curOfs = (int)(TransitionBlock.GetOffsetOfArgs() + SizeOfArgStack());
+                        _curOfs = (int)(TransitionBlock.GetOffsetOfArgs() + initialArgOffset);
+#endif
+
+#elif _TARGET_AMD64_
+#if UNIX_AMD64_ABI
+                _idxGenReg = numRegistersUsed;
+                _idxStack = 0;
+                _idxFPReg = 0;
+#else
+                _curOfs = TransitionBlock.GetOffsetOfArgs() + numRegistersUsed * IntPtr.Size;
+#endif
+#elif _TARGET_ARM_
+                _idxGenReg = numRegistersUsed;
+                _idxStack = 0;
+
+                _wFPRegs = 0;
+#elif _TARGET_ARM64_
+                _idxGenReg = numRegistersUsed;
+                _idxStack = 0;
+
+                _idxFPReg = 0;
+#elif _TARGET_WASM_
+                throw new NotImplementedException();
+#else
+                PORTABILITY_ASSERT("ArgIterator::GetNextOffset");
+#endif
+
+#if !_TARGET_WASM_
+                _argNum = (_skipFirstArg ? 1 : 0);
+
+                _ITERATION_STARTED = true;
+#endif // !_TARGET_WASM_
+            }
+
+            if (_argNum >= this.NumFixedArgs())
+                return TransitionBlock.InvalidOffset;
+
+            CorElementType argType = this.GetArgumentType(_argNum, out _argTypeHandle, out _argForceByRef);
+
+            _argTypeHandleOfByRefParam = (argType == CorElementType.ELEMENT_TYPE_BYREF ? _argData.GetByRefArgumentType(_argNum) : default(TypeHandle));
+
+            _argNum++;
+
+            int argSize = TypeHandle.GetElemSize(argType, _argTypeHandle);
+
+#if _TARGET_ARM64_
+            // NOT DESKTOP BEHAVIOR: The S and D registers overlap, and the UniversalTransitionThunk copies D registers to the transition blocks. We'll need
+            // to work with the D registers here as well.
+            bool processingFloatsAsDoublesFromTransitionBlock = false;
+            if (argType == CorElementType.ELEMENT_TYPE_VALUETYPE && _argTypeHandle.IsHFA() && _argTypeHandle.GetHFAType() == CorElementType.ELEMENT_TYPE_R4)
+            {
+                if ((argSize / sizeof(float)) + _idxFPReg <= 8)
+                {
+                    argSize *= 2;
+                    processingFloatsAsDoublesFromTransitionBlock = true;
+                }
+            }
+#endif
+
+            _argType = argType;
+            _argSize = argSize;
+
+            argType = _argForceByRef ? CorElementType.ELEMENT_TYPE_BYREF : argType;
+            argSize = _argForceByRef ? IntPtr.Size : argSize;
+
+#pragma warning disable 219,168 // Unused local
+            int argOfs;
+#pragma warning restore 219,168
+
+#if _TARGET_X86_
+#if FEATURE_INTERPRETER
+            if (_interpreterCallingConvention != CallingConventions.ManagedStatic && _interpreterCallingConvention != CallingConventions.ManagedInstance)
+            {
+                argOfs = _curOfs;
+                _curOfs += ArchitectureConstants.StackElemSize(argSize);
+                return argOfs;
+            }
+#endif
+            if (IsArgumentInRegister(ref _numRegistersUsed, argType, _argTypeHandle))
+            {
+                return TransitionBlock.GetOffsetOfArgumentRegisters() + (ArchitectureConstants.NUM_ARGUMENT_REGISTERS - _numRegistersUsed) * IntPtr.Size;
+            }
+
+            // DESKTOP BEHAVIOR _curOfs -= ArchitectureConstants.StackElemSize(argSize);
+            // DESKTOP BEHAVIOR return _curOfs;
+            argOfs = _curOfs;
+            _curOfs += ArchitectureConstants.StackElemSize(argSize);
+            Debug.Assert(argOfs >= TransitionBlock.GetOffsetOfArgs());
+            return argOfs;
+#elif _TARGET_AMD64_
+#if UNIX_AMD64_ABI
+            int cFPRegs = 0;
+
+            switch (argType)
+            {
+
+                case CorElementType.ELEMENT_TYPE_R4:
+                    // 32-bit floating point argument.
+                    cFPRegs = 1;
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_R8:
+                    // 64-bit floating point argument.
+                    cFPRegs = 1;
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_VALUETYPE:
+                    {
+                        // UNIXTODO: FEATURE_UNIX_AMD64_STRUCT_PASSING: Passing of structs, HFAs. For now, use the Windows convention.
+                        argSize = IntPtr.Size;
+                        break;
+                    }
+
+                default:
+                    break;
+            }
+
+            int cbArg = ArchitectureConstants.StackElemSize(argSize);
+            int cArgSlots = cbArg / ArchitectureConstants.STACK_ELEM_SIZE;
+
+            if (cFPRegs > 0)
+            {
+                if (cFPRegs + m_idxFPReg <= 8)
+                {
+                    int argOfsInner = TransitionBlock.GetOffsetOfFloatArgumentRegisters() + m_idxFPReg * 8;
+                    m_idxFPReg += cFPRegs;
+                    return argOfsInner;
+                }
+            }
+            else
+            {
+                if (m_idxGenReg + cArgSlots <= 6)
+                {
+                    int argOfsInner = TransitionBlock.GetOffsetOfArgumentRegisters() + m_idxGenReg * 8;
+                    m_idxGenReg += cArgSlots;
+                    return argOfsInner;
+                }
+            }
+
+            argOfs = TransitionBlock.GetOffsetOfArgs() + m_idxStack * 8;
+            m_idxStack += cArgSlots;
+            return argOfs;
+#else
+            int cFPRegs = 0;
+
+            switch (argType)
+            {
+                case CorElementType.ELEMENT_TYPE_R4:
+                    // 32-bit floating point argument.
+                    cFPRegs = 1;
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_R8:
+                    // 64-bit floating point argument.
+                    cFPRegs = 1;
+                    break;
+            }
+
+            // Each argument takes exactly one slot on AMD64
+            argOfs = _curOfs - TransitionBlock.GetOffsetOfArgs();
+            _curOfs += IntPtr.Size;
+
+            if ((cFPRegs == 0) || (argOfs >= sizeof(ArgumentRegisters)))
+            {
+                return argOfs + TransitionBlock.GetOffsetOfArgs();
+            }
+            else
+            {
+                int idxFpReg = argOfs / IntPtr.Size;
+                return TransitionBlock.GetOffsetOfFloatArgumentRegisters() + idxFpReg * sizeof(M128A);
+            }
+#endif
+#elif _TARGET_ARM_
+            // First look at the underlying type of the argument to determine some basic properties:
+            //  1) The size of the argument in bytes (rounded up to the stack slot size of 4 if necessary).
+            //  2) Whether the argument represents a floating point primitive (ELEMENT_TYPE_R4 or ELEMENT_TYPE_R8).
+            //  3) Whether the argument requires 64-bit alignment (anything that contains a Int64/UInt64).
+
+            bool fFloatingPoint = false;
+            bool fRequiresAlign64Bit = false;
+
+            switch (argType)
+            {
+                case CorElementType.ELEMENT_TYPE_I8:
+                case CorElementType.ELEMENT_TYPE_U8:
+                    // 64-bit integers require 64-bit alignment on ARM.
+                    fRequiresAlign64Bit = true;
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_R4:
+                    // 32-bit floating point argument.
+                    fFloatingPoint = true;
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_R8:
+                    // 64-bit floating point argument.
+                    fFloatingPoint = true;
+                    fRequiresAlign64Bit = true;
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_VALUETYPE:
+                    {
+                        // Value type case: extract the alignment requirement, note that this has to handle 
+                        // the interop "native value types".
+                        fRequiresAlign64Bit = _argTypeHandle.RequiresAlign8();
+
+                        // Handle HFAs: packed structures of 1-4 floats or doubles that are passed in FP argument
+                        // registers if possible.
+                        if (_argTypeHandle.IsHFA())
+                            fFloatingPoint = true;
+
+                        break;
+                    }
+
+                default:
+                    // The default is are 4-byte arguments (or promoted to 4 bytes), non-FP and don't require any
+                    // 64-bit alignment.
+                    break;
+            }
+
+            // Now attempt to place the argument into some combination of floating point or general registers and
+            // the stack.
+
+            // Save the alignment requirement
+            _fRequires64BitAlignment = fRequiresAlign64Bit;
+
+            int cbArg = ArchitectureConstants.StackElemSize(argSize);
+            int cArgSlots = cbArg / 4;
+
+            // Ignore floating point argument placement in registers if we're dealing with a vararg function (the ABI
+            // specifies this so that vararg processing on the callee side is simplified).
+            if (fFloatingPoint && !this.IsVarArg())
+            {
+                // Handle floating point (primitive) arguments.
+
+                // First determine whether we can place the argument in VFP registers. There are 16 32-bit
+                // and 8 64-bit argument registers that share the same register space (e.g. D0 overlaps S0 and
+                // S1). The ABI specifies that VFP values will be passed in the lowest sequence of registers that
+                // haven't been used yet and have the required alignment. So the sequence (float, double, float)
+                // would be mapped to (S0, D1, S1) or (S0, S2/S3, S1).
+                //
+                // We use a 16-bit bitmap to record which registers have been used so far.
+                //
+                // So we can use the same basic loop for each argument type (float, double or HFA struct) we set up
+                // the following input parameters based on the size and alignment requirements of the arguments:
+                //   wAllocMask : bitmask of the number of 32-bit registers we need (1 for 1, 3 for 2, 7 for 3 etc.)
+                //   cSteps     : number of loop iterations it'll take to search the 16 registers
+                //   cShift     : how many bits to shift the allocation mask on each attempt
+
+                ushort wAllocMask = checked((ushort)((1 << (cbArg / 4)) - 1));
+                ushort cSteps = (ushort)(fRequiresAlign64Bit ? 9 - (cbArg / 8) : 17 - (cbArg / 4));
+                ushort cShift = fRequiresAlign64Bit ? (ushort)2 : (ushort)1;
+
+                // Look through the availability bitmask for a free register or register pair.
+                for (ushort i = 0; i < cSteps; i++)
+                {
+                    if ((_wFPRegs & wAllocMask) == 0)
+                    {
+                        // We found one, mark the register or registers as used. 
+                        _wFPRegs |= wAllocMask;
+
+                        // Indicate the registers used to the caller and return.
+                        return TransitionBlock.GetOffsetOfFloatArgumentRegisters() + (i * cShift * 4);
+                    }
+                    wAllocMask <<= cShift;
+                }
+
+                // The FP argument is going to live on the stack. Once this happens the ABI demands we mark all FP
+                // registers as unavailable.
+                _wFPRegs = 0xffff;
+
+                // Doubles or HFAs containing doubles need the stack aligned appropriately.
+                if (fRequiresAlign64Bit)
+                    _idxStack = ALIGN_UP(_idxStack, 2);
+
+                // Indicate the stack location of the argument to the caller.
+                int argOfsInner = TransitionBlock.GetOffsetOfArgs() + _idxStack * 4;
+
+                // Record the stack usage.
+                _idxStack += cArgSlots;
+
+                return argOfsInner;
+            }
+
+            //
+            // Handle the non-floating point case.
+            //
+
+            if (_idxGenReg < 4)
+            {
+                if (fRequiresAlign64Bit)
+                {
+                    // The argument requires 64-bit alignment. Align either the next general argument register if
+                    // we have any left.  See step C.3 in the algorithm in the ABI spec.       
+                    _idxGenReg = ALIGN_UP(_idxGenReg, 2);
+                }
+
+                int argOfsInner = TransitionBlock.GetOffsetOfArgumentRegisters() + _idxGenReg * 4;
+
+                int cRemainingRegs = 4 - _idxGenReg;
+                if (cArgSlots <= cRemainingRegs)
+                {
+                    // Mark the registers just allocated as used.
+                    _idxGenReg += cArgSlots;
+                    return argOfsInner;
+                }
+
+                // The ABI supports splitting a non-FP argument across registers and the stack. But this is
+                // disabled if the FP arguments already overflowed onto the stack (i.e. the stack index is not
+                // zero). The following code marks the general argument registers as exhausted if this condition
+                // holds.  See steps C.5 in the algorithm in the ABI spec.
+
+                _idxGenReg = 4;
+
+                if (_idxStack == 0)
+                {
+                    _idxStack += cArgSlots - cRemainingRegs;
+                    return argOfsInner;
+                }
+            }
+
+            if (fRequiresAlign64Bit)
+            {
+                // The argument requires 64-bit alignment. If it is going to be passed on the stack, align
+                // the next stack slot.  See step C.6 in the algorithm in the ABI spec.  
+                _idxStack = ALIGN_UP(_idxStack, 2);
+            }
+
+            argOfs = TransitionBlock.GetOffsetOfArgs() + _idxStack * 4;
+
+            // Advance the stack pointer over the argument just placed.
+            _idxStack += cArgSlots;
+
+            return argOfs;
+#elif _TARGET_ARM64_
+
+            int cFPRegs = 0;
+
+            switch (argType)
+            {
+                case CorElementType.ELEMENT_TYPE_R4:
+                    // 32-bit floating point argument.
+                    cFPRegs = 1;
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_R8:
+                    // 64-bit floating point argument.
+                    cFPRegs = 1;
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_VALUETYPE:
+                    {
+                        // Handle HFAs: packed structures of 2-4 floats or doubles that are passed in FP argument
+                        // registers if possible.
+                        if (_argTypeHandle.IsHFA())
+                        {
+                            CorElementType type = _argTypeHandle.GetHFAType();
+                            if (processingFloatsAsDoublesFromTransitionBlock)
+                                cFPRegs = argSize / sizeof(double);
+                            else
+                                cFPRegs = (type == CorElementType.ELEMENT_TYPE_R4) ? (argSize / sizeof(float)) : (argSize / sizeof(double));
+                        }
+                        else
+                        {
+                            // Composite greater than 16bytes should be passed by reference
+                            if (argSize > ArchitectureConstants.ENREGISTERED_PARAMTYPE_MAXSIZE)
+                            {
+                                argSize = IntPtr.Size;
+                            }
+                        }
+
+                        break;
+                    }
+
+                default:
+                    break;
+            }
+
+            int cbArg = ArchitectureConstants.StackElemSize(argSize);
+            int cArgSlots = cbArg / ArchitectureConstants.STACK_ELEM_SIZE;
+
+            if (cFPRegs > 0 && !this.IsVarArg())
+            {
+                if (cFPRegs + _idxFPReg <= 8)
+                {
+                    int argOfsInner = TransitionBlock.GetOffsetOfFloatArgumentRegisters() + _idxFPReg * 8;
+                    _idxFPReg += cFPRegs;
+                    return argOfsInner;
+                }
+                else
+                {
+                    _idxFPReg = 8;
+                }
+            }
+            else
+            {
+                if (_idxGenReg + cArgSlots <= 8)
+                {
+                    int argOfsInner = TransitionBlock.GetOffsetOfArgumentRegisters() + _idxGenReg * 8;
+                    _idxGenReg += cArgSlots;
+                    return argOfsInner;
+                }
+                else
+                {
+                    _idxGenReg = 8;
+                }
+            }
+
+            argOfs = TransitionBlock.GetOffsetOfArgs() + _idxStack * 8;
+            _idxStack += cArgSlots;
+            return argOfs;
+#elif _TARGET_WASM_
+            throw new NotImplementedException();
+#else
+#error            PORTABILITY_ASSERT("ArgIterator::GetNextOffset");
+#endif
+        }
+
+
+        public CorElementType GetArgType(out TypeHandle pTypeHandle)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+            pTypeHandle = _argTypeHandle;
+            return _argType;
+        }
+
+        public CorElementType GetByRefArgType(out TypeHandle pByRefArgTypeHandle)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+            pByRefArgTypeHandle = _argTypeHandleOfByRefParam;
+            return _argType;
+        }
+
+        public int GetArgSize()
+        {
+            //        LIMITED_METHOD_CONTRACT;
+            return _argSize;
+        }
+
+        private unsafe void ForceSigWalk()
+        {
+            // This can be only used before the actual argument iteration started
+            Debug.Assert(!_ITERATION_STARTED);
+
+#if _TARGET_X86_
+            //
+            // x86 is special as always
+            //
+
+            int numRegistersUsed = 0;
+            int nSizeOfArgStack = 0;
+
+            if (this.HasThis())
+                numRegistersUsed++;
+
+            if (this.HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
+            {
+                // DESKTOP BEHAVIOR                numRegistersUsed++;
+                // On ProjectN ret buff arg is passed on the call stack as the top stack arg
+                nSizeOfArgStack += IntPtr.Size;
+            }
+
+            // DESKTOP BEHAVIOR - This block is disabled for x86 as the param arg is the last argument on desktop x86.
+            if (this.HasParamType())
+            {
+                numRegistersUsed++;
+                _paramTypeLoc = (numRegistersUsed == 1) ?
+                    ParamTypeLocation.Ecx : ParamTypeLocation.Edx;
+                Debug.Assert(numRegistersUsed <= 2);
+            }
+
+            if (this.IsVarArg())
+            {
+                nSizeOfArgStack += IntPtr.Size;
+                numRegistersUsed = ArchitectureConstants.NUM_ARGUMENT_REGISTERS; // Nothing else gets passed in registers for varargs
+            }
+
+#if FEATURE_INTERPRETER
+            switch (_interpreterCallingConvention)
+            {
+                case CallingConventions.StdCall:
+                    numRegistersUsed = ArchitectureConstants.NUM_ARGUMENT_REGISTERS;
+                    break;
+
+                case CallingConventions.ManagedStatic:
+                case CallingConventions.ManagedInstance:
+                    break;
+
+                default:
+                    Environment.FailFast("Unsupported calling convention.");
+                    break;
+            }
+#endif // FEATURE_INTERPRETER
+
+            int nArgs = this.NumFixedArgs();
+            for (int i = (_skipFirstArg ? 1 : 0); i < nArgs; i++)
+            {
+                TypeHandle thArgType;
+                bool argForcedToBeByref;
+                CorElementType type = this.GetArgumentType(i, out thArgType, out argForcedToBeByref);
+                if (argForcedToBeByref)
+                    type = CorElementType.ELEMENT_TYPE_BYREF;
+
+                if (!IsArgumentInRegister(ref numRegistersUsed, type, thArgType))
+                {
+                    int structSize = TypeHandle.GetElemSize(type, thArgType);
+
+                    nSizeOfArgStack += ArchitectureConstants.StackElemSize(structSize);
+
+                    if (nSizeOfArgStack > ArchitectureConstants.MAX_ARG_SIZE)
+                    {
+                        throw new NotSupportedException();
+                    }
+                }
+            }
+
+#if DESKTOP            // DESKTOP BEHAVIOR
+            if (this.HasParamType())
+            {
+                if (numRegistersUsed < ArchitectureConstants.NUM_ARGUMENT_REGISTERS)
+                {
+                    numRegistersUsed++;
+                    paramTypeLoc = (numRegistersUsed == 1) ?
+                        ParamTypeLocation.Ecx : ParamTypeLocation.Edx;
+                }
+                else
+                {
+                    nSizeOfArgStack += IntPtr.Size;
+                    paramTypeLoc = ParamTypeLocation.Stack;
+                }
+            }
+#endif // DESKTOP BEHAVIOR
+
+#else // _TARGET_X86_
+
+            int maxOffset = TransitionBlock.GetOffsetOfArgs();
+
+            int ofs;
+            while (TransitionBlock.InvalidOffset != (ofs = GetNextOffset()))
+            {
+                int stackElemSize;
+
+#if _TARGET_AMD64_
+                // All stack arguments take just one stack slot on AMD64 because of arguments bigger 
+                // than a stack slot are passed by reference. 
+                stackElemSize = ArchitectureConstants.STACK_ELEM_SIZE;
+#else
+                stackElemSize = ArchitectureConstants.StackElemSize(GetArgSize());
+                if (IsArgPassedByRef())
+                    stackElemSize = ArchitectureConstants.STACK_ELEM_SIZE;
+#endif
+
+                int endOfs = ofs + stackElemSize;
+                if (endOfs > maxOffset)
+                {
+                    if (endOfs > ArchitectureConstants.MAX_ARG_SIZE)
+                    {
+                        throw new NotSupportedException();
+                    }
+                    maxOffset = endOfs;
+                }
+            }
+            // Clear the iterator started flag
+            _ITERATION_STARTED = false;
+
+            int nSizeOfArgStack = maxOffset - TransitionBlock.GetOffsetOfArgs();
+
+#if _TARGET_AMD64_ && !UNIX_AMD64_ABI
+            nSizeOfArgStack = (nSizeOfArgStack > (int)sizeof(ArgumentRegisters)) ?
+                (nSizeOfArgStack - sizeof(ArgumentRegisters)) : 0;
+#endif
+
+#endif // _TARGET_X86_
+
+            // Cache the result
+            _nSizeOfArgStack = nSizeOfArgStack;
+            _SIZE_OF_ARG_STACK_COMPUTED = true;
+
+            this.Reset();
+        }
+
+
+#if !_TARGET_X86_
+        // Accessors for built in argument descriptions of the special implicit parameters not mentioned directly
+        // in signatures (this pointer and the like). Whether or not these can be used successfully before all the
+        // explicit arguments have been scanned is platform dependent.
+        public unsafe void GetThisLoc(ArgLocDesc* pLoc) { GetSimpleLoc(GetThisOffset(), pLoc); }
+        public unsafe void GetRetBuffArgLoc(ArgLocDesc* pLoc) { GetSimpleLoc(GetRetBuffArgOffset(), pLoc); }
+        public unsafe void GetParamTypeLoc(ArgLocDesc* pLoc) { GetSimpleLoc(GetParamTypeArgOffset(), pLoc); }
+        public unsafe void GetVASigCookieLoc(ArgLocDesc* pLoc) { GetSimpleLoc(GetVASigCookieOffset(), pLoc); }
+#endif // !_TARGET_X86_
+
+#if _TARGET_ARM_
+        // Get layout information for the argument that the ArgIterator is currently visiting.
+        public ArgLocDesc? GetArgLoc(int argOffset)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+
+            ArgLocDesc pLoc = new ArgLocDesc();
+
+            pLoc.m_fRequires64BitAlignment = _fRequires64BitAlignment;
+
+            int cSlots = (GetArgSize() + 3) / 4;
+
+            if (TransitionBlock.IsFloatArgumentRegisterOffset(argOffset))
+            {
+                pLoc.m_idxFloatReg = (argOffset - TransitionBlock.GetOffsetOfFloatArgumentRegisters()) / 4;
+                pLoc.m_cFloatReg = cSlots;
+                return;
+            }
+
+            if (!TransitionBlock.IsStackArgumentOffset(argOffset))
+            {
+                pLoc.m_idxGenReg = TransitionBlock.GetArgumentIndexFromOffset(argOffset);
+
+                if (cSlots <= (4 - pLoc.m_idxGenReg))
+                {
+                    pLoc.m_cGenReg = cSlots;
+                }
+                else
+                {
+                    pLoc.m_cGenReg = 4 - pLoc->m_idxGenReg;
+
+                    pLoc.m_idxStack = 0;
+                    pLoc.m_cStack = cSlots - pLoc->m_cGenReg;
+                }
+            }
+            else
+            {
+                pLoc.m_idxStack = TransitionBlock.GetArgumentIndexFromOffset(argOffset) - 4;
+                pLoc.m_cStack = cSlots;
+            }
+            return argLocDesc;
+        }
+#endif // _TARGET_ARM_
+
+#if _TARGET_ARM64_
+        // Get layout information for the argument that the ArgIterator is currently visiting.
+        public ArgLocDesc? GetArgLoc(int argOffset)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+
+            ArgLocDesc pLoc = new ArgLocDesc();
+
+            if (TransitionBlock.IsFloatArgumentRegisterOffset(argOffset))
+            {
+                // Dividing by 8 as size of each register in FloatArgumentRegisters is 8 bytes.
+                pLoc->m_idxFloatReg = (argOffset - TransitionBlock.GetOffsetOfFloatArgumentRegisters()) / 8;
+
+                if (!_argTypeHandle.IsNull() && _argTypeHandle.IsHFA())
+                {
+                    CorElementType type = _argTypeHandle.GetHFAType();
+                    bool isFloatType = (type == CorElementType.ELEMENT_TYPE_R4);
+
+                    // DESKTOP BEHAVIOR pLoc->m_cFloatReg = isFloatType ? GetArgSize() / sizeof(float) : GetArgSize() / sizeof(double);
+                    pLoc->m_cFloatReg = GetArgSize() / sizeof(double);
+                    pLoc->m_isSinglePrecision = isFloatType;
+                }
+                else
+                {
+                    pLoc->m_cFloatReg = 1;
+                }
+                return;
+            }
+
+            int cSlots = (GetArgSize() + 7) / 8;
+
+            // Composites greater than 16bytes are passed by reference
+            TypeHandle dummy;
+            if (GetArgType(out dummy) == CorElementType.ELEMENT_TYPE_VALUETYPE && GetArgSize() > ArchitectureConstants.ENREGISTERED_PARAMTYPE_MAXSIZE)
+            {
+                cSlots = 1;
+            }
+
+            if (!TransitionBlock.IsStackArgumentOffset(argOffset))
+            {
+                pLoc->m_idxGenReg = TransitionBlock.GetArgumentIndexFromOffset(argOffset);
+                pLoc->m_cGenReg = cSlots;
+            }
+            else
+            {
+                pLoc->m_idxStack = TransitionBlock.GetStackArgumentIndexFromOffset(argOffset);
+                pLoc->m_cStack = cSlots;
+            }
+            return pLoc;
+        }
+#endif // _TARGET_ARM64_
+
+#if _TARGET_AMD64_ && UNIX_AMD64_ABI
+        // Get layout information for the argument that the ArgIterator is currently visiting.
+        public ArgLocDesc? GetArgLoc(int argOffset)
+        {
+            //        LIMITED_METHOD_CONTRACT;
+
+            if (argOffset == TransitionBlock.StructInRegsOffset)
+            {
+                // We always already have argLocDesc for structs passed in registers, we 
+                // compute it in the GetNextOffset for those since it is always needed.
+                Debug.Assert(false);
+                return null;
+            }
+        
+            ArgLocDesc pLoc = new ArgLocDesc();
+
+            if (TransitionBlock.IsFloatArgumentRegisterOffset(argOffset))
+            {
+                // Dividing by 8 as size of each register in FloatArgumentRegisters is 8 bytes.
+                pLoc.m_idxFloatReg = (argOffset - TransitionBlock.GetOffsetOfFloatArgumentRegisters()) / 8;
+
+                // UNIXTODO: Passing of structs, HFAs. For now, use the Windows convention.
+                pLoc.m_cFloatReg = 1;
+                return;
+            }
+
+            // UNIXTODO: Passing of structs, HFAs. For now, use the Windows convention.
+            int cSlots = 1;
+
+            if (!TransitionBlock.IsStackArgumentOffset(argOffset))
+            {
+                pLoc.m_idxGenReg = TransitionBlock.GetArgumentIndexFromOffset(argOffset);
+                pLoc.m_cGenReg = cSlots;
+            }
+            else
+            {
+                pLoc.m_idxStack = (argOffset - TransitionBlock.GetOffsetOfArgs()) / 8;
+                pLoc.m_cStack = cSlots;
+            }
+            return pLoc;
+        }
+#endif // _TARGET_AMD64_ && UNIX_AMD64_ABI
+
+#if (_TARGET_AMD64_ && !UNIX_AMD64_ABI) || _TARGET_X86_
+        // Get layout information for the argument that the ArgIterator is currently visiting.
+        public ArgLocDesc? GetArgLoc(int argOffset)
+        {
+            return null;
+        }
+#endif
+
+        private int _nSizeOfArgStack;      // Cached value of SizeOfArgStack
+
+        private int _argNum;
+
+        // Cached information about last argument
+        private CorElementType _argType;
+        private int _argSize;
+        private TypeHandle _argTypeHandle;
+        private TypeHandle _argTypeHandleOfByRefParam;
+        private bool _argForceByRef;
+
+#if _TARGET_X86_
+        private int _curOfs;           // Current position of the stack iterator
+        private int _numRegistersUsed;
+#endif
+
+#if _TARGET_AMD64_
+#if UNIX_AMD64_ABI
+        int _idxGenReg;
+        int _idxStack;
+        int _idxFPReg;
+#else
+        private int _curOfs;           // Current position of the stack iterator
+#endif
+#endif
+
+#if _TARGET_ARM_
+        private int _idxGenReg;        // Next general register to be assigned a value
+        private int _idxStack;         // Next stack slot to be assigned a value
+
+        private ushort _wFPRegs;          // Bitmask of available floating point argument registers (s0-s15/d0-d7)
+        private bool _fRequires64BitAlignment; // Cached info about the current arg
+#endif
+
+#if _TARGET_ARM64_
+        private int _idxGenReg;        // Next general register to be assigned a value
+        private int _idxStack;         // Next stack slot to be assigned a value
+        private int _idxFPReg;         // Next FP register to be assigned a value
+#endif
+
+        // These are enum flags in CallingConventions.h, but that's really ugly in C#, so I've changed them to bools.
+        private bool _ITERATION_STARTED; // Started iterating over arguments
+        private bool _SIZE_OF_ARG_STACK_COMPUTED;
+        private bool _RETURN_FLAGS_COMPUTED;
+        private bool _RETURN_HAS_RET_BUFFER; // Cached value of HasRetBuffArg
+        private uint _fpReturnSize;
+
+        //        enum {
+        /*        ITERATION_STARTED               = 0x0001,   
+                SIZE_OF_ARG_STACK_COMPUTED      = 0x0002,
+                RETURN_FLAGS_COMPUTED           = 0x0004,
+                RETURN_HAS_RET_BUFFER           = 0x0008,   // Cached value of HasRetBuffArg
+        */
+#if _TARGET_X86_
+        private enum ParamTypeLocation
+        {
+            Stack,
+            Ecx,
+            Edx
+        }
+        private ParamTypeLocation _paramTypeLoc;
+        /*        PARAM_TYPE_REGISTER_MASK        = 0x0030,
+                PARAM_TYPE_REGISTER_STACK       = 0x0010,
+                PARAM_TYPE_REGISTER_ECX         = 0x0020,
+                PARAM_TYPE_REGISTER_EDX         = 0x0030,*/
+#endif
+
+        //        METHOD_INVOKE_NEEDS_ACTIVATION  = 0x0040,   // Flag used by ArgIteratorForMethodInvoke
+
+        //        RETURN_FP_SIZE_SHIFT            = 8,        // The rest of the flags is cached value of GetFPReturnSize
+        //    };
+
+        internal static void ComputeReturnValueTreatment(CorElementType type, TypeHandle thRetType, bool isVarArgMethod, out bool usesRetBuffer, out uint fpReturnSize)
+
+        {
+            usesRetBuffer = false;
+            fpReturnSize = 0;
+
+            switch (type)
+            {
+                case CorElementType.ELEMENT_TYPE_TYPEDBYREF:
+                    throw new NotSupportedException();
+#if ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+                //                    if (sizeof(TypedByRef) > ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE)
+                //                        flags |= RETURN_HAS_RET_BUFFER;
+#else
+//                    flags |= RETURN_HAS_RET_BUFFER;
+#endif
+                //                    break;
+
+                case CorElementType.ELEMENT_TYPE_R4:
+                    fpReturnSize = sizeof(float);
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_R8:
+                    fpReturnSize = sizeof(double);
+                    break;
+
+                case CorElementType.ELEMENT_TYPE_VALUETYPE:
+#if ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+                    {
+                        Debug.Assert(!thRetType.IsNull() && thRetType.IsValueType());
+
+#if FEATURE_HFA
+                        if (thRetType.IsHFA() && !isVarArgMethod)
+                        {
+                            CorElementType hfaType = thRetType.GetHFAType();
+
+#if _TARGET_ARM64_
+                            // DESKTOP BEHAVIOR fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ? (4 * (uint)sizeof(float)) : (4 * (uint)sizeof(double));
+                            // S and D registers overlap. Since we copy D registers in the UniversalTransitionThunk, we'll
+                            // thread floats like doubles during copying.
+                            fpReturnSize = 4 * (uint)sizeof(double);
+#else
+                            fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ?
+                                (4 * (uint)sizeof(float)) :
+                                (4 * (uint)sizeof(double));
+#endif
+
+                            break;
+                        }
+#endif
+
+                        uint size = thRetType.GetSize();
+
+#if _TARGET_X86_ || _TARGET_AMD64_
+                        // Return value types of size which are not powers of 2 using a RetBuffArg
+                        if ((size & (size - 1)) != 0)
+                        {
+                            usesRetBuffer = true;
+                            break;
+                        }
+#endif
+
+                        if (size <= ArchitectureConstants.ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE)
+                            break;
+                    }
+#endif // ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+
+                    // Value types are returned using return buffer by default
+                    usesRetBuffer = true;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        private void ComputeReturnFlags()
+        {
+            TypeHandle thRetType;
+            CorElementType type = this.GetReturnType(out thRetType, out _RETURN_HAS_RET_BUFFER);
+
+            if (!_RETURN_HAS_RET_BUFFER)
+            {
+                ComputeReturnValueTreatment(type, thRetType, this.IsVarArg(), out _RETURN_HAS_RET_BUFFER, out _fpReturnSize);
+            }
+
+            _RETURN_FLAGS_COMPUTED = true;
+        }
+
+
+#if !_TARGET_X86_
+        private unsafe void GetSimpleLoc(int offset, ArgLocDesc* pLoc)
+        {
+            //        WRAPPER_NO_CONTRACT; 
+            pLoc->Init();
+            pLoc->m_idxGenReg = TransitionBlock.GetArgumentIndexFromOffset(offset);
+            pLoc->m_cGenReg = 1;
+        }
+#endif
+
+        public static int ALIGN_UP(int input, int align_to)
+        {
+            return (input + (align_to - 1)) & ~(align_to - 1);
+        }
+
+        public static bool IS_ALIGNED(IntPtr val, int alignment)
+        {
+            Debug.Assert(0 == (alignment & (alignment - 1)));
+            return 0 == (val.ToInt64() & (alignment - 1));
+        }
+
+        public static bool IsRetBuffPassedAsFirstArg()
+        {
+            //        WRAPPER_NO_CONTRACT; 
+#if !_TARGET_ARM64_
+            return true;
+#else
+            return false;
+#endif
+        }
+    };
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// This class represents a single indirection cell used to call delay load helpers.
+    /// In addition to PrecodeHelperImport instances of this import type emit GC ref map
+    /// entries into the R2R executable.
+    /// </summary>
+    public class DelayLoadHelperMethodImport : DelayLoadHelperImport, IMethodNode
+    {
+        private readonly MethodFixupSignature _signature;
+
+        private readonly ReadyToRunHelper _helper;
+
+        private readonly ImportThunk _delayLoadHelper;
+
+        public DelayLoadHelperMethodImport(
+            ReadyToRunCodegenNodeFactory factory, 
+            ImportSectionNode importSectionNode, 
+            ReadyToRunHelper helper, 
+            MethodFixupSignature methodSignature, 
+            string callSite = null)
+            : base(factory, importSectionNode, helper, methodSignature, callSite)
+        {
+            _helper = helper;
+            _signature = methodSignature;
+            _delayLoadHelper = new ImportThunk(helper, factory, this);
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("DelayLoadHelperMethodImport(");
+            sb.Append(_helper.ToString());
+            sb.Append(") -> ");
+            ImportSignature.AppendMangledName(nameMangler, sb);
+            if (CallSite != null)
+            {
+                sb.Append(" @ ");
+                sb.Append(CallSite);
+            }
+        }
+
+        public override int ClassCode => 192837465;
+
+        public MethodDesc Method => _signature.Method;
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     /// </summary>
     public class DelayLoadHelperMethodImport : DelayLoadHelperImport, IMethodNode
     {
-        private readonly MethodFixupSignature _signature;
+        private readonly MethodDesc _methodDesc;
 
         private readonly ReadyToRunHelper _helper;
 
@@ -25,12 +25,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ReadyToRunCodegenNodeFactory factory, 
             ImportSectionNode importSectionNode, 
             ReadyToRunHelper helper, 
-            MethodFixupSignature methodSignature, 
+            MethodDesc methodDesc,
+            Signature instanceSignature, 
             string callSite = null)
-            : base(factory, importSectionNode, helper, methodSignature, callSite)
+            : base(factory, importSectionNode, helper, instanceSignature, callSite)
         {
             _helper = helper;
-            _signature = methodSignature;
+            _methodDesc = methodDesc;
             _delayLoadHelper = new ImportThunk(helper, factory, this);
         }
 
@@ -49,6 +50,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override int ClassCode => 192837465;
 
-        public MethodDesc Method => _signature.Method;
+        public MethodDesc Method => _methodDesc;
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -272,19 +272,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 throw new NotImplementedException();
             }
 
-            if (type is DefType defType)
+            Debug.Assert(type is DefType);
+            DefType defType = (DefType)type;
+            foreach (FieldDesc field in defType.GetFields())
             {
-                FieldLayoutAlgorithm fieldLayoutAlgorithm = _factory.TypeSystemContext.GetLayoutAlgorithmForType(defType);
-                ComputedInstanceFieldLayout instanceFieldLayout = fieldLayoutAlgorithm.ComputeInstanceLayout(defType, InstanceLayoutKind.TypeAndFields);
-                foreach (FieldAndOffset fieldAndOffset in instanceFieldLayout.Offsets)
+                if (!field.IsStatic)
                 {
-                    FieldDesc field = fieldAndOffset.Field;
-                    GcScanRoots(field.FieldType, argDest, fieldAndOffset.Offset.AsInt, frame);
+                    GcScanRoots(field.FieldType, argDest, field.Offset.AsInt, frame);
                 }
-                return;
             }
-
-            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -150,7 +150,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private void FakeGcScanRoots(MethodDesc method, ArgIterator argit, CORCOMPILE_GCREFMAP_TOKENS[] frame)
         {
             // Encode generic instantiation arg
-            if (argit.HasParamType())
+            if (argit.HasParamType)
             {
                 if (method.RequiresInstMethodDescArg())
                 {
@@ -163,7 +163,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             // If the function has a this pointer, add it to the mask
-            if (argit.HasThis())
+            if (argit.HasThis)
             {
                 bool isUnboxingStub = false; // TODO: is this correct?
                 bool interior = method.OwningType.IsValueType && !isUnboxingStub;
@@ -171,7 +171,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 frame[_transitionBlock.ThisOffset] = (interior ? CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_INTERIOR : CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_REF);
             }
 
-            if (argit.IsVarArg())
+            if (argit.IsVarArg)
             {
                 frame[argit.GetVASigCookieOffset()] = CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_VASIG_COOKIE;
 
@@ -183,7 +183,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // so always promote it.
             if (argit.HasRetBuffArg())
             {
-                frame[argit.GetRetBuffArgOffset()] = CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_INTERIOR;
+                frame[_transitionBlock.GetRetBuffArgOffset(argit.HasThis)] = CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_INTERIOR;
             }
 
             //
@@ -260,7 +260,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private void GcScanValueType(TypeDesc type, ArgDestination argDest, int delta, CORCOMPILE_GCREFMAP_TOKENS[] frame)
         {
-            if (ArgIterator.IsArgPassedByRef(_transitionBlock, new TypeHandle(type)))
+            if (_transitionBlock.IsArgPassedByRef(new TypeHandle(type)))
             {
                 argDest.GcMark(frame, delta, interior: true);
                 return;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -1,0 +1,394 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.TypeSystem;
+
+// The GCRef map is used to encode GC type of arguments for callsites. Logically, it is sequence <pos, token> where pos is 
+// position of the reference in the stack frame and token is type of GC reference (one of GCREFMAP_XXX values).
+//
+// - The encoding always starts at the byte boundary. The high order bit of each byte is used to signal end of the encoding 
+// stream. The last byte has the high order bit zero. It means that there are 7 useful bits in each byte.
+// - "pos" is always encoded as delta from previous pos.
+// - The basic encoding unit is two bits. Values 0, 1 and 2 are the common constructs (skip single slot, GC reference, interior 
+// pointer). Value 3 means that extended encoding follows. 
+// - The extended information is integer encoded in one or more four bit blocks. The high order bit of the four bit block is 
+// used to signal the end.
+// - For x86, the encoding starts by size of the callee poped stack. The size is encoded using the same mechanism as above (two bit
+// basic encoding, with extended encoding for large values).
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class GCRefMapBuilder
+    {
+        /// <summary>
+        /// Node factory to use
+        /// </summary>
+        private readonly NodeFactory _factory;
+
+        /// <summary>
+        /// Pending value, not yet written out
+        /// </summary>
+        private int _pendingByte;
+
+        /// <summary>
+        /// Number of bits in pending byte. Note that the trailing zero bits are not written out, 
+        /// so this can be more than 7.
+        /// </summary>
+        private int _bits;
+
+        /// <summary>
+        /// Current position
+        /// </summary>
+        private uint _pos;
+
+        /// <summary>
+        /// Builder for the generated data
+        /// </summary>
+        public ObjectDataBuilder Builder;
+
+        public GCRefMapBuilder(NodeFactory factory, bool relocsOnly)
+        {
+            _factory = factory;
+            _pendingByte = 0;
+            _bits = 0;
+            _pos = 0;
+            Builder = new ObjectDataBuilder(factory, relocsOnly);
+        }
+
+        public void GetCallRefMap(MethodDesc method)
+        {
+            bool hasThis = (method.Signature.Flags & MethodSignatureFlags.Static) == 0;
+            bool isVarArg = false;
+            TypeHandle returnType = new TypeHandle(method.Signature.ReturnType);
+            TypeHandle[] parameterTypes = new TypeHandle[method.Signature.Length];
+            for (int parameterIndex = 0; parameterIndex < parameterTypes.Length; parameterIndex++)
+            {
+                parameterTypes[parameterIndex] = new TypeHandle(method.Signature[parameterIndex]);
+            }
+            CallingConventions callingConventions = (hasThis ? CallingConventions.ManagedInstance : CallingConventions.ManagedStatic);
+            bool hasParamType = method.GetCanonMethodTarget(CanonicalFormKind.Specific).RequiresInstArg();
+            bool extraFunctionPointerArg = false;
+            bool[] forcedByRefParams = new bool[parameterTypes.Length];
+            bool skipFirstArg = false;
+            bool extraObjectFirstArg = false;
+            ArgIteratorData argIteratorData = new ArgIteratorData(hasThis, isVarArg, parameterTypes, returnType);
+
+            ArgIterator argit = new ArgIterator(
+                method.Context,
+                argIteratorData,
+                callingConventions,
+                hasParamType,
+                extraFunctionPointerArg,
+                forcedByRefParams,
+                skipFirstArg,
+                extraObjectFirstArg);
+
+            int nStackBytes = argit.SizeOfFrameArgumentArray();
+
+            // Allocate a fake stack
+            CORCOMPILE_GCREFMAP_TOKENS[] fakeStack = new CORCOMPILE_GCREFMAP_TOKENS[TransitionBlock.Size + nStackBytes];
+
+            // Fill it in
+            FakeGcScanRoots(method, argit, fakeStack);
+
+            // Encode the ref map
+            uint nStackSlots;
+            if (_factory.Target.Architecture == TargetArchitecture.X86)
+            {
+                uint cbStackPop = argit.CbStackPop();
+                WriteStackPop(cbStackPop / (uint)_factory.Target.PointerSize);
+
+                nStackSlots = (uint)(nStackBytes / _factory.Target.PointerSize + ArchitectureConstants.NUM_ARGUMENT_REGISTERS);
+            }
+            else
+            {
+                nStackSlots = (uint)((TransitionBlock.Size + nStackBytes - TransitionBlock.GetOffsetOfArgumentRegisters()) / _factory.Target.PointerSize);
+            }
+
+            for (uint pos = 0; pos < nStackSlots; pos++)
+            {
+                int ofs;
+
+                if (_factory.Target.Architecture == TargetArchitecture.X86)
+                {
+                    ofs = (int)(pos < ArchitectureConstants.NUM_ARGUMENT_REGISTERS ?
+                        TransitionBlock.GetOffsetOfArgumentRegisters() + ArchitectureConstants.ARGUMENTREGISTERS_SIZE - (pos + 1) * _factory.Target.PointerSize :
+                        TransitionBlock.GetOffsetOfArgs() + (pos - ArchitectureConstants.NUM_ARGUMENT_REGISTERS) * _factory.Target.PointerSize);
+                }
+                else
+                {
+                    ofs = (int)(TransitionBlock.GetOffsetOfArgumentRegisters() + pos * _factory.Target.PointerSize);
+                }
+
+                CORCOMPILE_GCREFMAP_TOKENS token = fakeStack[ofs];
+
+                if (token != CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_SKIP)
+                {
+                    WriteToken(pos, (byte)token);
+                }
+            }
+
+            Flush();
+        }
+
+        /// <summary>
+        /// Fill in the GC-relevant stack frame locations.
+        /// </summary>
+        private void FakeGcScanRoots(MethodDesc method, ArgIterator argit, CORCOMPILE_GCREFMAP_TOKENS[] frame)
+        {
+            // Encode generic instantiation arg
+            if (argit.HasParamType())
+            {
+                if (method.RequiresInstMethodDescArg())
+                {
+                    frame[argit.GetParamTypeArgOffset()] = CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_METHOD_PARAM;
+                }
+                else if (method.RequiresInstMethodTableArg())
+                {
+                    frame[argit.GetParamTypeArgOffset()] = CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_TYPE_PARAM;
+                }
+            }
+
+            // If the function has a this pointer, add it to the mask
+            if (argit.HasThis())
+            {
+                bool isUnboxingStub = false; // TODO: is this correct?
+                bool interior = method.OwningType.IsValueType && !isUnboxingStub;
+
+                frame[ArgIterator.GetThisOffset()] = (interior ? CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_INTERIOR : CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_REF);
+            }
+
+            if (argit.IsVarArg())
+            {
+                frame[argit.GetVASigCookieOffset()] = CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_VASIG_COOKIE;
+
+                // We are done for varargs - the remaining arguments are reported via vasig cookie
+                return;
+            }
+
+            // Also if the method has a return buffer, then it is the first argument, and could be an interior ref,
+            // so always promote it.
+            if (argit.HasRetBuffArg())
+            {
+                frame[argit.GetRetBuffArgOffset()] = CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_INTERIOR;
+            }
+
+            //
+            // Now iterate the arguments
+            //
+
+            // Cycle through the arguments, and call GcScanRoots for each
+            int argIndex = 0;
+            int argOffset;
+            while ((argOffset = argit.GetNextOffset()) != TransitionBlock.InvalidOffset)
+            {
+                ArgLocDesc? argLocDescForStructInRegs = argit.GetArgLoc(argOffset);
+                ArgDestination argDest = new ArgDestination(argOffset, argLocDescForStructInRegs);
+                GcScanRoots(method.Signature[argIndex], in argDest, delta: 0, frame);
+                argIndex++;
+            }
+        }
+
+        /// <summary>
+        /// Report GC locations for a single method parameter.
+        /// </summary>
+        /// <param name="type">Parameter type</param>
+        /// <param name="argDest">Location of the parameter</param>
+        /// <param name="frame">Frame map to update by marking GC locations</param>
+        private void GcScanRoots(TypeDesc type, in ArgDestination argDest, int delta, CORCOMPILE_GCREFMAP_TOKENS[] frame)
+        {
+            switch (type.Category)
+            {
+                // TYPE_GC_NONE
+                case TypeFlags.Void:
+                case TypeFlags.Boolean:
+                case TypeFlags.Char:
+                case TypeFlags.Byte:
+                case TypeFlags.SByte:
+                case TypeFlags.Int16:
+                case TypeFlags.UInt16:
+                case TypeFlags.Int32:
+                case TypeFlags.UInt32:
+                case TypeFlags.Int64:
+                case TypeFlags.UInt64:
+                case TypeFlags.Single:
+                case TypeFlags.Double:
+                case TypeFlags.IntPtr:
+                case TypeFlags.UIntPtr:
+                case TypeFlags.Pointer:
+                case TypeFlags.FunctionPointer:
+                case TypeFlags.Enum:
+                    break;
+
+                // TYPE_GC_REF
+                case TypeFlags.Class:
+                case TypeFlags.Interface:
+                case TypeFlags.Array:
+                case TypeFlags.SzArray:
+                    argDest.GcMark(frame, delta, interior: false);
+                    break;
+
+                // TYPE_GC_BYREF
+                case TypeFlags.ByRef:
+                    argDest.GcMark(frame, delta, interior: true);
+                    break;
+
+                // TYPE_GC_OTHER
+                case TypeFlags.ValueType:
+                case TypeFlags.Nullable:
+                    GcScanValueType(type, argDest, delta, frame);
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        private void GcScanValueType(TypeDesc type, ArgDestination argDest, int delta, CORCOMPILE_GCREFMAP_TOKENS[] frame)
+        {
+            if (ArgIterator.IsArgPassedByRef(new TypeHandle(type)))
+            {
+                argDest.GcMark(frame, delta, interior: true);
+                return;
+            }
+
+#if UNIX_AMD64_ABI
+            // ReportPointersFromValueTypeArg
+            if (argDest.IsStructPassedInRegs)
+            {
+                // ReportPointersFromStructPassedInRegs
+                throw new NotImplementedException();
+            }
+#endif
+            // ReportPointersFromValueType
+            if (type.IsByRefLike)
+            {
+                // TODO: FindByRefPointersInByRefLikeObject
+                throw new NotImplementedException();
+            }
+
+            if (type is DefType defType)
+            {
+                FieldLayoutAlgorithm fieldLayoutAlgorithm = _factory.TypeSystemContext.GetLayoutAlgorithmForType(defType);
+                ComputedInstanceFieldLayout instanceFieldLayout = fieldLayoutAlgorithm.ComputeInstanceLayout(defType, InstanceLayoutKind.TypeAndFields);
+                foreach (FieldAndOffset fieldAndOffset in instanceFieldLayout.Offsets)
+                {
+                    FieldDesc field = fieldAndOffset.Field;
+                    GcScanRoots(field.FieldType, argDest, fieldAndOffset.Offset.AsInt, frame);
+                }
+                return;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Append single bit to the stream
+        /// </summary>
+        /// <param name="bit"></param>
+        private void AppendBit(uint bit)
+        {
+            if (bit != 0)
+            {
+                while (_bits >= 7)
+                {
+                    Builder.EmitByte((byte)(_pendingByte | 0x80));
+                    _pendingByte = 0;
+                    _bits -= 7;
+                }
+
+                _pendingByte |= (1 << _bits);
+            }
+
+            _bits++;
+        }
+
+        private void AppendTwoBit(uint bits)
+        {
+            AppendBit(bits & 1);
+            AppendBit(bits >> 1);
+        }
+
+        private void AppendInt(uint val)
+        {
+            do
+            {
+                AppendBit(val & 1);
+                AppendBit((val >> 1) & 1);
+                AppendBit((val >> 2) & 1);
+
+                val >>= 3;
+
+                AppendBit((val != 0) ? 1u : 0u);
+            }
+            while (val != 0);
+        }
+
+        /// <summary>
+        /// Emit stack pop into the stream (X86 only).
+        /// </summary>
+        /// <param name="stackPop">Stack pop value</param>
+        public void WriteStackPop(uint stackPop)
+        {
+            if (stackPop < 3)
+            {
+                AppendTwoBit(stackPop);
+            }
+            else
+            {
+                AppendTwoBit(3);
+                AppendInt((uint)(stackPop - 3));
+            }
+        }
+
+        public void WriteToken(uint pos, uint gcRefMapToken)
+        {
+            uint posDelta = pos - _pos;
+            _pos = pos + 1;
+
+            if (posDelta != 0)
+            {
+                if (posDelta < 4)
+                {
+                    // Skipping by one slot at a time for small deltas produces smaller encoding.
+                    while (posDelta > 0)
+                    {
+                        AppendTwoBit(0);
+                        posDelta--;
+                    }
+                }
+                else
+                {
+                    AppendTwoBit(3);
+                    AppendInt((posDelta - 4) << 1);
+                }
+            }
+
+            if (gcRefMapToken < 3)
+            {
+                AppendTwoBit(gcRefMapToken);
+            }
+            else
+            {
+                AppendTwoBit(3);
+                AppendInt(((gcRefMapToken - 3) << 1) | 1);
+            }
+        }
+
+        public void Flush()
+        {
+            if ((_pendingByte & 0x7F) != 0 || _pos == 0)
+                Builder.EmitByte((byte)(_pendingByte & 0x7F));
+
+            _pendingByte = 0;
+            _bits = 0;
+
+            _pos = 0;
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class GCRefMapNode : ObjectNode, ISymbolDefinitionNode
+    {
+        /// <summary>
+        /// Number of GC ref map records to represent with a single lookup pointer
+        /// </summary>
+        public const int GCREFMAP_LOOKUP_STRIDE = 1024;
+
+        private readonly ImportSectionNode _importSection;
+        private readonly List<MethodDesc> _methods;
+
+        private int _index;
+
+        public GCRefMapNode(ImportSectionNode importSection)
+        {
+            _importSection = importSection;
+            _methods = new List<MethodDesc>();
+            _index = 0;
+        }
+
+        public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
+
+        public override bool IsShareable => false;
+
+        public override int ClassCode => 555444333;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public int Offset => 0;
+
+        public void AddImport(Import import)
+        {
+            if (import is IMethodNode methodNode)
+            {
+                while (_methods.Count <= _index)
+                {
+                    _methods.Add(null);
+                }
+                _methods[_index] = methodNode.Method;
+            }
+            _index++;
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("GCRefMap->");
+            sb.Append(_importSection.Name);
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            if (_methods.Count == 0 || relocsOnly)
+            {
+                return new ObjectData(
+                    data: Array.Empty<byte>(), 
+                    relocs: Array.Empty<Relocation>(), 
+                    alignment: 1, 
+                    definedSymbols: new ISymbolDefinitionNode[] { this });
+            }
+
+            GCRefMapBuilder builder = new GCRefMapBuilder(factory, relocsOnly);
+            builder.Builder.RequireInitialAlignment(4);
+            builder.Builder.AddSymbol(this);
+
+            // First, emit the initial ref map offset and reserve the offset map entries
+            int offsetCount = _methods.Count / GCREFMAP_LOOKUP_STRIDE;
+            builder.Builder.EmitInt((offsetCount + 1) * sizeof(int));
+
+            ObjectDataBuilder.Reservation[] offsets = new ObjectDataBuilder.Reservation[offsetCount];
+            for (int offsetIndex = 0; offsetIndex < offsetCount; offsetIndex++)
+            {
+                offsets[offsetIndex] = builder.Builder.ReserveInt();
+            }
+
+            // Next, generate the actual method GC ref maps and update the offset map
+            int nextOffsetIndex = 0;
+            int nextMethodIndex = GCREFMAP_LOOKUP_STRIDE - 1;
+            for (int methodIndex = 0; methodIndex < _methods.Count; methodIndex++)
+            {
+                if (methodIndex >= nextMethodIndex)
+                {
+                    builder.Builder.EmitInt(offsets[nextOffsetIndex], builder.Builder.CountBytes);
+                    nextOffsetIndex++;
+                    nextMethodIndex += GCREFMAP_LOOKUP_STRIDE;
+                }
+                builder.GetCallRefMap(_methods[methodIndex]);
+            }
+            Debug.Assert(nextOffsetIndex == offsets.Length);
+
+            return builder.Builder.ToObjectData();
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            Utf8StringBuilder sb = new Utf8StringBuilder();
+            AppendMangledName(factory.NameMangler, sb);
+            return sb.ToString();
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
@@ -96,9 +96,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     nextMethodIndex += GCREFMAP_LOOKUP_STRIDE;
                 }
                 IMethodNode methodNode = _methods[methodIndex];
-                if (methodNode is LocalMethodImport localMethodImport && localMethodImport.MethodCodeNode.IsEmpty)
+                if (methodNode == null)
                 {
-                    // Emit an empty entry into the GC ref map for the uncompilable method
+                    // Flush an empty GC ref map block to prevent
+                    // the indexed records to fall out of sync with methods
                     builder.Flush();
                 }
                 else

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -43,6 +43,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _isInstantiatingStub = isInstantiatingStub;
         }
 
+        public MethodDesc Method => _methodDesc;
+
         public override int ClassCode => 150063499;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperMethodImport.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// This class represents a single method indirection cell resolved using fixup table
+    /// at function startup; in addition to PrecodeHelperImport instances of this import type
+    /// emit GC ref map entries into the R2R executable.
+    /// </summary>
+    public class PrecodeHelperMethodImport : PrecodeHelperImport, IMethodNode
+    {
+        private readonly MethodFixupSignature _signature;
+
+        public PrecodeHelperMethodImport(ReadyToRunCodegenNodeFactory factory, MethodFixupSignature signature)
+            : base(factory, signature)
+        {
+            _signature = signature;
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return "PrecodeHelperMethodImport->" + ImportSignature.GetMangledName(factory.NameMangler);
+        }
+
+        public override int ClassCode => 668765432;
+
+        public MethodDesc Method => _signature.Method;
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperMethodImport.cs
@@ -15,12 +15,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     /// </summary>
     public class PrecodeHelperMethodImport : PrecodeHelperImport, IMethodNode
     {
-        private readonly MethodFixupSignature _signature;
+        private readonly MethodDesc _methodDesc;
 
-        public PrecodeHelperMethodImport(ReadyToRunCodegenNodeFactory factory, MethodFixupSignature signature)
+        public PrecodeHelperMethodImport(ReadyToRunCodegenNodeFactory factory, MethodDesc methodDesc, Signature signature)
             : base(factory, signature)
         {
-            _signature = signature;
+            _methodDesc = methodDesc;
         }
 
         protected override string GetName(NodeFactory factory)
@@ -30,6 +30,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override int ClassCode => 668765432;
 
-        public MethodDesc Method => _signature.Method;
+        public MethodDesc Method => _methodDesc;
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -1,0 +1,478 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// This file is a line by line port of callingconvention.h from the CLR with the intention that we may wish to merge
+// changes from the CLR in at a later time. As such, the normal coding conventions are ignored.
+//
+
+//
+#if ARM
+#define _TARGET_ARM_
+#define CALLDESCR_ARGREGS                          // CallDescrWorker has ArgumentRegister parameter
+#define CALLDESCR_FPARGREGS                        // CallDescrWorker has FloatArgumentRegisters parameter
+#define ENREGISTERED_RETURNTYPE_MAXSIZE
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+#define FEATURE_HFA
+#elif ARM64
+#define _TARGET_ARM64_
+#define CALLDESCR_ARGREGS                          // CallDescrWorker has ArgumentRegister parameter
+#define CALLDESCR_FPARGREGS                        // CallDescrWorker has FloatArgumentRegisters parameter
+#define ENREGISTERED_RETURNTYPE_MAXSIZE
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+#define ENREGISTERED_PARAMTYPE_MAXSIZE
+#define FEATURE_HFA
+#elif X86
+#define _TARGET_X86_
+#define ENREGISTERED_RETURNTYPE_MAXSIZE
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+#define CALLDESCR_ARGREGS                          // CallDescrWorker has ArgumentRegister parameter
+#elif AMD64
+#if PLATFORM_UNIX
+#define UNIX_AMD64_ABI
+#define CALLDESCR_ARGREGS                          // CallDescrWorker has ArgumentRegister parameter
+#else
+#endif
+#define CALLDESCR_FPARGREGS                        // CallDescrWorker has FloatArgumentRegisters parameter
+#define _TARGET_AMD64_
+#define ENREGISTERED_RETURNTYPE_MAXSIZE
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
+#define ENREGISTERED_PARAMTYPE_MAXSIZE
+#elif WASM
+#define _TARGET_WASM_
+#else
+#error Unknown architecture!
+#endif
+
+// Provides an abstraction over platform specific calling conventions (specifically, the calling convention
+// utilized by the JIT on that platform). The caller enumerates each argument of a signature in turn, and is 
+// provided with information mapping that argument into registers and/or stack locations.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+#if _TARGET_AMD64_
+#pragma warning disable 0169
+#if UNIX_AMD64_ABI
+    struct ReturnBlock
+    {
+        IntPtr returnValue;
+        IntPtr returnValue2;
+    }
+
+    struct ArgumentRegisters
+    {
+        IntPtr rdi;
+        IntPtr rsi;
+        IntPtr rdx;
+        IntPtr rcx;
+        IntPtr r8;
+        IntPtr r9;
+    }
+#else // UNIX_AMD64_ABI
+    struct ReturnBlock
+    {
+        IntPtr returnValue;
+    }
+
+    struct ArgumentRegisters
+    {
+        IntPtr rdx;
+        IntPtr rcx;
+        IntPtr r8;
+        IntPtr r9;
+    }
+#endif // UNIX_AMD64_ABI
+#pragma warning restore 0169
+
+#pragma warning disable 0169
+    struct M128A
+    {
+        IntPtr a;
+        IntPtr b;
+    }
+    struct FloatArgumentRegisters
+    {
+        M128A d0;
+        M128A d1;
+        M128A d2;
+        M128A d3;
+#if UNIX_AMD64_ABI
+        M128A d4;
+        M128A d5;
+        M128A d6;
+        M128A d7;
+#endif
+    }
+#pragma warning restore 0169
+
+    struct ArchitectureConstants
+    {
+        // To avoid corner case bugs, limit maximum size of the arguments with sufficient margin
+        public const int MAX_ARG_SIZE = 0xFFFFFF;
+
+#if UNIX_AMD64_ABI
+        public const int NUM_ARGUMENT_REGISTERS = 6;
+#else
+        public const int NUM_ARGUMENT_REGISTERS = 4;
+#endif
+        public const int ARGUMENTREGISTERS_SIZE = NUM_ARGUMENT_REGISTERS * 8;
+        public const int ENREGISTERED_RETURNTYPE_MAXSIZE = 8;
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE = 8;
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE_PRIMITIVE = 8;
+        public const int ENREGISTERED_PARAMTYPE_MAXSIZE = 8;
+        public const int STACK_ELEM_SIZE = 8;
+        public static int StackElemSize(int size) { return (((size) + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1)); }
+    }
+#elif _TARGET_ARM64_
+#pragma warning disable 0169
+    struct ReturnBlock
+    {
+        IntPtr returnValue;
+        IntPtr returnValue2;
+        IntPtr returnValue3;
+        IntPtr returnValue4;
+    }
+
+    struct ArgumentRegisters
+    {
+        IntPtr x0;
+        IntPtr x1;
+        IntPtr x2;
+        IntPtr x3;
+        IntPtr x4;
+        IntPtr x5;
+        IntPtr x6;
+        IntPtr x7;
+        IntPtr x8;
+        public static unsafe int GetOffsetOfx8()
+        {
+            return sizeof(IntPtr) * 8;
+        }
+    }
+#pragma warning restore 0169
+
+#pragma warning disable 0169
+    struct FloatArgumentRegisters
+    {
+        double d0;
+        double d1;
+        double d2;
+        double d3;
+        double d4;
+        double d5;
+        double d6;
+        double d7;
+    }
+#pragma warning restore 0169
+
+    struct ArchitectureConstants
+    {
+        // To avoid corner case bugs, limit maximum size of the arguments with sufficient margin
+        public const int MAX_ARG_SIZE = 0xFFFFFF;
+
+        public const int NUM_ARGUMENT_REGISTERS = 8;
+        public const int ARGUMENTREGISTERS_SIZE = NUM_ARGUMENT_REGISTERS * 8;
+        public const int ENREGISTERED_RETURNTYPE_MAXSIZE = 32;                  // bytes (four FP registers: d0,d1,d2 and d3)
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE = 16;          // bytes (two int registers: x0 and x1)
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE_PRIMITIVE = 8;
+        public const int ENREGISTERED_PARAMTYPE_MAXSIZE = 16;                   // bytes (max value type size that can be passed by value)
+        public const int STACK_ELEM_SIZE = 8;
+        public static int StackElemSize(int size) { return (((size) + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1)); }
+    }
+#elif _TARGET_X86_
+#pragma warning disable 0169, 0649
+    struct ReturnBlock
+    {
+        public IntPtr returnValue;
+        public IntPtr returnValue2;
+    }
+
+    struct ArgumentRegisters
+    {
+        public IntPtr edx;
+        public static unsafe int GetOffsetOfEdx()
+        {
+            return 0;
+        }
+        public IntPtr ecx;
+        public static unsafe int GetOffsetOfEcx()
+        {
+            return sizeof(IntPtr);
+        }
+    }
+    // This struct isn't used by x86, but exists for compatibility with the definition of the CallDescrData struct
+    struct FloatArgumentRegisters
+    {
+    }
+#pragma warning restore 0169, 0649
+
+    struct ArchitectureConstants
+    {
+        // To avoid corner case bugs, limit maximum size of the arguments with sufficient margin
+        public const int MAX_ARG_SIZE = 0xFFFFFF;
+
+        public const int NUM_ARGUMENT_REGISTERS = 2;
+        public const int ARGUMENTREGISTERS_SIZE = NUM_ARGUMENT_REGISTERS * 4;
+        public const int ENREGISTERED_RETURNTYPE_MAXSIZE = 8;
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE = 4;
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE_PRIMITIVE = 4;
+        public const int STACK_ELEM_SIZE = 4;
+        public static int StackElemSize(int size) { return (((size) + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1)); }
+    }
+#elif _TARGET_ARM_
+#pragma warning disable 0169
+    struct ReturnBlock
+    {
+        IntPtr returnValue;
+        IntPtr returnValue2;
+        IntPtr returnValue3;
+        IntPtr returnValue4;
+        IntPtr returnValue5;
+        IntPtr returnValue6;
+        IntPtr returnValue7;
+        IntPtr returnValue8;
+    }
+
+    struct ArgumentRegisters
+    {
+        IntPtr r0;
+        IntPtr r1;
+        IntPtr r2;
+        IntPtr r3;
+    }
+
+    struct FloatArgumentRegisters
+    {
+        double d0;
+        double d1;
+        double d2;
+        double d3;
+        double d4;
+        double d5;
+        double d6;
+        double d7;
+    }
+#pragma warning restore 0169
+
+    struct ArchitectureConstants
+    {
+        // To avoid corner case bugs, limit maximum size of the arguments with sufficient margin
+        public const int MAX_ARG_SIZE = 0xFFFFFF;
+
+        public const int NUM_ARGUMENT_REGISTERS = 4;
+        public const int ARGUMENTREGISTERS_SIZE = NUM_ARGUMENT_REGISTERS * 4;
+        public const int ENREGISTERED_RETURNTYPE_MAXSIZE = 32;
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE = 4;
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE_PRIMITIVE = 8;
+        public const int STACK_ELEM_SIZE = 4;
+        public static int StackElemSize(int size) { return (((size) + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1)); }
+    }
+
+#elif _TARGET_WASM_
+#pragma warning disable 0169
+    struct ReturnBlock
+    {
+        IntPtr returnValue;
+    }
+
+    struct ArgumentRegisters
+    {
+        // No registers on WASM
+    }
+    
+    struct FloatArgumentRegisters
+    {
+        // No registers on WASM
+    }
+#pragma warning restore 0169
+
+    struct ArchitectureConstants
+    {
+        // To avoid corner case bugs, limit maximum size of the arguments with sufficient margin
+        public const int MAX_ARG_SIZE = 0xFFFFFF;
+
+        public const int NUM_ARGUMENT_REGISTERS = 0;
+        public const int ARGUMENTREGISTERS_SIZE = NUM_ARGUMENT_REGISTERS * 4;
+        public const int ENREGISTERED_RETURNTYPE_MAXSIZE = 32;
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE = 4;
+        public const int ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE_PRIMITIVE = 8;
+        public const int STACK_ELEM_SIZE = 4;
+        public static int StackElemSize(int size) { return (((size) + STACK_ELEM_SIZE - 1) & ~(STACK_ELEM_SIZE - 1)); }
+    }
+#endif
+
+    //
+    // TransitionBlock is layout of stack frame of method call, saved argument registers and saved callee saved registers. Even though not 
+    // all fields are used all the time, we use uniform form for simplicity.
+    //
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct TransitionBlock
+    {
+#pragma warning disable 0169,0649
+
+#if _TARGET_X86_
+        public ArgumentRegisters m_argumentRegisters;
+        public static unsafe int GetOffsetOfArgumentRegisters()
+        {
+            return 0;
+        }
+        public ReturnBlock m_returnBlock;
+        public static unsafe int GetOffsetOfReturnValuesBlock()
+        {
+            return sizeof(ArgumentRegisters);
+        }
+        IntPtr m_ebp;
+        IntPtr m_ReturnAddress;
+#elif _TARGET_AMD64_
+
+#if UNIX_AMD64_ABI
+        public ReturnBlock m_returnBlock;
+        public static unsafe int GetOffsetOfReturnValuesBlock()
+        {
+            return 0;
+        }
+
+        public ArgumentRegisters m_argumentRegisters;
+        public static unsafe int GetOffsetOfArgumentRegisters()
+        {
+            return sizeof(ReturnBlock);
+        }
+
+        IntPtr m_alignmentPadding;
+        IntPtr m_ReturnAddress;
+#else // UNIX_AMD64_ABI
+        IntPtr m_returnBlockPadding;
+        ReturnBlock m_returnBlock;
+        public static unsafe int GetOffsetOfReturnValuesBlock()
+        {
+            return sizeof(IntPtr);
+        }
+        IntPtr m_alignmentPadding;
+        IntPtr m_ReturnAddress;
+        public static unsafe int GetOffsetOfArgumentRegisters()
+        {
+            return sizeof(TransitionBlock);
+        }
+#endif // UNIX_AMD64_ABI
+
+#elif _TARGET_ARM_
+        public ReturnBlock m_returnBlock;
+        public static unsafe int GetOffsetOfReturnValuesBlock()
+        {
+            return 0;
+        }
+
+        public ArgumentRegisters m_argumentRegisters;
+        public static unsafe int GetOffsetOfArgumentRegisters()
+        {
+            return sizeof(ReturnBlock);
+        }
+#elif _TARGET_ARM64_
+        public ReturnBlock m_returnBlock;
+        public static unsafe int GetOffsetOfReturnValuesBlock()
+        {
+            return 0;
+        }
+
+        public ArgumentRegisters m_argumentRegisters;
+        public static unsafe int GetOffsetOfArgumentRegisters()
+        {
+            return sizeof(ReturnBlock);
+        }
+
+        public IntPtr m_alignmentPad;
+#elif _TARGET_WASM_
+        public ReturnBlock m_returnBlock;
+        public static unsafe int GetOffsetOfReturnValuesBlock()
+        {
+            return 0;
+        }
+
+        public ArgumentRegisters m_argumentRegisters;
+        public static unsafe int GetOffsetOfArgumentRegisters()
+        {
+            return sizeof(ReturnBlock);
+        }
+#else
+#error Portability problem
+#endif
+#pragma warning restore 0169, 0649
+
+        // The transition block should define everything pushed by callee. The code assumes in number of places that
+        // end of the transition block is caller's stack pointer.
+
+        public static unsafe byte GetOffsetOfArgs()
+        {
+            return (byte)sizeof(TransitionBlock);
+        }
+
+
+        public static bool IsStackArgumentOffset(int offset)
+        {
+            int ofsArgRegs = GetOffsetOfArgumentRegisters();
+
+            return offset >= (int)(ofsArgRegs + ArchitectureConstants.ARGUMENTREGISTERS_SIZE);
+        }
+
+        public static bool IsArgumentRegisterOffset(int offset)
+        {
+            int ofsArgRegs = GetOffsetOfArgumentRegisters();
+
+            return offset >= ofsArgRegs && offset < (int)(ofsArgRegs + ArchitectureConstants.ARGUMENTREGISTERS_SIZE);
+        }
+
+#if !_TARGET_X86_
+        public static unsafe int GetArgumentIndexFromOffset(int offset)
+        {
+            return ((offset - GetOffsetOfArgumentRegisters()) / IntPtr.Size);
+        }
+
+        public static int GetStackArgumentIndexFromOffset(int offset)
+        {
+            return (offset - GetOffsetOfArgs()) / ArchitectureConstants.STACK_ELEM_SIZE;
+        }
+#endif
+
+#if CALLDESCR_FPARGREGS
+        public static bool IsFloatArgumentRegisterOffset(int offset)
+        {
+            return offset < 0;
+        }
+
+        public static int GetOffsetOfFloatArgumentRegisters()
+        {
+            return -GetNegSpaceSize();
+        }
+#endif
+
+        public static unsafe int GetNegSpaceSize()
+        {
+            int negSpaceSize = 0;
+#if CALLDESCR_FPARGREGS
+            negSpaceSize += sizeof(FloatArgumentRegisters);
+#endif
+            return negSpaceSize;
+        }
+
+        public static unsafe int Size => sizeof(TransitionBlock);
+
+        public static int GetThisOffset()
+        {
+            // This pointer is in the first argument register by default
+            int ret = TransitionBlock.GetOffsetOfArgumentRegisters();
+
+#if _TARGET_X86_
+            // x86 is special as always
+            ret += ArgumentRegisters.GetOffsetOfEcx();
+#endif
+
+            return ret;
+        }
+
+        public const int InvalidOffset = -1;
+    };
+}

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -57,12 +57,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 #if _TARGET_AMD64_
 #pragma warning disable 0169
 #if UNIX_AMD64_ABI
-    struct ReturnBlock
-    {
-        IntPtr returnValue;
-        IntPtr returnValue2;
-    }
-
     struct ArgumentRegisters
     {
         IntPtr rdi;
@@ -72,18 +66,33 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         IntPtr r8;
         IntPtr r9;
     }
-#else // UNIX_AMD64_ABI
-    struct ReturnBlock
+    struct CalleeSavedRegisters
     {
-        IntPtr returnValue;
+        IntPtr r12;
+        IntPtr r13;
+        IntPtr r14;
+        IntPtr r15;
+        IntPtr rbx;
+        IntPtr rbp;
     }
-
+#else // UNIX_AMD64_ABI
     struct ArgumentRegisters
     {
-        IntPtr rdx;
         IntPtr rcx;
+        IntPtr rdx;
         IntPtr r8;
         IntPtr r9;
+    }
+    struct CalleeSavedRegisters
+    {
+        IntPtr rdi;
+        IntPtr rsi;
+        IntPtr rbx;
+        IntPtr rbp;
+        IntPtr r12;
+        IntPtr r13;
+        IntPtr r14;
+        IntPtr r15;
     }
 #endif // UNIX_AMD64_ABI
 #pragma warning restore 0169
@@ -129,14 +138,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     }
 #elif _TARGET_ARM64_
 #pragma warning disable 0169
-    struct ReturnBlock
-    {
-        IntPtr returnValue;
-        IntPtr returnValue2;
-        IntPtr returnValue3;
-        IntPtr returnValue4;
-    }
-
     struct ArgumentRegisters
     {
         IntPtr x0;
@@ -147,13 +148,28 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         IntPtr x5;
         IntPtr x6;
         IntPtr x7;
-        IntPtr x8;
         public static unsafe int GetOffsetOfx8()
         {
             return sizeof(IntPtr) * 8;
         }
     }
 #pragma warning restore 0169
+
+    struct CalleeSavedRegisters
+    {
+        IntPtr x29;
+        IntPtr x30;
+        IntPtr x19;
+        IntPtr x20;
+        IntPtr x21;
+        IntPtr x22;
+        IntPtr x23;
+        IntPtr x24;
+        IntPtr x25;
+        IntPtr x26;
+        IntPtr x27;
+        IntPtr x28;
+    }
 
 #pragma warning disable 0169
     struct FloatArgumentRegisters
@@ -185,12 +201,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     }
 #elif _TARGET_X86_
 #pragma warning disable 0169, 0649
-    struct ReturnBlock
-    {
-        public IntPtr returnValue;
-        public IntPtr returnValue2;
-    }
-
     struct ArgumentRegisters
     {
         public IntPtr edx;
@@ -204,6 +214,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return sizeof(IntPtr);
         }
     }
+    
+    struct CalleeSavedRegisters
+    {
+        public IntPtr edi;
+        public IntPtr esi;
+        public IntPtr ebx;
+        public IntPtr ebp;
+    }
+    
     // This struct isn't used by x86, but exists for compatibility with the definition of the CallDescrData struct
     struct FloatArgumentRegisters
     {
@@ -225,24 +244,25 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     }
 #elif _TARGET_ARM_
 #pragma warning disable 0169
-    struct ReturnBlock
-    {
-        IntPtr returnValue;
-        IntPtr returnValue2;
-        IntPtr returnValue3;
-        IntPtr returnValue4;
-        IntPtr returnValue5;
-        IntPtr returnValue6;
-        IntPtr returnValue7;
-        IntPtr returnValue8;
-    }
-
     struct ArgumentRegisters
     {
         IntPtr r0;
         IntPtr r1;
         IntPtr r2;
         IntPtr r3;
+    }
+
+    struct CalleeSavedRegisters
+    {
+        IntPtr r4;
+        IntPtr r5;
+        IntPtr r6;
+        IntPtr r7;
+        IntPtr r8;
+        IntPtr r9;
+        IntPtr r10;
+        IntPtr r11;
+        IntPtr r14;
     }
 
     struct FloatArgumentRegisters
@@ -274,11 +294,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
 #elif _TARGET_WASM_
 #pragma warning disable 0169
-    struct ReturnBlock
-    {
-        IntPtr returnValue;
-    }
-
     struct ArgumentRegisters
     {
         // No registers on WASM
@@ -320,82 +335,48 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             return 0;
         }
-        public ReturnBlock m_returnBlock;
-        public static unsafe int GetOffsetOfReturnValuesBlock()
-        {
-            return sizeof(ArgumentRegisters);
-        }
-        IntPtr m_ebp;
+        public CalleeSavedRegisters m_calleeSavedRegisters;
         IntPtr m_ReturnAddress;
 #elif _TARGET_AMD64_
 
 #if UNIX_AMD64_ABI
-        public ReturnBlock m_returnBlock;
-        public static unsafe int GetOffsetOfReturnValuesBlock()
-        {
-            return 0;
-        }
-
         public ArgumentRegisters m_argumentRegisters;
         public static unsafe int GetOffsetOfArgumentRegisters()
         {
-            return sizeof(ReturnBlock);
+            return 0;
         }
-
-        IntPtr m_alignmentPadding;
-        IntPtr m_ReturnAddress;
 #else // UNIX_AMD64_ABI
-        IntPtr m_returnBlockPadding;
-        ReturnBlock m_returnBlock;
-        public static unsafe int GetOffsetOfReturnValuesBlock()
-        {
-            return sizeof(IntPtr);
-        }
-        IntPtr m_alignmentPadding;
-        IntPtr m_ReturnAddress;
         public static unsafe int GetOffsetOfArgumentRegisters()
         {
             return sizeof(TransitionBlock);
         }
 #endif // UNIX_AMD64_ABI
+        public CalleeSavedRegisters m_calleeSavedRegisters;
+        IntPtr m_ReturnAddress;
 
 #elif _TARGET_ARM_
-        public ReturnBlock m_returnBlock;
-        public static unsafe int GetOffsetOfReturnValuesBlock()
-        {
-            return 0;
-        }
-
+        public CalleeSavedRegisters m_calleeSavedRegisers;
         public ArgumentRegisters m_argumentRegisters;
         public static unsafe int GetOffsetOfArgumentRegisters()
         {
-            return sizeof(ReturnBlock);
+            return sizeof(CalleeSavedRegisters);
         }
 #elif _TARGET_ARM64_
-        public ReturnBlock m_returnBlock;
-        public static unsafe int GetOffsetOfReturnValuesBlock()
-        {
-            return 0;
-        }
-
-        public ArgumentRegisters m_argumentRegisters;
-        public static unsafe int GetOffsetOfArgumentRegisters()
-        {
-            return sizeof(ReturnBlock);
-        }
-
+        public CalleeSavedRegisters m_calleeSavedRegisters;
         public IntPtr m_alignmentPad;
-#elif _TARGET_WASM_
-        public ReturnBlock m_returnBlock;
-        public static unsafe int GetOffsetOfReturnValuesBlock()
+        public IntPtr m_x8RetBuffReg;
+        public ArgumentRegisters m_argumentRegisters;
+
+        public static unsafe int GetOffsetOfArgumentRegisters()
         {
-            return 0;
+            return sizeof(CalleeSavedRegisters) + 2 * sizeof(IntPtr);
         }
 
+#elif _TARGET_WASM_
         public ArgumentRegisters m_argumentRegisters;
         public static unsafe int GetOffsetOfArgumentRegisters()
         {
-            return sizeof(ReturnBlock);
+            return 0;
         }
 #else
 #error Portability problem

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -286,7 +286,8 @@ namespace ILCompiler.DependencyAnalysis
                 CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN,
                 CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_EAGER,
                 (byte)Target.PointerSize,
-                emitPrecode: false);
+                emitPrecode: false,
+                emitGCRefMap: false);
             ImportSectionsTable.AddEmbeddedObject(EagerImports);
 
             // All ready-to-run images have a module import helper which gets patched by the runtime on image load
@@ -314,7 +315,8 @@ namespace ILCompiler.DependencyAnalysis
                 CorCompileImportType.CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH,
                 CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
                 (byte)Target.PointerSize,
-                emitPrecode: false);
+                emitPrecode: false,
+                emitGCRefMap: true);
             ImportSectionsTable.AddEmbeddedObject(MethodImports);
 
             DispatchImports = new ImportSectionNode(
@@ -322,7 +324,8 @@ namespace ILCompiler.DependencyAnalysis
                 CorCompileImportType.CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH,
                 CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
                 (byte)Target.PointerSize,
-                emitPrecode: false);
+                emitPrecode: false,
+                emitGCRefMap: false);
             ImportSectionsTable.AddEmbeddedObject(DispatchImports);
 
             HelperImports = new ImportSectionNode(
@@ -330,7 +333,8 @@ namespace ILCompiler.DependencyAnalysis
                 CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN,
                 CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
                 (byte)Target.PointerSize,
-                emitPrecode: false);
+                emitPrecode: false,
+                emitGCRefMap: false);
             ImportSectionsTable.AddEmbeddedObject(HelperImports);
 
             PrecodeImports = new ImportSectionNode(
@@ -338,7 +342,8 @@ namespace ILCompiler.DependencyAnalysis
                 CorCompileImportType.CORCOMPILE_IMPORT_TYPE_UNKNOWN,
                 CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
                 (byte)Target.PointerSize,
-                emitPrecode: true);
+                emitPrecode: true,
+                emitGCRefMap: false);
             ImportSectionsTable.AddEmbeddedObject(PrecodeImports);
 
             StringImports = new ImportSectionNode(
@@ -346,7 +351,8 @@ namespace ILCompiler.DependencyAnalysis
                 CorCompileImportType.CORCOMPILE_IMPORT_TYPE_STRING_HANDLE,
                 CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_UNKNOWN,
                 (byte)Target.PointerSize,
-                emitPrecode: true);
+                emitPrecode: true,
+                emitGCRefMap: false);
             ImportSectionsTable.AddEmbeddedObject(StringImports);
 
             graph.AddRoot(ImportSectionsTable, "Import sections table is always generated");

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -325,7 +325,7 @@ namespace ILCompiler.DependencyAnalysis
                 CorCompileImportFlags.CORCOMPILE_IMPORT_FLAGS_PCODE,
                 (byte)Target.PointerSize,
                 emitPrecode: false,
-                emitGCRefMap: false);
+                emitGCRefMap: true);
             ImportSectionsTable.AddEmbeddedObject(DispatchImports);
 
             HelperImports = new ImportSectionNode(

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -202,7 +202,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private ISymbolNode CreateVirtualCallHelper(MethodWithToken methodWithToken, SignatureContext signatureContext)
         {
-            return new DelayLoadHelperImport(
+            return new DelayLoadHelperMethodImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.DispatchImports,
                 ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj,
@@ -585,7 +585,7 @@ namespace ILCompiler.DependencyAnalysis
             MethodAndCallSite cellKey = new MethodAndCallSite(method, callSite);
             if (!_interfaceDispatchCells.TryGetValue(cellKey, out ISymbolNode dispatchCell))
             {
-                dispatchCell = new DelayLoadHelperImport(
+                dispatchCell = new DelayLoadHelperMethodImport(
                     _codegenNodeFactory,
                     _codegenNodeFactory.DispatchImports,
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_MethodCall |
@@ -610,7 +610,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (!_genericDictionaryCache.TryGetValue(method, out ISortableSymbolNode genericDictionary))
             {
-                genericDictionary = new PrecodeHelperImport(
+                genericDictionary = new PrecodeHelperMethodImport(
                     _codegenNodeFactory,
                     _codegenNodeFactory.MethodSignature(
                         ReadyToRunFixupKind.READYTORUN_FIXUP_MethodDictionary,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -206,6 +206,7 @@ namespace ILCompiler.DependencyAnalysis
                 _codegenNodeFactory,
                 _codegenNodeFactory.DispatchImports,
                 ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj,
+                methodWithToken.Method,
                 _codegenNodeFactory.MethodSignature(
                     ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry, methodWithToken.Method,
                     constrainedType: null, 
@@ -590,6 +591,7 @@ namespace ILCompiler.DependencyAnalysis
                     _codegenNodeFactory.DispatchImports,
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_MethodCall |
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_FLAG_VSD,
+                    method,
                     _codegenNodeFactory.MethodSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry, method,
                         null, methodToken, signatureContext, isUnboxingStub, isInstantiatingStub: false),
                     callSite);
@@ -612,6 +614,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 genericDictionary = new PrecodeHelperMethodImport(
                     _codegenNodeFactory,
+                    method,
                     _codegenNodeFactory.MethodSignature(
                         ReadyToRunFixupKind.READYTORUN_FIXUP_MethodDictionary,
                         method,
@@ -859,10 +862,11 @@ namespace ILCompiler.DependencyAnalysis
             ISymbolNode node;
             if (!_genericLookupHelpers.TryGetValue(key, out node))
             {
-                node = new DelayLoadHelperImport(
+                node = new DelayLoadHelperMethodImport(
                     _codegenNodeFactory,
                     _codegenNodeFactory.HelperImports,
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                    methodArgument.Method,
                     new GenericLookupSignature(runtimeLookupKind,  fixupKind,  typeArgument: null, methodArgument, fieldArgument: null, methodContext, signatureContext));
                 _genericLookupHelpers.Add(key, node);
             }

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -28,6 +28,7 @@
   
   <ItemGroup>
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ArgIterator.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ExceptionInfoLookupTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternalTypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunCodegenNodeFactory.cs" />
@@ -36,6 +37,8 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CompilerIdentifierNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DebugInfoTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadHelperImport.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\GCRefMapBuilder.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\GCRefMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\GenericLookupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ImportThunk.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelegateCtorSignature.cs" />
@@ -74,6 +77,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Target_ARM\ImportThunk.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Target_X64\ImportThunk.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Target_X86\ImportThunk.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TransitionBlock.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypeFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypesTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunSymbolNodeFactory.cs" />

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ArgIterator.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadHelperMethodImport.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ExceptionInfoLookupTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternalTypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunCodegenNodeFactory.cs" />
@@ -63,6 +64,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\NewObjectFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\NibbleWriter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\PrecodeHelperImport.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\PrecodeHelperMethodImport.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ReadyToRunHelperSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RuntimeFunctionsGCInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RuntimeFunctionsTableNode.cs" />


### PR DESCRIPTION
I have basically forked away ArgIterator and TransitionBlock from
the calling convention converter and I adapted it to use by the
CPAOT compiler. I have not yet added multi-architecture support,
for now it only works for the compiler build architecture. There are
also a few NotImplemented cases I'll fix once I hit them in testing.

My initial thinking is that, after finalizing this code and after
we start working on other architectures, I'll further refactor this
code based on JanK's suggestion by merging in preprocessed versions
of the ArgIterator source file for the four architectures.

I also plan to further experiment with runtime architecture
virtualization that I tried to prototype in a trimmed-down
clone of TransitionBlock I coded up for the purpose of R2RDump
GC ref map decoder and I'm quite pleased with the result which
looks quite elegant and compact to me.

Thanks

Tomas