### PR TITLE
Fix data blob offset for dynamic statics

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -77,14 +77,14 @@ namespace ILCompiler
             private const int ThreadLocalModuleDataBlobOffsetAsIntPtrCount = 3;
 
             /// <summary>
-            /// CoreCLR DomainLocalModule::NormalDynamicEntry::OffsetOfDataBlob for 32-bit platforms
+            /// CoreCLR DomainLocalModule::NormalDynamicEntry::OffsetOfDataBlob for X86
             /// </summary>
-            private const int DomainLocalModuleNormalDynamicEntryOffsetOfDataBlob32Bit = 4;
+            private const int DomainLocalModuleNormalDynamicEntryOffsetOfDataBlobX86 = 4;
 
             /// <summary>
-            /// CoreCLR DomainLocalModule::NormalDynamicEntry::OffsetOfDataBlob for 64-bit platforms
+            /// CoreCLR DomainLocalModule::NormalDynamicEntry::OffsetOfDataBlob for Amd64
             /// </summary>
-            private const int DomainLocalModuleNormalDynamicEntryOffsetOfDataBlob64Bit = 16;
+            private const int DomainLocalModuleNormalDynamicEntryOffsetOfDataBlobAmd64 = 8;
 
             protected override bool CompareKeyToValue(EcmaModule key, ModuleFieldLayout value)
             {
@@ -306,14 +306,14 @@ namespace ILCompiler
                 if (!moduleFieldLayout.TryGetDynamicLayout(defType, out fieldsForType))
                 {
                     int nonGcOffset;
-                    switch (moduleFieldLayout.Module.Context.Target.PointerSize)
+                    switch (moduleFieldLayout.Module.Context.Target.Architecture)
                     {
-                        case 4:
-                            nonGcOffset = DomainLocalModuleNormalDynamicEntryOffsetOfDataBlob32Bit;
+                        case TargetArchitecture.X86:
+                            nonGcOffset = DomainLocalModuleNormalDynamicEntryOffsetOfDataBlobX86;
                             break;
 
-                        case 8:
-                            nonGcOffset = DomainLocalModuleNormalDynamicEntryOffsetOfDataBlob64Bit;
+                        case TargetArchitecture.X64:
+                            nonGcOffset = DomainLocalModuleNormalDynamicEntryOffsetOfDataBlobAmd64;
                             break;
 
                         default:


### PR DESCRIPTION
In my initial implementation of dynamic statics, I misread the code
in DomainLocalModule::NormalDynamicEntry as I incorrectly thought
that FEATURE_64BIT_ALIGNMENT would be set for AMD64. This is wrong,
the flag is only used on ARM32 where it makes sure that the data
blob starts at an 8-byte boundary. This also implies that the constants
must be per architecture, not per pointer size. This change seems to be
fixing almost a hundred CoreCLR Pri#0 test failures.

Thanks

Tomas