### PR TITLE
Trivial bug fix - use EmitByte for fixup type in signatures

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -57,7 +57,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
             dataBuilder.AddSymbol(this);
 
-            dataBuilder.EmitUInt((uint)_fixupKind);
+            dataBuilder.EmitByte((byte)_fixupKind);
             dataBuilder.EmitMethodSignature(_methodDesc, _constrainedType, _methodToken, enforceDefEncoding: false,
                 _signatureContext, _isUnboxingStub, _isInstantiatingStub);
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunHelperSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunHelperSignature.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             ObjectDataSignatureBuilder builder = new ObjectDataSignatureBuilder();
             builder.AddSymbol(this);
-            builder.EmitUInt((uint)ReadyToRunFixupKind.READYTORUN_FIXUP_Helper);
+            builder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_Helper);
             builder.EmitUInt((uint)_helperID);
             return builder.ToObjectData();
         }


### PR DESCRIPTION
During code review of Andon's change to add initial support for
module overrides to R2RDump signature parser I noticed that
I had previously incorrectly used ReadUInt instead of ReadByte
for reading the fixup type from the signature.

Based on this observation I audited all places in the CPAOT
compiler that emit signatures to double-check whether I might
have made the same mistake there. Indeed I found the same bug
in two cases - in MethodFixupSignature and in encoding of
READYTORUN_FIXUP_Helper. Interestingly enough the same harmless
bug is in CoreCLR, please see

https://github.com/dotnet/coreclr/blob/04c4df8c9ecf53499838945197af70f11ddf840a/src/zap/zapimport.cpp#L2292

The AppendData performs the signature uint encoding which is
harmless in this case because all READYTORUN_FIXUP_* have codes
less than 128 however semantically it's still a bug, AppendByte
should be used instead as is clearly visible from the only place
where the fixup is consumed,

https://github.com/dotnet/coreclr/blob/04c4df8c9ecf53499838945197af70f11ddf840a/src/vm/jitinterface.cpp#L13715

Thanks

Tomas