### PR TITLE
Impose limits on array sizes

### DIFF
--- a/src/Native/Runtime/AsmOffsets.h
+++ b/src/Native/Runtime/AsmOffsets.h
@@ -34,6 +34,7 @@ ASM_OFFSET(    4,     8, String, m_Length)
 ASM_OFFSET(    8,     C, String, m_FirstChar)
 ASM_CONST(     2,     2, STRING_COMPONENT_SIZE)
 ASM_CONST(     E,    16, STRING_BASE_SIZE)
+ASM_CONST(3FFFFFDF,3FFFFFDF,MAX_STRING_LENGTH)
 
 ASM_OFFSET(    0,     0, EEType, m_usComponentSize)
 ASM_OFFSET(    2,     2, EEType, m_usFlags)

--- a/src/Native/Runtime/ObjectLayout.h
+++ b/src/Native/Runtime/ObjectLayout.h
@@ -125,3 +125,6 @@ static UIntNative const STRING_COMPONENT_SIZE = StringConstants::ComponentSize;
 
 //-------------------------------------------------------------------------------------------------
 static UIntNative const STRING_BASE_SIZE = StringConstants::BaseSize;
+
+//-------------------------------------------------------------------------------------------------
+static UIntNative const MAX_STRING_LENGTH = 0x3FFFFFDF;

--- a/src/Native/Runtime/amd64/AllocFast.S
+++ b/src/Native/Runtime/amd64/AllocFast.S
@@ -124,7 +124,7 @@ NESTED_END RhpNewObject, _TEXT
 //  ESI == character/element count
 NESTED_ENTRY RhNewString, _TEXT, NoHandler
         // we want to limit the element count to the non-negative 32-bit int range
-        cmp         rsi, 07fffffffh
+        cmp         rsi, MAX_STRING_LENGTH
         ja          LOCAL_LABEL(StringSizeOverflow)
 
         push_nonvol_reg rbx

--- a/src/Native/Runtime/amd64/AllocFast.asm
+++ b/src/Native/Runtime/amd64/AllocFast.asm
@@ -108,7 +108,7 @@ NESTED_END RhpNewObject, _TEXT
 LEAF_ENTRY RhNewString, _TEXT
 
         ; we want to limit the element count to the non-negative 32-bit int range
-        cmp         rdx, 07fffffffh
+        cmp         rdx, MAX_STRING_LENGTH
         ja          StringSizeOverflow
 
         ; Compute overall allocation size (align(base size + (element size * elements), 8)).

--- a/src/Native/Runtime/amd64/AllocFast.asm
+++ b/src/Native/Runtime/amd64/AllocFast.asm
@@ -159,15 +159,25 @@ LEAF_END RhNewString, _TEXT
 ;;  EDX == element count
 LEAF_ENTRY RhpNewArray, _TEXT
 
-        ; we want to limit the element count to the non-negative 32-bit int range
-        cmp         rdx, 07fffffffh
-        ja          ArraySizeOverflow
+        ; Read the components size out of the provided EEType
+        movzx       eax, word ptr [rcx + OFFSETOF__EEType__m_usComponentSize]
 
+        ; Impose limits on maximum array length in each dimension to allow efficient 
+        ; implementation of advanced range check elimination in future. We have to allow 
+        ; higher limit for array of bytes (or one byte structs) for backward compatibility.
+        ; Keep in sync with Array.MaxArrayLength in BCL.
+        cmp         rdx, 07fefffffh
+        jbe         ArrayElementCountOK
+        cmp         eax, 1
+        ja          ArraySizeTooBig
+        cmp         rdx, 07fffffc7h
+        ja          ArraySizeTooBig
+
+ArrayElementCountOK:
         ; save element count
         mov         r8, rdx
 
         ; Compute overall allocation size (align(base size + (element size * elements), 8)).
-        movzx       eax, word ptr [rcx + OFFSETOF__EEType__m_usComponentSize]
         mul         rdx
         mov         edx, [rcx + OFFSETOF__EEType__m_uBaseSize]
         add         rax, rdx
@@ -204,13 +214,29 @@ LEAF_ENTRY RhpNewArray, _TEXT
 
         ret
 
-ArraySizeOverflow:
+ArraySizeTooBig:
+        ; rcx == EEType
+        ; rdx == element count
+        
+        ; we want to limit the element count to the non-negative 32-bit int range
+        cmp         rdx, 07fffffffh
+        jbe         ArraySizeOutOfMemory
+
         ; We get here if the size of the final array object can't be represented as an unsigned 
         ; 32-bit value. We're going to tail-call to a managed helper that will throw
         ; an overflow exception that the caller of this allocator understands.
 
         ; rcx holds EEType pointer already
         mov         edx, 1              ; Indicate that we should throw OverflowException
