### PR TITLE
[CppCodeGen] Fix inheritance emitting

### DIFF
--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
@@ -1718,10 +1718,18 @@ namespace ILCompiler.CppCodeGen
             typeDefinitions.Append("class " + mangledName.Substring(current));
             if (!nodeType.IsValueType)
             {
-                // Don't emit inheritance if base type has not been marked for emission
-                if (nodeType.BaseType != null && _emittedTypes.Contains(nodeType.BaseType))
+                if (nodeType.BaseType != null)
                 {
-                    typeDefinitions.Append(" : public " + GetCppTypeName(nodeType.BaseType));
+                    TypeDesc baseType = nodeType.BaseType;
+
+                    if (!nodeType.IsGenericDefinition && baseType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                        baseType = baseType.ConvertToCanonForm(CanonicalFormKind.Specific);
+
+                    // Don't emit inheritance if base type has not been marked for emission
+                    if (_emittedTypes.Contains(baseType))
+                    {
+                        typeDefinitions.Append(" : public " + GetCppTypeName(baseType));
+                    }
                 }
             }
             typeDefinitions.Append(" {");

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/DependencyNodeIterator.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/DependencyNodeIterator.cs
@@ -53,7 +53,11 @@ namespace ILCompiler.Compiler.CppCodeGen
                 EETypeNode baseTypeNode;
                 if (node.Type.BaseType != null)
                 {
-                    _typeToNodeMap.TryGetValue(node.Type.BaseType, out baseTypeNode);
+                    TypeDesc baseType = node.Type.BaseType;
+                    if (!node.Type.IsGenericDefinition && baseType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                        baseType = baseType.ConvertToCanonForm(CanonicalFormKind.Specific);
+
+                    _typeToNodeMap.TryGetValue(baseType, out baseTypeNode);
                     if (!node.Type.IsPrimitive)
                         AddTypeNode(baseTypeNode);
                     else if (!_nodes.Contains(baseTypeNode)) _nodes.Add(baseTypeNode);


### PR DESCRIPTION
If the base type is partially instantiated we use its canonical form:

class A<T, U> {}

class B<T> : A<string, T> {}

In this case we will have:

class B<System.__Canon> : A<System.__Canon, System.__Canon>

This patch fixes https://github.com/dotnet/corert/issues/6682