### PR TITLE
Remove unused parameter to ReadyToRunHelperNode constructor

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ILScanNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ILScanNodeFactory.cs
@@ -70,7 +70,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
         {
-            return new ReadyToRunHelperNode(this, helperCall.HelperId, helperCall.Target);
+            return new ReadyToRunHelperNode(helperCall.HelperId, helperCall.Target);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -40,10 +40,10 @@ namespace ILCompiler.DependencyAnalysis
 
     public partial class ReadyToRunHelperNode : AssemblyStubNode, INodeWithDebugInfo
     {
-        private ReadyToRunHelperId _id;
-        private Object _target;
+        private readonly ReadyToRunHelperId _id;
+        private readonly Object _target;
 
-        public ReadyToRunHelperNode(NodeFactory factory, ReadyToRunHelperId id, Object target)
+        public ReadyToRunHelperNode(ReadyToRunHelperId id, Object target)
         {
             _id = id;
             _target = target;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
@@ -280,7 +280,7 @@ namespace ILCompiler
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
         {
-            return new ReadyToRunHelperNode(this, helperCall.HelperId, helperCall.Target);
+            throw new NotSupportedException();
         }
 
         public GCStaticDescRegionNode GCStaticDescRegion = new GCStaticDescRegionNode(

--- a/src/ILCompiler.CppCodeGen/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/DependencyAnalysis/CppCodegenNodeFactory.cs
@@ -53,8 +53,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
         {
-            // TODO: this is wrong: this returns an assembly stub node
-            return new ReadyToRunHelperNode(this, helperCall.HelperId, helperCall.Target);
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ILCompiler.RyuJit/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -67,7 +67,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
         {
-            return new ReadyToRunHelperNode(this, helperCall.HelperId, helperCall.Target);
+            return new ReadyToRunHelperNode(helperCall.HelperId, helperCall.Target);
         }
     }
 }

--- a/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
@@ -56,8 +56,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ISymbolNode CreateReadyToRunHelperNode(ReadyToRunHelperKey helperCall)
         {
-            // TODO: this is wrong: this returns an assembly stub node
-            return new ReadyToRunHelperNode(this, helperCall.HelperId, helperCall.Target);
+            throw new NotSupportedException();
         }
     }
 }


### PR DESCRIPTION
Became unnecessary after #6688. Should have done it then...

Also delete references to it from places that don't actually use it.