### PR TITLE
[Interpreter] Array

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -164,9 +164,14 @@ namespace Internal.Runtime.Augments
             return Array.NewMultiDimArray(typeHandleForArrayType.ToEETypePtr(), pLengths, lengths.Length);
         }
 
+        public static void StelemRef(Array array, int index, object obj)
+        {
+            TypeCast.StelemRef(array, index, obj);
+        }
+
         public static ref byte GetSzArrayElementAddress(Array array, int index)
         {
-            ref byte start = ref array.GetRawArrayData();
+            ref byte start = ref array.GetRawSzArrayData();
             return ref Unsafe.Add(ref start, (IntPtr)((nuint)index * array.ElementSize));
         }
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -33,6 +33,12 @@ using Internal.Runtime.CompilerServices;
 
 using Volatile = System.Threading.Volatile;
 
+#if BIT64
+using nuint = System.UInt64;
+#else
+using nuint = System.UInt32;
+#endif
+
 namespace Internal.Runtime.Augments
 {
     [ReflectionBlocked]
@@ -156,6 +162,17 @@ namespace Internal.Runtime.Augments
                 pLengths[i] = lengths[i];
 
             return Array.NewMultiDimArray(typeHandleForArrayType.ToEETypePtr(), pLengths, lengths.Length);
+        }
+
+        public static ref byte GetRawDataForArray(Array array)
+        {
+            return ref array.GetRawArrayData();
+        }
+
+        [CLSCompliant(false)]
+        public static nuint GetElementSizeForArray(Array array)
+        {
+            return array.ElementSize;
         }
 
         public static IntPtr GetAllocateObjectHelperForType(RuntimeTypeHandle type)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -164,15 +164,10 @@ namespace Internal.Runtime.Augments
             return Array.NewMultiDimArray(typeHandleForArrayType.ToEETypePtr(), pLengths, lengths.Length);
         }
 
-        public static ref byte GetRawDataForArray(Array array)
+        public static ref byte GetSzArrayElementAddress(Array array, int index)
         {
-            return ref array.GetRawArrayData();
-        }
-
-        [CLSCompliant(false)]
-        public static nuint GetElementSizeForArray(Array array)
-        {
-            return array.ElementSize;
+            ref byte start = ref array.GetRawArrayData();
+            return ref Unsafe.Add(ref start, (IntPtr)((nuint)index * array.ElementSize));
         }
 
         public static IntPtr GetAllocateObjectHelperForType(RuntimeTypeHandle type)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -164,13 +164,11 @@ namespace Internal.Runtime.Augments
             return Array.NewMultiDimArray(typeHandleForArrayType.ToEETypePtr(), pLengths, lengths.Length);
         }
 
-        public static void StelemRef(Array array, int index, object obj)
-        {
-            TypeCast.StelemRef(array, index, obj);
-        }
-
         public static ref byte GetSzArrayElementAddress(Array array, int index)
         {
+            if ((uint)index >= (uint)array.Length)
+                throw new IndexOutOfRangeException();
+
             ref byte start = ref array.GetRawSzArrayData();
             return ref Unsafe.Add(ref start, (IntPtr)((nuint)index * array.ElementSize));
         }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2178,7 +2178,8 @@ namespace Internal.Runtime.Interpreter
                     break;
             }
 
-            Debug.Assert(index >= 0);
+            if (index < 0 || index >= array.Length)
+                throw new IndexOutOfRangeException();
 
             ref byte start = ref RuntimeAugments.GetRawDataForArray(array);
             ref byte position = ref Unsafe.Add(ref start, (IntPtr)((nuint)index * RuntimeAugments.GetElementSizeForArray(array)));
@@ -2236,7 +2237,8 @@ namespace Internal.Runtime.Interpreter
                     break;
             }
 
-            Debug.Assert(index >= 0);
+            if (index < 0 || index >= array.Length)
+                throw new IndexOutOfRangeException();
 
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
             ref byte start = ref RuntimeAugments.GetRawDataForArray(array);
@@ -2315,7 +2317,8 @@ namespace Internal.Runtime.Interpreter
                     break;
             }
 
-            Debug.Assert(index >= 0);
+            if (index < 0 || index >= array.Length)
+                throw new IndexOutOfRangeException();
 
             ref byte start = ref RuntimeAugments.GetRawDataForArray(array);
             ref byte position = ref Unsafe.Add(ref start, (IntPtr)((nuint)index * RuntimeAugments.GetElementSizeForArray(array)));
@@ -2380,7 +2383,8 @@ namespace Internal.Runtime.Interpreter
                     break;
             }
 
-            Debug.Assert(index >= 0);
+            if (index < 0 || index >= array.Length)
+                throw new IndexOutOfRangeException();
 
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
             ref byte start = ref RuntimeAugments.GetRawDataForArray(array);

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -370,7 +370,8 @@ namespace Internal.Runtime.Interpreter
                         InterpretNewArray(reader.ReadILToken());
                         break;
                     case ILOpcode.ldlen:
