### PR TITLE
Fix ProjectN build break

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/AsyncCausalityTracer.WinRT.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/AsyncCausalityTracer.WinRT.cs
@@ -26,6 +26,10 @@ namespace System.Threading.Tasks
     //
     internal static class AsyncCausalityTracer
     {
+        public static void EnableToETW(bool enabled)
+        {
+        }
+
         //==============================================================================================================
         // This section of the class encapsulates the call to AsyncCausalityTracer for the async-aware callstacks.
         //==============================================================================================================


### PR DESCRIPTION
Pull request #6862 added references to `EnableToETW` that doesn't exist. I guess this is a NOP?