### PR TITLE
Don't fail compilation if a native file was an input

### DIFF
--- a/src/ILCompiler/src/ApplicationAssemblyRootProvider.cs
+++ b/src/ILCompiler/src/ApplicationAssemblyRootProvider.cs
@@ -36,7 +36,18 @@ namespace ILCompiler
 
         private void ProcessAssembly(string inputFile, IRootingServiceProvider rootProvider)
         {
-            var assembly = (EcmaModule)_context.ResolveAssembly(new AssemblyName(inputFile), false);
+            EcmaModule assembly;
+            try
+            {
+                assembly = (EcmaModule)_context.ResolveAssembly(new AssemblyName(inputFile), false);
+            }
+            catch (TypeSystemException.BadImageFormatException)
+            {
+                // Native files can sometimes end up in the input. It would be nice if they didn't, but
+                // it's pretty safe to just ignore them.
+                // See: https://github.com/dotnet/corert/issues/2785
+                return;
+            }
 
             if (FrameworkStringResourceBlockingPolicy.IsFrameworkAssembly(assembly))
                 return;


### PR DESCRIPTION
Sometimes we see garbage passed as input to ILC. This is normally ignored, but `--rootallapplicationassemblies` looks at all inputs.