### PR TITLE
Fix bug: InvalidCastException Unable to cast object of type 'Internal.TypeSystem.InstantiatedGenericParameter' to type 'Internal.TypeSystem.MetadataType

### DIFF
--- a/src/ILVerification/src/AccessVerificationHelpers.cs
+++ b/src/ILVerification/src/AccessVerificationHelpers.cs
@@ -216,6 +216,12 @@ namespace ILVerify
 
         private static bool CanAccessFamily(TypeDesc currentType, TypeDesc targetTypeDef, TypeDesc instanceType)
         {
+            // if instanceType is generics and inherit from targetTypeDef members of targetTypeDef are accessible
+            if (instanceType.IsGenericParameter && instanceType.CanCastTo(targetTypeDef))
+            {
+                return true;
+            }
+
             // Iterate through all containing types of instance
             while (instanceType != null)
             {

--- a/src/ILVerification/src/AccessVerificationHelpers.cs
+++ b/src/ILVerification/src/AccessVerificationHelpers.cs
@@ -217,9 +217,9 @@ namespace ILVerify
         private static bool CanAccessFamily(TypeDesc currentType, TypeDesc targetTypeDef, TypeDesc instanceType)
         {
             // if instanceType is generics and inherit from targetTypeDef members of targetTypeDef are accessible
-            if (instanceType.IsGenericParameter && instanceType.CanCastTo(targetTypeDef))
+            if (instanceType.IsGenericParameter)
             {
-                return true;
+                return instanceType.CanCastTo(targetTypeDef);
             }
 
             // Iterate through all containing types of instance

--- a/src/ILVerification/tests/ILTests/AccessTests.il
+++ b/src/ILVerification/tests/ILTests/AccessTests.il
@@ -397,6 +397,9 @@
     }
 }
 
+
+// Test for bug https://github.com/dotnet/corert/issues/6693
+
 .class public auto ansi beforefieldinit Issue6693
 	extends [System.Runtime]System.Object
 {

--- a/src/ILVerification/tests/ILTests/AccessTests.il
+++ b/src/ILVerification/tests/ILTests/AccessTests.il
@@ -396,3 +396,86 @@
         }
     }
 }
+
+.class public auto ansi beforefieldinit Issue6693
+	extends [System.Runtime]System.Object
+{
+
+	.class nested public auto ansi abstract beforefieldinit InnerClass`1<(Issue6693) T>
+		extends class Issue6693Base`1<!T>
+	{
+		.method public hidebysig virtual 
+			instance void BaseMethod_Valid (
+				int32 index,
+				!T item
+			) cil managed 
+		{
+			.maxstack 8
+
+			IL_0000: nop
+			IL_0001: ldarg.2
+			IL_0002: box !T
+			IL_0007: callvirt instance void Issue6693::ParentMethod()
+			IL_000c: nop
+			IL_000d: ret
+		}
+
+		.method family hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void class Issue6693Base`1<!T>::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		}
+	}
+
+	.method family hidebysig 
+		instance void ParentMethod () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: nop
+		IL_0001: ret
+	}
+
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	}
+}
+
+.class public auto ansi beforefieldinit Issue6693Base`1<T>
+	extends [System.Runtime]System.Object
+{
+	.method public hidebysig newslot virtual 
+		instance void BaseMethod_Valid (
+			int32 index,
+			!T item
+		) cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: nop
+		IL_0001: ret
+	}
+
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	}
+}

--- a/src/ILVerification/tests/ILTests/AccessTests.il
+++ b/src/ILVerification/tests/ILTests/AccessTests.il
@@ -397,8 +397,7 @@
     }
 }
 
-
-// Test for bug https://github.com/dotnet/corert/issues/6693
+// Test for bugfix https://github.com/dotnet/corert/issues/6693
 
 .class public auto ansi beforefieldinit Issue6693
 	extends [System.Runtime]System.Object


### PR DESCRIPTION
Fixes https://github.com/dotnet/corert/issues/6693
The issue happen here https://github.com/dotnet/corert/blob/master/src/ILVerification/src/AccessVerificationHelpers.cs#L247
If instance type is a generic parameter his type definition is not a MetadataType.
However here code verify if calling type(instanceType) has got "Family" access to target type, so if generic instanceType is subclass of targetTypeDef should be ok,  ECMA-335 page 28.

/cc @jkotas @jcouv 

~~EDIT: Could be useful add some tests with "reported bug" code sample(if code owner agrees)?Something like ILTests\Bugs.il with all sample IL inside.~~