### PR TITLE
Add cross-targeting support to ObjectWriter

### DIFF
--- a/Documentation/how-to-build-ObjectWriter.md
+++ b/Documentation/how-to-build-ObjectWriter.md
@@ -39,7 +39,8 @@ The following manual steps are useful for troubleshooting ObjWriter build issues
     cmake --build . -j 10 --config Release --target install
     cd install/bin
     ```
-    On Windows add the following arguments `-G "Visual Studio 14 2015 Win64" -Thost=x64` to `cmake` configuration command (not the one with `--build`)
+    On Windows add the following arguments `-G "Visual Studio 15 2017 Win64" -Thost=x64` to `cmake` configuration command (not the one with `--build`)
+    Note that `-j 10` on `cmake --build .` is requiring cmake `3.12+`
 
 * For ARM(cross/non-cross) please specify Triple for LLVM as Cmake configuration option:
     ```

--- a/Documentation/how-to-build-ObjectWriter.md
+++ b/Documentation/how-to-build-ObjectWriter.md
@@ -39,8 +39,8 @@ The following manual steps are useful for troubleshooting ObjWriter build issues
     cmake --build . -j 10 --config Release --target install
     cd install/bin
     ```
-    On Windows add the following arguments `-G "Visual Studio 15 2017 Win64" -Thost=x64` to `cmake` configuration command (not the one with `--build`)
-    Note that `-j 10` on `cmake --build .` is requiring cmake `3.12+`
+    On Windows add the following arguments `-G "Visual Studio 15 2017 Win64" -Thost=x64` to `cmake` configuration command (not the one with `--build`).
+    Note that `-j 10` on `cmake --build .` requires cmake `3.12+`.
 
 * For ARM(cross/non-cross) please specify Triple for LLVM as Cmake configuration option:
     ```

--- a/Documentation/how-to-build-ObjectWriter.md
+++ b/Documentation/how-to-build-ObjectWriter.md
@@ -35,10 +35,11 @@ The following manual steps are useful for troubleshooting ObjWriter build issues
     ```
     mkdir build
     cd build
-    cmake ../ -DCMAKE_BUILD_TYPE=Release -DLLVM_OPTIMIZED_TABLEGEN=1 -DHAVE_POSIX_SPAWN=0 -DLLVM_ENABLE_PIC=1 -DLLVM_BUILD_TESTS=0 -DLLVM_ENABLE_DOXYGEN=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_TESTS=0
-    make -j10 objwriter
-    cd ..
+    cmake ../ -DCMAKE_BUILD_TYPE=Release -DLLVM_OPTIMIZED_TABLEGEN=1 -DHAVE_POSIX_SPAWN=0 -DLLVM_ENABLE_PIC=1 -DLLVM_BUILD_TESTS=0 -DLLVM_ENABLE_DOXYGEN=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_TESTS=0 -DLLVM_TARGETS_TO_BUILD="ARM;X86;AArch64" -DCMAKE_INSTALL_PREFIX=install -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly
+    cmake --build . -j 10 --config Release --target install
+    cd install/bin
     ```
