### PR TITLE
Move Contracts.cs (CoreCLR version) to shared CoreLib

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -180,6 +180,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\DefaultBinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\SuppressMessageAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\ConditionalAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Contracts\Contracts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Debug.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggableAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerBrowsableAttribute.cs" />

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Contracts/Contracts.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Contracts/Contracts.cs
@@ -2,10 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+/*============================================================
+**
+** 
+**
+** Purpose: The contract class allows for expressing preconditions,
+** postconditions, and object invariants about methods in source
+** code for runtime checking & static analysis.
+**
+** Two classes (Contract and ContractHelper) are split into partial classes
+** in order to share the public front for multiple platforms (this file)
+** while providing separate implementation details for each platform.
+**
+===========================================================*/
 #define DEBUG // The behavior of this contract library should be consistent regardless of build type.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 
@@ -94,39 +108,6 @@ namespace System.Diagnostics.Contracts
     {
     }
 
-    /*
-#if FEATURE_SERIALIZATION
-    [Serializable]
-#endif
-    internal enum Mutability
-    {
-        Immutable,    // read-only after construction, except for lazy initialization & caches
-        // Do we need a "deeply immutable" value?
-        Mutable,
-        HasInitializationPhase,  // read-only after some point.  
-        // Do we need a value for mutable types with read-only wrapper subclasses?
-    }
-
-    // Note: This hasn't been thought through in any depth yet.  Consider it experimental.
-    // We should replace this with Joe's concepts.
-    [Conditional("CONTRACTS_FULL")]
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
-    [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "Thank you very much, but we like the names we've defined for the accessors")]
-    internal sealed class MutabilityAttribute : Attribute 
-    {
-        private Mutability _mutabilityMarker;
-
-        public MutabilityAttribute(Mutability mutabilityMarker)
-        {
-            _mutabilityMarker = mutabilityMarker;
-        }
-
-        public Mutability Mutability {
-            get { return _mutabilityMarker; }
-        }
-    }
-    */
-
     /// <summary>
     /// Instructs downstream tools whether to assume the correctness of this assembly, type or member without performing any verification or not.
     /// Can use [ContractVerification(false)] to explicitly mark assembly, type or member as one to *not* have verification performed on it.
@@ -158,7 +139,6 @@ namespace System.Diagnostics.Contracts
     /// </summary>
     [Conditional("CONTRACTS_FULL")]
     [AttributeUsage(AttributeTargets.Field)]
