### PR TITLE
Annotate EventCounter as a relocated type

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
@@ -26,7 +26,7 @@ namespace System.Diagnostics.Tracing
     /// See https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs
     /// which shows tests, which are also useful in seeing actual use.  
     /// </summary>
-    public class EventCounter : IDisposable
+    public partial class EventCounter : IDisposable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EventCounter"/> class.

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -203,6 +203,7 @@
     <Compile Include="System\Diagnostics\StackFrame.CoreRT.cs" />
     <Compile Include="System\Diagnostics\StackFrameExtensions.cs" />
     <Compile Include="System\Diagnostics\StackTrace.CoreRT.cs" />
+    <Compile Include="System\Diagnostics\Tracing\EventCounter.ProjectN.cs" Condition="'$(IsProjectNLibrary)' == 'true'" />
     <Compile Include="System\Diagnostics\Tracing\EventSource_CoreRT.cs" />
     <Compile Include="System\Diagnostics\Tracing\FrameworkEventSource.cs" />
     <Compile Include="System\Diagnostics\Tracing\UnsafeNativeMethods.cs" />

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventCounter.ProjectN.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventCounter.ProjectN.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.Tracing
+{
+    [Internal.Runtime.CompilerServices.RelocatedType("System.Diagnostics.Tracing")]
+    partial class EventCounter
+    {
+    }
+}


### PR DESCRIPTION
This moved to CoreLib and needs to be annotated as such for Project N.