### PR TITLE
[Interpreter] Arguments

### DIFF
--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -690,6 +690,12 @@ namespace Internal.Runtime.Interpreter
                             case StackValueKind.Int64:
                                 _stack.Push(StackItem.FromInt64(GetArgument<long>(index)));
                                 break;
+                            case StackValueKind.NativeInt:
+                                _stack.Push(StackItem.FromNativeInt(GetArgument<IntPtr>(index)));
+                                break;
+                            case StackValueKind.Float:
+                                _stack.Push(StackItem.FromDouble(GetArgument<double>(index)));
+                                break;
                             default:
                                 ThrowHelper.ThrowInvalidProgramException();
                                 break;
@@ -798,6 +804,12 @@ namespace Internal.Runtime.Interpreter
                                 break;
                             case StackValueKind.Int64:
                                 SetReturnValue(stackItem.AsInt64());
+                                break;
+                            case StackValueKind.NativeInt:
+                                SetReturnValue(stackItem.AsNativeInt());
+                                break;
+                            case StackValueKind.Float:
+                                SetReturnValue(stackItem.AsDouble());
                                 break;
                             default:
                                 ThrowHelper.ThrowInvalidProgramException();

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -654,11 +654,19 @@ namespace Internal.Runtime.Interpreter
             switch (argument.Category)
             {
                 case TypeFlags.Boolean:
+                    _stack.Push(StackItem.FromInt32(GetArgument<bool>(index) ? 1 : 0));
+                    break;
                 case TypeFlags.Char:
+                    _stack.Push(StackItem.FromInt32(GetArgument<char>(index)));
+                    break;
                 case TypeFlags.SByte:
                 case TypeFlags.Byte:
+                    _stack.Push(StackItem.FromInt32(GetArgument<byte>(index)));
+                    break;
                 case TypeFlags.Int16:
                 case TypeFlags.UInt16:
+                    _stack.Push(StackItem.FromInt32(GetArgument<short>(index)));
+                    break;
                 case TypeFlags.Int32:
                 case TypeFlags.UInt32:
                     _stack.Push(StackItem.FromInt32(GetArgument<int>(index)));

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -544,11 +544,13 @@ namespace Internal.Runtime.Interpreter
                         InterpretStoreArgument(reader.ReadILUInt16());
                         break;
                     case ILOpcode.ldloc:
-                        throw new NotImplementedException();
+                        InterpretLoadLocal(reader.ReadILUInt16());
+                        break;
                     case ILOpcode.ldloca:
                         throw new NotImplementedException();
                     case ILOpcode.stloc:
-                        throw new NotImplementedException();
+                        InterpretStoreLocal(reader.ReadILUInt16());
+                        break;
                     case ILOpcode.localloc:
                         throw new NotImplementedException();
                     case ILOpcode.endfilter:

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/InterpreterCallInterceptor.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/InterpreterCallInterceptor.cs
@@ -30,15 +30,13 @@ namespace Internal.Runtime.Interpreter
         {
             get
             {
-                int delta = 1;
-
-                LocalVariableType[] localVariableTypes = new LocalVariableType[_method.Signature.Length + 1];
+                int delta = (_method.Signature.IsStatic ? 1 : 2);
+                LocalVariableType[] localVariableTypes = new LocalVariableType[_method.Signature.Length + delta];
                 localVariableTypes[0] = new LocalVariableType(GetRuntimeTypeHandleForUnknownType(_method.Signature.ReturnType), false, _method.Signature.ReturnType.IsByRef);
 
                 if (!_method.Signature.IsStatic)
                 {
                     localVariableTypes[1] = new LocalVariableType(GetRuntimeTypeHandleForUnknownType(_method.OwningType), false, _method.OwningType.IsByRef);
-                    delta = 2;
                 }
 
                 for (int i = 0; i < _method.Signature.Length; i++)


### PR DESCRIPTION
This PR adds support for the following opcodes:

* `ldarg.*`
* `starg.*`

which allows methods like the following to be interpreted:

```csharp
public static int Sum(int a, int b)
{
    return a + b;
}
```

It also updates `InterpreterCallInterceptor` to ensure a non-zero `RuntimeMethodHandle` is returned for non-primitive argument and local variable types, which is needed for interpreting methods like the following:

```csharp
public static DateTime ForwardDateTime(DateTime d)
{
    return d;
}

public static Exception ForwardException(Exception e)
{
    return e;
}
```
