### PR TITLE
Add `--tokens` option to command line

### DIFF
--- a/src/ILVerification/src/ILImporter.Verify.cs
+++ b/src/ILVerification/src/ILImporter.Verify.cs
@@ -47,6 +47,7 @@ namespace Internal.IL
 
         readonly bool _initLocals;
         readonly int _maxStack;
+        readonly bool _displayTokensOnErrorMessage;
 
         bool[] _instructionBoundaries; // For IL verification
 
@@ -147,7 +148,7 @@ namespace Internal.IL
             return stackValue;
         }
 
-        public ILImporter(MethodDesc method, MethodIL methodIL)
+        public ILImporter(MethodDesc method, MethodIL methodIL, bool displayTokensOnErrorMessage)
         {
             _typeSystemContext = method.Context;
 
@@ -200,6 +201,8 @@ namespace Internal.IL
             {
                 _exceptionRegions[i] = new ExceptionRegion() { ILRegion = ilExceptionRegions[i] };
             }
+
+            _displayTokensOnErrorMessage = displayTokensOnErrorMessage;
         }
 
         public Action<ErrorArgument[], VerifierError> ReportVerificationError

--- a/src/ILVerification/src/ILImporter.Verify.cs
+++ b/src/ILVerification/src/ILImporter.Verify.cs
@@ -47,7 +47,6 @@ namespace Internal.IL
 
         readonly bool _initLocals;
         readonly int _maxStack;
-        readonly bool _displayTokensOnErrorMessage;
 
         bool[] _instructionBoundaries; // For IL verification
 
@@ -148,7 +147,7 @@ namespace Internal.IL
             return stackValue;
         }
 
-        public ILImporter(MethodDesc method, MethodIL methodIL, bool displayTokensOnErrorMessage)
+        public ILImporter(MethodDesc method, MethodIL methodIL)
         {
             _typeSystemContext = method.Context;
 
@@ -201,8 +200,6 @@ namespace Internal.IL
             {
                 _exceptionRegions[i] = new ExceptionRegion() { ILRegion = ilExceptionRegions[i] };
             }
-
-            _displayTokensOnErrorMessage = displayTokensOnErrorMessage;
         }
 
         public Action<ErrorArgument[], VerifierError> ReportVerificationError

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -16,6 +16,8 @@ namespace Internal.TypeVerifier
         private readonly EcmaModule _module;
         private readonly TypeDefinitionHandle _typeDefinitionHandle;
         private readonly ILVerifyTypeSystemContext _typeSystemContext;
+        private readonly bool _displayTokensOnErrorMessage;
+
         public Action<VerifierError, object[]> ReportVerificationError
         {
             set;
@@ -27,11 +29,12 @@ namespace Internal.TypeVerifier
             ReportVerificationError(error, args);
         }
 
-        public TypeVerifier(EcmaModule module, TypeDefinitionHandle typeDefinitionHandle, ILVerifyTypeSystemContext typeSystemContext)
+        public TypeVerifier(EcmaModule module, TypeDefinitionHandle typeDefinitionHandle, ILVerifyTypeSystemContext typeSystemContext, bool displayTokensOnErrorMessage)
         {
             _module = module;
             _typeDefinitionHandle = typeDefinitionHandle;
             _typeSystemContext = typeSystemContext;
+            _displayTokensOnErrorMessage = displayTokensOnErrorMessage;
         }
 
         public void Verify()

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -16,7 +16,7 @@ namespace Internal.TypeVerifier
         private readonly EcmaModule _module;
         private readonly TypeDefinitionHandle _typeDefinitionHandle;
         private readonly ILVerifyTypeSystemContext _typeSystemContext;
-        private readonly bool _displayTokensOnErrorMessage;
+        private readonly VerifierOptions _verifierOptions;
 
         public Action<VerifierError, object[]> ReportVerificationError
         {
@@ -29,12 +29,12 @@ namespace Internal.TypeVerifier
             ReportVerificationError(error, args);
         }
 
