### PR TITLE
Fix IL scanning of unboxing thunks on byref-like generic types

### DIFF
--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -35,6 +35,7 @@ class Program
         TestNullableCasting.Run();
         TestMDArrayAddressMethod.Run();
         TestNativeLayoutGeneration.Run();
+        TestByRefLikeVTables.Run();
 #endif
         return 100;
     }
@@ -2180,6 +2181,33 @@ class Program
                 throw new Exception();
 
             if (!(((object)new Mine<object>()) is Nullable<Mine<object>>))
+                throw new Exception();
+        }
+    }
+
+    class TestByRefLikeVTables
+    {
+        class Atom<T> { }
+
+        ref struct RefStruct<T>
+        {
+            public override bool Equals(object o) => o is Atom<T[]>;
+            public override int GetHashCode() => 0;
+
+            public override string ToString()
+            {
+                return typeof(T).ToString();
+            }
+        }
+
+        public static void Run()
+        {
+            // This is a regression test making sure we can build a vtable for the byref-like type.
+            // The vtable is necessary for a generic dictionary lookup in the ToString method.
+            // Method bodies of Equals and GetHashCode become reachable through the magical
+            // "unboxing" thunks we generate for byref-like types, and only through them.
+            RefStruct<string> r = default;
+            if (r.ToString() != "System.String")
                 throw new Exception();
         }
     }


### PR DESCRIPTION
Fixes a compilation failure when compiling ASP.NET with `<RootAllApplicationAssemblies>true</RootAllApplicationAssemblies>`.

The fix is to mirror the dependency that the normal `MethodCodeNode` has for special unboxing thunks.