+        jmp         RhExceptionHandling_FailedAllocation
+
+ArraySizeOutOfMemory:
+        ; We get here if the we hit the artificial limit on number of elements in an array.
+        ; We're going to tail-call to a managed helper that will throw
+        ; an OutOfMemory exception that the caller of this allocator understands.
+
+        ; rcx holds EEType pointer already
+        xor         edx, edx            ; Indicate that we should throw OOM.
         jmp         RhExceptionHandling_FailedAllocation
 LEAF_END RhpNewArray, _TEXT
 

--- a/src/Native/Runtime/amd64/AllocFast.asm
+++ b/src/Native/Runtime/amd64/AllocFast.asm
@@ -167,13 +167,9 @@ LEAF_ENTRY RhpNewArray, _TEXT
         ; higher limit for array of bytes (or one byte structs) for backward compatibility.
         ; Keep in sync with Array.MaxArrayLength in BCL.
         cmp         rdx, 07fefffffh
-        jbe         ArrayElementCountOK
-        cmp         eax, 1
-        ja          ArraySizeTooBig
-        cmp         rdx, 07fffffc7h
-        ja          ArraySizeTooBig
+        ja          ArrayMaybeTooBig
 
-ArrayElementCountOK:
+ArraySizeOK:
         ; save element count
         mov         r8, rdx
 
@@ -213,6 +209,16 @@ ArrayElementCountOK:
         mov         [rax + OFFSETOF__Array__m_Length], edx
 
         ret
+
+ArrayMaybeTooBig:
+        ; rax == component size
+        ; rcx == EEType
+        ; rdx == element count
+
+        cmp         eax, 1
+        ja          ArraySizeTooBig
+        cmp         rdx, 07fffffc7h
+        jbe         ArraySizeOK
 
 ArraySizeTooBig:
         ; rcx == EEType

--- a/src/Native/Runtime/amd64/AllocFast.asm
+++ b/src/Native/Runtime/amd64/AllocFast.asm
@@ -167,9 +167,13 @@ LEAF_ENTRY RhpNewArray, _TEXT
         ; higher limit for array of bytes (or one byte structs) for backward compatibility.
         ; Keep in sync with Array.MaxArrayLength in BCL.
         cmp         rdx, 07fefffffh
-        ja          ArrayMaybeTooBig
+        jbe         ArrayElementCountOK
+        cmp         eax, 1
+        ja          ArraySizeTooBig
+        cmp         rdx, 07fffffc7h
+        ja          ArraySizeTooBig
 
-ArraySizeOK:
+ArrayElementCountOK:
         ; save element count
         mov         r8, rdx
 
@@ -209,16 +213,6 @@ ArraySizeOK:
         mov         [rax + OFFSETOF__Array__m_Length], edx
 
         ret
-
-ArrayMaybeTooBig:
-        ; rax == component size
-        ; rcx == EEType
-        ; rdx == element count
-
-        cmp         eax, 1
-        ja          ArraySizeTooBig
-        cmp         rdx, 07fffffc7h
-        jbe         ArraySizeOK
 
 ArraySizeTooBig:
         ; rcx == EEType

--- a/src/Native/Runtime/arm/AllocFast.S
+++ b/src/Native/Runtime/arm/AllocFast.S
@@ -119,7 +119,7 @@ NESTED_END RhpNewObject, _TEXT
 LEAF_ENTRY RhNewString, _TEXT
         PROLOG_PUSH "{r4-r6,lr}"
         // Make sure computing the overall allocation size won't overflow
-        MOV32       r12, ((0xFFFFFFFF - STRING_BASE_SIZE - 3) / STRING_COMPONENT_SIZE)
+        MOV32       r12, MAX_STRING_LENGTH
         cmp         r1, r12
         bhi         LOCAL_LABEL(StringSizeOverflow)
 

--- a/src/Native/Runtime/arm/AllocFast.asm
+++ b/src/Native/Runtime/arm/AllocFast.asm
@@ -119,7 +119,7 @@ NewOutOfMemory
         LEAF_ENTRY RhNewString
 
         ; Make sure computing the overall allocation size won't overflow
-        MOV32       r2, ((0xFFFFFFFF - STRING_BASE_SIZE - 3) / STRING_COMPONENT_SIZE)
+        MOV32       r2, MAX_STRING_LENGTH
         cmp         r1, r2
         bhs         StringSizeOverflow
 

--- a/src/Native/Runtime/arm64/AllocFast.asm
+++ b/src/Native/Runtime/arm64/AllocFast.asm
@@ -113,7 +113,7 @@ NewOutOfMemory
 ;;  x1 == element/character count
     LEAF_ENTRY RhNewString
         ;; Make sure computing the overall allocation size won't overflow
