### PR TITLE
Generic lookup fixes

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -30,6 +30,7 @@ namespace ILCompiler.DependencyAnalysis
         // The following helpers are used for generic lookups only
         TypeHandle,
         NecessaryTypeHandle,
+        DeclaringTypeHandle,
         MethodHandle,
         FieldHandle,
         MethodDictionary,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
@@ -25,13 +25,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         CORCOMPILE_IMPORT_FLAGS_PCODE = 0x0004,   // Section contains pointers to code.
     }
 
-    public static class CorInfoRuntimeLookup
-    {
-        // CORINFO_RUNTIME_LOOKUP indicates the details of the runtime lookup
-        // operation to be performed.
-        public const ushort CORINFO_USEHELPER = 0xffff;
-    }
-
     /// <summary>
     /// Constants for method and field encoding
     /// </summary>

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
@@ -25,6 +25,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         CORCOMPILE_IMPORT_FLAGS_PCODE = 0x0004,   // Section contains pointers to code.
     }
 
+    public static class CorInfoRuntimeLookup
+    {
+        // CORINFO_RUNTIME_LOOKUP indicates the details of the runtime lookup
+        // operation to be performed.
+        public const ushort CORINFO_USEHELPER = 0xffff;
+    }
+
     /// <summary>
     /// Constants for method and field encoding
     /// </summary>

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -20,6 +20,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly MethodWithToken _methodArgument;
 
+        private readonly FieldDesc _fieldArgument;
+
         private readonly GenericContext _methodContext;
 
         private readonly SignatureContext _signatureContext;
@@ -29,6 +31,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ReadyToRunFixupKind fixupKind, 
             TypeDesc typeArgument, 
             MethodWithToken methodArgument,
+            FieldDesc fieldArgument,
             GenericContext methodContext,
             SignatureContext signatureContext)
         {
@@ -36,6 +39,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _fixupKind = fixupKind;
             _typeArgument = typeArgument;
             _methodArgument = methodArgument;
+            _fieldArgument = fieldArgument;
             _methodContext = methodContext;
             _signatureContext = signatureContext;
         }
@@ -85,6 +89,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         context: _signatureContext,
                         isUnboxingStub: false,
                         isInstantiatingStub: true);
+                }
+                else if (_fieldArgument != null)
+                {
+                    dataBuilder.EmitFieldSignature(_fieldArgument, _signatureContext);
                 }
                 else
                 {

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -481,6 +481,16 @@ namespace ILCompiler.DependencyAnalysis
                             (TypeDesc)helperKey.Target,
                             InputModuleContext));
 
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    return new DelayLoadHelperImport(
+                        this,
+                        HelperImports,
+                        ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GenericNonGcStaticBase,
+                        new TypeFixupSignature(
+                            ReadyToRunFixupKind.READYTORUN_FIXUP_Invalid,
+                            (TypeDesc)helperKey.Target,
+                            InputModuleContext));
+
                 default:
                     throw new NotImplementedException();
             }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -448,52 +448,57 @@ namespace ILCompiler.DependencyAnalysis
             throw new NotImplementedException();
         }
 
