### PR TITLE
Do not use R2R helpers for casting and allocation

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -146,8 +146,11 @@ namespace ILCompiler.DependencyAnalysis
             public GenericLookupResult UnwrapNullableType(TypeDesc type)
             {
                 // An actual unwrap nullable lookup is only required if the type is exactly a runtime 
-                // determined type associated with System.__UniversalCanon itself
-                if (type.IsRuntimeDeterminedType && ((RuntimeDeterminedType)type).CanonicalType.IsCanonicalDefinitionType(CanonicalFormKind.Universal))
+                // determined type associated with System.__UniversalCanon itself, or if it's
+                // a runtime determined instance of Nullable.
+                if (type.IsRuntimeDeterminedType && (
+                    ((RuntimeDeterminedType)type).CanonicalType.IsCanonicalDefinitionType(CanonicalFormKind.Universal) ||
+                    ((RuntimeDeterminedType)type).CanonicalType.IsNullable))
                     return _unwrapNullableSymbols.GetOrAdd(type);
                 else
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -43,6 +43,10 @@ namespace ILCompiler.DependencyAnalysis
             {
                 case ReadyToRunHelperId.TypeHandle:
                     return factory.GenericLookup.Type((TypeDesc)target);
+                case ReadyToRunHelperId.TypeHandleForCasting:
+                    // Check that we unwrapped the cases that could be unwrapped to prevent duplicate entries
+                    Debug.Assert(factory.GenericLookup.Type((TypeDesc)target) != factory.GenericLookup.UnwrapNullableType((TypeDesc)target));
+                    return factory.GenericLookup.UnwrapNullableType((TypeDesc)target);
                 case ReadyToRunHelperId.MethodHandle:
                     return factory.GenericLookup.MethodHandle((MethodDesc)target);
                 case ReadyToRunHelperId.FieldHandle:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -50,28 +50,6 @@ namespace ILCompiler.DependencyAnalysis
 
             switch (id)
             {
-                case ReadyToRunHelperId.NewHelper:
-                case ReadyToRunHelperId.NewArr1:
-                    {
-                        // Make sure that if the EEType can't be generated, we throw the exception now.
-                        // This way we can fail generating code for the method that references the EEType
-                        // and (depending on the policy), we could avoid scraping the entire compilation.
-                        TypeDesc type = (TypeDesc)target;
-                        factory.ConstructedTypeSymbol(type);
-                    }
-                    break;
-                case ReadyToRunHelperId.IsInstanceOf:
-                case ReadyToRunHelperId.CastClass:
-                    {
-                        // Make sure that if the EEType can't be generated, we throw the exception now.
-                        // This way we can fail generating code for the method that references the EEType
-                        // and (depending on the policy), we could avoid scraping the entire compilation.
-                        TypeDesc type = (TypeDesc)target;
-                        factory.NecessaryTypeSymbol(type);
-
-                        Debug.Assert(!type.IsNullable, "Nullable needs to be unwrapped");
-                    }
-                    break;
                 case ReadyToRunHelperId.GetNonGCStaticBase:
                 case ReadyToRunHelperId.GetGCStaticBase:
                 case ReadyToRunHelperId.GetThreadStaticBase:
@@ -109,20 +87,8 @@ namespace ILCompiler.DependencyAnalysis
         {
             switch (_id)
             {
-                case ReadyToRunHelperId.NewHelper:
-                    sb.Append("__NewHelper_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
-                    break;
-                case ReadyToRunHelperId.NewArr1:
-                    sb.Append("__NewArr1_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
-                    break;
                 case ReadyToRunHelperId.VirtualCall:
                     sb.Append("__VirtualCall_").Append(nameMangler.GetMangledMethodName((MethodDesc)_target));
-                    break;
-                case ReadyToRunHelperId.IsInstanceOf:
-                    sb.Append("__IsInstanceOf_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
-                    break;
-                case ReadyToRunHelperId.CastClass:
-                    sb.Append("__CastClass_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
                     break;
                 case ReadyToRunHelperId.GetNonGCStaticBase:
                     sb.Append("__GetNonGCStaticBase_").Append(nameMangler.GetMangledTypeName((TypeDesc)_target));
@@ -241,10 +207,6 @@ namespace ILCompiler.DependencyAnalysis
 
             switch (_id)
             {
-                case ReadyToRunHelperId.NewHelper:
-                case ReadyToRunHelperId.NewArr1:
-                case ReadyToRunHelperId.IsInstanceOf:
-                case ReadyToRunHelperId.CastClass:
                 case ReadyToRunHelperId.GetNonGCStaticBase:
                 case ReadyToRunHelperId.GetGCStaticBase:
                 case ReadyToRunHelperId.GetThreadStaticBase:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -35,6 +35,7 @@ namespace ILCompiler.DependencyAnalysis
         MethodEntry,
         VirtualDispatchCell,
         DefaultConstructor,
+        TypeHandleForCasting,
     }
 
     public partial class ReadyToRunHelperNode : AssemblyStubNode, INodeWithDebugInfo

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -203,6 +203,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.MethodEntry:
                 case ReadyToRunHelperId.VirtualDispatchCell:
                 case ReadyToRunHelperId.DefaultConstructor:
+                case ReadyToRunHelperId.TypeHandleForCasting:
                     {
                         EmitDictionaryLookup(factory, ref encoder, contextRegister, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
                         encoder.EmitRET();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
@@ -20,14 +20,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             switch (Id)
             {
-                case ReadyToRunHelperId.NewHelper:
-                    {
-                        TypeDesc target = (TypeDesc)Target;
-                        encoder.EmitMOV(encoder.TargetRegister.Arg0, factory.ConstructedTypeSymbol(target));
-                        encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetNewObjectHelperForType(target)));
-                    }
-                    break;
-
                 case ReadyToRunHelperId.VirtualCall:
                     {
                         MethodDesc targetMethod = (MethodDesc)Target;
@@ -48,31 +40,6 @@ namespace ILCompiler.DependencyAnalysis
                         encoder.EmitLDR(encoder.TargetRegister.InterproceduralScratch, encoder.TargetRegister.InterproceduralScratch,
                                         EETypeNode.GetVTableOffset(pointerSize) + (slot * pointerSize));
                         encoder.EmitJMP(encoder.TargetRegister.InterproceduralScratch);
-                    }
-                    break;
-
-                case ReadyToRunHelperId.IsInstanceOf:
-                    {
-                        TypeDesc target = (TypeDesc)Target;
-                        encoder.EmitMOV(encoder.TargetRegister.Arg1, factory.NecessaryTypeSymbol(target));
-                        encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetCastingHelperNameForType(target, false)));
-                    }
-                    break;
-
-                case ReadyToRunHelperId.CastClass:
-                    {
-                        TypeDesc target = (TypeDesc)Target;
-                        encoder.EmitMOV(encoder.TargetRegister.Arg1, factory.NecessaryTypeSymbol(target));
-                        encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetCastingHelperNameForType(target, true)));
-                    }
-                    break;
-
-                case ReadyToRunHelperId.NewArr1:
-                    {
-                        TypeDesc target = (TypeDesc)Target;
-                        encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Arg0);
-                        encoder.EmitMOV(encoder.TargetRegister.Arg0, factory.ConstructedTypeSymbol(target));
-                        encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetNewArrayHelperForType(target)));
                     }
                     break;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -210,6 +210,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.MethodEntry:
                 case ReadyToRunHelperId.VirtualDispatchCell:
                 case ReadyToRunHelperId.DefaultConstructor:
+                case ReadyToRunHelperId.TypeHandleForCasting:
                     {
                         EmitDictionaryLookup(factory, ref encoder, contextRegister, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
                         encoder.EmitRET();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -19,14 +19,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             switch (Id)
             {
-                case ReadyToRunHelperId.NewHelper:
-                    {
-                        TypeDesc target = (TypeDesc)Target;
-                        encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.ConstructedTypeSymbol(target));
-                        encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetNewObjectHelperForType(target)));
-                    }
-                    break;
-
                 case ReadyToRunHelperId.VirtualCall:
                     {
                         MethodDesc targetMethod = (MethodDesc)Target;
@@ -49,33 +41,6 @@ namespace ILCompiler.DependencyAnalysis
 
                         AddrMode jmpAddrMode = new AddrMode(encoder.TargetRegister.Result, null, EETypeNode.GetVTableOffset(pointerSize) + (slot * pointerSize), 0, AddrModeSize.Int64);
                         encoder.EmitJmpToAddrMode(ref jmpAddrMode);
-                    }
-                    break;
-
-                case ReadyToRunHelperId.IsInstanceOf:
-                    {
-                        TypeDesc target = (TypeDesc)Target;
-                        encoder.EmitLEAQ(encoder.TargetRegister.Arg1, factory.NecessaryTypeSymbol(target));
-                        encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetCastingHelperNameForType(target, false)));
-                    }
-                    break;
-
-                case ReadyToRunHelperId.CastClass:
-                    {
-                        TypeDesc target = (TypeDesc)Target;
-                        encoder.EmitLEAQ(encoder.TargetRegister.Arg1, factory.NecessaryTypeSymbol(target));
-                        encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetCastingHelperNameForType(target, true)));
-                    }
-                    break;
-
-                case ReadyToRunHelperId.NewArr1:
-                    {
-                        TypeDesc target = (TypeDesc)Target;
-
-                        // TODO: Swap argument order instead
-                        encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Arg0);
-                        encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.ConstructedTypeSymbol(target));
-                        encoder.EmitJMP(factory.ExternSymbol(JitHelper.GetNewArrayHelperForType(target)));
                     }
                     break;
 

