### PR TITLE
Fix ProjectN regression in `ByReference<T>`

### DIFF
--- a/src/System.Private.CoreLib/shared/System/ByReference.cs
+++ b/src/System.Private.CoreLib/shared/System/ByReference.cs
@@ -11,11 +11,19 @@ namespace System
     // around lack of first class support for byref fields in C# and IL. The JIT and 
     // type loader has special handling for it that turns it into a thin wrapper around ref T.
     [NonVersionable]
-    internal readonly ref struct ByReference<T>
+    internal
+#if !PROJECTN
+    readonly
+#endif
+    ref struct ByReference<T>
     {
         // CS0169: The private field '{blah}' is never used
 #pragma warning disable 169
-         private readonly IntPtr _value;
+         private
+#if !PROJECTN // readonly breaks codegen contract and asserts UTC
+         readonly
+#endif
+         IntPtr _value;
 #pragma warning restore
 
         [Intrinsic]

--- a/src/System.Private.CoreLib/shared/System/ByReference.cs
+++ b/src/System.Private.CoreLib/shared/System/ByReference.cs
@@ -12,18 +12,14 @@ namespace System
     // type loader has special handling for it that turns it into a thin wrapper around ref T.
     [NonVersionable]
     internal
-#if !PROJECTN
+#if !PROJECTN // readonly breaks codegen contract and asserts UTC
     readonly
 #endif
     ref struct ByReference<T>
     {
         // CS0169: The private field '{blah}' is never used
 #pragma warning disable 169
-         private
-#if !PROJECTN // readonly breaks codegen contract and asserts UTC
-         readonly
-#endif
-         IntPtr _value;
+         private readonly IntPtr _value;
 #pragma warning restore
 
         [Intrinsic]


### PR DESCRIPTION
Making the field `initonly` breaks the contract with the codegen.