-        protected override ISymbolNode CreateGenericLookupFromDictionaryNode(ReadyToRunGenericHelperKey helperKey)
+        private ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper GetGenericStaticHelper(ReadyToRunHelperId helperId)
         {
-            switch (helperKey.HelperId)
+            ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper r2rHelper;
+
+            switch (helperId)
             {
                 case ReadyToRunHelperId.GetGCStaticBase:
-                    return new DelayLoadHelperImport(
-                        this,
-                        HelperImports,
-                        ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GenericGcStaticBase,
-                        new TypeFixupSignature(
-                            ReadyToRunFixupKind.READYTORUN_FIXUP_Invalid,
-                            (TypeDesc)helperKey.Target,
-                            InputModuleContext));
+                    r2rHelper = ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GenericGcStaticBase;
+                    break;
+
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    r2rHelper = ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GenericNonGcStaticBase;
+                    break;
+
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    r2rHelper = ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GenericGcTlsBase;
+                    break;
+
+                case ReadyToRunHelperId.GetThreadNonGcStaticBase:
+                    r2rHelper = ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GenericNonGcTlsBase;
+                    break;
 
                 default:
                     throw new NotImplementedException();
             }
+
+            return r2rHelper;
+        }
+
+        protected override ISymbolNode CreateGenericLookupFromDictionaryNode(ReadyToRunGenericHelperKey helperKey)
+        {
+            return new DelayLoadHelperImport(
+                this,
+                HelperImports,
+                GetGenericStaticHelper(helperKey.HelperId),
+                new TypeFixupSignature(
+                    ReadyToRunFixupKind.READYTORUN_FIXUP_Invalid,
+                    (TypeDesc)helperKey.Target,
+                    InputModuleContext));
         }
 
         protected override ISymbolNode CreateGenericLookupFromTypeNode(ReadyToRunGenericHelperKey helperKey)
         {
-            switch (helperKey.HelperId)
-            {
-                case ReadyToRunHelperId.GetGCStaticBase:
-                    return new DelayLoadHelperImport(
-                        this,
-                        HelperImports,
-                        ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GenericGcStaticBase,
-                        new TypeFixupSignature(
-                            ReadyToRunFixupKind.READYTORUN_FIXUP_Invalid,
-                            (TypeDesc)helperKey.Target,
-                            InputModuleContext));
-
-                case ReadyToRunHelperId.GetNonGCStaticBase:
-                    return new DelayLoadHelperImport(
-                        this,
-                        HelperImports,
-                        ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GenericNonGcStaticBase,
-                        new TypeFixupSignature(
-                            ReadyToRunFixupKind.READYTORUN_FIXUP_Invalid,
-                            (TypeDesc)helperKey.Target,
-                            InputModuleContext));
-
-                default:
-                    throw new NotImplementedException();
-            }
+            return new DelayLoadHelperImport(
+                this,
+                HelperImports,
+                GetGenericStaticHelper(helperKey.HelperId),
+                new TypeFixupSignature(
+                    ReadyToRunFixupKind.READYTORUN_FIXUP_Invalid,
+                    (TypeDesc)helperKey.Target,
+                    InputModuleContext));
         }
 
         private Dictionary<string, SectionStartNode> _sectionStartNodes = new Dictionary<string, SectionStartNode>();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/RuntimeDeterminedTypeHelper.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/RuntimeDeterminedTypeHelper.cs
@@ -109,6 +109,17 @@ namespace ILCompiler
             return true;
         }
 