-                        throw new NotImplementedException();
+                        InterpretLoadLength();
+                        break;
                     case ILOpcode.ldelema:
                         throw new NotImplementedException();
                     case ILOpcode.ldelem_i1:
@@ -2153,6 +2154,12 @@ namespace Internal.Runtime.Interpreter
             Array array = RuntimeAugments.NewArray(arrayType.GetRuntimeTypeHandle(), length);
 
             _stack.Push(StackItem.FromObjectRef(array));
+        }
+
+        private void InterpretLoadLength()
+        {
+            Array array = (Array)PopWithValidation().AsObjectRef();
+            _stack.Push(StackItem.FromInt32(array.Length));
         }
     }
 }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2168,7 +2168,8 @@ namespace Internal.Runtime.Interpreter
                 case StackValueKind.NativeInt:
                     {
                         long value = (long)indexItem.AsNativeInt();
-                        Debug.Assert(value >= int.MinValue && value <= int.MaxValue);
+                        if (value >= int.MinValue && value <= int.MaxValue)
+                            throw new IndexOutOfRangeException();
                         index = (int)value;
                     }
                     break;
@@ -2176,9 +2177,6 @@ namespace Internal.Runtime.Interpreter
                     ThrowHelper.ThrowInvalidProgramException();
                     break;
             }
-
-            if (index < 0 || index >= array.Length)
-                throw new IndexOutOfRangeException();
 
             ref byte address = ref RuntimeAugments.GetSzArrayElementAddress(array, index);
 
@@ -2206,7 +2204,7 @@ namespace Internal.Runtime.Interpreter
                     Unsafe.Write(ref address, valueItem.AsDouble());
                     break;
                 case ILOpcode.stelem_ref:
-                    RuntimeAugments.StelemRef(array, index, valueItem.AsObjectRef());
+                    Unsafe.As<Object[]>(array)[index] = valueItem.AsObjectRef();
                     break;
                 default:
                     Debug.Assert(false);
@@ -2230,7 +2228,8 @@ namespace Internal.Runtime.Interpreter
                 case StackValueKind.NativeInt:
                     {
                         long value = (long)indexItem.AsNativeInt();
-                        Debug.Assert(value >= int.MinValue && value <= int.MaxValue);
+                        if (value >= int.MinValue && value <= int.MaxValue)
+                            throw new IndexOutOfRangeException();
                         index = (int)value;
                     }
                     break;
@@ -2238,9 +2237,6 @@ namespace Internal.Runtime.Interpreter
                     ThrowHelper.ThrowInvalidProgramException();
                     break;
             }
-
-            if (index < 0 || index >= array.Length)
-                throw new IndexOutOfRangeException();
 
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
             ref byte address = ref RuntimeAugments.GetSzArrayElementAddress(array, index);
@@ -2291,7 +2287,7 @@ namespace Internal.Runtime.Interpreter
                 case TypeFlags.Interface:
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
-                    RuntimeAugments.StelemRef(array, index, valueItem.AsObjectRef());
+                    Unsafe.As<Object[]>(array)[index] = valueItem.AsObjectRef();
                     break;
                 default:
                     // TODO: Support more complex return types
@@ -2313,7 +2309,8 @@ namespace Internal.Runtime.Interpreter
                 case StackValueKind.NativeInt:
                     {
                         long value = (long)indexItem.AsNativeInt();
-                        Debug.Assert(value >= int.MinValue && value <= int.MaxValue);
+                        if (value >= int.MinValue && value <= int.MaxValue)
+                            throw new IndexOutOfRangeException();
                         index = (int)value;
                     }
                     break;
@@ -2321,9 +2318,6 @@ namespace Internal.Runtime.Interpreter
                     ThrowHelper.ThrowInvalidProgramException();
                     break;
             }
-
-            if (index < 0 || index >= array.Length)
-                throw new IndexOutOfRangeException();
 
             ref byte address = ref RuntimeAugments.GetSzArrayElementAddress(array, index);
 
@@ -2382,7 +2376,8 @@ namespace Internal.Runtime.Interpreter
                 case StackValueKind.NativeInt:
                     {
                         long value = (long)indexItem.AsNativeInt();
-                        Debug.Assert(value >= int.MinValue && value <= int.MaxValue);
+                        if (value >= int.MinValue && value <= int.MaxValue)
+                            throw new IndexOutOfRangeException();
                         index = (int)value;
                     }
                     break;
@@ -2390,9 +2385,6 @@ namespace Internal.Runtime.Interpreter
                     ThrowHelper.ThrowInvalidProgramException();
                     break;
             }
