### PR TITLE
Make _reader not readonly

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/ILStreamReader.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILStreamReader.cs
@@ -18,7 +18,7 @@ namespace Internal.Compiler
     /// </summary>
     public struct ILStreamReader
     {
-        private readonly ILReader _reader;
+        private ILReader _reader;
         private readonly MethodIL _methodIL;
 
         public ILStreamReader(MethodIL methodIL)


### PR DESCRIPTION
I was too eager on adding `readonly` in #6863. This breaks the desired semantics.