### PR TITLE
Linux/ARM assembly stub fixes

### DIFF
--- a/src/Native/Runtime/StackFrameIterator.cpp
+++ b/src/Native/Runtime/StackFrameIterator.cpp
@@ -182,8 +182,12 @@ void StackFrameIterator::InternalInit(Thread * pThreadToWalk, PTR_PInvokeTransit
     if (pFrame->m_Flags & PTFF_SAVE_R4)  { m_RegDisplay.pR4 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_R5)  { m_RegDisplay.pR5 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_R6)  { m_RegDisplay.pR6 = pPreservedRegsCursor++; }
+#ifdef PROJECTN
     ASSERT(!(pFrame->m_Flags & PTFF_SAVE_R7)); // R7 should never contain a GC ref because we require
                                                // a frame pointer for methods with pinvokes
+#else
+    if (pFrame->m_Flags & PTFF_SAVE_R7)  { m_RegDisplay.pR7 = pPreservedRegsCursor++; }
+#endif
     if (pFrame->m_Flags & PTFF_SAVE_R8)  { m_RegDisplay.pR8 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_R9)  { m_RegDisplay.pR9 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_R10)  { m_RegDisplay.pR10 = pPreservedRegsCursor++; }

--- a/src/Native/Runtime/arm/WriteBarriers.S
+++ b/src/Native/Runtime/arm/WriteBarriers.S
@@ -302,9 +302,11 @@ LOCAL_LABEL(RhpCheckedXchgRetry):
           strex        r3, r1, [r0]
           cmp          r3, #0
           bne          LOCAL_LABEL(RhpCheckedXchgRetry)
-          mov          r0, r2
 
           DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedXchg, r1
+
+          // The original value is currently in r2. We need to return it in r0.
+          mov          r0, r2
 
           bx           lr
 LEAF_END RhpCheckedXchg, _TEXT

--- a/src/Native/Runtime/inc/rhbinder.h
+++ b/src/Native/Runtime/inc/rhbinder.h
@@ -783,8 +783,13 @@ struct PInvokeTransitionFrame
 // RBX, RSI, RDI, RAX, RSP
 #define PInvokeTransitionFrame_SaveRegs_count 5
 #elif defined(_TARGET_ARM_)
+#ifdef PROJECTN
 // R4-R6,R8-R10, R0, SP
 #define PInvokeTransitionFrame_SaveRegs_count 8
+#else // PROJECTN
+// R4-R10, R0, SP
+#define PInvokeTransitionFrame_SaveRegs_count 9
+#endif // PROJECTN
 #endif
 #define PInvokeTransitionFrame_MAX_SIZE (sizeof(PInvokeTransitionFrame) + (POINTER_SIZE * PInvokeTransitionFrame_SaveRegs_count))
 

--- a/src/Native/Runtime/unix/unixasmmacrosarm.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm.inc
@@ -15,7 +15,7 @@
 #define TSF_SuppressGcStress            0x08
 #define TSF_DoNotTriggerGc              0x10
 
-#define PTFF_SAVE_ALL_PRESERVED 0x00000077  // NOTE: FP is not included in this set!
+#define PTFF_SAVE_ALL_PRESERVED 0x0000007F  // NOTE: R11 is not included in this set!
 #define PTFF_SAVE_SP 0x00000100
 #define DEFAULT_FRAME_SAVE_FLAGS (PTFF_SAVE_ALL_PRESERVED + PTFF_SAVE_SP)
 
@@ -231,14 +231,14 @@ C_FUNC(\Name):
 .macro PUSH_COOP_PINVOKE_FRAME trashReg
 
         PROLOG_STACK_ALLOC 4          // Save space for caller's SP
-        PROLOG_PUSH "{r4-r6,r8-r10}"  // Save preserved registers
+        PROLOG_PUSH "{r4-r10}"        // Save preserved registers
         PROLOG_STACK_ALLOC 8          // Save space for flags and Thread*
         PROLOG_PUSH "{r11}"           // Save caller's FP
         PROLOG_PUSH "{r11,lr}"        // Save caller's frame-chain pointer and PC
 
-        // Compute SP value at entry to this method and save it in the last slot of the frame (slot #11).
-        add         \trashReg, sp, #(12 * 4)
-        str         \trashReg, [sp, #(11 * 4)]
+        // Compute SP value at entry to this method and save it in the last slot of the frame (slot #12).
+        add         \trashReg, sp, #(13 * 4)
+        str         \trashReg, [sp, #(12 * 4)]
 
         // Record the bitmask of saved registers in the frame (slot #4).
         mov         \trashReg, #DEFAULT_FRAME_SAVE_FLAGS
@@ -252,7 +252,7 @@ C_FUNC(\Name):
         EPILOG_POP  "{r11,lr}"        // Restore caller's frame-chain pointer and PC (return address)
         EPILOG_POP  "{r11}"           // Restore caller's FP
         EPILOG_STACK_FREE 8           // Discard flags and Thread*
-        EPILOG_POP  "{r4-r6,r8-r10}"  // Restore preserved registers
+        EPILOG_POP  "{r4-r10}"        // Restore preserved registers
         EPILOG_STACK_FREE 4           // Discard caller's SP
 .endm
 


### PR DESCRIPTION
There are two small fixes in this patch:
 * R7 on Linux/arm is a general purpose callee-saved register and should be preserved in `PInvokeTransitionFrame`
 * Fix `RhpCheckedXchgRetry` return value
CC @jkotas @alpencolt @iarischenko 