### PR TITLE
Annotate types moved from S.R.Extensions

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Environment.SpecialFolder.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.SpecialFolder.cs
@@ -6,6 +6,9 @@ namespace System
 {
     public static partial class Environment
     {
+#if PROJECTN
+        [Internal.Runtime.CompilerServices.RelocatedType("System.Runtime.Extensions")]
+#endif
         public enum SpecialFolder
         {
             ApplicationData = SpecialFolderValues.CSIDL_APPDATA,

--- a/src/System.Private.CoreLib/shared/System/Environment.SpecialFolderOption.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.SpecialFolderOption.cs
@@ -6,6 +6,9 @@ namespace System
 {
     public static partial class Environment
     {
+#if PROJECTN
+        [Internal.Runtime.CompilerServices.RelocatedType("System.Runtime.Extensions")]
+#endif
         public enum SpecialFolderOption
         {
             None = 0,

--- a/src/System.Private.CoreLib/shared/System/EnvironmentVariableTarget.cs
+++ b/src/System.Private.CoreLib/shared/System/EnvironmentVariableTarget.cs
@@ -4,6 +4,9 @@
 
 namespace System
 {
+#if PROJECTN
+	[Internal.Runtime.CompilerServices.RelocatedType("System.Runtime.Extensions")]
+#endif
 	public enum EnvironmentVariableTarget
 	{
 		Process = 0,

--- a/src/System.Private.CoreLib/shared/System/OperatingSystem.cs
+++ b/src/System.Private.CoreLib/shared/System/OperatingSystem.cs
@@ -7,6 +7,9 @@ using System.Runtime.Serialization;
 
 namespace System
 {
+#if PROJECTN
+    [Internal.Runtime.CompilerServices.RelocatedType("System.Runtime.Extensions")]
+#endif
     public sealed class OperatingSystem : ISerializable, ICloneable
     {
         private readonly Version _version;

--- a/src/System.Private.CoreLib/src/System/Environment.CoreRT.ProjectN.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.CoreRT.ProjectN.cs
@@ -6,6 +6,7 @@ using System;
 
 namespace System
 {
+    [Internal.Runtime.CompilerServices.RelocatedType("System.Runtime.Extensions")]
     public static partial class Environment
     {
         public static void Exit(int exitCode) =>


### PR DESCRIPTION
Testing how much hate this is going to bring me.

These annotations let ProjectN deal with the fact that we now have two
definitions of System.Environment in the system. This is needed as long
as Project N is stuck on 2.1-level version of the framework.