### PR TITLE
Fix ProjectN build break

### DIFF
--- a/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -7,6 +7,7 @@
 #endif // ENABLE_WINRT
 
 using Internal.Reflection.Augments;
+using Internal.Runtime.Augments;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
Using statement got deleted, but it's used in the WinRT code paths.