### PR TITLE
Enable support for lazy static constructors

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -98,10 +98,11 @@ namespace ILCompiler
 
         private SharedGenericsMode _genericsMode;
         
-        public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode)
+        public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode, bool supportsLazyCctors = false)
             : base(details)
         {
             _genericsMode = genericsMode;
+            _supportsLazyCctors = supportsLazyCctors;
 
             _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
 
@@ -130,7 +131,7 @@ namespace ILCompiler
         public override void SetSystemModule(ModuleDesc systemModule)
         {
             base.SetSystemModule(systemModule);
-            _supportsLazyCctors = systemModule.GetType("System.Runtime.CompilerServices", "ClassConstructorRunner", false) != null;
+            _supportsLazyCctors = _supportsLazyCctors || (systemModule.GetType("System.Runtime.CompilerServices", "ClassConstructorRunner", false) != null);
         }
 
         public override ModuleDesc ResolveAssembly(System.Reflection.AssemblyName name, bool throwIfNotFound)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -25,6 +25,7 @@ namespace ILCompiler.DependencyAnalysis
         GetThreadNonGcStaticBase,
         DelegateCtor,
         ResolveVirtualFunction,
+        CctorTrigger,
 
         // The following helpers are used for generic lookups only
         TypeHandle,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -99,8 +99,12 @@ namespace ILCompiler.DependencyAnalysis
                     helperNode = CreateDelegateCtorHelper((DelegateCreationInfo)target, signatureContext);
                     break;
 
+                case ReadyToRunHelperId.CctorTrigger:
+                    helperNode = CreateCctorTrigger((TypeDesc)target, signatureContext);
+                    break;
+
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException(id.ToString());
             }
 
             helperNodeMap.Add(target, helperNode);
@@ -211,6 +215,15 @@ namespace ILCompiler.DependencyAnalysis
         private ISymbolNode CreateDelegateCtorHelper(DelegateCreationInfo info, SignatureContext signatureContext)
         {
             return info.Constructor;
+        }
+
+        private ISymbolNode CreateCctorTrigger(TypeDesc type, SignatureContext signatureContext)
+        {
+            return new DelayLoadHelperImport(
+                _codegenNodeFactory,
+                _codegenNodeFactory.DispatchImports,
+                ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
+                new TypeFixupSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_CctorTrigger, type, signatureContext));
         }
 
         private readonly Dictionary<FieldDesc, ISymbolNode> _fieldAddressCache = new Dictionary<FieldDesc, ISymbolNode>();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -17,7 +17,7 @@ namespace ILCompiler
         private VectorFieldLayoutAlgorithm _vectorFieldLayoutAlgorithm;
 
         public ReadyToRunCompilerContext(TargetDetails details, SharedGenericsMode genericsMode)
-            : base(details, genericsMode)
+            : base(details, genericsMode, supportsLazyCctors: true)
         {
             _r2rFieldLayoutAlgorithm = new ReadyToRunMetadataFieldLayoutAlgorithm();
             _systemObjectFieldLayoutAlgorithm = new SystemObjectFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -205,29 +205,12 @@ namespace Internal.JitInterface
                         if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
                             return false;
 
-                        pLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.ReadyToRunHelper(ReadyToRunHelperId.GetNonGCStaticBase, type, _signatureContext));
+                        pLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.ReadyToRunHelper(ReadyToRunHelperId.CctorTrigger, type, _signatureContext));
                     }
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE:
-                    {
-                        // Token == 0 means "initialize this class". We only expect RyuJIT to call it for this case.
-                        Debug.Assert(pResolvedToken.token == 0 && pResolvedToken.tokenScope == null);
-                        Debug.Assert(pGenericLookupKind.needsRuntimeLookup);
-
-                        DefType typeToInitialize = (DefType)MethodBeingCompiled.OwningType;
-                        Debug.Assert(typeToInitialize.IsCanonicalSubtype(CanonicalFormKind.Any));
-
-                        DefType helperArg = typeToInitialize.ConvertToSharedRuntimeDeterminedForm();
-                        GenericContext methodContext = new GenericContext(entityFromContext(pResolvedToken.tokenContext));
-                        ISymbolNode helper = _compilation.SymbolNodeFactory.GenericLookupHelper(
-                            pGenericLookupKind.runtimeLookupKind,
-                            ReadyToRunHelperId.GetNonGCStaticBase, 
-                            helperArg, 
-                            methodContext, 
-                            _signatureContext);
-                        pLookup = CreateConstLookupToSymbol(helper);
-                    }
-                    break;
+                    // This helper is only used in CoreRT, not in the CoreCLR runtime
+                    throw new NotImplementedException(id.ToString());
                 case CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_HANDLE:
                     {
                         Debug.Assert(pGenericLookupKind.needsRuntimeLookup);


### PR DESCRIPTION
To emit code compatible with Crossgen in CPAOT, we need JIT to be
able to emit calls to lazy static constructors. Apart from enabling
support for lazy cctors as such, the change also adds the new
required helper and fixes CorInfoImpl.ReadyToRun where the helper
was previously incorrectly encoded - it didn't matter as it was
never called before I enabled the lazy cctor support.

Thanks

Tomas

P.S. With a combination of this and the GC ref map change, I have
received the first 100% passing local run of CoreCLR Top200 tests.