-
-            if (index < 0 || index >= array.Length)
-                throw new IndexOutOfRangeException();
 
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
             ref byte address = ref RuntimeAugments.GetSzArrayElementAddress(array, index);

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2151,9 +2151,23 @@ namespace Internal.Runtime.Interpreter
 
         private void InterpretStoreElement(ILOpcode opcode)
         {
-            StackItem stackItem = PopWithValidation();
+            StackItem valueItem = PopWithValidation();
 
-            int index = PopWithValidation().AsInt32();
+            int index = 0;
+            StackItem indexItem = PopWithValidation();
+
+            switch (indexItem.Kind)
+            {
+                case StackValueKind.Int32:
+                    index = indexItem.AsInt32();
+                    break;
+                case StackValueKind.NativeInt:
+                    index = (int)indexItem.AsNativeInt();
+                    break;
+                default:
+                    ThrowHelper.ThrowInvalidProgramException();
+                    break;
+            }
             Debug.Assert(index >= 0);
 
             Array array = (Array)PopWithValidation().AsObjectRef();
@@ -2161,25 +2175,25 @@ namespace Internal.Runtime.Interpreter
             switch (opcode)
             {
                 case ILOpcode.stelem_i:
-                    array.SetValue(stackItem.AsNativeInt(), index);
+                    array.SetValue(valueItem.AsNativeInt(), index);
                     break;
                 case ILOpcode.stelem_i1:
-                    array.SetValue((sbyte)stackItem.AsInt32(), index);
+                    array.SetValue((sbyte)valueItem.AsInt32(), index);
                     break;
                 case ILOpcode.stelem_i2:
-                    array.SetValue((short)stackItem.AsInt32(), index);
+                    array.SetValue((short)valueItem.AsInt32(), index);
                     break;
                 case ILOpcode.stelem_i4:
-                    array.SetValue(stackItem.AsInt32(), index);
+                    array.SetValue(valueItem.AsInt32(), index);
                     break;
                 case ILOpcode.stelem_i8:
-                    array.SetValue(stackItem.AsInt64(), index);
+                    array.SetValue(valueItem.AsInt64(), index);
                     break;
                 case ILOpcode.stelem_r4:
-                    array.SetValue((float)stackItem.AsDouble(), index);
+                    array.SetValue((float)valueItem.AsDouble(), index);
                     break;
                 case ILOpcode.stelem_r8:
-                    array.SetValue(stackItem.AsDouble(), index);
+                    array.SetValue(valueItem.AsDouble(), index);
                     break;
                 case ILOpcode.stelem_ref:
                     // TODO: Add support for ByRef
@@ -2194,8 +2208,23 @@ namespace Internal.Runtime.Interpreter
         {
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
 
-            StackItem stackItem = PopWithValidation();
-            int index = PopWithValidation().AsInt32();
+            StackItem valueItem = PopWithValidation();
+
+            int index = 0;
+            StackItem indexItem = PopWithValidation();
+
+            switch (indexItem.Kind)
+            {
+                case StackValueKind.Int32:
+                    index = indexItem.AsInt32();
+                    break;
+                case StackValueKind.NativeInt:
+                    index = (int)indexItem.AsNativeInt();
+                    break;
+                default:
+                    ThrowHelper.ThrowInvalidProgramException();
+                    break;
+            }
             Debug.Assert(index >= 0);
 
             Array array = (Array)PopWithValidation().AsObjectRef();
@@ -2204,40 +2233,40 @@ namespace Internal.Runtime.Interpreter
             switch (elementType.Category)
             {
                 case TypeFlags.Boolean:
-                    array.SetValue(stackItem.AsInt32() != 0, index);
+                    array.SetValue(valueItem.AsInt32() != 0, index);
                     break;
                 case TypeFlags.Char:
-                    array.SetValue((char)stackItem.AsInt32(), index);
+                    array.SetValue((char)valueItem.AsInt32(), index);
                     break;
                 case TypeFlags.SByte:
                 case TypeFlags.Byte:
-                    array.SetValue((sbyte)stackItem.AsInt32(), index);
+                    array.SetValue((sbyte)valueItem.AsInt32(), index);
                     break;
                 case TypeFlags.Int16:
                 case TypeFlags.UInt16:
-                    array.SetValue((short)stackItem.AsInt32(), index);
+                    array.SetValue((short)valueItem.AsInt32(), index);
                     break;
                 case TypeFlags.Int32:
                 case TypeFlags.UInt32:
-                    array.SetValue(stackItem.AsInt32(), index);
+                    array.SetValue(valueItem.AsInt32(), index);
                     break;
                 case TypeFlags.Int64:
                 case TypeFlags.UInt64:
-                    array.SetValue(stackItem.AsInt64(), index);
+                    array.SetValue(valueItem.AsInt64(), index);
                     break;
                 case TypeFlags.IntPtr:
                 case TypeFlags.UIntPtr:
-                    array.SetValue(stackItem.AsNativeInt(), index);
+                    array.SetValue(valueItem.AsNativeInt(), index);
                     break;
                 case TypeFlags.Single:
-                    array.SetValue((float)stackItem.AsDouble(), index);
+                    array.SetValue((float)valueItem.AsDouble(), index);
                     break;
                 case TypeFlags.Double:
-                    array.SetValue(stackItem.AsDouble(), index);
+                    array.SetValue(valueItem.AsDouble(), index);
                     break;
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:
-                    array.SetValue(stackItem.AsValueType(), index);
+                    array.SetValue(valueItem.AsValueType(), index);
                     break;
                 case TypeFlags.Enum:
                     elementType = elementType.UnderlyingType;
@@ -2246,7 +2275,7 @@ namespace Internal.Runtime.Interpreter
                 case TypeFlags.Interface:
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
-                    array.SetValue(stackItem.AsObjectRef(), index);
+                    array.SetValue(valueItem.AsObjectRef(), index);
                     break;
                 default:
                     // TODO: Support more complex return types
@@ -2256,7 +2285,21 @@ namespace Internal.Runtime.Interpreter
 
         private void InterpretLoadElement(ILOpcode opcode)
         {
-            int index = PopWithValidation().AsInt32();
+            int index = 0;
+            StackItem indexItem = PopWithValidation();
+
+            switch (indexItem.Kind)
+            {
+                case StackValueKind.Int32:
+                    index = indexItem.AsInt32();
+                    break;
+                case StackValueKind.NativeInt:
+                    index = (int)indexItem.AsNativeInt();
+                    break;
+                default:
+                    ThrowHelper.ThrowInvalidProgramException();
+                    break;
+            }
             Debug.Assert(index >= 0);
 
             Array array = (Array)PopWithValidation().AsObjectRef();
@@ -2336,7 +2379,21 @@ namespace Internal.Runtime.Interpreter
         {
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
 
-            int index = PopWithValidation().AsInt32();
+            int index = 0;
+            StackItem indexItem = PopWithValidation();
+
+            switch (indexItem.Kind)
+            {
+                case StackValueKind.Int32:
+                    index = indexItem.AsInt32();
+                    break;
+                case StackValueKind.NativeInt:
+                    index = (int)indexItem.AsNativeInt();
+                    break;
+                default:
+                    ThrowHelper.ThrowInvalidProgramException();
+                    break;
+            }
             Debug.Assert(index >= 0);
 
             Array array = (Array)PopWithValidation().AsObjectRef();

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2166,7 +2166,11 @@ namespace Internal.Runtime.Interpreter
                     index = indexItem.AsInt32();
                     break;
                 case StackValueKind.NativeInt:
-                    index = (int)indexItem.AsNativeInt();
+                    {
+                        long value = (long)indexItem.AsNativeInt();
+                        Debug.Assert(value >= int.MinValue && value <= int.MaxValue);
+                        index = (int)value;
+                    }
                     break;
                 default:
                     ThrowHelper.ThrowInvalidProgramException();
@@ -2224,7 +2228,11 @@ namespace Internal.Runtime.Interpreter
                     index = indexItem.AsInt32();
                     break;
                 case StackValueKind.NativeInt:
-                    index = (int)indexItem.AsNativeInt();
+                    {
+                        long value = (long)indexItem.AsNativeInt();
+                        Debug.Assert(value >= int.MinValue && value <= int.MaxValue);
+                        index = (int)value;
+                    }
                     break;
                 default:
                     ThrowHelper.ThrowInvalidProgramException();
@@ -2303,7 +2311,11 @@ namespace Internal.Runtime.Interpreter
                     index = indexItem.AsInt32();
                     break;
                 case StackValueKind.NativeInt:
-                    index = (int)indexItem.AsNativeInt();
+                    {
+                        long value = (long)indexItem.AsNativeInt();
+                        Debug.Assert(value >= int.MinValue && value <= int.MaxValue);
+                        index = (int)value;
+                    }
                     break;
                 default:
                     ThrowHelper.ThrowInvalidProgramException();
@@ -2368,7 +2380,11 @@ namespace Internal.Runtime.Interpreter
                     index = indexItem.AsInt32();
                     break;
                 case StackValueKind.NativeInt:
-                    index = (int)indexItem.AsNativeInt();
+                    {
+                        long value = (long)indexItem.AsNativeInt();
+                        Debug.Assert(value >= int.MinValue && value <= int.MaxValue);
+                        index = (int)value;
+                    }
                     break;
                 default:
                     ThrowHelper.ThrowInvalidProgramException();

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -11,11 +11,6 @@ using Internal.Runtime.CallInterceptor;
 using Internal.Runtime.CompilerServices;
 using Internal.TypeSystem;
 
-#if BIT64
-using nuint = System.UInt64;
-#else
-using nuint = System.UInt32;
-#endif
 
 namespace Internal.Runtime.Interpreter
 {
@@ -2181,34 +2176,33 @@ namespace Internal.Runtime.Interpreter
             if (index < 0 || index >= array.Length)
                 throw new IndexOutOfRangeException();
 
-            ref byte start = ref RuntimeAugments.GetRawDataForArray(array);
-            ref byte position = ref Unsafe.Add(ref start, (IntPtr)((nuint)index * RuntimeAugments.GetElementSizeForArray(array)));
+            ref byte address = ref RuntimeAugments.GetSzArrayElementAddress(array, index);
 
             switch (opcode)
             {
                 case ILOpcode.stelem_i:
-                    Unsafe.Write(ref position, valueItem.AsNativeInt());
+                    Unsafe.Write(ref address, valueItem.AsNativeInt());
                     break;
                 case ILOpcode.stelem_i1:
-                    Unsafe.Write(ref position, (sbyte)valueItem.AsInt32());
+                    Unsafe.Write(ref address, (sbyte)valueItem.AsInt32());
                     break;
                 case ILOpcode.stelem_i2:
-                    Unsafe.Write(ref position, (short)valueItem.AsInt32());
+                    Unsafe.Write(ref address, (short)valueItem.AsInt32());
                     break;
                 case ILOpcode.stelem_i4:
-                    Unsafe.Write(ref position, valueItem.AsInt32());
+                    Unsafe.Write(ref address, valueItem.AsInt32());
                     break;
                 case ILOpcode.stelem_i8:
-                    Unsafe.Write(ref position, valueItem.AsInt64());
+                    Unsafe.Write(ref address, valueItem.AsInt64());
                     break;
                 case ILOpcode.stelem_r4:
-                    Unsafe.Write(ref position, (float)valueItem.AsDouble());
+                    Unsafe.Write(ref address, (float)valueItem.AsDouble());
                     break;
                 case ILOpcode.stelem_r8:
-                    Unsafe.Write(ref position, valueItem.AsDouble());
+                    Unsafe.Write(ref address, valueItem.AsDouble());
                     break;
                 case ILOpcode.stelem_ref:
-                    Unsafe.Write(ref position, valueItem.AsObjectRef());
+                    Unsafe.Write(ref address, valueItem.AsObjectRef());
                     break;
                 default:
                     Debug.Assert(false);
@@ -2241,47 +2235,46 @@ namespace Internal.Runtime.Interpreter
                 throw new IndexOutOfRangeException();
 
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
-            ref byte start = ref RuntimeAugments.GetRawDataForArray(array);
-            ref byte position = ref Unsafe.Add(ref start, (IntPtr)((nuint)index * RuntimeAugments.GetElementSizeForArray(array)));
+            ref byte address = ref RuntimeAugments.GetSzArrayElementAddress(array, index);
 
         again:
             switch (elementType.Category)
             {
                 case TypeFlags.Boolean:
-                    Unsafe.Write(ref position, valueItem.AsInt32() != 0);
+                    Unsafe.Write(ref address, valueItem.AsInt32() != 0);
                     break;
                 case TypeFlags.Char:
-                    Unsafe.Write(ref position, (char)valueItem.AsInt32());
+                    Unsafe.Write(ref address, (char)valueItem.AsInt32());
                     break;
                 case TypeFlags.SByte:
                 case TypeFlags.Byte:
-                    Unsafe.Write(ref position, (sbyte)valueItem.AsInt32());
+                    Unsafe.Write(ref address, (sbyte)valueItem.AsInt32());
                     break;
                 case TypeFlags.Int16:
                 case TypeFlags.UInt16:
-                    Unsafe.Write(ref position, (short)valueItem.AsInt32());
+                    Unsafe.Write(ref address, (short)valueItem.AsInt32());
                     break;
                 case TypeFlags.Int32:
                 case TypeFlags.UInt32:
-                    Unsafe.Write(ref position, valueItem.AsInt32());
+                    Unsafe.Write(ref address, valueItem.AsInt32());
                     break;
                 case TypeFlags.Int64:
                 case TypeFlags.UInt64:
-                    Unsafe.Write(ref position, valueItem.AsInt64());
+                    Unsafe.Write(ref address, valueItem.AsInt64());
                     break;
                 case TypeFlags.IntPtr:
                 case TypeFlags.UIntPtr:
-                    Unsafe.Write(ref position, valueItem.AsNativeInt());
+                    Unsafe.Write(ref address, valueItem.AsNativeInt());
                     break;
                 case TypeFlags.Single:
-                    Unsafe.Write(ref position, (float)valueItem.AsDouble());
+                    Unsafe.Write(ref address, (float)valueItem.AsDouble());
                     break;
                 case TypeFlags.Double:
-                    Unsafe.Write(ref position, valueItem.AsDouble());
+                    Unsafe.Write(ref address, valueItem.AsDouble());
                     break;
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:
-                    Unsafe.Write(ref position, valueItem.AsValueType());
+                    Unsafe.Write(ref address, valueItem.AsValueType());
                     break;
                 case TypeFlags.Enum:
                     elementType = elementType.UnderlyingType;
@@ -2290,7 +2283,7 @@ namespace Internal.Runtime.Interpreter
                 case TypeFlags.Interface:
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
-                    Unsafe.Write(ref position, valueItem.AsObjectRef());
+                    Unsafe.Write(ref address, valueItem.AsObjectRef());
                     break;
                 default:
                     // TODO: Support more complex return types
@@ -2320,43 +2313,42 @@ namespace Internal.Runtime.Interpreter
             if (index < 0 || index >= array.Length)
                 throw new IndexOutOfRangeException();
 
-            ref byte start = ref RuntimeAugments.GetRawDataForArray(array);
-            ref byte position = ref Unsafe.Add(ref start, (IntPtr)((nuint)index * RuntimeAugments.GetElementSizeForArray(array)));
+            ref byte address = ref RuntimeAugments.GetSzArrayElementAddress(array, index);
 
             switch (opcode)
             {
                 case ILOpcode.ldelem_i1:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<sbyte>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<sbyte>(ref address)));
                     break;
                 case ILOpcode.ldelem_u1:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<byte>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<byte>(ref address)));
                     break;
                 case ILOpcode.ldelem_i2:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<short>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<short>(ref address)));
                     break;
                 case ILOpcode.ldelem_u2:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<ushort>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<ushort>(ref address)));
                     break;
                 case ILOpcode.ldelem_i4:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<int>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<int>(ref address)));
                     break;
                 case ILOpcode.ldelem_u4:
-                    _stack.Push(StackItem.FromInt32((int)Unsafe.Read<uint>(ref position)));
+                    _stack.Push(StackItem.FromInt32((int)Unsafe.Read<uint>(ref address)));
                     break;
                 case ILOpcode.ldelem_i8:
-                    _stack.Push(StackItem.FromInt64(Unsafe.Read<long>(ref position)));
+                    _stack.Push(StackItem.FromInt64(Unsafe.Read<long>(ref address)));
                     break;
                 case ILOpcode.ldelem_i:
-                    _stack.Push(StackItem.FromNativeInt(Unsafe.Read<IntPtr>(ref position)));
+                    _stack.Push(StackItem.FromNativeInt(Unsafe.Read<IntPtr>(ref address)));
                     break;
                 case ILOpcode.ldelem_r4:
-                    _stack.Push(StackItem.FromDouble(Unsafe.Read<float>(ref position)));
+                    _stack.Push(StackItem.FromDouble(Unsafe.Read<float>(ref address)));
                     break;
                 case ILOpcode.ldelem_r8:
-                    _stack.Push(StackItem.FromDouble(Unsafe.Read<double>(ref position)));
+                    _stack.Push(StackItem.FromDouble(Unsafe.Read<double>(ref address)));
                     break;
                 case ILOpcode.ldelem_ref:
-                    _stack.Push(StackItem.FromObjectRef(Unsafe.Read<object>(ref position)));
+                    _stack.Push(StackItem.FromObjectRef(Unsafe.Read<object>(ref address)));
                     break;
                 default:
                     Debug.Assert(false);
@@ -2387,47 +2379,46 @@ namespace Internal.Runtime.Interpreter
                 throw new IndexOutOfRangeException();
 
             TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
-            ref byte start = ref RuntimeAugments.GetRawDataForArray(array);
-            ref byte position = ref Unsafe.Add(ref start, (IntPtr)((nuint)index * RuntimeAugments.GetElementSizeForArray(array)));
+            ref byte address = ref RuntimeAugments.GetSzArrayElementAddress(array, index);
 
         again:
             switch (elementType.Category)
             {
                 case TypeFlags.Boolean:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<bool>(ref position) ? 1 : 0));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<bool>(ref address) ? 1 : 0));
                     break;
                 case TypeFlags.Char:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<char>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<char>(ref address)));
                     break;
                 case TypeFlags.SByte:
                 case TypeFlags.Byte:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<sbyte>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<sbyte>(ref address)));
                     break;
                 case TypeFlags.Int16:
                 case TypeFlags.UInt16:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<short>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<short>(ref address)));
                     break;
                 case TypeFlags.Int32:
                 case TypeFlags.UInt32:
