### PR TITLE
Fix for static enum field placement

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -60,7 +60,7 @@ namespace ILCompiler
             TypeDesc fieldType = field.FieldType;
             if (fieldType.IsValueType)
             {
-                return !fieldType.IsPrimitive; // In CoreCLR, all structs are implicitly boxed i.e. stored as GC pointers
+                return !fieldType.IsPrimitive && !fieldType.IsEnum; // In CoreCLR, all structs are implicitly boxed i.e. stored as GC pointers
             }
             else
             {


### PR DESCRIPTION
I found out that my static field placement changes were incorrect
for enums. This change fixes the deficiency and, in doing so,
it fixes one of the remaining CoreCLR Top200 bug buckets.

Thanks

Tomas