### PR TITLE
[ILVerify]Include metadata token for type verifier

### DIFF
--- a/src/ILVerification/src/Resources/Strings.resx
+++ b/src/ILVerification/src/Resources/Strings.resx
@@ -442,6 +442,6 @@
     <value>Interface implementation has a duplicate. Class '{0}' Interface: '{1}'</value>
   </data>
   <data name="InterfaceMethodNotImplemented" xml:space="preserve">
-    <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Method: '{2}'.</value>
+    <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Missing method: '{2}'.</value>
   </data>
 </root>

--- a/src/ILVerification/src/Resources/Strings.resx
+++ b/src/ILVerification/src/Resources/Strings.resx
@@ -442,6 +442,6 @@
     <value>Interface implementation has a duplicate. Class '{0}' Interface: '{1}'</value>
   </data>
   <data name="InterfaceMethodNotImplemented" xml:space="preserve">
-    <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Method: {2}.</value>
+    <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Method: '{2}'.</value>
   </data>
 </root>

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -141,10 +141,7 @@ namespace Internal.TypeVerifier
                 EcmaModule module = typeSystemContext.GetModule(ecmaAssembly.PEReader);
                 MetadataReader reader = ecmaAssembly.PEReader.GetMetadataReader();
 
-                return string.Format("{0}([{1}]0x{2:X8})",
-                                    methodDesc,
-                                    module,
-                                    reader.GetToken(((EcmaMethod)methodDesc.GetTypicalMethodDefinition()).Handle));
+                return string.Format("{0}([{1}]0x{2:X8})", methodDesc, module, reader.GetToken(((EcmaMethod)methodDesc.GetTypicalMethodDefinition()).Handle));
             }
             else
             {

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -134,16 +134,9 @@ namespace Internal.TypeVerifier
 
         private string GetModule(DefType defType)
         {
-            InstantiatedType instantiatedType = defType as InstantiatedType;
-            if (!(instantiatedType is null))
+            if (defType is MetadataType metadataType)
             {
-                return instantiatedType.Module.ToString();
-            }
-
-            EcmaType ecmaType = defType as EcmaType;
-            if (!(ecmaType is null))
-            {
-                return ecmaType.Module.ToString();
+                return metadataType.Module.ToString();
             }
 
             Debug.Fail("ModuleNotFound");
@@ -165,18 +158,15 @@ namespace Internal.TypeVerifier
 
         private string GetModule(MethodDesc methodDesc)
         {
-            MethodForInstantiatedType methodForInstantiatedType = methodDesc as MethodForInstantiatedType;
-            if (!(methodForInstantiatedType is null))
+            if (methodDesc is MethodForInstantiatedType methodForInstantiatedType)
             {
-                InstantiatedType instantiatedType = methodForInstantiatedType.OwningType as InstantiatedType;
-                if (!(instantiatedType is null))
+                if (methodForInstantiatedType.OwningType is InstantiatedType instantiatedType)
                 {
                     return instantiatedType.Module.ToString();
                 }
             }
 
-            EcmaMethod ecmaMethod = methodDesc as EcmaMethod;
-            if (!(ecmaMethod is null))
+            if (methodDesc is EcmaMethod ecmaMethod)
             {
                 return ecmaMethod.Module.ToString();
             }

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -122,7 +122,6 @@ namespace Internal.TypeVerifier
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
-
                 return string.Format("{0}([{1}]0x{2:X8})", defType, _module, _module.MetadataReader.GetToken(interfaceImplementation.Interface));
             }
             else

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -76,7 +76,7 @@ namespace Internal.TypeVerifier
                 InterfaceMetadataObjects imo = new InterfaceMetadataObjects
                 {
                     DefType = interfaceType,
-                    InterfaceImplementation = interfaceImplementation
+                    InterfaceImplementationHandle = interfaceHandle
                 };
 
                 if (!implementedInterfaces.Contains(imo))
@@ -85,7 +85,7 @@ namespace Internal.TypeVerifier
                 }
                 else
                 {
-                    VerificationError(VerifierError.InterfaceImplHasDuplicate, Format(type), Format(imo.DefType, imo.InterfaceImplementation));
+                    VerificationError(VerifierError.InterfaceImplHasDuplicate, Format(type), Format(imo.DefType, imo.InterfaceImplementationHandle));
                 }
             }
 