+        public static bool Equals(FieldDesc field1, FieldDesc field2)
+        {
+            if (field1 == null || field2 == null)
+            {
+                return field1 == null && field2 == null;
+            }
+            return field1.Name == field2.Name &&
+                RuntimeDeterminedTypeHelper.Equals(field1.OwningType, field2.OwningType) &&
+                RuntimeDeterminedTypeHelper.Equals(field1.FieldType, field2.FieldType);
+        }
+
         public static int GetHashCode(Instantiation instantiation)
         {
             int hashcode = unchecked(instantiation.Length << 24);
@@ -134,6 +145,11 @@ namespace ILCompiler
         {
             return unchecked(GetHashCode(method.OwningType) + 97 * (
                 method.GetTypicalMethodDefinition().GetHashCode() + 31 * GetHashCode(method.Instantiation)));
+        }
+
+        public static int GetHashCode(FieldDesc field)
+        {
+            return unchecked(GetHashCode(field.OwningType) + 97 * GetHashCode(field.FieldType) + 31 * field.Name.GetHashCode());
         }
 
         public static void WriteTo(Instantiation instantiation, Utf8StringBuilder sb)

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -99,47 +99,49 @@ namespace Internal.JitInterface
             if (_compilation.NeedsRuntimeLookup(helperId, entity))
             {
                 lookup.lookupKind.needsRuntimeLookup = true;
+
                 lookup.runtimeLookup.signature = null;
 
                 MethodDesc contextMethod = methodFromContext(pResolvedToken.tokenContext);
 
                 // Do not bother computing the runtime lookup if we are inlining. The JIT is going
                 // to abort the inlining attempt anyway.
-                if (contextMethod != MethodBeingCompiled)
-                    return;
-
-                GenericDictionaryLookup genericLookup = _compilation.ComputeGenericLookup(contextMethod, helperId, entity);
-
-                if (genericLookup.UseHelper)
+                if (contextMethod != _methodCodeNode.Method)
                 {
-                    lookup.runtimeLookup.indirections = CORINFO.USEHELPER;
-                    lookup.lookupKind.runtimeLookupFlags = (ushort)genericLookup.HelperId;
-                    lookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(genericLookup.HelperObject);
+                    return;
+                }
+
+                // There is a pathological case where invalid IL refereces __Canon type directly, but there is no dictionary availabled to store the lookup. 
+                // All callers of ComputeRuntimeLookupForSharedGenericToken have to filter out this case. We can't do much about it here.
+                Debug.Assert(contextMethod.IsSharedByGenericInstantiations);
+
+                if (contextMethod.RequiresInstMethodDescArg())
+                {
+                    lookup.lookupKind.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_METHODPARAM;
                 }
                 else
                 {
-                    if (genericLookup.ContextSource == GenericContextSource.MethodParameter)
+                    if (contextMethod.RequiresInstMethodTableArg())
                     {
-                        lookup.runtimeLookup.helper = CorInfoHelpFunc.CORINFO_HELP_RUNTIMEHANDLE_METHOD;
+                        lookup.lookupKind.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_CLASSPARAM;
                     }
                     else
                     {
-                        lookup.runtimeLookup.helper = CorInfoHelpFunc.CORINFO_HELP_RUNTIMEHANDLE_CLASS;
+                        lookup.lookupKind.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_THISOBJ;
                     }
-
-                    lookup.runtimeLookup.indirections = (ushort)genericLookup.NumberOfIndirections;
-                    lookup.runtimeLookup.offset0 = (IntPtr)genericLookup[0];
-                    if (genericLookup.NumberOfIndirections > 1)
-                        lookup.runtimeLookup.offset1 = (IntPtr)genericLookup[1];
-                    lookup.runtimeLookup.testForFixup = false; // TODO: this will be needed in true multifile
-                    lookup.runtimeLookup.testForNull = false;
-                    lookup.runtimeLookup.indirectFirstOffset = false;
-                    lookup.runtimeLookup.indirectSecondOffset = false;
-                    lookup.lookupKind.runtimeLookupFlags = 0;
-                    lookup.lookupKind.runtimeLookupArgs = null;
                 }
 
-                lookup.lookupKind.runtimeLookupKind = GetLookupKindFromContextSource(genericLookup.ContextSource);
+                // Unless we decide otherwise, just do the lookup via a helper function
+                lookup.runtimeLookup.indirections = CORINFO.USEHELPER;
+
+                lookup.lookupKind.runtimeLookupFlags = (ushort)helperId;
+                lookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(entity);
+
+                lookup.runtimeLookup.indirectFirstOffset = false;
+                lookup.runtimeLookup.indirectSecondOffset = false;
+
+                // For R2R compilations, we don't generate the dictionary lookup signatures (dictionary lookups are done in a 
+                // different way that is more version resilient... plus we can't have pointers to existing MTs/MDs in the sigs)
             }
             else
             {
@@ -728,62 +730,6 @@ namespace Internal.JitInterface
                 }
             }
             return false;
