### PR TITLE
Add option to root all application assemblies

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -195,6 +195,9 @@ See the LICENSE file in the project root for more information.
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(AppContextSwitchOverrides->'--appcontextswitch:%(Identity)')" />
       <IlcArg Condition="$(ServerGarbageCollection) != ''" Include="--runtimeopt:RH_UseServerGC=1" />
+      <IlcArg Condition="$(IlcGenerateCompleteTypeMetadata) == 'true'" Include="--completetypemetadata" />
+      <IlcArg Condition="$(IlcGenerateStackTraceData) == 'true'" Include="--stacktracedata" />
+      <IlcArg Condition="$(RootAllApplicationAssemblies) == 'true'" Include="--rootallapplicationassemblies" />
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />

--- a/src/ILCompiler.Compiler/src/Compiler/FrameworkStringResourceBlockingPolicy.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/FrameworkStringResourceBlockingPolicy.cs
@@ -59,7 +59,7 @@ namespace ILCompiler
         /// <summary>
         /// Gets a value indicating whether '<paramref name="module"/>' is a framework assembly.
         /// </summary>
-        private static bool IsFrameworkAssembly(EcmaModule module)
+        public static bool IsFrameworkAssembly(EcmaModule module)
         {
             MetadataReader reader = module.MetadataReader;
 

--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -70,6 +70,9 @@
     <Compile Include="..\src\EcmaOnlyDebugInformationProvider.cs">
       <Link>EcmaOnlyDebugInformationProvider.cs</Link>
     </Compile>
+    <Compile Include="..\src\ApplicationAssemblyRootProvider.cs">
+      <Link>ApplicationAssemblyRootProvider.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\CommandLine\CommandLineException.cs">

--- a/src/ILCompiler/src/ApplicationAssemblyRootProvider.cs
+++ b/src/ILCompiler/src/ApplicationAssemblyRootProvider.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using AssemblyName = System.Reflection.AssemblyName;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Root provider that roots all code and types in the non-framework assemblies.
+    /// </summary>
+    class ApplicationAssemblyRootProvider : ICompilationRootProvider
+    {
+        private readonly CompilerTypeSystemContext _context;
+
+        public ApplicationAssemblyRootProvider(CompilerTypeSystemContext context)
+        {
+            _context = context;
+        }
+
+        public void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        {
+            foreach (var inputFile in _context.ReferenceFilePaths.Keys)
+            {
+                ProcessAssembly(inputFile, rootProvider);
+            }
+
+            foreach (var inputFile in _context.InputFilePaths.Keys)
+            {
+                ProcessAssembly(inputFile, rootProvider);
+            }
+        }
+
+        private void ProcessAssembly(string inputFile, IRootingServiceProvider rootProvider)
+        {
+            var assembly = (EcmaModule)_context.ResolveAssembly(new AssemblyName(inputFile), false);
+
+            if (FrameworkStringResourceBlockingPolicy.IsFrameworkAssembly(assembly))
+                return;
+
+            rootProvider.RootModuleMetadata(assembly, "Application assembly root");
+
+            foreach (TypeDesc type in assembly.GetAllTypes())
+            {
+                RdXmlRootProvider.RootType(rootProvider, type, "Application assembly root");
+            }
+        }
+    }
+}

--- a/src/ILCompiler/src/ILCompiler.csproj
+++ b/src/ILCompiler/src/ILCompiler.csproj
@@ -33,6 +33,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="RdXmlRootProvider.cs" />
     <Compile Include="EcmaOnlyDebugInformationProvider.cs" />
+    <Compile Include="ApplicationAssemblyRootProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\CommandLine\CommandLineException.cs">

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -58,6 +58,8 @@ namespace ILCompiler
         private string _singleMethodName;
         private IReadOnlyList<string> _singleMethodGenericArgs;
 
+        private bool _rootAllApplicationAssemblies;
+
         private IReadOnlyList<string> _codegenOptions = Array.Empty<string>();
 
         private IReadOnlyList<string> _rdXmlFilePaths = Array.Empty<string>();
@@ -161,6 +163,7 @@ namespace ILCompiler
                 syntax.DefineOption("usesharedgenerics", ref _useSharedGenerics, "Enable shared generics");
                 syntax.DefineOptionList("codegenopt", ref _codegenOptions, "Define a codegen option");
                 syntax.DefineOptionList("rdxml", ref _rdXmlFilePaths, "RD.XML file(s) for compilation");
+                syntax.DefineOption("rootallapplicationassemblies", ref _rootAllApplicationAssemblies, "Consider all non-framework assemblies dynamically used");
                 syntax.DefineOption("map", ref _mapFileName, "Generate a map file");
                 syntax.DefineOption("metadatalog", ref _metadataLogFileName, "Generate a metadata log file");
                 syntax.DefineOption("nometadatablocking", ref _noMetadataBlocking, "Ignore metadata blocking for internal implementation details");