@@ -99,7 +99,7 @@ namespace Internal.TypeVerifier
                         MethodDesc resolvedMethod = type.ResolveInterfaceMethodTarget(method);
                         if (resolvedMethod is null)
                         {
-                            VerificationError(VerifierError.InterfaceMethodNotImplemented, Format(type), Format(implementedInterface.DefType, implementedInterface.InterfaceImplementation), Format(method));
+                            VerificationError(VerifierError.InterfaceMethodNotImplemented, Format(type), Format(implementedInterface.DefType, implementedInterface.InterfaceImplementationHandle), Format(method));
                         }
                     }
                 }
@@ -110,7 +110,7 @@ namespace Internal.TypeVerifier
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
-                return string.Format("{0}([{1}]0x{2:X8})", type, type.Module, _module.MetadataReader.GetToken(type.Handle));
+                return string.Format("{0}([{1}]0x{2:X8})", type, _module, _module.MetadataReader.GetToken(_typeDefinitionHandle));
             }
             else
             {
@@ -118,12 +118,12 @@ namespace Internal.TypeVerifier
             }
         }
 
-        private string Format(DefType defType, InterfaceImplementation interfaceImplementation)
+        private string Format(DefType defType, InterfaceImplementationHandle interfaceImplementation)
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
 
-                return string.Format("{0}([{1}]0x{2:X8})", defType, GetModule(defType), _module.MetadataReader.GetToken(interfaceImplementation.Interface));
+                return string.Format("{0}([{1}]0x{2:X8})", defType, _module, _module.MetadataReader.GetToken(interfaceImplementation));
             }
             else
             {
@@ -131,22 +131,11 @@ namespace Internal.TypeVerifier
             }
         }
 
-        private string GetModule(DefType defType)
-        {
-            if (defType is MetadataType metadataType)
-            {
-                return metadataType.Module.ToString();
-            }
-
-            Debug.Fail("ModuleNotFound");
-            return "ModuleNotFound";
-        }
-
         private string Format(MethodDesc methodDesc)
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
-                return string.Format("{0}([{1}]0x{2:X8})", methodDesc, GetModule(methodDesc), _module.MetadataReader.GetToken(((EcmaMethod)methodDesc.GetTypicalMethodDefinition()).Handle));
+                return string.Format("{0}([{1}]0x{2:X8})", methodDesc, _module, _module.MetadataReader.GetToken(((EcmaMethod)methodDesc.GetTypicalMethodDefinition()).Handle));
             }
             else
             {
@@ -154,21 +143,10 @@ namespace Internal.TypeVerifier
             }
         }
 
-        private string GetModule(MethodDesc methodDesc)
-        {
-            if (methodDesc.GetMethodDefinition().OwningType is MetadataType metadataType)
-            {
-                return metadataType.Module.ToString();
-            }
-
-            Debug.Fail("ModuleNotFound");
-            return "ModuleNotFound";
-        }
-
         private class InterfaceMetadataObjects : IEquatable<InterfaceMetadataObjects>
         {
             public DefType DefType { get; set; }
-            public InterfaceImplementation InterfaceImplementation { set; get; }
+            public InterfaceImplementationHandle InterfaceImplementationHandle { set; get; }
             public bool Equals(InterfaceMetadataObjects other)
             {
                 return other.DefType == DefType;

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -74,7 +74,7 @@ namespace Internal.TypeVerifier
 
                 InterfaceMetadataObjects imo = new InterfaceMetadataObjects
                 {
-                    InterfaceTypeDesc = interfaceTypeDesc,
+                    InterfaceType = interfaceTypeDesc,
                     InterfaceImplementation = interfaceImplementation
                 };
 
@@ -84,7 +84,7 @@ namespace Internal.TypeVerifier
                 }
                 else
                 {
-                    VerificationError(VerifierError.InterfaceImplHasDuplicate, Format(type, _typeDefinitionHandle), Format(imo.InterfaceTypeDesc, _module, imo.InterfaceImplementation));
+                    VerificationError(VerifierError.InterfaceImplHasDuplicate, Format(type), Format(imo.InterfaceType, _module, imo.InterfaceImplementation));
                 }
             }
 
