### PR TITLE
[CppCodeGen] Enable reflection support

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.DependencyAnalysis
     /// types. It only fills out enough pieces of the EEType structure so that the GC can operate on it. Runtime should
     /// never see these.
     /// </summary>
-    internal class GCStaticEETypeNode : ObjectNode, ISymbolDefinitionNode
+    public class GCStaticEETypeNode : ObjectNode, ISymbolDefinitionNode
     {
         private GCPointerMap _gcMap;
         private TargetDetails _target;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -89,7 +89,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            if (factory.Target.Abi == TargetAbi.CoreRT)
+            if (factory.Target.Abi == TargetAbi.CoreRT || factory.Target.Abi == TargetAbi.CppCodegen)
             {
                 ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
@@ -157,9 +157,9 @@ namespace ILCompiler.DependencyAnalysis
                                         uint index = _externalReferences.GetIndex(staticsNode, field.Offset.AsInt);
                                         vertex = writer.GetTuple(vertex, writer.GetUnsignedConstant(index));
                                     }
-                                    else
+                                    else if (factory.Target.Abi == TargetAbi.CoreRT || factory.Target.Abi == TargetAbi.CppCodegen)
                                     {
-                                        Debug.Assert(field.HasGCStaticBase && factory.Target.Abi == TargetAbi.CoreRT);
+                                        Debug.Assert(field.HasGCStaticBase);
 
                                         uint index = _externalReferences.GetIndex(staticsNode);
                                         vertex = writer.GetTuple(vertex, writer.GetUnsignedConstant(index));

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
@@ -1038,8 +1038,6 @@ namespace ILCompiler.CppCodeGen
             if (node is ISymbolDefinitionNode)
             {
                 offset = (node as ISymbolDefinitionNode).Offset;
-                i = offset;
-                lastByteIndex = offset;
             }
             while (i < nodeData.Data.Length)
             {
@@ -1130,7 +1128,7 @@ namespace ILCompiler.CppCodeGen
             else
                 nodeCode.Append(" } " + mangledName.Replace("::", "_") + " = {");
 
-            nodeCode.Append(GetCodeForNodeData(nodeDataSections, relocs, nodeData.Data, node, offset, factory));
+            nodeCode.Append(GetCodeForNodeData(nodeDataSections, relocs, nodeData.Data, node, 0, factory));
 
             nodeCode.Append("};");
 
@@ -1149,7 +1147,9 @@ namespace ILCompiler.CppCodeGen
                 {
                     nodeCode.Append("return ( ");
                     nodeCode.Append(retType);
-                    nodeCode.Append(")&mt;");
+                    nodeCode.Append(")((char*)&mt + ");
+                    nodeCode.Append(offset.ToString());
+                    nodeCode.Append(");");
                 }
 
                 nodeCode.Exdent();

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2655,7 +2655,7 @@ namespace Internal.IL
 
                 if (field.IsStatic)
                 {
-                    Append(_writer.GetCppStaticsName(owningType, field.HasGCStaticBase, field.IsThreadStatic));
+                    Append(_writer.GetCppStaticsName(owningType, field.HasGCStaticBase, field.IsThreadStatic, true));
                     Append(".");
                     Append(_writer.GetCppFieldName(field));
                 }
@@ -2733,7 +2733,7 @@ namespace Internal.IL
 
                 if (field.IsStatic)
                 {
-                    Append(_writer.GetCppStaticsName(owningType, field.HasGCStaticBase, field.IsThreadStatic));
+                    Append(_writer.GetCppStaticsName(owningType, field.HasGCStaticBase, field.IsThreadStatic, true));
                     Append(".");
                     Append(_writer.GetCppFieldName(field));
                 }
@@ -2800,7 +2800,7 @@ namespace Internal.IL
                 AppendLine();
                 if (field.IsStatic)
                 {
-                    Append(_writer.GetCppStaticsName(owningType, field.HasGCStaticBase, field.IsThreadStatic));
+                    Append(_writer.GetCppStaticsName(owningType, field.HasGCStaticBase, field.IsThreadStatic, true));
                     Append(".");
                     Append(_writer.GetCppFieldName(field));
                 }

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2993,11 +2993,9 @@ namespace Internal.IL
 
             AppendSemicolon();
 
-            string typeName = GetStackValueKindCPPTypeName(GetStackValueKind(type), type);
-
             // TODO: Write barrier as necessary
             AppendLine();
-            Append("*(" + typeName + " *)((void **)");
+            Append("*(" + _writer.GetCppSignatureTypeName(type) + " *)((void **)");
             Append(tempName);
             Append(" + 1) = ");
             Append(value);
@@ -3311,9 +3309,9 @@ namespace Internal.IL
                 if (opCode == ILOpcode.unbox_any)
                 {
                     string typeName = GetStackValueKindCPPTypeName(GetStackValueKind(type), type);
-                    Append("*(");
+                    Append("(");
                     Append(typeName);
-                    Append("*)");
+                    Append(")*");
                 }
 
                 Append("(");

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -3378,7 +3378,7 @@ namespace Internal.IL
                 }
                 else
                 {
-                    AddTypeReference(type, false);
+                    AddTypeReference(type, true);
 
                     name = String.Concat(
                         name,

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -1867,8 +1867,9 @@ namespace Internal.IL
                     {
                         if (canonMethod.RequiresInstMethodDescArg())
                         {
-                            Append("&");
+                            Append("(char*)&");
                             AppendMethodGenericDictionary(method);
+                            Append(" + sizeof(void*)");
                         }
                         else
                         {

--- a/src/Native/Bootstrap/CppCodeGen.h
+++ b/src/Native/Bootstrap/CppCodeGen.h
@@ -61,4 +61,11 @@ struct PInvokeTransitionFrame
                             // can be an invalid pointer in universal transition cases (which never need to call GetThread)
     uint32_t    m_Flags;  // PInvokeTransitionFrameFlags
 };
+
+// Should be synchronized with System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
+struct StaticClassConstructionContext
+{
+    void*       m_cctorMethodAddress;
+    uint32_t    m_initialized;
+};
 #endif

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -1151,6 +1151,14 @@ namespace Internal.Runtime.Augments
         {
             RuntimeImports.RhYield();
         }
+
+        public static bool SupportsRelativePointers
+        {
+            get
+            {
+                return Internal.Runtime.EEType.SupportsRelativePointers;
+            }
+        }
     }
 }
 

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -29,11 +29,11 @@ class Program
         TestGvmDependencies.Run();
         TestInterfaceVTableTracking.Run();
         TestClassVTableTracking.Run();
+        TestReflectionInvoke.Run();
+        TestFieldAccess.Run();
 #if !CODEGEN_CPP
         TestNullableCasting.Run();
-        TestReflectionInvoke.Run();
         TestMDArrayAddressMethod.Run();
-        TestFieldAccess.Run();
         TestNativeLayoutGeneration.Run();
 #endif
         return 100;

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -30,8 +30,12 @@ internal class ReflectionTest
 #if !OPTIMIZED_MODE_WITHOUT_SCANNER
         TestContainment.Run();
         TestInterfaceMethod.Run();
+        // Need to implement RhGetCodeTarget for CppCodeGen
+#if !CODEGEN_CPP
         TestByRefLikeTypeMethod.Run();
 #endif
+#endif
+
         TestAttributeInheritance.Run();
         TestStringConstructor.Run();
         TestAssemblyAndModuleAttributes.Run();
@@ -46,8 +50,9 @@ internal class ReflectionTest
         TestCreateDelegate.Run();
         TestInstanceFields.Run();
         TestReflectionInvoke.Run();
+#if !CODEGEN_CPP
         TestByRefReturnInvoke.Run();
-
+#endif
         return 100;
     }
 
@@ -687,9 +692,12 @@ internal class ReflectionTest
             if (!HasTypeHandle(usedNestedType))
                 throw new Exception($"{nameof(NeverUsedContainerType.UsedNestedType)} should have an EEType");
 
+            // Need to implement exceptions for CppCodeGen
+#if !CODEGEN_CPP
             // But the containing type doesn't need an EEType
             if (HasTypeHandle(neverUsedContainerType))
                 throw new Exception($"{nameof(NeverUsedContainerType)} should not have an EEType");
+#endif
         }
     }
 

--- a/tests/src/Simple/Reflection/no_cpp
+++ b/tests/src/Simple/Reflection/no_cpp
@@ -1,1 +1,0 @@
-Skip this test for cpp codegen mode


### PR DESCRIPTION
With this change and https://github.com/dotnet/corert/pull/6695 reflection tests are passed with following constraints:
- Some tests are skipped due to missing exceptions support
- `TestByRefLikeTypeMethod` is skipped (it's necessary to implement `RhGetCodeTarget` for CppCodeGen)
- `TestByRefReturnInvoke` is skipped (it's necessary to implement Nullable box/unbox)

Also https://github.com/dotnet/corert/issues/6405 and https://github.com/dotnet/corert/issues/6423 should be fixed.