-        mov         x2, #0x7FFFFFFF
+        mov         x2, #MAX_STRING_LENGTH
         cmp         x1, x2
         bhi         StringSizeOverflow
 

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -267,6 +267,35 @@ COOP_PINVOKE_HELPER(void*, RhpGcAlloc, (EEType *pEEType, UInt32 uFlags, UIntNati
     if (cbSize >= max_object_size)
         return NULL;
 
+    const int MaxArrayLength = 0x7FEFFFFF;
+    const int MaxByteArrayLength = 0x7FFFFFC7;
+
+    // Impose limits on maximum array length in each dimension to allow efficient
+    // implementation of advanced range check elimination in future. We have to allow
+    // higher limit for array of bytes (or one byte structs) for backward compatibility.
+    // Keep in sync with Array.MaxArrayLength in BCL.
+    if (cbSize > MaxByteArrayLength /* note: comparing allocation size with element count */)
+    {
+        // Ensure the above if check covers the minimal interesting size
+        static_assert(MaxByteArrayLength < (uint64_t)MaxArrayLength * 2, "");
+
+        if (pEEType->IsArray())
+        {
+            if (pEEType->get_ComponentSize() != 1)
+            {
+                size_t elementCount = (cbSize - pEEType->get_BaseSize()) / pEEType->get_ComponentSize();
+                if (elementCount > MaxArrayLength)
+                    return NULL;
+            }
+            else
+            {
+                int elementCount = cbSize - pEEType->get_BaseSize();
+                if (elementCount > MaxByteArrayLength)
+                    return NULL;
+            }
+        }
+    }
+
     // Save the EEType for instrumentation purposes.
     RedhawkGCInterface::SetLastAllocEEType(pEEType);
 

--- a/src/Native/Runtime/i386/AllocFast.asm
+++ b/src/Native/Runtime/i386/AllocFast.asm
@@ -170,7 +170,7 @@ FASTCALL_FUNC   RhNewString, 8
         push        edx
 
         ;; Make sure computing the aligned overall allocation size won't overflow
-        cmp         edx, ((0FFFFFFFFh - STRING_BASE_SIZE - 3) / STRING_COMPONENT_SIZE)
+        cmp         edx, MAX_STRING_LENGTH
         ja          StringSizeOverflow
 
         ; Compute overall allocation size (align(base size + (element size * elements), 4)).

--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -872,12 +872,6 @@ namespace System
             Debug.Assert(false);
         }
 
-        // We impose limits on maximum array length in each dimension to allow efficient 
-        // implementation of advanced range check elimination in future.
-        // Keep in sync with vm\gcscan.cpp and HashHelpers.MaxPrimeArrayLength.
-        internal const int MaxArrayLength = 0X7FEFFFFF;
-        internal const int MaxByteArrayLength = MaxArrayLength;
-
         public int GetLength(int dimension)
         {
             int length = GetUpperBound(dimension) + 1;

--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -876,7 +876,7 @@ namespace System
         // implementation of advanced range check elimination in future.
         // Keep in sync with vm\gcscan.cpp and HashHelpers.MaxPrimeArrayLength.
         internal const int MaxArrayLength = 0X7FEFFFFF;
-        internal const int MaxByteArrayLength = 0x7FFFFFC7;
+        internal const int MaxByteArrayLength = MaxArrayLength;
 
         public int GetLength(int dimension)
         {

--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -876,7 +876,7 @@ namespace System
         // implementation of advanced range check elimination in future.
         // Keep in sync with vm\gcscan.cpp and HashHelpers.MaxPrimeArrayLength.
         internal const int MaxArrayLength = 0X7FEFFFFF;
-        internal const int MaxByteArrayLength = MaxArrayLength;
+        internal const int MaxByteArrayLength = 0x7FFFFFC7;
 
         public int GetLength(int dimension)
         {

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -312,6 +312,12 @@ namespace System
             }
         }
 
+        // We impose limits on maximum array length in each dimension to allow efficient 
+        // implementation of advanced range check elimination in future.
+        // Keep in sync with vm\gcscan.cpp and HashHelpers.MaxPrimeArrayLength.
+        internal const int MaxArrayLength = 0X7FEFFFFF;
+        internal const int MaxByteArrayLength = 0x7FFFFFC7;
+
         public long LongLength
         {
             get


### PR DESCRIPTION
The CLR imposes limits on the sizes of arrays. Impose the same limits.

Fixes the failing test after #6914.

Only did x64 Windows so far because I want to get an agreement on the merits and structure first.