### PR TITLE
Unify IL readers

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILReader.cs
+++ b/src/Common/src/TypeSystem/IL/ILReader.cs
@@ -20,9 +20,25 @@ namespace Internal.IL
             }
         }
 
-        public ILReader(MethodIL methodIL)
+        public int Size
         {
-            _ilBytes = methodIL.GetILBytes();
+            get
+            {
+                return _ilBytes.Length;
+            }
+        }
+
+        public bool HasNext
+        {
+            get
+            {
+                return _currentOffset < _ilBytes.Length;
+            }
+        }
+
+        public ILReader(byte[] ilBytes)
+        {
+            _ilBytes = ilBytes;
             _currentOffset = 0;
         }
 
@@ -73,19 +89,26 @@ namespace Internal.IL
             return *(double*)(&value);
         }
 
-        public bool Read(out ILOpcode opcode)
+        public ILOpcode ReadILOpcode()
         {
-            opcode = default(byte);
-            if (_currentOffset == _ilBytes.Length)
-                return false;
-
-            opcode = (ILOpcode)ReadILByte();
+            ILOpcode opcode = (ILOpcode)ReadILByte();
             if (opcode == ILOpcode.prefix1)
             {
                 opcode = (ILOpcode)(0x100 + ReadILByte());
             }
 
-            return true;
+            return opcode;
+        }
+
+        public ILOpcode PeekILOpcode()
+        {
+            ILOpcode opcode = (ILOpcode)_ilBytes[_currentOffset];
+            if (opcode == ILOpcode.prefix1)
+            {
+                opcode = (ILOpcode)(0x100 + _ilBytes[_currentOffset + 1]);
+            }
+
+            return opcode;
         }
 
         public void Seek(int offset)

--- a/src/ILCompiler.Compiler/src/Compiler/ILStreamReader.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILStreamReader.cs
@@ -3,12 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text;
 
 using Internal.TypeSystem;
 using Internal.IL;