-    [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "Thank you very much, but we like the names we've defined for the accessors")]
     public sealed class ContractPublicPropertyNameAttribute : Attribute
     {
         private string _publicName;
@@ -268,9 +248,6 @@ namespace System.Diagnostics.Contracts
         [Pure]
         [Conditional("DEBUG")]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Assume(bool condition)
         {
             if (!condition)
@@ -290,9 +267,6 @@ namespace System.Diagnostics.Contracts
         [Pure]
         [Conditional("DEBUG")]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Assume(bool condition, string userMessage)
         {
             if (!condition)
@@ -312,9 +286,6 @@ namespace System.Diagnostics.Contracts
         [Pure]
         [Conditional("DEBUG")]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Assert(bool condition)
         {
             if (!condition)
@@ -329,9 +300,6 @@ namespace System.Diagnostics.Contracts
         [Pure]
         [Conditional("DEBUG")]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Assert(bool condition, string userMessage)
         {
             if (!condition)
@@ -353,9 +321,6 @@ namespace System.Diagnostics.Contracts
         /// </remarks>
         [Pure]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Requires(bool condition)
         {
             AssertMustUseRewriter(ContractFailureKind.Precondition, "Requires");
@@ -373,9 +338,6 @@ namespace System.Diagnostics.Contracts
         /// </remarks>
         [Pure]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Requires(bool condition, string userMessage)
         {
             AssertMustUseRewriter(ContractFailureKind.Precondition, "Requires");
@@ -390,12 +352,7 @@ namespace System.Diagnostics.Contracts
         /// This contract is exposed to clients so must only reference members at least as visible as the enclosing method.
         /// Use this form when you want to throw a particular exception.
         /// </remarks>
-        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "condition")]
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Requires<TException>(bool condition) where TException : Exception
         {
             AssertMustUseRewriter(ContractFailureKind.Precondition, "Requires<TException>");
@@ -411,13 +368,7 @@ namespace System.Diagnostics.Contracts
         /// This contract is exposed to clients so must only reference members at least as visible as the enclosing method.
         /// Use this form when you want to throw a particular exception.
         /// </remarks>
-        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "userMessage")]
-        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "condition")]
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Requires<TException>(bool condition, string userMessage) where TException : Exception
         {
             AssertMustUseRewriter(ContractFailureKind.Precondition, "Requires<TException>");
@@ -438,9 +389,6 @@ namespace System.Diagnostics.Contracts
         /// </remarks>
         [Pure]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Ensures(bool condition)
         {
             AssertMustUseRewriter(ContractFailureKind.Postcondition, "Ensures");
@@ -458,9 +406,6 @@ namespace System.Diagnostics.Contracts
         /// </remarks>
         [Pure]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Ensures(bool condition, string userMessage)
         {
             AssertMustUseRewriter(ContractFailureKind.Postcondition, "Ensures");
@@ -478,10 +423,6 @@ namespace System.Diagnostics.Contracts
         /// </remarks>
         [Pure]
         [Conditional("CONTRACTS_FULL")]
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Exception type used in tools.")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void EnsuresOnThrow<TException>(bool condition) where TException : Exception
         {
             AssertMustUseRewriter(ContractFailureKind.PostconditionOnException, "EnsuresOnThrow");
@@ -500,10 +441,6 @@ namespace System.Diagnostics.Contracts
         /// </remarks>
         [Pure]
         [Conditional("CONTRACTS_FULL")]
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Exception type used in tools.")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void EnsuresOnThrow<TException>(bool condition, string userMessage) where TException : Exception
         {
             AssertMustUseRewriter(ContractFailureKind.PostconditionOnException, "EnsuresOnThrow");
@@ -519,12 +456,8 @@ namespace System.Diagnostics.Contracts
         /// <remarks>
         /// This method can only be used within the argument to the <seealso cref="Ensures(bool)"/> contract.
         /// </remarks>
-        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Not intended to be called at runtime.")]
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
-        public static T Result<T>() { return default(T); }
+        public static T Result<T>() { return default; }
 
         /// <summary>
         /// Represents the final (output) value of an out parameter when returning from a method.
@@ -535,12 +468,8 @@ namespace System.Diagnostics.Contracts
         /// <remarks>
         /// This method can only be used within the argument to the <seealso cref="Ensures(bool)"/> contract.
         /// </remarks>
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Not intended to be called at runtime.")]
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
-        public static T ValueAtReturn<T>(out T value) { value = default(T); return value; }
+        public static T ValueAtReturn<T>(out T value) { value = default; return value; }
 
         /// <summary>
         /// Represents the value of <paramref name="value"/> as it was at the start of the method or property.
@@ -551,12 +480,8 @@ namespace System.Diagnostics.Contracts
         /// <remarks>
         /// This method can only be used within the argument to the <seealso cref="Ensures(bool)"/> contract.
         /// </remarks>
-        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "value")]
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
-        public static T OldValue<T>(T value) { return default(T); }
+        public static T OldValue<T>(T value) { return default; }
 
         #endregion Old, Result, and Out Parameters
 
@@ -575,9 +500,6 @@ namespace System.Diagnostics.Contracts
         /// </remarks>
         [Pure]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Invariant(bool condition)
         {
             AssertMustUseRewriter(ContractFailureKind.Invariant, "Invariant");
@@ -595,9 +517,6 @@ namespace System.Diagnostics.Contracts
         /// </remarks>
         [Pure]
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
         public static void Invariant(bool condition, string userMessage)
         {
             AssertMustUseRewriter(ContractFailureKind.Invariant, "Invariant");
@@ -620,16 +539,12 @@ namespace System.Diagnostics.Contracts
         /// starting from <paramref name="fromInclusive"/> to <paramref name="toExclusive"/> - 1.</returns>
         /// <seealso cref="System.Collections.Generic.List&lt;T&gt;.TrueForAll"/>
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]  // Assumes predicate obeys CER rules.
-#endif
         public static bool ForAll(int fromInclusive, int toExclusive, Predicate<int> predicate)
         {
             if (fromInclusive > toExclusive)
                 throw new ArgumentException(SR.Argument_ToExclusiveLessThanFromExclusive);
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
-            Contract.EndContractBlock();
 
             for (int i = fromInclusive; i < toExclusive; i++)
                 if (!predicate(i)) return false;
@@ -647,16 +562,12 @@ namespace System.Diagnostics.Contracts
         /// <paramref name="collection"/>.</returns>
         /// <seealso cref="System.Collections.Generic.List&lt;T&gt;.TrueForAll"/>
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]  // Assumes predicate & collection enumerator obey CER rules.
-#endif
         public static bool ForAll<T>(IEnumerable<T> collection, Predicate<T> predicate)
         {
             if (collection == null)
                 throw new ArgumentNullException(nameof(collection));
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
-            Contract.EndContractBlock();
 
             foreach (T t in collection)
                 if (!predicate(t)) return false;
@@ -678,16 +589,12 @@ namespace System.Diagnostics.Contracts
         /// starting from <paramref name="fromInclusive"/> to <paramref name="toExclusive"/> - 1.</returns>
         /// <seealso cref="System.Collections.Generic.List&lt;T&gt;.Exists"/>
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]  // Assumes predicate obeys CER rules.
-#endif
         public static bool Exists(int fromInclusive, int toExclusive, Predicate<int> predicate)
         {
             if (fromInclusive > toExclusive)
                 throw new ArgumentException(SR.Argument_ToExclusiveLessThanFromExclusive);
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
-            Contract.EndContractBlock();
 
             for (int i = fromInclusive; i < toExclusive; i++)
                 if (predicate(i)) return true;
@@ -704,16 +611,12 @@ namespace System.Diagnostics.Contracts
         /// <paramref name="collection"/>.</returns>
         /// <seealso cref="System.Collections.Generic.List&lt;T&gt;.Exists"/>
         [Pure]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]  // Assumes predicate & collection enumerator obey CER rules.
-#endif
         public static bool Exists<T>(IEnumerable<T> collection, Predicate<T> predicate)
         {
             if (collection == null)
                 throw new ArgumentNullException(nameof(collection));
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
-            Contract.EndContractBlock();
 
             foreach (T t in collection)
                 if (predicate(t)) return true;
@@ -725,107 +628,6 @@ namespace System.Diagnostics.Contracts
         #endregion Quantifiers
 
         #region Pointers
-#if FEATURE_UNSAFE_CONTRACTS    
-        /// <summary>
-        /// Runtime checking for pointer bounds is not currently feasible. Thus, at runtime, we just return
-        /// a very long extent for each pointer that is writable. As long as assertions are of the form
-        /// WritableBytes(ptr) >= ..., the runtime assertions will not fail.
-        /// The runtime value is 2^64 - 1 or 2^32 - 1.
-        /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1802", Justification = "FxCop is confused")]
-        static readonly ulong MaxWritableExtent = (UIntPtr.Size == 4) ? uint.MaxValue : ulong.MaxValue;
-
-        /// <summary>
-        /// Allows specifying a writable extent for a UIntPtr, similar to SAL's writable extent.
-        /// NOTE: this is for static checking only. No useful runtime code can be generated for this
-        /// at the moment.
-        /// </summary>
-        /// <param name="startAddress">Start of memory region</param>
-        /// <returns>The result is the number of bytes writable starting at <paramref name="startAddress"/></returns>
-        [CLSCompliant(false)]
-        [Pure]
-        [ContractRuntimeIgnored]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
-        public static ulong WritableBytes(UIntPtr startAddress) { return MaxWritableExtent - startAddress.ToUInt64(); }
-
-        /// <summary>
-        /// Allows specifying a writable extent for a UIntPtr, similar to SAL's writable extent.
-        /// NOTE: this is for static checking only. No useful runtime code can be generated for this
-        /// at the moment.
-        /// </summary>
-        /// <param name="startAddress">Start of memory region</param>
-        /// <returns>The result is the number of bytes writable starting at <paramref name="startAddress"/></returns>
-        [CLSCompliant(false)]
-        [Pure]
-        [ContractRuntimeIgnored]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
-        public static ulong WritableBytes(IntPtr startAddress) { return MaxWritableExtent - (ulong)startAddress; }
-
-        /// <summary>
-        /// Allows specifying a writable extent for a UIntPtr, similar to SAL's writable extent.
-        /// NOTE: this is for static checking only. No useful runtime code can be generated for this
-        /// at the moment.
-        /// </summary>
-        /// <param name="startAddress">Start of memory region</param>
-        /// <returns>The result is the number of bytes writable starting at <paramref name="startAddress"/></returns>
-        [CLSCompliant(false)]
-        [Pure]
-        [ContractRuntimeIgnored]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
-        //TODO: FxCop would prefer WritableBytes to return a boolean instead of a size.
-        unsafe public static ulong WritableBytes(void* startAddress) { return MaxWritableExtent - (ulong)startAddress; }
-
-        /// <summary>
-        /// Allows specifying a readable extent for a UIntPtr, similar to SAL's readable extent.
-        /// NOTE: this is for static checking only. No useful runtime code can be generated for this
-        /// at the moment.
-        /// </summary>
-        /// <param name="startAddress">Start of memory region</param>
-        /// <returns>The result is the number of bytes readable starting at <paramref name="startAddress"/></returns>
-        [CLSCompliant(false)]
-        [Pure]
-        [ContractRuntimeIgnored]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
-        public static ulong ReadableBytes(UIntPtr startAddress) { return MaxWritableExtent - startAddress.ToUInt64(); }
-
-        /// <summary>
-        /// Allows specifying a readable extent for a UIntPtr, similar to SAL's readable extent.
-        /// NOTE: this is for static checking only. No useful runtime code can be generated for this
-        /// at the moment.
-        /// </summary>
-        /// <param name="startAddress">Start of memory region</param>
-        /// <returns>The result is the number of bytes readable starting at <paramref name="startAddress"/></returns>
-        [CLSCompliant(false)]
-        [Pure]
-        [ContractRuntimeIgnored]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
-        public static ulong ReadableBytes(IntPtr startAddress) { return MaxWritableExtent - (ulong)startAddress; }
-
-        /// <summary>
-        /// Allows specifying a readable extent for a UIntPtr, similar to SAL's readable extent.
-        /// NOTE: this is for static checking only. No useful runtime code can be generated for this
-        /// at the moment.
-        /// </summary>
-        /// <param name="startAddress">Start of memory region</param>
-        /// <returns>The result is the number of bytes readable starting at <paramref name="startAddress"/></returns>
-        [CLSCompliant(false)]
-        [Pure]
-        [ContractRuntimeIgnored]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
-        unsafe public static ulong ReadableBytes(void* startAddress) { return MaxWritableExtent - (ulong)startAddress; }
-#endif // FEATURE_UNSAFE_CONTRACTS
         #endregion
 
         #region Misc.
@@ -834,150 +636,22 @@ namespace System.Diagnostics.Contracts
         /// Marker to indicate the end of the contract section of a method.
         /// </summary>
         [Conditional("CONTRACTS_FULL")]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
         public static void EndContractBlock() { }
 
         #endregion
 
         #endregion User Methods
-
-        #region Failure Behavior
-
-        /// <summary>
-        /// Without contract rewriting, failing Assert/Assumes end up calling this method.
-        /// Code going through the contract rewriter never calls this method. Instead, the rewriter produced failures call
-        /// System.Runtime.CompilerServices.ContractHelper.RaiseContractFailedEvent, followed by 
-        /// System.Runtime.CompilerServices.ContractHelper.TriggerFailure.
-        /// </summary>
-        static partial void ReportFailure(ContractFailureKind failureKind, string userMessage, string conditionText, Exception innerException);
-
-        /// <summary>
-        /// This method is used internally to trigger a failure indicating to the "programmer" that he is using the interface incorrectly.
-        /// It is NEVER used to indicate failure of actual contracts at runtime.
-        /// </summary>
-        static partial void AssertMustUseRewriter(ContractFailureKind kind, string contractKind);
-        #endregion
     }
 
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public enum ContractFailureKind
     {
         Precondition,
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Postcondition")]
         Postcondition,
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Postcondition")]
         PostconditionOnException,
         Invariant,
         Assert,
         Assume,
-    }
-}
-
-//// Note: In .NET FX 4.5, we duplicated the ContractHelper class in the System.Runtime.CompilerServices
-//// namespace to remove an ugly wart of a namespace from the Windows 8 profile.  But we still need the
-//// old locations left around, so we can support rewritten .NET FX 4.0 libraries.  Consider removing
-//// these from our reference assembly in a future version.
-//namespace System.Diagnostics.Contracts.Internal
-//{
-//    [Obsolete("Use the ContractHelper class in the System.Runtime.CompilerServices namespace instead.")]
-//    public static class ContractHelper
-//    {
-//        #region Rewriter Failure Hooks
-
-//        /// <summary>
-//        /// Rewriter will call this method on a contract failure to allow listeners to be notified.
-//        /// The method should not perform any failure (assert/throw) itself.
-//        /// </summary>
-//        /// <returns>null if the event was handled and should not trigger a failure.
-//        ///          Otherwise, returns the localized failure message</returns>
-//        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
-//        [System.Diagnostics.DebuggerNonUserCode]
-//#if FEATURE_RELIABILITY_CONTRACTS
-//        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-//#endif
-//        public static string RaiseContractFailedEvent(ContractFailureKind failureKind, String userMessage, String conditionText, Exception innerException)
-//        {
-//            return System.Runtime.CompilerServices.ContractHelper.RaiseContractFailedEvent(failureKind, userMessage, conditionText, innerException);
-//        }
-
-//        /// <summary>
-//        /// Rewriter calls this method to get the default failure behavior.
-//        /// </summary>
-//        [System.Diagnostics.DebuggerNonUserCode]
-//#if FEATURE_RELIABILITY_CONTRACTS
-//        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-//#endif
-//        public static void TriggerFailure(ContractFailureKind kind, String displayMessage, String userMessage, String conditionText, Exception innerException)
-//        {
-//            System.Runtime.CompilerServices.ContractHelper.TriggerFailure(kind, displayMessage, userMessage, conditionText, innerException);
-//        }
-
-//        #endregion Rewriter Failure Hooks
-//    }
-//}  // namespace System.Diagnostics.Contracts.Internal
-
-
-namespace System.Runtime.CompilerServices
-{
-    public static partial class ContractHelper
-    {
-        #region Rewriter Failure Hooks
-
-        /// <summary>
-        /// Rewriter will call this method on a contract failure to allow listeners to be notified.
-        /// The method should not perform any failure (assert/throw) itself.
-        /// </summary>
-        /// <returns>null if the event was handled and should not trigger a failure.
-        ///          Otherwise, returns the localized failure message</returns>
-        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
-        [System.Diagnostics.DebuggerNonUserCode]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-#endif
-        public static string RaiseContractFailedEvent(ContractFailureKind failureKind, string userMessage, string conditionText, Exception innerException)
-        {
-            string resultFailureMessage = "Contract failed"; // default in case implementation does not assign anything.
-            RaiseContractFailedEventImplementation(failureKind, userMessage, conditionText, innerException, ref resultFailureMessage);
-            return resultFailureMessage;
-        }
-
-
-        /// <summary>
-        /// Rewriter calls this method to get the default failure behavior.
-        /// </summary>
-        [System.Diagnostics.DebuggerNonUserCode]
-#if FEATURE_RELIABILITY_CONTRACTS
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
-        public static void TriggerFailure(ContractFailureKind kind, string displayMessage, string userMessage, string conditionText, Exception innerException)
-        {
-            TriggerFailureImplementation(kind, displayMessage, userMessage, conditionText, innerException);
-        }
-
-        #endregion Rewriter Failure Hooks
-
-        #region Implementation Stubs
-
-        /// <summary>
-        /// Rewriter will call this method on a contract failure to allow listeners to be notified.
-        /// The method should not perform any failure (assert/throw) itself.
-        /// This method has 3 functions:
-        /// 1. Call any contract hooks (such as listeners to Contract failed events)
-        /// 2. Determine if the listeneres deem the failure as handled (then resultFailureMessage should be set to null)
-        /// 3. Produce a localized resultFailureMessage used in advertising the failure subsequently.
-        /// </summary>
-        /// <param name="resultFailureMessage">Should really be out (or the return value), but partial methods are not flexible enough.
-        /// On exit: null if the event was handled and should not trigger a failure.
-        ///          Otherwise, returns the localized failure message</param>
-        static partial void RaiseContractFailedEventImplementation(ContractFailureKind failureKind, string userMessage, string conditionText, Exception innerException, ref string resultFailureMessage);
-
-        /// <summary>
-        /// Implements the default failure behavior of the platform. Under the BCL, it triggers an Assert box.
-        /// </summary>
-        static partial void TriggerFailureImplementation(ContractFailureKind kind, string displayMessage, string userMessage, string conditionText, Exception innerException);
-        #endregion Implementation Stubs
     }
 }  // namespace System.Runtime.CompilerServices
 

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -208,7 +208,6 @@
     <Compile Include="System\IO\FileLoadException.CoreRT.cs" />
     <Compile Include="System\IO\Stream.CoreRT.cs" />
     <Compile Include="System\RuntimeMethodHandle.cs" />
-    <Compile Include="System\Diagnostics\Contracts\Contracts.cs" />
     <Compile Include="System\Diagnostics\Debug.CoreRT.cs" />
     <Compile Include="System\Diagnostics\Debugger.cs" />
     <Compile Include="System\Diagnostics\LowLevelDebugFuncEval.cs" />


### PR DESCRIPTION
Not sure what to do about `SuppressMessage` attributes, which are present in CoreRT version and not in CoreCLR version.
The CoreRT version also had couple of `Contract.EndContractBlock();` lines that are missing in CoreCLR, but it looks reasonable to add them.

Opinions?