### PR TITLE
Basic infra support for running local CPAOT GC stress tests

### DIFF
--- a/tests/CoreCLR/runtest/runtest.cmd
+++ b/tests/CoreCLR/runtest/runtest.cmd
@@ -62,7 +62,7 @@ if /i "%1" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&set __SkipWrap
 if /i "%1" == "PerfTests"             (set __PerfTests=true&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
 REM change it to COMPlus_GCStress when we stop using xunit harness
-if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop) 
+if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=3600000&shift&shift&goto Arg_Loop) 
 if /i "%1" == "LogsDir"         (set __LogsDir=%2&shift&shift&goto Arg_Loop) 
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs

--- a/tests/CoreCLR/runtest/runtest.cmd
+++ b/tests/CoreCLR/runtest/runtest.cmd
@@ -62,8 +62,8 @@ if /i "%1" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&set __SkipWrap
 if /i "%1" == "PerfTests"             (set __PerfTests=true&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
 REM change it to COMPlus_GCStress when we stop using xunit harness
-if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=3600000&shift&shift&goto Arg_Loop) 
-if /i "%1" == "LogsDir"         (set __LogsDir=%2&shift&shift&goto Arg_Loop) 
+if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=3600000&shift&shift&goto Arg_Loop)
+if /i "%1" == "LogsDir"               (set __LogsDir=%2&shift&shift&goto Arg_Loop) 
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -80,8 +80,10 @@ echo     /multimodule  : Compile the framework as a .lib and link tests against 
 echo     /determinism  : Compile the test twice with randomized dependency node mark stack to validate
 echo                      compiler determinism in multi-threaded compilation.
 echo     /nocleanup    : Do not delete compiled test artifacts after running each test
-echo     /r2rframework : Create ready-to-run images for the CoreCLR framework assemblies
-echo     /gcstresslevel: GC stress level to use for testing
+echo.
+echo     --- CPAOT-specific flags ---
+echo       /r2rframework : Create ready-to-run images for the CoreCLR framework assemblies
+echo       /gcstresslevel: GC stress level to use for testing
 echo.
 echo     --- CoreCLR Subset ---
 echo        Top200     : Runs broad coverage / CI validation (~200 tests).

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -61,6 +61,7 @@ if /i "%1" == "/determinism" (set CoreRT_DeterminismMode=true&shift&goto ArgLoop
 if /i "%1" == "/nocleanup" (set CoreRT_NoCleanup=true&shift&goto ArgLoop)
 if /i "%1" == "/r2rframework" (set CoreRT_R2RFramework=true&shift&goto ArgLoop)
 if /i "%1" == "/user2rframework" (set CoreRT_UseR2RFramework=true&shift&goto ArgLoop)
+if /i "%1" == "/gcstresslevel" (set __GCSTRESSLEVEL=%2&set __TestTimeout=3600000&shift&shift&goto ArgLoop) 
 echo Invalid command line argument: %1
 goto :Usage
 
@@ -80,6 +81,7 @@ echo     /determinism  : Compile the test twice with randomized dependency node 
 echo                      compiler determinism in multi-threaded compilation.
 echo     /nocleanup    : Do not delete compiled test artifacts after running each test
 echo     /r2rframework : Create ready-to-run images for the CoreCLR framework assemblies
+echo     /gcstresslevel: GC stress level to use for testing
 echo.
 echo     --- CoreCLR Subset ---
 echo        Top200     : Runs broad coverage / CI validation (~200 tests).
@@ -556,8 +558,9 @@ goto :eof
         )
         call %CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd !TestFolderName! !TestFileName!
     ) else (
-        echo runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
-        call runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
+        set __RunTestCommand=runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
+        echo !__RunTestCommand!
+        call !__RunTestCommand!
     )
     
     set __SavedErrorLevel=%ErrorLevel%

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -14,6 +14,7 @@ set CoreRT_RunCoreFXTests=
 set CoreRT_CoreCLRTargetsFile=
 set CoreRT_TestLogFileName=testResults.xml
 set CoreRT_TestName=*
+set CoreRT_GCStressLevel=
 
 :ArgLoop
 if "%1" == "" goto :ArgsDone
@@ -61,7 +62,7 @@ if /i "%1" == "/determinism" (set CoreRT_DeterminismMode=true&shift&goto ArgLoop
 if /i "%1" == "/nocleanup" (set CoreRT_NoCleanup=true&shift&goto ArgLoop)
 if /i "%1" == "/r2rframework" (set CoreRT_R2RFramework=true&shift&goto ArgLoop)
 if /i "%1" == "/user2rframework" (set CoreRT_UseR2RFramework=true&shift&goto ArgLoop)
-if /i "%1" == "/gcstresslevel" (set __GCSTRESSLEVEL=%2&set __TestTimeout=3600000&shift&shift&goto ArgLoop) 
+if /i "%1" == "/gcstresslevel" (set CoreRT_GCStressLevel=%2&shift&shift&goto ArgLoop)
 echo Invalid command line argument: %1
 goto :Usage
 
@@ -561,6 +562,7 @@ goto :eof
         call %CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd !TestFolderName! !TestFileName!
     ) else (
         set __RunTestCommand=runtest.cmd %CoreRT_BuildArch% %CoreRT_BuildType% %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile% LogsDir %__LogDir%
+        if not "%CoreRT_GCStressLevel%" == "" ( set __RunTestCommand=!__RunTestCommand! gcstresslevel !CoreRT_GCStressLevel! )
         echo !__RunTestCommand!
         call !__RunTestCommand!
     )

--- a/tests/src/tools/ReadyToRun.TestHarness/Program.cs
+++ b/tests/src/tools/ReadyToRun.TestHarness/Program.cs
@@ -24,7 +24,10 @@ namespace ReadyToRun.TestHarness
     class Program
     {
         // Default timeout in milliseconds
-        private const int DefaultTestTimeOut = 2 * 60 * 1000;
+        private const int NormalTestTimeout = 2 * 60 * 1000;
+
+        // Timeout under GC stress in milliseconds
+        private const int GCStressTestTimeout = 30 * 60 * 1000;
 
         // Error code returned when events get lost. Use this to re-run the test a few times.
         private const int StatusTestErrorEventsLost = -101;
@@ -266,7 +269,9 @@ namespace ReadyToRun.TestHarness
                         Console.WriteLine(args.Data);
                     };
 
-                    if (process.WaitForExit(DefaultTestTimeOut))
+                    int timeoutToUse = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("__GCSTRESSLEVEL")) ? NormalTestTimeout : GCStressTestTimeout;
+
+                    if (process.WaitForExit(timeoutToUse))
                     {
                         exitCode = process.ExitCode;
                     }
@@ -281,7 +286,7 @@ namespace ReadyToRun.TestHarness
                         {
                         }
 
-                        Console.WriteLine("Test execution timed out.");
+                        Console.WriteLine("Test execution timed out after {0} seconds.", timeoutToUse / 1000);
                         exitCode = StatusTestErrorTimeOut;
                     }
 


### PR DESCRIPTION
This change basically introduces a new option /gcstresslevel
in tests\runtest.cmd akin to a similar option in the CoreCLR-specific
script. I have also bumped up the timeouts to 1 hour as CPAOT
Top200 test suite is currently timing out in ILC compilation of
1~2 tests (typically the bigvtbl tests).

Thanks

Tomas