### PR TITLE
Enable detection of HW intrinsics

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/HardwareIntrinsicHelpers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/HardwareIntrinsicHelpers.cs
@@ -38,7 +38,7 @@ namespace ILCompiler
 
         public static MethodIL GetUnsupportedImplementationIL(MethodDesc method)
         {
-            if (method.Name == "IsSupported")
+            if (method.Name == "get_IsSupported")
             {
                 return new ILStubMethodIL(method,
                     new byte[] {

--- a/src/ILCompiler.Compiler/src/Compiler/HardwareIntrinsicHelpers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/HardwareIntrinsicHelpers.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+using Internal.IL;
+using Internal.IL.Stubs;
+
+namespace ILCompiler
+{
+    public static class HardwareIntrinsicHelpers
+    {
+        public static bool IsHardwareIntrinsic(MethodDesc method)
+        {
+            TypeDesc owningType = method.OwningType;
+
+            if (owningType.IsIntrinsic && owningType is MetadataType mdType)
+            {
+                TargetArchitecture targetArch = owningType.Context.Target.Architecture;
+
+                if (targetArch == TargetArchitecture.X64 || targetArch == TargetArchitecture.X86)
+                {
+                    mdType = (MetadataType)mdType.ContainingType ?? mdType;
+                    if (mdType.Namespace == "System.Runtime.Intrinsics.X86")
+                        return true;
+                }
+                else if (targetArch == TargetArchitecture.ARM64)
+                {
+                    if (mdType.Namespace == "System.Runtime.Intrinsics.Arm.Arm64")
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static MethodIL GetUnsupportedImplementationIL(MethodDesc method)
+        {
+            if (method.Name == "IsSupported")
+            {
+                return new ILStubMethodIL(method,
+                    new byte[] {
+                        (byte)ILOpcode.ldc_i4_0,
+                        (byte)ILOpcode.ret
+                    },
+                    Array.Empty<LocalVariableDefinition>(), null);
+            }
+
+            MethodDesc throwPnse = method.Context.GetHelperEntryPoint("ThrowHelpers", "ThrowPlatformNotSupportedException");
+
+            return new ILStubMethodIL(method,
+                    new byte[] {
+                        (byte)ILOpcode.call, 1, 0, 0, 0,
+                        (byte)ILOpcode.br_s, unchecked((byte)-7),
+                    },
+                    Array.Empty<LocalVariableDefinition>(),
+                    new object[] { throwPnse });
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ImportedNodeProvider.cs" />
     <Compile Include="Compiler\FrameworkStringResourceBlockingPolicy.cs" />
     <Compile Include="Compiler\GeneratingMetadataManager.cs" />
+    <Compile Include="Compiler\HardwareIntrinsicHelpers.cs" />
     <Compile Include="Compiler\InternalCompilerErrorException.cs" />
     <Compile Include="Compiler\ManifestResourceBlockingPolicy.cs" />
     <Compile Include="Compiler\NoManifestResourceBlockingPolicy.cs" />

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/CppWriter.cs
@@ -658,6 +658,9 @@ namespace ILCompiler.CppCodeGen
             if (methodIL == null)
                 return;
 
+            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))
+                methodIL = HardwareIntrinsicHelpers.GetUnsupportedImplementationIL(method);
+
             try
             {
                 var ilImporter = new ILImporter(_compilation, this, method, methodIL);

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Aes.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Aes.PlatformNotSupported.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Aes.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Aes.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
@@ -9,6 +13,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
     /// Arm64 CPU indicate support for this feature by setting
     /// ID_AA64ISAR0_EL1.AES is 1 or better
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public static class Aes
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.PlatformNotSupported.cs
@@ -1,6 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-
 
 namespace System.Runtime.Intrinsics.Arm.Arm64
 {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.cs
@@ -1,6 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-
 
 namespace System.Runtime.Intrinsics.Arm.Arm64
 {
@@ -9,6 +12,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
     ///
     /// These intrinsics are supported by all Arm64 CPUs
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public static class Base
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha1.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha1.PlatformNotSupported.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha1.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
@@ -9,6 +13,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
     /// Arm64 CPU indicate support for this feature by setting
     /// ID_AA64ISAR0_EL1.SHA1 is 1 or better
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public static class Sha1
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha256.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha256.PlatformNotSupported.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha256.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha256.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
@@ -9,6 +13,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
     /// Arm64 CPU indicate support for this feature by setting
     /// ID_AA64ISAR0_EL1.SHA2 is 1 or better
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public static class Sha256
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.PlatformNotSupported.cs
@@ -1,6 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-
 
 namespace System.Runtime.Intrinsics.Arm.Arm64
 {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.cs
@@ -1,6 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-
 
 namespace System.Runtime.Intrinsics.Arm.Arm64
 {
@@ -10,6 +13,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
     /// Arm64 CPU indicate support for this feature by setting
     /// ID_AA64PFR0_EL1.AdvSIMD == 0 or better.
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public static class Simd
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Aes.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Aes.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel AES hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Aes : Sse2
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using Internal.Runtime.CompilerServices;
 
@@ -11,6 +12,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel AVX hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Avx : Sse42
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel AVX2 hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Avx2 : Avx
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel BMI1 hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Bmi1
     {
@@ -17,6 +19,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public abstract class X64
         {
             internal X64() { }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel BMI2 hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Bmi2
     {
@@ -17,6 +19,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public abstract class X64
         {
             internal X64() { }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Fma.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Fma.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel FMA hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Fma : Avx
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel LZCNT hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Lzcnt
     {
@@ -17,6 +19,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public abstract class X64
         {
             internal X64() { }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Pclmulqdq.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Pclmulqdq.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel PCLMULQDQ hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Pclmulqdq : Sse2
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel POPCNT hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Popcnt : Sse42
     {
@@ -17,6 +19,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public new abstract class X64 : Sse41.X64
         {
             internal X64() { }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel SSE hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Sse
     {
@@ -18,6 +19,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public abstract class X64
         {
             internal X64() { }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel SSE2 hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Sse2 : Sse
     {
@@ -18,6 +19,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public new abstract class X64 : Sse.X64
         {
             internal X64() { }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse3.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse3.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel SSE3 hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Sse3 : Sse2
     {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel SSE4.1 hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Sse41 : Ssse3
     {
@@ -17,6 +19,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public new abstract class X64 : Sse2.X64
         {
             internal X64() { }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel SSE4.2 hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Sse42 : Sse41
     {
@@ -17,6 +19,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public new abstract class X64 : Sse41.X64
         {
             internal X64() { }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Ssse3.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Ssse3.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.X86
@@ -10,6 +11,7 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel SSSE3 hardware instructions via intrinsics
     /// </summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Ssse3 : Sse3
     {

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -43,6 +43,9 @@
     <FeaturePortableThreadPool Condition="'$(FeaturePortableThreadPool)' == ''">false</FeaturePortableThreadPool>
     <FeaturePortableThreadPool Condition="'$(TargetsUnix)' == 'true'">true</FeaturePortableThreadPool>
   </PropertyGroup>
+  <PropertyGroup>
+    <FeatureHardwareIntrinsics Condition="'$(IsProjectNLibrary)' != 'true'">true</FeatureHardwareIntrinsics>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\src\Internal\Runtime\RuntimeConstants.cs">
       <Link>Internal\Runtime\RuntimeConstants.cs</Link>

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -134,6 +134,7 @@
     <Compile Include="$(ILCompilerBasePath)\Compiler\JitHelper.cs" />
     <Compile Include="$(ILCompilerBasePath)\Compiler\GenericDictionaryLookup.cs" />
     <Compile Include="$(ILCompilerBasePath)\Compiler\SimdHelper.cs" />
+    <Compile Include="$(ILCompilerBasePath)\Compiler\HardwareIntrinsicHelpers.cs" />
     <Compile Include="$(ILCompilerBasePath)\Compiler\MethodExtensions.cs" />
     <Compile Include="$(ILCompilerBasePath)\Compiler\ReadyToRun.cs" />
     <Compile Include="$(ILCompilerBasePath)\Compiler\TypeExtensions.cs" />


### PR DESCRIPTION
I took the liberty of marking the types containing the hardware intrinsics as `[Intrinsic]` to avoid doing a name check on everything in the system module. It feels like we should take advantage of this attribute in CoreCLR too.

This doesn't actually enable the support because RyuJIT unconditionally disables HW intrinsics for prejit (both CoreRT and CPAOT are considered prejit). We might want to do something about this on the RyuJIT side to address that (for CPAOT, to be able to pregenerate best code possible ahead of time, assuming a fixed ISA; and for CoreRT without JIT, where the concerns about AVX-SSE penalty don't apply). See conversation in dotnet/coreclr#21603