### PR TITLE
Fix enumeration value of R2R helpers [Dbl|Flt][Rem|Round]

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
@@ -219,10 +219,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         READYTORUN_HELPER_Dbl2ULngOvf = 0xD7,
 
         // Floating point ops
-        READYTORUN_HELPER_DblRem = 0xE0,
-        READYTORUN_HELPER_FltRem = 0xE1,
-        READYTORUN_HELPER_DblRound = 0xE2,
-        READYTORUN_HELPER_FltRound = 0xE3,
+        READYTORUN_HELPER_FltRem = 0xE0,
+        READYTORUN_HELPER_DblRem = 0xE1,
+        READYTORUN_HELPER_FltRound = 0xE2,
+        READYTORUN_HELPER_DblRound = 0xE3,
 
         // Personality rountines
         READYTORUN_HELPER_PersonalityRoutine = 0xF0,


### PR DESCRIPTION
In accordance with my CoreCLR change 

https://github.com/dotnet/coreclr/pull/21836

I'm fixing the incorrect enumeration values we inherited
from an old typo in CoreCLR. This change seems to fix
about a dozen CoreCLR Pri#0 tests.

Thanks

Tomas