-        }
-
-        private void ComputeRuntimeLookupForSharedGenericToken(
-            ReadyToRunHelperId entryKind,
-            ref CORINFO_RESOLVED_TOKEN pResolvedToken,
-            TypeSystemEntity target,
-            ref CORINFO_LOOKUP pResultLookup)
-        {
-            pResultLookup.lookupKind.needsRuntimeLookup = true;
-            pResultLookup.lookupKind.runtimeLookupFlags = 0;
-
-            pResultLookup.runtimeLookup.signature = null;
-
-            pResultLookup.runtimeLookup.indirectFirstOffset = false;
-            pResultLookup.runtimeLookup.indirectSecondOffset = false;
-
-            // Unless we decide otherwise, just do the lookup via a helper function
-            pResultLookup.runtimeLookup.indirections = CorInfoRuntimeLookup.CORINFO_USEHELPER;
-
-            MethodDesc contextMD = methodFromContext(pResolvedToken.tokenContext);
-            TypeDesc contextMT = contextMD.OwningType;
-
-            /* TODO - right now we don't have the method being compiled readily available
-            // Do not bother computing the runtime lookup if we are inlining. The JIT is going
-            // to abort the inlining attempt anyway.
-            if (contextMD != m_pMethodBeingCompiled)
-            {
-                return;
-            }
-            */
-
-            // There is a pathological case where invalid IL refereces __Canon type directly, but there is no dictionary availabled to store the lookup. 
-            // All callers of ComputeRuntimeLookupForSharedGenericToken have to filter out this case. We can't do much about it here.
-            Debug.Assert(contextMD.IsSharedByGenericInstantiations);
-
-            if (contextMD.RequiresInstMethodDescArg())
-            {
-                pResultLookup.lookupKind.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_METHODPARAM;
-            }
-            else
-            {
-                if (contextMD.RequiresInstMethodTableArg())
-                {
-                    pResultLookup.lookupKind.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_CLASSPARAM;
-                }
-                else
-                {
-                    pResultLookup.lookupKind.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_THISOBJ;
-                }
-            }
-
-            pResultLookup.lookupKind.runtimeLookupFlags = (ushort)entryKind;
-            pResultLookup.lookupKind.runtimeLookupArgs = (void *)ObjectToHandle(target);
-
-            // For R2R compilations, we don't generate the dictionary lookup signatures (dictionary lookups are done in a 
-            // different way that is more version resilient... plus we can't have pointers to existing MTs/MDs in the sigs)
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -338,6 +338,24 @@ namespace Internal.JitInterface
                     id = ReadyToRunHelper.Ldelema_Ref;
                     break;
 
+
+                case CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_GCSTATIC_BASE:
+                    id = ReadyToRunHelper.GenericGcStaticBase;
+                    break;
+
+                case CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_NONGCSTATIC_BASE:
+                    id = ReadyToRunHelper.GenericNonGcStaticBase;
+                    break;
+
+                case CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_GCTHREADSTATIC_BASE:
+                    id = ReadyToRunHelper.GenericGcTlsBase;
+                    break;
+
+                case CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_NONGCTHREADSTATIC_BASE:
+                    id = ReadyToRunHelper.GenericNonGcTlsBase;
+                    break;
+
+
                 case CorInfoHelpFunc.CORINFO_HELP_MEMSET:
                     id = ReadyToRunHelper.MemSet;
                     break;

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -111,7 +111,7 @@ namespace Internal.JitInterface
                     return;
                 }
 
