### PR TITLE
Make reflection on anonymous types work

### DIFF
--- a/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
+++ b/src/Common/src/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
@@ -127,6 +127,18 @@ namespace Internal.TypeSystem
                 return false;
             }
         }
+
+        /// <summary>
+        /// Gets a value specifying whether this method has special semantics.
+        /// The name indicates the semantics.
+        /// </summary>
+        public virtual bool IsSpecialName
+        {
+            get
+            {
+                return false;
+            }
+        }
     }
 
     // Additional members of InstantiatedMethod related to code generation.
@@ -203,6 +215,14 @@ namespace Internal.TypeSystem
                 return _methodDef.IsNativeCallable;
             }
         }
+
+        public override bool IsSpecialName
+        {
+            get
+            {
+                return _methodDef.IsSpecialName;
+            }
+        }
     }
 
     // Additional members of MethodForInstantiatedType related to code generation.
@@ -277,6 +297,14 @@ namespace Internal.TypeSystem
             get
             {
                 return _typicalMethodDef.IsNativeCallable;
+            }
+        }
+
+        public override bool IsSpecialName
+        {
+            get
+            {
+                return _typicalMethodDef.IsSpecialName;
             }
         }
     }

--- a/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaMethod.cs
@@ -338,6 +338,14 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
+        public override bool IsSpecialName
+        {
+            get
+            {
+                return (Attributes & MethodAttributes.SpecialName) != 0;
+            }
+        }
+
         public override bool IsDefaultConstructor
         {
             get

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -471,7 +471,7 @@ namespace ILCompiler
 
             ManifestResourceBlockingPolicy resBlockingPolicy = new NoManifestResourceBlockingPolicy();
 
-            UsageBasedMetadataGenerationOptions metadataGenerationOptions = UsageBasedMetadataGenerationOptions.None;
+            UsageBasedMetadataGenerationOptions metadataGenerationOptions = UsageBasedMetadataGenerationOptions.AnonymousTypeHeuristic;
             if (_completeTypesMetadata)
                 metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.CompleteTypesOnly;
 


### PR DESCRIPTION
Anonymous types are generic, so rooting all application types still doesn't make reflection access to their properties work.

If we see an anonymous type get allocated, we compile all property accessors.

This logic is specific to the usage-base metadata analyzer and will only kick in if the compiler is building the reflectable closure. The code won't run if e.g. reflection information is provided externally, or if we don't generate any metadata.

Fixes #6951.