### PR TITLE
[CppCodeGen] Fix importing ldftn

### DIFF
--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2281,6 +2281,10 @@ namespace Internal.IL
                 }
                 else
                 {
+                    // pop object reference off the stack
+                    if (opCode == ILOpcode.ldvirtftn)
+                        _stack.Pop();
+
                     bool exactContextNeedsRuntimeLookup;
                     if (method.HasInstantiation)
                     {


### PR DESCRIPTION
In the case of ldvirtftn we should pop object off the stack. This patch fixes `InvalidProgramException` during compilation:
```
Common Language Runtime detected an invalid program. ([S.P.CoreLib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1<bool,System.__Canon>.get_MoveNextAction())
```