@@ -427,6 +430,11 @@ namespace ILCompiler
                 foreach (var rdXmlFilePath in _rdXmlFilePaths)
                 {
                     compilationRoots.Add(new RdXmlRootProvider(typeSystemContext, rdXmlFilePath));
+                }
+
+                if (_rootAllApplicationAssemblies)
+                {
+                    compilationRoots.Add(new ApplicationAssemblyRootProvider(typeSystemContext));
                 }
             }
 

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -157,101 +157,19 @@ namespace ILCompiler
         {
             rootProvider.AddCompilationRoot(type, reason);
 
-            // Instantiate generic types over something that will be useful at runtime
             if (type.IsGenericDefinition)
-            {
-                List<TypeDesc> inst = new List<TypeDesc>();
-                foreach (GenericParameterDesc param in type.Instantiation)
-                {
-                    TypeDesc arg = GetTypeThatMeetsConstraints(param);
-
-                    // If we can't come up with an instantiation that meets constraints, we're done
-                    if (arg == null)
-                        return;
-
-                    inst.Add(arg);
-                }
-
-                type = ((MetadataType)type).MakeInstantiatedType(new Instantiation(inst.ToArray()));
-
-                rootProvider.AddCompilationRoot(type, reason);
-            }
+                return;
             
             if (type.IsDefType)
             {
                 foreach (var method in type.GetMethods())
                 {
                     if (method.HasInstantiation)
-                    {
-                        // Instantiate generic methods over something that will be useful at runtime
-                        List<TypeDesc> inst = new List<TypeDesc>();
-                        foreach (GenericParameterDesc param in method.Instantiation)
-                        {
-                            TypeDesc arg = GetTypeThatMeetsConstraints(param);
-
-                            // If we can't come up with an instantiation that meets constraints, we're done
-                            if (arg == null)
-                                break;
-
-                            inst.Add(arg);
-                        }
-
-                        if (inst.Count == method.Instantiation.Length)
-                        {
-                            RootMethod(rootProvider, method.MakeInstantiatedMethod(new Instantiation(inst.ToArray())), reason);
-                        }
-                    }
-                    else
-                    {
-                        RootMethod(rootProvider, method, reason);
-                    }
+                        continue;
+                    
+                    RootMethod(rootProvider, method, reason);
                 }
             }
-        }
-
-        private static TypeDesc GetTypeThatMeetsConstraints(GenericParameterDesc genericParam)
-        {
-            GenericConstraints constraints = genericParam.Constraints;
-            if ((constraints & GenericConstraints.NotNullableValueTypeConstraint) != 0)
-            {
-                return null;
-            }
-
-            TypeDesc result = null;
-            foreach (var c in genericParam.TypeConstraints)
-            {
-                // Can't do multiple type constraints
-                if (result != null)
-                {
-                    return null;
-                }
-
-                // Constraints in the form of T : U
-                if (c.IsSignatureVariable)
-                {
-                    return null;
-                }
-
-                // Other potentially complex constraints
-                if (c.HasInstantiation)
-                {
-                    return null;
-                }
-
-                result = c;
-            }
-
-            // If there's a new() constraint and a type constraint, make sure the
-            // type constraint meets it.
-            if (result != null &&
-                (constraints & GenericConstraints.DefaultConstructorConstraint) != 0 &&
-                result.GetDefaultConstructor() == null)
-            {
-                return null;
-            }
-
-
-            return result ?? genericParam.Context.GetWellKnownType(WellKnownType.Object);
         }
 
         private static void RootMethod(IRootingServiceProvider rootProvider, MethodDesc method, string reason)

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -166,7 +166,7 @@ namespace ILCompiler
                 {
                     if (method.HasInstantiation)
                         continue;
-                    
+
                     RootMethod(rootProvider, method, reason);
                 }
             }

--- a/src/ILCompiler/src/RdXmlRootProvider.cs
+++ b/src/ILCompiler/src/RdXmlRootProvider.cs
@@ -226,6 +226,18 @@ namespace ILCompiler
                     return null;
                 }
 
+                // Constraints in the form of T : U
+                if (c.IsSignatureVariable)
+                {
+                    return null;
+                }
+
+                // Other potentially complex constraints
+                if (c.HasInstantiation)
+                {
+                    return null;
+                }
+
                 result = c;
             }
 


### PR DESCRIPTION
This is similar to the option IL Linker exposes.

I'm also tweaking the RD.XML rooting logic (that this new root provider calls into) to attempt to root generic types as well, if possible.