### PR TITLE
Disable bad CoreCLR test

### DIFF
--- a/tests/CoreCLR.issues.targets
+++ b/tests/CoreCLR.issues.targets
@@ -986,5 +986,7 @@
     <!-- Expectations about HW exceptions in unmanaged code being catchable -->
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\calli_excep\calli_excep.*" />
 
+    <!-- Expectations about finalization order -->
+    <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\Finalize2\Finalize2.*" />
   </ItemGroup>
 </Project>

--- a/tests/ReadyToRun.CoreCLR.issues.targets
+++ b/tests/ReadyToRun.CoreCLR.issues.targets
@@ -11,7 +11,6 @@
     <Includelist Include="$(xunitteStbiNBAse)\GC\API\GC\Collect0\Collect0.cmd" /> 
     <Includelist Include="$(xunitteStbiNBAse)\GC\API\GC\Collect1\Collect1.cmd" /> 
     <Includelist Include="$(xunitteStbiNBAse)\GC\API\GCHandleCollector\Count\Count.cmd" /> 
-    <Includelist Include="$(xunitteStbiNBAse)\GC\API\WeakReference\Finalize2\Finalize2.cmd" /> 
     <Includelist Include="$(xunitteStbiNBAse)\GC\Coverage\LargeObjectAlloc\LargeObjectAlloc.cmd" /> 
     <Includelist Include="$(xunitteStbiNBAse)\GC\Regressions\v2.0-beta2\452950\452950\452950.cmd" /> 
     <Includelist Include="$(xunitteStbiNBAse)\GC\Regressions\v2.0-beta2\460373\460373\460373.cmd" /> 

--- a/tests/Top200.CoreCLR.issues.targets
+++ b/tests/Top200.CoreCLR.issues.targets
@@ -28,7 +28,6 @@
     <IncludeList Include="$(XunitTestBinBase)\GC\API\GCHandleCollector\NegTests\NegTests.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\GC\API\GCSettings\InputValidation\InputValidation.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\GC\API\NoGCRegion\NoGC\NoGC.cmd" />
-    <IncludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\Finalize2\Finalize2.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\multipleWRs\multipleWRs.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\multipleWRs_1\multipleWRs_1.cmd" />
     <IncludeList Include="$(XunitTestBinBase)\GC\Coverage\LargeObjectAlloc\LargeObjectAlloc.cmd" />


### PR DESCRIPTION
The test makes an assumption that objects are finalized in a specific order. It is not a safe assumption to make.