+    On Windows add the following arguments `-G "Visual Studio 14 2015 Win64" -Thost=x64` to `cmake` configuration command (not the one with `--build`)
 
 * For ARM(cross/non-cross) please specify Triple for LLVM as Cmake configuration option:
     ```

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1208,7 +1208,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             // We create a triple based on the Target
             // Detect the LLVM arch
-            string arch = null;
+            string arch;
             // Not used
             string sub = string.Empty;
             switch (target.Architecture)
@@ -1232,9 +1232,9 @@ namespace ILCompiler.DependencyAnalysis
                     throw new InvalidOperationException($"The architecture `{target.Architecture}` is not supported by ObjectWriter");
             }
 
-            string vendor = null;
-            string sys = null;
-            string abi = null;
+            string vendor;
+            string sys;
+            string abi;
             switch (target.OperatingSystem)
             {
                 case TargetOS.Windows:
@@ -1245,10 +1245,8 @@ namespace ILCompiler.DependencyAnalysis
                 case TargetOS.Linux:
                 case TargetOS.FreeBSD:
                 case TargetOS.NetBSD:
-                    // TODO: vendor for ARM/ARM64 could be changed? We might need another information in TargetDetails to make a decision
                     vendor = "pc";
                     sys = "linux";
-                    // TODO: same for ARM/ARM64, quid of gnueabi?
                     abi = "elf";
                     break;
                 case TargetOS.OSX:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1207,6 +1207,7 @@ namespace ILCompiler.DependencyAnalysis
         private static string GetLLVMTripleFromTarget(TargetDetails target)
         {
             // We create a triple based on the Target
+            // See https://clang.llvm.org/docs/CrossCompilation.html#target-triple
             // Detect the LLVM arch
             string arch;
             // Not used

--- a/src/Native/ObjWriter/objwriter.cpp
+++ b/src/Native/ObjWriter/objwriter.cpp
@@ -60,8 +60,8 @@ bool error(const Twine &Error) {
   return false;
 }
 
-void ObjectWriter::InitTripleName() {
-  TripleName = sys::getDefaultTargetTriple();
+void ObjectWriter::InitTripleName(const char* tripleName) {
+  TripleName = tripleName != nullptr ? tripleName : sys::getDefaultTargetTriple();
 }
 
 Triple ObjectWriter::GetTriple() {
@@ -77,16 +77,17 @@ Triple ObjectWriter::GetTriple() {
   return TheTriple;
 }
 
-bool ObjectWriter::Init(llvm::StringRef ObjectFilePath) {
+bool ObjectWriter::Init(llvm::StringRef ObjectFilePath, const char* tripleName) {
   llvm_shutdown_obj Y; // Call llvm_shutdown() on exit.
 
   // Initialize targets
-  InitializeNativeTarget();
-  InitializeNativeTargetAsmPrinter();
-
+  InitializeAllTargets();
+  InitializeAllTargetMCs();
+  InitializeAllAsmPrinters();
+  
   TargetMOptions = InitMCTargetOptionsFromFlags();
 
-  InitTripleName();
+  InitTripleName(tripleName);
   Triple TheTriple = GetTriple();
 
   // Get the target specific parser.

--- a/src/Native/ObjWriter/objwriter.h
+++ b/src/Native/ObjWriter/objwriter.h
@@ -50,7 +50,7 @@ enum class RelocType {
 
 class ObjectWriter {
 public:
-  bool Init(StringRef FunctionName);
+  bool Init(StringRef FunctionName, const char* tripleName = 0);
   void Finish();
 
   void SwitchSection(const char *SectionName,
@@ -136,7 +136,7 @@ private:
 
   void EmitCVUserDefinedTypesSymbols();
 
-  void InitTripleName();
+  void InitTripleName(const char* tripleName = nullptr);
   Triple GetTriple();
   unsigned GetDFSize();
   bool EmitRelocDirective(const int Offset, StringRef Name, const MCExpr *Expr);
@@ -180,9 +180,9 @@ private:
 
 // When object writer is created/initialized successfully, it is returned.
 // Or null object is returned. Client should check this.
-DLL_EXPORT ObjectWriter *InitObjWriter(const char *ObjectFilePath) {
+DLL_EXPORT ObjectWriter *InitObjWriter(const char *ObjectFilePath, const char* tripleName = 0) {
   ObjectWriter *OW = new ObjectWriter();
-  if (OW->Init(ObjectFilePath)) {
+  if (OW->Init(ObjectFilePath, tripleName)) {
     return OW;
   }
   delete OW;

--- a/src/Native/ObjWriter/objwriter.h
+++ b/src/Native/ObjWriter/objwriter.h
@@ -180,9 +180,9 @@ private:
 
 // When object writer is created/initialized successfully, it is returned.
 // Or null object is returned. Client should check this.
-DLL_EXPORT ObjectWriter *InitObjWriter(const char *ObjectFilePath, const char* tripleName = nullptr) {
+DLL_EXPORT ObjectWriter *InitObjWriter(const char *ObjectFilePath, const char* TripleName = nullptr) {
   ObjectWriter *OW = new ObjectWriter();
-  if (OW->Init(ObjectFilePath, tripleName)) {
+  if (OW->Init(ObjectFilePath, TripleName)) {
     return OW;
   }
   delete OW;

--- a/src/Native/ObjWriter/objwriter.h
+++ b/src/Native/ObjWriter/objwriter.h
@@ -50,7 +50,7 @@ enum class RelocType {
 
 class ObjectWriter {
 public:
-  bool Init(StringRef FunctionName, const char* tripleName = 0);
+  bool Init(StringRef FunctionName, const char* tripleName = nullptr);
   void Finish();
 
   void SwitchSection(const char *SectionName,
@@ -180,7 +180,7 @@ private:
 
 // When object writer is created/initialized successfully, it is returned.
 // Or null object is returned. Client should check this.
-DLL_EXPORT ObjectWriter *InitObjWriter(const char *ObjectFilePath, const char* tripleName = 0) {
+DLL_EXPORT ObjectWriter *InitObjWriter(const char *ObjectFilePath, const char* tripleName = nullptr) {
   ObjectWriter *OW = new ObjectWriter();
   if (OW->Init(ObjectFilePath, tripleName)) {
     return OW;


### PR DESCRIPTION
This PR is for the following item from issue #2606 

> - [ ]  Add cross-targeting support to ObjectWriter https://github.com/dotnet/llilc/tree/master/lib/ObjWriter (add a new argument to Initialize method to specify target platform)

It allows typically to generate ELF output from Windows directly

There is a TODO in this PR related to the ARM/ARM64 platforms/abi. It would require for example to add Tizen as a platform to be able to specify properly the `gnueabi`

cc: @jkotas  @alpencolt