### PR TITLE
Mark monitor helpers as requiring runtime JIT

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -496,11 +496,12 @@ namespace ILCompiler.DependencyAnalysis
                     r2rHelper = ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_FltRound;
                     break;
 
-                case ILCompiler.ReadyToRunHelper.GetRefAny:
-                    // TODO-PERF: currently not implemented in Crossgen
-                    ThrowHelper.ThrowInvalidProgramException();
-                    // ThrowInvalidProgramException should never return
-                    throw new NotImplementedException();
+                case ILCompiler.ReadyToRunHelper.MonitorEnter:
+                case ILCompiler.ReadyToRunHelper.MonitorExit:
+                case ILCompiler.ReadyToRunHelper.MonitorEnterStatic:
+                case ILCompiler.ReadyToRunHelper.MonitorExitStatic:
+                case ILCompiler.ReadyToRunHelper.GetRefAny: // TODO-PERF: currently not implemented in Crossgen
+                    throw new RequiresRuntimeJitException(helper.ToString());
 
                 // JIT32 x86-specific write barriers
                 case ILCompiler.ReadyToRunHelper.WriteBarrier_EAX:


### PR DESCRIPTION
In accordance with Crossgen behavior I am blocking out the
Monitor-related R2R helpers as requiring runtime JIT.

Thanks

Tomas