### PR TITLE
Disable strongname signing for ILCompiler.Build.Tasks

### DIFF
--- a/src/ILCompiler.Build.Tasks/src/ILCompiler.Build.Tasks.csproj
+++ b/src/ILCompiler.Build.Tasks/src/ILCompiler.Build.Tasks.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>ILCompiler.Build.Tasks</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
     <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/tools</OutputPath>
+    <!-- Workaround for https://github.com/dotnet/corert/issues/6306 -->
+    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ComputeManagedAssemblies.cs" />


### PR DESCRIPTION
Workaround for https://github.com/dotnet/corert/issues/6306