-                // There is a pathological case where invalid IL refereces __Canon type directly, but there is no dictionary availabled to store the lookup. 
+                // There is a pathological case where invalid IL refereces __Canon type directly, but there is no dictionary available to store the lookup. 
                 // All callers of ComputeRuntimeLookupForSharedGenericToken have to filter out this case. We can't do much about it here.
                 Debug.Assert(contextMethod.IsSharedByGenericInstantiations);
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1979,8 +1979,24 @@ namespace Internal.JitInterface
                 else if (field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any))
                 {
                     // The JIT wants to know how to access a static field on a generic type. We need a runtime lookup.
+#if READYTORUN
+                    fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER;
+                    if (field.IsThreadStatic)
+                    {
+                        pResult->helper = (field.HasGCStaticBase ?
+                            CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_GCTHREADSTATIC_BASE:
+                            CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_NONGCTHREADSTATIC_BASE);
+                    }
+                    else
+                    {
+                        pResult->helper = (field.HasGCStaticBase ?
+                            CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_GCSTATIC_BASE:
+                            CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_NONGCSTATIC_BASE);
+                    }
+#else
                     fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_READYTORUN_HELPER;
                     pResult->helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE;
+#endif
 
                     // Don't try to compute the runtime lookup if we're inlining. The JIT is going to abort the inlining
                     // attempt anyway.

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1987,7 +1987,12 @@ namespace Internal.JitInterface
                     MethodDesc contextMethod = methodFromContext(pResolvedToken.tokenContext);
                     if (contextMethod == MethodBeingCompiled)
                     {
-                        FieldDesc runtimeDeterminedField = (FieldDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+                        FieldDesc runtimeDeterminedField;
+#if READYTORUN
+                        runtimeDeterminedField = field;
+#else
+                        runtimeDeterminedField = (FieldDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+#endif
 
                         ReadyToRunHelperId helperId;
 

--- a/tests/src/Simple/ReadyToRunUnit/Program.cs
+++ b/tests/src/Simple/ReadyToRunUnit/Program.cs
@@ -697,6 +697,80 @@ internal class Program
 
         return true;
     }
+    
+    class MyGen<T>
+    {
+        public static string GcValue;
+        public static int NonGcValue;
+        [ThreadStatic]
+        public static string TlsGcValue;
+        [ThreadStatic]
+        public static int TlsNonGcValue;
+    }
+
+    private static void SetGenericGcStatic<U, V>(string uValue, string vValue)
+    {
+        MyGen<U>.GcValue = uValue;
+        MyGen<V>.GcValue = vValue;
+    }
+
+    private static void SetGenericNonGcStatic<U, V>(int uValue, int vValue)
+    {
+        MyGen<U>.NonGcValue = uValue;
+        MyGen<V>.NonGcValue = vValue;
+    }
+
+    private static void SetGenericTlsGcStatic<U, V>(string uValue, string vValue)
+    {
+        MyGen<U>.TlsGcValue = uValue;
+        MyGen<V>.TlsGcValue = vValue;
+    }
+
+    private static void SetGenericTlsNonGcStatic<U, V>(int uValue, int vValue)
+    {
+        MyGen<U>.TlsNonGcValue = uValue;
+        MyGen<V>.TlsNonGcValue = vValue;
+    }
+
+    private static bool SharedGenericGcStaticTest()
+    {
+        string objectValue = "Hello";
+        string stringValue = "World";
+        SetGenericGcStatic<object, string>(objectValue, stringValue);
+        Console.WriteLine("Object GC value: {0}, expected {1}", MyGen<object>.GcValue, objectValue);
+        Console.WriteLine("String GC value: {0}, expected {1}", MyGen<string>.GcValue, stringValue);
+        return MyGen<object>.GcValue == objectValue && MyGen<string>.GcValue == stringValue;
+    }
+
+    private static bool SharedGenericNonGcStaticTest()
+    {
+        int objectValue = 42;
+        int stringValue = 666;
+        SetGenericNonGcStatic<object, string>(objectValue, stringValue);
+        Console.WriteLine("Object non-GC value: {0}, expected {1}", MyGen<object>.NonGcValue, objectValue);
+        Console.WriteLine("String non-GC value: {0}, expected {1}", MyGen<string>.NonGcValue, stringValue);
+        return MyGen<object>.NonGcValue == objectValue && MyGen<string>.NonGcValue == stringValue;
+    }
+
+    private static bool SharedGenericTlsGcStaticTest()
+    {
+        string objectValue = "Cpaot";
+        string stringValue = "Rules";
+        SetGenericTlsGcStatic<object, string>(objectValue, stringValue);
+        Console.WriteLine("Object TLS GC value: {0}, expected {1}", MyGen<object>.TlsGcValue, objectValue);
+        Console.WriteLine("String TLS GC value: {0}, expected {1}", MyGen<string>.TlsGcValue, stringValue);
+        return MyGen<object>.TlsGcValue == objectValue && MyGen<string>.TlsGcValue == stringValue;
+    }
+
+    private static bool SharedGenericTlsNonGcStaticTest()
+    {
+        int objectValue = 1234;
+        int stringValue = 5678;
+        SetGenericTlsNonGcStatic<object, string>(objectValue, stringValue);
+        Console.WriteLine("Object TLS non-GC value: {0}, expected {1}", MyGen<object>.TlsNonGcValue, objectValue);
+        Console.WriteLine("String TLS non-GC value: {0}, expected {1}", MyGen<string>.TlsNonGcValue, stringValue);
+        return MyGen<object>.TlsNonGcValue == objectValue && MyGen<string>.TlsNonGcValue == stringValue;
+    }
 
     static bool RVAFieldTest()
     {
@@ -764,6 +838,10 @@ internal class Program
         RunTest("VectorTest", VectorTest());
         RunTest("EnumHashValueTest", EnumHashValueTest());
         RunTest("RVAFieldTest", RVAFieldTest());
+        RunTest("SharedGenericGcStaticTest", SharedGenericGcStaticTest());
+        RunTest("SharedGenericNonGcStaticTest", SharedGenericNonGcStaticTest());
+        RunTest("SharedGenericTlsGcStaticTest", SharedGenericTlsGcStaticTest());
+        RunTest("SharedGenericTlsNonGcStaticTest", SharedGenericTlsNonGcStaticTest());
 
         Console.WriteLine($@"{_passedTests.Count} tests pass:");
         foreach (string testName in _passedTests)


### PR DESCRIPTION
1) Add new form of generic lookup for generic non-GC static base.

2) Stop back-translating canonical fields to their runtime
determined counterparts for the purpose of emitting R2R signatures.

These changes fix three Pri# 0 CoreCLR tests.

Thanks

Tomas