-
-using Debug = System.Diagnostics.Debug;
 
 namespace Internal.Compiler
 {
@@ -21,145 +18,33 @@ namespace Internal.Compiler
     /// </summary>
     public struct ILStreamReader
     {
-        private byte[] _ilBytes;
-        private MethodIL _methodIL;
-        private int _currentOffset;
+        private readonly ILReader _reader;
+        private readonly MethodIL _methodIL;
 
         public ILStreamReader(MethodIL methodIL)
         {
             _methodIL = methodIL;
-            _ilBytes = methodIL.GetILBytes();
-            _currentOffset = 0;
-        }
-
-        //
-        // IL stream reading
-        //
-
-        private byte ReadILByte()
-        {
-            return _ilBytes[_currentOffset++];
-        }
-
-        private ILOpcode ReadILOpcode()
-        {
-            return (ILOpcode)ReadILByte();
-        }
-        
-        private byte PeekILByte()
-        {
-            return _ilBytes[_currentOffset];
-        }
-
-        private ILOpcode PeekILOpcode()
-        {
-            return (ILOpcode)PeekILByte();
-        }
-
-        private bool TryReadILByte(out byte ilbyte)
-        {
-            if (_currentOffset >= _ilBytes.Length)
-                throw new BadImageFormatException();
-
-            ilbyte = ReadILByte();
-            return true;
-        }
-
-        private UInt16 ReadILUInt16()
-        {
-            UInt16 val = (UInt16)(_ilBytes[_currentOffset] + (_ilBytes[_currentOffset + 1] << 8));
-            _currentOffset += 2;
-            return val;
-        }
-
-        private bool TryReadILUInt16(out UInt16 ilUint16)
-        {
-            if (checked(_currentOffset + 1) >= _ilBytes.Length)
-                throw new BadImageFormatException();
-
-            ilUint16 = ReadILUInt16();
-            return true;
-        }
-
-        private UInt32 ReadILUInt32()
-        {
-            UInt32 val = (UInt32)(_ilBytes[_currentOffset] + (_ilBytes[_currentOffset + 1] << 8) + (_ilBytes[_currentOffset + 2] << 16) + (_ilBytes[_currentOffset + 3] << 24));
-            _currentOffset += 4;
-            return val;
-        }
-
-        private bool TryReadILUInt32(out UInt32 ilUint32)
-        {
-            if (checked(_currentOffset + 3) >= _ilBytes.Length)
-                throw new BadImageFormatException();
-
-            ilUint32 = ReadILUInt32();
-            return true;
-        }
-
-        private int ReadILToken()
-        {
-            return (int)ReadILUInt32();
-        }
-
-        private bool TryReadILToken(out int ilToken)
-        {
-            uint ilTokenUint;
-            bool result = TryReadILUInt32(out ilTokenUint);
-            ilToken = (int)ilTokenUint;
-            return result;
-        }
-
-        private ulong ReadILUInt64()
-        {
-            ulong value = ReadILUInt32();
-            value |= (((ulong)ReadILUInt32()) << 32);
-            return value;
-        }
-
-        private unsafe float ReadILFloat()
-        {
-            uint value = ReadILUInt32();
-            return *(float*)(&value);
-        }
-
-        private unsafe double ReadILDouble()
-        {
-            ulong value = ReadILUInt64();
-            return *(double*)(&value);
-        }
-
-        private void SkipIL(int bytes)
-        {
-            _currentOffset += bytes;
+            _reader = new ILReader(methodIL.GetILBytes());
         }
 
         public bool HasNextInstruction
         {
             get
             {
-                return _currentOffset < _ilBytes.Length;
-            }
-        }
-
-        public int CodeSize
-        {
-            get
-            {
-                return _ilBytes.Length;
+                return _reader.HasNext;
             }
         }
 
         public bool TryReadLdtoken(out int token)
         {
-            if (PeekILOpcode() != ILOpcode.ldtoken)
+            if (_reader.PeekILOpcode() != ILOpcode.ldtoken)
             {
                 token = 0;
                 return false;
             }
 
-            ReadILOpcode();
-            token = ReadILToken();
+            _reader.ReadILOpcode();
+            token = _reader.ReadILToken();
             return true;
         }
 
@@ -201,27 +86,27 @@ namespace Internal.Compiler
 
         public bool TryReadLdcI4(out int value)
         {
-            ILOpcode opcode = PeekILOpcode();
+            ILOpcode opcode = _reader.PeekILOpcode();
 
             if (opcode == ILOpcode.ldc_i4) // ldc.i4
             {
-                ReadILOpcode();
-                value = unchecked((int)ReadILUInt32());
+                _reader.ReadILOpcode();
+                value = unchecked((int)_reader.ReadILUInt32());
                 return true;
             }
 
             if ((opcode >= ILOpcode.ldc_i4_m1) && (opcode <= ILOpcode.ldc_i4_8)) // ldc.m1 to ldc.i4.8
             {
-                ReadILOpcode();
+                _reader.ReadILOpcode();
                 value = -1 + ((int)opcode) - 0x15;
                 return true;
             }
 
             if (opcode == ILOpcode.ldc_i4_s) // ldc.i4.s
             {
-                ReadILOpcode();
+                _reader.ReadILOpcode();
 
-                value = (int)unchecked((sbyte)ReadILByte());
+                value = (int)unchecked((sbyte)_reader.ReadILByte());
                 return true;
             }
             value = 0;
@@ -239,10 +124,10 @@ namespace Internal.Compiler
 
         public bool TryReadRet()
         {
-            ILOpcode opcode = PeekILOpcode();
+            ILOpcode opcode = _reader.PeekILOpcode();
             if (opcode == ILOpcode.ret)
             {
-                ReadILOpcode();
+                _reader.ReadILOpcode();
                 return true;
             }
             return false;
@@ -256,10 +141,10 @@ namespace Internal.Compiler
 
         public bool TryReadPop()
         {
-            ILOpcode opcode = PeekILOpcode();
+            ILOpcode opcode = _reader.PeekILOpcode();
             if (opcode == ILOpcode.pop)
             {
-                ReadILOpcode();
+                _reader.ReadILOpcode();
                 return true;
             }
             return false;
@@ -273,14 +158,14 @@ namespace Internal.Compiler
 
         public bool TryReadLdstr(out string ldstrString)
         {
-            if (PeekILOpcode() != ILOpcode.ldstr)
+            if (_reader.PeekILOpcode() != ILOpcode.ldstr)
             {
                 ldstrString = null;
                 return false;
             }
 
-            ReadILOpcode();
-            int token = ReadILToken();
+            _reader.ReadILOpcode();
+            int token = _reader.ReadILToken();
             ldstrString = (string)_methodIL.GetObject(token);
             return true;
         }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -52,6 +52,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILImporter.cs">
       <Link>IL\ILImporter.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\ILReader.cs">
+      <Link>IL\ILReader.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\IL\StackValueKind.cs">
       <Link>IL\StackValueKind.cs</Link>
     </Compile>

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -65,10 +65,11 @@ namespace Internal.Runtime.Interpreter
         public void InterpretMethod(ref CallInterceptorArgs callInterceptorArgs)
         {
             _callInterceptorArgs = callInterceptorArgs;
-            ILReader reader = new ILReader(_methodIL);
+            ILReader reader = new ILReader(_methodIL.GetILBytes());
 
-            while (reader.Read(out ILOpcode opcode))
+            while (reader.HasNext)
             {
+                ILOpcode opcode = reader.ReadILOpcode();
                 switch (opcode)
                 {
                     case ILOpcode.nop:


### PR DESCRIPTION
`ILReader` added in #6849 can be used in `ILStreamReader`, saving us 100 lines of code.