@@ -93,7 +93,7 @@ namespace Internal.TypeVerifier
                 if (!type.IsAbstract)
                 {
                     // Look for missing method implementation
-                    foreach (MethodDesc method in implementedInterface.InterfaceTypeDesc.GetAllMethods())
+                    foreach (MethodDesc method in implementedInterface.InterfaceType.GetAllMethods())
                     {
                         if (method.Signature.IsStatic)
                         {
@@ -103,21 +103,21 @@ namespace Internal.TypeVerifier
                         MethodDesc resolvedMethod = type.ResolveInterfaceMethodTarget(method);
                         if (resolvedMethod is null)
                         {
-                            VerificationError(VerifierError.InterfaceMethodNotImplemented, Format(type, _typeDefinitionHandle), Format(implementedInterface.InterfaceTypeDesc, _module, implementedInterface.InterfaceImplementation), Format(method));
+                            VerificationError(VerifierError.InterfaceMethodNotImplemented, Format(type), Format(implementedInterface.InterfaceType, _module, implementedInterface.InterfaceImplementation), Format(method));
                         }
                     }
                 }
             }
         }
 
-        private string Format(TypeDesc type, TypeDefinitionHandle typeDefinitionHandle)
+        private string Format(TypeDesc type)
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
                 TypeDesc typeDesc = type.GetTypeDefinition();
                 EcmaModule module = (EcmaModule)((MetadataType)typeDesc).Module;
 
-                return string.Format("{0}([{1}]0x{2:X8})", type, module, module.MetadataReader.GetToken(typeDefinitionHandle));
+                return string.Format("{0}([{1}]0x{2:X8})", type, module, module.MetadataReader.GetToken(((EcmaType)type).Handle));
             }
             else
             {
@@ -154,11 +154,11 @@ namespace Internal.TypeVerifier
 
         private class InterfaceMetadataObjects : IEquatable<InterfaceMetadataObjects>
         {
-            public TypeDesc InterfaceTypeDesc { get; set; }
+            public TypeDesc InterfaceType { get; set; }
             public InterfaceImplementation InterfaceImplementation { get; set; }
             public bool Equals(InterfaceMetadataObjects other)
             {
-                return other.InterfaceTypeDesc == InterfaceTypeDesc;
+                return other.InterfaceType == InterfaceType;
             }
         }
     }

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -140,23 +140,10 @@ namespace Internal.TypeVerifier
                 ILVerifyTypeSystemContext typeSystemContext = (ILVerifyTypeSystemContext)ecmaAssembly.Context;
                 EcmaModule module = typeSystemContext.GetModule(ecmaAssembly.PEReader);
                 MetadataReader reader = ecmaAssembly.PEReader.GetMetadataReader();
-                
-                TypeDefinitionHandle typeDefHandleToken = default;
-                foreach (TypeDefinitionHandle typeDefHandle in reader.TypeDefinitions)
-                {
-                    if (typeDesc == module.GetType(typeDefHandle))
-                    {
-                        typeDefHandleToken = typeDefHandle;
-                        break;
-                    }
-                }
 
