### PR TITLE
Remove the context cookie from method context

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -20,7 +20,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly MethodWithToken _methodArgument;
 
-        private readonly MethodContext _methodContext;
+        private readonly GenericContext _methodContext;
 
         private readonly SignatureContext _signatureContext;
 
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ReadyToRunFixupKind fixupKind, 
             TypeDesc typeArgument, 
             MethodWithToken methodArgument,
-            MethodContext methodContext,
+            GenericContext methodContext,
             SignatureContext signatureContext)
         {
             _runtimeLookupKind = runtimeLookupKind;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -123,14 +123,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 throw new NotImplementedException();
             }
-            if (_methodContext != null)
-            {
-                sb.Append(" (");
-                sb.Append(_methodContext.Method.ToString());
-                sb.Append(":0x");
-                sb.Append(_methodContext.Context.ToString());
-                sb.Append(")");
-            }
+            sb.Append(" (");
+            sb.Append(_methodContext.ToString());
+            sb.Append(")");
         }
 
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                     case CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_THISOBJ:
                         dataBuilder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_ThisObjDictionaryLookup);
-                        dataBuilder.EmitTypeSignature(_methodContext.Method.OwningType, _signatureContext);
+                        dataBuilder.EmitTypeSignature(_methodContext.ContextType, _signatureContext);
                         break;
 
                     default:

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -713,7 +713,7 @@ namespace ILCompiler.DependencyAnalysis
                     (int)FixupKind +
                     (TypeArgument != null ? 31 * RuntimeDeterminedTypeHelper.GetHashCode(TypeArgument) : 0) +
                     (MethodArgument != null ? 31 * RuntimeDeterminedTypeHelper.GetHashCode(MethodArgument.Method) : 0) +
-                    (MethodContext != null ? MethodContext.GetHashCode() : 0));
+                    MethodContext.GetHashCode());
             }
         }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -677,14 +677,14 @@ namespace ILCompiler.DependencyAnalysis
             public readonly ReadyToRunFixupKind FixupKind;
             public readonly TypeDesc TypeArgument;
             public readonly MethodWithToken MethodArgument;
-            public readonly MethodContext MethodContext;
+            public readonly GenericContext MethodContext;
 
             public GenericLookupKey(
                 CORINFO_RUNTIME_LOOKUP_KIND lookupKind,
                 ReadyToRunFixupKind fixupKind,
                 TypeDesc typeArgument,
                 MethodWithToken methodArgument,
-                MethodContext methodContext)
+                GenericContext methodContext)
             {
                 LookupKind = lookupKind;
                 FixupKind = fixupKind;
@@ -723,7 +723,7 @@ namespace ILCompiler.DependencyAnalysis
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunHelperId helperId,
             object helperArgument,
-            MethodContext methodContext,
+            GenericContext methodContext,
             SignatureContext signatureContext)
         {
             switch (helperId)
@@ -777,7 +777,7 @@ namespace ILCompiler.DependencyAnalysis
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunFixupKind fixupKind,
             TypeDesc typeArgument,
-            MethodContext methodContext,
+            GenericContext methodContext,
             SignatureContext signatureContext)
         {
             GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument, methodArgument: null, methodContext);
@@ -798,7 +798,7 @@ namespace ILCompiler.DependencyAnalysis
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunFixupKind fixupKind,
             MethodWithToken methodArgument,
-            MethodContext methodContext,
+            GenericContext methodContext,
             SignatureContext signatureContext)
         {
             GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument: null, methodArgument, methodContext);

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -29,29 +29,22 @@ namespace Internal.JitInterface
         }
     }
 
-    public class MethodContext
+    public struct MethodContext : IEquatable<MethodContext>
     {
         public readonly MethodDesc Method;
-        public readonly IntPtr Context;
 
-        public MethodContext(MethodDesc method, IntPtr context)
+        public MethodContext(MethodDesc method)
         {
             Method = method;
-            Context = context;
         }
 
-        public override bool Equals(object obj)
-        {
-            return obj is MethodContext other && Method == other.Method && Context == other.Context;
-        }
+        public bool Equals(MethodContext other) => Method == other.Method;
 
-        public override int GetHashCode()
-        {
-            int hashCode = -117376276;
-            hashCode = hashCode * -1521134295 + Method.GetHashCode();
-            hashCode = hashCode * -1521134295 + Context.GetHashCode();
-            return hashCode;
-        }
+        public override bool Equals(object obj) => obj is MethodContext other && Method == other.Method;
+
+        public override int GetHashCode() => Method.GetHashCode();
+
+        public override string ToString() => Method.ToString();
     }
 
     public class RequiresRuntimeJitException : Exception