-        public TypeVerifier(EcmaModule module, TypeDefinitionHandle typeDefinitionHandle, ILVerifyTypeSystemContext typeSystemContext, bool displayTokensOnErrorMessage)
+        public TypeVerifier(EcmaModule module, TypeDefinitionHandle typeDefinitionHandle, ILVerifyTypeSystemContext typeSystemContext, VerifierOptions verifierOptions)
         {
             _module = module;
             _typeDefinitionHandle = typeDefinitionHandle;
             _typeSystemContext = typeSystemContext;
-            _displayTokensOnErrorMessage = displayTokensOnErrorMessage;
+            _verifierOptions = verifierOptions;
         }
 
         public void Verify()

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -32,12 +32,7 @@ namespace ILVerify
         internal Verifier(ILVerifyTypeSystemContext context, VerifierOptions verifierOptions)
         {
             _typeSystemContext = context;
-            _verifierOptions = verifierOptions ?? GetDefaultVerifierOptions();
-        }
-
-        private VerifierOptions GetDefaultVerifierOptions()
-        {
-            return new VerifierOptions();
+            _verifierOptions = verifierOptions ?? new VerifierOptions();
         }
 
         public void SetSystemModuleName(AssemblyName name)

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -25,9 +25,11 @@ namespace ILVerify
         private ILVerifyTypeSystemContext _typeSystemContext;
         private VerifierOptions _verifierOptions;
 
-        public Verifier(IResolver resolver, VerifierOptions verifierOptions)
+        public Verifier(IResolver resolver, VerifierOptions verifierOptions) : this(new ILVerifyTypeSystemContext(resolver), verifierOptions) { }
+
+        internal Verifier(ILVerifyTypeSystemContext context, VerifierOptions verifierOptions)
         {
-            _typeSystemContext = new ILVerifyTypeSystemContext(resolver);
+            _typeSystemContext = context;
             _verifierOptions = verifierOptions ?? GetDefaultVerifierOptions();
         }
 
@@ -36,10 +38,6 @@ namespace ILVerify
             return new VerifierOptions { IncludeMetadataTokensInErrorMessages = false };
         }
 
-        internal Verifier(ILVerifyTypeSystemContext context)
-        {
-            _typeSystemContext = context;
-        }
 
         public void SetSystemModuleName(AssemblyName name)
         {

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -38,7 +38,6 @@ namespace ILVerify
             return new VerifierOptions { IncludeMetadataTokensInErrorMessages = false };
         }
 
-
         public void SetSystemModuleName(AssemblyName name)
         {
             PEReader peReader = _typeSystemContext._resolver.Resolve(name.Name);

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -25,7 +25,7 @@ namespace ILVerify
         private ILVerifyTypeSystemContext _typeSystemContext;
         private VerifierOptions _verifierOptions;
 
-        public Verifier(IResolver resolver) : this(resolver, GetDefaultVerifierOptions()) { }
+        public Verifier(IResolver resolver) : this(resolver, null){ }
 
         public Verifier(IResolver resolver, VerifierOptions verifierOptions) : this(new ILVerifyTypeSystemContext(resolver), verifierOptions) { }
 
@@ -35,7 +35,7 @@ namespace ILVerify
             _verifierOptions = verifierOptions ?? GetDefaultVerifierOptions();
         }
 
-        private static VerifierOptions GetDefaultVerifierOptions()
+        private VerifierOptions GetDefaultVerifierOptions()
         {
             return new VerifierOptions();
         }

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -23,10 +23,12 @@ namespace ILVerify
             new Lazy<ResourceManager>(() => new ResourceManager("FxResources.ILVerification.SR", typeof(Verifier).GetTypeInfo().Assembly));
 
         private ILVerifyTypeSystemContext _typeSystemContext;
+        private bool _displayTokensOnErrorMessage;
 
-        public Verifier(IResolver resolver)
+        public Verifier(IResolver resolver, bool displayTokensOnErrorMessage = false)
         {
             _typeSystemContext = new ILVerifyTypeSystemContext(resolver);
+            _displayTokensOnErrorMessage = displayTokensOnErrorMessage;
         }
 
         internal Verifier(ILVerifyTypeSystemContext context)