-                Debug.Assert(typeDefHandleToken != default);
-
-                return string.Format("{0}([{1}]Interface type token 0x{2:X8}  Method token 0x{3:X8})",
+                return string.Format("{0}([{1}]0x{2:X8})",
                                     methodDesc,
                                     module,
-                                    reader.GetToken(typeDefHandleToken),
                                     reader.GetToken(((EcmaMethod)methodDesc.GetTypicalMethodDefinition()).Handle));
             }
             else

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -140,7 +140,6 @@ namespace Internal.TypeVerifier
             }
 
             Debug.Fail("ModuleNotFound");
-
             return "ModuleNotFound";
         }
 
@@ -158,21 +157,12 @@ namespace Internal.TypeVerifier
 
         private string GetModule(MethodDesc methodDesc)
         {
-            if (methodDesc is MethodForInstantiatedType methodForInstantiatedType)
+            if (methodDesc.GetMethodDefinition().OwningType is MetadataType metadataType)
             {
-                if (methodForInstantiatedType.OwningType is InstantiatedType instantiatedType)
-                {
-                    return instantiatedType.Module.ToString();
-                }
-            }
-
-            if (methodDesc is EcmaMethod ecmaMethod)
-            {
-                return ecmaMethod.Module.ToString();
+                return metadataType.Module.ToString();
             }
 
             Debug.Fail("ModuleNotFound");
-
             return "ModuleNotFound";
         }
 

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -63,7 +63,6 @@ namespace Internal.TypeVerifier
 
             // Look for duplicates and prepare distinct list of implemented interfaces to avoid 
             // subsequent error duplication
-            VirtualMethodAlgorithm virtualMethodAlg = _typeSystemContext.GetVirtualMethodAlgorithmForType(type);
             List<InterfaceMetadataObjects> implementedInterfaces = new List<InterfaceMetadataObjects>();
             foreach (InterfaceImplementationHandle interfaceHandle in interfaceHandles)
             {
@@ -77,8 +76,7 @@ namespace Internal.TypeVerifier
                 InterfaceMetadataObjects imo = new InterfaceMetadataObjects
                 {
                     DefType = interfaceType,
-                    InterfaceImplementation = interfaceImplementation,
-                    InterfaceImplementationHandle = interfaceHandle
+                    InterfaceImplementation = interfaceImplementation
                 };
 
                 if (!implementedInterfaces.Contains(imo))
@@ -171,7 +169,6 @@ namespace Internal.TypeVerifier
         {
             public DefType DefType { get; set; }
             public InterfaceImplementation InterfaceImplementation { set; get; }
-            public InterfaceImplementationHandle InterfaceImplementationHandle { get; set; }
             public bool Equals(InterfaceMetadataObjects other)
             {
                 return other.DefType == DefType;

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -77,6 +77,7 @@ namespace Internal.TypeVerifier
                 InterfaceMetadataObjects imo = new InterfaceMetadataObjects
                 {
                     DefType = interfaceType,
+                    InterfaceImplementation = interfaceImplementation,
                     InterfaceImplementationHandle = interfaceHandle
                 };
 
@@ -86,7 +87,7 @@ namespace Internal.TypeVerifier
                 }
                 else
                 {
-                    VerificationError(VerifierError.InterfaceImplHasDuplicate, Format(type), Format(imo.DefType, imo.InterfaceImplementationHandle));
+                    VerificationError(VerifierError.InterfaceImplHasDuplicate, Format(type), Format(imo.DefType, imo.InterfaceImplementation));
                 }
             }
 
@@ -100,7 +101,7 @@ namespace Internal.TypeVerifier
                         MethodDesc resolvedMethod = type.ResolveInterfaceMethodTarget(method);
                         if (resolvedMethod is null)
                         {
-                            VerificationError(VerifierError.InterfaceMethodNotImplemented, Format(type), Format(implementedInterface.DefType, implementedInterface.InterfaceImplementationHandle), Format(method));
+                            VerificationError(VerifierError.InterfaceMethodNotImplemented, Format(type), Format(implementedInterface.DefType, implementedInterface.InterfaceImplementation), Format(method));
                         }
                     }
                 }
