### PR TITLE
[WIP] Fix PIC relocation issues

### DIFF
--- a/src/Native/ObjWriter/objwriter.h
+++ b/src/Native/ObjWriter/objwriter.h
@@ -63,7 +63,7 @@ public:
   void EmitAlignment(int ByteAlignment);
   void EmitBlob(int BlobSize, const char *Blob);
   void EmitIntValue(uint64_t Value, unsigned Size);
-  void EmitSymbolDef(const char *SymbolName);
+  void EmitSymbolDef(const char *SymbolName, bool global);
   void EmitWinFrameInfo(const char *FunctionName, int StartOffset,
                         int EndOffset, const char *BlobSymbolName);
   int EmitSymbolRef(const char *SymbolName, RelocType RelocType, int Delta);
@@ -225,9 +225,9 @@ DLL_EXPORT void EmitIntValue(ObjectWriter *OW, uint64_t Value, unsigned Size) {
   OW->EmitIntValue(Value, Size);
 }
 
-DLL_EXPORT void EmitSymbolDef(ObjectWriter *OW, const char *SymbolName) {
+DLL_EXPORT void EmitSymbolDef(ObjectWriter *OW, const char *SymbolName, bool global) {
   assert(OW && "ObjWriter is null");
-  OW->EmitSymbolDef(SymbolName);
+  OW->EmitSymbolDef(SymbolName, global);
 }
 
 DLL_EXPORT int EmitSymbolRef(ObjectWriter *OW, const char *SymbolName,

--- a/src/Native/Runtime/amd64/AllocFast.S
+++ b/src/Native/Runtime/amd64/AllocFast.S
@@ -115,7 +115,7 @@ LOCAL_LABEL(NewOutOfMemory):
 
         POP_COOP_PINVOKE_FRAME
 
-        jmp         C_FUNC(RhExceptionHandling_FailedAllocation)
+        jmp         EXTERNAL_C_FUNC(RhExceptionHandling_FailedAllocation)
 NESTED_END RhpNewObject, _TEXT
 
 
@@ -193,7 +193,7 @@ LOCAL_LABEL(StringSizeOverflow):
 
         // rdi holds EEType pointer already
         xor         esi, esi            // Indicate that we should throw OOM.
-        jmp         C_FUNC(RhExceptionHandling_FailedAllocation)
+        jmp         EXTERNAL_C_FUNC(RhExceptionHandling_FailedAllocation)
 
 NESTED_END RhNewString, _TEXT
 
@@ -276,7 +276,7 @@ LOCAL_LABEL(ArraySizeOverflow):
 
         // rdi holds EEType pointer already
         mov         esi, 1              // Indicate that we should throw OverflowException
-        jmp         C_FUNC(RhExceptionHandling_FailedAllocation)
+        jmp         EXTERNAL_C_FUNC(RhExceptionHandling_FailedAllocation)
 
 NESTED_END RhpNewArray, _TEXT
 
@@ -338,7 +338,7 @@ LOCAL_LABEL(ArrayOutOfMemory):
 
         POP_COOP_PINVOKE_FRAME
 
-        jmp         C_FUNC(RhExceptionHandling_FailedAllocation)
+        jmp         EXTERNAL_C_FUNC(RhExceptionHandling_FailedAllocation)
 
 NESTED_END RhpNewArrayRare, _TEXT
 

--- a/src/Native/Runtime/amd64/ExceptionHandling.S
+++ b/src/Native/Runtime/amd64/ExceptionHandling.S
@@ -69,7 +69,7 @@ NESTED_ENTRY RhpThrowHwEx, _TEXT, NoHandler
 
         // rdi still contains the exception code
         // rsi contains the address of the ExInfo
-        call    C_FUNC(RhThrowHwEx)
+        call    EXTERNAL_C_FUNC(RhThrowHwEx)
 
         EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowHwEx2
 
@@ -150,7 +150,7 @@ NESTED_ENTRY RhpThrowEx, _TEXT, NoHandler
 
         // rdi still contains the exception object
         // rsi contains the address of the ExInfo
-        call    C_FUNC(RhThrowEx)
+        call    EXTERNAL_C_FUNC(RhThrowEx)
 
         EXPORT_POINTER_TO_ADDRESS PointerToRhpThrowEx2
 
@@ -221,7 +221,7 @@ NESTED_ENTRY RhpRethrow, _TEXT, NoHandler
 
         // rdi contains the currently active ExInfo
         // rsi contains the address of the new ExInfo
-        call    C_FUNC(RhRethrow)
+        call    EXTERNAL_C_FUNC(RhRethrow)
 
         EXPORT_POINTER_TO_ADDRESS PointerToRhpRethrow2
 

--- a/src/Native/Runtime/amd64/StubDispatch.S
+++ b/src/Native/Runtime/amd64/StubDispatch.S
@@ -94,7 +94,7 @@ LEAF_ENTRY RhpInterfaceDispatchSlow, _TEXT
         // r10 contains indirection cell address, move to r11 where it will be passed by
         // the universal transition thunk as an argument to RhpCidResolve
         mov r11, r10
-        lea r10, [rip + C_FUNC(RhpCidResolve)]
-        jmp C_FUNC(RhpUniversalTransition_DebugStepTailCall)
+        lea r10, [rip + EXTERNAL_C_FUNC(RhpCidResolve)]
+        jmp EXTERNAL_C_FUNC(RhpUniversalTransition_DebugStepTailCall)
 
 LEAF_END RhpInterfaceDispatchSlow, _TEXT

--- a/tests/src/Simple/SharedLibrary/SharedLibrary.cpp
+++ b/tests/src/Simple/SharedLibrary/SharedLibrary.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
 #elif __APPLE__
     void *handle = dlopen(strcat(argv[0], ".dylib"), RTLD_LAZY);
 #else
-    void *handle = dlopen(strcat(argv[0], ".so"), RTLD_LAZY);
+    void *handle = dlopen("SharedLibrary.so", RTLD_LAZY);
 #endif
 
     if (!handle)

--- a/tests/src/Simple/SharedLibrary/SharedLibrary.csproj
+++ b/tests/src/Simple/SharedLibrary/SharedLibrary.csproj
@@ -23,6 +23,7 @@
       <NativeRunnerCompilerArg Include="-o $(NativeRunnerBinary)" Condition="'$(OS)' != 'Windows_NT'" />
       <NativeRunnerCompilerArg Include="/Fo$(NativeRunnerBinary)" Condition="'$(OS)' == 'Windows_NT'" />
       <NativeRunnerCompilerArg Include="/Fe$(NativeRunnerBinary)" Condition="'$(OS)' == 'Windows_NT'" />
+      <NativeRunnerCompilerArg Include="-ldl" />
     </ItemGroup>
 
     <Exec Command="$(CppCompiler) @(NativeRunnerCompilerArg, ' ')" Condition="'$(OS)' != 'Windows_NT'" />

--- a/tests/src/Simple/SharedLibrary/no_linux
+++ b/tests/src/Simple/SharedLibrary/no_linux
@@ -1,1 +1,0 @@
-Skip this test for linux


### PR DESCRIPTION
Progress towards #4988.

The relocation issues we're having are due to two things: we emit all symbols as global, and we don't do the dance that is necessary to access symbols someone else could redefine in a different module and make them "too far away" to fit in a 32bit relocation. Ideally, we should find a way to ban this because I think it's breaking our ability to have static libraries built by different versions of CoreRT in the same process (they're going to redefine each other's symbols and that sounds bad).

I ran out of time I allocated for myself for this. This is enough to actually build SharedLibrary.so, but the test is failing (because dlopen fails for reasons that I didn't investigate) and I didn't validate this doesn't break Windows or other (non-dynamic library) scenarios.

I'll need to read up more on ELF relocs at some point.

Putting it up in case someone would like to pick this up. I don't know when I'll be able to make time for this again.

Cc @tonerdo @tim241 @sebastianulm 