### PR TITLE
Avoid failing compilation with RootAllApplicationAssemblies

### DIFF
--- a/src/ILCompiler/src/ApplicationAssemblyRootProvider.cs
+++ b/src/ILCompiler/src/ApplicationAssemblyRootProvider.cs
@@ -58,7 +58,15 @@ namespace ILCompiler
 
             foreach (TypeDesc type in assembly.GetAllTypes())
             {
-                RdXmlRootProvider.RootType(rootProvider, type, "Application assembly root");
+                try
+                {
+                    RdXmlRootProvider.RootType(rootProvider, type, "Application assembly root");
+                }
+                catch (TypeSystemException)
+                {
+                    // The type might end up being not loadable (due to e.g. missing references).
+                    // If so, we will quietly ignore it: rooting all application types is best effort.
+                }
             }
         }
     }


### PR DESCRIPTION
When rooting all applicaiton assemblies is requested but the input doesn't form a proper closure, we won't be able to root all types. Skip those that can't be loaded so that we don't fail compilation.