@@ -119,12 +120,12 @@ namespace Internal.TypeVerifier
             }
         }
 
-        private string Format(DefType defType, InterfaceImplementationHandle interfaceImplementationHandle)
+        private string Format(DefType defType, InterfaceImplementation interfaceImplementation)
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
 
-                return string.Format("{0}([{1}]0x{2:X8})", defType, GetModule(defType), _module.MetadataReader.GetToken(interfaceImplementationHandle));
+                return string.Format("{0}([{1}]0x{2:X8})", defType, GetModule(defType), _module.MetadataReader.GetToken(interfaceImplementation.Interface));
             }
             else
             {
@@ -169,6 +170,7 @@ namespace Internal.TypeVerifier
         private class InterfaceMetadataObjects : IEquatable<InterfaceMetadataObjects>
         {
             public DefType DefType { get; set; }
+            public InterfaceImplementation InterfaceImplementation { set; get; }
             public InterfaceImplementationHandle InterfaceImplementationHandle { get; set; }
             public bool Equals(InterfaceMetadataObjects other)
             {

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -110,7 +110,7 @@ namespace Internal.TypeVerifier
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
-                return $"{type.ToString()}(0x{_module.MetadataReader.GetToken(type.Handle)})";
+                return $"{type}(0x{_module.MetadataReader.GetToken(type.Handle)})";
             }
             else
             { 
@@ -122,7 +122,7 @@ namespace Internal.TypeVerifier
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
-                return $"{defType.ToString()}(0x{_module.MetadataReader.GetToken(interfaceImplementationHandle)})";
+                return $"{defType}(0x{_module.MetadataReader.GetToken(interfaceImplementationHandle)})";
             }
             else
             {
@@ -134,7 +134,7 @@ namespace Internal.TypeVerifier
         {
             if (_verifierOptions.IncludeMetadataTokensInErrorMessages)
             {
-                return $"{methodDesc.ToString()}(0x{_module.MetadataReader.GetToken(methodDesc.IsTypicalMethodDefinition ? ((EcmaMethod)methodDesc).Handle : ((EcmaMethod)methodDesc.GetTypicalMethodDefinition()).Handle)})";
+                return $"{methodDesc}(0x{_module.MetadataReader.GetToken(methodDesc.IsTypicalMethodDefinition ? ((EcmaMethod)methodDesc).Handle : ((EcmaMethod)methodDesc.GetTypicalMethodDefinition()).Handle)})";
             }
             else
             {

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -145,7 +145,7 @@ namespace Internal.TypeVerifier
         private class InterfaceMetadataObjects : IEquatable<InterfaceMetadataObjects>
         {
             public DefType DefType { get; set; }
-            public InterfaceImplementationHandle InterfaceImplementationHandle { set; get; }
+            public InterfaceImplementationHandle InterfaceImplementationHandle { get; set; }
             public bool Equals(InterfaceMetadataObjects other)
             {
                 return other.DefType == DefType;

--- a/src/ILVerification/src/TypeVerifier.cs
+++ b/src/ILVerification/src/TypeVerifier.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using ILVerify;


### PR DESCRIPTION
contributes to https://github.com/dotnet/corert/issues/6694
without `-t`
```
Error: Class implements interface but not method, Class: '[InterfaceImplementation]MissingMethod_InvalidType_InterfaceMethodNotImplemented' Interface: '[InterfaceDefinition]Interface' Method: [InterfaceDefinition]Interface.M1().
```
with `-t`
```
Error: Class implements interface but not method, Class: '[InterfaceImplementation]MissingMethod_InvalidType_InterfaceMethodNotImplemented(0x33554436)' Interface: '[InterfaceDefinition]Interface(0x150994948)' Method: '[InterfaceDefinition]Interface.M1()(0x100663297)'.
```

/cc @jkotas 