### PR TITLE
Clean up CPAOT statics management per Michal's advice

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -58,9 +58,9 @@ namespace ILCompiler
             Debug.Assert(field.IsStatic);
 
             TypeDesc fieldType = field.FieldType;
-            if (fieldType.IsValueType && !fieldType.IsPrimitive)
+            if (fieldType.IsValueType)
             {
-                return true; // In CoreCLR, all structs are implicitly boxed i.e. stored as GC pointers
+                return !fieldType.IsPrimitive; // In CoreCLR, all structs are implicitly boxed i.e. stored as GC pointers
             }
             else
             {

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -58,10 +58,14 @@ namespace ILCompiler
             Debug.Assert(field.IsStatic);
 
             TypeDesc fieldType = field.FieldType;
-            if (fieldType.IsValueType)
-                return ((DefType)fieldType).ContainsGCPointers;
+            if (fieldType.IsValueType && !fieldType.IsPrimitive)
+            {
+                return true; // In CoreCLR, all structs are implicitly boxed i.e. stored as GC pointers
+            }
             else
+            {
                 return fieldType.IsGCPointer;
+            }
         }
 
         /// <summary>

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1953,17 +1953,14 @@ namespace Internal.JitInterface
 
             if (field.IsStatic)
             {
-                bool allocateStaticOnGCHeap = field.HasGCStaticBase;
-
                 fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_STATIC;
 
 #if READYTORUN
-                if (!field.HasRva && field.FieldType.IsValueType && !field.FieldType.IsPrimitive)
+                if (field.FieldType.IsValueType && field.HasGCStaticBase)
                 {
                     // statics of struct types are stored as implicitly boxed in CoreCLR i.e.
-                    // we switch over to the GC heap to allocate the box and modify field static flags appropriately
+                    // we need to modify field access flags appropriately
                     fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_STATIC_IN_HEAP;
-                    allocateStaticOnGCHeap = true;
                 }
 #endif
 
@@ -1999,7 +1996,7 @@ namespace Internal.JitInterface
                         if (field.IsThreadStatic)
                         {
 #if READYTORUN
-                            if (allocateStaticOnGCHeap)
+                            if (field.HasGCStaticBase)
                             {
                                 helperId = ReadyToRunHelperId.GetThreadStaticBase;
                             }
@@ -2011,7 +2008,7 @@ namespace Internal.JitInterface
                             helperId = ReadyToRunHelperId.GetThreadStaticBase;
 #endif
                         }
-                        else if (allocateStaticOnGCHeap)
+                        else if (field.HasGCStaticBase)
                         {
                             helperId = ReadyToRunHelperId.GetGCStaticBase;
                         }
@@ -2053,7 +2050,7 @@ namespace Internal.JitInterface
                     else if (field.IsThreadStatic)
                     {
 #if READYTORUN
-                        if (allocateStaticOnGCHeap)
+                        if (field.HasGCStaticBase)
                         {
                             helperId = ReadyToRunHelperId.GetThreadStaticBase;
                         }
@@ -2065,7 +2062,7 @@ namespace Internal.JitInterface
                         helperId = ReadyToRunHelperId.GetThreadStaticBase;
 #endif
                     }
-                    else if (allocateStaticOnGCHeap)
+                    else if (field.HasGCStaticBase)
                     {
                         helperId = ReadyToRunHelperId.GetGCStaticBase;
                     }


### PR DESCRIPTION
Based on PR discussion towards my previous change I have prepared
another PR to clean up static management. I have modified the
implementation of ComputeHasGCStaticBase in ReadyToRunCompilerContext
and I reverted some of my changes to CorInfoImpl.

I still don't see how to completely eliminate R2R-specific code
in getFieldInfo as I believe we need the special flag
CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_STATIC_IN_HEAP so that JIT takes
care of the automatic unboxing and we need special treatment
for fields with types outside of the version bubble.

Thanks

Tomas