### PR TITLE
Suppress integral constant overflow warnings

### DIFF
--- a/src/Native/Bootstrap/CppCodeGen.h
+++ b/src/Native/Bootstrap/CppCodeGen.h
@@ -15,6 +15,7 @@
 #pragma warning(disable:4102) // unreferenced label
 #pragma warning(disable:4244) // possible loss of data
 #pragma warning(disable:4717) // recursive on all control paths
+#pragma warning(disable:4307) // integral constant overflow
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
These always show up in CppCodegen because we have a type in CoreLib where the C# compiler generated a `GetHashCode` method with a static integer constant overflow.