-                    _stack.Push(StackItem.FromInt32(Unsafe.Read<int>(ref position)));
+                    _stack.Push(StackItem.FromInt32(Unsafe.Read<int>(ref address)));
                     break;
                 case TypeFlags.Int64:
                 case TypeFlags.UInt64:
-                    _stack.Push(StackItem.FromInt64(Unsafe.Read<long>(ref position)));
+                    _stack.Push(StackItem.FromInt64(Unsafe.Read<long>(ref address)));
                     break;
                 case TypeFlags.IntPtr:
                 case TypeFlags.UIntPtr:
-                    _stack.Push(StackItem.FromNativeInt(Unsafe.Read<IntPtr>(ref position)));
+                    _stack.Push(StackItem.FromNativeInt(Unsafe.Read<IntPtr>(ref address)));
                     break;
                 case TypeFlags.Single:
-                    _stack.Push(StackItem.FromDouble(Unsafe.Read<float>(ref position)));
+                    _stack.Push(StackItem.FromDouble(Unsafe.Read<float>(ref address)));
                     break;
                 case TypeFlags.Double:
-                    _stack.Push(StackItem.FromDouble(Unsafe.Read<double>(ref position)));
+                    _stack.Push(StackItem.FromDouble(Unsafe.Read<double>(ref address)));
                     break;
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:
-                    _stack.Push(StackItem.FromValueType(Unsafe.Read<ValueType>(ref position)));
+                    _stack.Push(StackItem.FromValueType(Unsafe.Read<ValueType>(ref address)));
                     break;
                 case TypeFlags.Enum:
                     elementType = elementType.UnderlyingType;