@@ -221,7 +214,7 @@ namespace Internal.JitInterface
                         Debug.Assert(typeToInitialize.IsCanonicalSubtype(CanonicalFormKind.Any));
 
                         DefType helperArg = typeToInitialize.ConvertToSharedRuntimeDeterminedForm();
-                        MethodContext methodContext = new MethodContext(methodFromContext(pResolvedToken.tokenContext), new IntPtr(pResolvedToken.tokenContext));
+                        MethodContext methodContext = new MethodContext(methodFromContext(pResolvedToken.tokenContext));
                         ISymbolNode helper = _compilation.SymbolNodeFactory.GenericLookupHelper(
                             pGenericLookupKind.runtimeLookupKind,
                             ReadyToRunHelperId.GetNonGCStaticBase, 
@@ -241,7 +234,7 @@ namespace Internal.JitInterface
                         {
                             helperArg = new MethodWithToken(methodArg, new ModuleToken(_tokenContext, pResolvedToken.token));
                         }
-                        MethodContext methodContext = new MethodContext(methodFromContext(pResolvedToken.tokenContext), new IntPtr(pResolvedToken.tokenContext));
+                        MethodContext methodContext = new MethodContext(methodFromContext(pResolvedToken.tokenContext));
                         ISymbolNode helper = _compilation.SymbolNodeFactory.GenericLookupHelper(
                             pGenericLookupKind.runtimeLookupKind,
                             helperId,

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -29,7 +29,7 @@ namespace Internal.JitInterface
         }
     }
 