@@ -179,7 +181,7 @@ namespace ILVerify
 
             try
             {
-                var importer = new ILImporter(method, methodIL);
+                var importer = new ILImporter(method, methodIL, _displayTokensOnErrorMessage);
 
                 importer.ReportVerificationError = (args, code) =>
                 {
@@ -247,7 +249,7 @@ namespace ILVerify
 
             try
             {
-                TypeVerifier typeVerifier = new TypeVerifier(module, typeHandle, _typeSystemContext);
+                TypeVerifier typeVerifier = new TypeVerifier(module, typeHandle, _typeSystemContext, _displayTokensOnErrorMessage);
 
                 typeVerifier.ReportVerificationError = (code, args) =>
                 {

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -23,12 +23,17 @@ namespace ILVerify
             new Lazy<ResourceManager>(() => new ResourceManager("FxResources.ILVerification.SR", typeof(Verifier).GetTypeInfo().Assembly));
 
         private ILVerifyTypeSystemContext _typeSystemContext;
-        private bool _displayTokensOnErrorMessage;
+        private VerifierOptions _verifierOptions;
 
-        public Verifier(IResolver resolver, bool displayTokensOnErrorMessage = false)
+        public Verifier(IResolver resolver, VerifierOptions verifierOptions)
         {
             _typeSystemContext = new ILVerifyTypeSystemContext(resolver);
-            _displayTokensOnErrorMessage = displayTokensOnErrorMessage;
+            _verifierOptions = verifierOptions ?? GetDefaultVerifierOptions();
+        }
+
+        private VerifierOptions GetDefaultVerifierOptions()
+        {
+            return new VerifierOptions { IncludeMetadataTokensInErrorMessages = false };
         }
 
         internal Verifier(ILVerifyTypeSystemContext context)
@@ -181,7 +186,7 @@ namespace ILVerify
 
             try
             {
-                var importer = new ILImporter(method, methodIL, _displayTokensOnErrorMessage);
+                var importer = new ILImporter(method, methodIL);
 
                 importer.ReportVerificationError = (args, code) =>
                 {
@@ -249,7 +254,7 @@ namespace ILVerify
 
             try
             {
-                TypeVerifier typeVerifier = new TypeVerifier(module, typeHandle, _typeSystemContext, _displayTokensOnErrorMessage);
+                TypeVerifier typeVerifier = new TypeVerifier(module, typeHandle, _typeSystemContext, _verifierOptions);
 
                 typeVerifier.ReportVerificationError = (code, args) =>
                 {
@@ -308,5 +313,10 @@ namespace ILVerify
         {
             throw new VerifierException("No system module specified");
         }
+    }
+
+    public class VerifierOptions
+    {
+        public bool IncludeMetadataTokensInErrorMessages { get; set; }
     }
 }

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -25,7 +25,7 @@ namespace ILVerify
         private ILVerifyTypeSystemContext _typeSystemContext;
         private VerifierOptions _verifierOptions;
 
-        public Verifier(IResolver resolver) : this(resolver, new VerifierOptions()) { }
+        public Verifier(IResolver resolver) : this(resolver, GetDefaultVerifierOptions()) { }
 
         public Verifier(IResolver resolver, VerifierOptions verifierOptions) : this(new ILVerifyTypeSystemContext(resolver), verifierOptions) { }
 
@@ -35,7 +35,7 @@ namespace ILVerify
             _verifierOptions = verifierOptions ?? GetDefaultVerifierOptions();
         }
 
-        private VerifierOptions GetDefaultVerifierOptions()
+        private static VerifierOptions GetDefaultVerifierOptions()
         {
             return new VerifierOptions();
         }

--- a/src/ILVerification/src/Verifier.cs
+++ b/src/ILVerification/src/Verifier.cs
@@ -25,6 +25,8 @@ namespace ILVerify
         private ILVerifyTypeSystemContext _typeSystemContext;
         private VerifierOptions _verifierOptions;
 
+        public Verifier(IResolver resolver) : this(resolver, new VerifierOptions()) { }
+
         public Verifier(IResolver resolver, VerifierOptions verifierOptions) : this(new ILVerifyTypeSystemContext(resolver), verifierOptions) { }
 
         internal Verifier(ILVerifyTypeSystemContext context, VerifierOptions verifierOptions)
@@ -35,7 +37,7 @@ namespace ILVerify
 
         private VerifierOptions GetDefaultVerifierOptions()
         {
-            return new VerifierOptions { IncludeMetadataTokensInErrorMessages = false };
+            return new VerifierOptions();
         }
 
         public void SetSystemModuleName(AssemblyName name)

--- a/src/ILVerification/tests/ILMethodTester.cs
+++ b/src/ILVerification/tests/ILMethodTester.cs
@@ -59,7 +59,7 @@ namespace ILVerification.Tests
             EcmaModule module = TestDataLoader.GetModuleForTestAssembly(testCase.ModuleName);
             var methodHandle = (MethodDefinitionHandle) MetadataTokens.EntityHandle(testCase.MetadataToken);
             var method = (EcmaMethod)module.GetMethod(methodHandle);
-            var verifier = new Verifier((ILVerifyTypeSystemContext)method.Context);
+            var verifier = new Verifier((ILVerifyTypeSystemContext)method.Context, new VerifierOptions() { IncludeMetadataTokensInErrorMessages = true });
             return verifier.Verify(module.PEReader, methodHandle);
         }
     }

--- a/src/ILVerification/tests/ILTypeVerificationTester.cs
+++ b/src/ILVerification/tests/ILTypeVerificationTester.cs
@@ -59,7 +59,7 @@ namespace ILVerification.Tests
             EcmaModule module = TestDataLoader.GetModuleForTestAssembly(testCase.ModuleName);
             var typeHandle = (TypeDefinitionHandle)MetadataTokens.EntityHandle(testCase.MetadataToken);
             var type = (EcmaType)module.GetType(typeHandle);
-            var verifier = new Verifier((ILVerifyTypeSystemContext)type.Context);
+            var verifier = new Verifier((ILVerifyTypeSystemContext)type.Context, new VerifierOptions() { IncludeMetadataTokensInErrorMessages = true });
             return verifier.Verify(module.PEReader, typeHandle);
         }
     }

--- a/src/ILVerify/src/Program.cs
+++ b/src/ILVerify/src/Program.cs
@@ -23,6 +23,7 @@ namespace ILVerify
         private bool _help;
         private bool _verbose;
         private bool _printStatistics;
+        private bool _displayTokensOnValidationErrorMessage;
 
         private AssemblyName _systemModule = new AssemblyName("mscorlib");
         private Dictionary<string, string> _inputFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase); // map of simple name to file path