--- a/src/ILCompiler.Compiler/src/Compiler/GenericDictionaryLookup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/GenericDictionaryLookup.cs
@@ -4,6 +4,7 @@
 
 using System;
 
+using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysis;
 
 using Debug = System.Diagnostics.Debug;
@@ -22,8 +23,17 @@ namespace ILCompiler
         private readonly short _offset1;
         private readonly short _offset2;
 
+        /// <summary>
+        /// Gets the information about the source of the generic context for shared code.
+        /// </summary>
         public readonly GenericContextSource ContextSource;
 
+        /// <summary>
+        /// Gets the target object of the lookup. Only valid when <see cref="UseHelper"/> is true.
+        /// This is typically a <see cref="TypeDesc"/> whose <see cref="TypeDesc.IsRuntimeDeterminedSubtype"/>
+        /// is true, a <see cref="FieldDesc"/> on a runtime determined type, a <see cref="MethodDesc"/>, or
+        /// a <see cref="DelegateCreationInfo"/>.
+        /// </summary>
         public object HelperObject
         {
             get
@@ -33,6 +43,9 @@ namespace ILCompiler
             }
         }
 
+        /// <summary>
+        /// Gets the ID of the helper to use if <see cref="UseHelper"/> is true.
+        /// </summary>
         public ReadyToRunHelperId HelperId
         {
             get
@@ -42,6 +55,9 @@ namespace ILCompiler
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the lookup needs to be performed by calling a helper method. 
+        /// </summary>
         public bool UseHelper
         {
             get
@@ -50,6 +66,9 @@ namespace ILCompiler
             }
         }
 
