### PR TITLE
[CppCodeGen] Fix ImportStoreField and ImportLoadField

### DIFF
--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2637,6 +2637,13 @@ namespace Internal.IL
             {
                 AddTypeReference(fieldType, false);
 
+                if (fieldType.IsValueType)
+                {
+                    Append("*(");
+                    Append(_writer.GetCppSignatureTypeName(fieldType));
+                    Append("*)&(");
+                }
+
                 Append("(((");
                 Append(_writer.GetCppStaticsTypeName(owningType, field.HasGCStaticBase, field.IsThreadStatic));
                 Append("*)");
@@ -2646,6 +2653,9 @@ namespace Internal.IL
                 Append("))->");
                 Append(_writer.GetCppFieldName(field));
                 Append(")");
+
+                if (fieldType.IsValueType)
+                    Append(")");
             }
             else
             {
@@ -2779,6 +2789,10 @@ namespace Internal.IL
 
             if (runtimeDeterminedOwningType.IsRuntimeDeterminedSubtype && field.IsStatic)
             {
+                Append("*(");
+                Append(_writer.GetCppSignatureTypeName(fieldType));
+                Append("*)&(");
+
                 Append("(((");
                 Append(_writer.GetCppStaticsTypeName(owningType, field.HasGCStaticBase, field.IsThreadStatic));
                 Append("*)");
@@ -2787,6 +2801,8 @@ namespace Internal.IL
                 Append(GetGenericContext());
                 Append("))->");
                 Append(_writer.GetCppFieldName(field));
+                Append(")");
+
                 Append(")");
             }
             else


### PR DESCRIPTION
Add cast in `ImportStoreField` and `ImportLoadField` to handle cases like following:
```cs
class A<T, U>
{
    public T t;
    public U u;
}

class B<T> : A<string, T>>
{
    public B() { t = "123"; }
}
```
As `A<System.__Canon, System.__Canon>` is used as base for `B<System.__Canon>` `t` has `System.__Canon` type in B's ctor and we need to cast it to `string`.