@@ -2436,7 +2427,7 @@ namespace Internal.Runtime.Interpreter
                 case TypeFlags.Interface:
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
-                    _stack.Push(StackItem.FromObjectRef(Unsafe.Read<object>(ref position)));
+                    _stack.Push(StackItem.FromObjectRef(Unsafe.Read<object>(ref address)));
                     break;
                 default:
                     // TODO: Support more complex return types

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -397,25 +397,20 @@ namespace Internal.Runtime.Interpreter
                     case ILOpcode.ldelem_ref:
                         throw new NotImplementedException();
                     case ILOpcode.stelem_i:
-                        throw new NotImplementedException();
                     case ILOpcode.stelem_i1:
-                        throw new NotImplementedException();
                     case ILOpcode.stelem_i2:
-                        throw new NotImplementedException();
                     case ILOpcode.stelem_i4:
-                        throw new NotImplementedException();
                     case ILOpcode.stelem_i8:
-                        throw new NotImplementedException();
                     case ILOpcode.stelem_r4:
-                        throw new NotImplementedException();
                     case ILOpcode.stelem_r8:
-                        throw new NotImplementedException();
                     case ILOpcode.stelem_ref:
-                        throw new NotImplementedException();
+                        InterpretStoreElement(opcode);
+                        break;
                     case ILOpcode.ldelem:
                         throw new NotImplementedException();
                     case ILOpcode.stelem:
-                        throw new NotImplementedException();
+                        InterpretStoreElement(reader.ReadILToken());
+                        break;
                     case ILOpcode.unbox_any:
                         throw new NotImplementedException();
                     case ILOpcode.conv_ovf_i1:
@@ -2160,6 +2155,110 @@ namespace Internal.Runtime.Interpreter
         {
             Array array = (Array)PopWithValidation().AsObjectRef();
             _stack.Push(StackItem.FromInt32(array.Length));
+        }
+
+        private void InterpretStoreElement(ILOpcode opcode)
+        {
+            StackItem stackItem = PopWithValidation();
+
+            int index = PopWithValidation().AsInt32();
+            Debug.Assert(index >= 0);
+
+            Array array = (Array)PopWithValidation().AsObjectRef();
+
+            switch (opcode)
+            {
+                case ILOpcode.stelem_i:
+                    array.SetValue(stackItem.AsNativeInt(), index);
+                    break;
+                case ILOpcode.stelem_i1:
+                    array.SetValue((sbyte)stackItem.AsInt32(), index);
+                    break;
+                case ILOpcode.stelem_i2:
+                    array.SetValue((short)stackItem.AsInt32(), index);
+                    break;
+                case ILOpcode.stelem_i4:
+                    array.SetValue(stackItem.AsInt32(), index);
+                    break;
+                case ILOpcode.stelem_i8:
+                    array.SetValue(stackItem.AsInt64(), index);
+                    break;
+                case ILOpcode.stelem_r4:
+                    array.SetValue((float)stackItem.AsDouble(), index);
+                    break;
+                case ILOpcode.stelem_r8:
+                    array.SetValue(stackItem.AsDouble(), index);
+                    break;
+                case ILOpcode.stelem_ref:
+                    // TODO: Add support for ByRef
+                    throw new NotImplementedException();
+                default:
+                    Debug.Assert(false);
+                    break;
+            }
+
+        }
+
+        private void InterpretStoreElement(int token)
+        {
+            TypeDesc elementType = (TypeDesc)_methodIL.GetObject(token);
+
+            StackItem stackItem = PopWithValidation();
+            int index = PopWithValidation().AsInt32();
+            Debug.Assert(index >= 0);
+
+            Array array = (Array)PopWithValidation().AsObjectRef();
+
+        again:
+            switch (elementType.Category)
+            {
+                case TypeFlags.Boolean:
+                    array.SetValue(stackItem.AsInt32() != 0, index);
+                    break;
+                case TypeFlags.Char:
+                    array.SetValue((char)stackItem.AsInt32(), index);
+                    break;
+                case TypeFlags.SByte:
+                case TypeFlags.Byte:
+                    array.SetValue((sbyte)stackItem.AsInt32(), index);
+                    break;
+                case TypeFlags.Int16:
+                case TypeFlags.UInt16:
+                    array.SetValue((short)stackItem.AsInt32(), index);
+                    break;
+                case TypeFlags.Int32:
+                case TypeFlags.UInt32:
+                    array.SetValue(stackItem.AsInt32(), index);
+                    break;
+                case TypeFlags.Int64:
+                case TypeFlags.UInt64:
+                    array.SetValue(stackItem.AsInt64(), index);
+                    break;
+                case TypeFlags.IntPtr:
+                case TypeFlags.UIntPtr:
+                    array.SetValue(stackItem.AsNativeInt(), index);
+                    break;
+                case TypeFlags.Single:
+                case TypeFlags.Double:
+                    array.SetValue(stackItem.AsDouble(), index);
+                    break;
+                case TypeFlags.ValueType:
+                case TypeFlags.Nullable:
+                    array.SetValue(stackItem.AsValueType(), index);
+                    break;
+                case TypeFlags.Enum:
+                    elementType = elementType.UnderlyingType;
+                    goto again;
+                case TypeFlags.Class:
+                case TypeFlags.Interface:
+                case TypeFlags.Array:
+                case TypeFlags.SzArray:
+                    array.SetValue(stackItem.AsObjectRef(), index);
+                    break;
+                default:
+                    // TODO: Support more complex return types
+                    throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2168,7 +2168,7 @@ namespace Internal.Runtime.Interpreter
                 case StackValueKind.NativeInt:
                     {
                         long value = (long)indexItem.AsNativeInt();
-                        if (value >= int.MinValue && value <= int.MaxValue)
+                        if ((int)value != value)
                             throw new IndexOutOfRangeException();
                         index = (int)value;
                     }
@@ -2228,7 +2228,7 @@ namespace Internal.Runtime.Interpreter
                 case StackValueKind.NativeInt:
                     {
                         long value = (long)indexItem.AsNativeInt();
-                        if (value >= int.MinValue && value <= int.MaxValue)
+                        if ((int)value != value)
                             throw new IndexOutOfRangeException();
                         index = (int)value;
                     }
@@ -2309,7 +2309,7 @@ namespace Internal.Runtime.Interpreter
                 case StackValueKind.NativeInt:
                     {
                         long value = (long)indexItem.AsNativeInt();
-                        if (value >= int.MinValue && value <= int.MaxValue)
+                        if ((int)value != value)
                             throw new IndexOutOfRangeException();
                         index = (int)value;
                     }
@@ -2376,7 +2376,7 @@ namespace Internal.Runtime.Interpreter
                 case StackValueKind.NativeInt:
                     {
                         long value = (long)indexItem.AsNativeInt();
-                        if (value >= int.MinValue && value <= int.MaxValue)
+                        if ((int)value != value)
                             throw new IndexOutOfRangeException();
                         index = (int)value;
                     }

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2202,7 +2202,7 @@ namespace Internal.Runtime.Interpreter
                     Unsafe.Write(ref address, valueItem.AsDouble());
                     break;
                 case ILOpcode.stelem_ref:
-                    Unsafe.Write(ref address, valueItem.AsObjectRef());
+                    RuntimeAugments.StelemRef(array, index, valueItem.AsObjectRef());
                     break;
                 default:
                     Debug.Assert(false);
@@ -2283,7 +2283,7 @@ namespace Internal.Runtime.Interpreter
                 case TypeFlags.Interface:
                 case TypeFlags.Array:
                 case TypeFlags.SzArray:
-                    Unsafe.Write(ref address, valueItem.AsObjectRef());
+                    RuntimeAugments.StelemRef(array, index, valueItem.AsObjectRef());
                     break;
                 default:
                     // TODO: Support more complex return types

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/EcmaFormat/EcmaFormatMethodCommon.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/EcmaFormat/EcmaFormatMethodCommon.cs
@@ -349,6 +349,7 @@ namespace System.Reflection.Runtime.MethodInfos.EcmaFormat
                 for (int i = 0 ; i < numParameters; i++)
                 {
                     signatureHandles[i + 1] = new QSignatureTypeHandle(_reader, signatureBlob);
+                    EcmaMetadataHelpers.SkipType(ref signatureBlob);
                 }
 
                 return signatureHandles;


### PR DESCRIPTION
This PR adds support for single-dimension zero-based arrays. It adds interpretation of the following opcodes:

* `newarr`
* `ldlen`
* `stelem.*`
* `ldelem.*`

which allows methods like the following to be interpreted:

```csharp
public static int[] GetArray()
{
    int[] array = new int[5];
    array[0] = 23;
    array[1] = 34;
    array[2] = 43;
    array[3] = 122;
    array[4] = 4;
    return array;
}

public static int GetArrayElement(int[] array, int index)
{
    return array[index];
}

public static int GetArrayLength(int l)
{
    return new int[l].Length;
}
```