+        /// <summary>
+        /// Gets the number of indirections to follow. Only valid if <see cref="UseHelper"/> is false.
+        /// </summary>
         public int NumberOfIndirections
         {
             get

--- a/src/ILCompiler.Compiler/src/Compiler/GenericDictionaryLookup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/GenericDictionaryLookup.cs
@@ -4,6 +4,8 @@
 
 using System;
 
+using ILCompiler.DependencyAnalysis;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler
@@ -15,10 +17,30 @@ namespace ILCompiler
     {
         private const short UseHelperOffset = -1;
 
-        private short _offset1;
-        private short _offset2;
+        private readonly object _helperObject;
+
+        private readonly short _offset1;
+        private readonly short _offset2;
 
         public readonly GenericContextSource ContextSource;
+
+        public object HelperObject
+        {
+            get
+            {
+                Debug.Assert(_offset1 == UseHelperOffset);
+                return _helperObject;
+            }
+        }
+
+        public ReadyToRunHelperId HelperId
+        {
+            get
+            {
+                Debug.Assert(_offset1 == UseHelperOffset);
+                return (ReadyToRunHelperId)_offset2;
+            }
+        }
 
         public bool UseHelper
         {
@@ -56,22 +78,23 @@ namespace ILCompiler
             }
         }
 
-        private GenericDictionaryLookup(GenericContextSource contextSource, int offset1, int offset2)
+        private GenericDictionaryLookup(GenericContextSource contextSource, int offset1, int offset2, object helperObject)
         {
             ContextSource = contextSource;
             _offset1 = checked((short)offset1);
             _offset2 = checked((short)offset2);
+            _helperObject = helperObject;
         }
 
         public static GenericDictionaryLookup CreateFixedLookup(GenericContextSource contextSource, int offset1, int offset2 = UseHelperOffset)
         {
             Debug.Assert(offset1 != UseHelperOffset);
-            return new GenericDictionaryLookup(contextSource, offset1, offset2);
+            return new GenericDictionaryLookup(contextSource, offset1, offset2, null);
         }
 
-        public static GenericDictionaryLookup CreateHelperLookup(GenericContextSource contextSource)
+        public static GenericDictionaryLookup CreateHelperLookup(GenericContextSource contextSource, ReadyToRunHelperId helperId, object helperObject)
         {
-            return new GenericDictionaryLookup(contextSource, UseHelperOffset, UseHelperOffset);
+            return new GenericDictionaryLookup(contextSource, UseHelperOffset, checked((short)helperId), helperObject);
         }
     }
 

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -160,14 +160,17 @@ namespace Internal.IL
 
         private ISymbolNode GetGenericLookupHelper(ReadyToRunHelperId helperId, object helperArgument)
         {
+            GenericDictionaryLookup lookup = _compilation.ComputeGenericLookup(_canonMethod, helperId, helperArgument);
+            Debug.Assert(lookup.UseHelper);
+
             if (_canonMethod.RequiresInstMethodDescArg())
             {
-                return _compilation.NodeFactory.ReadyToRunHelperFromDictionaryLookup(helperId, helperArgument, _canonMethod);
+                return _compilation.NodeFactory.ReadyToRunHelperFromDictionaryLookup(lookup.HelperId, lookup.HelperObject, _canonMethod);
             }
             else
             {
                 Debug.Assert(_canonMethod.RequiresInstArg() || _canonMethod.AcquiresInstMethodTableFromThis());
-                return _compilation.NodeFactory.ReadyToRunHelperFromTypeLookup(helperId, helperArgument, _canonMethod.OwningType);
+                return _compilation.NodeFactory.ReadyToRunHelperFromTypeLookup(lookup.HelperId, lookup.HelperObject, _canonMethod.OwningType);
             }
         }
 
