### PR TITLE
Bring up CoreFX tests on ARM

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -164,11 +164,6 @@ namespace ILCompiler.DependencyAnalysis
 
                 case ReadyToRunHelperId.DelegateCtor:
                     {
-                        ARMDebug.EmitNYIAssert(factory, ref encoder, "DelegateCtor EmitCode is not implemented");
-                        /*
-                       ***
-                       NOT TESTED!!!
-                       ***
                         // This is a weird helper. Codegen populated Arg0 and Arg1 with the values that the constructor
                         // method expects. Codegen also passed us the generic context in Arg2.
                         // We now need to load the delegate target method into Arg2 (using a dictionary lookup)
@@ -191,7 +186,6 @@ namespace ILCompiler.DependencyAnalysis
                         }
 
                         encoder.EmitJMP(target.Constructor);
-                        */
                     }
                     break;
 

--- a/src/Native/Runtime/StackFrameIterator.cpp
+++ b/src/Native/Runtime/StackFrameIterator.cpp
@@ -188,9 +188,11 @@ void StackFrameIterator::InternalInit(Thread * pThreadToWalk, PTR_PInvokeTransit
     if (pFrame->m_Flags & PTFF_SAVE_R9)  { m_RegDisplay.pR9 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_R10)  { m_RegDisplay.pR10 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_SP)  { m_RegDisplay.SP  = *pPreservedRegsCursor++; }
-
+#ifdef PROJECTN
     m_RegDisplay.pR7 = (PTR_UIntNative) PTR_HOST_MEMBER(PInvokeTransitionFrame, pFrame, m_FramePointer);
-
+#else
+    m_RegDisplay.pR11 = (PTR_UIntNative) PTR_HOST_MEMBER(PInvokeTransitionFrame, pFrame, m_FramePointer);
+#endif
     if (pFrame->m_Flags & PTFF_SAVE_R0)  { m_RegDisplay.pR0 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_R1)  { m_RegDisplay.pR1 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_R2)  { m_RegDisplay.pR2 = pPreservedRegsCursor++; }

--- a/src/Native/Runtime/arm/ExceptionHandling.S
+++ b/src/Native/Runtime/arm/ExceptionHandling.S
@@ -478,8 +478,8 @@ NESTED_ENTRY RhpCallFilterFunclet, _TEXT, NoHandler
         PROLOG_PUSH "{r4-r11,lr}"
         PROLOG_VPUSH {d8-d15}
 
-        ldr         r12, [r2, #OFFSETOF__REGDISPLAY__pR7]
-        ldr         r7, [r12]
+        ldr         r12, [r2, #OFFSETOF__REGDISPLAY__pR11]
+        ldr         r11, [r12]
 
         mov         r12, r1                              // r12 <- handler funclet address
         // r0 still contains the exception object

--- a/src/Native/Runtime/unix/unixasmmacrosarm.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm.inc
@@ -233,7 +233,7 @@ C_FUNC(\Name):
         PROLOG_STACK_ALLOC 4          // Save space for caller's SP
         PROLOG_PUSH "{r4-r6,r8-r10}"  // Save preserved registers
         PROLOG_STACK_ALLOC 8          // Save space for flags and Thread*
-        PROLOG_PUSH "{r7}"            // Save caller's FP
+        PROLOG_PUSH "{r11}"           // Save caller's FP
         PROLOG_PUSH "{r11,lr}"        // Save caller's frame-chain pointer and PC
 
         // Compute SP value at entry to this method and save it in the last slot of the frame (slot #11).
@@ -250,7 +250,7 @@ C_FUNC(\Name):
 // Pop the frame and restore register state preserved by PUSH_COOP_PINVOKE_FRAME
 .macro POP_COOP_PINVOKE_FRAME
         EPILOG_POP  "{r11,lr}"        // Restore caller's frame-chain pointer and PC (return address)
-        EPILOG_POP  "{r7}"            // Restore caller's FP
+        EPILOG_POP  "{r11}"           // Restore caller's FP
         EPILOG_STACK_FREE 8           // Discard flags and Thread*
         EPILOG_POP  "{r4-r6,r8-r10}"  // Restore preserved registers
         EPILOG_STACK_FREE 4           // Discard caller's SP


### PR DESCRIPTION
With this change and https://github.com/dotnet/coreclr/pull/21669 CoreFX tests on Linux/ARM no longer crash, and test results are as follows:
```
=== TEST EXECUTION SUMMARY ===
   System.Collections.Tests  Total: 2835, Errors: 0, Failed: 0, Skipped: 13, Time: 68.510s 
```
Changes:
* Fixed frame pointer to be R11 instead of R7 in `PInvokeTransitionFrame` and in `RhpCallFilterFunclet`;
* Uncommented `DelegateCtor` helper implementation
CC @jkotas @alpencolt @sergign60 @iarischenko