-    public struct MethodContext : IEquatable<MethodContext>
+    public struct GenericContext : IEquatable<GenericContext>
     {
         public readonly TypeSystemEntity Context;
 
@@ -37,14 +37,14 @@ namespace Internal.JitInterface
 
         public MethodDesc ContextMethod { get { return (MethodDesc)Context; } }
 
-        public MethodContext(TypeSystemEntity context)
+        public GenericContext(TypeSystemEntity context)
         {
             Context = context;
         }
 
-        public bool Equals(MethodContext other) => Context == other.Context;
+        public bool Equals(GenericContext other) => Context == other.Context;
 
-        public override bool Equals(object obj) => obj is MethodContext other && Context == other.Context;
+        public override bool Equals(object obj) => obj is GenericContext other && Context == other.Context;
 
         public override int GetHashCode() => Context.GetHashCode();
 
@@ -218,7 +218,7 @@ namespace Internal.JitInterface
                         Debug.Assert(typeToInitialize.IsCanonicalSubtype(CanonicalFormKind.Any));
 
                         DefType helperArg = typeToInitialize.ConvertToSharedRuntimeDeterminedForm();
-                        MethodContext methodContext = new MethodContext(entityFromContext(pResolvedToken.tokenContext));
+                        GenericContext methodContext = new GenericContext(entityFromContext(pResolvedToken.tokenContext));
                         ISymbolNode helper = _compilation.SymbolNodeFactory.GenericLookupHelper(
                             pGenericLookupKind.runtimeLookupKind,
                             ReadyToRunHelperId.GetNonGCStaticBase, 
@@ -238,7 +238,7 @@ namespace Internal.JitInterface
                         {
                             helperArg = new MethodWithToken(methodArg, new ModuleToken(_tokenContext, pResolvedToken.token));
                         }
-                        MethodContext methodContext = new MethodContext(entityFromContext(pResolvedToken.tokenContext));
+                        GenericContext methodContext = new GenericContext(entityFromContext(pResolvedToken.tokenContext));
                         ISymbolNode helper = _compilation.SymbolNodeFactory.GenericLookupHelper(
                             pGenericLookupKind.runtimeLookupKind,
                             helperId,

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -31,20 +31,24 @@ namespace Internal.JitInterface
 
     public struct MethodContext : IEquatable<MethodContext>
     {
-        public readonly MethodDesc Method;
+        public readonly TypeSystemEntity Context;
 
-        public MethodContext(MethodDesc method)
+        public TypeDesc ContextType { get { return (Context is MethodDesc contextAsMethod ? contextAsMethod.OwningType : (TypeDesc)Context); } }
+
+        public MethodDesc ContextMethod { get { return (MethodDesc)Context; } }
+
+        public MethodContext(TypeSystemEntity context)
         {
-            Method = method;
+            Context = context;
         }
 
-        public bool Equals(MethodContext other) => Method == other.Method;
+        public bool Equals(MethodContext other) => Context == other.Context;
 
-        public override bool Equals(object obj) => obj is MethodContext other && Method == other.Method;
+        public override bool Equals(object obj) => obj is MethodContext other && Context == other.Context;
 
-        public override int GetHashCode() => Method.GetHashCode();
+        public override int GetHashCode() => Context.GetHashCode();
 
-        public override string ToString() => Method.ToString();
+        public override string ToString() => Context.ToString();
     }
 
     public class RequiresRuntimeJitException : Exception
@@ -214,7 +218,7 @@ namespace Internal.JitInterface
                         Debug.Assert(typeToInitialize.IsCanonicalSubtype(CanonicalFormKind.Any));
 
                         DefType helperArg = typeToInitialize.ConvertToSharedRuntimeDeterminedForm();
-                        MethodContext methodContext = new MethodContext(methodFromContext(pResolvedToken.tokenContext));
+                        MethodContext methodContext = new MethodContext(entityFromContext(pResolvedToken.tokenContext));
                         ISymbolNode helper = _compilation.SymbolNodeFactory.GenericLookupHelper(
                             pGenericLookupKind.runtimeLookupKind,
                             ReadyToRunHelperId.GetNonGCStaticBase, 
@@ -234,7 +238,7 @@ namespace Internal.JitInterface
                         {
                             helperArg = new MethodWithToken(methodArg, new ModuleToken(_tokenContext, pResolvedToken.token));
                         }
-                        MethodContext methodContext = new MethodContext(methodFromContext(pResolvedToken.tokenContext));
+                        MethodContext methodContext = new MethodContext(entityFromContext(pResolvedToken.tokenContext));
                         ISymbolNode helper = _compilation.SymbolNodeFactory.GenericLookupHelper(
                             pGenericLookupKind.runtimeLookupKind,
                             helperId,

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -571,14 +571,7 @@ namespace Internal.JitInterface
 
         private TypeSystemEntity entityFromContext(CORINFO_CONTEXT_STRUCT* contextStruct)
         {
-            if (((ulong)contextStruct & (ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_MASK) == (ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_CLASS)
-            {
-                return HandleToObject((CORINFO_CLASS_STRUCT_*)((ulong)contextStruct & ~(ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_MASK));
-            }
-            else
-            {
-                return HandleToObject((CORINFO_METHOD_STRUCT_*)((ulong)contextStruct & ~(ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_MASK));
-            }
+            return (TypeSystemEntity)HandleToObject((IntPtr)((ulong)contextStruct & ~(ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_MASK));
         }
 
         private uint getMethodAttribsInternal(MethodDesc method)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -569,6 +569,18 @@ namespace Internal.JitInterface
             }
         }
 
+        private TypeSystemEntity entityFromContext(CORINFO_CONTEXT_STRUCT* contextStruct)
+        {
+            if (((ulong)contextStruct & (ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_MASK) == (ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_CLASS)
+            {
+                return HandleToObject((CORINFO_CLASS_STRUCT_*)((ulong)contextStruct & ~(ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_MASK));
+            }
+            else
+            {
+                return HandleToObject((CORINFO_METHOD_STRUCT_*)((ulong)contextStruct & ~(ulong)CorInfoContextFlags.CORINFO_CONTEXTFLAGS_MASK));
+            }
+        }
+
         private uint getMethodAttribsInternal(MethodDesc method)
         {
             CorInfoFlag result = 0;


### PR DESCRIPTION
Based on Michal's feedback I have removed the cookie from
MethodContext as unreliable for method context comparisons. Thanks
to this change I could carry out several additional simplifications
- I have changed MethodContext to be a struct and I simplified
its manipulation in the CPAOT code.

Thanks

Tomas