@@ -242,28 +245,13 @@ namespace Internal.IL
         {
             TypeDesc type = (TypeDesc)_methodIL.GetObject(token);
 
-            // Nullable needs to be unwrapped
-            if (type.IsNullable)
-                type = type.Instantiation[0];
-
             if (type.IsRuntimeDeterminedSubtype)
             {
-                _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandle, type), "IsInst/CastClass");
+                _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandleForCasting, type), "IsInst/CastClass");
             }
             else
             {
-                ReadyToRunHelperId helperId;
-                if (opcode == ILOpcode.isinst)
-                {
-                    helperId = ReadyToRunHelperId.IsInstanceOf;
-                }
-                else
-                {
-                    Debug.Assert(opcode == ILOpcode.castclass);
-                    helperId = ReadyToRunHelperId.CastClass;
-                }
-
-                _dependencies.Add(_factory.ReadyToRunHelper(helperId, type), "IsInst/CastClass");
+                _dependencies.Add(_compilation.ComputeConstantLookup(ReadyToRunHelperId.TypeHandleForCasting, type), "IsInst/CastClass");
             }
         }
         

--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -958,7 +958,7 @@ namespace Internal.IL
             }
             else
             {
-                _dependencies.Add(_factory.ReadyToRunHelper(ReadyToRunHelperId.NewArr1, type), "newarr");
+                _dependencies.Add(_factory.ConstructedTypeSymbol(type), "newarr");
             }
         }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -38,12 +38,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public ISymbolNode ReadyToRunHelper(ReadyToRunHelperId id, object target, SignatureContext signatureContext)
         {
-            if (id == ReadyToRunHelperId.NecessaryTypeHandle)
-            {
-                // We treat TypeHandle and NecessaryTypeHandle the same - don't emit two copies of the same import
-                id = ReadyToRunHelperId.TypeHandle;
-            }
-
             if (!_r2rHelpers.TryGetValue(id, out Dictionary<object, ISymbolNode> helperNodeMap))
             {
                 helperNodeMap = new Dictionary<object, ISymbolNode>();
@@ -728,7 +722,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             switch (helperId)
             {
-                case ReadyToRunHelperId.NecessaryTypeHandle:
                 case ReadyToRunHelperId.TypeHandle:
                     return GenericLookupTypeHelper(
                         runtimeLookupKind,

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -85,18 +85,13 @@ namespace Internal.JitInterface
                 if (contextMethod != MethodBeingCompiled)
                     return;
 
-                // Necessary type handle is not something that can be in a dictionary (only a constructed type).
-                // We only use necessary type handles if we can do a constant lookup.
-                if (helperId == ReadyToRunHelperId.NecessaryTypeHandle)
-                    helperId = ReadyToRunHelperId.TypeHandle;
-
                 GenericDictionaryLookup genericLookup = _compilation.ComputeGenericLookup(contextMethod, helperId, entity);
 
                 if (genericLookup.UseHelper)
                 {
                     lookup.runtimeLookup.indirections = CORINFO.USEHELPER;
-                    lookup.lookupKind.runtimeLookupFlags = (ushort)helperId;
-                    lookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(entity);
+                    lookup.lookupKind.runtimeLookupFlags = (ushort)genericLookup.HelperId;
+                    lookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(genericLookup.HelperObject);
                 }
                 else
                 {
@@ -688,6 +683,16 @@ namespace Internal.JitInterface
         private CorInfoHelpFunc getCastingHelper(ref CORINFO_RESOLVED_TOKEN pResolvedToken, bool fThrowing)
         {
             return fThrowing ? CorInfoHelpFunc.CORINFO_HELP_CHKCASTANY : CorInfoHelpFunc.CORINFO_HELP_ISINSTANCEOFANY;
+        }
+
+        private CorInfoHelpFunc getNewHelper(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle)
+        {
+            return CorInfoHelpFunc.CORINFO_HELP_NEWFAST;
+        }
+
+        private CorInfoHelpFunc getNewArrHelper(CORINFO_CLASS_STRUCT_* arrayCls)
+        {
+            return CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_DIRECT;
         }
     }
 }

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -296,6 +296,14 @@ namespace Internal.JitInterface
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST:
                     return _compilation.NodeFactory.ExternSymbol("RhpNewFast");
+                case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_FINALIZE:
+                    return _compilation.NodeFactory.ExternSymbol("RhpNewFinalizable");
+                case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8:
+                    return _compilation.NodeFactory.ExternSymbol("RhpNewFastAlign8");
+                case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8_FINALIZE:
+                    return _compilation.NodeFactory.ExternSymbol("RhpNewFinalizableAlign8");
+                case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8_VC:
+                    return _compilation.NodeFactory.ExternSymbol("RhpNewFastMisalign");
                 case CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_DIRECT:
                     id = ReadyToRunHelper.NewArray;
                     break;
@@ -905,13 +913,19 @@ namespace Internal.JitInterface
 
             Debug.Assert(!type.IsString && !type.IsArray && !type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
 
-            // TODO: disambiguate to the specialized helpers we have (see GetNewObjectHelperForType)
-
             if (type.RequiresAlign8())
-                return CorInfoHelpFunc.CORINFO_HELP_NEWFAST;
+            {
+                if (type.HasFinalizer)
+                    return CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8_FINALIZE;
+
+                if (type.IsValueType)
+                    return CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8_VC;
+
+                return CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8;
+            }
 
             if (type.HasFinalizer)
-                return CorInfoHelpFunc.CORINFO_HELP_NEWFAST;
+                return CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_FINALIZE;
 
             return CorInfoHelpFunc.CORINFO_HELP_NEWSFAST;
         }

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -62,18 +62,13 @@ namespace Internal.JitInterface
                 if (contextMethod != MethodBeingCompiled)
                     return;
 
-                // Necessary type handle is not something that can be in a dictionary (only a constructed type).
-                // We only use necessary type handles if we can do a constant lookup.
-                if (helperId == ReadyToRunHelperId.NecessaryTypeHandle)
-                    helperId = ReadyToRunHelperId.TypeHandle;
-
                 GenericDictionaryLookup genericLookup = _compilation.ComputeGenericLookup(contextMethod, helperId, entity);
 
                 if (genericLookup.UseHelper)
                 {
                     lookup.runtimeLookup.indirections = CORINFO.USEHELPER;
-                    lookup.lookupKind.runtimeLookupFlags = (ushort)helperId;
-                    lookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(entity);
+                    lookup.lookupKind.runtimeLookupFlags = (ushort)genericLookup.HelperId;
+                    lookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(genericLookup.HelperObject);
                 }
                 else
                 {
@@ -113,51 +108,10 @@ namespace Internal.JitInterface
             switch (id)
             {
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_NEW:
-                    {
-                        var type = HandleToObject(pResolvedToken.hClass);
-                        Debug.Assert(type.IsDefType);
-                        if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
-                            return false;
-
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.NewHelper, type));
-                    }
-                    break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_NEWARR_1:
-                    {
-                        var type = HandleToObject(pResolvedToken.hClass);
-                        Debug.Assert(type.IsSzArray);
-                        if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
-                            return false;
-
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.NewArr1, type));
-                    }
-                    break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_ISINSTANCEOF:
-                    {
-                        var type = HandleToObject(pResolvedToken.hClass);
-                        if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
-                            return false;
-
-                        // ECMA-335 III.4.3:  If typeTok is a nullable type, Nullable<T>, it is interpreted as "boxed" T
-                        if (type.IsNullable)
-                            type = type.Instantiation[0];
-
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.IsInstanceOf, type));
-                    }
-                    break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_CHKCAST:
-                    {
-                        var type = HandleToObject(pResolvedToken.hClass);
-                        if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
-                            return false;
-
-                        // ECMA-335 III.4.3:  If typeTok is a nullable type, Nullable<T>, it is interpreted as "boxed" T
-                        if (type.IsNullable)
-                            type = type.Instantiation[0];
-
-                        pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.CastClass, type));
-                    }
-                    break;
+                    return false;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_STATIC_BASE:
                     {
                         var type = HandleToObject(pResolvedToken.hClass);
@@ -340,9 +294,15 @@ namespace Internal.JitInterface
                 case CorInfoHelpFunc.CORINFO_HELP_NEWFAST:
                     id = ReadyToRunHelper.NewObject;
                     break;
+                case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST:
+                    return _compilation.NodeFactory.ExternSymbol("RhpNewFast");
                 case CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_DIRECT:
                     id = ReadyToRunHelper.NewArray;
                     break;
+                case CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_ALIGN8:
+                    return _compilation.NodeFactory.ExternSymbol("RhpNewArrayAlign8");
+                case CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_VC:
+                    return _compilation.NodeFactory.ExternSymbol("RhpNewArray");
 
                 case CorInfoHelpFunc.CORINFO_HELP_LMUL:
                     id = ReadyToRunHelper.LMul;
@@ -872,11 +832,6 @@ namespace Internal.JitInterface
 
         private ISymbolNode GetGenericLookupHelper(CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind, ReadyToRunHelperId helperId, object helperArgument)
         {
-            // Necessary type handle is not something that can be in a dictionary (only a constructed type).
-            // We only use necessary type handles if we can do a constant lookup.
-            if (helperId == ReadyToRunHelperId.NecessaryTypeHandle)
-                helperId = ReadyToRunHelperId.TypeHandle;
-
             if (runtimeLookupKind == CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_THISOBJ
                 || runtimeLookupKind == CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_CLASSPARAM)
             {
@@ -942,6 +897,35 @@ namespace Internal.JitInterface
             }
 
             return helper;
+        }
+
+        private CorInfoHelpFunc getNewHelper(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle)
+        {
+            TypeDesc type = HandleToObject(pResolvedToken.hClass);
+
+            Debug.Assert(!type.IsString && !type.IsArray && !type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
+
+            // TODO: disambiguate to the specialized helpers we have (see GetNewObjectHelperForType)
+
+            if (type.RequiresAlign8())
+                return CorInfoHelpFunc.CORINFO_HELP_NEWFAST;
+
+            if (type.HasFinalizer)
+                return CorInfoHelpFunc.CORINFO_HELP_NEWFAST;
+
+            return CorInfoHelpFunc.CORINFO_HELP_NEWSFAST;
+        }
+
+        private CorInfoHelpFunc getNewArrHelper(CORINFO_CLASS_STRUCT_* arrayCls)
+        {
+            TypeDesc type = HandleToObject(arrayCls);
+
+            Debug.Assert(type.IsArray);
+
+            if (type.RequiresAlign8())
+                return CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_ALIGN8;
+
+            return CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_VC;
         }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1410,16 +1410,6 @@ namespace Internal.JitInterface
         private bool checkMethodModifier(CORINFO_METHOD_STRUCT_* hMethod, byte* modifier, bool fOptional)
         { throw new NotImplementedException("checkMethodModifier"); }
 
-        private CorInfoHelpFunc getNewHelper(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle)
-        {
-            return CorInfoHelpFunc.CORINFO_HELP_NEWFAST;
-        }
-
-        private CorInfoHelpFunc getNewArrHelper(CORINFO_CLASS_STRUCT_* arrayCls)
-        {
-            return CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_DIRECT;
-        }
-
         private CorInfoHelpFunc getSharedCCtorHelper(CORINFO_CLASS_STRUCT_* clsHnd)
         { throw new NotImplementedException("getSharedCCtorHelper"); }
         private CorInfoHelpFunc getSecurityPrologHelper(CORINFO_METHOD_STRUCT_* ftn)
@@ -2561,17 +2551,26 @@ namespace Internal.JitInterface
                     }
                 }
 
+#if READYTORUN
+                helperId = ReadyToRunHelperId.TypeHandle;
+#else
                 if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_NewObj
+                        || pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Newarr
                         || pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Box
                         || pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Constrained
                         || (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Ldtoken && ConstructedEETypeNode.CreationAllowed(td)))
                 {
                     helperId = ReadyToRunHelperId.TypeHandle;
                 }
+                else if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Casting)
+                {
+                    helperId = ReadyToRunHelperId.TypeHandleForCasting;
+                }
                 else
                 {
                     helperId = ReadyToRunHelperId.NecessaryTypeHandle;
                 }
+#endif
             }
 
             Debug.Assert(pResult.compileTimeHandle != null);


### PR DESCRIPTION
This avoids generation of some of the helpers in favor of RyuJIT generating code that does what the helper would do. While this causes an about 1% regression in size of the generated executable, the benefit is better code density and fewer calls.