@@ -78,6 +79,7 @@ namespace ILVerify
                 syntax.DefineOption("exclude-file", ref excludeFile, "Same as --exclude, but the regular expression(s) are declared line by line in the specified file.");
                 syntax.DefineOption("statistics", ref _printStatistics, "Print verification statistics");
                 syntax.DefineOption("v|verbose", ref _verbose, "Verbose output");
+                syntax.DefineOption("t|tokens", ref _displayTokensOnValidationErrorMessage, "Display tokens value on validation error message");
 
                 syntax.DefineParameterList("in", ref inputFiles, "Input file(s)");
             });
@@ -138,7 +140,7 @@ namespace ILVerify
             if (_inputFilePaths.Count == 0)
                 throw new CommandLineException("No input files specified");
 
-            _verifier = new Verifier(this);
+            _verifier = new Verifier(this, _displayTokensOnValidationErrorMessage);
             _verifier.SetSystemModuleName(_systemModule);
 
             foreach (var kvp in _inputFilePaths)

--- a/src/ILVerify/src/Program.cs
+++ b/src/ILVerify/src/Program.cs
@@ -23,7 +23,7 @@ namespace ILVerify
         private bool _help;
         private bool _verbose;
         private bool _printStatistics;
-        private bool _displayTokensOnValidationErrorMessage;
+        private bool _includeMetadataTokensInErrorMessages;
 
         private AssemblyName _systemModule = new AssemblyName("mscorlib");
         private Dictionary<string, string> _inputFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase); // map of simple name to file path
@@ -79,7 +79,7 @@ namespace ILVerify
                 syntax.DefineOption("exclude-file", ref excludeFile, "Same as --exclude, but the regular expression(s) are declared line by line in the specified file.");
                 syntax.DefineOption("statistics", ref _printStatistics, "Print verification statistics");
                 syntax.DefineOption("v|verbose", ref _verbose, "Verbose output");
-                syntax.DefineOption("t|tokens", ref _displayTokensOnValidationErrorMessage, "Display tokens value on validation error message");
+                syntax.DefineOption("t|tokens", ref _includeMetadataTokensInErrorMessages, "Include metadata tokens in error messages");
 
                 syntax.DefineParameterList("in", ref inputFiles, "Input file(s)");
             });
@@ -140,7 +140,7 @@ namespace ILVerify
             if (_inputFilePaths.Count == 0)
                 throw new CommandLineException("No input files specified");
 
-            _verifier = new Verifier(this, _displayTokensOnValidationErrorMessage);
+            _verifier = new Verifier(this, GetVerifierOptions());
             _verifier.SetSystemModuleName(_systemModule);
 
             foreach (var kvp in _inputFilePaths)
@@ -149,6 +149,11 @@ namespace ILVerify
             }
 
             return 0;
+        }
+
+        private VerifierOptions GetVerifierOptions()
+        {
+            return new VerifierOptions { IncludeMetadataTokensInErrorMessages = _includeMetadataTokensInErrorMessages };
         }
 
         private void PrintVerifyMethodsResult(VerificationResult result, EcmaModule module, string pathOrModuleName)


### PR DESCRIPTION
contributes to https://github.com/dotnet/corert/issues/6694
Step forward added `--tokens` options to command line and flow to internal verifiers.

/cc @jkotas @MichalStrehovsky 

:christmas_tree: Merry Christmas!